### PR TITLE
feat: apps/web-demo — server-side parser demo (mailwoman.sister.software)

### DIFF
--- a/apps/web-demo/README.md
+++ b/apps/web-demo/README.md
@@ -1,0 +1,62 @@
+# `apps/web-demo` — live parser demo
+
+Small server-side demo that loads a `@mailwoman/neural-weights-*` ONNX model and serves a single-page UI for pasting an address and seeing per-token labels + confidence + decoded components.
+
+Hosted at <https://mailwoman.sister.software/> (gated by Cloudflare; behind the playpen host's nginx → systemd `mailwoman-demo.service` on `127.0.0.1:8888`).
+
+## What it shows
+
+- Per-token BIO label + confidence (color-coded chips with confidence bars)
+- Decoded components dict (the `first-occurrence-wins` reduction)
+- Mean token confidence + model filename
+- 7 preset examples covering bitter-lesson kryptonite cases
+- Raw JSON response for power users
+
+## Stack
+
+- **Backend**: Python 3.12 + onnxruntime + sentencepiece + numpy. Single-file `server.py`. Built-in `http.server` (no framework dependency). Loads model + tokenizer once on startup; per-request inference is <50 ms on CPU.
+- **Frontend**: One `index.html` file, embedded CSS + JS, no build step.
+
+## Configuration (env vars)
+
+| var                   | default                                         | purpose                  |
+| --------------------- | ----------------------------------------------- | ------------------------ |
+| `PORT`                | `8888`                                          | bind port                |
+| `MAILWOMAN_MODEL`     | `/data/models/quantized/model-v0.1.0-int8.onnx` | ONNX file path           |
+| `MAILWOMAN_TOKENIZER` | `/data/models/tokenizer/v0.1.0/tokenizer.model` | SentencePiece model path |
+
+Swap to v0.2.0 weights by changing `MAILWOMAN_MODEL` — no code change.
+
+## Run locally
+
+```sh
+python3 -m venv venv
+venv/bin/pip install onnxruntime sentencepiece numpy
+venv/bin/python server.py
+# open http://localhost:8888/
+```
+
+## Production deployment (playpen host)
+
+See [`playpen/docs/docs/runbooks/adding-a-public-service.md`](../../playpen) for the full pattern. Short version:
+
+- Files installed to `/opt/mailwoman-demo/{server.py,index.html,venv/}` on the playpen host
+- `mailwoman-demo.service` systemd unit binds `127.0.0.1:8888`
+- nginx server block `mailwoman.sister.software` proxies through host nginx (port 8080) — see `/etc/nginx/sites-available/mailwoman-demo`
+- Cloudflare tunnel routes the public hostname to `localhost:8080`
+- No authentik gating (public demo)
+
+## What this does NOT do (yet)
+
+- **No browser-side WebGPU** — server-side inference only. The full WebGPU/onnxruntime-web path (per `#47`) needs SentencePiece-in-WASM, which is a real research task. Server-side is fine for the demo; WebGPU is a future enhancement.
+- **No rule-baseline comparison** — doesn't yet run mailwoman's existing `AddressRouter` alongside for A/B comparison
+- **No request logging or rate limiting** — single-user demo, not a service
+- **No history** — query state is client-side only; refresh loses it
+
+## How to update when v0.2.0+ ships
+
+1. Replace the int8 ONNX at `/mnt/playpen/mailwoman-data/models/quantized/`
+2. `sudo systemctl restart mailwoman-demo.service`
+3. Confirm via `curl -X POST https://mailwoman.sister.software/parse -d '{"text":"..."}'`
+
+The model card warning banner in `index.html` should also be updated to reflect the new version's quality bracket.

