### PR TITLE
ci: switch publish workflow to npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,25 +1,29 @@
-# Manual-dispatch release workflow.
+# Manual-dispatch publish workflow with npm Trusted Publishing.
 #
 # Triggered from GitHub Actions UI → "Run workflow". Bumps versions
 # (sync across all workspaces), tags, pushes, publishes to npm, and
 # creates a GitHub release. Same flow as the local `yarn release`
 # documented in RELEASING.md, just running in CI.
 #
-# Requires repo secret NPM_TOKEN (npm "Automation" token type — bypasses
-# 2FA). GITHUB_TOKEN is provided automatically by the runtime.
+# Auth: npm Trusted Publishing (OIDC). No NPM_TOKEN secret needed in
+# this workflow — npmjs.com is configured to accept publishes from
+# this exact workflow file (path: .github/workflows/publish.yml). The
+# `id-token: write` permission below is what lets GitHub Actions mint
+# the OIDC token npm verifies against.
 #
-# ⚠ Weights packages — the neural-weights-{en-us,fr-fr} workspaces need
-# real model.onnx + tokenizer.model binaries before `yarn npm publish`.
-# Those binaries live at /mnt/playpen/mailwoman-data/ on the operator's
-# host and aren't checked into git. This workflow looks for them at the
-# upload path you pass via `weights_artifact` input; if missing AND
-# `release_weights=true`, the workflow fails fast with a clear message.
+# GITHUB_TOKEN is provided automatically by the runtime.
 #
-# Default behavior (`release_weights=false`) excludes the weights
-# workspaces from the publish set entirely — code packages ship,
-# weights stay at their last-published version. Use the local
+# ⚠ Weights packages — the neural-weights-{en-us,fr-fr} workspaces
+# need real model.onnx + tokenizer.model binaries before publish.
+# Those binaries live at /mnt/playpen/mailwoman-data/ on the
+# operator's host and aren't checked into git. Default behavior
+# (`release_weights=false`) skips the weights publish step entirely:
+# scripts/copy-weights.mjs short-circuits, and publish-workspace.mjs
+# detects weights workspaces and exits 0. The plugin still bumps
+# their package.json versions on disk (keeps monorepo versions in
+# sync) — only the npm publish is skipped. Use the local
 # `yarn release` flow when you want to cut a new weights release.
-name: release
+name: publish
 
 on:
     workflow_dispatch:
@@ -45,7 +49,7 @@ permissions:
     id-token: write
 
 jobs:
-    release:
+    publish:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
@@ -64,11 +68,6 @@ jobs:
 
             - name: Enable Corepack (yarn 4)
               run: corepack enable
-
-            - name: Configure npm auth
-              run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Configure git identity (for release-it commits)
               run: |
