### PR TITLE
apps/web-demo: update banner for v0.2.0 ship

### DIFF
--- a/apps/web-demo/index.html
+++ b/apps/web-demo/index.html
@@ -217,9 +217,10 @@
 	<body>
 		<h1>Mailwoman address parser — live demo</h1>
 		<div class="model-banner">
-			<strong>⚠ Alpha — v0.1.0 baseline weights.</strong>
-			This model trained 6,000 of 50,000 planned steps and ships below targets (macro F1 ~0.03) due to corpus-imbalance
-			overfit. Use to demo the API + UX shape; v0.2.0 should land in ~1h with much better numbers.
+			<strong>v0.2.0 — Stage 1 (coarse).</strong>
+			9× macro-F1 over v0.1.0 on the same eval set; calibration much tighter (conf&gt;0.9 accuracy 0.34 → 0.88).
+			Still below the §6 95% target on country / region / locality, and Stage 1 only labels coarse components — venue,
+			street, house_number, and unit get their own labels in Stage 2+.
 		</div>
 
 		<textarea id="input" autofocus>1600 Pennsylvania Avenue NW, Washington, DC 20500</textarea>


### PR DESCRIPTION
Mirrors the in-place banner edit on the live demo. Reflects v0.2.0's headline (9× macro-F1 win, calibration tightening), keeps the honest §6-target shortfall + Stage 1 coarse-only caveat.

Live demo at https://mailwoman.sister.software/ was already updated; this PR brings the repo's source in sync so the next deploy / local-run picks it up.

Related: #43 (v0.2.0 ship), #47 (browser/WebGPU follow-up).