--- a/apps/web-demo/index.html
+++ b/apps/web-demo/index.html
@@ -1,0 +1,348 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Mailwoman — address parser demo</title>
+		<style>
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				font-family:
+					ui-sans-serif,
+					system-ui,
+					-apple-system,
+					sans-serif;
+				margin: 0;
+				padding: 2rem;
+				max-width: 920px;
+				margin-inline: auto;
+				line-height: 1.5;
+				color: #222;
+				background: #fafafa;
+			}
+			h1 {
+				font-weight: 600;
+				margin-top: 0;
+			}
+			h2 {
+				font-weight: 500;
+				margin-top: 1.5rem;
+				border-bottom: 1px solid #ddd;
+				padding-bottom: 0.25rem;
+			}
+			.meta {
+				color: #888;
+				font-size: 0.85em;
+			}
+			.model-banner {
+				background: #fff3cd;
+				border-left: 3px solid #f6a;
+				padding: 0.5rem 1rem;
+				margin-bottom: 1rem;
+				font-size: 0.9em;
+			}
+			textarea {
+				width: 100%;
+				font-family: ui-monospace, "SF Mono", monospace;
+				font-size: 1em;
+				padding: 0.75rem;
+				min-height: 70px;
+				border: 1px solid #ccc;
+				border-radius: 4px;
+				resize: vertical;
+			}
+			.row {
+				display: flex;
+				gap: 1rem;
+				align-items: center;
+				margin: 1rem 0;
+			}
+			button {
+				padding: 0.5rem 1.25rem;
+				font-size: 0.95em;
+				cursor: pointer;
+				background: #345;
+				color: white;
+				border: none;
+				border-radius: 4px;
+				transition: background 0.1s;
+			}
+			button:hover {
+				background: #456;
+			}
+			button.secondary {
+				background: #e4e4e4;
+				color: #333;
+				font-size: 0.85em;
+				padding: 0.3rem 0.75rem;
+				margin: 2px;
+			}
+			button.secondary:hover {
+				background: #d4d4d4;
+			}
+			.examples {
+				margin: 0.5rem 0 1.5rem;
+			}
+			.legend {
+				display: flex;
+				gap: 1rem;
+				flex-wrap: wrap;
+				font-size: 0.85em;
+				margin: 1rem 0;
+			}
+			.legend-item {
+				display: flex;
+				align-items: center;
+				gap: 0.35rem;
+			}
+			.swatch {
+				width: 14px;
+				height: 14px;
+				border-radius: 3px;
+				display: inline-block;
+			}
+			.components {
+				margin: 1rem 0;
+				padding: 0.75rem 1rem;
+				background: white;
+				border: 1px solid #ddd;
+				border-radius: 4px;
+			}
+			.comp-row {
+				display: grid;
+				grid-template-columns: 160px 1fr;
+				gap: 1rem;
+				padding: 0.3rem 0;
+				border-bottom: 1px solid #f0f0f0;
+			}
+			.comp-row:last-child {
+				border-bottom: none;
+			}
+			.comp-tag {
+				font-weight: 600;
+				color: #345;
+			}
+			.comp-value {
+				font-family: ui-monospace, monospace;
+				word-break: break-all;
+			}
+			.empty-components {
+				color: #888;
+				font-style: italic;
+				padding: 0.5rem;
+			}
+			.token-grid {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 6px;
+				margin: 1rem 0;
+			}
+			.token {
+				padding: 0.4rem 0.6rem;
+				border-radius: 4px;
+				font-family: ui-monospace, monospace;
+				font-size: 0.85em;
+				color: white;
+				min-width: 60px;
+				text-align: center;
+				box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+			}
+			.token-piece {
+				font-weight: 600;
+			}
+			.token-meta {
+				font-size: 0.7em;
+				opacity: 0.85;
+				margin-top: 0.15rem;
+			}
+			.conf-bar {
+				height: 3px;
+				background: rgba(255, 255, 255, 0.3);
+				border-radius: 2px;
+				margin-top: 0.25rem;
+			}
+			.conf-fill {
+				height: 100%;
+				background: rgba(255, 255, 255, 0.9);
+				border-radius: 2px;
+			}
+			/* Per-class colors — keep in sync with backend LABELS */
+			.label-O {
+				background: #aaa;
+			}
+			.label-country {
+				background: #c0392b;
+			}
+			.label-region {
+				background: #d35400;
+			}
+			.label-locality {
+				background: #27ae60;
+			}
+			.label-postcode {
+				background: #2980b9;
+			}
+			.label-subregion {
+				background: #8e44ad;
+			}
+			.label-dependent_locality {
+				background: #16a085;
+			}
+			.label-cedex {
+				background: #e91e63;
+			}
+			pre {
+				background: #1e1e1e;
+				color: #d4d4d4;
+				padding: 1rem;
+				border-radius: 4px;
+				overflow-x: auto;
+				font-size: 0.85em;
+			}
+			.stat {
+				display: inline-block;
+				padding: 0.15rem 0.5rem;
+				background: #eee;
+				border-radius: 3px;
+				font-size: 0.85em;
+				margin-right: 0.5rem;
+			}
+			.stat strong {
+				color: #345;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Mailwoman address parser — live demo</h1>
+		<div class="model-banner">
+			<strong>⚠ Alpha — v0.1.0 baseline weights.</strong>
+			This model trained 6,000 of 50,000 planned steps and ships below targets (macro F1 ~0.03) due to corpus-imbalance
+			overfit. Use to demo the API + UX shape; v0.2.0 should land in ~1h with much better numbers.
+		</div>
+
+		<textarea id="input" autofocus>1600 Pennsylvania Avenue NW, Washington, DC 20500</textarea>
+
+		<div class="row">
+			<button onclick="parseIt()">Parse →</button>
+			<span class="meta">or press <kbd>Ctrl+Enter</kbd></span>
+		</div>
+
+		<div class="examples">
+			<div class="meta" style="margin-bottom: 0.3rem">try one of these:</div>
+			<button class="secondary" onclick="setEx('Buffalo Health Center Inc., 200 Elmwood Ave, Buffalo, NY 14222')">
+				venue with name collision
+			</button>
+			<button class="secondary" onclick="setEx('245 1st Ave N, Saint Petersburg, FL 33701')">
+				St. Petersburg disambiguation
+			</button>
+			<button class="secondary" onclick="setEx('15 Rue de Rivoli, 75004 Paris, France')">French street address</button>
+			<button class="secondary" onclick="setEx('RR 2 Box 67, Rural Springs, MT 59101')">rural route</button>
+			<button class="secondary" onclick="setEx('PO Box 1234, Anchorage, AK 99501')">PO box</button>
+			<button class="secondary" onclick="setEx('40-12 Bell Blvd, Bayside, NY 11361')">hyphenated NYC house</button>
+			<button class="secondary" onclick="setEx('The New York Steakhouse, 123 Main St, New York, NY 10001')">
+				name repetition
+			</button>
+		</div>
+
+		<div class="legend">
+			<span class="legend-item"><span class="swatch label-country"></span>country</span>
+			<span class="legend-item"><span class="swatch label-region"></span>region</span>
+			<span class="legend-item"><span class="swatch label-locality"></span>locality</span>
+			<span class="legend-item"><span class="swatch label-postcode"></span>postcode</span>
+			<span class="legend-item"><span class="swatch label-subregion"></span>subregion</span>
+			<span class="legend-item"><span class="swatch label-dependent_locality"></span>dep_locality</span>
+			<span class="legend-item"><span class="swatch label-cedex"></span>cedex</span>
+			<span class="legend-item"><span class="swatch label-O"></span>O (no label)</span>
+		</div>
+
+		<div id="results"></div>
+
+		<script>
+			function setEx(text) {
+				document.getElementById("input").value = text
+				parseIt()
+			}
+
+			async function parseIt() {
+				const text = document.getElementById("input").value.trim()
+				if (!text) return
+				const out = document.getElementById("results")
+				out.innerHTML = '<p class="meta">…parsing…</p>'
+				let data
+				try {
+					const res = await fetch("/parse", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ text }),
+					})
+					data = await res.json()
+					if (!res.ok) {
+						out.innerHTML = `<p style="color:#c0392b">${escapeHtml(data.error || res.statusText)}</p>`
+						return
+					}
+				} catch (e) {
+					out.innerHTML = `<p style="color:#c0392b">network error: ${escapeHtml(String(e))}</p>`
+					return
+				}
+				render(data)
+			}
+
+			function colorClass(label) {
+				if (label === "O") return "label-O"
+				const tag = label.split("-").slice(1).join("-")
+				return `label-${tag}`
+			}
+
+			function render(data) {
+				let html = ""
+				html += `<h2>Parsed components</h2><div class="components">`
+				const comps = Object.entries(data.components)
+				if (comps.length === 0) {
+					html += `<div class="empty-components">none — model produced no recognized labels (everything came back as O)</div>`
+				} else {
+					for (const [tag, value] of comps) {
+						html += `<div class="comp-row"><span class="comp-tag">${tag}</span><span class="comp-value">${escapeHtml(value)}</span></div>`
+					}
+				}
+				html += `</div>`
+
+				html += `<h2>Per-token BIO labels + confidence</h2>`
+				html += `<div><span class="stat">mean conf: <strong>${data.mean_confidence.toFixed(3)}</strong></span>`
+				html += `<span class="stat">tokens: <strong>${data.tokens.length}</strong></span>`
+				html += `<span class="stat">model: <strong>${escapeHtml(data.model)}</strong></span></div>`
+				html += `<div class="token-grid">`
+				for (const t of data.tokens) {
+					html += `<div class="token ${colorClass(t.label)}">
+      <div class="token-piece">${escapeHtml(t.piece)}</div>
+      <div class="token-meta">${escapeHtml(t.label)} · ${(t.confidence * 100).toFixed(0)}%</div>
+      <div class="conf-bar"><div class="conf-fill" style="width:${t.confidence * 100}%"></div></div>
+    </div>`
+				}
+				html += `</div>`
+
+				html += `<h2>Raw JSON response</h2><pre>${escapeHtml(JSON.stringify(data, null, 2))}</pre>`
+				document.getElementById("results").innerHTML = html
+			}
+
+			function escapeHtml(s) {
+				return String(s)
+					.replace(/&/g, "&amp;")
+					.replace(/</g, "&lt;")
+					.replace(/>/g, "&gt;")
+					.replace(/"/g, "&quot;")
+					.replace(/'/g, "&#39;")
+			}
+
+			document.getElementById("input").addEventListener("keydown", (e) => {
+				if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+					parseIt()
+				}
+			})
+
+			// auto-fire on load with the default example
+			window.addEventListener("DOMContentLoaded", parseIt)
+		</script>
+	</body>
+</html>

--- a/apps/web-demo/server.py
+++ b/apps/web-demo/server.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Mailwoman web demo backend.
+
+Loads the v0.1.0 int8 ONNX + SentencePiece tokenizer once on startup, serves /parse + index.html.
+Drop-in compatible with v0.2.0 once weights ship — just swap MODEL_PATH.
+"""
+
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+import numpy as np
+import onnxruntime as ort
+import sentencepiece as spm
+
+HERE = Path(__file__).parent
+MODEL_PATH = os.environ.get("MAILWOMAN_MODEL", "/data/models/quantized/model-v0.1.0-int8.onnx")
+TOKENIZER_PATH = os.environ.get("MAILWOMAN_TOKENIZER", "/data/models/tokenizer/v0.1.0/tokenizer.model")
+INDEX_HTML = HERE / "index.html"
+
+LABELS = [
+	"O",
+	"B-country", "I-country",
+	"B-region", "I-region",
+	"B-locality", "I-locality",
+	"B-dependent_locality", "I-dependent_locality",
+	"B-postcode", "I-postcode",
+	"B-subregion", "I-subregion",
+	"B-cedex", "I-cedex",
+]
+MAX_LENGTH = 128
+
+print(f"loading model:     {MODEL_PATH}")
+session = ort.InferenceSession(MODEL_PATH, providers=["CPUExecutionProvider"])
+input_names = [i.name for i in session.get_inputs()]
+print(f"  inputs:          {input_names}")
+
+print(f"loading tokenizer: {TOKENIZER_PATH}")
+sp = spm.SentencePieceProcessor()
+sp.Load(TOKENIZER_PATH)
+PAD_ID = sp.pad_id() if sp.pad_id() >= 0 else 0
+print(f"  vocab_size:      {sp.vocab_size()}, pad_id={PAD_ID}")
+
+
+def softmax(x: np.ndarray) -> np.ndarray:
+	e_x = np.exp(x - np.max(x, axis=-1, keepdims=True))
+	return e_x / e_x.sum(axis=-1, keepdims=True)
+
+
+def build_piece_spans(raw: str, pieces: list[str]) -> list[tuple[int, int]]:
+	"""Reconstruct char offsets per piece by replaying the encoding against raw."""
+	cursor = 0
+	spans: list[tuple[int, int]] = []
+	for p in pieces:
+		text = p.lstrip("▁")  # SentencePiece word-boundary marker
+		if not text:
+			spans.append((cursor, cursor))
+			continue
+		idx = raw.find(text, cursor)
+		if idx == -1:
+			idx = cursor
+		spans.append((idx, idx + len(text)))
+		cursor = idx + len(text)
+	return spans
+
+
+def parse_address(raw: str) -> dict:
+	pieces = sp.encode_as_pieces(raw)[:MAX_LENGTH]
+	piece_ids = [sp.piece_to_id(p) for p in pieces]
+	spans = build_piece_spans(raw, pieces)
+
+	attn = [1] * len(piece_ids)
+	while len(piece_ids) < MAX_LENGTH:
+		piece_ids.append(PAD_ID)
+		attn.append(0)
+
+	ids_np = np.array([piece_ids], dtype=np.int64)
+	attn_np = np.array([attn], dtype=np.int64)
+	outputs = session.run(None, {input_names[0]: ids_np, input_names[1]: attn_np})
+	logits = outputs[0][0]  # (max_length, num_labels)
+
+	real_len = len(pieces)
+	probs = softmax(logits[:real_len])
+	pred_ids = probs.argmax(axis=-1).tolist()
+	confidences = probs.max(axis=-1).tolist()
+
+	tokens = []
+	for i, (p, lid, conf) in enumerate(zip(pieces, pred_ids, confidences)):
+		tokens.append({
+			"piece": p,
+			"char_begin": spans[i][0],
+			"char_end": spans[i][1],
+			"label": LABELS[lid] if 0 <= lid < len(LABELS) else "?",
+			"confidence": round(float(conf), 4),
+		})
+
+	# First-occurrence-wins decoder (mirrors mailwoman_train.eval.decode_components)
+	components: dict[str, str] = {}
+	cur_tag: str | None = None
+	cur_begin = cur_end = -1
+	for tok in tokens:
+		label = tok["label"]
+		if label == "O":
+			if cur_tag and cur_tag not in components:
+				components[cur_tag] = raw[cur_begin:cur_end].strip()
+			cur_tag = None
+			continue
+		prefix, tag = label.split("-", 1)
+		if prefix == "B" or cur_tag != tag:
+			if cur_tag and cur_tag not in components:
+				components[cur_tag] = raw[cur_begin:cur_end].strip()
+			cur_tag = tag
+			cur_begin = tok["char_begin"]
+			cur_end = tok["char_end"]
+		else:
+			cur_end = tok["char_end"]
+	if cur_tag and cur_tag not in components:
+		components[cur_tag] = raw[cur_begin:cur_end].strip()
+
+	return {
+		"raw": raw,
+		"tokens": tokens,
+		"components": components,
+		"mean_confidence": round(float(np.mean(confidences)), 4),
+		"model": Path(MODEL_PATH).name,
+	}
+
+
+class Handler(BaseHTTPRequestHandler):
+	def log_message(self, format, *args):
+		pass
+
+	def _send_json(self, status: int, payload: dict):
+		body = json.dumps(payload).encode("utf-8")
+		self.send_response(status)
+		self.send_header("Content-Type", "application/json")
+		self.send_header("Content-Length", str(len(body)))
+		self.end_headers()
+		self.wfile.write(body)
+
+	def do_GET(self):
+		parsed = urlparse(self.path)
+		if parsed.path in ("/", "/index.html"):
+			try:
+				body = INDEX_HTML.read_bytes()
+				self.send_response(200)
+				self.send_header("Content-Type", "text/html; charset=utf-8")
+				self.send_header("Content-Length", str(len(body)))
+				self.end_headers()
+				self.wfile.write(body)
+			except FileNotFoundError:
+				self.send_error(500, f"missing {INDEX_HTML}")
+			return
+		self.send_error(404)
+
+	def do_POST(self):
+		if self.path != "/parse":
+			self.send_error(404)
+			return
+		length = int(self.headers.get("Content-Length", 0))
+		body = self.rfile.read(length).decode("utf-8")
+		try:
+			payload = json.loads(body)
+			raw = (payload.get("text") or "").strip()
+			if not raw:
+				self._send_json(400, {"error": "empty text"})
+				return
+			self._send_json(200, parse_address(raw))
+		except Exception as e:
+			self._send_json(500, {"error": str(e), "type": type(e).__name__})
+
+
+if __name__ == "__main__":
+	port = int(os.environ.get("PORT", 8888))
+	server = ThreadingHTTPServer(("0.0.0.0", port), Handler)
+	print(f"\nserving on 0.0.0.0:{port}")
+	print(f"  open: http://<container-ip>:{port}/")
+	server.serve_forever()


### PR DESCRIPTION
Server-side first cut of #47. Live at https://mailwoman.sister.software/

Single-file Python backend (~200 LOC) + single-file HTML frontend (no build step). Loads any `@mailwoman/neural-weights-*` ONNX file, serves paste-an-address UX with per-token BIO labels + confidence + decoded components.

## What's running in prod

- `/opt/mailwoman-demo/server.py` (this PR's file)
- `/opt/mailwoman-demo/index.html` (this PR's file)
- `mailwoman-demo.service` systemd unit (in playpen repo, separate PR)
- nginx server block (in playpen repo, separate PR)
- Cloudflare tunnel route (operator-managed via CF dashboard)

## What's NOT here

- Browser-side WebGPU path (needs SentencePiece-in-WASM; tracked in #47)
- Rule-baseline A/B comparison (would call mailwoman's existing AddressRouter)
- Auth (public demo by design)
- Request logging / rate limiting

## Swap to v0.2.0 when ready

```sh
sudo systemctl edit mailwoman-demo.service  # change MAILWOMAN_MODEL env
sudo systemctl restart mailwoman-demo.service
```

The model card warning banner in index.html should be updated to reflect v0.2.0's quality bracket when that lands.

Related: #47, #43.