@@ -89,7 +88,6 @@ jobs:
 
             - name: Release
               env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   # When release_weights=false (default): skip copy-weights AND
                   # tell publish-workspace.mjs to skip the neural-weights-*

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,23 +80,23 @@ The binaries are gitignored in the workspace dirs (`neural-weights-*/.gitignore`
 | Hook `yarn test --run` fails              | Pre-existing test breakage                         | Fix tests OR temporarily comment the hook in `.release-it.json` and document the divergence in the release notes |
 | `copy-weights.mjs` `Missing source model` | Running from a machine without `/mnt/playpen/`     | Set `MAILWOMAN_PUBLISH_MODEL` + `MAILWOMAN_PUBLISH_TOKENIZER` env vars                                           |
 
-## Releasing from CI (manual dispatch)
+## Releasing from CI (manual dispatch + npm Trusted Publishing)
 
-`.github/workflows/release.yml` exposes the same flow from the GitHub Actions UI.
+`.github/workflows/publish.yml` exposes the same flow from the GitHub Actions UI. Auth uses **npm Trusted Publishing** (OIDC) — no `NPM_TOKEN` secret in the repo, no auth token in `~/.npmrc`. npmjs.com is configured to accept publishes from this exact workflow file path.
 
-1. **One-time** — add an `NPM_TOKEN` secret to the mailwoman repo (Settings → Secrets and variables → Actions → New repository secret). Generate via npmjs.com → Access Tokens → "Automation" type (bypasses 2FA). Scope to `@mailwoman` + `mailwoman`.
-2. **Run a release** — Actions tab → `release` workflow → Run workflow.
+1. **One-time setup on the npm side** (already done): each `@mailwoman/*` package + `mailwoman` has a Trusted Publisher configured pointing at `sister-software/mailwoman` repo + workflow file `.github/workflows/publish.yml`. If you move/rename that file, update the npm side too.
+2. **Run a release** — Actions tab → `publish` workflow → Run workflow.
    - `version` — `patch` / `minor` / `major` / specific semver like `2.1.0`. Default `patch`.
    - `release_weights` — boolean. Default **false**. See below.
    - `dry_run` — boolean. Default false. Set true to preview without publishing.
 
-The workflow checks out main, installs, runs `yarn release --ci --increment=<version>`. release-it's pre-flight hooks (compile + test + copy-weights) run as usual.
+The workflow checks out main, installs, runs `yarn release --ci --increment=<version>`. release-it's pre-flight hooks (compile + test + copy-weights) run as usual. Per-workspace publish uses `yarn pack -o <tmpfile>` (translates `workspace:*` → concrete versions) followed by `npm publish <tmpfile>` (the npm CLI auto-detects the OIDC environment and authenticates via Trusted Publishing; `--provenance` is auto-enabled).
 
 ### CI weights handling
 
 Weight binaries (`model.onnx`, `tokenizer.model`) live at `/mnt/playpen/mailwoman-data/` on your host and aren't fetchable from CI runners. The release workflow has two modes:
 
-- **`release_weights=false` (default)** — bumps + publishes only the code workspaces (`mailwoman`, `@mailwoman/{core,classifiers,corpus,neural}`). `@mailwoman/neural-weights-*` are excluded from this release; they stay at whatever their last-published version is. `copy-weights.mjs` is skipped via `MAILWOMAN_SKIP_WEIGHTS_COPY=1`.
+- **`release_weights=false` (default)** — bumps + publishes only the code workspaces (`mailwoman`, `@mailwoman/{core,classifiers,corpus,neural}`). `@mailwoman/neural-weights-*` are excluded from this release; they stay at whatever their last-published version is. `copy-weights.mjs` is skipped via `MAILWOMAN_SKIP_WEIGHTS_COPY=1`; `publish-workspace.mjs` skips the actual publish via `MAILWOMAN_SKIP_WEIGHTS=1`. The bump phase still touches their `package.json` versions on disk (keeps monorepo in sync) — only the npm publish is skipped.
 - **`release_weights=true`** — requires `neural-weights-{en-us,fr-fr}/model.onnx` already present in the workspace (uploaded as a workflow artifact before this run, etc.). Otherwise the workflow's pre-publish guard fails fast.
 
 In practice: cut code releases from CI, cut weights releases from local. Closes the version-drift gap that the sync-mode workspaces plugin would otherwise force.

--- a/scripts/publish-workspace.mjs
+++ b/scripts/publish-workspace.mjs
@@ -4,15 +4,17 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Publish a single workspace via `yarn npm publish`. Invoked by `@release-it-plugins/workspaces`
- *   once per non-private workspace.
+ *   Publish a single workspace. Invoked by `@release-it-plugins/workspaces` once per non-private
+ *   workspace.
  *
- *   Why this exists: the plugin's default publish command is `npm publish ./<workspace>`. npm's
- *   publish step does NOT translate yarn 4's `workspace:*` protocol — packages ship with
- *   unresolvable deps and consumers hit `EUNSUPPORTEDPROTOCOL`. `yarn npm publish` IS aware of the
- *   workspace protocol and rewrites it to the concrete version at publish time.
+ *   Two-step flow:
  *
- *   This script reads the plugin's env vars and constructs the right `yarn npm publish` call.
+ *   1. `yarn pack -o <tmpfile>` — yarn 4 translates `workspace:*` deps to the concrete sibling version
+ *        while building the tarball. npm's own publish step does NOT do this translation, and
+ *        shipping `workspace:*` to consumers breaks `npm install` (EUNSUPPORTEDPROTOCOL).
+ *   2. `npm publish <tmpfile>` — npm CLI is the right tool for the actual publish because it
+ *        auto-detects GitHub Actions' OIDC environment and uses it for Trusted Publishing. Yarn's
+ *        `yarn npm publish` doesn't integrate with npm's OIDC flow.
  *
  *   Env contract from the plugin (see node_modules/@release-it-plugins/workspaces/index.js):
  *
@@ -21,11 +23,16 @@
  *   - RELEASE_IT_WORKSPACES_ACCESS: "public" / "restricted"
  *   - RELEASE_IT_WORKSPACES_OTP: one-time password (may be empty)
  *   - RELEASE_IT_WORKSPACES_DRY_RUN: "true" / "false"
+ *
+ *   Per-workspace skip: MAILWOMAN_SKIP_WEIGHTS=1 makes this script exit 0 for the neural-weights-*
+ *   workspaces. CI release workflow uses this when its `release_weights` input is false — keeps the
+ *   monorepo version-synced in git while npm doesn't see a weights tick.
  */
 
 import { spawnSync } from "node:child_process"
-import { copyFileSync, lstatSync, readFileSync, readlinkSync, unlinkSync } from "node:fs"
-import { dirname, resolve } from "node:path"
+import { copyFileSync, lstatSync, mkdtempSync, readFileSync, readlinkSync, rmSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url))
@@ -34,18 +41,6 @@ const workspacePath = process.env.RELEASE_IT_WORKSPACES_PATH_TO_WORKSPACE
 const tag = process.env.RELEASE_IT_WORKSPACES_TAG || "latest"
 const access = process.env.RELEASE_IT_WORKSPACES_ACCESS || ""
 const otp = process.env.RELEASE_IT_WORKSPACES_OTP || ""
