### PR TITLE
neural/data_loader: bump shuffle reservoir 16k → 128k for v0.2.0 corpus scale

### DIFF
--- a/packages/corpus-python/src/mailwoman_train/data_loader.py
+++ b/packages/corpus-python/src/mailwoman_train/data_loader.py
@@ -141,7 +141,7 @@ def iter_rows(
     source_weights: dict[str, float] | None = None,
     coarse_filter: bool,
     row_limit: int | None = None,
-    shuffle_buffer: int = 16384,
+    shuffle_buffer: int = 131072,
 ) -> Iterator[dict]:
     """Yield rows from parquet shards, filtered + shuffled.
 
@@ -166,7 +166,10 @@ def iter_rows(
 
     Memory: each buffered row is a dict of {raw: str, tokens: list[str], labels: list[str],
     country: str, source: str}. For Stage 1 coarse rows, that's ~1 KB per row; default
-    16384 buffer is ~16 MB resident, well within budget.
+    131072 buffer is ~128 MB resident, well within budget. The v0.1.1 default of 16384
+    was sized for a 22M-row corpus; v0.2.0 ships 263M rows so the same 16k buffer would
+    sample only 0.006% per shuffle — within-shard order would dominate. 128k buffer
+    samples 0.05% which restores effective randomness without meaningful RAM impact.
     """
     if not country_weights:
         raise ValueError("country_weights must be non-empty")


### PR DESCRIPTION
**Why:** v0.1.1 default of 16384 was sized for a 22M-row corpus (sampling 0.07% per shuffle). v0.2.0 ships 263M rows so the same 16k buffer samples only 0.006% — within-shard sequential order dominates the training stream. Bumping to 131072 restores the same magnitude of effective shuffle quality (~0.05%) for ~112 MB extra RAM.

**Scope:** one default-value change + docstring update. Function signature is backward-compatible; callers passing an explicit `shuffle_buffer` override are unaffected.

**Why merge before v0.2.0 training:** the Phase 2 v0.1.0 retro identified sequential-data overfitting as one of two real training bugs. Source-weights (PR #44) fixes one half of the imbalance; this fixes the other half (sampling resolution).

Related: #43 (v0.2.0 retrain — primary consumer).
