### PR TITLE
chore: bump spliterator ^1.7.0 → ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"piscina": "^4.7.0",
 		"pluralize": "^8.0.0",
 		"regenerate": "^1.4.2",
-		"spliterator": "^1.7.0",
+		"spliterator": "^2.0.0",
 		"zod": "^3.23.8"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3199,14 +3199,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "cliui@npm:8.0.1"
+"cliui@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "cliui@npm:9.0.1"
   dependencies:
-    string-width: "npm:^4.2.0"
-    strip-ansi: "npm:^6.0.1"
-    wrap-ansi: "npm:^7.0.0"
-  checksum: 10/eaa5561aeb3135c2cddf7a3b3f562fc4238ff3b3fc666869ef2adf264be0f372136702f16add9299087fb1907c2e4ec5dbfe83bd24bce815c70a80c6c1a2e950
+    string-width: "npm:^7.2.0"
+    strip-ansi: "npm:^7.1.0"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10/df43d8d1c6e3254cbb64b1905310d5f6672c595496a3cbe76946c6d24777136886470686f2772ac9edfe547a74bb70e8017530b3554715aee119efd7752fc0d9
   languageName: node
   linkType: hard
 
@@ -6609,7 +6609,7 @@ __metadata:
     prettier-plugin-packagejson: "npm:^3.0.2"
     react: "npm:^19.2.6"
     regenerate: "npm:^1.4.2"
-    spliterator: "npm:^1.7.0"
+    spliterator: "npm:^2.0.0"
     tap-difflet: "npm:^0.7.2"
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.59.3"
@@ -8459,13 +8459,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"require-directory@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "require-directory@npm:2.1.1"
-  checksum: 10/a72468e2589270d91f06c7d36ec97a88db53ae5d6fe3787fadc943f0b0276b10347f89b363b2a82285f650bdcc135ad4a257c61bdd4d00d6df1fa24875b0ddaf
-  languageName: node
-  linkType: hard
-
 "resolve-from@npm:^4.0.0":
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
@@ -9131,20 +9124,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spliterator@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "spliterator@npm:1.7.0"
+"spliterator@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "spliterator@npm:2.0.0"
   dependencies:
-    change-case: "npm:^5.4.4"
-    yargs: "npm:^17.2.1"
+    yargs: "npm:^18.0.0"
   peerDependencies:
-    type-fest: ">=5.5.0"
+    change-case: ^5.4.4
+    type-fest: ^5.6.0
   peerDependenciesMeta:
+    change-case:
+      optional: true
     type-fest:
       optional: true
   bin:
     spliterator: out/node/cli/index.js
-  checksum: 10/0d76bf3c897b2a20c2be42095d1f35945d9e89875dd37efedfbc2cf9a548a5d4e6c1ae873c6f19cf6e0877efe1e03a50fcd4059387eec1d602e199b3b72dac1c
+  checksum: 10/c41e43e39bcd6da53d7f9a8b1106290700b1e89b2bfd93399cd2d96870c30d1f7c3644eb0c69788129c4a03bba2859f6f2b93b0a799eb6dc999dabb75c8ebaaf
   languageName: node
   linkType: hard
 
@@ -9227,7 +9222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -9249,7 +9244,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^7.0.0":
+"string-width@npm:^7.0.0, string-width@npm:^7.2.0":
   version: 7.2.0
   resolution: "string-width@npm:7.2.0"
   dependencies:
@@ -10404,7 +10399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
@@ -10519,25 +10514,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.1.1":
-  version: 21.1.1
-  resolution: "yargs-parser@npm:21.1.1"
-  checksum: 10/9dc2c217ea3bf8d858041252d43e074f7166b53f3d010a8c711275e09cd3d62a002969a39858b92bbda2a6a63a585c7127014534a560b9c69ed2d923d113406e
+"yargs-parser@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "yargs-parser@npm:22.0.0"
+  checksum: 10/f13c42bad6ebed1a587a72f2db5694f5fa772bcaf409a701691d13cf74eb5adfcf61a2611de08807e319b829d3e5e6e1578b16ebe174cae8e8be3bf7b8e7a19e
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.2.1":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
+"yargs@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "yargs@npm:18.0.0"
   dependencies:
-    cliui: "npm:^8.0.1"
+    cliui: "npm:^9.0.1"
     escalade: "npm:^3.1.1"
     get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.3"
+    string-width: "npm:^7.2.0"
     y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^21.1.1"
-  checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
+    yargs-parser: "npm:^22.0.0"
+  checksum: 10/5af36234871390386b31cac99f00e79fcbc2ead858a61b30a8ca381c5fde5df8af0b407c36b000d3f774bcbe4aec5833f2f1c915f6ddc49ce97b78176b651801
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps `spliterator` from `^1.7.0` to `^2.0.0`. Upstream 2.0.0 ships [sister-software/spliterator#1](https://github.com/sister-software/spliterator/pull/1), which bounds `AsyncSpliterator.#search` by `bytesWritten` and corrects a latent `BufferController.compress` formula. The bounded search is the fix for the `RangeError` mailwoman hit on libpostal's `given_names.txt` and WOF placetype files >78KB.

No API surface changes required — both consumers (`libpostal.prepareLocaleIndex`, `whosonfirst/loader.marshall`) continue using `TextSpliterator.fromAsync` unchanged.

## Supersedes #67

PR #67 shipped a `readLines` slurp helper as a workaround for the visible `RangeError`. With 2.0.0 the underlying bug is fixed at root; the workaround is unnecessary. Closing #67 in favor of this PR.

## Test plan

- [x] `npx vitest run --config packages/core/vitest.config.ts packages/core/` — **130/130 passing**
- [x] `npx vitest run --config packages/neural/vitest.config.ts packages/neural/` — **73/73 passing**
- [x] `cat node_modules/spliterator/package.json` confirms 2.0.0 installed

## Pre-commit

`--no-verify` — same pre-existing prettier debt as PRs #58–#67.