### PR TITLE
docs(corpus/tiger): fix ogr2ogr ingest — ADDRFEAT is per-county, no STATEFP column

### DIFF
--- a/packages/corpus/src/adapters/tiger/README.md
+++ b/packages/corpus/src/adapters/tiger/README.md
@@ -27,31 +27,70 @@ mailwoman dep would be opinionated. Pick whichever fits your pipeline.
 
 ### Recommended ingest: `ogr2ogr`
 
-The GDAL command-line tool ships in every major Linux distribution. To
-build the expected schema from raw TIGER:
+The GDAL command-line tool ships in every major Linux distribution. The
+ingest has two important wrinkles the operator should know before running:
+
+1. **ADDRFEAT is published per-COUNTY, not per-state.** Filename pattern is
+   `tl_2024_<5-digit-FIPS>_addrfeat.zip` where the 5-digit FIPS is the
+   2-digit state FIPS concatenated with the 3-digit county FIPS. A single
+   state can ship anywhere from ~3 county zips (DC) to ~250 (Texas). PLACE
+   *is* per-state (`tl_2024_<state-fips>_place.zip`).
+2. **`STATEFP` is NOT a column in ADDRFEAT shapefiles.** It's present in
+   PLACE but not ADDRFEAT. The mailwoman adapter expects `tiger_streets`
+   to have a `statefp` column, so it must be derived at ingest time. The
+   `LINEARID` first-2-chars trick does NOT work — LINEARID's structure
+   doesn't carry state FIPS in its prefix; every TIGER LINEARID starts
+   with the same prefix bytes. Derive it from the filename instead.
+
+Here's a complete ingest loop for one state's worth of data:
 
 ```sh
-# Download the latest TIGER ADDRFEAT (street segments) + PLACE
-# shapefiles per state from https://www2.census.gov/geo/tiger/TIGER2024/
-# Per-state ADDRFEAT: tl_2024_<state-fips>_addrfeat.zip
-# Per-state PLACE:    tl_2024_<state-fips>_place.zip
+# Download:
+#   Per-county ADDRFEAT: https://www2.census.gov/geo/tiger/TIGER2024/ADDRFEAT/
+#   Per-state PLACE:     https://www2.census.gov/geo/tiger/TIGER2024/PLACE/
 
+# Extract all the zips into a flat dir (extracted/), then:
+
+STATE_FIPS=50   # Vermont, for example
+
+# Initialize tiger_streets from the first county's ADDRFEAT.
+FIRST=$(ls extracted/tl_2024_${STATE_FIPS}???_addrfeat.shp | head -1)
+LAYER=$(basename "$FIRST" .shp)
 ogr2ogr -f SQLite tiger.db \
     -nln tiger_streets \
-    -select LINEARID,FULLNAME,ZIPL,ZIPR,STATEFP \
-    tl_2024_50_addrfeat/tl_2024_50_addrfeat.shp
+    -dialect SQLite \
+    -sql "SELECT LINEARID, FULLNAME, ZIPL, ZIPR, '${STATE_FIPS}' AS STATEFP
+          FROM '${LAYER}' WHERE FULLNAME IS NOT NULL" \
+    "$FIRST"
 
-ogr2ogr -f SQLite -update tiger.db \
+# Append every subsequent county's ADDRFEAT into the same table.
+for shp in extracted/tl_2024_${STATE_FIPS}???_addrfeat.shp; do
+    [ "$shp" = "$FIRST" ] && continue
+    LAYER=$(basename "$shp" .shp)
+    ogr2ogr -update -append tiger.db -nln tiger_streets \
+        -dialect SQLite \
+        -sql "SELECT LINEARID, FULLNAME, ZIPL, ZIPR, '${STATE_FIPS}' AS STATEFP
+              FROM '${LAYER}' WHERE FULLNAME IS NOT NULL" \
+        "$shp"
+done
+
+# PLACE has STATEFP natively + is per-state, so it's one call.
+ogr2ogr -update -append tiger.db \
     -nln tiger_places \
     -select GEOID,NAME,STATEFP,LSAD \
-    tl_2024_50_place/tl_2024_50_place.shp
+    extracted/tl_2024_${STATE_FIPS}_place.shp
 
-# Repeat -update for each state shapefile you want in the corpus.
+# Repeat the whole block per state with a different STATE_FIPS.
 ```
 
-The column names match TIGER's canonical Shapefile column names (just
-lowercased — SQLite's identifier folding handles that), so this is
-typically a one-pass conversion.
+The `WHERE FULLNAME IS NOT NULL` filter drops the small fraction of segment
+rows that have no name (typically unnamed alleys or parcel edges) — they
+contribute no signal to a street-name training corpus.
+
+The PLACE column names match TIGER's canonical names (just lowercased —
+SQLite's identifier folding handles that). For ADDRFEAT the SQL extract
+above renames the literal `STATE_FIPS` shell variable into a `STATEFP`
+column, producing the column the adapter expects.
 
 ## Expected schema
 


### PR DESCRIPTION
## Summary

The TIGER adapter's `README.md` documented an `ogr2ogr` ingest that doesn't work against real Census shapefiles. Surfaced during 2026-05-17 real-data corpus build prep (Phase 1 §3 operator-side task in #18). Adapter code is unaffected — only the README's instructions were wrong.

**Two errors corrected:**

1. **ADDRFEAT is per-COUNTY, not per-state.** Filename pattern is `tl_2024_<5-digit-FIPS>_addrfeat.zip` where the 5-digit FIPS = 2-digit state + 3-digit county. A single state can ship ~3 to ~250 county zips. PLACE *is* per-state.
2. **ADDRFEAT shapefiles have NO `STATEFP` column.** Only PLACE does. The previous `-select LINEARID,FULLNAME,ZIPL,ZIPR,STATEFP` errored with `Field 'STATEFP' not found in source layer`. The LINEARID-first-2-chars trick doesn't work — every TIGER LINEARID starts with the same prefix bytes. STATEFP must be derived from the filename.

**Fix:** rewrite the ingest block to loop over per-county ADDRFEAT zips for one state, inject `STATE_FIPS` as a literal via `-dialect SQLite -sql "SELECT ..., '\${STATE_FIPS}' AS STATEFP FROM ..."`, keep PLACE simple.

## Test plan

- [x] Validated against real ADDRFEAT + PLACE shapefiles for VT (50) + WY (56) + ND (38) — 90 county zips → 360,997 streets, 791 places in `tiger.db`, `statefp` column populated correctly per state
- [x] Adapter integration tests pass (unchanged; they consume the fixture SQL which had a synthetic STATEFP)
- [x] `npx prettier --check` clean on the modified file

Closes the README half of the Phase 1.5 TIGER work; adapter code is correct as-is.

Refs #15 (epic), #18 (Phase 1.5 — the data prep this surfaced from).