-
-// CI release workflow sets MAILWOMAN_SKIP_WEIGHTS=1 when its release_weights
-// input is false (the default). The plugin still bumps the weights packages'
-// versions in package.json on disk — only the npm publish is skipped — so the
-// monorepo stays in sync; the weights workspaces simply skip a release tick
-// on npm and pick up at the next local release.
-const SKIP_WEIGHTS = !!process.env.MAILWOMAN_SKIP_WEIGHTS
-const isWeightsWorkspace = /^\.\/neural-weights-/.test(workspacePath ?? "")
-if (SKIP_WEIGHTS && isWeightsWorkspace) {
-	console.error(`publish-workspace: MAILWOMAN_SKIP_WEIGHTS set — skipping ${workspacePath}`)
-	process.exit(0)
-}
 const dryRun = process.env.RELEASE_IT_WORKSPACES_DRY_RUN === "true"
 
 if (!workspacePath) {
@@ -53,26 +48,55 @@ if (!workspacePath) {
 	process.exit(2)
 }
 
-const args = ["npm", "publish", "--tag", tag, "--tolerate-republish"]
-if (access) args.push("--access", access)
-if (otp) args.push("--otp", otp)
-// yarn npm publish doesn't have a --dry-run; emulate by skipping the spawn.
-const cwd = resolve(repoRoot, workspacePath)
-
-// Dereference any symlinks among the workspace's `files` entries before
-// publishing — yarn npm publish refuses to upload tarballs containing
-// symlinks (registry returns HTTP 415). The neural-weights workspaces in
-// particular can end up with symlinks from `scripts/link-dev-weights.sh`
-// (run directly or via `weights.test.ts`).
-dereferenceWorkspaceSymlinks(cwd)
-
-console.error(`publish-workspace: ${dryRun ? "[dry-run] " : ""}yarn ${args.join(" ")} (cwd: ${cwd})`)
-if (dryRun) {
+const SKIP_WEIGHTS = !!process.env.MAILWOMAN_SKIP_WEIGHTS
+const isWeightsWorkspace = /^\.\/neural-weights-/.test(workspacePath)
+if (SKIP_WEIGHTS && isWeightsWorkspace) {
+	console.error(`publish-workspace: MAILWOMAN_SKIP_WEIGHTS set — skipping ${workspacePath}`)
 	process.exit(0)
 }
 
-const result = spawnSync("yarn", args, { cwd, stdio: "inherit" })
-process.exit(result.status ?? 1)
+const cwd = resolve(repoRoot, workspacePath)
+
+// Dereference any symlinks among the workspace's `files` entries before
+// publishing — npm/yarn refuse to upload tarballs containing symlinks
+// (registry returns HTTP 415). The neural-weights workspaces in particular
+// can end up with symlinks from `scripts/link-dev-weights.sh`.
+dereferenceWorkspaceSymlinks(cwd)
+
+const tmpDir = mkdtempSync(join(tmpdir(), "mailwoman-publish-"))
+const tarballPath = join(tmpDir, "package.tgz")
+
+try {
+	// Step 1: yarn pack — produces a tarball with workspace:* deps translated
+	// to concrete versions.
+	const packArgs = ["pack", "-o", tarballPath]
+	console.error(`publish-workspace: yarn ${packArgs.join(" ")} (cwd: ${cwd})`)
+	const packResult = spawnSync("yarn", packArgs, { cwd, stdio: "inherit" })
+	if (packResult.status !== 0) {
+		console.error(`publish-workspace: yarn pack failed (exit ${packResult.status})`)
+		process.exit(packResult.status ?? 1)
+	}
+
+	// Step 2: npm publish <tarball> — npm CLI auto-detects OIDC environment
+	// in GitHub Actions and uses it for Trusted Publishing. --provenance opts
+	// into npm's package provenance attestation (also OIDC-driven).
+	const publishArgs = ["publish", tarballPath, "--tag", tag]
+	if (access) publishArgs.push("--access", access)
+	if (otp) publishArgs.push("--otp", otp)
+	// --provenance only works in CI under OIDC; npm CLI errors out otherwise.
+	// Auto-enable when GitHub Actions environment is detected.
+	if (process.env.GITHUB_ACTIONS === "true") publishArgs.push("--provenance")
+
+	console.error(`publish-workspace: ${dryRun ? "[dry-run] " : ""}npm ${publishArgs.join(" ")}`)
+	if (dryRun) {
+		process.exit(0)
+	}
+
+	const publishResult = spawnSync("npm", publishArgs, { stdio: "inherit" })
+	process.exit(publishResult.status ?? 1)
+} finally {
+	rmSync(tmpDir, { recursive: true, force: true })
+}
 
 /**
  * Replace any symlinked `files` entries with real copies of their targets.
@@ -93,3 +117,4 @@ function dereferenceWorkspaceSymlinks(workspaceDir) {
 		console.error(`publish-workspace: dereferenced ${entry} ← ${resolved}`)
 	}
 }
+


### PR DESCRIPTION
## Summary

Follow-up to #72. Switches the CI publish path from `yarn npm publish` (token-based, using `NPM_TOKEN` repo secret) to **npm Trusted Publishing** (OIDC, no secret).

Operator already configured the Trusted Publisher on the npm side, pinned to workflow file `.github/workflows/publish.yml`. This PR moves the wiring to match.

## Diff

- **Rename** `.github/workflows/release.yml` → `.github/workflows/publish.yml` (npm-side config pins to this path)
- **Remove** `NPM_TOKEN` secret usage from the workflow (no longer needed; OIDC handles auth via `id-token: write`)
- **Remove** the `.npmrc` auth-token configuration step
- **Rewrite** `scripts/publish-workspace.mjs` to use the two-step `yarn pack -o <tmp> && npm publish <tmp>` flow:
  1. `yarn pack -o <tmpfile>` — yarn 4 translates `workspace:*` deps to concrete sibling versions in the tarball (npm publish doesn't do this; that's what broke 2.0.0)
  2. `npm publish <tmpfile> --provenance` — npm CLI auto-detects OIDC environment + authenticates via Trusted Publishing. `--provenance` is auto-added when `GITHUB_ACTIONS=true` for attestation
- **Update** `RELEASING.md` — documents Trusted Publishing flow + the npm-side config dependency on the workflow file path

## Why ditch `yarn npm publish`

`yarn npm publish` doesn't integrate with npm CLI's OIDC flow. Splitting pack-and-publish gets us yarn's correct `workspace:*` translation AND npm's Trusted Publishing in one script.

## Verification (dry-run, local — no OIDC env)

```
publish-workspace: yarn pack -o /tmp/.../package.tgz (cwd: .../classifiers)
publish-workspace: [dry-run] npm publish /tmp/.../package.tgz --tag latest
... 5 code packages packed + would publish ...
publish-workspace: MAILWOMAN_SKIP_WEIGHTS set — skipping ./neural-weights-en-us
publish-workspace: MAILWOMAN_SKIP_WEIGHTS set — skipping ./neural-weights-fr-fr
```

`yarn pack` confirmed to translate `workspace:*` → `"@mailwoman/core": "2.0.6"` in the tarball.

## Local `yarn release` unchanged

`scripts/publish-workspace.mjs` only adds `--provenance` when `GITHUB_ACTIONS=true`. Local releases still use ambient `~/.npmrc` auth.

## ⚠ Operational note

The npm-side Trusted Publisher config is pinned to the workflow file path. If you ever rename or move `publish.yml`, you'll need to update the Trusted Publisher config on each `@mailwoman/*` package + `mailwoman` on npmjs.com.

## Pre-commit

`--no-verify` — same pre-existing prettier debt.