### PR TITLE
docs: migrate the neural implementation plan into docs/plan/ + refresh AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,57 +2,66 @@
 
 Notes for AI agents (and humans) working on this repo.
 
-## Publishing the neural-weights workspaces
+## Orientation
 
-The `neural-weights-<locale>` workspaces ship binary artifacts (`model.onnx`,
-`tokenizer.model`) that are **not** committed to git. Multiple pieces cooperate
-to get those files in place — be careful when changing any of them:
+Mailwoman is a postal-address parser shipped as one root npm package (`mailwoman`) plus six scoped workspaces (`@mailwoman/{core,classifiers,corpus,neural,neural-weights-en-us,neural-weights-fr-fr}`). The monorepo orchestration package is `@mailwoman/universe` (private, not published).
 
-- `<workspace>/scripts/link-dev-weights.sh` — symlinks the artifacts from
-  `/mnt/playpen/mailwoman-data/...` into the workspace so `@mailwoman/neural`
-  can find them during local dev.
-- `neural/test/weights.test.ts` — invokes `link-dev-weights.sh` to verify
-  auto-resolve. **Running `yarn test` re-creates the symlinks** in
-  `neural-weights-en-us/` as a side effect.
-- `scripts/copy-weights.mjs` — invoked by release-it's `before:init` hook.
-  Materializes the real binaries into each workspace.
-- `scripts/publish-workspace.mjs` — invoked per workspace by release-it. Calls
-  `yarn npm publish` and, as a final safety net, dereferences any symlinks
-  among the workspace's declared `files` before publishing.
+| Workspace               | npm package                       | Purpose                                                                                                                                                   |
+| ----------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mailwoman/`            | `mailwoman`                       | CLI + high-level `AddressParser` (the user-facing entry)                                                                                                  |
+| `core/`                 | `@mailwoman/core`                 | Tokenization, classification primitives, solver, decoder, policy registry. Ships ~9 MB of libpostal + WOF + chromium-i18n dictionaries under `core/data/` |
+| `classifiers/`          | `@mailwoman/classifiers`          | Rule-based classifiers                                                                                                                                    |
+| `corpus/`               | `@mailwoman/corpus`               | BIO-labeled training-corpus pipeline                                                                                                                      |
+| `neural/`               | `@mailwoman/neural`               | SentencePiece tokenizer + ONNX runtime + decoder wiring                                                                                                   |
+| `neural-weights-en-us/` | `@mailwoman/neural-weights-en-us` | Trained model bundle (en-us locale)                                                                                                                       |
+| `neural-weights-fr-fr/` | `@mailwoman/neural-weights-fr-fr` | Trained model bundle (fr-fr locale)                                                                                                                       |
+
+Source files live at each workspace's root (no `src/` nesting). The repo root holds workspace config + `scripts/` + `docs/` only.
+
+## Where to read next
+
+- **[`docs/plan/README.md`](./docs/plan/README.md)** — the implementation plan that drove the neural classifier work. Phases 0–3 are substantially shipped; Phases 4–6 are the forward roadmap. Read this first if you're working on anything model-related.
+- **[`docs/plan/reference/`](./docs/plan/reference/)** — design rationale, schema source of truth, TS contracts, operations playbook, address-data-sources catalog. `SCHEMA.md` is the single source of truth for the `ComponentTag` union.
+- **[`RELEASING.md`](./RELEASING.md)** — local and CI release flows. Read before cutting a release.
+- **[`docs/evals/`](./docs/evals/)** — eval reports per training step, plus the train-log CSV. Format documented in `docs/plan/reference/eval-ledger.schema.json`.
+
+## Release pipeline pitfalls
+
+Local: `yarn release`. CI: GitHub Actions → `publish` workflow → manual dispatch. See `RELEASING.md` for setup + flow. The notes below cover the gotchas that have bitten this pipeline before — read before touching `scripts/copy-weights.mjs`, `scripts/publish-workspace.mjs`, or `.release-it.json`.
+
+### The weights workspaces have moving binaries
+
+The `neural-weights-<locale>` workspaces ship binary artifacts (`model.onnx`, `tokenizer.model`) that are **not** committed to git. Multiple pieces cooperate to get those files in place — be careful when changing any of them:
+
+- `<workspace>/scripts/link-dev-weights.sh` — symlinks the artifacts from `/mnt/playpen/mailwoman-data/...` into the workspace so `@mailwoman/neural` can find them during local dev.
+- `neural/test/weights.test.ts` — invokes `link-dev-weights.sh` to verify auto-resolve. **Running `yarn test` re-creates the symlinks** in `neural-weights-en-us/` as a side effect.
+- `scripts/copy-weights.mjs` — invoked by release-it's `before:init` hook. Materializes the real binaries into each workspace. Skipped in CI when `MAILWOMAN_SKIP_WEIGHTS_COPY=1` (the default for the `publish` workflow when `release_weights=false`).
+- `scripts/publish-workspace.mjs` — invoked per workspace by release-it. Calls `yarn pack -o <tmp>` (translates `workspace:*` → concrete versions) then `npm publish <tmp>` (npm CLI handles npm-side auth, including Trusted Publishing OIDC in CI).
 
 ### Pitfall: symlinks in the publish tarball
 
-`yarn npm publish` refuses to upload tarballs containing symlinks — the
-registry returns HTTP 415 (`YN0035: Symbolic link is not allowed`). Two
-specific traps make this easy to hit:
+`yarn npm publish` (and `npm publish`) refuse to upload tarballs containing symlinks — the registry returns HTTP 415 (`YN0035: Symbolic link is not allowed`). Two specific traps make this easy to hit:
 
-1. **`fs.copyFile` follows symlinks at the destination.** A naïve
-   `fs.copyFile(SOURCE, dest)` where `dest` is a symlink writes through the
-   symlink — the symlink stays in place. `scripts/copy-weights.mjs` mitigates
-   this by `unlink`ing each destination first. Any new script that
-   materializes files into these workspaces **must do the same** (or use
-   `cp --remove-destination` / `fs.cp` with equivalent semantics).
-2. **Tests re-create symlinks.** `weights.test.ts` calls `link-dev-weights.sh`
-   on every run. Even if `copy-weights.mjs` was already run, a subsequent
-   `yarn test` (manual or otherwise) re-symlinks `neural-weights-en-us/`.
+1. **`fs.copyFile` follows symlinks at the destination.** A naïve `fs.copyFile(SOURCE, dest)` where `dest` is a symlink writes through the symlink — the symlink stays in place. `scripts/copy-weights.mjs` mitigates this by `unlink`ing each destination first. Any new script that materializes files into these workspaces **must do the same** (or use `cp --remove-destination` / `fs.cp` with equivalent semantics).
+2. **Tests re-create symlinks.** `weights.test.ts` calls `link-dev-weights.sh` on every run. Even if `copy-weights.mjs` was already run, a subsequent `yarn test` (manual or otherwise) re-symlinks `neural-weights-en-us/`.
 
-To make publish robust regardless of repo state, `scripts/publish-workspace.mjs`
-walks the workspace's `package.json` `files` array right before
-`yarn npm publish` and dereferences any symlinks
-(`readlink` → `unlink` → `copyFile`). **Do not remove this safety net** — it
-closes the window between `copy-weights.mjs` (one-shot, at `before:init`) and
-the actual publish.
+To make publish robust regardless of repo state, `scripts/publish-workspace.mjs` walks the workspace's `package.json` `files` array right before publishing and dereferences any symlinks (`readlink` → `unlink` → `copyFile`). **Do not remove this safety net** — it closes the window between `copy-weights.mjs` (one-shot, at `before:init`) and the actual publish.
+
+### Pitfall: provenance attestation on a private repo
+
+`scripts/publish-workspace.mjs` only adds `--provenance` to `npm publish` when `MAILWOMAN_NPM_PROVENANCE=1` is set. npm rejects provenance signatures from private source repositories (the sigstore attestation would be unverifiable by third parties). Trusted Publishing itself works fine on private repos — it's only the attestation that needs a public source. Flip the env on once `sister-software/mailwoman` is public.
+
+### Pitfall: `workspace:*` doesn't survive `npm publish`
+
+`yarn 4`'s `workspace:*` protocol is yarn-specific. `npm publish` ships the literal string and consumers hit `EUNSUPPORTEDPROTOCOL`. `yarn pack` translates `workspace:*` to the concrete sibling version in the tarball. That's why `publish-workspace.mjs` does pack-then-publish instead of either tool alone.
 
 ### Recovering from a partial release
 
 If a release fails partway through publishing:
 
 - The git commit + tag are already created by release-it.
-- `yarn npm publish --tolerate-republish` (used by
-  `scripts/publish-workspace.mjs`) makes re-publishing already-published
-  versions a no-op.
-- Fix the underlying issue, then resume by invoking the publish script
-  directly for each remaining workspace:
+- `yarn npm publish --tolerate-republish` (used by `scripts/publish-workspace.mjs`) makes re-publishing already-published versions a no-op.
+- Fix the underlying issue, then resume by invoking the publish script directly for each remaining workspace:
 
   ```bash
   for ws in <remaining workspaces>; do
@@ -64,5 +73,14 @@ If a release fails partway through publishing:
   done
   ```
 
-  npm 2FA OTPs expire in ~30s, so do this in quick succession; a single OTP
-  usually covers all remaining workspaces.
+  npm 2FA OTPs expire in ~30s, so do this in quick succession; a single OTP usually covers all remaining workspaces.
+
+## Workspace + test conventions
+
+- Each workspace has its own `tsconfig.json` + (for `core/` and `neural/`) a `vitest.config.ts` that aliases sibling `@mailwoman/*` subpath imports to source. This lets `yarn test` run without a precompile step. The cross-package aliases are fiddly — see the file headers for the resolution rules.
+- `core/utils/repo.ts` has a `__isCompiledTree` flag that distinguishes source mode from compiled mode for path-builder math. Don't reach across that boundary without reading the comment.
+- The TLA in `core/resources/libpostal.ts` (top-level `await readdir`) is a known fragility surface. When test files import `@mailwoman/core` bare AND a subpath, Vite's TLA-aware loader treats it as a cycle — classifier base classes evaluate as `undefined`. Workaround: side-effect `import "@mailwoman/core"` at the top of the affected test file. See `classifiers/adapter.test.ts` for an example.
+
+## When in doubt
+
+Read the workspace-local docstrings before changing infrastructure files. The headers in `scripts/*.mjs`, `.release-it.json`, and `.github/workflows/*.yml` explain why each piece exists. If a file's purpose isn't documented inline and you're about to touch it, add the docstring as part of your change — future-you (or future-claude) will thank you.

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -1,0 +1,60 @@
+# Mailwoman Neural — Implementation Plan
+
+The plan that drove the neural address parser work inside Mailwoman: TypeScript-first, deployed as a new classifier that progressively replaces rule-based classifiers as confidence metrics justify (Ship of Theseus).
+
+**Status (last edited at migration into mailwoman/docs/plan):** Phases 0 through 3 are substantially shipped:
+
+- `@mailwoman/neural` published to npm at v2.0.x
+- `mailwoman parse --neural --format json|tuple|xml` works end-to-end
+- Decoder + tokenizer + ONNX runtime + per-component policy registry all live
+- `neural-weights-en-us` / `neural-weights-fr-fr` weight packages publish at the same cadence
+
+What's described below as "next" or "future" should be read as the historical plan; the actual state is whatever this directory's most-recently-committed phase file says.
+
+## Read order
+
+1. This file
+2. `reference/CONTEXT.md` — background, prior art, design rationale
+3. `reference/ARCHITECTURE.md` — system shape, key abstractions, locale strategy
+4. `reference/SCHEMA.md` — canonical component tag union (single source of truth)
+5. `reference/INTERFACES.md` — TypeScript contracts at every boundary
+6. `reference/OPERATIONS.md` — how to work, how to commit, how to report progress
+7. `phases/PHASE_0_foundation.md` — start here once you have read 1–6
+
+Subsequent phases (`phases/PHASE_1_*` through `phases/PHASE_6_*`) are sequential. Do not begin a phase until the previous phase's success criteria are met.
+
+## Hard constraints
+
+- **TypeScript-first.** Inference runtime is `onnxruntime-node`. Training is allowed in Python but is not shipped to npm.
+- **Coexistence, not replacement.** The neural classifier is additive. Rule classifiers are not deleted until per-component metrics justify retirement.
+- **Locale scope (v1):** US + France. English + French. Japanese is a deliberate Phase 6 stress test of the architecture, not v1.
+- **Staged components:** coarse (country/region/locality/postcode) first, street second, venue third. Each stage ships.
+- **No new ML in places where rules are already correct.** Postcodes are a regex problem. Don't burn a model on them.
+- **Schema-first.** Touching `reference/SCHEMA.md` requires a written rationale in the commit. Downstream code keys off it.
+
+## What good looks like
+
+By end of Phase 3 you will have shipped `@mailwoman/neural@0.1.0` to npm. It loads a quantized ONNX model on demand, emits `ClassificationProposal` objects that flow through Mailwoman's existing solver unchanged, and beats rule-based Mailwoman on the held-out golden set for at least the `country` and `region` components.
+
+By end of Phase 6 the same architecture supports Japanese addresses with schema additions but no core refactor. That is the validation that the design is sound.
+
+## What failure looks like
+
+- Schema churn after Phase 1 — means Phase 0 was rushed.
+- Tokenizer drift between Python training and TypeScript inference — silent accuracy loss in prod.
+- Training data leakage (same locality in train and eval splits) — model looks great in eval, fails in the wild.
+- Coupling the model to a specific Mailwoman internal type, then needing to refactor to ship the model standalone later.
+
+Any of these means stop and re-read `reference/ARCHITECTURE.md`.
+
+## How to ask for help
+
+You will inevitably hit decisions the plan does not anticipate. When that happens:
+
+1. Write the decision and the options to `DECISIONS.md` (create it if absent) under a new heading with date.
+2. Pick the option that is most reversible and lowest-blast-radius.
+3. Continue. Do not block waiting for input from outside the lab unless the decision is genuinely irreversible (npm package name, public API contract, data license commitment).
+
+## How to report progress
+
+Append to `LOG.md` (create if absent) after every meaningful unit of work. One line per entry: `YYYY-MM-DD HH:MM | <phase> | <what was done> | <next>`. Keep it terse — the radio-console format from the user preferences. This log is the only thing the human will read between check-ins.

--- a/docs/plan/phases/PHASE_0_foundation.md
+++ b/docs/plan/phases/PHASE_0_foundation.md
@@ -1,0 +1,119 @@
+# Phase 0 — Foundation
+
+**Goal:** lock the contracts (schema, classifier interface, policy, locale) before writing any model code. Refactor existing rule classifiers to use the new interface with zero behavior change.
+
+**Duration estimate:** 1 week.
+
+**Branch:** `neural/phase-0-foundation`
+
+## Pre-flight checks
+
+- [ ] Mailwoman main branch checked out at latest commit
+- [ ] `npm test` passes on a clean clone
+- [ ] You have read `README.md`, `reference/CONTEXT.md`, `reference/ARCHITECTURE.md`, `reference/SCHEMA.md`, `reference/INTERFACES.md`, `reference/OPERATIONS.md`
+
+## Tasks
+
+### 1. Monorepo restructure
+
+Current Mailwoman is a single TypeScript project. Migrate to a workspaces layout.
+
+- [ ] Set up `pnpm` workspaces (preferred) or yarn workspaces (Mailwoman currently uses yarn — verify and stick with it).
+- [ ] Create `packages/core/` and move existing `core/`, `utils/`, `commands/`, `solvers/`, `filters/` into it. Keep import paths working via package.json `exports`.
+- [ ] Create `packages/classifiers/` and move existing `classifiers/` into it. Depends on `@mailwoman/core`.
+- [ ] Update root `package.json`, `tsconfig.json`, `vitest.config.ts` to be workspace-aware.
+- [ ] Verify `npm test` still passes. No behavior change yet.
+
+**Success:** all existing tests pass, `cli.ts` still works, `sdk/` still exports the same surface.
+
+### 2. Schema implementation
+
+Implement `reference/SCHEMA.md` in code.
+
+- [ ] Create `packages/core/src/types/component.ts` with `COMPONENT_TAGS`, `ComponentTag`, `BIO_LABELS`, `BioLabel` as specified.
+- [ ] Add unit tests in `packages/core/test/component.test.ts`:
+  - Every tag appears exactly once in `COMPONENT_TAGS`
+  - `BIO_LABELS` has correct length (1 + 2 × tags)
+  - `BioLabel` type narrows correctly
+- [ ] Export from `packages/core/src/index.ts`.
+
+**Success:** schema is the single source of truth, importable as `import { ComponentTag } from '@mailwoman/core'`.
+
+### 3. ClassificationProposal and Classifier interfaces
+
+Implement `reference/INTERFACES.md`.
+
+- [ ] Create `packages/core/src/types/classifier.ts` with `ClassificationProposal`, `Classifier`, `ClassifierContext`.
+- [ ] Create `packages/classifiers/src/adapter.ts` with `wrapLegacyClassifier`.
+- [ ] For every existing rule classifier in `packages/classifiers/src/`, write a wrapper that adapts its output to `ClassificationProposal`. Do not change the rule logic itself.
+- [ ] Add unit tests verifying each wrapped classifier produces output equivalent to the pre-wrap output (modulo the new `source` and `source_id` fields).
+
+**Success:** every rule classifier emits `ClassificationProposal[]`. The solver code is updated minimally to consume the new shape but produces identical solutions.
+
+### 4. Policy registry
+
+Implement `ClassifierPolicy` and `PolicyRegistry`.
+
+- [ ] Create `packages/core/src/policy.ts` with the types from `reference/INTERFACES.md`.
+- [ ] Create `packages/core/src/policy-defaults.ts` — a default policy table where every component is `rule_only`.
+- [ ] Wire the registry into the solver path: before solving, filter proposals through `PolicyRegistry.apply()`.
+- [ ] Unit tests: policy filtering is correct for each mode.
+
+**Success:** policy registry exists, defaults to current behavior (rule-only everywhere), is the single place a future migration to neural will edit.
+
+### 5. Locale profile
+
+Implement `LocaleProfile` and `LocaleRegistry`.
+
+- [ ] Create `packages/core/src/locale.ts` with the types from `reference/INTERFACES.md`.
+- [ ] Create `packages/core/src/locales/en-us.ts` and `packages/core/src/locales/fr-fr.ts` with initial profiles.
+  - `en-US`: all current US-applicable rule classifiers, components `country, region, locality, postcode, house_number, street, street_prefix, street_suffix, unit, venue, attention, po_box, intersection_a, intersection_b`.
+  - `fr-FR`: rule classifiers that apply to FR (most of the universal ones), components above plus `cedex, street_prefix_particle, dependent_locality`.
+- [ ] Wire locale into `ClassifierContext` and the classification loop. If no locale is provided, all classifiers with `locales: ['*']` plus all registered locales' classifiers run (backward compat with current behavior).
+- [ ] Unit tests: locale filtering works, profiles register correctly.
+
+**Success:** the system has a concept of locale. Default behavior is unchanged. Setting a locale narrows the active classifiers.
+
+### 6. CLI flag passthrough
+
+- [ ] Add `--locale <bcp47>` flag to `cli.ts`. When set, passes through to classification.
+- [ ] Unit test: `npx mailwoman parse --locale en-US "..."` works.
+
+### 7. Documentation
+
+- [ ] Update root `README.md` with a section on the new architecture. Brief, links to plan docs.
+- [ ] Update `docs/` (if it exists) with the new component schema as a reference table.
+
+### 8. Forward-compat sanity check
+
+Before declaring Phase 0 done, verify the design handles Phase 6 (Japan) cleanly:
+
+- [ ] Mentally add a `ja-JP` `LocaleProfile` with `componentsSupported: ['prefecture', 'municipality', 'district', 'block', 'sub_block', 'building_number', 'building_name', 'country', 'postcode']` (no `street`, no `house_number`).
+- [ ] Does any core code break? It shouldn't. If it does, the abstraction is wrong — fix it now, not in Phase 6.
+- [ ] Verify by running the test suite with a hypothetical JP profile registered (you don't need actual JP classifiers; just verify the registration doesn't throw and the type system is happy).
+
+## Success criteria checklist
+
+Before tagging `neural-phase-0-complete`:
+
+- [ ] `npm test` passes across all workspaces
+- [ ] `npm run lint` clean
+- [ ] `npx mailwoman parse "Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA"` produces output equivalent to pre-refactor
+- [ ] `npx mailwoman parse --locale fr-FR "8 rue de la République, 75008 Paris, France"` runs without error (output quality not yet judged — that's Phase 2+)
+- [ ] Forward-compat JP check passes
+- [ ] `LOG.md` has entries for each task
+- [ ] `DECISIONS.md` records any non-obvious choices
+- [ ] Branch is merged to main, tagged
+
+## Things that look like Phase 0 but aren't
+
+These are tempting in Phase 0; resist:
+
+- ❌ Writing any neural code. `packages/neural/` doesn't exist yet.
+- ❌ Building any corpus adapters. `packages/corpus/` doesn't exist yet.
+- ❌ Adding new rule classifiers for FR-specific concepts. That's Phase 1 work, after corpus exists to validate against.
+- ❌ Optimizing the solver. Don't change behavior in Phase 0; only refactor.
+
+## When to call this phase done
+
+When you can demonstrate: "the system runs identically to before, but every classifier output flows through a typed, locale-aware, policy-gated pipeline ready for a neural classifier to plug into."

--- a/docs/plan/phases/PHASE_1_corpus.md
+++ b/docs/plan/phases/PHASE_1_corpus.md
@@ -1,0 +1,200 @@
+# Phase 1 — Corpus Pipeline
+
+**Goal:** build a reproducible, versioned dataset pipeline. End state is `corpus-v0.1.0` on disk, containing aligned BIO-labeled Parquet shards for US + FR, with a hand-labeled golden eval set.
+
+**Duration estimate:** 2 weeks.
+
+**Branch:** `neural/phase-1-corpus`
+
+**Depends on:** Phase 0 complete and tagged.
+
+## Pre-flight
+
+- [ ] Phase 0 success criteria all green
+- [ ] Disk space available at `/data/corpus/` per `reference/OPERATIONS.md` layout
+- [ ] You understand BIO labeling and the `LabeledRow` shape
+
+## Tasks
+
+### 1. Package scaffolding
+
+- [ ] Create `packages/corpus/` workspace
+- [ ] Create `packages/corpus-python/` (Python, not in workspaces — has its own `pyproject.toml`)
+- [ ] `packages/corpus/src/types.ts` — `CanonicalRow`, `LabeledRow`, `CorpusAdapter`, `AdapterOptions` per `reference/INTERFACES.md`
+- [ ] Add to root tsconfig references, root package.json scripts
+
+### 2. Adapter framework
+
+- [ ] `packages/corpus/src/adapter.ts` — base `CorpusAdapter` interface, helper utilities (streaming, checksum, dedup)
+- [ ] `packages/corpus/src/runner.ts` — drives an adapter, writes intermediate JSONL, reports progress, handles backpressure
+- [ ] CLI: `npx mailwoman corpus run <adapter-id> --input <path> --output <dir> [--country XX] [--limit N]`
+
+### 3. Adapters — priority order
+
+Build adapters in this order. Each must have:
+
+- A small fixture in `packages/corpus/fixtures/<adapter-id>/` (license-clean, hand-crafted, < 1MB)
+- An integration test that runs the adapter against the fixture
+- A README documenting the source, license, download instructions, expected schema, known quirks
+
+#### 3a. `wof-admin` (P1, coarse)
+
+- [ ] Input: WOF SQLite distributions (`whosonfirst-data-admin-us-latest.spatial.db`, `-fr`)
+- [ ] Emit one row per WOF record, with synthesized `raw` strings using country-appropriate templates
+- [ ] Walk the ancestry chain — emit hierarchical variants (city alone, city+region, city+region+country)
+- [ ] License: WOF is CC0
+- [ ] Expected output: ~50k US localities, ~36k FR communes, plus regions/countries
+
+#### 3b. `wof-postalcode` (P1, coarse)
+
+- [ ] Input: WOF postalcode SQLite distributions
+- [ ] Emit rows pairing postcode with its parent locality/region
+- [ ] License: CC0
+
+#### 3c. `osm-places` (P1, coarse corroboration)
+
+- [ ] Input: OSM PBF file, filtered to `place=city|town|village|hamlet|suburb|neighbourhood`
+- [ ] Emit rows for each named place, with admin hierarchy from `is_in:*` tags or reverse-geocoded from WOF
+- [ ] License: ODbL — tag in `license` field
+- [ ] Use `osm-pbf-parser-node` or equivalent (verify maintenance before committing)
+
+#### 3d. `address-formatting` (P1, synthesis support)
+
+- [ ] Vendor or fetch OpenCageData's `address-formatting` repo (MIT). It contains country-keyed templates for rendering component dicts into strings.
+- [ ] `packages/corpus/src/format.ts` exposes `formatAddress(components: ComponentDict, country: string): string`
+- [ ] This is not an adapter — it's a utility used by adapters and synthesis to render `raw` from component dicts.
+
+#### 3e. `ban` (P2, FR street-level)
+
+- [ ] Input: Base Adresse Nationale dump from `adresse.data.gouv.fr`. Format: CSV, very large (~25M rows).
+- [ ] Emit rows with `house_number, street, postcode, locality, region, country='FR'`
+- [ ] License: ODbL / Licence Ouverte
+- [ ] Note: BAN has authoritative French addresses. This is your highest-quality FR source.
+
+#### 3f. `openaddresses` (P2, US/global street-level)
+
+- [ ] Input: OpenAddresses GeoJSON, country-partitioned downloads
+- [ ] License: varies per source — propagate per-row
+- [ ] Emit street-level rows
+
+#### 3g. `osm-addr` (P2, US/FR street-level)
+
+- [ ] Same OSM PBF, filtered to `addr:*` tagged ways/nodes
+- [ ] Lower quality than OpenAddresses or BAN but broader coverage
+
+#### 3h. US gov registries (P3, US venue-level)
+
+Defer to end of Phase 1 or push to Phase 2 if running long. Each is a small adapter, none individually critical:
+
+- [ ] `usgov/hrsa` — Health Resources & Services Administration facility list
+- [ ] `usgov/npi` — National Provider Identifier (medical providers)
+- [ ] `usgov/fcc` — FCC licensee addresses
+
+#### 3i. SIRENE (P3, FR venue-level)
+
+- [ ] Input: SIRENE bulk download (FR business registry)
+- [ ] License: Licence Ouverte
+- [ ] Defer if running long
+
+### 4. Alignment
+
+Given a `CanonicalRow` with `raw` and `components`, produce a `LabeledRow` with token-level BIO labels.
+
+- [ ] `packages/corpus/src/align.ts`
+- [ ] Strategy: for each component value, find its character span in `raw` using fuzzy match (`fastest-levenshtein`). Tokenize `raw` with SentencePiece. Assign BIO labels to tokens whose spans overlap component spans.
+- [ ] Reject rows where any component cannot be aligned (component text doesn't appear in `raw` within edit distance threshold). Write rejected rows to `/data/corpus/quarantine/` with a reason for human review.
+- [ ] Unit tests: alignment correct on hand-crafted examples covering: missing components, reordered components, abbreviated forms, accented vs unaccented text.
+
+⚠ Use the **same SentencePiece model** that training and inference will use. Train it first (next task), then run alignment.
+
+### 5. SentencePiece tokenizer training
+
+The tokenizer is trained on the corpus, not picked off the shelf.
+
+- [ ] `packages/corpus-python/scripts/train_tokenizer.py`
+- [ ] Input: a sample (say 5M lines) of `raw` strings from coarse adapters, balanced US/FR
+- [ ] Train SentencePiece with: `vocab_size=16000`, `character_coverage=0.9995`, `model_type=unigram`, `byte_fallback=true`
+- [ ] Output: `tokenizer.model` and `tokenizer.vocab` written to `/data/models/tokenizer/v0.1.0/`
+- [ ] Run alignment using this tokenizer.
+
+⚠ Tokenizer version is locked into corpus version. `corpus-v0.1.0` ships with `tokenizer-v0.1.0`. Don't retrain mid-corpus.
+
+### 6. Synthesis / augmentation
+
+- [ ] `packages/corpus/src/synthesize.ts`
+- [ ] Augmentations for both US and FR:
+  - Case perturbation (random upper/lower)
+  - Punctuation drop/add (commas)
+  - Abbreviation swap (`Street` ↔ `St` using Mailwoman's existing dictionaries — reuse from `resources/`)
+  - Whitespace normalization variants (single/double space, tab/newline)
+  - Typo injection (single-char edits, low rate ~2%)
+- [ ] FR-specific augmentations:
+  - Accent stripping (`Hôtel` ↔ `Hotel`)
+  - Particle variants (`Rue de la République` ↔ `Rue République`)
+  - Arrondissement notation (`Paris 8e` ↔ `Paris VIII` ↔ `75008 Paris`)
+  - CEDEX variants (with and without)
+- [ ] US-specific augmentations:
+  - State abbreviation vs full (`OR` ↔ `Oregon`)
+  - Directional abbreviation (`SE` ↔ `Southeast`)
+  - ZIP+4 with and without dash
+- [ ] Each augmented row carries `synth.method` and `synth.base_source_id`.
+
+### 7. Parquet output
+
+- [ ] `packages/corpus/src/parquet.ts` — write labeled rows to Parquet shards, ~1M rows per shard
+- [ ] Schema: `raw: string, tokens: list<string>, labels: list<string>, country: string, locale: string, source: string, source_id: string, corpus_version: string, license: string, synth_method: string?, synth_base_id: string?`
+- [ ] Use `@dsnp/parquetjs` or, if that proves limiting, write JSONL and convert via a tiny Python script (PyArrow). Either is acceptable.
+- [ ] Output path: `/data/corpus/versioned/corpus-v0.1.0/`
+
+### 8. Eval splits
+
+⚠ This is where corpora silently leak. Do it correctly.
+
+- [ ] `packages/corpus/src/split.ts`
+- [ ] Split strategy: **hold out by locality**, not random row sampling
+  - US: hold out all rows from Vermont, Wyoming, North Dakota (low-density states, ensures generalization)
+  - FR: hold out all rows from Corse, Lozère, Creuse (small departments)
+- [ ] Output: split manifests as JSON files listing source_ids in each split. Manifests go in git.
+- [ ] Splits: 90% train, 5% val, 5% test
+- [ ] Document the holdout choices in `DECISIONS.md`
+
+### 9. Golden eval set
+
+- [ ] `/data/eval/golden/v0.1.0/`
+- [ ] 500 US addresses, 500 FR addresses, hand-labeled by a human (the maintainer). Use the existing Mailwoman parser as a starting point and hand-correct.
+- [ ] Each entry: `{ raw, components: { ... }, source: 'golden', notes: '...' }`
+- [ ] Cover: residential, commercial, PO boxes, intersections, venues, edge cases (single-line, multi-line, abbreviations, typos)
+- [ ] Check into git. This is the contract for "what good looks like."
+
+▶ Drafting the golden set takes real time. Start it in week 1 of Phase 1 even while building adapters. Don't leave it for the end.
+
+### 10. Corpus build pipeline
+
+- [ ] `npx mailwoman corpus build --version 0.1.0` — single command that runs all adapters, alignment, synthesis, splits, writes Parquet
+- [ ] Reproducible — same inputs → same outputs
+- [ ] Logs progress, writes a manifest with file checksums to `/data/corpus/versioned/corpus-v0.1.0/MANIFEST.json`
+
+## Success criteria checklist
+
+- [ ] `corpus-v0.1.0/` exists on disk with Parquet shards
+- [ ] MANIFEST.json has checksums for every shard
+- [ ] At least 5M labeled rows (coarse + street where available)
+- [ ] Eval split manifests in git
+- [ ] Golden set in git: 1000 hand-labeled entries
+- [ ] Tokenizer v0.1.0 saved alongside corpus
+- [ ] All adapters have fixtures + integration tests
+- [ ] `npm test` green
+- [ ] `LOG.md`, `DECISIONS.md` up to date
+- [ ] Branch tagged `neural-phase-1-complete`
+
+## Common pitfalls
+
+- ❌ Splitting train/test randomly. Locality holdout or it doesn't count.
+- ❌ Retraining the tokenizer after some alignment has been done. Tokens shift, labels become wrong.
+- ❌ Skipping the quarantine pile. The alignment failures are where future bugs hide.
+- ❌ Forgetting to record the license per source. You'll regret this when someone asks if they can use a derived model commercially.
+- ❌ Letting OSM dominate by row count. Stratified sampling at training time, but warn now if one source is > 60% of rows.
+
+## When to call this phase done
+
+When you can run `npx mailwoman corpus build --version 0.1.0` from a clean state, get a complete corpus on disk, and run a small Python script that loads a shard and prints `(tokens, labels)` pairs that look obviously correct.

--- a/docs/plan/phases/PHASE_2_training.md
+++ b/docs/plan/phases/PHASE_2_training.md
@@ -1,0 +1,154 @@
+# Phase 2 — Model Training
+
+**Goal:** train a token-classification model on `corpus-v0.1.0+`, export to ONNX, quantize to int8, evaluate against the golden set. End state is shippable `neural-weights-en-us` + `neural-weights-fr-fr` weight packages ready for publishing.
+
+**Cadence (revised 2026-05-18):** ~3-7 days per iteration, multiple iterations rather than a single 2-week run. See [`reference/ARCHITECTURE.md` § "Training cadence vs. plan"](../reference/ARCHITECTURE.md) for the iteration history + roadmap. The original "2 weeks single run to >95% F1" framing has been superseded.
+
+**Branch:** ad-hoc per iteration (e.g. `feat/v0.2.0-shipping`, `feat/v0.3.0-stage2`), merged to main between iterations.
+
+**Depends on:** Phase 1 complete (corpus build pipeline running, golden set v0.1.0 in place).
+
+**Language:** Python in `packages/corpus-python/`. No TypeScript in this phase.
+
+## Iteration log (live)
+
+- **v0.1.0** (shipped 2026-05-18, PR #42) — first Stage 1 ship. F1 below targets (~0.03 macro) due to positional-heuristic overfit; calibration 0.337 in conf>0.9 bucket. Honest below-target ship with `v0.2.0 retrain recipe` in session-notes.
+- **v0.2.0** (shipped 2026-05-18, PR #53) — `source_weights` mechanism + relaxed coarse gate. 9× macro-F1 (0.037 → 0.335); calibration tightened 2.6× (0.337 → 0.882 in conf>0.9 bucket). Still below 95% target on country/region/locality but real, measurable, ship-worthy improvement.
+- **v0.3.0** (next — issue #43 follow-up) — Stage 2 label expansion (venue/street/house_number) + CRF decoder + corpus rebuild including NAD/OA-CA.
+
+## Pre-flight
+
+- [ ] `corpus-v0.1.0` exists at `/data/corpus/versioned/corpus-v0.1.0/`
+- [ ] Golden set v0.1.0 exists at `/data/eval/golden/v0.1.0/`
+- [ ] Python environment set up with PyTorch, Transformers, ONNX, ONNX Runtime, datasets, sentencepiece
+- [ ] GPU available (Phase 2 is GPU-bound). If lab has no GPU, document training time and proceed on CPU — the model is small.
+
+## Tasks
+
+### 1. Python project setup
+
+- [ ] `packages/corpus-python/pyproject.toml` with deps locked
+- [ ] `packages/corpus-python/src/mailwoman_train/` package
+- [ ] Subcommand CLI: `python -m mailwoman_train <command>`
+
+### 2. Data loading
+
+- [ ] `data_loader.py` — load Parquet shards via `datasets.load_dataset('parquet', ...)`. Lazy, streaming, memory-stable.
+- [ ] Stratified sampling: per-country weights to prevent imbalance. Configurable in YAML.
+- [ ] Length filtering: drop rows where token count > 128. Address text is short by nature; long rows are usually adapter bugs.
+- [ ] Verify tokenizer alignment: load `tokenizer-v0.1.0`, re-tokenize a sample of `raw` strings, assert the tokenization matches the stored `tokens` field. If it doesn't, the corpus is corrupt — stop and investigate.
+
+### 3. Model architecture
+
+- [ ] `model.py` — small encoder-only transformer
+  - Layers: 6
+  - Hidden: 256
+  - Attention heads: 4
+  - FF intermediate: 1024
+  - Max position: 128
+  - Vocab: from tokenizer v0.1.0
+  - Token classification head: linear → `|BIO_LABELS|` logits
+- [ ] Use HuggingFace `transformers` library: `BertConfig` + `BertForTokenClassification` with custom small config. Or `RoBERTa`. Pick one and stick with it.
+- [ ] From-scratch initialization (not pretrained). Address vocabulary is too small to benefit from English-internet pretraining.
+
+### 4. Training loop
+
+- [ ] `train.py`
+- [ ] Optimizer: AdamW, lr 5e-4, weight decay 0.01
+- [ ] LR schedule: linear warmup 1000 steps, then cosine decay
+- [ ] Batch size: 256 (lower if OOM)
+- [ ] Steps: ~50k for Stage 1 coarse-only. Eval every 2k steps on val set.
+- [ ] Mixed precision (fp16/bf16) on GPU
+- [ ] Save checkpoint every 5k steps to `/data/models/checkpoints/`
+- [ ] Track: train loss, val loss, val F1 per component, val full-parse exact match
+- [ ] Use Weights & Biases or TensorBoard or plain CSV — pick one and stick with it. Don't ship a logging refactor in the middle of training.
+
+### 5. Staged training plan
+
+#### Stage 1: Coarse-only (this phase)
+
+- [ ] Train only on rows where `country` and at least one of (`region`, `locality`, `postcode`) is present
+- [ ] Labels restricted to: `country`, `region`, `locality`, `dependent_locality`, `postcode`, `subregion`, `cedex`, `O`
+- [ ] Target: > 95% F1 per component on golden set
+- [ ] This is the v0.1.0 model.
+
+Stages 2 (street) and 3 (venue) are explicitly future phases. Do not attempt to train all stages in Phase 2.
+
+### 6. Evaluation
+
+- [ ] `eval.py` — load checkpoint, run inference on golden set, compute metrics
+- [ ] Metrics:
+  - Per-component F1, precision, recall
+  - Full-parse exact match (all components correct)
+  - Mean token confidence
+  - Calibration: bucket predictions by confidence, check accuracy per bucket
+- [ ] Output: a markdown report saved alongside the checkpoint
+- [ ] Compare against rule-based Mailwoman on the same golden set. Rule baseline numbers should be cached so this doesn't require running Mailwoman during training.
+
+### 7. ONNX export
+
+- [ ] `export_onnx.py`
+- [ ] Export with dynamic axes for batch and sequence length
+- [ ] Opset 17
+- [ ] Verify ONNX inference matches PyTorch inference within 1e-4 on a sample of 1000 inputs
+- [ ] Output: `/data/models/onnx/model-v0.1.0-en-us.onnx`, same for fr-fr
+
+⚠ If you trained a single multilingual model (recommended for Stage 1 — coarse is cheap to share), export it twice with the same weights, named per locale. Splitting into per-locale models is a Phase 3 decision based on size and load behavior.
+
+### 8. Quantization
+
+- [ ] `quantize.py` — int8 dynamic quantization via `onnxruntime.quantization`
+- [ ] Calibrate on 1000 val-set examples
+- [ ] Verify quantized model F1 on golden set drops by less than 0.5% from fp32. If it drops more, investigate (likely a quantization config issue, not a fundamental limit).
+- [ ] Output: `/data/models/quantized/model-v0.1.0-en-us-int8.onnx`
+
+### 9. Weights package preparation
+
+- [ ] `packages/neural-weights-en-us/` and `packages/neural-weights-fr-fr/`
+- [ ] Each contains:
+  - `model.onnx` (int8 quantized)
+  - `tokenizer.model` (SentencePiece)
+  - `model-card.json` (ModelCard per `reference/INTERFACES.md`)
+  - `package.json` with name, version, license
+  - `README.md` describing the model, training corpus, eval scores
+- [ ] These packages are data-only. No JS code. They are loaded by `@mailwoman/neural` at runtime.
+- [ ] Verify package size: aim for < 30MB int8 model. Tokenizer is ~1MB. Total package < 40MB.
+
+### 10. Model card
+
+- [ ] `ModelCard` filled in honestly
+- [ ] Include: training corpus version, training duration, hardware, eval scores per component on golden set + holdout splits, known failure modes (e.g., "underperforms on Hawaiian addresses", "confused by historical Paris arrondissement notation pre-1860")
+- [ ] This is a public document. Users will read it before adopting.
+
+## Success criteria checklist
+
+- [ ] Stage 1 model trained, checkpoint saved
+- [ ] ONNX export verified parity with PyTorch
+- [ ] Int8 quantized model meets eval threshold
+- [ ] `neural-weights-en-us@0.1.0` and `neural-weights-fr-fr@0.1.0` package directories complete
+- [ ] Model cards filled in
+- [ ] Eval reports committed to git (numbers, not models)
+- [ ] Beats rule-based Mailwoman on golden set for `country` and `region` components by at least 2 F1 points. If not, investigate before proceeding — the architecture is fine, the corpus is probably the issue.
+
+## When to ship vs train more (original framing — superseded by iteration cadence)
+
+If after the first training run, golden F1 is:
+
+- > 95% per coarse component → ship.
+- 90–95% → analyze failure modes. Likely fixable with corpus tweaks (more synthesis, deduplication, a missing source). One additional iteration is fine.
+- < 90% → stop and re-examine. Could be: tokenizer mismatch, label misalignment, schema bug, severely imbalanced training data. Do not "train longer" without diagnosing first.
+
+⚠ Resist the urge to add street-level components in this phase to "get more value." Stage 1 ships coarse. Stage 2 is its own phase. Mixing them blurs the metrics and slows iteration.
+
+### Revised (2026-05-18)
+
+The above original framing assumed a single training run. After v0.1.0 + v0.2.0, the actual cadence is:
+
+- **Each iteration ships an artifact**, target or no target. Below-target ships are OK if they're honest about it (model card + eval ledger entry) AND the Ship-of-Theseus coexistence model means the rule classifiers still run alongside.
+- **Per-iteration F1 floor** (not target): each iteration must improve over the prior one in at least one of: per-component F1, calibration tightness, or capability surface (new labels supported).
+- **Stage label expansion** (Stage 2 → venue+street+house_number; Stage 3 → organization/POI venue) happens as **iteration deltas within Phase 2**, not as separate phases. Same encoder, more head classes. Each lands in its own retrain.
+- **The eval ledger is the success record** — `evals/scores-by-version.json` with corpus + golden-set sha-pinning makes every iteration's delta empirically defensible.
+
+## When to call this phase done
+
+When the weights packages exist on disk, model cards are accurate, eval scores beat the rule baseline on coarse components, and the only remaining work for shipping is TypeScript integration (Phase 3).

--- a/docs/plan/phases/PHASE_3_integration.md
+++ b/docs/plan/phases/PHASE_3_integration.md
@@ -1,0 +1,174 @@
+# Phase 3 — TypeScript Integration & Ship
+
+**Goal:** integrate the trained model into Mailwoman via `NeuralSequenceClassifier`, wire it through the policy system, publish `@mailwoman/neural@0.1.0` and weight packages to npm. End state: a user can `npm install @mailwoman/neural @mailwoman/neural-weights-en-us` and get neural classification for coarse components.
+
+**Duration estimate:** 1.5 weeks.
+
+**Branch:** `neural/phase-3-integration`
+
+**Depends on:** Phase 2 complete with weights packages on disk.
+
+## Pre-flight
+
+- [ ] Phase 2 weights packages exist and pass eval
+- [ ] You have npm publish access (or know how to coordinate with the maintainer for publishing)
+- [ ] `onnxruntime-node` installs cleanly in the dev environment
+
+## Tasks
+
+### 1. Package scaffolding
+
+- [ ] Create `packages/neural/` workspace
+- [ ] Dependencies: `onnxruntime-node`, SentencePiece WASM (pick one — `@bloomberg/sentencepiece` or a maintained alternative; verify and document in `DECISIONS.md`), `@mailwoman/core`
+- [ ] Strict TypeScript config
+
+### 2. SentencePiece tokenizer wrapper
+
+- [ ] `packages/neural/src/tokenizer.ts`
+- [ ] Loads the SentencePiece model from a weights package
+- [ ] Exposes `encode(text: string): { ids: number[]; tokens: string[]; offsets: [number, number][] }`
+- [ ] The `offsets` field is critical — it's how we map model output BIO labels back to character spans in the original input.
+
+⚠ **Tokenizer parity check** — the single most important test in this phase:
+
+- [ ] `packages/neural/test/tokenizer-parity.test.ts`
+- [ ] Loads 10k `(raw, tokens)` pairs from corpus-v0.1.0
+- [ ] Re-tokenizes each `raw` with the TS SentencePiece
+- [ ] Asserts byte-for-byte equality with the stored `tokens`
+- [ ] If a single example fails, the integration is broken. Fix before continuing.
+
+### 3. ONNX inference wrapper
+
+- [ ] `packages/neural/src/onnx-runner.ts`
+- [ ] Loads ONNX model via `onnxruntime-node`
+- [ ] Exposes `infer(tokenIds: number[]): Promise<number[][]>` returning logits per token
+- [ ] Handles batching (group multiple sections for one inference call)
+- [ ] Configurable execution provider (CPU default, CUDA via env var)
+- [ ] Lazy loading: model loads on first `infer` call, not on construction (unless `warmup: true`)
+
+### 4. BIO decoding
+
+- [ ] `packages/neural/src/decode.ts`
+- [ ] Input: logits per token, original token offsets
+- [ ] Output: list of `(span, component, confidence)` tuples
+- [ ] BIO decoding rules:
+  - `B-T` starts a new span
+  - `I-T` continues the previous span if it was `B-T` or `I-T`, else treat as `B-T` (graceful)
+  - `O` ends any open span
+- [ ] Confidence per span = mean softmax probability of the predicted label across the span's tokens
+- [ ] Test cases: well-formed BIO, ill-formed BIO (recovery), all-O input, single-token spans
+
+### 5. `NeuralSequenceClassifier`
+
+- [ ] `packages/neural/src/sequence-classifier.ts`
+- [ ] Implements `Classifier` from `@mailwoman/core`
+- [ ] Constructor takes `NeuralSequenceClassifierOptions`, resolves and loads the weights package
+- [ ] `classify(section, context)`:
+  1. Tokenize the section's text
+  2. Run ONNX inference
+  3. Decode BIO labels to spans
+  4. Filter by `minConfidence`
+  5. Map spans back to `Span` objects in the original input (use SentencePiece offsets, then translate to original-input offsets via section's start offset)
+  6. Emit `ClassificationProposal[]` with `source: 'neural'`, `source_id` from the model card version
+- [ ] Returns empty array if model fails to load (graceful degradation per `reference/OPERATIONS.md`)
+
+### 6. Weights package loader
+
+- [ ] `packages/neural/src/weights.ts`
+- [ ] `loadWeights(packageName: string): Promise<{ modelBytes, tokenizerBytes, modelCard }>`
+- [ ] Resolves package via Node module resolution
+- [ ] Reads files from package's distribution directory
+- [ ] Caches in memory across instances of `NeuralSequenceClassifier`
+
+### 7. Solver integration
+
+- [ ] In `packages/core/src/solver.ts` (or wherever the existing solver entry lives), add the neural classifier path:
+  - If a `LocaleProfile` has a `weightsPackage`, instantiate a `NeuralSequenceClassifier` for that locale
+  - Run it alongside rule classifiers during the classify phase
+  - All proposals flow through `PolicyRegistry.apply` before solving
+- [ ] No solver logic changes needed — the abstraction from Phase 0 was designed for this.
+
+### 8. Policy migration: `country` → `neural_preferred`
+
+The first Ship of Theseus step.
+
+- [ ] Update `packages/core/src/policy-defaults.ts`:
+  - `country`: from `rule_only` to `neural_preferred` with `confidence_threshold: 0.8`
+- [ ] Run the full test suite + golden set eval
+- [ ] Verify on the golden set that `country` accuracy improved (or held) and no other component regressed
+- [ ] If anything regresses, revert the policy change and investigate. The migration is gated on metrics, not on intent.
+
+▶ Repeat the same for `region` if Phase 2 metrics justify. Coarse components only. Do not migrate `locality` or below in Phase 3 — defer until Stage 2 trains.
+
+### 9. End-to-end test
+
+- [ ] `packages/neural/test/e2e.test.ts`
+- [ ] Test: `parse("123 Main St, Portland, OR 97215", { locale: 'en-US' })`
+  - Neural classifier emits `country: USA` (inferred even though "USA" is absent from input)
+  - Rule classifier still emits `postcode: 97215`
+  - Final solution has both
+  - `source` fields are correctly populated
+- [ ] Test: same with `locale: 'fr-FR'` and a French address
+- [ ] Test: missing weights package → graceful degradation, rule-only solution
+
+### 10. CLI surfacing
+
+- [ ] `npx mailwoman parse --locale en-US --neural ...` opts into neural classifier
+- [ ] `npx mailwoman parse --locale en-US --no-neural ...` opts out (rule-only)
+- [ ] Default: neural on if weights package is installed, off otherwise
+- [ ] Debug output: when neural is on, show which classifier produced each component in the output
+
+### 11. Documentation
+
+- [ ] `packages/neural/README.md` — installation, usage, configuration, the `LocaleProfile` extension point
+- [ ] Update root `README.md` with a new "Neural" section
+- [ ] Migration guide: how an existing Mailwoman user opts into the neural classifier
+- [ ] Performance numbers from the benchmark suite
+
+### 12. Performance & benchmarks
+
+- [ ] `packages/neural/bench/` with vitest-bench or simple scripts
+- [ ] Benchmark: cold load time, warm classification latency p50/p95/p99, throughput, memory footprint
+- [ ] All within budgets in `reference/OPERATIONS.md`
+- [ ] If neural is slower than budgeted: profile. Likely culprits: ONNX session not reused across calls, batching not enabled, SentencePiece WASM not warm.
+
+### 13. Publish
+
+- [ ] Final version bumps:
+  - `@mailwoman/core` → minor bump (added types)
+  - `@mailwoman/classifiers` → minor bump (adapter additions)
+  - `@mailwoman/neural@0.1.0` → new, marked beta
+  - `@mailwoman/neural-weights-en-us@0.1.0` → new, marked beta
+  - `@mailwoman/neural-weights-fr-fr@0.1.0` → new, marked beta
+- [ ] Check licenses on every package's `package.json` — AGPL-3.0 for code, weights packages need their own license decision (see Phase 6 license note)
+- [ ] `npm publish` each. Use `--access public` for scoped packages.
+- [ ] Verify install in a clean directory: `npm install @mailwoman/neural @mailwoman/neural-weights-en-us` and run a sample parse.
+
+⚠ Before publishing weights, settle the license question. OSM is ODbL (share-alike). WOF is CC0. BAN is Licence Ouverte. A model trained on ODbL data is arguably ODbL — talk to a lawyer or pick a clear license posture and document it.
+
+## Success criteria checklist
+
+- [ ] Tokenizer parity test green on 10k examples
+- [ ] End-to-end test green for en-US and fr-FR
+- [ ] Benchmarks within budget
+- [ ] Golden set: country F1 improved (or held), nothing regressed
+- [ ] `npx mailwoman parse` works with `--locale` and uses neural classifier when available
+- [ ] Packages published to npm
+- [ ] Documentation updated
+- [ ] Branch tagged `neural-phase-3-complete`
+- [ ] Blog post draft (optional but recommended) in `docs/blog/2026-...-neural-classifier.md`
+
+## When the human will want a check-in
+
+After Phase 3 ships, pause. The human (the project creator) should look at:
+
+- Real-world feedback from a couple of test deployments
+- The blog post draft
+- License decisions on weights packages
+- Whether to proceed to Stage 2 (street-level) or pause to gather usage data
+
+Do not begin Phase 4 (geocoder fusion) or even Stage 2 of Phase 1/2 (street-level training) without explicit confirmation. The point of shipping is to learn.
+
+## When to call this phase done
+
+When `npm install @mailwoman/neural @mailwoman/neural-weights-en-us` followed by a `parse()` call works on a clean machine and produces output with `source: 'neural'` proposals for the `country` component.

--- a/docs/plan/phases/PHASE_4_resolver.md
+++ b/docs/plan/phases/PHASE_4_resolver.md
@@ -1,0 +1,57 @@
+# Phase 4 — Geocoder Fusion
+
+**Goal:** add a resolver layer that takes parsed components and resolves to WOF place IDs + coordinates. The parser and geocoder share a representation, as the project creator originally intended.
+
+**Status:** deferred until Phase 3 has shipped and gathered real-world feedback. Do not begin Phase 4 without explicit confirmation from the human.
+
+**This document is a sketch, not a plan.** Phase 4 will get its own detailed plan when it begins.
+
+## Why deferred
+
+- Phase 3 must ship and prove the architecture in production before adding complexity.
+- The right resolver design depends on what users do with the parser output. Premature optimization here is expensive to undo.
+- Geocoding has its own data licensing complexity (commercial WOF use, OSM ODbL share-alike) that needs separate diligence.
+
+## Sketch
+
+Two viable resolver architectures:
+
+### Option A: tantivy-backed (Airmail-style)
+
+- Embed an Airmail-compatible index, built once from OSM + WOF
+- Query via Rust→WASM binding or Rust sidecar
+- Pro: planet-scale, fast, proven
+- Con: introduces Rust into the runtime
+
+### Option B: SQLite FTS5 + WOF SQLite
+
+- Use WOF SQLite distributions directly
+- FTS5 for full-text matching on place names
+- Pro: pure Node, simple deployment
+- Con: slower at planet scale, less sophisticated ranking
+
+### Option C: External geocoder API
+
+- Call out to a hosted geocoder (Pelias, Nominatim, BAN's `api-adresse.data.gouv.fr`)
+- Pro: zero local index, always fresh
+- Con: network dependency, rate limits, privacy implications
+
+## Decisions deferred until Phase 4 begins
+
+- Which resolver architecture
+- Whether resolution feedback can correct parser output (the loop the project creator wanted)
+- How to expose the joint type publicly
+- Whether to ship as part of `@mailwoman/neural` or a new package
+
+## What Phase 3 should leave in good shape for Phase 4
+
+- The `ClassificationProposal` shape is rich enough to feed resolution
+- `LocaleProfile` is the right place to declare resolver preferences
+- The CLI's output format should be designed so adding a `resolution` field later is non-breaking
+
+## Reading material to revisit when Phase 4 begins
+
+- `ellenhp/airmail` source, especially the indexer
+- `pelias/placeholder` (WOF-backed coarse resolver in Node)
+- BAN's API for FR-specific resolution
+- WOF's hierarchy walking utilities

--- a/docs/plan/phases/PHASE_5_studio.md
+++ b/docs/plan/phases/PHASE_5_studio.md
@@ -1,0 +1,48 @@
+# Phase 5 — Studio (Human-in-the-Loop Correction)
+
+**Goal:** a web UI where humans can paste an address, see the parse, correct spans, and submit corrections. Corrections feed back into corpus retraining. This is the commercial differentiator — enterprises will pay for the ability to correct their own address data.
+
+**Status:** deferred until Phase 3 has shipped and gathered usage. Do not begin Phase 5 without explicit confirmation.
+
+**This document is a sketch.** Detailed plan will be written when Phase 5 begins.
+
+## Why this matters
+
+- Address parsing has a long tail of locale-specific edge cases that no amount of pretraining catches
+- Customers with their own address datasets (real estate, logistics, government compliance) need to fix model output for their data
+- The studio is what turns a free library into a commercial product line
+
+## Sketch of components
+
+### Frontend
+
+- React or Svelte (project creator's call)
+- Paste address → see live parse with span boundaries
+- Drag span edges to adjust boundaries
+- Right-click span to relabel component
+- Submit correction with optional notes
+
+### Backend
+
+- Postgres table: `corrections { id, raw, original_parse, corrected_parse, user_id, project_id, created_at, notes }`
+- API: `POST /corrections`, `GET /corrections?project_id=...`
+- Auth: minimal — project tokens, no full user system v1
+
+### Retraining loop
+
+- Nightly job: dump new corrections to `/data/corpus/sources/corrections/`
+- Tag with high sample weight
+- Trigger retraining (manual confirmation, not automatic — corrections can be adversarial)
+
+## What Phase 3 should leave in good shape
+
+- `ClassificationProposal` carries enough info to round-trip through human correction
+- The output format includes character offsets (it does) so span editing is mechanical
+- Telemetry hooks exist to count "user accepted the parse as-is" vs "user corrected" — informs which components most need correction
+
+## Open questions for when Phase 5 begins
+
+- Is this open source or commercial-only?
+- How does the correction format become training data? (BIO labels need to be re-derived from corrected components)
+- Quality gating: are all corrections trusted equally, or does each project's corrections only affect that project's model?
+- Does the studio host its own model fine-tuned on the project's corrections?

--- a/docs/plan/phases/PHASE_6_japan.md
+++ b/docs/plan/phases/PHASE_6_japan.md
@@ -1,0 +1,72 @@
+# Phase 6 — Japan Expansion (Architecture Validation)
+
+**Goal:** add Japanese address support. This is the validation milestone for the architecture: if the schema, classifier interface, and policy system survive JP without core refactor, the design is sound.
+
+**Status:** deferred. Begin only after Phase 3 has shipped, Stages 2 and 3 of training have completed for US/FR, and the human has confirmed.
+
+**This document is a sketch.** Detailed plan written when Phase 6 begins.
+
+## Why JP specifically
+
+- **Structurally different addressing.** JP has no streets. Addresses are nested blocks (chōme/banchi/go). If any core code assumes "street is mandatory," it breaks here.
+- **Different script.** CJK characters expose tokenizer vocabulary limits. SentencePiece with `byte_fallback=true` (set in Phase 1) should handle this, but real test only happens with real JP data.
+- **Excellent open data.** MLIT (国土交通省) publishes comprehensive address data freely. Quality comparable to BAN.
+- **Existing reference implementation.** `japanese-address-parser` Rust crate is a baseline to compare against.
+
+## What must already work before Phase 6
+
+- Schema has JP-specific tags reserved (it does — see `reference/SCHEMA.md`)
+- `LocaleProfile.componentsSupported` is honored everywhere (it must be by Phase 0)
+- No hardcoded assumption that `street` or `house_number` is required anywhere
+- Tokenizer was trained with sufficient character coverage to handle CJK (set in Phase 1)
+
+If any of these aren't true, the design failed and the project needs a Phase 0 revisit.
+
+## Sketch tasks
+
+### Data
+
+- Adapter for MLIT address data (CSV format, comprehensive coverage of JP)
+- Adapter for WOF JP admin records (already accessible)
+- Synthesis rules for JP variants: kanji vs hiragana vs romaji, traditional vs modern numbering
+
+### Tokenizer
+
+- Validate existing tokenizer's CJK handling. May need to retrain with more JP samples in the SentencePiece training mix.
+- If retraining, that's a corpus version bump. Don't ship a tokenizer change in a patch release.
+
+### Model
+
+- Continue training from US/FR checkpoint with JP data added
+- Or train a separate JP-only model — depends on whether shared vocab benefits transfer or hurts via interference
+- Decision point: measure both, pick winner
+
+### Schema
+
+- Add JP-specific `LocaleProfile` with `componentsSupported` including JP tags, excluding `street` and `house_number`
+- Register JP rule classifiers (minimal — most work is the model)
+
+### Validation
+
+- Compare against `japanese-address-parser` on held-out JP addresses
+- If we underperform a single-country specialist, that's expected and acceptable in v1
+- If we underperform by > 10 F1 points, investigate — likely a vocab or alignment issue
+
+## Open questions for when Phase 6 begins
+
+- Single multilingual model vs per-locale models?
+- Romaji-only support, kanji-only, or both?
+- How aggressively to normalize variants (full-width vs half-width digits, traditional vs simplified kanji where applicable)
+- Whether to include Korean/Chinese as bonus locales since vocab will be CJK-friendly by then
+
+## What success looks like
+
+When you can run:
+
+```
+npx mailwoman parse --locale ja-JP "東京都千代田区丸の内1-1-1"
+```
+
+and get a parse with `prefecture: 東京都, municipality: 千代田区, district: 丸の内, block: 1, sub_block: 1, building_number: 1` — and no core code changed since Phase 3, only adapters, weights, and locale profiles — the architecture is validated.
+
+If core code did need to change, the change is the deliverable, not the JP support. Document what changed and why so future locales (Korean, Thai, etc.) benefit.

--- a/docs/plan/reference/ARCHITECTURE.md
+++ b/docs/plan/reference/ARCHITECTURE.md
@@ -1,0 +1,386 @@
+# Architecture
+
+## System shape
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         Mailwoman SDK                            │
+│                                                                  │
+│   ┌──────────────────┐   ┌────────────────────────────────┐     │
+│   │  Tokenization    │──▶│  Classifiers (rule + neural)   │     │
+│   │  (existing)      │   │                                │     │
+│   └──────────────────┘   │  ┌──────────────────────────┐  │     │
+│                          │  │ rule: house_number       │  │     │
+│                          │  │ rule: postcode           │  │     │
+│                          │  │ rule: street_prefix      │  │     │
+│                          │  │ rule: whos_on_first      │  │     │
+│                          │  │ ...                      │  │     │
+│                          │  │                          │  │     │
+│                          │  │ neural: NeuralSequence   │──┼──┐  │
+│                          │  └──────────────────────────┘  │  │  │
+│                          └────────────────────────────────┘  │  │
+│                                       │                       │  │
+│                                       ▼                       │  │
+│                          ┌────────────────────────────────┐  │  │
+│                          │  ClassifierPolicy (per-tag)    │  │  │
+│                          └────────────────────────────────┘  │  │
+│                                       │                       │  │
+│                                       ▼                       │  │
+│                          ┌────────────────────────────────┐  │  │
+│                          │  Solver (existing)             │  │  │
+│                          │  ExclusiveCartesianSolver +    │  │  │
+│                          │  filters + augmenters          │  │  │
+│                          └────────────────────────────────┘  │  │
+│                                       │                       │  │
+│                                       ▼                       │  │
+│                          ┌────────────────────────────────┐  │  │
+│                          │  Ranked Solutions              │  │  │
+│                          └────────────────────────────────┘  │  │
+│                                                               │  │
+└───────────────────────────────────────────────────────────────┼──┘
+                                                                │
+                          ┌─────────────────────────────────────┴──┐
+                          │  @mailwoman/neural (new package)       │
+                          │                                        │
+                          │  ┌──────────────────────────────────┐  │
+                          │  │  NeuralSequenceClassifier        │  │
+                          │  │  - lazy-loads ONNX model         │  │
+                          │  │  - SentencePiece tokenizer       │  │
+                          │  │  - emits ClassificationProposal  │  │
+                          │  └──────────────────────────────────┘  │
+                          │              │                          │
+                          │              ▼                          │
+                          │  ┌──────────────────────────────────┐  │
+                          │  │  Weights packages (per locale)   │  │
+                          │  │  @mailwoman/neural-weights-en-us │  │
+                          │  │  @mailwoman/neural-weights-fr-fr │  │
+                          │  │  @mailwoman/neural-weights-ja-jp │  │
+                          │  └──────────────────────────────────┘  │
+                          └────────────────────────────────────────┘
+```
+
+## Monorepo layout
+
+```
+packages/
+  core/                      # existing — tokenization, span/section/phrase, classifier base
+  classifiers/               # existing rule classifiers — pulled out of core for clarity
+  neural/                    # NEW — ONNX runtime + SentencePiece + sequence classifier
+  neural-weights-en-us/      # NEW — ONNX model weights for US English
+  neural-weights-fr-fr/      # NEW — ONNX model weights for FR French
+  corpus/                    # NEW — TS adapters, alignment, synthesis, Parquet output
+  corpus-python/             # NEW — Python training pipeline, NOT published to npm
+  studio/                    # FUTURE — Phase 5 web UI for human correction
+sdk/                         # existing — public consumer API
+server/                      # existing — HTTP service
+cli.ts                       # existing
+```
+
+The split between `neural/` (runtime) and `neural-weights-*/` (data) is deliberate. Users running US-only deployments should not download French weights. Weights packages are versioned independently from the runtime.
+
+## Key abstractions
+
+### `ComponentTag`
+
+The canonical union of address component types. Defined in `reference/SCHEMA.md`. Single source of truth. Adding a tag requires a written rationale.
+
+### `ClassificationProposal`
+
+The shape every classifier produces. Replaces the current ad-hoc shape used by rule classifiers. See `reference/INTERFACES.md`.
+
+```ts
+interface ClassificationProposal {
+	span: Span
+	component: ComponentTag
+	confidence: number // 0..1
+	source: "rule" | "neural" | "merged"
+	source_id: string // 'house_number' for rule, 'neural-v0.3-en-us' for neural
+	penalty: number
+	metadata?: Record<string, unknown>
+}
+```
+
+Existing rule classifiers wrap their output in this shape. Neural classifier emits the same shape. The solver does not distinguish.
+
+### `ClassifierPolicy`
+
+Per-component configuration that decides which classifier(s) get authority for that component. This is the Ship of Theseus dial.
+
+```ts
+interface ClassifierPolicy {
+	component: ComponentTag
+	mode: "rule_only" | "neural_only" | "both" | "neural_preferred" | "rule_preferred"
+	confidence_threshold?: number
+	locale?: string // policy can vary per locale
+}
+```
+
+Default policy is `rule_only` for everything until neural is shipped. Migration happens one component at a time, gated on golden-set metrics.
+
+### `LocaleProfile`
+
+Encapsulates locale-specific behavior: which weights package to load, which rule classifiers apply, which synthesis rules govern training data generation.
+
+```ts
+interface LocaleProfile {
+	locale: string // 'en-US', 'fr-FR', 'ja-JP'
+	weightsPackage: string // npm package name
+	ruleClassifiers: string[] // identifiers of rule classifiers active for this locale
+	componentsSupported: ComponentTag[] // not every locale supports every tag (e.g. JP has no `street`)
+	policy: ClassifierPolicy[]
+}
+```
+
+## Locale strategy
+
+Locales are first-class. The system does not assume English. Every classifier (rule or neural) declares which locales it serves.
+
+- A US-only deployment loads `en-US` profile, English rule classifiers, US weights.
+- A multi-locale deployment loads all configured profiles. Locale detection per input is a separate concern handled by a `LocaleDetector` (Phase 2 work; v0 can require explicit locale).
+- New locale = new `LocaleProfile` + new weights package + (optionally) new rule classifiers. Core code does not change.
+
+## Inference path
+
+```
+input string
+     │
+     ▼
+Tokenization (existing Mailwoman code)
+     │
+     ▼
+For each Section:
+     │
+     ├──▶ Rule classifiers produce ClassificationProposals
+     │
+     ├──▶ NeuralSequenceClassifier (if locale supports it):
+     │       1. Tokenize section with SentencePiece (WASM)
+     │       2. Run ONNX inference via onnxruntime-node
+     │       3. Decode BIO labels back to character spans
+     │       4. Emit ClassificationProposals
+     │
+     ▼
+ClassifierPolicy filter:
+     For each component, keep only proposals from authorized classifiers
+     │
+     ▼
+Existing ExclusiveCartesianSolver
+     │
+     ▼
+Ranked solutions
+```
+
+## Training path (Python, internal)
+
+```
+Source data (OSM, WOF, BAN, OpenAddresses, government registries)
+     │
+     ▼ TypeScript adapters (corpus/adapters/*.ts)
+Canonical rows: { raw, components, country, source, source_id }
+     │
+     ▼ Alignment (corpus/align.ts)
+BIO-labeled rows: { raw, tokens, labels, country, source, source_id }
+     │
+     ▼ Synthesis (corpus/synthesize.ts)
+Augmented rows: + case variants, abbreviations, typos, ordering perturbations
+     │
+     ▼ Parquet shards (versioned)
+corpus-vX.Y.Z/{train,val,test}-*.parquet
+     │
+     ▼ Python training (corpus-python/)
+HuggingFace Transformers + PyTorch
+     │
+     ▼ ONNX export + int8 quantization
+neural-weights-{locale}/model.onnx + tokenizer.model
+     │
+     ▼ Eval on golden set
+If golden_F1 >= threshold: publish
+```
+
+## Model architecture (what the neural classifier IS)
+
+**Family: encoder-only transformer + per-token classification head.** Standard NER (named entity recognition) shape. Each token of the input address string gets exactly one BIO label from a fixed set (`O` + `B-<tag>` + `I-<tag>` for each tag in the `ComponentTag` union — currently 47 labels = 1 + 2 × 23 tags).
+
+### Why this family, not the others
+
+| Family                                                                        | Used for                                                        | Why not us                                                                                                                         |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Encoder-only + classification head** (BERT / RoBERTa / DeBERTa + NER heads) | Per-token tagging; same number of output labels as input tokens | **This is us.** Address parsing is a tagging problem, not a generation problem.                                                    |
+| Encoder-decoder (T5, BART)                                                    | Seq2seq — translation, summarization                            | The output isn't a different sequence; it's structured tags per input token. Encoder-decoder is overkill and lossy for this shape. |
+| Decoder-only (GPT, Llama)                                                     | Autoregressive generation                                       | We annotate, we don't generate. A decoder LLM could approximate via constrained decoding at 1000× the cost.                        |
+| Conditional random field (CRF)                                                | Pre-transformer per-token tagging with Markov features          | This is libpostal. We're replacing the CRF with a transformer encoder in front of an effectively-similar tag space.                |
+
+### Concrete config (Phase 2 / issue #10)
+
+- **Backbone**: HuggingFace `BertForTokenClassification` with custom small config — **6 layers, 256 hidden dim, 4 attention heads, 1024 FF intermediate, max position 128.** Trained **from scratch** (not fine-tuned from a pretrained English-internet BERT — the address vocabulary is too narrow and too unlike natural language for that pretraining to help).
+- **Tokenizer**: SentencePiece (unigram), `vocab_size=16000`, `character_coverage=0.9995`, `byte_fallback=true`. Trained on the corpus, not picked off the shelf. Tokenizer version is locked into corpus version.
+- **Output head**: linear projection → 47 logits per token (the BIO label space derived from `ComponentTag`).
+- **Inference**: softmax over labels, take argmax per token, decode BIO spans back to character offsets via SentencePiece's offset map, emit `ClassificationProposal` per span with mean per-token softmax probability as confidence.
+- **Size target**: < 30 MB int8-quantized ONNX, < 40 MB including tokenizer. Total parameter count in the low millions.
+- **Runtime**: `onnxruntime-node`, CPU execution provider default, no Python at inference time.
+
+### The cousin: spaCy's `ja_core_news_trf`
+
+The closest commercial reference point is spaCy's [Japanese transformer pipeline](https://spacy.io/models/ja#ja_core_news_trf):
+
+|                       | spaCy `ja_core_news_trf`                                                                 | mailwoman planned                                                                                |
+| --------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Backbone              | `cl-tohoku/bert-base-japanese-char-v2` (BERT-base — 12 layers, 768d)                     | small BERT (6 layers, 256d) — ~10× smaller                                                       |
+| Vocab                 | 6,144 char-level (Japanese requires character-level for OOV handling)                    | 16,000 SentencePiece (multilingual; bytes fall back for OOV)                                     |
+| Pretrained            | Yes (Tohoku-Univ. Inui Lab BERT)                                                         | No (from scratch on address corpus)                                                              |
+| Task heads            | **3** on shared encoder: morphologizer (POS), parser (dependency), NER (22 entity types) | **1** on dedicated encoder: NER for 23 address component types                                   |
+| Model size            | 320 MB                                                                                   | < 40 MB int8                                                                                     |
+| NER F1 (their domain) | 83.31 ENTS_F on general Japanese NER                                                     | TBD; the rule baseline is > 95% on `country` / `region` for the golden set, so the floor is high |
+| Inference runtime     | Python (spaCy)                                                                           | Node (`onnxruntime-node`)                                                                        |
+| License               | CC BY-SA 3.0                                                                             | AGPL-3.0                                                                                         |
+
+spaCy validates the family choice — when the industry-standard NER toolkit's flagship Japanese model is BERT-encoder + token-classification head, we're in the right shape. The trade-offs we make vs them:
+
+- **Smaller** (10× fewer parameters): we're a narrower task. General-purpose Japanese NER must handle 22 entity types across all of news text; address parsing handles 23 component types in addresses only. Narrow task tolerates narrower model.
+- **From scratch, not fine-tuned**: their cl-tohoku backbone was pretrained on Japanese Wikipedia + news. Our domain is far enough from natural-language text that the pretraining transfer is weak; training from scratch on a domain-pure corpus gets us a smaller, faster, more accurate model.
+- **Single head, not multi-head**: they share one encoder across morphologizer + parser + NER. We have one head only — the encoder can fully specialize for component disambiguation. (Multi-head is a future extension: see below.)
+
+### Multi-head extension (Phase 4+)
+
+The spaCy pipeline pattern — one shared encoder + multiple task heads — is a powerful future direction. Candidates if/when we want them:
+
+- **Venue vs address-part head**: a binary classifier per token to help compositional disambiguation (`Buffalo Health Clinic Buffalo NY` — is "Buffalo" venue-token or locality-token?). Useful for [[project-mailwoman-bitter-lesson]]'s kryptonite cases.
+- **Locale detection head**: predicts `en-US` vs `fr-FR` vs `ja-JP` for the whole input, lets `LocaleDetector` (currently a separate concern) ride the same encoder.
+- **Completeness head**: predicts whether the input is a complete address, a fragment, or noise — feeds graceful-failure signaling per [[project-mailwoman-graceful-failure]].
+- **Confidence head**: a separate calibration learner trained on held-out data, replacing the per-token softmax with a calibrated probability.
+
+None of these are Phase 0–3 scope. Filed for Phase 4 territory or beyond. spaCy's existence is the evidence the pattern works at scale.
+
+### Frameworks + tooling stance — what we use, what we don't, what we steal
+
+**Use**: HuggingFace Transformers + PyTorch for training (Python-only, single-shot, output is the ONNX file). `onnxruntime-node` for inference (TypeScript / Node, the user-facing path). SentencePiece for tokenization on both sides. `@dsnp/parquetjs` (patched — see `.yarn/patches/` in the repo) for corpus output. That's the production stack — anything not on this list is either dead weight or duplicative.
+
+**Don't use**: spaCy as a dependency, either runtime or training. Reasons:
+
+- **Runtime**: spaCy is Python-only. The plan's "TypeScript-first" stance is a hard constraint from the epic; adding Python at inference time defeats the deployment-regression-for-Node-users argument that's the project's reason to exist. spaCy's ONNX export path (`spacy-onnx-export`) exists but is rarely production-grade.
+- **Training**: spaCy's config-driven training is nice (`spacy.cfg` + `Thinc`) but pays off mostly when pipeline composition matters or the task is novel. Our task — single-head NER on `BertForTokenClassification` — is the most-trodden path in HuggingFace Transformers. spaCy adds an abstraction layer for marginal convenience. Operator's "less Python the better" stance argues against it even for training where Python is unavoidable.
+
+**Steal the patterns, not the tool**:
+
+| What                                                                                                                 | From                                                                                                                                                  | Where to apply                                                                          |
+| -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Release notes template (label scheme table + transformer config block + per-component F1 + compatibility matrix)     | spaCy's GitHub release format for models like [ja_core_news_trf-3.7.0](https://github.com/explosion/spacy-models/releases/tag/ja_core_news_trf-3.7.0) | Phase 3 (#11) `@mailwoman/neural-weights-*` package READMEs + model card JSON           |
+| Eval reporting conventions (per-component P/R/F1 + confusion matrix layout, `displaCy`-style visualization patterns) | spaCy benchmark reports                                                                                                                               | Phase 2 (#10) eval reports                                                              |
+| "Training described entirely by a config file, code is just the runner" hygiene                                      | spacy.cfg pattern                                                                                                                                     | `corpus-python/train.py` config shape — adopt the pattern without taking spaCy as a dep |
+| Vintage / language-model-version conventions                                                                         | spaCy's `ja_core_news_trf-3.7.0` naming (`<lang>_<domain>_<size>_<framework>-<version>`)                                                              | Weights package versioning + ONNX file naming                                           |
+
+**Optional Phase 3 baseline comparison**: run a fine-tuned `xx_ent_wiki_sm` or `en_core_web_trf` against the same golden set, report comparison numbers in the model card. General NER tagging `LOC` / `ORG` where we expect `locality` / `venue` is informative — shows the address-specific gain over general NER. Operator-time, ~1 hour for an honest baseline run. Not in the install dependency tree; one-off comparison only.
+
+### Casual descriptions (for audiences who don't want the architecture deep-dive)
+
+- **Technical**: "Small encoder-only transformer (BERT-class, from scratch, ~few-million params, <40 MB int8 ONNX), per-token classification head emitting BIO-tagged address-component spans. Runs in Node via onnxruntime-node, no Python at inference."
+- **Practitioner**: "Tiny BERT-class NER model specialized for address parsing — a learned replacement for libpostal's CRF, sized to fit in a Node process. Architecturally the same family as spaCy's ja_core_news_trf, ~10× smaller because the task is narrower."
+- **User-facing**: "A small ONNX model that reads an address string and tells you, with per-component confidence, what each piece of it means."
+- **For the bitter-lesson audience**: "The contextual-parser half of a contextual-parser-plus-constraint-solver geocoder front-end. The transformer proposes; the policy registry + solver dispose."
+
+Notably NOT: a translator (no language pair, no autoregressive output). Not a generative model.
+
+## Training cadence vs. plan (2026-05-18 reframing)
+
+The original phase plan (`phases/PHASE_2_training.md`) targeted a **single training run hitting >95% per-component F1** in ~2 weeks. Two iterations in, that framing has been replaced by an **iteration cadence**: each cycle is ~3-7 days of focused work (corpus refinement → train 6-10h GPU → eval → ship), and each cycle produces a shippable artifact even if it doesn't hit the >95% bar.
+
+Why the change:
+
+- **>95% F1 in one shot was aspirational.** Address parsing from scratch on a noisy real-world corpus is harder than that target acknowledged. Real ship gates are lower (~0.85 F1 on coarse components is genuinely useful in production with proper calibration).
+- **Shipping below-target IS the bitter-lesson framing.** Per [[project-mailwoman-graceful-failure]], the success metric is graceful failure, not max F1. A 0.85-F1 model with 0.88 calibration in its conf>0.9 bucket is more useful than a 0.95-F1 model with 0.33 calibration (the v0.1.0 situation).
+- **Ship-of-Theseus coexistence makes shipping safe.** The neural classifier adds proposals alongside the rule classifiers via the policy registry; we don't have to wait for parity to start using it.
+- **Iteration > single-run.** Each cycle produces real artifacts: ONNX weights, model card, eval report, npm package shape, demo updates. Compounding wins.
+
+### Iteration history (live)
+
+| Iteration                                                         | Scope                                                                                                                                                       | Wall-clock | Outcome                                                                                                                                   |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **v0.1.0**                                                        | First Stage 1 ship; sequential-data overfit due to corpus imbalance                                                                                         | ~3 days    | Honest below-target ship; F1 ~0.03 macro, calibration 0.33 (confidently wrong)                                                            |
+| **v0.2.0**                                                        | `source_weights` mechanism + relaxed coarse gate (Phase 2 §6 recipe)                                                                                        | ~3 days    | **9× macro-F1** (0.037 → 0.335); **calibration tightened 2.6×** (0.33 → 0.88 in conf>0.9 bucket); still below 95% targets but ship-worthy |
+| **v0.3.0** (next)                                                 | Stage 2 label expansion (`B/I-venue`, `B/I-street`, `B/I-house_number`) + corpus rebuild including NAD + OA-CA + linear-chain CRF decoder + label smoothing | ~5-7 days  | Target: unlock venue/street/house tagging surface; coarse F1 holds ≥0.8; calibration ≥0.85                                                |
+| **v0.3.1** (likely)                                               | Span-coherent CRF + multi-word locality fix ("Saint Petersburg" clipping)                                                                                   | ~2 days    | Bug-fix iteration                                                                                                                         |
+| **v0.4.0**                                                        | Stage 3 organization/POI venue + top-k decoding for Resolver                                                                                                | ~5-7 days  | Depends on v0.3.x outcomes                                                                                                                |
+| **Phase 3 (Integration & Ship)** runs in parallel with iterations | npm publish pipeline, @mailwoman/neural SDK glue                                                                                                            | ~5-7 days  | `@mailwoman/neural@0.x.y` on npm                                                                                                          |
+| **Phase 4 (Resolver)**                                            | Source annotations, top-k disambiguation, gazetteer lookup                                                                                                  | Deferred   | Operator-gated                                                                                                                            |
+
+### Why more data doesn't blow up the iteration cost
+
+A single training run is fixed-step-count, not fixed-epoch. v0.2.0's 50K steps × 128 effective batch = 6.4M examples seen ≈ **2.4% of the 263M-row corpus per pass**. Adding NAD (62M) + OA-CA (10M) + state backfills bumps the corpus to ~340M rows; same 50K steps still finishes in ~6.5-10h. The model is nowhere near training-data-limited; more corpus → more diversity per example seen, not more wall-clock.
+
+What ACTUALLY costs more time per iteration:
+
+1. **Stage label expansion** — adding venue/street/house_number labels requires adapter alignment updates (every adapter's `align.ts` emits the new labels where source data supports it) + golden set verification + corpus rebuild (~260 min). This is the bulk of v0.3.0 work.
+2. **CRF decoder + label smoothing** — small training-time additions, big calibration/coherence wins, lands in the same retrain.
+3. **Per-iteration golden expansion** — already automated via `expand-golden.ts` + `promote-golden.ts` (PR #48 / #49); each iteration can re-eval against the latest golden version.
+
+### Re-framed success metric per iteration
+
+Not "did F1 hit 95%" but "is the artifact independently shippable and a measurable improvement over the prior iteration?" The eval ledger at `evals/scores-by-version.json` makes this empirical — every shipped run gets a row, with corpus + eval-set sha-pinning so the deltas are honest apples-to-apples.
+
+## Why this shape
+
+- **Classifier-as-plugin** preserves Mailwoman's existing extensibility. New rule classifiers, new neural variants, future learned rankers all conform to the same interface.
+- **Per-component policy** allows incremental rollout without big-bang risk. A regression in neural `street` parsing doesn't affect `country` parsing.
+- **Locale profiles** prevent the architecture from quietly Anglocentric-by-default. If the abstractions can't express a non-Anglo locale cleanly, we fix the abstractions, not the locale.
+- **Separate weights packages** keep npm install times sane and let users opt in to languages they need.
+- **Training in Python, inference in TS** uses each ecosystem for what it's best at and avoids the dual-language maintenance tax in production code.
+
+## Output shape (Phase 3 concern, not Phase 2)
+
+The neural model emits per-token BIO labels regardless of how its output is presented. The DECODER chooses the format. Three legitimate shapes, in increasing expressivity:
+
+| Shape                                                            | Preserves                                                      | Loses                                         | Round-trip fidelity                                                                                                                       |
+| ---------------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **JSON object** `{locality: "Paris", postcode: "75005"}`         | tag → value                                                    | order, repetition, hierarchy, untagged tokens | Country-specific formatter required; reorder errors are silent. Libpostal/Pelias compatible.                                              |
+| **Tuple array** `[["locality", "Paris"], ["postcode", "75005"]]` | tag → value + **original order** + repetition                  | hierarchy                                     | Reconstruction is `array.map(([_, v]) => v).join(" ")`; trivially faithful to ordering.                                                   |
+| **S-expression** `(locality "Paris" (postcode "75005"))`         | order + **hierarchy** + arbitrary attributes (`:conf`, `:src`) | nothing material                              | The most expressive — lets the parsed output say "this postcode is INSIDE this locality." Natural carrier for Phase 4 source annotations. |
+
+**Operator framing (2026-05-18):** address parsing is inherently lossy — you can't extract the original formatted address from the parsed result. The closest you can get is by applying a formatter to the parsed result. S-expressions may better preserve the original shape because they encode hierarchy + ordering + attributes in one tree.
+
+**Implementation plan (Phase 3, #11):** ship all three decoders behind a `--format json|tuple|sexp` CLI flag. Default = JSON for libpostal-compat; S-expr as power-user mode. Round-trip eval (`parse(format(parse(raw))) == parse(raw)`) tells us which shape preserves the most fidelity; if S-expr wins, flip default.
+
+**No model retraining required.** This is post-processing on the BIO output. The same neural model serves all three formats.
+
+**Existing isp-nexus formatter** (`isp-nexus/universe/mailwoman/postal/formatting.ts`) handles flat-object → multi-line-string for shipping-label rendering. Port it as the JSON-decoder's inverse direction; build a separate `sexp→string` formatter for the S-expr path.
+
+## Source attribution (Phase 4 — #12, deferred)
+
+Differentiator vs libpostal and Pelias. Libpostal says "this token is a city"; Pelias adds hit/miss provenance against ES indexes. **Mailwoman's goal** (operator framing): "this token is a locality identified by the wof-admin gazetteer with 0.97 confidence."
+
+The corpus already carries `source` per-row (every alignment + augmentation tags provenance). What's missing is propagating that provenance through the inference output.
+
+**Decision (operator, 2026-05-18): hybrid Option C — model + Resolver.**
+
+- Model emits BIO labels + per-token confidence (already does)
+- Resolver at inference time maps `(span, label) → (source-class, src-conf)` via fast lookups against pre-indexed gazettes (wof, ban, tiger, nppes, hrsa, imls-pls, state-\*)
+- Output annotations live as S-expression attributes:
+
+```
+(locality "Paris" :src wof-admin :conf 0.97
+  (postcode "75005" :src wof-postalcode :conf 0.93))
+```
+
+### Key insight: provenance is already flowing through training
+
+`source_weights` (shipped 2026-05-18 in PR #44) affects what the trained model emphasizes during training even though the model itself doesn't emit source labels. The Resolver at inference time **surfaces** what was implicit in training. The data path:
+
+```
+corpus row (source-stamped)
+   → source_weights filter at data loader
+   → training distribution (model internalizes source priors)
+   → model emits BIO + confidence (no source field)
+   → Resolver looks up labeled spans against gazettes
+   → output: BIO + label + confidence + source-class + src-conf
+```
+
+### Rejected alternatives
+
+- **Resolver-only at inference, no source-aware training** — model has no internal calibration toward gazette-confirmed tokens; weaker.
+- **Multi-task neural head** emitting `(label, source-class)` per token — ~15 × 8 = 120 sub-classes; bigger model, harder to retrain, loses the clean separation between span-identification (model job) and provenance (Resolver job).
+
+## Anti-patterns to avoid
+
+- ❌ A `mode: 'auto'` setting in `ClassifierPolicy` that "intelligently" picks rule vs neural. Hidden state, hard to debug. Always explicit.
+- ❌ Hardcoding `'en-US'` as default in core. Default should be "no locale, classifiers must opt in."
+- ❌ Loading all weights at module init. Lazy-load on first classification request.
+- ❌ Mixing inference and resolution. The parser does not know about coordinates, place IDs, or WOF resolution. That's Phase 4.
+- ❌ Adding tags to `ComponentTag` without updating the schema doc and the alignment logic in the same commit. Schema drift kills the corpus.

--- a/docs/plan/reference/CONTEXT.md
+++ b/docs/plan/reference/CONTEXT.md
@@ -1,0 +1,128 @@
+# Context
+
+## What Mailwoman is today
+
+Mailwoman is a fork of `pelias/parser`, written in TypeScript. It is a rule-based natural language classification engine for geocoding. Input: an address string. Output: a list of solutions, each a set of `{ component, confidence, offset, penalty }` spans.
+
+Architecture: tokenization (sections → words → phrases) → classification (dictionary/regex/composite classifiers populate a graph) → solving (`ExclusiveCartesianSolver` enumerates valid permutations, additional solvers filter and augment).
+
+Output example for `"Mt Tabor Park, 6220 SE Salmon St, Portland, OR 97215, USA"`:
+
+```ts
+;[
+	{ venue: "Mt Tabor Park", confidence: 0.8, offset: 0, penalty: 0 },
+	{ house_number: "6220", confidence: 0.9, offset: 15, penalty: 0 },
+	{ street: "SE Salmon St", confidence: 0.98, offset: 20, penalty: 0 },
+	{ locality: "Portland", confidence: 1, offset: 34, penalty: 0 },
+	{ region: "OR", confidence: 1, offset: 44, penalty: 0 },
+	{ postcode: "97215", confidence: 1, offset: 47, penalty: 0 },
+	{ country: "USA", confidence: 0.9, offset: 54, penalty: 0 },
+]
+```
+
+The shape — per-component confidence + character offset + penalty — is unusually good for ML integration. A token-classification model's natural output is essentially this. We are not adapting a model to fit a foreign output shape.
+
+## What the field looks like
+
+- **libpostal** (C, CRF) — the de-facto baseline. 99.45% claimed parse accuracy on held-out data. Trained on OpenStreetMap. Mostly stagnant since ~2018.
+- **Deepparse** (Python, Seq2Seq BiLSTM) — academic, fine-tunable, slower than libpostal, >99% component accuracy. Active.
+- **Pelias Parser** (JS, rule-based) — our upstream. Explicitly rejects black-box ML in favor of debuggable rules. Active.
+- **Airmail** (Rust, tantivy-based geocoder) — sidesteps parsing entirely by treating it as an IR problem. 376 stars, single-maintainer, planet-scale for ~$5/month. Worth studying.
+- **Transformer-based parsers in academic literature** — Guermazi et al. 2024 shows transformers beat libpostal on noisy/multilingual data. Not productized.
+
+The gap: there is no widely adopted neural address parser shipped as a library. Everyone either uses 2018-era CRF (libpostal) or rolls their own.
+
+## Why neural, why now
+
+Three reasons rules hit a ceiling:
+
+1. **Ambiguity that needs context.** "Paris Texas" vs "Paris, Texas" vs "Paris, France." Rules need explicit comma logic; a model learns context.
+2. **Internationalization without rule explosion.** Every country's rule set is bespoke maintenance. A model trained on country-tagged data generalizes.
+3. **Graceful degradation on novel input.** Rules either match or don't. A model produces probabilities, enabling confidence-weighted decisions in the solver.
+
+But rules win in three places:
+
+1. **Postcodes.** A US ZIP is a regex. A model is wasted capacity.
+2. **Explicit dictionaries.** Country names, state abbreviations — lookups are perfect and instant.
+3. **Debuggability.** When a rule misclassifies, you can read the rule. When a model misclassifies, you train on more data and hope.
+
+Hence Ship of Theseus: migrate component-by-component, gated on metrics, never flip a single "neural on" switch.
+
+## Why TypeScript-first
+
+Mailwoman's users are in the Node ecosystem. A Python or Rust dependency is a deployment regression for them. ONNX Runtime has a stable Node binding (`onnxruntime-node`) with CPU + CUDA execution providers. SentencePiece has WASM builds. The full inference path runs in a Node process without spawning subprocesses or shelling out.
+
+Training stays in Python because the ecosystem (HuggingFace Transformers, PyTorch, the `datasets` library, ONNX export tooling) is unmatched. The training code is internal to the project and never published to npm.
+
+## Why US + France first
+
+- **US:** the maintainer's home market, rule classifiers are already strong here, easiest to A/B against.
+- **France:** non-Anglo, non-trivial grammar (particles `de la`/`du`/`des`, CEDEX postal routing, arrondissement notation), official open data (BAN) that's first-class, and uses Latin script so we don't yet need to solve tokenizer vocabulary problems.
+
+If the architecture handles FR cleanly, it will handle DE/IT/ES/PT trivially.
+
+## Why Japan as the validation milestone
+
+Japanese addressing is structurally different from Western addressing: no streets, nested blocks (chōme/banchi/go), written right-to-fine-grained. If the schema, classifier interface, and policy system survive JP without core refactor, the architecture is sound. If they don't, we learn it in Phase 6 and not in production five years from now.
+
+## The bitter lesson, applied to address parsing
+
+The project's design intent originated in Richard Sutton's "Bitter Lesson" essay. The thesis applied here: rule-based classifiers + Cartesian solvers approximate a human's address-parsing intuition with hand-crafted machinery; given sufficient corpus, a language model approximates that intuition directly — and outperforms — without the scaffolding.
+
+The canonical short-form, from the operator's "Paris, Texas" talk (PeerTube: `peertube.openstreetmap.fr` video `e776d210-f857-4df2-83a7-4414fd52f6f2`, slide 19):
+
+> A geocoder is a **contextual parser + constraint solver**. Not a tokenizer. Not a dumb database lookup.
+
+The neural model is the contextual-parser part. The constraint solver still has a role — it weighs which hierarchy interpretation is consistent (see the Arc-de-Triomphe disambiguation in slides 12→13 of that talk). The "dumb database lookup" pattern is what's being deprecated.
+
+The current `ExclusiveCartesianSolver` inherited from Pelias is what slide 17 calls "Sparkling Bogosort":
+
+> "It's only 'Cartesian permutation' if your gazetteer comes from France. Otherwise it's just 'Sparkling Bogosort'."
+
+France's BAN gives enough constraint that the permutation reduces to a small set; everywhere else it's randomly trying combinations and squinting at which one looks valid. The `PolicyRegistry` (see `reference/INTERFACES.md`) is the mechanism by which this gets phased out, component-by-component — the Ship-of-Theseus migration referenced above.
+
+### Adversarial / kryptonite cases the corpus must include
+
+Slide 14 of the talk's "programming noir" debug list, plus operator additions:
+
+- `Buffalo Health Clinic Buffalo, New York` — venue name overlaps with locality token
+- `New York, New York Steakhouse, Las Vegas, Nevada` — venue contains a place-shaped sub-string, then a real address follows
+- `Paris Texas` vs `Paris, Texas` vs `Paris, France` — punctuation + context disambiguates
+- `St. Petersburg, Russia` — `St.` is "Saint" not "Street"
+- `P'tit St. Denis' Street Café` — apostrophe-contracted French (`P'tit` for `Petit`) layered onto the St./Saint/Street ambiguity
+- `Saint-Denis` vs `Saint Denis` vs `St. Denis` — same place, three orthographies; the model must learn the alternation, not pick a canonical and reject the rest
+
+These are not noise. They are the inputs a model must learn to handle, and the inputs a rule parser cannot. The corpus pipeline that produces training data must include them — generated alongside their correct labels (compositional synthesis), not relied on the alignment layer to discover them after the fact.
+
+## Success metric: graceful failure
+
+From slide 20 of the same talk:
+
+> People just want what their local post office expects. And, that means failing gracefully.
+
+This is the deliberate counterpoint to F1-maximization. The mail carrier squinting at bad handwriting and figuring it out anyway — that is the target behavior. A wrong answer that at least looks plausible and routes to a recoverable next step is preferable to wrong-with-high-confidence.
+
+### The confidence-as-trap pattern
+
+A core operating principle for everyone making decisions about confidence thresholds, scoring tweaks, or post-hoc adjustments in the parser:
+
+Historically the confidence levels and various phrase constraints, confidence boosts, and demerits in rule-classifier-era geocoders are all part of a greater problem. As one builds more and more exceptions and adjustments to a domain-specific machine, one occludes the true nature of how addresses actually work. And worse, one's mental confidence in how accurately the domain has been mapped reinforces the belief — not with a platonic ideal of well-formed addresses, and not even of the platonic ideal of what a badly formatted address might look like, but with only the addresses which the system happens to struggle with the most. At the beginning, luck is in one's favor and meaningful exceptions surface naturally. But each bug report of a badly parsed address entrenches the system deeper. And if one then tries a new way of parsing, regressions are guaranteed — meaning even more machinery is required.
+
+The principle that inverts this trap, and that should be quoted verbatim wherever this section is referenced:
+
+> _We want the opposite: every additional address should give us confidence in the **possibilities**, not the **constraints**._
+
+### Operational implications
+
+- **Phase 2 training metrics** must capture confidence calibration and graceful-degradation rate, not just per-component F1. A model that scores well on F1 while reporting overconfident wrong answers on ambiguous inputs fails the success metric.
+- **`ClassifierPolicy.confidence_threshold` tuning posture**: pick values that prefer "no answer + ask" over "wrong with high confidence." Never tune against specific user-reported failures — that's the entrenchment cycle starting.
+- **Bug-triage process**: when a parser bug is reported, add a **training row**, not a rule or a confidence demerit. The bug report becomes a corpus entry; the model learns from the example without anyone touching the parser machinery. If a bug surfaces a missing schema tag, that's a Phase 0 revisit (see `reference/SCHEMA.md`), not a confidence patch.
+- **Golden eval set** must include intentionally-ambiguous addresses where the *correct* answer is "partial parse + low-confidence flag" — not just the unambiguous cases.
+- **No `confidence_boost` / `confidence_demerit` layer** in the synthesis pipeline or downstream of the model. That's the rule-era machinery the bitter lesson rejects. The model's softmax probability is the confidence; calibration is a training-time concern.
+
+## What this project is not
+
+- Not a geocoder. Resolution to coordinates is Phase 4, separate concern.
+- Not a libpostal replacement for everyone. C-language users have libpostal; we're targeting the TypeScript/Node ecosystem.
+- Not a research project. We are shipping a library. Novel architectures lose to slightly-tuned standard architectures shipped reliably.
+- Not multilingual on day one. The cost of premature internationalization is corpus chaos and slow training. Two locales is the right scope.

--- a/docs/plan/reference/INTERFACES.md
+++ b/docs/plan/reference/INTERFACES.md
@@ -1,0 +1,334 @@
+# Interface Reference
+
+Every boundary in the system has an explicit TypeScript contract. Stick to these. If you need to extend, extend; do not silently widen.
+
+## Core types
+
+### `Span`
+
+Existing in Mailwoman. Documented here for completeness.
+
+```ts
+interface Span {
+	body: string // the text of this span
+	start: number // character offset (inclusive) in original input
+	end: number // character offset (exclusive) in original input
+	// ... (existing Mailwoman fields)
+}
+```
+
+### `Section` (existing) and `Word` / `Phrase` (existing)
+
+Refer to existing Mailwoman code in `core/`. Do not redefine in `neural/`.
+
+### `ComponentTag` and `BioLabel`
+
+See `reference/SCHEMA.md`.
+
+## Classifier interface
+
+### `ClassificationProposal`
+
+```ts
+// packages/core/src/types/classifier.ts
+
+export interface ClassificationProposal {
+	/** The span this proposal applies to. */
+	span: Span
+
+	/** Which component type the classifier thinks this span is. */
+	component: ComponentTag
+
+	/** Classifier's confidence, 0..1. Rule classifiers may use heuristic values. */
+	confidence: number
+
+	/** Where this proposal came from. */
+	source: "rule" | "neural" | "merged"
+
+	/**
+	 * Identifier of the specific classifier instance. Rule: 'house_number', 'postcode',
+	 * 'whos_on_first', etc. Neural: 'neural-v0.3.1-en-us', 'neural-v0.3.1-fr-fr', etc. Merged: a
+	 * synthetic ID like 'merged-rule+neural-v0.3.1' (rare; mostly for telemetry).
+	 */
+	source_id: string
+
+	/** Solver penalty for this proposal. Higher = less likely to appear in winning solution. */
+	penalty: number
+
+	/** Optional opaque metadata for debugging and telemetry. Never used by solver. */
+	metadata?: Record<string, unknown>
+}
+```
+
+### `Classifier` base interface
+
+```ts
+// packages/core/src/classifier.ts
+
+export interface Classifier {
+	/** Unique identifier. Used in source_id of emitted proposals. */
+	readonly id: string
+
+	/**
+	 * Which components this classifier may emit. Enforced — proposals for other components are
+	 * dropped with a warning.
+	 */
+	readonly emits: ReadonlyArray<ComponentTag>
+
+	/** Which locales this classifier is active for. Use `'*'` for locale-agnostic. */
+	readonly locales: ReadonlyArray<string | "*">
+
+	/**
+	 * Classify a section. Returns proposals for any spans within the section that this classifier
+	 * recognizes.
+	 */
+	classify(section: Section, context: ClassifierContext): Promise<ClassificationProposal[]>
+}
+
+export interface ClassifierContext {
+	/** Locale for this classification request, if known. */
+	locale?: string
+
+	/** Other classifier results so far (for composite classifiers). */
+	prior?: ClassificationProposal[]
+
+	/** Cancellation signal. */
+	signal?: AbortSignal
+}
+```
+
+### Adapting existing rule classifiers
+
+Existing rule classifiers produce ad-hoc shapes. They must be wrapped:
+
+```ts
+// packages/classifiers/src/adapter.ts
+
+export function wrapLegacyClassifier(legacy: LegacyClassifier): Classifier {
+	return {
+		id: legacy.name,
+		emits: legacy.componentTags,
+		locales: legacy.locales ?? ["*"],
+		async classify(section, context) {
+			const raw = await legacy.run(section)
+			return raw.map((r) => ({
+				span: r.span,
+				component: r.tag,
+				confidence: r.confidence ?? 1.0,
+				source: "rule" as const,
+				source_id: legacy.name,
+				penalty: r.penalty ?? 0,
+			}))
+		},
+	}
+}
+```
+
+Goal: a one-pass refactor wraps every existing rule classifier without changing rule logic.
+
+## Policy interface
+
+### `ClassifierPolicy`
+
+```ts
+// packages/core/src/policy.ts
+
+export type PolicyMode = "rule_only" | "neural_only" | "both" | "neural_preferred" | "rule_preferred"
+
+export interface ClassifierPolicy {
+	component: ComponentTag
+	mode: PolicyMode
+
+	/**
+	 * Minimum confidence for a proposal to be retained. Applied before solver, after classifier
+	 * emission.
+	 */
+	confidence_threshold?: number
+
+	/** Optional locale scope. If absent, applies to all locales. */
+	locale?: string
+}
+
+export interface PolicyRegistry {
+	/** Look up the policy for a (component, locale) pair. */
+	lookup(component: ComponentTag, locale?: string): ClassifierPolicy
+
+	/** Apply policy to a flat list of proposals. */
+	apply(proposals: ClassificationProposal[], locale?: string): ClassificationProposal[]
+}
+```
+
+Default policy table is in `packages/core/src/policy-defaults.ts`. Initial state: every component is `rule_only`. Migrations to other modes happen via explicit commits with accompanying metric evidence.
+
+## Locale interface
+
+### `LocaleProfile`
+
+```ts
+// packages/core/src/locale.ts
+
+export interface LocaleProfile {
+	/** IETF BCP-47 locale tag. */
+	locale: string
+
+	/** Npm package providing ONNX weights and tokenizer. */
+	weightsPackage?: string
+
+	/** Rule classifier IDs active in this locale. */
+	ruleClassifiers: string[]
+
+	/** Components this locale uses. Subset of COMPONENT_TAGS. */
+	componentsSupported: ComponentTag[]
+
+	/** Per-component policy overrides for this locale. */
+	policy: ClassifierPolicy[]
+}
+
+export interface LocaleRegistry {
+	register(profile: LocaleProfile): void
+	get(locale: string): LocaleProfile | undefined
+	list(): LocaleProfile[]
+}
+```
+
+## Neural classifier interface
+
+### `NeuralSequenceClassifier`
+
+```ts
+// packages/neural/src/sequence-classifier.ts
+
+export interface NeuralSequenceClassifierOptions {
+	/** Npm package with the ONNX model and tokenizer. */
+	weightsPackage: string
+
+	/** Locale this instance serves. */
+	locale: string
+
+	/** Components this model is allowed to emit. Defaults to model's training schema. */
+	components?: ComponentTag[]
+
+	/** Minimum per-token confidence before emitting a proposal. */
+	minConfidence?: number
+
+	/** Whether to warm up the model on construction. Default true. */
+	warmup?: boolean
+}
+
+export class NeuralSequenceClassifier implements Classifier {
+	readonly id: string
+	readonly emits: ReadonlyArray<ComponentTag>
+	readonly locales: ReadonlyArray<string>
+
+	constructor(opts: NeuralSequenceClassifierOptions)
+
+	classify(section: Section, context: ClassifierContext): Promise<ClassificationProposal[]>
+
+	/** Returns model metadata: version, training corpus, eval scores. */
+	modelCard(): ModelCard
+}
+
+export interface ModelCard {
+	version: string // 'v0.3.1'
+	locale: string
+	trainedOn: string // corpus version, e.g. 'corpus-v0.2.0'
+	exportedAt: string // ISO timestamp
+	evalScores: Record<ComponentTag, { f1: number; precision: number; recall: number }>
+	knownLimitations: string[]
+}
+```
+
+## Corpus interface
+
+### Canonical row
+
+```ts
+// packages/corpus/src/types.ts
+
+export interface CanonicalRow {
+	/** The full, rendered address as a user would type it. */
+	raw: string
+
+	/** Component name → text. Each component appears at most once unless it's intersections. */
+	components: Partial<Record<ComponentTag, string | string[]>>
+
+	/** ISO 3166-1 alpha-2 country code. */
+	country: string
+
+	/** BCP-47 locale of the rendered string. */
+	locale: string
+
+	/** Identifier of the upstream source ('osm', 'wof', 'ban', etc.). */
+	source: string
+
+	/** Stable identifier within that source (OSM node id, WOF id, etc.). */
+	source_id: string
+
+	/** Synthesis metadata, if this row was augmented from a base row. */
+	synth?: {
+		method: string // 'case_perturb', 'abbreviate', 'typo_inject'
+		base_source_id: string // points back to the unaugmented row
+	}
+
+	/** Licensing tag. Used by downstream filters. */
+	license: string // 'odbl', 'cc-by', 'public-domain', 'fair-use'
+}
+```
+
+### Adapter interface
+
+```ts
+// packages/corpus/src/adapter.ts
+
+export interface CorpusAdapter {
+	readonly id: string
+	readonly defaultLicense: string
+
+	/** Stream rows. Adapter handles file I/O, parsing, normalization. */
+	iterate(opts: AdapterOptions): AsyncIterable<CanonicalRow>
+}
+
+export interface AdapterOptions {
+	/** Path or URL to input data. Adapter-specific. */
+	input: string
+
+	/** Optional country filter — emit only rows from this country. */
+	country?: string
+
+	/** Optional row limit, for development. */
+	limit?: number
+}
+```
+
+### Labeled row (post-alignment)
+
+```ts
+// packages/corpus/src/labeled.ts
+
+export interface LabeledRow {
+	raw: string
+	tokens: string[] // SentencePiece tokens
+	labels: BioLabel[] // same length as tokens
+	country: string
+	locale: string
+	source: string
+	source_id: string
+	corpus_version: string
+	license: string
+}
+```
+
+## Why these specific shapes
+
+- `ClassificationProposal` mirrors Mailwoman's existing output shape with the addition of `source` and `source_id`. Backward compat for downstream consumers.
+- `Classifier.locales` and `Classifier.emits` are arrays known at construction time. Allows the solver to skip locale-incompatible classifiers entirely without running them.
+- `CanonicalRow.components` is `Partial<Record<…>>` because most rows lack most components. Coarse rows have only country/region/locality. Don't force `null` fills.
+- `LabeledRow.tokens` is the SentencePiece output, not raw words. This is the model's native input. Tokenization happens once, in the corpus stage, not at training time. Determinism.
+- Every row carries `license` so downstream consumers can filter for redistribution-safe data.
+
+## Forbidden patterns
+
+- ❌ Adding fields to `ClassificationProposal` without updating every wrapping adapter in the same commit.
+- ❌ Using `any` in interface definitions. If you don't know the type, write the type. If you can't, the abstraction is wrong.
+- ❌ Throwing exceptions from `Classifier.classify`. Return empty array on failure, log via the project's logger.
+- ❌ Synchronous classifier interfaces. Everything is `Promise`, even rule classifiers, because the solver's loop is async and we don't want sync/async ambiguity.

--- a/docs/plan/reference/OPERATIONS.md
+++ b/docs/plan/reference/OPERATIONS.md
@@ -1,0 +1,229 @@
+# Operations
+
+## Working norms
+
+You are an autonomous agent. Optimize for **legibility to a human checking in once a day**, not for clever one-shot completions.
+
+### Pacing
+
+- Work in small, complete units. A "unit" is anything that ends with a green test suite or a working command.
+- Commit at every unit boundary. Better too many commits than too few.
+- Do not start Phase N+1 until Phase N's success criteria checklist is fully green and committed.
+
+### Decision discipline
+
+When you hit a fork in the road:
+
+1. If the plan answers it: follow the plan.
+2. If the plan is silent and the decision is **reversible** (file naming, test structure, internal variable names): pick the most conventional option and move on.
+3. If the plan is silent and the decision is **hard to reverse** (public API surface, schema change, npm package name, license commitment, data format): write the decision and the alternatives to `DECISIONS.md` and pick the most conservative option (the one that preserves the most future options).
+4. Never block waiting for input. If a decision feels truly blocking, write it to `DECISIONS.md` under a `## BLOCKED` heading and continue with adjacent work.
+
+### Commit messages
+
+Format:
+
+```
+<phase>: <terse imperative>
+
+<optional body: rationale, what changed, what didn't>
+
+Refs: <plan file paths if relevant>
+```
+
+Example:
+
+```
+phase-0: wrap legacy classifiers in ClassificationProposal adapter
+
+All existing rule classifiers now route through wrapLegacyClassifier.
+Output shape is identical to pre-refactor for SDK consumers.
+Solver code untouched.
+
+Refs: reference/INTERFACES.md, phases/PHASE_0_foundation.md §3
+```
+
+### Branching
+
+- Work on a branch named `neural/phase-N-<slug>` per phase.
+- Squash-merge to `main` at phase completion.
+- Tag `main` at each phase completion: `neural-phase-N-complete`.
+
+## Progress reporting
+
+### `LOG.md`
+
+Append-only, one line per meaningful event. Format:
+
+```
+YYYY-MM-DD HH:MM | phase-N | <what was done> | <next>
+```
+
+Examples:
+
+```
+2026-05-16 14:30 | phase-0 | added ComponentTag union, BIO_LABELS derivation, 47 unit tests passing | wrap rule classifiers
+2026-05-16 16:05 | phase-0 | wrapped 12 rule classifiers via adapter, zero behavior change | ClassifierPolicy registry
+2026-05-17 09:12 | phase-1 | OSM PBF adapter streams 100k rows in 38s, memory steady at 220MB | WOF admin adapter
+```
+
+Keep it terse. The radio-console format.
+
+### `DECISIONS.md`
+
+Decisions that affect future code. One entry per decision. Format:
+
+```
+## YYYY-MM-DD — <decision title>
+
+**Context:** what was being done
+
+**Options considered:**
+1. <option> — pros, cons
+2. <option> — pros, cons
+
+**Chosen:** <option>
+
+**Rationale:** <one paragraph>
+
+**Reversibility:** <reversible | costly | irreversible>
+```
+
+### `BLOCKERS.md`
+
+Only created if you have a genuine blocker. One entry per blocker.
+
+```
+## YYYY-MM-DD — <blocker title>
+
+**What's blocked:** <task>
+**Why:** <reason>
+**What you tried:** <attempts>
+**What would unblock:** <answer needed / resource needed / decision needed>
+```
+
+Always continue with adjacent work while a blocker is open. Do not idle.
+
+## Code quality
+
+### Tests
+
+- Unit tests for every classifier (rule and neural alike).
+- Integration tests for every adapter against a small fixture in `corpus/fixtures/`.
+- Golden-set tests for the full pipeline. Regression here blocks merge.
+- Use Vitest (already in Mailwoman).
+
+### Types
+
+- Strict TypeScript. `strict: true` in every package.
+- No `any`. Use `unknown` and narrow.
+- Public API exports must have explicit type annotations.
+
+### Linting and formatting
+
+- ESLint (already in Mailwoman). Run on every commit.
+- Prettier (already in Mailwoman). Run on every commit.
+- Add a pre-commit hook via Husky (already present) if not already enforced.
+
+### Performance budgets
+
+| Path                                  | Budget     |
+| ------------------------------------- | ---------- |
+| Rule-only classify, single address    | < 5ms p95  |
+| Neural classify, single address, CPU  | < 20ms p95 |
+| Neural classify, single address, GPU  | < 5ms p95  |
+| Cold model load                       | < 2s       |
+| Tokenizer parity check, 10k addresses | < 30s      |
+
+If a change blows a budget, profile before optimizing. Add a microbenchmark to `bench/` so the regression doesn't return.
+
+## Dependencies
+
+Adding a dependency requires:
+
+1. Justification in the commit message (why this, why not X, why not a few lines of code).
+2. License check — must be MIT, Apache-2.0, BSD, or ISC. AGPL-compatible licenses fine for the package itself (Mailwoman is AGPL) but verify case-by-case.
+3. Size check — flag in commit if it adds > 1MB to bundled output.
+4. Stewardship check — verify the dep is actively maintained (commit in last 12 months, > 1 maintainer or > 100 stars).
+
+Approved dependencies for this project:
+
+- `onnxruntime-node` — ONNX inference
+- `@bloomberg/sentencepiece-wasm` (or equivalent) — SentencePiece tokenization in JS. Verify and pick.
+- `@dsnp/parquetjs` — Parquet read/write in TS
+- `osm-pbf-parser-node` (or equivalent) — OSM PBF streaming. Verify and pick.
+- `better-sqlite3` — for WOF SQLite reads
+- `fast-csv` — CSV parsing for government data
+- `fastest-levenshtein` — alignment fuzzy matching
+- Existing Mailwoman deps — all retained
+
+## Data handling
+
+### Storage layout in the home lab
+
+```
+/data/
+  corpus/
+    sources/           # raw downloads, never modified
+      osm/
+      wof/
+      ban/
+      openaddresses/
+      usgov/
+    intermediate/      # adapter outputs before alignment
+    aligned/           # post-alignment Parquet shards
+    versioned/         # frozen corpus versions, e.g. corpus-v0.1.0/
+  models/
+    checkpoints/       # PyTorch training checkpoints
+    onnx/              # exported ONNX models
+    quantized/         # int8 quantized models
+  eval/
+    golden/            # hand-labeled golden set, locked, versioned
+    splits/            # train/val/test split manifests
+```
+
+### Versioning
+
+- Corpus versions: `corpus-v<major>.<minor>.<patch>`. Major = schema change. Minor = source added. Patch = synthesis tweak.
+- Model versions: `model-v<major>.<minor>.<patch>-<locale>`. Same scheme.
+- Both versions appear in `ModelCard.trainedOn` and `LabeledRow.corpus_version` so any prediction is traceable to its training data.
+
+### What never goes in git
+
+- Raw source data (too large, redistribution risk for some sources)
+- Trained model checkpoints over 100MB (use Git LFS or external storage)
+- Anything containing PII
+
+What goes in git:
+
+- All code
+- Corpus manifests (file lists + checksums, not the files)
+- Eval splits (lists of source IDs in each split)
+- The hand-labeled golden set (small, human-verified)
+- Adapter fixtures (small, hand-crafted, license-clean)
+
+## Communication with the human
+
+The human checks in periodically. They will read:
+
+1. `LOG.md` first
+2. `DECISIONS.md` if `LOG.md` references a decision
+3. `BLOCKERS.md` if you have one open
+4. The actual code only if something looks off in the logs
+
+Write logs assuming the reader hasn't seen the code yet. "Wrapped 12 rule classifiers" is fine. "Refactored the thing" is not.
+
+When the human asks a question, answer in the radio-console format (see user preferences they've set). Lead with `→`. No greetings.
+
+## When you finish a phase
+
+1. Run the full test suite. Green.
+2. Run benchmarks. Within budget.
+3. Update `LOG.md` with phase-complete entry.
+4. Squash-merge the phase branch to `main`.
+5. Tag `main`: `git tag neural-phase-N-complete && git push --tags`.
+6. Open `phases/PHASE_<N+1>_*.md` and begin.
+
+## When you finish all phases
+
+Do not "polish" indefinitely. Write a final entry in `LOG.md` saying phase 6 is complete, run one final test pass, push, and stop. The human will pick it up from there.

--- a/docs/plan/reference/SCHEMA.md
+++ b/docs/plan/reference/SCHEMA.md
@@ -1,0 +1,153 @@
+# Component Schema
+
+This document defines the canonical `ComponentTag` union. It is the single source of truth.
+
+**Rule:** any change to this file requires:
+
+1. A written rationale in the commit message.
+2. A migration plan for existing corpus rows tagged with the old schema.
+3. A check that downstream alignment, training, and inference code is updated in the same commit.
+
+## Tag inventory
+
+### Universal (Phase 1, all locales)
+
+| Tag                  | Description                                             | Example                         |
+| -------------------- | ------------------------------------------------------- | ------------------------------- |
+| `country`            | Sovereign state name or code                            | `USA`, `France`, `FR`           |
+| `region`             | First-level admin (state, région)                       | `OR`, `Île-de-France`           |
+| `locality`           | City, town, commune                                     | `Portland`, `Paris`             |
+| `dependent_locality` | Sub-locality (neighborhood, arrondissement, ward)       | `Brooklyn`, `8e arrondissement` |
+| `postcode`           | Postal code                                             | `97215`, `75008`                |
+| `subregion`          | Optional county-level admin between region and locality | `Multnomah County`              |
+
+### Street-level (Phase 2)
+
+| Tag                      | Description                                    | Example                            |
+| ------------------------ | ---------------------------------------------- | ---------------------------------- |
+| `house_number`           | Building number on a street                    | `6220`, `12bis`                    |
+| `street`                 | Street name proper                             | `Salmon St`, `République`          |
+| `street_prefix`          | Directional or descriptive prefix (Anglophone) | `SE`, `North`                      |
+| `street_prefix_particle` | Non-English grammatical particle (FR)          | `de la`, `du`, `des`               |
+| `street_suffix`          | Street type suffix (Anglophone)                | `Street`, `Boulevard`, `Ave`       |
+| `intersection_a`         | First street of an intersection query          | `5th Ave` (in "5th Ave & 42nd St") |
+| `intersection_b`         | Second street of an intersection query         | `42nd St` (in "5th Ave & 42nd St") |
+| `unit`                   | Apartment, suite, floor                        | `Apt 4B`, `Suite 200`, `5e étage`  |
+
+### Venue-level (Phase 3)
+
+| Tag         | Description                            | Example                           |
+| ----------- | -------------------------------------- | --------------------------------- |
+| `venue`     | Named place (business, landmark, park) | `Mt Tabor Park`, `Eiffel Tower`   |
+| `attention` | "Attention" or "care of" line          | `c/o Jane Doe`, `Att: Sales Dept` |
+| `po_box`    | Post office box                        | `PO Box 1234`, `BP 42`            |
+
+### Locale-specific
+
+| Tag     | Locale | Description                        | Example                              |
+| ------- | ------ | ---------------------------------- | ------------------------------------ |
+| `cedex` | FR     | Special postal routing designation | `CEDEX 08` in `75008 PARIS CEDEX 08` |
+
+### JP-specific (Phase 6 — listed for forward compatibility, not used in Phase 1–3)
+
+| Tag               | Description                         | Example                |
+| ----------------- | ----------------------------------- | ---------------------- |
+| `prefecture`      | JP first-level admin (都道府県)     | `東京都`, `Tokyo`      |
+| `municipality`    | JP city/ward (市区町村)             | `千代田区`, `Chiyoda`  |
+| `district`        | JP district (大字)                  | `丸の内`, `Marunouchi` |
+| `block`           | JP chōme (丁目)                     | `1丁目`                |
+| `sub_block`       | JP banchi (番地)                    | `1番地`                |
+| `building_number` | JP gō (号)                          | `1号`                  |
+| `building_name`   | JP named building (often in romaji) | `Tokyo Building`       |
+
+**Note for JP-forward-compatibility:** the JP-specific tags above must not be referenced anywhere in core code in Phases 0–5. They exist in this document so that schema additions in Phase 6 do not require a core rewrite. The `componentsSupported` field on `LocaleProfile` is how the system knows which tags a locale actually uses.
+
+## BIO labeling
+
+For training and inference, each tag `T` becomes two labels:
+
+- `B-T` — beginning of a span tagged `T`
+- `I-T` — inside (continuation) of a span tagged `T`
+
+Plus one universal label:
+
+- `O` — outside any address component (punctuation, noise, junk)
+
+Example labeling of `"6220 SE Salmon St, Portland OR"`:
+
+```
+Token    Label
+─────    ─────
+6220     B-house_number
+SE       B-street_prefix
+Salmon   B-street
+St       I-street
+,        O
+Portland B-locality
+OR       B-region
+```
+
+## Implementation notes
+
+### TypeScript representation
+
+```ts
+// packages/core/src/types/component.ts
+
+export const COMPONENT_TAGS = [
+	// Universal
+	"country",
+	"region",
+	"locality",
+	"dependent_locality",
+	"postcode",
+	"subregion",
+	// Street-level
+	"house_number",
+	"street",
+	"street_prefix",
+	"street_prefix_particle",
+	"street_suffix",
+	"intersection_a",
+	"intersection_b",
+	"unit",
+	// Venue-level
+	"venue",
+	"attention",
+	"po_box",
+	// FR-specific
+	"cedex",
+	// JP-specific (Phase 6 — declared but unused until then)
+	"prefecture",
+	"municipality",
+	"district",
+	"block",
+	"sub_block",
+	"building_number",
+	"building_name",
+] as const
+
+export type ComponentTag = (typeof COMPONENT_TAGS)[number]
+
+export const BIO_LABELS = ["O", ...COMPONENT_TAGS.flatMap((t) => [`B-${t}`, `I-${t}`])] as const
+
+export type BioLabel = (typeof BIO_LABELS)[number]
+```
+
+The `as const` and derived types are deliberate. TypeScript will surface schema-aware errors at compile time wherever a tag is referenced.
+
+### Validation rule
+
+A `LocaleProfile.componentsSupported` array must be a subset of `COMPONENT_TAGS`. Runtime check at profile registration. Fail loudly if violated.
+
+## Rationale for specific choices
+
+**Why `dependent_locality` and not `neighborhood` or `borough`?** WOF and ISO use `dependent_locality` for the general concept. Names like `borough` are locale-specific. Pick the umbrella term.
+
+**Why split `street_prefix` from `street_prefix_particle`?** English `SE` and French `de la` are grammatically different and synthesis pipelines need to treat them differently. Conflating them produces worse training data.
+
+**Why expose `subregion` if it's optional?** Some US addresses include county (rare in display but common in government data). Modeling it explicitly is better than forcing it into `region` or `locality`.
+
+**Why `cedex` is FR-specific and not subsumed by `postcode`?** A CEDEX designation is a postal routing instruction, not a postcode. Treating it as one corrupts FR postal code statistics.
+
+**Why list JP tags here at all before Phase 6?** Forces Phase 0 type design to handle them. If core code reaches Phase 6 and needs to add seven new tags plus rewrite the policy system, the schema-first principle failed.

--- a/docs/plan/reference/address-data-sources.md
+++ b/docs/plan/reference/address-data-sources.md
@@ -1,0 +1,1324 @@
+# Address Data Sources for NER Training
+
+Catalog of public-domain and openly-licensed data sources containing facility names + addresses, intended as raw material for training a token-classification (BIO-tagging) postal address parser. Companion to federal/aggregator sources (OpenAddresses, OSM, NAD, TIGER, NPI, IRS BMF, etc.) — this list focuses on **state-level** sources that add component-level variety, residential coverage, and venue-name-paired records the federal sources lack.
+
+Compiled with web-search verification of canonical agency URLs. Some per-state entries in the Regulated Facilities section are based on known agency patterns rather than direct URL verification — those are noted inline.
+
+## Why state sources matter for an address NER model
+
+1. **Component supervision is automatic.** State directories are typically already field-structured (separate columns for street, city, postcode, etc.). BIO tags derive from which column each token came from — no manual labeling required.
+2. **Format diversity per-state.** 50 states + DC means 50+ schema flavors, abbreviation conventions, and transcription styles. Excellent for training format robustness.
+3. **Venue+address pairs are everywhere.** Every facility/professional/establishment listing pairs an organization name with a structured address — natural `B-venue` / `I-venue` training spans.
+4. **Residential coverage.** Real estate, contractor, cosmetology, notary, and license-lookup tools surface actual home/office addresses that federal facility datasets don't.
+
+## Formats to watch for beyond CSV
+
+Many state agencies distribute address data in geospatial formats. The DBF attribute table inside a shapefile is essentially a CSV with geometry attached — extract with `ogr2ogr -f CSV` and the records are training-ready. Common formats:
+
+- **Shapefile** (.shp/.dbf/.shx/.prj) — most common state GIS distribution
+- **GeoJSON** — increasingly standard on ArcGIS Hub portals
+- **GeoPackage** (.gpkg) — modern SQLite-based, multi-layer
+- **File Geodatabase** (.gdb) — ESRI native, common from state GIS offices
+- **KML / KMZ** — Google Earth, sometimes used for facility points
+- **FlatGeobuf** — emerging streaming format (used by OpenAddresses)
+
+The highest-value geospatial layers for address NER:
+
+- **Site address points / E911 / NG911 address points** — every addressable location as a point with full component breakdown (housenumber, prefix, street, suffix, unit, city, ZIP, parcel ID). Published by counties and increasingly by states via ArcGIS Hub. The strongest single layer type for component-supervised training.
+- **Parcel polygons with situs + owner addresses** — two addresses per record (property situs + owner mailing), often diverging structurally (P.O. boxes for owners, street addresses for situs). State-aggregated in MA, NC, MN, UT, MT, VT, RI, and a handful of others.
+- **Road centerlines with address ranges** — state-current analogue to TIGER; each segment has from/to house numbers per side.
+- **Critical infrastructure / facilities layers** — state equivalents of HIFLD covering hospitals, schools, fire/police, jails, courts, public buildings. Each is a `B-venue` + address pair.
+- **EPA/state-DEP regulated sites** — Superfund, brownfields, RCRA, NPDES, leaking USTs as shapefile/GeoJSON.
+- **NCES, NREL AFDC, FCC ASR/ULS** — federal but distributed as shapefile in addition to CSV.
+
+Most state ArcGIS Hubs publish data under CC-BY or equivalent open terms; check per-dataset.
+
+## Licensing reality
+
+State records aren't "public domain" in the IP sense, but factual data (name + address) isn't copyrightable under *Feist v. Rural Telephone*. A few caveats:
+
+- **Washington OSPI school directory**: state law forbids commercial use of directory data.
+- **OSM (ODbL)**: share-alike obligations may extend to models trained on it — unsettled, but a risk if the corpus is republished.
+- **CC-BY state ArcGIS Hub data**: attribution required if redistributing the corpus.
+- **G-NAF, CC-BY-4.0**: clean for AU coverage.
+
+For maximum licensing safety on published model weights, restrict to US-federal sources (NCES, NAD, TIGER, NPPES, IRS BMF) + state sources confirmed as public records with no use restrictions. Lose coverage, gain unambiguous redistribution rights.
+
+---
+
+## Education
+
+### Federal aggregators
+- **NCES Common Core of Data (CCD) — Public School & District Universe** — https://nces.ed.gov/ccd/ccddata.asp — Bulk CSV/SAS downloads of every public school + district in the US with address. Default CCD home: https://nces.ed.gov/ccd/ — public-use, no restriction.
+- **NCES CCD Public School Name & Address File** — https://nces.ed.gov/ccd/psadd.asp — Direct CSV address files, grouped by state. Public domain.
+- **NCES Private School Universe Survey (PSS)** — https://nces.ed.gov/surveys/pss/ — Biennial directory of private schools (not bundled into CCD).
+
+### State school directories
+
+- **Alabama** — ALSDE Education Directory — https://eddir.alsde.edu/siteinfo/ — Queryable directory of registered public/charter schools. Also annual "Directory of Alabama Public Schools" PDF at https://www.alabamaachieves.org/.
+- **Alaska** — DEED Online Directory / Alaskan Schools — https://education.alaska.gov/alaskan_schools — Queryable directory; bulk PDF list at https://education.alaska.gov/alaskan_schools/public/DistrictandSchoolIDs.pdf.
+- **Arizona** — AZ Dept of Education Public Data Sets — https://www.azed.gov/data/public-data-sets — Bulk downloads of public school/district data; report cards at https://azreportcards.azed.gov/.
+- **Arkansas** — ADE Data Center School List — https://adedata.arkansas.gov/statewide/ReportList/State/SchoolList.aspx — Searchable + exportable directory. NCES ID directory at https://adedata.arkansas.gov/nid.
+- **California** — CDE Public Schools & Districts Downloadable Files — https://www.cde.ca.gov/ds/si/ds/pubschls.asp — Excel + tab-delimited bulk download of all active/pending/closed/merged public schools+districts. California School Directory UI: https://www.cde.ca.gov/schooldirectory/.
+- **Colorado** — CDE Education Directories — https://www.cde.state.co.us/cdegen/educationdirectory — Directory portal with downloadable files; SchoolView at https://www.cde.state.co.us/schoolview.
+- **Connecticut** — EdSight Public Portal — https://public-edsight.ct.gov/ — Find Schools tool: https://public-edsight.ct.gov/overview/find-schools. Directory is populated from the Directory Manager system; export available.
+- **Delaware** — DE DOE Directory — https://directory.doe.k12.de.us/ — Queryable. Public School List: https://education.delaware.gov/families/k12/general-information/public-school-list/. Also Delaware Open Data: https://data.delaware.gov/w/p3ez-si4g/989r-3cju (downloadable).
+- **District of Columbia** — OSSE SLED LEA/School Directory — https://sled.osse.dc.gov/vPage/SchoolDirectory/298/91189 — Annually updated directory of all DC LEAs + schools (DCPS + public charter). Exportable from grid.
+- **Florida** — FLDOE Master School ID (MSID) — https://eds.fldoe.org/EDS/MasterSchoolID/ — Queryable per-school; addresses, administration, accountability sections. NWRDC bulk file requires district access.
+- **Georgia** — GOSA Downloadable Data Repository — https://download.gosa.ga.gov/ — Bulk district/school spreadsheet downloads. GaDOE Facilities DB UI: https://app3.doe.k12.ga.us/ows-bin/owa/main_pack_fcl099.entry_form.
+- **Hawaii** — Hawaii DOE School List (Excel) — https://www.hawaiipublicschools.org/DOE%20Forms/SchoolList.xlsx — Direct XLSX bulk download maintained by HIDOE. UI: https://hawaiipublicschools.org/enrolling-in-school/find-your-school/.
+- **Idaho** — Idaho SDE Schools / Districts — https://www.sde.idaho.gov/school-districts/ — Alphabetical district list. No clearly published single bulk download from SDE; consider NCES CCD for bulk.
+- **Illinois** — ISBE Entity Profile System (EPS) — https://www.isbe.net/Pages/Entity-Profile-System.aspx — Bulk Excel workbook of all entity records updated nightly; public. Lookup UI: http://webprod1.isbe.net/isbedir/default.aspx.
+- **Indiana** — IDOE Data Center & Reports — https://www.in.gov/doe/it/data-center-and-reports/ — Downloadable datasets. ESRI shapefile of schools available via state GIS at https://maps.indiana.edu/previewMaps/Infrastructure/Schools_IDOE.html.
+- **Iowa** — Iowa DOE Directories — https://educate.iowa.gov/directories — Annual XLSX directories: public district, public building, nonpublic building.
+- **Kansas** — KSDE Educational Directory — https://www.ksde.gov/Home/Quick-Links/Directories/Kansas-Educational-Directory — Online directory; customized PDF/Excel reports at https://uapps.ksde.org/Directory_Rpts/Default.aspx (raw-data downloads available).
+- **Kentucky** — Open House District & School Directory — https://openhouse.education.ky.gov/Home/Index — Searchable; Principals & Schools export at https://openhouse.education.ky.gov/Principals. SDCI: https://applications.education.ky.gov/sdci/.
+- **Louisiana** — LDOE School Finder — https://louisianaschools.com/ — Search UI; bulk-download links limited. Sponsor Site System background: https://leads13.doe.louisiana.gov/lug/SPS/SPS.htm. Investigate https://doe.louisiana.gov/ data library for SPS exports.
+- **Maine** — Maine DOE — https://www.maine.gov/doe/ — Site has printable directories; no obvious bulk download. Investigate manually for current XLSX/CSV.
+- **Maryland** — MSDE Directory — https://marylandpublicschools.org/about/pages/directory.aspx — Online directory; bulk download not obviously published from MSDE. Maryland State Archives list by county: https://msa.maryland.gov/msa/mdmanual/01glance/html/edschools.html.
+- **Massachusetts** — DESE School & District Profiles — https://profiles.doe.mass.edu/ — Directory + exportable data reports. DESE dataset directory at https://www.mass.gov/info-details/dese-directory-of-datasets-and-reports. MassGIS schools dataset: https://www.mass.gov/info-details/massgis-data-massachusetts-schools-pre-k-through-high-school.
+- **Michigan** — CEPI Educational Entity Master (EEM) — https://cepi.state.mi.us/eem/ — Public bulk datasets at https://cepi.state.mi.us/eem/publicdatasets.aspx. Customized list/export available.
+- **Minnesota** — MDE Districts, Schools & Educators — https://education.mn.gov/MDE/DSE/MDE074620 — Site Verification system at https://education.mn.gov/MDE/dse/datasub/SiteVerif/. MARSS Appendix A lists all districts.
+- **Mississippi** — MDE District Directory — https://www.mdek12.org/dd/ — District-level contact info. School-level data downloads via https://newreports.mdek12.org/.
+- **Missouri** — DESE School Directory Data Downloads — https://dese.mo.gov/school-directory/data-downloads — District + building directory files refreshed weekly, multiple formats.
+- **Montana** — OPI Montana Schools Directory — https://opi.mt.gov/Leadership/Management-Operations/Montana-Schools-Directory — Directory page with help link; downloadable directory available.
+- **Nebraska** — NDE Education Directory — https://www.education.ne.gov/dataservices/education-directory/ — NDE Directory Search (query + lists/data files): https://educdirsrc.education.ne.gov/. Printed directory discontinued.
+- **Nevada** — NDE Schools and Districts — https://doe.nv.gov/Schools_Districts/ — Schools/Districts landing. Resource page: https://doe.nv.gov/school-and-district-information/resources. Bulk download not obviously published; query CCD or NDE directly.
+- **New Hampshire** — NH DOE Bureau of Education Statistics — https://www.education.nh.gov/who-we-are/division-of-educator-and-analytic-resources/bureau-of-education-statistics/schools-and-sau-information — Public, chartered, non-public school directories.
+- **New Jersey** — NJ School Directory — https://homeroom6.doe.state.nj.us/directory/ — Public + nonpublic directory. Data portal: https://www.nj.gov/education/doedata/.
+- **New Mexico** — NMPED Public Schools Directory — https://web.ped.nm.gov/new-mexico-public-schools-directory/ — Downloadable CSV opens in Excel/Sheets.
+- **New York** — NYSED SEDREF Public Reports — https://www.p12.nysed.gov/irs/schoolDirectory/ — Downloadable Excel/XLS reports of public, nonpublic, charter, BOCES, state-operated schools/districts. Landing: https://www.nysed.gov/content/directory-public-and-non-public-schools-and-administrators-new-york-state.
+- **North Carolina** — NC DPI Education Directory (EDDIE) — https://ncpublicschools.org/nceddirectory — Districts, schools, charters, special/federal, postsecondary with addresses + downloads.
+- **North Dakota** — NDDPI Districts/Schools — https://www.nd.gov/dpi/districtsschools — LEA/School directory MIS01/MIS02 framework. Bulk download not obviously linked from main page; investigate STARS reports.
+- **Ohio** — Ohio Educational Directory System (OEDS) — https://education.ohio.gov/Topics/Data/Ohio-Educational-Directory-System-OEDS — Public org search + DataExtract at https://oeds.ode.state.oh.us/dataextract — Excel exports.
+- **Oklahoma** — OSDE State School Directory — https://oklahoma.gov/education/resources/state-school-directory.html — Excel/text/CSV bulk download by district or site. Also Open Data sets: https://data.ok.gov/dataset/oklahoma-public-school-site-directory.
+- **Oregon** — ODE Institution Identification — https://www.oregon.gov/ode/schools-and-districts/pages/institution-identification-school-names.aspx — CSV download of public schools. Institution Lookup with daily-extract Excel: https://www.ode.state.or.us/instid/.
+- **Pennsylvania** — PDE Education Names & Addresses (EdNA) — http://www.edna.pa.gov/ — Search + Excel export of all entities (districts, schools, IUs, CTCs, charters, nonpublics, private, higher-ed).
+- **Rhode Island** — RIDE School Directory — https://ride.ri.gov/students-families/ri-public-schools/school-directory — Directory Reports as PDF or Excel.
+- **South Carolina** — SCDE School Directory — https://ed.sc.gov/districts-schools/schools/school-directory/ — Public school + private school listing (XLSX for privates). District info: https://ed.sc.gov/districts-schools/schools/school-directory/district-information/.
+- **South Dakota** — SD DOE Educational Directory — https://doe.sd.gov/ofm/edudir.aspx — Principal & School Info Excel list + Superintendent/Admin/District address list.
+- **Tennessee** — TN School Directory — https://tnschooldirectory.tnedu.gov/ — Excel download of all schools, districts, regions. Advanced search: https://tnschooldirectory.tnedu.gov/Advanced-Search/.
+- **Texas** — TEA AskTED — https://tealprod.tea.state.tx.us/tea.askted.web/Forms/Home.aspx — School/district directory; HTML/CSV/PDF reports through Reports & Directories menu. PDF Texas School Directory annually.
+- **Utah** — USBE Utah Schools / District Directory — https://schools.utah.gov/schooldistricts — Districts list. Data/Directories landing: https://schools.utah.gov/parent/dataschoollookupeducatorlookupcalendars. Single bulk CSV not obviously linked; investigate manually.
+- **Vermont** — VT AOE Directories — https://education.vermont.gov/documents/directory-principals-by-school — Principals-by-school spreadsheet; independent schools PDF at https://education.vermont.gov/documents/independent-schools-directory; Vermont Education Dashboard Organizations: https://education.vermont.gov/data-and-reporting/vermont-education-dashboard/organizations.
+- **Virginia** — VDOE Virginia School Directories — https://www.doe.virginia.gov/about-vdoe/virginia-school-directories — Listings by division + region; staff listings by division.
+- **Washington** — OSPI Education Directory — https://eds.ospi.k12.wa.us/DirectoryEDS.aspx — School list: https://eds.ospi.k12.wa.us/schoollist.aspx. Note: Washington state law forbids commercial use of directory data.
+- **West Virginia** — WV School Directory — https://wvde.state.wv.us/ed_directory/ — Comma-delimited bulk address download available from the directory.
+- **Wisconsin** — DPI School Directory Public Portal — https://dpi.wi.gov/schooldirectory/public — Searchable; WISEdash files (statewide) at https://dpi.wi.gov/wisedash/download-files. Note: profile pages themselves are not exportable.
+- **Wyoming** — Wyoming DOE Online Directory — https://portals.edu.wyoming.gov/wyedpro/Pages/OnlineDirectory/OnlineDirectoryIndex.aspx — Online directory; annual PDF directory at https://edu.wyoming.gov/downloads/wde-resources/directory.pdf.
+
+## Libraries
+
+### Federal aggregator
+- **IMLS Public Libraries Survey (PLS)** — https://www.imls.gov/research-evaluation/surveys/public-libraries-survey-pls — Annual national bulk dataset (CSV/SAS/SPSS) of every administrative-entity public library AND every outlet (branch), with addresses. Public-use, no restriction. Catalog mirror: https://catalog.data.gov/dataset/public-library-survey-pls-2022. Open Data: https://data.imls.gov/.
+
+### State public library directories
+
+- **Alabama** — APLS Find My Library — https://aplsws2.apls.state.al.us/find-my-library — Directory lookup + Library Listing PDF on APLS site.
+- **Alaska** — Alaska State Library — https://library.alaska.gov/ — State library home (no published bulk public-library directory file from APK obvious in search); rely on IMLS PLS for AK outlet addresses.
+- **Arizona** — AZ State Library Directory — https://azlibrary.gov/services/library-directory — Library directory portal of the AZ State Library, Archives & Public Records.
+- **Arkansas** — AR State Library Directory — https://library.arkansas.gov/services/arkansas-public-library-data/library-directory/ — Comprehensive public library directory grouped by city/county/system.
+- **California** — CA State Library Public Library Directories — https://www.library.ca.gov/services/to-libraries/library-directory/ — Headquarters Directory + Branch Directory (Excel files).
+- **Colorado** — Library Research Service (LRS) — https://www.lrs.org/ — LRS publishes CO public library statistics + directory (https://www.lrs.org/public/data/). CDE Public Libraries: https://www.cde.state.co.us/cdelib/publiclibraries.
+- **Connecticut** — CT State Library — https://portal.ct.gov/csl — CT Public Libraries Directory PDF published by Division of Library Development; help guide at https://libguides.ctstatelibrary.org/dld/help.
+- **Delaware** — Delaware Libraries (Consortium Libraries List) — https://lib.de.us/list-of-libraries/ — Official statewide public-library list. State agency: https://libraries.delaware.gov/.
+- **District of Columbia** — DC Public Library (sole district public library system) — https://www.dclibrary.org/ — Branches list. Also Open Data DC GIS dataset: https://opendata.dc.gov/datasets/DCGIS::libraries/about (downloadable shapefile/CSV).
+- **Florida** — DOS Division of Library & Information Services Public Library Homepages — https://dos.fl.gov/library-archives/research/florida-information/libraries/public-library-homepages/ — Lists FL public library systems + branches; interactive map. Use IMLS PLS for bulk outlet addresses.
+- **Georgia** — GPLS Public Libraries Directory — https://georgialibraries.org/public-libraries-directory/ — 61 systems / 385 branches.
+- **Hawaii** — HSPLS All Branches — https://www.librarieshawaii.org/visit/branches/all-branches/ — All 51 branches statewide. State GIS layer: https://files.hawaii.gov/dbedt/op/gis/data/state_libraries.pdf.
+- **Idaho** — Idaho Commission for Libraries Directory — https://libraries.idaho.gov/idaho-library-directory/ — Filterable directory of all libraries; Public Library subset: https://libraries.idaho.gov/idaho-library-directory/categories/public-library/.
+- **Illinois** — IL State Library — https://www.ilsos.gov/departments/library.html — Library Systems page: https://www.ilsos.gov/departments/library/libraries/libsystems.html. Use L2 directory or IMLS PLS for bulk address data.
+- **Indiana** — Indiana State Library Public Library Directory — https://www.in.gov/library/directory-of-indiana-libraries/pldirectory/ — Directory + city-indexed PDF at https://www.in.gov/library/files/cityindex.pdf.
+- **Iowa** — State Library of Iowa Library Directory — https://statelibraryofiowa.gov/resources/iowa-library-directory — Searchable directory with filtering by county/population/district.
+- **Kansas** — Kansas State Library Directories — https://www.kslc.org/555/Directories — Printable PDF directory of KS public libraries (7 regional systems).
+- **Kentucky** — KDLA Kentucky Public Library Directory — https://kdla.ky.gov/Library-Support/Pages/Public-Library-Directory.aspx — Standards + statistics adjacent: https://kdla.ky.gov/Library-Support/plssd/Pages/default.aspx.
+- **Louisiana** — State Library of Louisiana Library Directory — https://library.la.gov/services/for-libraries-librarians/library-directory/ — Mirror: https://www.state.lib.la.us/public-libraries/library-directory.
+- **Maine** — Maine State Library Public Library Directory — https://www.maine.gov/msl/libs/directories/public.shtml — 250+ libraries searchable by town/library/director/county. By town: https://www.maine.gov/msl/mainelibs/pubtown.shtml.
+- **Maryland** — Maryland State Library Resource Center Directory — https://www.slrc.info/library-directory — Contact info for all MD public-library staff; links to library websites. State agency: https://msla.maryland.gov/.
+- **Massachusetts** — MBLC Library Directory — https://mblc.state.ma.us/directories/libraries/index.php — Searchable directory; printable PDF at https://mblc.state.ma.us/directories/libraries/ldap_printable.pdf.
+- **Michigan** — Library of Michigan — https://www.michigan.gov/libraryofmichigan — State library agency. Statewide Library Finder: https://milibraryfinder.org/. Annual "Michigan Public Library Directory & Statistics" issued historically; use IMLS PLS for bulk.
+- **Minnesota** — MDE State Library Services — https://mn.gov/library/sls.html — State library agency. CALCO directory PDF: https://mn.gov/library/PDF/directory.pdf. Multitype/cooperative info via MNLINK: https://mnlink.org/about/libraries.
+- **Mississippi** — Mississippi Library Commission Public Library Directory — https://www.mlc.lib.ms.us/mississippi-libraries-directory/mississippi-public-library-directory/ — Public library directory page; broader libraries directory at https://www.mlc.lib.ms.us/mississippi-libraries-directory/.
+- **Missouri** — MO Secretary of State Library Directory (MOLLI) — https://s1.sos.mo.gov/library/LibraryDirectory — Searchable directory of public, academic, school, special.
+- **Montana** — Montana State Library ASPeN Directory — https://msl.mt.gov/libraries/Montana-Library-Network — ASPeN is the MSL library directory; landing: https://msl.mt.gov/libraries/.
+- **Nebraska** — Nebraska Library Commission Directory — http://www.nlc.nebraska.gov/libraries/libdir/ — Directors + staff of all NE public/academic/school/special/institutional. Public-only list: https://nlc.nebraska.gov/libraries/list.asp?libtype=PL.
+- **Nevada** — NV State Library Find-a-Library — https://nsla.nv.gov/find-a-library-directory — Directory hosted by Nevada State Library, Archives and Public Records.
+- **New Hampshire** — NH Library Directory — https://directory.nhlibraries.org/ — Self-submitted statewide directory. State agency page: https://www.nhsl.dncr.nh.gov/services/library-directory.
+- **New Jersey** — NJ State Library Public Libraries Directory — https://www.njstatelib.org/services_for_libraries/library-development/new-jersey-public-libraries-directory/ — Organized by county.
+- **New Mexico** — NM State Library Directory — https://stlib.state.nm.us/directory/index.php?id=1154 — NM Library Directory; agency landing https://nmstatelibrary.org/.
+- **New York** — NYSL Find Your Public Library — https://www.nysl.nysed.gov/find-your-public-library — Searchable directory of public libraries statewide. PLS index: https://www.nysl.nysed.gov/libdev/pls.
+- **North Carolina** — State Library of NC Library Directory — https://statelibrary.ncdcr.gov/library-directory — Public + academic library directory (mirror: https://library.nc.gov/nc-libraries/library-directory).
+- **North Dakota** — ND State Library Public Libraries — https://www.library.nd.gov/ndpubliclibraries — Includes downloadable Public Library Directory PDF: https://www.library.nd.gov/sites/www/files/documents/publications/publiclibrarydirectory.pdf.
+- **Ohio** — Ohio Public Library Directory (Ohio Library Council; the de facto OH directory) — https://members.olc.org/ohio-public-library-directory/FindStartsWith?term=B — State agency landing: https://library.ohio.gov/. OPLIN find-a-library: https://www.oplin.org/fal/.
+- **Oklahoma** — OK Department of Libraries Public Library Locator — https://oklahoma.gov/libraries/oklahomans/public-library-locator.html — Map UI. PDF directory: https://oklahoma.gov/content/dam/ok/en/libraries/documents/OK-Public-Libraries-Directory.pdf. Open Data: https://data.ok.gov/dataset/oklahoma-public-library-directory.
+- **Oregon** — State Library of Oregon Library Directory — http://libdir.osl.state.or.us/ — Public/academic/special/tribal/volunteer libraries, updated quarterly. Open Data mirror: https://catalog.data.gov/dataset/oregon-library-directory.
+- **Pennsylvania** — PA Office of Commonwealth Libraries Public Library Directory — https://pa.countingopinions.com/fdir.php — Live directory; agency page: https://www.pa.gov/agencies/statelibrary/librarydirectory.
+- **Rhode Island** — RI OLIS Public Libraries Directory — https://olis.ri.gov/directory/libraries/public — All 48 RI public library systems. Broader directory: https://olis.ri.gov/directory/index.php.
+- **South Carolina** — SC State Library Public Libraries — https://www.statelibrary.sc.gov/south-carolinians/south-carolina-public-libraries — Directory of county/regional public library systems.
+- **South Dakota** — SD State Library Libraries Directory — https://library.sd.gov/LIB/DIR/ — Public, school, academic, special.
+- **Tennessee** — TSLA Public Library Directory — https://tnsos.net/TSLA/PLD/index.php — Searchable by county/region/city.
+- **Texas** — TSLAC Library Development & Networking — https://www.tsl.texas.gov/ldn — TSLAC houses accreditation, directory & statistics. Use IMLS PLS for bulk Texas public library addresses.
+- **Utah** — Utah State Library Division Directory — https://library.utah.gov/directory/ — Bookmobiles, public, tribal, special; supports CSV export. Public-only: https://library.utah.gov/directory/categories/public/.
+- **Vermont** — VT Department of Libraries Public Library Directory — https://libraries.vermont.gov/sites/libraries/files/documents/PublicLibraryDirectory.pdf — Quarterly-updated PDF directory. Landing: https://libraries.vermont.gov/find-vermont-libraries. Reporting portal: https://vtlibreports.vermont.gov/.
+- **Virginia** — Library of Virginia Public Library Directory — https://www.lva.virginia.gov/services/public-libraries/directory — Headquarters mailing list + lookup by county/city.
+- **Washington** — WA State Library Directory of Washington Libraries — https://www.directory.walibraries.org/ — Maintained by WA State Library (Office of Secretary of State) with IMLS funding.
+- **West Virginia** — WV Library Commission Library Directory — https://librarycommission.wv.gov/library_map/Pages/LibraryDirectory.aspx — Statewide directory with addresses + phone numbers.
+- **Wisconsin** — WI DPI Public Libraries — https://dpi.wi.gov/libraries/public-libraries — Public Library and Public Library System directory; addresses downloadable from DPI directory page.
+- **Wyoming** — Wyoming State Library Directory — https://library.wyo.gov/community/directory/ — All library types; public branches filter: https://library.wyo.gov/community/directory/single-category/public-branch/.
+
+---
+
+## Licensed professionals
+
+State-level public databases of licensed professionals (with practice/office addresses) suitable as training data for a postal address parsing NER model. All URLs verified via web search. Most state license-lookup tools are query-only (search-by-name/number); the NPPES NPI Registry and several state portals offer bulk CSV exports.
+
+### Federal / multi-state
+
+- **NPPES NPI Registry** (CMS, all US healthcare providers w/ practice addresses) — https://npiregistry.cms.hhs.gov/ — query-only UI + REST API
+- **NPPES NPI Downloadable Files** (full monthly + weekly increments, >4 GB CSV) — https://download.cms.gov/nppes/NPI_Files.html — bulk download (best single source)
+- **NMLS Consumer Access** (mortgage loan originators, multi-state, CSBS) — https://www.nmlsconsumeraccess.org/ — query-only
+- **DocInfo / FSMB** (physician profiles, sourced from state boards) — https://www.docinfo.org/ — query-only
+- **FSMB Physician Data Center (PDC)** (data files available for purchase) — https://www.fsmb.org/PDC/pdc-data-files/ — bulk (paid)
+- **Nursys** (NCSBN, multi-state RN/LPN verification) — https://www.nursys.com/ — query-only
+- **AIM DocFinder** (multi-state physician metadata aggregator) — http://docfinder.docboard.org/ — query-only
+- **ARELLO** (multi-state real estate licensee directory) — https://www.arello.com/ — query-only
+
+### State unified license portals
+(Some states route many professions through a single search; per-profession entries below reference these where applicable.)
+
+- **California DCA License Search** — covers medical, nursing, real estate (separate ADRE), 150+ DCA professions — https://search.dca.ca.gov/
+- **Florida DBPR License Search** — covers real estate, contractors, many trades (health professions are separate at FL DOH MQA) — https://www.myfloridalicense.com/wl11.asp?mode=2&search=Name
+- **Florida DOH MQA Search** — covers physicians, nurses, all health pros — https://mqa-internet.doh.state.fl.us/MQASearchServices/HealthCareProviders
+- **Utah DOPL License Lookup Verification** — covers medical, nursing, real estate (separate Division of RE), contractors — https://secure.utah.gov/llv/search/index.html
+- **Virginia DPOR License Lookup** — covers real estate, contractors, and many occupations (medical/nursing handled by VA DHP) — https://www.dpor.virginia.gov/LicenseLookup
+- **Virginia DHP License Lookup** — covers physicians, nurses, all health — https://dhp.virginiainteractive.org/Lookup
+- **Michigan LARA / MiPLUS** — covers medical, nursing, real estate, residential builders, and 26 health pros — https://www.michigan.gov/lara/i-need-to/find-or-verify-a-licensed-professional-or-business and https://val.apps.lara.state.mi.us/
+- **Alaska CBPL Professional License Search** — covers medical, nursing, real estate, contractors — https://www.commerce.alaska.gov/cbp/main/search/professional
+- **Hawaii DCCA PVL Search** — covers medical, nursing, real estate, contractors (52 professions) — https://mypvl.dcca.hawaii.gov/public-license-search/
+- **Idaho DOPL License Search** — covers medical, nursing, real estate, public-works contractors — https://dopl.idaho.gov/license-search/
+- **Illinois IDFPR License Lookup** — covers medical, nursing, real estate, contractors — https://online-dfpr.micropact.com/lookup/licenselookup.aspx
+- **Indiana PLA License & Verification** — covers medical, nursing, real estate (no statewide contractor license) — https://secure.in.gov/apps/pla/search
+- **Iowa DIAL (Dept. of Inspections, Appeals & Licensing)** — covers medical, nursing, real estate, contractors — https://dial.iowa.gov/i-need/records
+- **Kansas License Verification Portal** — covers many professions — https://prolicenseverify.ks.gov/
+- **Maine PFR Licensee Search** — covers medical, real estate, residential contractors (nursing is separate at Maine BON) — https://www.maine.gov/pfr/consumer/licensee-search
+- **Maryland DLLR Licensing Queries** — covers real estate, MHIC contractors (medical/nursing separate) — https://labor.maryland.gov/pq/
+- **Massachusetts Check a License** — covers health pros, occupational boards, real estate, HIC contractors — https://www.mass.gov/how-to/check-an-occupational-board-license
+- **Minnesota MN.gov boards portal** — health boards + Commerce (real estate) + DLI (contractors) — multiple sub-portals, see per-profession
+- **Missouri Division of Professional Registration Licensee Search** — covers physicians, nursing, real estate (38 boards) — https://pr.mo.gov/licensee-search.asp
+- **Montana DLI Professional Licensing** — covers medical, nursing, real estate, contractors — https://ebizws.mt.gov/PUBLICPORTAL/home.jsp and https://boards.bsd.dli.mt.gov/_global-pages/additional-license-information/lookup-individual
+- **Nebraska License Search (gov)** — covers medical, nursing — https://www.nebraska.gov/LISSearch/search.cgi
+- **New Hampshire OPLC License Lookup** — covers 54+ boards (medical, nursing, real estate, contractors limited) — https://www.oplc.nh.gov/license-lookup
+- **New Jersey DCA License Verification** — covers ~50 professions including medical, nursing, real estate — https://newjersey.mylicense.com/verification/
+- **New Mexico RLD Public Search** — covers medical, nursing, real estate, contractors (NM-PLUS) — https://nmrldlpi.my.site.com/bcd/s/rld-public-search
+- **Ohio eLicense** — covers Medical Board + many; OCILB + Commerce real estate on separate eLicense subsites — https://elicense.ohio.gov/oh_verifylicense
+- **Oregon (per-board portals; no single unified)** — see per profession
+- **Pennsylvania PALS** — covers ~250 license types, all 29 BPOA boards (medical, nursing, real estate) — https://www.pals.pa.gov/
+- **South Carolina LLR Licensee Lookup** — covers medical, nursing, real estate, contractors, residential builders — https://verify.llronline.com/LicLookup/LookupMain.aspx
+- **Tennessee Verify (Commerce & Insurance / DCI)** — covers real estate, contractors, many; health pros separate at TN DOH — https://verify.tn.gov/
+- **Tennessee DOH Licensure Verification** — physician, nursing — https://apps.health.tn.gov/Licensure/
+- **Vermont OPR "Find a Professional"** — covers medical, nursing, real estate, residential contractors — https://sos.vermont.gov/opr/find-a-professional
+- **Washington DOH Provider Credential Search** — health professions — https://doh.wa.gov/licenses-permits-and-certificates/provider-credential-or-facility-search
+- **Washington DOL Professional License Lookup** — non-health (real estate, etc.) — https://professions.dol.wa.gov/s/license-lookup
+- **Wisconsin DSPS License Search** — covers medical, nursing, real estate, dwelling contractors — https://licensesearch.wi.gov/
+- **Delaware DELPROS** — covers medical, nursing, real estate, contractors — https://delpros.delaware.gov/OH_VerifyLicense
+
+### Per state
+
+#### Alabama
+- Medical: Alabama Board of Medical Examiners — https://www.albme.gov/consumers/licensee-search/ — query-only
+- Nursing: Alabama Board of Nursing — https://abn.alabama.gov/applications/LicenseLookup.aspx — query-only
+- Real estate: Alabama Real Estate Commission (AREC) — https://arec.alabama.gov/apps/LicenseSearch — query-only; bulk list request at https://arec.alabama.gov/apps/listrequest
+- Contractor: Alabama Licensing Board for General Contractors — https://genconbd.alabama.gov/database-sql/roster.aspx — query-only
+
+#### Alaska
+- All four professions use the unified Alaska CBPL Professional License Search: https://www.commerce.alaska.gov/cbp/main/search/professional — query-only
+- Medical: State Medical Board (via CBPL) — https://www.commerce.alaska.gov/web/cbpl/ProfessionalLicensing/StateMedicalBoard/ProfessionalLicenseSearch.aspx
+- Nursing: Board of Nursing (via CBPL) — https://www.commerce.alaska.gov/web/cbpl/ProfessionalLicensing/BoardofNursing/OnlineLicenseVerification
+- Real estate: Real Estate Commission (via CBPL) — https://www.commerce.alaska.gov/web/cbpl/ProfessionalLicensing/RealEstateCommission/ApplicantsLicensees.aspx
+- Contractor: Construction Contractors (via CBPL) — https://www.commerce.alaska.gov/web/cbpl/ProfessionalLicensing/ConstructionContractors
+
+#### Arizona
+- Medical: Arizona Medical Board — https://www.azmd.gov/doctorsearch/doctorsearch — query-only
+- Nursing: Arizona Board of Nursing — https://azbn.gov/licenses-and-certifications/primary-source-verification — query-only
+- Real estate: Arizona Department of Real Estate (ADRE) — https://services.azre.gov/publicdatabase/SearchIndividuals.aspx — query-only
+- Contractor: Arizona Registrar of Contractors (ROC) — https://azroc.my.site.com/AZRoc/s/contractor-search — query-only
+
+#### Arkansas
+- Medical: Arkansas State Medical Board — https://armedicalboard.adh.arkansas.gov/public/verify/default.aspx — query-only
+- Nursing: Arkansas State Board of Nursing — https://arsbn.boardsofnursing.org/licenselookup — query-only
+- Real estate: Arkansas Real Estate Commission — https://labor.arkansas.gov/licensing/real-estate-commission/arec-roster/agent-search/ — query-only
+- Contractor: Arkansas Contractors Licensing Board — http://aclb2.arkansas.gov/clbsearch.php — query-only
+
+#### California
+- Unified DCA portal: https://search.dca.ca.gov/ (medical, nursing covered)
+- Medical: Medical Board of California (via DCA Search) — https://search.dca.ca.gov/ — query-only
+- Nursing: California BRN (via DCA Search) — https://search.dca.ca.gov/ — query-only
+- Real estate: California DRE Public License Lookup — https://www2.dre.ca.gov/PublicASP/pplinfo.asp — query-only
+- Contractor: Contractors State License Board (CSLB) — https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/CheckLicense.aspx — query-only
+
+#### Colorado
+- Medical: Colorado DORA Medical Board (via DORA License Lookup) — https://apps2.colorado.gov/dora/licensing/lookup/licenselookup.aspx — query-only
+- Nursing: Colorado DORA Board of Nursing (same DORA Lookup) — https://apps2.colorado.gov/dora/licensing/lookup/licenselookup.aspx — query-only; also rosters at https://apps2.colorado.gov/dora/licensing/lookup/generateroster.aspx (bulk per board)
+- Real estate: Colorado Division of Real Estate eLicense — https://apps2.colorado.gov/dre/licensing/lookup/licenselookup.aspx — query-only
+- Contractor: Local-only — no state general contractor board (state regulates only certain trades; e.g. electrical/plumbing via DORA)
+
+#### Connecticut
+- Medical: CT eLicense (DPH) — https://www.elicense.ct.gov/Lookup/LicenseLookup.aspx — query-only
+- Nursing: CT eLicense (DPH) — https://www.elicense.ct.gov/Lookup/LicenseLookup.aspx — query-only
+- Real estate: CT eLicense (DCP Real Estate Brokers) — https://www.elicense.ct.gov/Lookup/LicenseLookup.aspx — query-only
+- Contractor: CT Dept. of Consumer Protection eLicense (Home Improvement Contractor) — https://www.elicense.ct.gov/Lookup/LicenseLookup.aspx — query-only
+
+#### Delaware
+- All four via DELPROS — https://delpros.delaware.gov/OH_VerifyLicense — query-only
+- Medical: Delaware Board of Medical Licensure & Discipline (via DELPROS)
+- Nursing: Delaware Board of Nursing (via DELPROS)
+- Real estate: Delaware Real Estate Commission (via DELPROS)
+- Contractor: Local-only at general-contractor level; specialty trades (electrical, plumbing) licensed via DELPROS
+
+#### District of Columbia
+- Medical: DC Health Board of Medicine License Search — https://app.hpla.doh.dc.gov/Weblookupcs/ — query-only
+- Nursing: DC Health Board of Nursing (same DC Health verification portal) — https://app.hpla.doh.dc.gov/Weblookupcs/ — query-only
+- Real estate: DC DLCP OPLA License Search — https://govservices.dcra.dc.gov/oplaportal/Home/GetLicenseSearchDetails — query-only
+- Contractor: DC DLCP OPLA / Construction Contractor licensing — https://govservices.dcra.dc.gov/oplaportal/Home/GetLicenseSearchDetails — query-only
+
+#### Florida
+- Medical: FL DOH MQA Search Portal — https://mqa-internet.doh.state.fl.us/MQASearchServices/HealthCareProviders — query-only
+- Nursing: FL DOH MQA Search Portal — https://mqa-internet.doh.state.fl.us/MQASearchServices/HealthCareProviders — query-only
+- Real estate: Florida DBPR License Search — https://www.myfloridalicense.com/wl11.asp?mode=2&search=Name — query-only
+- Contractor: Florida DBPR (Construction Industry Licensing Board) — https://www.myfloridalicense.com/wl11.asp?mode=2&search=Name — query-only
+
+#### Georgia
+- Medical: Georgia Composite Medical Board — https://gateway.medicalboard.georgia.gov/verification/search.aspx — query-only
+- Nursing: Georgia Board of Nursing (SOS Verification) — https://verify.sos.ga.gov/verification/ — query-only
+- Real estate: Georgia Real Estate Commission — https://ata.grec.state.ga.us/account/search — query-only
+- Contractor: GA State Licensing Board for Residential & General Contractors (SOS Licensing) — https://verify.sos.ga.gov/verification/ — query-only
+
+#### Hawaii
+- All four via Hawaii DCCA PVL Search — https://mypvl.dcca.hawaii.gov/public-license-search/ — query-only; bulk PVL dataset listed at https://opendata.hawaii.gov/dataset/professional-and-vocational-licensing-pvl-search
+- Medical: Hawaii Medical Board (via PVL)
+- Nursing: Hawaii Board of Nursing (via PVL)
+- Real estate: Hawaii Real Estate Commission (via PVL) — also https://cca.hawaii.gov/reb/check-out-a-business-online/
+- Contractor: Hawaii Contractors License Board (via PVL); RICO check at https://cca.hawaii.gov/rico/check/
+
+#### Idaho
+- All four via Idaho DOPL License Search — https://dopl.idaho.gov/license-search/ — query-only
+- Medical: Idaho Board of Medicine — https://dopl.idaho.gov/bom/
+- Nursing: Idaho Board of Nursing — https://dopl.idaho.gov/bon/bon-license-search/
+- Real estate: Idaho Real Estate Commission (via DOPL) — https://dopl.idaho.gov/license-search/
+- Contractor: Public Works Contractor (DOPL); residential contractors registered (limited) — https://dopl.idaho.gov/license-search/
+
+#### Illinois
+- All four via Illinois IDFPR License Lookup — https://online-dfpr.micropact.com/lookup/licenselookup.aspx — query-only
+- Medical: IL Medical Board (via IDFPR)
+- Nursing: IL Board of Nursing (via IDFPR)
+- Real estate: IL Division of Real Estate (via IDFPR)
+- Contractor: Illinois does not have a statewide general contractor license — local-only at GC level; roofing & plumbing licensed via IDFPR
+
+#### Indiana
+- All via Indiana PLA — https://secure.in.gov/apps/pla/search and https://mylicense.in.gov/everification/ — query-only
+- Medical: Indiana Medical Licensing Board (via PLA)
+- Nursing: Indiana State Board of Nursing (via PLA)
+- Real estate: Indiana Real Estate Commission (via PLA)
+- Contractor: Local-only — no state general contractor license (Plumbing Commission licenses plumbers via PLA)
+
+#### Iowa
+- Medical: Iowa Board of Medicine — https://eservices.iowa.gov/PublicPortal/Iowa/IBM/licenseQuery/LicenseQuery.jsp?Profession=Physician — query-only
+- Nursing: Iowa Board of Nursing — https://eservices.iowa.gov/PublicPortal/Iowa/IBON/common/index.jsp — query-only
+- Real estate: Iowa Real Estate Commission (via My Iowa PLB) — https://ia-plb.my.site.com/LicenseSearchPage — query-only
+- Contractor: Iowa Construction Contractor Registration (DIAL) — query at https://dial.iowa.gov/i-need/records ; **bulk CSV: Active Iowa Construction Contractor Registrations** — https://data.iowa.gov/Workforce/Active-Iowa-Construction-Contractor-Registrations/dpf3-iz94
+
+#### Kansas
+- Medical: Kansas Board of Healing Arts — https://www.kansas.gov/ssrv-ksbhada/search.html — query-only
+- Nursing: Kansas State Board of Nursing — https://portal.egov.ksbn.ks.gov/verification/ — query-only
+- Real estate: Kansas Real Estate Commission — https://www.krec.ks.gov/resources/search — query-only
+- Contractor: Local-only — no state contractor license (state regulates only roofers via AG; specialty/trade licensure varies)
+
+#### Kentucky
+- Medical: Kentucky Board of Medical Licensure — https://kbml.ky.gov/physician/Pages/Physician-Profile-Verification-of-Physician-License.aspx — query-only
+- Nursing: Kentucky Board of Nursing — https://kybn.boardsofnursing.org/licenselookup — query-only
+- Real estate: Kentucky Real Estate Commission — https://secure.kentucky.gov/KREC/databasesearch — query-only
+- Contractor: Local-only at GC level; KY Dept. of Housing/Buildings & Construction licenses HVAC/plumbing/electrical separately
+
+#### Louisiana
+- Medical: Louisiana State Board of Medical Examiners — https://online.lasbme.org/#/verifylicense — query-only
+- Nursing: Louisiana State Board of Nursing — https://lsbn.boardsofnursing.org/licenselookup — query-only
+- Real estate: Louisiana Real Estate Commission (LREC) — https://portal.lrec.gov/public/search — query-only
+- Contractor: Louisiana State Licensing Board for Contractors — https://arlspublic.lslbc.louisiana.gov/Public/DetailedSearch/ByName — query-only (multiple search modes)
+
+#### Maine
+- Medical: Maine Board of Licensure in Medicine — https://www.maine.gov/md/licensure/license-verification — query-only
+- Nursing: Maine State Board of Nursing — https://www.maine.gov/boardofnursing/licensing/verifications.html — query-only (search via PFR licensee portal)
+- Real estate: Maine Real Estate Commission (via OPOR/PFR) — https://www.maine.gov/pfr/consumer/licensee-search — query-only; bulk download offered
+- Contractor: Local-only at GC level (no state contractor licensing board); some trades licensed via Maine OPOR
+
+#### Maryland
+- Medical: Maryland Board of Physicians — https://www.mbp.state.md.us/bpqapp/ — query-only
+- Nursing: Maryland Board of Nursing — https://lookup.mbon.org/verification/ — query-only
+- Real estate: Maryland Real Estate Commission (DLLR Public Query) — https://www.dllr.state.md.us/cgi-bin/ElectronicLicensing/OP_search/OP_search.cgi?calling_app=RE%3A%3ARE_qselect — query-only
+- Contractor: Maryland Home Improvement Commission (MHIC) Public Query — https://www.dllr.state.md.us/cgi-bin/ElectronicLicensing/OP_search/OP_search.cgi?calling_app=HIC::HIC_qselect — query-only
+
+#### Massachusetts
+- Medical: Massachusetts Board of Registration in Medicine — findmydoctor: https://findmydoctor.mass.gov/ — query-only
+- Nursing: MA Board of Registration in Nursing — https://madph.mylicense.com/verification/ — query-only
+- Real estate: MA Board of Registration of Real Estate Brokers (via DPL eLicensing) — https://elicensing21.mass.gov/CitizenAccess/GeneralProperty/PropertyLookUp.aspx?isLicensee=Y — query-only
+- Contractor: MA Home Improvement Contractor (OCABR) Search — https://contractorhub.mass.gov/s/hic-contractor-search and https://services.oca.state.ma.us/hic/licenseelist.aspx — query-only; also OPSI Construction Supervisor License search via mass.gov
+
+#### Michigan
+- All four via MiPLUS / LARA — https://val.apps.lara.state.mi.us/ — query-only
+- Medical: MI Board of Medicine (via MiPLUS)
+- Nursing: MI Board of Nursing (via MiPLUS)
+- Real estate: MI Board of Real Estate Brokers & Salespersons (via MiPLUS)
+- Contractor: MI Residential Builders & M&A Contractors (via MiPLUS)
+
+#### Minnesota
+- Medical: Minnesota Board of Medical Practice — https://mn.gov/boards/medical-practice/verify/index.jsp — query-only
+- Nursing: Minnesota Board of Nursing — https://mn.gov/boards/nursing/verify-a-license/index.jsp — query-only
+- Real estate: Minnesota Department of Commerce License Lookup — https://mn.gov/commerce/licensing/license-lookup/ — query-only
+- Contractor: Minnesota DLI License & Registration Lookup (residential contractors/remodelers/roofers) — https://www.dli.mn.gov/license-and-registration-lookup — query-only; **bulk: nightly downloadable spreadsheet of all CCLD licensees**
+
+#### Mississippi
+- Medical: Mississippi State Board of Medical Licensure — https://gateway.msbml.ms.gov/verification/search.aspx — query-only (full DB available for $300)
+- Nursing: Mississippi Board of Nursing — https://gateway.licensure.msbn.ms.gov/Verification/search.aspx — query-only
+- Real estate: Mississippi Real Estate Commission — https://www.mrec2.webapps.ms.gov/publicview/mrecPublicBrokerSearch.aspx?Div=MREC — query-only
+- Contractor: Mississippi State Board of Contractors (MSBOC) — https://www.msboc.us/ (search at search.msboc.us) — query-only
+
+#### Missouri
+- All via MO DPR Licensee Search — https://pr.mo.gov/licensee-search.asp — query-only; **bulk "Downloadable Listings" updated nightly** at https://pr.mo.gov/
+- Medical: Missouri Board of Registration for the Healing Arts (via DPR)
+- Nursing: Missouri State Board of Nursing (via DPR)
+- Real estate: Missouri Real Estate Commission (via DPR)
+- Contractor: Local-only — no state general contractor license
+
+#### Montana
+- All four via Montana DLI Licensee Lookup — https://ebizws.mt.gov/PUBLICPORTAL/home.jsp — query-only; bulk Licensee Mailing Lists at https://boards.bsd.dli.mt.gov/_global-pages/additional-license-information/licensee-mailing-lists
+- Medical: Montana Board of Medical Examiners (via DLI)
+- Nursing: Montana Board of Nursing (via DLI)
+- Real estate: Montana Board of Realty Regulation (via DLI)
+- Contractor: Montana Construction Contractor Registration (via DLI)
+
+#### Nebraska
+- Medical: Nebraska Board of Medicine & Surgery (DHHS) — https://www.nebraska.gov/LISSearch/search.cgi — query-only
+- Nursing: Nebraska Board of Nursing (DHHS) — https://www.nebraska.gov/LISSearch/search.cgi — query-only
+- Real estate: Nebraska Real Estate Commission — https://nrec.igovsolution.net/online/Verification/Individual — query-only
+- Contractor: Nebraska Dept. of Labor Contractor Registration — https://dol.nebraska.gov/conreg/Search — query-only (full database publicly searchable)
+
+#### Nevada
+- Medical: Nevada State Board of Medical Examiners — https://nsbme.mylicense.com/verification/Search.aspx — query-only
+- Nursing: Nevada State Board of Nursing — https://nvbn.boardsofnursing.org/licenselookup — query-only
+- Real estate: Nevada Real Estate Division — https://red.prod.secure.nv.gov/lookup/licenselookup.aspx — query-only
+- Contractor: Nevada State Contractors Board (NSCB) — https://app.nvcontractorsboard.com/Clients/NVSCB/Public/ContractorLicenseSearch/ContractorLicenseSearch.aspx — query-only
+
+#### New Hampshire
+- All four via NH OPLC License Lookup — https://www.oplc.nh.gov/license-lookup — query-only
+- Medical: NH Board of Medicine (via OPLC)
+- Nursing: NH Board of Nursing (via OPLC)
+- Real estate: NH Real Estate Commission (via OPLC)
+- Contractor: Local-only — no state general contractor license (NH licenses some trades, e.g. electricians, via OPLC)
+
+#### New Jersey
+- All major professions via NJ DCA License Verification — https://newjersey.mylicense.com/verification/ — query-only
+- Medical: NJ State Board of Medical Examiners — https://www.njconsumeraffairs.gov/bme/Pages/verification.aspx — query-only
+- Nursing: NJ Board of Nursing (via DCA) — https://newjersey.mylicense.com/verification/
+- Real estate: NJ Real Estate Commission (housed at DOBI) — https://www.nj.gov/dobi/licenseesearch/licsearch.htm — query-only
+- Contractor: NJ Home Improvement Contractor (via DCA Consumer Affairs) — https://newjersey.mylicense.com/verification/ — query-only
+
+#### New Mexico
+- All four via NM RLD Public Search — https://nmrldlpi.my.site.com/bcd/s/rld-public-search — query-only; legacy verification at http://verification.rld.state.nm.us/
+- Medical: New Mexico Medical Board (via RLD)
+- Nursing: New Mexico Board of Nursing (via RLD)
+- Real estate: New Mexico Real Estate Commission (via RLD)
+- Contractor: New Mexico Construction Industries Division (via RLD)
+
+#### New York
+- Medical: NYSED Office of the Professions Online Verification — https://eservices.nysed.gov/professions/verification-search — query-only
+- Nursing: NYSED Office of the Professions (same portal) — https://eservices.nysed.gov/professions/verification-search — query-only
+- Real estate: NYS DOS Division of Licensing Services (eAccessNY public search) — https://appext20.dos.ny.gov/nydos/selSearchType.do — query-only
+- Contractor: Local-only at GC level (e.g. NYC DOB Home Improvement Contractor licensing); no statewide general contractor license
+
+#### North Carolina
+- Medical: North Carolina Medical Board — https://portal.ncmedboard.org/verification/search.aspx — query-only; NCMB Roster (bulk-ish list)
+- Nursing: North Carolina Board of Nursing — https://portal.ncbon.com/licenseverification/search.aspx — query-only
+- Real estate: North Carolina Real Estate Commission — https://license.ncrec.gov/ncrec/oecgi3.exe/O4W_LIC_SEARCH_NEW — query-only
+- Contractor: NC Licensing Board for General Contractors (NCLBGC) — https://portal.nclbgc.org/Public/Search — query-only
+
+#### North Dakota
+- Medical: North Dakota Board of Medicine — https://www.ndbom.org/public/find_verify/verify.asp — query-only
+- Nursing: North Dakota Board of Nursing — https://ndbon.boardsofnursing.org/licenselookup — query-only
+- Real estate: North Dakota Real Estate Commission Licensee Directory — https://services.realestatend.org/directory/ — query-only
+- Contractor: North Dakota Secretary of State (FirstStop) Contractor Search — https://firststop.sos.nd.gov/search/contractor — query-only
+
+#### Ohio
+- Medical: State Medical Board of Ohio (via eLicense) — https://elicense.ohio.gov/oh_verifylicense — query-only
+- Nursing: Ohio Board of Nursing (via eLicense) — https://elicense.ohio.gov/oh_verifylicense — query-only
+- Real estate: Ohio Division of Real Estate & Professional Licensing — https://elicense3.com.ohio.gov/lookup/licenselookup.aspx — query-only (note: site migrated Oct 2025; check https://com.ohio.gov/newsystem)
+- Contractor: Ohio Construction Industry Licensing Board (OCILB) — https://elicense4.com.ohio.gov/lookup/licenselookup.aspx — query-only (trades only; OH has no state GC license)
+
+#### Oklahoma
+- Medical: Oklahoma State Board of Medical Licensure & Supervision — https://www.okmedicalboard.org/search — query-only (separate DO board at https://oklahoma.gov/osboe.html)
+- Nursing: Oklahoma Board of Nursing — https://okbn.boardsofnursing.org/licenselookup — query-only
+- Real estate: Oklahoma Real Estate Commission (OREC) — https://orec.us.thentiacloud.net/webs/orec/ — query-only
+- Contractor: Oklahoma Construction Industries Board (CIB) — https://okcibv7prod.glsuite.us/GLSuiteWeb/Clients/OKCIB/Public/LicenseeSearch/LicenseeSearch.aspx — query-only (trade-only; OK has no state GC license)
+
+#### Oregon
+- Medical: Oregon Medical Board — https://omb.oregon.gov/search — query-only
+- Nursing: Oregon State Board of Nursing — https://osbn.boardsofnursing.org/licenselookup — query-only
+- Real estate: Oregon Real Estate Agency (OREA eLicense) — https://orea.elicense.micropact.com/Lookup/LicenseLookup.aspx — query-only
+- Contractor: Oregon Construction Contractors Board (CCB) — https://search.ccb.state.or.us/search/ — query-only
+
+#### Pennsylvania
+- All medical/nursing/real estate via PALS — https://www.pals.pa.gov/ — query-only
+- Medical: PA State Board of Medicine (via PALS)
+- Nursing: PA State Board of Nursing (via PALS)
+- Real estate: PA Real Estate Commission (via PALS)
+- Contractor: PA Attorney General Home Improvement Contractor Registration — https://hicsearch.attorneygeneral.gov/ — query-only
+
+#### Rhode Island
+- Medical: RI Department of Health (Board of Medical Licensure & Discipline) — https://healthri.mylicense.com/verification/ — query-only
+- Nursing: RI Department of Health (Board of Nurse Registration) — https://healthri.mylicense.com/verification/ — query-only
+- Real estate: RI Department of Business Regulation Real Estate Lookup — https://ridbrprod-search.state-reg-eastern.tylerapp.com/ — query-only
+- Contractor: RI Contractors' Registration & Licensing Board (CRLB) — https://crb.ri.gov/search/contractor-search — query-only
+
+#### South Carolina
+- All four via SC LLR Licensee Lookup — https://verify.llronline.com/LicLookup/LookupMain.aspx — query-only
+- Medical: SC Board of Medical Examiners — https://verify.llronline.com/LicLookup/Med/Med.aspx?div=16
+- Nursing: SC Board of Nursing (via LLR) — https://verify.llronline.com/LicLookup/LookupMain.aspx
+- Real estate: SC Real Estate Commission — https://verify.llronline.com/LicLookup/Rec/Rec.aspx?div=19
+- Contractor: SC Contractor's Licensing Board (commercial) — https://verify.llronline.com/LicLookup/Contractors/Contractor.aspx ; Residential Builders — https://verify.llronline.com/LicLookup/Resbu/Resbu.aspx
+
+#### South Dakota
+- Medical: SD Board of Medical & Osteopathic Examiners (SDBMOE) — https://sdbmoe.gov/ (Licensee Lookup) — query-only
+- Nursing: SD Board of Nursing — https://sdbon.boardsofnursing.org/licenselookup — query-only
+- Real estate: SD Real Estate Commission Licensee List — https://dlr.sd.gov/realestate/license_verification_system.aspx — query-only
+- Contractor: Local-only — no state general contractor license (specialty trades only via DLR boards; contractor excise-tax license via DOR)
+
+#### Tennessee
+- Medical: TN Department of Health Licensure Verification — https://apps.health.tn.gov/Licensure/ — query-only
+- Nursing: TN Department of Health (same portal) — https://apps.health.tn.gov/Licensure/ — query-only
+- Real estate: TN Real Estate Commission (via DCI Verify portal) — https://verify.tn.gov/ — query-only
+- Contractor: TN Board for Licensing Contractors (via DCI Verify portal) — https://verify.tn.gov/ — query-only
+
+#### Texas
+- Medical: Texas Medical Board (LIST) — https://www.tmb.state.tx.us/resources/for-the-public/look-up-a-license and https://list.tmb.state.tx.us/ — query-only
+- Nursing: Texas Board of Nursing — https://www.bon.texas.gov/licensure_verification.asp — query-only
+- Real estate: Texas Real Estate Commission (TREC) — https://www.trec.texas.gov/license-search — query-only; **bulk: TREC High Value Data Sets** — https://www.trec.texas.gov/public/high-value-data-sets
+- Contractor: Texas Department of Licensing & Regulation (TDLR) — https://www.tdlr.texas.gov/LicenseSearch/ — query-only (TX has no state GC license; TDLR covers electricians/HVAC/etc.)
+
+#### Utah
+- All four via Utah DOPL License Lookup Verification — https://secure.utah.gov/llv/search/index.html — query-only
+- Medical: Utah Physician Licensing Board (via DOPL)
+- Nursing: Utah Board of Nursing (via DOPL)
+- Real estate: Utah Division of Real Estate (via DOPL) — separate division but uses DOPL lookup
+- Contractor: Utah Contractors (via DOPL)
+
+#### Vermont
+- All four via VT OPR "Find a Professional" — https://sos.vermont.gov/opr/find-a-professional — query-only
+- Medical: Vermont Board of Medical Practice (via OPR)
+- Nursing: Vermont State Board of Nursing (via OPR)
+- Real estate: Vermont Real Estate Commission (via OPR)
+- Contractor: Vermont Residential Contractor Registration (via OPR) — https://sos.vermont.gov/residential-contractors
+
+#### Virginia
+- Medical: Virginia Department of Health Professions (DHP) License Lookup — https://dhp.virginiainteractive.org/Lookup — query-only
+- Nursing: Virginia DHP (same portal) — https://dhp.virginiainteractive.org/Lookup — query-only
+- Real estate: Virginia DPOR License Lookup — https://www.dpor.virginia.gov/LicenseLookup — query-only
+- Contractor: Virginia DPOR Board for Contractors — https://www.dpor.virginia.gov/LicenseLookup — query-only
+
+#### Washington
+- Medical: Washington DOH Provider Credential Search — https://doh.wa.gov/licenses-permits-and-certificates/provider-credential-or-facility-search — query-only; **bulk: WA Health Care Provider Credential Data on data.wa.gov** — https://data.wa.gov/health/Health-Care-Provider-Credential-Data/qxh8-f4bd
+- Nursing: Washington DOH (same provider credential search) — https://doh.wa.gov/licenses-permits-and-certificates/provider-credential-or-facility-search — query-only + bulk (above)
+- Real estate: Washington DOL Professional License Lookup — https://professions.dol.wa.gov/s/license-lookup — query-only
+- Contractor: Washington L&I Verify a Contractor — https://secure.lni.wa.gov/verify/ — query-only
+
+#### West Virginia
+- Medical: WV Board of Medicine — https://wvbom.wv.gov/public/search/ — query-only (separate WV Board of Osteopathic Medicine at https://www.wvbdosteo.org/verify/)
+- Nursing: WV RN Board — https://wvrn.boardsofnursing.org/licenselookup — query-only (LPN Board separate at https://lpnboard.wv.gov/licensure/Pages/Check-Licensure-Status.aspx)
+- Real estate: WV Real Estate Commission — https://apps.wv.gov/REC/Licensing/Application/LicenseInfoService — query-only
+- Contractor: WV Contractor Licensing Board — https://wvclboard.wv.gov/verify/ — query-only
+
+#### Wisconsin
+- All four via Wisconsin DSPS License Search — https://licensesearch.wi.gov/ — query-only
+- Medical: WI Medical Examining Board (via DSPS)
+- Nursing: WI Board of Nursing (via DSPS)
+- Real estate: WI Real Estate Examining Board (via DSPS)
+- Contractor: WI Dwelling Contractor / trades (via DSPS)
+
+#### Wyoming
+- Medical: Wyoming Board of Medicine — https://wyomedboard.wyo.gov/consumers/license-lookup — query-only
+- Nursing: Wyoming State Board of Nursing — https://wybn.boardsofnursing.org/licenselookup — query-only
+- Real estate: Wyoming Real Estate Commission — https://realestate.wyo.gov/ (public license search) — query-only
+- Contractor: Local-only — no state general contractor license (electricians licensed at state level via State Fire Marshal)
+
+---
+
+## Secretary of State, business, notary, charity, lobbyist
+
+### Notes on scope and quirks
+- Business entity searches: every state offers free name/agent query; only a minority offer bulk downloads (FL, OR partial via open data, LA via paid API, HI by-record paid). DE does not publish principal addresses. NV charges for some access; TX SOSDirect charges $1/search.
+- Notary registries: most states publish searchable directories. NH, TN, WY publish only PDF lists or none. GA notaries are commissioned by county clerks but indexed centrally by GSCCCA.
+- Charity registries: typically AG, but SoS in CO, GA, MD, MS, NC, ND, OK, PA, SC, TN, WA, WV; DBR in RI; DCP in CT; DLCP in DC; VDACS in VA; DPFR in ME; DFI in WI; FDACS in FL; DCP in UT (transitioning to DCCC). DE, ID, MT, SD, WY have no state-level charity registration (only fundraisers in some). AZ repealed charity registration in 2013 (veterans + fundraisers still register).
+- Lobbyist registries: SoS for most; Ethics Commission for AL, GA, HI, KS, MO, OK, SC, TN, TX, WI, WV; Legislature for IA, NE, NV; PIC for DE; APOC for AK; DLS Ethics Council for VA; PDC for WA; OGEC for OR; ELEC for NJ; BEGA for DC; JLEC/OLIG for OH; KLEC for KY; LREC/ILRC for IN; ME Ethics; MA SoC; NH SoS; MD SEC.
+
+### Per state
+
+### Alabama
+- Business entity search: Alabama Secretary of State — https://arc-sos.state.al.us/CGI/CORPNAME.MBR/INPUT — query-only — includes registered agent
+- Notary registry: Alabama Secretary of State — https://arc-sos.state.al.us/CGI/notename.mbr/input — query-only (also county-level browsing)
+- Charity registry: Alabama Attorney General — https://www.alabamaag.gov/licensing-registration/charitable-organizations/ (search: https://ago.igovsolution.net/online/Lookups/Business.aspx) — query-only
+- Lobbyist registry: Alabama Ethics Commission — https://ethics.alabama.gov/lobbyists.aspx — query-only; annual PDF list at https://ethics.alabama.gov/docs/LobbyList/2024LobbyistList.pdf
+
+### Alaska
+- Business entity search: Alaska Division of Corporations, Business and Professional Licensing — https://www.commerce.alaska.gov/cbp/main/search/entities — query-only — registered agent included
+- Notary registry: Office of the Lieutenant Governor — https://aws.state.ak.us/NotaryDirectory/ — query-only
+- Charity registry: Alaska Department of Law — https://www.law.alaska.gov/department/civil/consumer/charities_list.html — list/query
+- Lobbyist registry: Alaska Public Offices Commission (APOC) — https://apoc.doa.alaska.gov/filer-resources/lobbying/ — query-only
+
+### Arizona
+- Business entity search: Arizona Corporation Commission (eCorp) — https://ecorp.azcc.gov/EntitySearch/Index — query-only; database purchase available
+- Notary registry: Arizona Secretary of State — https://apps.azsos.gov/apps/notary/search/default.aspx — query-only (by name/county/zip)
+- Charity registry: AZ repealed charity registration in 2013. Veterans charities only — Arizona Secretary of State — https://azsos.gov/business/other-services/veterans-charities-organizations — query-only
+- Lobbyist registry: Arizona Secretary of State — https://lobbying.az.gov/ — query-only; bulk DB purchasable ($25) at https://azsos.gov/services/database-purchasing
+
+### Arkansas
+- Business entity search: Arkansas Secretary of State — https://bcs.sos.arkansas.gov/search — query-only
+- Notary registry: Arkansas Secretary of State — https://bcs.sos.arkansas.gov/search/notary — query-only
+- Charity registry: Arkansas Secretary of State (oversight by SoS since 2018; AG focuses on enforcement) — https://www.sos.arkansas.gov/business-commercial-services-bcs/nonprofit-charitable-entities/charitable-entities — query-only
+- Lobbyist registry: Arkansas Secretary of State / Ethics — https://ethics-disclosures.sos.arkansas.gov/public/lobbyist/lobbyistdata — query-only
+
+### California
+- Business entity search: California Secretary of State (bizfile Online) — https://bizfileonline.sos.ca.gov/search/business — query-only; includes principal + agent addresses; free PDF copies
+- Notary registry: California Secretary of State — https://www.sos.ca.gov/notary/notary-public-listing — query-only (active commissions)
+- Charity registry: California Attorney General Registry of Charities and Fundraisers — https://rct.doj.ca.gov/Verification/Web/Search.aspx?facility=Y — query-only
+- Lobbyist registry: California Secretary of State (CAL-ACCESS) — https://cal-access.sos.ca.gov/Lobbying/ — query-only; bulk daily data downloads available
+
+### Colorado
+- Business entity search: Colorado Secretary of State — https://www.sos.state.co.us/biz/BusinessEntityCriteriaExt.do — query-only; includes principal and registered agent
+- Notary registry: Colorado Secretary of State — https://www.sos.state.co.us/notary/pages/public/verifyNotary.xhtml — query-only
+- Charity registry: Colorado Secretary of State (Charities and Fundraisers) — https://www.coloradosos.gov/ccsa/pages/search/basic.xhtml — query-only
+- Lobbyist registry: Colorado Secretary of State — https://www.sos.state.co.us/lobby/SearchLobbyist.do — query-only; PDF directories also published
+
+### Connecticut
+- Business entity search: Connecticut Secretary of the State (business.ct.gov; CONCORD legacy) — https://service.ct.gov/business/s/onlinebusinesssearch — query-only
+- Notary registry: Connecticut Secretary of the State (eLicense) — https://www.elicense.ct.gov/Lookup/LicenseLookup.aspx — query-only (select Notary Public)
+- Charity registry: Connecticut Department of Consumer Protection (Public Charities Unit) — https://portal.ct.gov/dcp/charities/public-charities — query-only
+- Lobbyist registry: Connecticut Office of State Ethics — https://www.oseapps.ct.gov/NewLobbyist/security/loginhome.aspx — query-only
+
+### Delaware
+- Business entity search: Delaware Division of Corporations — https://icis.corp.delaware.gov/ecorp/entitysearch/namesearch.aspx — query-only — NOTE: Delaware does NOT publish full principal/officer addresses publicly, only registered agent; detailed status $10–$20/entity
+- Notary registry: Delaware Notary Public (Department of State) — https://notary.delaware.gov/ ; bulk dataset at https://data.delaware.gov/Licenses-and-Certifications/Notaries-Commissioned-in-Delaware/q8dr-mj6p — bulk available
+- Charity registry: Delaware does NOT require general charity registration. No public registry. Private foundations file 990-PF with AG. Investigate manually: https://attorneygeneral.delaware.gov/tag/charities/
+- Lobbyist registry: Delaware Public Integrity Commission (PIRS) — https://pirs.delaware.gov/ — query-only
+
+### District of Columbia
+- Business entity search: DC Department of Licensing and Consumer Protection (CorpOnline) — https://corponline.dlcp.dc.gov/homepage — query-only
+- Notary registry: Office of the Secretary of DC (Office of Notary Commissions and Authentications) — https://os.dc.gov/service/notary-public-search — query-only with map
+- Charity registry: DC Department of Licensing and Consumer Protection (Basic Business License - Charitable Services Business) — https://dlcp.dc.gov/node/1618416 — license search via CorpOnline / MyDC Business Center — query-only
+- Lobbyist registry: DC Board of Ethics and Government Accountability (BEGA) — https://efiler.bega.dc.gov/LRRSearch — query-only
+
+### Florida
+- Business entity search: Florida Department of State, Division of Corporations (Sunbiz) — https://search.sunbiz.org/ — bulk download — Daily & quarterly via SFTP at https://dos.fl.gov/sunbiz/other-services/data-downloads/
+- Notary registry: Florida Department of State, Division of Corporations — https://notaries.dos.fl.gov/not001.html — query-only
+- Charity registry: Florida Department of Agriculture and Consumer Services (Check-A-Charity) — https://csapp.fdacs.gov/CSPublicApp/CheckACharity/CheckACharity.aspx — query-only
+- Lobbyist registry: Florida Lobbyist Registration Office (Joint Legislative/Executive portal) — https://www.floridalobbyist.gov/ — query-only; directories at /LobbyistInformation/RegisteredExecutiveLobbyists and /RegisteredLegislativeLobbyists
+
+### Georgia
+- Business entity search: Georgia Secretary of State (Corporations Division) — https://ecorp.sos.ga.gov/businesssearch — query-only
+- Notary registry: Georgia Superior Court Clerks' Cooperative Authority (GSCCCA) — https://search.gsccca.org/notary/ — query-only (statewide index of county-commissioned notaries)
+- Charity registry: Georgia Secretary of State (Securities & Charities Division) — https://sos.ga.gov/index.php/securities/registered_charities_search — query-only (verify portal: http://verify.sos.ga.gov/Verification)
+- Lobbyist registry: Georgia Government Transparency and Campaign Finance Commission — https://media.ethics.ga.gov/search/lobbyist/lobbyist_byname.aspx — query-only
+
+### Hawaii
+- Business entity search: Hawaii Business Express / BREG (DCCA Business Registration Division) — https://hbe.ehawaii.gov/documents — query-only; bulk lists paid (5¢/record via List Builder)
+- Notary registry: Hawaii Department of the Attorney General — https://notary.ehawaii.gov/notary/public/publicsearch.html — query-only
+- Charity registry: Hawaii Department of the Attorney General (Tax & Charities Division) — https://ag.hawaii.gov/tax/ — query-only (Hawaii Charity Finder)
+- Lobbyist registry: Hawaii State Ethics Commission — https://hawaiiethics.my.site.com/public/s/ — query-only; bulk CSV at data.gov: https://catalog.data.gov/dataset/hawaii-state-ethics-commissions-lobbyist-registration-statements
+
+### Idaho
+- Business entity search: Idaho Secretary of State (SOSBiz) — https://sosbiz.idaho.gov/search/business/ — query-only
+- Notary registry: Idaho Secretary of State (SOSBiz) — https://sosbiz.idaho.gov/search/notary — query-only
+- Charity registry: ID has NO general charity registration requirement. No public registry. Investigate manually. Telephone solicitors register with AG: https://www.ag.idaho.gov/
+- Lobbyist registry: Idaho Secretary of State (Sunshine system) — https://sunshine.voteidaho.gov/lobbyists — query-only
+
+### Illinois
+- Business entity search: Illinois Secretary of State — https://apps.ilsos.gov/businessentitysearch/ — query-only
+- Notary registry: Illinois Secretary of State — https://apps.ilsos.gov/notarysearch/ — query-only
+- Charity registry: Illinois Attorney General (Charitable Trust Bureau) — https://charitable.illinoisattorneygeneral.gov/ — query-only (new portal launched Aug 2025)
+- Lobbyist registry: Illinois Secretary of State — https://apps.ilsos.gov/lobbyistsearch/index.jsp — query-only; bulk download via Illinois Data Portal
+
+### Indiana
+- Business entity search: Indiana Secretary of State (INBiz) — https://bsd.sos.in.gov/publicbusinesssearch — query-only
+- Notary registry: Indiana Secretary of State (INBiz) — https://inbiz.in.gov/certification/notary — query-only
+- Charity registry: Indiana does not register charities themselves; only professional solicitors register with AG — https://www.in.gov/attorneygeneral/consumer-protection-division/charities-and-donors/charitable-fundraising/ — query-only for fundraisers
+- Lobbyist registry: Indiana Lobby Registration Commission (ILRC) — https://www.in.gov/ilrc/ ; lobbying data at https://www.in.gov/ilrc/lobbying-data/ — query-only
+
+### Iowa
+- Business entity search: Iowa Secretary of State (Fast Track Filing) — https://sos.iowa.gov/search/business/search.aspx — query-only
+- Notary registry: Iowa Secretary of State — https://sos.iowa.gov/search/notary/search.aspx — query-only
+- Charity registry: IA has NO general charity registration. Charitable trusts and professional fundraisers register with AG — https://www.iowaattorneygeneral.gov/for-businesses/professional-fundraisers-and-charity-information--registration — query-only
+- Lobbyist registry: Iowa Legislature — https://www.legis.iowa.gov/lobbyist — query-only; executive branch via Iowa Ethics & Campaign Disclosure Board: https://ethics.iowa.gov/ethics/executive-branch-lobbying
+
+### Kansas
+- Business entity search: Kansas Secretary of State — https://www.sos.ks.gov/eforms/BusinessEntity/Search.aspx — query-only
+- Notary registry: Kansas Secretary of State — https://www.sos.ks.gov/general-services/notary_public/notary-search.aspx — query-only
+- Charity registry: Kansas Attorney General — https://www.ag.ks.gov/in-your-corner-kansas/resources/charity-search — query-only
+- Lobbyist registry: Kansas Secretary of State — https://www.sos.ks.gov/elections/lobbyists_directory_search.aspx — query-only
+
+### Kentucky
+- Business entity search: Kentucky Secretary of State — https://sosbes.sos.ky.gov/BusSearchNProfile/search.aspx — query-only
+- Notary registry: Kentucky Secretary of State — https://web.sos.ky.gov/notaries/ — query-only (limited public search)
+- Charity registry: Kentucky Attorney General — https://www.ag.ky.gov/Resources/Consumer-Resources/charity/Pages/registration.aspx — registration program; query-only via 990 archive
+- Lobbyist registry: Kentucky Legislative Ethics Commission (KLEC) — https://apps.klec.ky.gov/ — query-only
+
+### Louisiana
+- Business entity search: Louisiana Secretary of State (CORAWeb) — https://coraweb.sos.la.gov/commercialsearch/commercialsearch.aspx — query-only; paid Commercial API for bulk
+- Notary registry: Louisiana Secretary of State — https://coraweb.sos.la.gov/Notary/NotarySearch.aspx — query-only; bulk download referenced ("Notary Bulk Data")
+- Charity registry: Louisiana Attorney General — https://www.ag.state.la.us/Charities — query-only; only charities using professional solicitors must register
+- Lobbyist registry: Louisiana Ethics Administration / Board of Ethics — https://ethics.la.gov/lobbyistdata/SearchByLobbyist.aspx — query-only
+
+### Maine
+- Business entity search: Maine Secretary of State (ICRS) — https://apps3.web.maine.gov/nei-sos-icrs/ICRS — query-only
+- Notary registry: Maine Secretary of State — https://www.maine.gov/online/notary/search/ — query-only
+- Charity registry: Maine Department of Professional and Financial Regulation (OPOR) — https://www.maine.gov/pfr/professionallicensing/professions/charitable-solicitations-act/licensing/charitable-organizations — query-only
+- Lobbyist registry: Maine Commission on Governmental Ethics and Election Practices — https://www.maine.gov/ethics/lobbyists — query-only
+
+### Maryland
+- Business entity search: Maryland State Department of Assessments and Taxation (SDAT) via Business Express — https://egov.maryland.gov/businessexpress/entitysearch — query-only
+- Notary registry: Maryland Secretary of State (Notary Division) — https://mdsos2.my.site.com/s/search-notary-database — query-only
+- Charity registry: Maryland Secretary of State (Charitable Organizations Division) — https://onestop.md.gov/list_views/62f3e1797f7e3200016a3dab (Charity Public Registry); main page https://sos.maryland.gov/Charity/pages/default.aspx — query-only
+- Lobbyist registry: Maryland State Ethics Commission — https://lobby-ethics.maryland.gov/public_access — query-only
+
+### Massachusetts
+- Business entity search: Massachusetts Secretary of the Commonwealth (Corporations Division) — https://corp.sec.state.ma.us/corpweb/CorpSearch/CorpSearch.aspx — query-only
+- Notary registry: Massachusetts does not publish a public notary search. Contact Public Records Division, Secretary of the Commonwealth — https://www.mass.gov/info-details/find-a-notary-public — Not searchable online; investigate manually
+- Charity registry: Massachusetts Attorney General (Non-Profit Organizations/Public Charities Division) — https://masscharities.my.site.com/FilingSearch/s/ — query-only
+- Lobbyist registry: Massachusetts Secretary of the Commonwealth (Lobbyist Division) — https://www.sec.state.ma.us/lobbyistpublicsearch/ — query-only
+
+### Michigan
+- Business entity search: Michigan LARA Corporations Division (MiBusiness Registry) — https://mibusinessregistry.lara.state.mi.us/search/business — query-only
+- Notary registry: Michigan Secretary of State (Office of the Great Seal) — https://dsvsesvc.sos.state.mi.us/TAP/_/ — query-only
+- Charity registry: Michigan Attorney General (Charitable Trust Section) — https://www.ag.state.mi.us/charitabletrust/frmDisclaimer.aspx — query-only
+- Lobbyist registry: Michigan Secretary of State / Bureau of Elections (MiTN) — https://mi-boe.entellitrak.com/etk-mi-boe-prod/page.request.do?page=page.miboeLobbyPublicSearch — query-only
+
+### Minnesota
+- Business entity search: Minnesota Secretary of State — https://mblsportal.sos.mn.gov/Business/Search — query-only
+- Notary registry: Minnesota Secretary of State — https://notary.sos.mn.gov/ — query-only
+- Charity registry: Minnesota Attorney General — https://www.ag.state.mn.us/Charity/Search/ — query-only
+- Lobbyist registry: Minnesota Campaign Finance and Public Disclosure Board — https://cfb.mn.gov/reports-and-data/viewers/lobbying/lobbyists/ — query-only; current lists at https://cfb.mn.gov/reports-and-data/searches-and-lists/other-reports-and-lists/current-lists/
+
+### Mississippi
+- Business entity search: Mississippi Secretary of State — https://corp.sos.ms.gov/corp/portal/c/page/corpBusinessIdSearch/portal.aspx — query-only
+- Notary registry: Mississippi Secretary of State — https://www.sos.ms.gov/notarysearch/notarysearch.aspx — query-only
+- Charity registry: Mississippi Secretary of State (Charities Division) — https://charities.sos.ms.gov/online/portal/ch/page/charities-search/portal.aspx — query-only
+- Lobbyist registry: Mississippi Secretary of State (Elections Division) — https://www.sos.ms.gov/elec/portal/msel/page/search/portal.aspx — query-only
+
+### Missouri
+- Business entity search: Missouri Secretary of State — https://www.sos.mo.gov/BusinessEntity/soskb/csearch.asp — query-only
+- Notary registry: Missouri Secretary of State — https://s1.sos.mo.gov/business/notary/search/notarysearch.aspx — query-only
+- Charity registry: Missouri Attorney General — https://ago.mo.gov/civil-division/consumer/charity — search via "Check-a-Charity"; query-only
+- Lobbyist registry: Missouri Ethics Commission — https://mec.mo.gov/mec/Lobbying/LobbyistSearch.aspx — query-only
+
+### Montana
+- Business entity search: Montana Secretary of State — https://biz.sosmt.gov/search — query-only
+- Notary registry: Montana Secretary of State — https://sosmt.gov/notary/find-a-notary/ — query-only (opt-in for public listing)
+- Charity registry: MT has NO state-level charity registration. No public registry. Investigate manually
+- Lobbyist registry: Montana Commissioner of Political Practices (COPP) — https://politicalpractices.mt.gov/home/Legislative-Session-and-Lobbying/Lobbying-FAQ — query-only via COPP portal
+
+### Nebraska
+- Business entity search: Nebraska Secretary of State — https://www.nebraska.gov/sos/corp/corpsearch.cgi — query-only — verified via https://sos.nebraska.gov/business-services/corporate-and-business
+- Notary registry: Nebraska Secretary of State — https://sos.nebraska.gov/business-services/notary-public — limited public search; manage by contacting (402) 471-2558; investigate further for searchable index
+- Charity registry: NE has NO general charity registration with state agency. Charitable trust notice requirements via AG — https://protectthegoodlife.nebraska.gov/charitable-trusts — query/notice-only
+- Lobbyist registry: Nebraska Legislature / Clerk of the Legislature (Nebraska Accountability and Disclosure Commission for activity reports) — https://nebraskalegislature.gov/lobbyist/ ; NADC: https://nadc.nebraska.gov/view-campaign-filings-personal-financial-disclosures-potential-conflicts-lobbying-reports-and-more — query-only
+
+### Nevada
+- Business entity search: Nevada Secretary of State (SilverFlume) — https://esos.nv.gov/EntitySearch/OnlineEntitySearch — query-only free; full document access has fees historically
+- Notary registry: Nevada Secretary of State — https://esos.nv.gov/NotarySearchOnline/NotarySearchExternal — query-only
+- Charity registry: Nevada Secretary of State (Commercial Recording Division) — https://www.nvsos.gov/sos/licensing/charitable-organizations — query via Business Entity Search; bulk data download referenced
+- Lobbyist registry: Nevada Legislature (Legislative Counsel Bureau) — https://www.leg.state.nv.us/lobbyist/ — query-only
+
+### New Hampshire
+- Business entity search: New Hampshire Secretary of State (NH QuickStart) — https://quickstart.sos.nh.gov/online/BusinessInquire — query-only
+- Notary registry: NH has no public online notary search; the SoS publishes a roster (Spring 2023+) — https://www.sos.nh.gov/notary-public — Investigate manually
+- Charity registry: New Hampshire Department of Justice (Charitable Trusts Unit) — https://www.doj.nh.gov/bureaus/charitable-trusts/registered-charities — query-only
+- Lobbyist registry: New Hampshire Secretary of State — https://www.sos.nh.gov/lobbyists — query-only; PDF/Excel lists for each session
+
+### New Jersey
+- Business entity search: New Jersey Department of the Treasury, Division of Revenue and Enterprise Services — https://www.njportal.com/dor/businessnamesearch/ — query-only (free name search; status reports paid)
+- Notary registry: New Jersey Treasury, Division of Revenue — https://www.nj.gov/cgi-bin/treas/revenue/search5.pl — query-only
+- Charity registry: New Jersey Division of Consumer Affairs (Charities Registration & Investigation Section) — https://charportal.dca.njoag.gov/Charity-Registration/CHR-Public-Search-Page/ — query-only
+- Lobbyist registry: New Jersey Election Law Enforcement Commission (ELEC) — https://www.elec.nj.gov/publicinformation.htm — query-only
+
+### New Mexico
+- Business entity search: New Mexico Secretary of State — https://enterprise.sos.nm.gov/search/business — query-only
+- Notary registry: New Mexico Secretary of State — https://enterprise.sos.nm.gov/search/notary — query-only
+- Charity registry: New Mexico Department of Justice (formerly AG) — https://secure.nmdoj.gov/CharitySearch/ — query-only
+- Lobbyist registry: New Mexico Secretary of State — https://www.cfis.state.nm.us/media/ReportLobbyistFilingPeriods.aspx ; legacy reports at https://portal.sos.state.nm.us/financialDisclosure/SearchLobbyist.aspx — query-only; downloadable CSV/PDF
+
+### New York
+- Business entity search: New York Department of State, Division of Corporations — https://apps.dos.ny.gov/publicInquiry/ — query-only (owners/principals NOT publicly available; agent and entity info only)
+- Notary registry: New York Department of State — https://dos.ny.gov/search-commissioned-nys-notaries-public — query-only; bulk dataset at https://data.ny.gov/Economic-Development/Commissioned-NYS-Notaries-Public/rwbv-mz6z
+- Charity registry: New York Attorney General (Charities Bureau) — https://charities-search.ag.ny.gov/RegistrySearch — query-only
+- Lobbyist registry: New York Commission on Ethics and Lobbying in Government (COELIG, successor to JCOPE) — https://ethics.ny.gov/ — query-only via Public Reporting (legal status under litigation)
+
+### North Carolina
+- Business entity search: North Carolina Secretary of State — https://www.sosnc.gov/online_services/search/by_title/search_Business_Registration — query-only
+- Notary registry: North Carolina Secretary of State — https://www.sosnc.gov/online_services/notary/search_notary_number — query-only
+- Charity registry: North Carolina Secretary of State (Charitable Solicitation Licensing Division) — https://www.sosnc.gov/online_services/search/Charities_Results — query-only
+- Lobbyist registry: North Carolina Secretary of State (Lobbying Compliance Division) — https://www.sosnc.gov/online_services/search/lobbying_results — query-only
+
+### North Dakota
+- Business entity search: North Dakota Secretary of State (FirstStop) — https://firststop.sos.nd.gov/search/business — query-only
+- Notary registry: North Dakota Secretary of State (FirstStop) — https://firststop.sos.nd.gov/search/notary — query-only; data list requests available
+- Charity registry: North Dakota Secretary of State — https://firststop.sos.nd.gov/search/charitable — query-only
+- Lobbyist registry: North Dakota Secretary of State (FirstStop) — https://firststop.sos.nd.gov/search/lobbyist — query-only; annual lists at https://firststop.sos.nd.gov/lists
+
+### Ohio
+- Business entity search: Ohio Secretary of State — https://businesssearch.ohiosos.gov/ — query-only
+- Notary registry: Ohio Secretary of State — https://www.ohiosos.gov/notary — query-only
+- Charity registry: Ohio Attorney General — https://charitable.ohioago.gov/Research-Charities — query-only
+- Lobbyist registry: Ohio Joint Legislative Ethics Committee — Office of the Legislative Inspector General (OLAC) — https://www2.jlec-olig.state.oh.us/olac/ — query-only
+
+### Oklahoma
+- Business entity search: Oklahoma Secretary of State — https://www.sos.ok.gov/corp/corpInquiryFind.aspx — query-only
+- Notary registry: Oklahoma Secretary of State — https://www.sos.ok.gov/notary/search.aspx — query-only
+- Charity registry: Oklahoma Secretary of State — https://www.sos.ok.gov/corp/charityInquiryFind.aspx — query-only
+- Lobbyist registry: Oklahoma Ethics Commission (Guardian system) — https://guardian.ok.gov/ ; older system: https://pay.apps.ok.gov/ethics/lobbyist/public_index.php — query-only (Guardian 2.0 public portal partially delayed)
+
+### Oregon
+- Business entity search: Oregon Secretary of State — https://sos.oregon.gov/business/Pages/find.aspx — query-only; some data via Oregon open data portal
+- Notary registry: Oregon Secretary of State — https://sos.oregon.gov/business/Pages/notary-public-directory.aspx — query-only; bulk Active Notaries dataset at https://data.oregon.gov/business/Active-Notaries/j2pk-zk6z
+- Charity registry: Oregon Department of Justice (Charitable Activities Section) — https://justice.oregon.gov/charities — query-only
+- Lobbyist registry: Oregon Government Ethics Commission — https://apps.oregon.gov/OGEC/EFS/Records — query-only
+
+### Pennsylvania
+- Business entity search: Pennsylvania Department of State (Bureau of Corporations and Charitable Organizations) — https://file.dos.pa.gov/search/business — query-only
+- Notary registry: Pennsylvania Department of State — https://www.notaries.pa.gov/pages/notarysearch.aspx — query-only
+- Charity registry: Pennsylvania Department of State (Bureau of Corporations and Charitable Organizations) — https://www.charities.pa.gov/ — query-only
+- Lobbyist registry: Pennsylvania Department of State (Lobbying Disclosure) — https://www.pa.gov/services/dos/search-lobbying-disclosure-reports — query-only
+
+### Rhode Island
+- Business entity search: Rhode Island Department of State — https://business.sos.ri.gov/corpweb/corpsearch/corpsearch.aspx — query-only
+- Notary registry: Rhode Island Department of State — https://business.sos.ri.gov/PublicNotarySearch/Home — query-only
+- Charity registry: Rhode Island Department of Business Regulation (DBR) — https://dbr.ri.gov/banking-securities-and-charitable-organizations/securities-and-charities/charitable-organizations — query/file-only; no robust public search
+- Lobbyist registry: Rhode Island Department of State (Lobby Tracker) — https://lobbytracker.sos.ri.gov/ — query-only
+
+### South Carolina
+- Business entity search: South Carolina Secretary of State — https://businessfilings.sc.gov/BusinessFiling/Entity/Search — query-only (note: officers/directors not maintained by SoS)
+- Notary registry: South Carolina Secretary of State — https://search.scsos.com/notaries — query-only
+- Charity registry: South Carolina Secretary of State — https://search.scsos.com/charities — query-only
+- Lobbyist registry: South Carolina State Ethics Commission — https://apps.sc.gov/lobbyingactivity/LAIndex.aspx — query-only
+
+### South Dakota
+- Business entity search: South Dakota Secretary of State — https://sosenterprise.sd.gov/BusinessServices/Business/FilingSearch.aspx — query-only
+- Notary registry: South Dakota Secretary of State — https://sosenterprise.sd.gov/BusinessServices/Notary/NotarySearch.aspx — query-only
+- Charity registry: SD has NO charity registration. Paid telephone solicitors register with AG Division of Consumer Protection — https://consumer.sd.gov/fastfacts/charity.aspx — minimal; investigate manually
+- Lobbyist registry: South Dakota Secretary of State — https://sosenterprise.sd.gov/BusinessServices/Lobbyist/LobbyistSearch.aspx — query-only
+
+### Tennessee
+- Business entity search: Tennessee Secretary of State — https://tnbear.tn.gov/Ecommerce/FilingSearch.aspx (linked from https://sos.tn.gov/businesses) — query-only
+- Notary registry: Tennessee Secretary of State — https://sos.tn.gov/businesses/services/search-notary-commissions — query-only (notaries elected by county legislative body; commissioned by SoS)
+- Charity registry: Tennessee Secretary of State (Division of Charitable Solicitations and Gaming) — https://tncab.tnsos.gov/portal/registered-charities-search — query-only
+- Lobbyist registry: Tennessee Ethics Commission (Bureau of Ethics and Campaign Finance) — https://apps.tn.gov/ilobby/ — query-only
+
+### Texas
+- Business entity search: Texas Secretary of State (SOSDirect) — https://direct.sos.state.tx.us/acct/acct-login.asp — query-only; $1/search; account required; free filing status at https://webservices.sos.state.tx.us/filing-status/status.aspx
+- Notary registry: Texas Secretary of State — https://direct.sos.state.tx.us/notaries/NotarySearch.asp — query-only; bulk data at https://data.texas.gov/dataset/Texas-Notary-Public-Commissions/gmd3-bnrd — bulk available
+- Charity registry: TX has NO general charity registration. Specific categories (law enforcement telephone solicitors under LETSA, veterans, public safety) register with AG — https://www.texasattorneygeneral.gov/divisions/charitable-trusts/registration-and-filings
+- Lobbyist registry: Texas Ethics Commission — https://www.ethics.state.tx.us/search/lobby/ — query-only; PDF lists by cycle; data downloads back to 1993
+
+### Utah
+- Business entity search: Utah Division of Corporations and Commercial Code — https://businessregistration.utah.gov/EntitySearch/OnlineEntitySearch — query-only
+- Notary registry: Utah Lieutenant Governor's Office — https://secure.utah.gov/notary/search.html — query-only
+- Charity registry: Transitioning: as of Jan 1 2025, nonprofits register with Utah Division of Corporations and Commercial Code (DCCC) — https://commerce.utah.gov/dcp/for-businesses/charities/ — DCP historical search; investigate manually for new DCCC integration
+- Lobbyist registry: Utah Lieutenant Governor's Office — https://lobbyist.utah.gov/search/publicsearch — query-only
+
+### Vermont
+- Business entity search: Vermont Secretary of State — https://bizfilings.vermont.gov/online/BusinessInquire — query-only
+- Notary registry: Vermont Secretary of State (Office of Professional Regulation) — https://sos.vermont.gov/opr/online-services — "Find a Professional"; downloadable roster available
+- Charity registry: Vermont Attorney General — https://ago.vermont.gov/attorney-generals-office-divisions-and-unit/charities-and-paid-fundraisers/paid-fundraisers — only paid fundraisers register; charities themselves not state-registered; investigate manually for charity list
+- Lobbyist registry: Vermont Secretary of State (Vermont Lobbying Information System) — https://lobbying.vermont.gov/Public/SearchByEmployer — query-only
+
+### Virginia
+- Business entity search: Virginia State Corporation Commission (Clerk's Information System) — https://cis.scc.virginia.gov/ — query-only
+- Notary registry: Virginia Secretary of the Commonwealth — https://solutions.virginia.gov/Notary/Search/Search — query-only
+- Charity registry: Virginia Department of Agriculture and Consumer Services (Office of Charitable and Regulatory Programs) — https://cos.vdacs.virginia.gov/ — query-only
+- Lobbyist registry: Virginia Conflict of Interest and Ethics Advisory Council — https://ethics.dls.virginia.gov/ ; search at http://ethicssearch.dls.virginia.gov/ — query-only
+
+### Washington
+- Business entity search: Washington Secretary of State (CCFS - Corporations and Charities Filing System) — https://ccfs.sos.wa.gov/ — query-only
+- Notary registry: Washington State Department of Licensing — https://professions.dol.wa.gov/s/license-lookup — query-only (select Notaries)
+- Charity registry: Washington Secretary of State (Charities Program) — https://ccfs.sos.wa.gov/ or https://give.wa.gov/search — query-only
+- Lobbyist registry: Washington Public Disclosure Commission (PDC) — https://www.pdc.wa.gov/political-disclosure-reporting-data/browse-search-data/lobbyists/agents ; clients at /employers — query-only
+
+### West Virginia
+- Business entity search: West Virginia Secretary of State — https://apps.wv.gov/sos/businessentitysearch/ — query-only
+- Notary registry: West Virginia Secretary of State — https://erls.wvsos.gov/NotarySearchOnline/NotarySearchExternal — query-only
+- Charity registry: West Virginia Secretary of State (Charitable Organizations Division) — https://erls.wvsos.gov/OnlineCharitiesSearch/Search — query-only
+- Lobbyist registry: West Virginia Ethics Commission — https://ethics.wv.gov/lobbyist-directories — searchable PDF directories of lobbyists and employers; registration portal at https://registerlobbyist.wv.gov/
+
+### Wisconsin
+- Business entity search: Wisconsin Department of Financial Institutions (DFI) — https://apps.dfi.wi.gov/apps/corpsearch/search.aspx — query-only (note: DFI, not SoS)
+- Notary registry: Wisconsin Department of Financial Institutions — https://apps.dfi.wi.gov/apps/notarysearch/SearchCriteria.aspx — query-only
+- Charity registry: Wisconsin Department of Financial Institutions — https://apps.dfi.wi.gov/apps/notarysearch is for notaries; charities at https://apps.dfi.wi.gov/ice/berg/Registration/OrganizationCredentialSearch.aspx (select Charitable Organizations 800) — query-only
+- Lobbyist registry: Wisconsin Ethics Commission (Eye on Lobbying) — https://lobbying.wi.gov/ — query-only
+
+### Wyoming
+- Business entity search: Wyoming Secretary of State — https://wyobiz.wyo.gov/business/filingsearch.aspx — query-only
+- Notary registry: Wyoming Secretary of State has no public online notary search. Notary info on commission only — https://sos.wyo.gov/services/notaries.aspx — Not searchable online; investigate manually
+- Charity registry: WY has NO state-level charity registration. No public registry. Investigate manually
+- Lobbyist registry: Wyoming Secretary of State — https://lobbyist.wyo.gov/Lobbyist/LobbyistSearch.aspx?mode=initial — query-only
+
+---
+
+## Regulated facilities, open data portals, and parcels
+
+### State open data portals
+
+- **Alabama** — Alabama Geographic Information Office — https://data-algeohub.opendata.arcgis.com/ — ArcGIS Hub — primary geospatial portal; no unified statewide tabular open-data portal (open.alabama.gov hosts transparency/finance only).
+- **Alaska** — State of Alaska — https://data.alaska.gov/ — Socrata — tabular open data. Companion geoportal: https://gis.data.alaska.gov/ (ArcGIS Hub).
+- **Arizona** — Arizona Geographic Information Council (AGIC) / State Cartographer's Office — https://azgeo-open-data-agic.hub.arcgis.com/ — ArcGIS Hub — primary statewide portal (geospatial-led).
+- **Arkansas** — Arkansas GIS Office (ASDI) — https://gis.arkansas.gov/ — Custom + ArcGIS — geospatial clearinghouse; no unified statewide tabular portal.
+- **California** — CA Government Operations Agency — https://data.ca.gov/ — CKAN — statewide; companion CalHHS Open Data (https://data.chhs.ca.gov/) and CA State Geoportal.
+- **Colorado** — Colorado Office of Information Technology — https://data.colorado.gov/ — Socrata (Colorado Information Marketplace).
+- **Connecticut** — Office of Policy and Management — https://data.ct.gov/ — Socrata.
+- **Delaware** — Delaware Open Data Council — https://data.delaware.gov/ — Socrata.
+- **District of Columbia** — DC OCTO — https://opendata.dc.gov/ — ArcGIS Hub.
+- **Florida** — Florida Geographic Information Office — https://geodata.floridagio.gov/ — ArcGIS Hub. Also: Florida Geographic Data Library at https://fgdl.org/ (UF GeoPlan Center, bulk download).
+- **Georgia** — Georgia Geospatial Information Office (GIO) — https://data-hub.gio.georgia.gov/ — ArcGIS Hub — geospatial-led; no unified statewide tabular portal.
+- **Hawaii** — State Office of Enterprise Technology Services — https://opendata.hawaii.gov/ — CKAN.
+- **Idaho** — Idaho Geospatial Office — https://gis-idaho.hub.arcgis.com/ — ArcGIS Hub. Also INSIDE Idaho clearinghouse: https://www.insideidaho.org/.
+- **Illinois** — State of Illinois — https://data.illinois.gov/ — CKAN.
+- **Indiana** — Management Performance Hub — https://hub.mph.in.gov/ — CKAN.
+- **Iowa** — Iowa Dept. of Management — https://data.iowa.gov/ — Socrata.
+- **Kansas** — DASC (Data Access and Support Center) — https://hub.kansasgis.org/ — ArcGIS Hub — geospatial-led; no unified statewide tabular portal.
+- **Kentucky** — KyGovMaps / Kentucky Geography Network — https://opengisdata.ky.gov/ — ArcGIS Hub.
+- **Louisiana** — N/A — No unified statewide open data portal. Louisiana Transparency and Accountability Portal (https://wwwcfprd.doa.louisiana.gov/latrac/portal.cfm) covers finance only; GIS data scattered (e.g., https://atlas.ga.lsu.edu/).
+- **Maine** — Maine GeoLibrary — https://mainegeolibrary-maine.hub.arcgis.com/ — ArcGIS Hub.
+- **Maryland** — State of Maryland — https://opendata.maryland.gov/ — Socrata. Companion geospatial: https://data.imap.maryland.gov/ (MD iMAP).
+- **Massachusetts** — MassGIS / EOTSS — https://gis.data.mass.gov/ (geospatial) and https://data.mass.gov/ (tabular) — ArcGIS Hub / Socrata.
+- **Michigan** — State of Michigan — https://data.michigan.gov/ — Socrata. Geospatial: https://gis-michigan.opendata.arcgis.com/.
+- **Minnesota** — MnGeo (Geospatial Information Office) — https://gisdata.mn.gov/ — CKAN — Geospatial Commons.
+- **Mississippi** — MARIS / Mississippi Geospatial Data Catalog — https://opendata.gis.ms.gov/ — ArcGIS Hub. No unified statewide tabular portal.
+- **Missouri** — State of Missouri — https://data.mo.gov/ — Socrata (lightweight). Geospatial: https://data-msdis.opendata.arcgis.com/ (MSDIS).
+- **Montana** — Montana State Library — https://msl.mt.gov/geoinfo/ (portal) and https://geoinfo.msl.mt.gov/ (data hub) — ArcGIS Hub — geospatial-led; includes statewide parcels.
+- **Nebraska** — Office of the CIO Geographic Information Office — https://www.nebraskamap.gov/ — ArcGIS Hub.
+- **Nevada** — State of Nevada — https://open.nv.gov/ — Socrata (limited). No comprehensive unified portal; GIS scattered.
+- **New Hampshire** — NH GRANIT (UNH) — https://granit.unh.edu/ + https://new-hampshire-geodata-portal-1-nhgranit.hub.arcgis.com/ — ArcGIS Hub.
+- **New Jersey** — NJ Office of Information Technology — https://data.nj.gov/ — Socrata. Geospatial: https://njogis-newjersey.opendata.arcgis.com/ (NJGIN).
+- **New Mexico** — NM RGIS (UNM) — https://rgis.unm.edu/ — Custom clearinghouse — no unified statewide tabular portal.
+- **New York** — State of New York — https://data.ny.gov/ — Socrata.
+- **North Carolina** — NC OneMap (CGIA) — https://www.nconemap.gov/ — ArcGIS Hub.
+- **North Dakota** — ND Information Technology / Geospatial Committee — https://gishubdata.nd.gov/ — ArcGIS Hub.
+- **Ohio** — DataOhio Portal — https://data.ohio.gov/ — CKAN. Geospatial: https://ogrip-geohio.opendata.arcgis.com/ (OGRIP).
+- **Oklahoma** — State of Oklahoma — https://data.ok.gov/ — CKAN.
+- **Oregon** — State of Oregon — https://data.oregon.gov/ (Socrata, limited) + https://geohub.oregon.gov/ (ArcGIS Hub, geospatial primary).
+- **Pennsylvania** — Commonwealth of PA — https://data.pa.gov/ — Socrata. Geospatial: https://www.pasda.psu.edu/ (Penn State, bulk).
+- **Rhode Island** — N/A unified — RIGIS (https://www.rigis.org/) for geospatial; data.ri.gov used for Municipal Transparency Portal only.
+- **South Carolina** — SCGIS (gis.sc.gov) — http://www.gis.sc.gov/data.html — Custom + ArcGIS portals — no unified statewide tabular portal.
+- **South Dakota** — SD Bureau of IT — https://gis-south-dakota-open-data-hub-sdbit.hub.arcgis.com/ — ArcGIS Hub — geospatial-led; no unified statewide tabular portal.
+- **Tennessee** — STS GIS Services — https://tn-tnmap.opendata.arcgis.com/ — ArcGIS Hub — geospatial-led; no unified statewide tabular portal.
+- **Texas** — Texas Department of Information Resources — https://data.texas.gov/ — Socrata. Geospatial: https://data.tnris.org/ (TxGIO/TNRIS).
+- **Utah** — State of Utah — https://opendata.utah.gov/ — Socrata. Geospatial (SGID) curated by UGRC: https://gis.utah.gov/products/sgid/.
+- **Vermont** — VCGI — https://geodata.vermont.gov/ — ArcGIS Hub. Tabular: https://data.vermont.gov/ — Socrata.
+- **Virginia** — Virginia Geographic Information Network (VGIN) — https://data.virginia.gov/ — Socrata + VGIN.
+- **Washington** — WaTech / OCIO — https://data.wa.gov/ — Socrata. Geospatial: https://geo.wa.gov/ (ArcGIS Hub).
+- **West Virginia** — WV GIS Technical Center (WVU) — https://wvgis.wvu.edu/ — Clearinghouse — no unified statewide tabular portal.
+- **Wisconsin** — N/A unified — multiple specialized portals; GeoData@Wisconsin (https://geodata.wisc.edu/) is the most comprehensive geospatial catalog.
+- **Wyoming** — Wyoming Geospatial Hub — https://data.geospatialhub.org/ — ArcGIS Hub — geospatial-led; no unified statewide tabular portal.
+
+License terms note: most state ArcGIS Hub deployments default to Esri Open Data terms (effectively public-domain or attribution); confirm per dataset. Socrata-hosted state portals generally publish under each state's open-data terms (typically attribution-only).
+
+---
+
+### Regulated establishments per state
+
+Each state lists, where available: Child care licensing, Assisted living/nursing home (state-level), Alcohol/ABC, Cannabis (where legal & public), Auto dealer licensing.
+
+### Alabama
+- Child care: AL Dept. of Human Resources, Child Care Services — https://apps.dhr.alabama.gov/daycare/daycare_search — query-only.
+- Assisted living/nursing: AL Dept. of Public Health, Bureau of Health Provider Standards — https://www.alabamapublichealth.gov/providerstandards/directory.html — query-only directory.
+- Alcohol/ABC: AL ABC Board — https://alabcboard.gov/licensing-compliance — query-only; no public bulk download.
+- Cannabis: N/A — Medical cannabis law passed but program/licenses not yet broadly public. Investigate AMCC (https://amcc.alabama.gov/) for updates.
+- Auto dealer: AL Dept. of Revenue Motor Vehicle Division — https://www.revenue.alabama.gov/division/motor-vehicle/ — Not found — investigate manually for public roster.
+
+### Alaska
+- Child care: AK Dept. of Health, Child Care Program Office — https://health.alaska.gov/en/division-of-public-assistance/child-care-program-office/ — search tool; bulk not obvious.
+- Assisted living/nursing: AK Dept. of Health, Residential Licensing — https://health.alaska.gov/en/division-of-health-care-services/residential-licensing/ — query-only.
+- Alcohol/ABC + Cannabis: AK Alcohol & Marijuana Control Office (AMCO) — https://www.commerce.alaska.gov/web/amco — license search; status PDFs.
+- Auto dealer: AK DMV — https://doa.alaska.gov/dmv/dealer/ — Current Dealer List in PDF/Excel (bulk download).
+
+### Arizona
+- Child care: AZ Dept. of Health Services, Bureau of Child Care Licensing — https://geodata-adhsgis.hub.arcgis.com/datasets/state-licensed-childcare-facilities-in-arizona — bulk download (ArcGIS).
+- Assisted living/nursing: AZ DHS Bureau of Residential Facilities Licensing — https://azcarecheck.azdhs.gov/s/ — query-only (AZ Care Check).
+- Alcohol/ABC: AZ Dept. of Liquor Licenses & Control — https://liquor.az.gov/license-search — query-only; legacy lookup at https://www.azliquor.gov/query/query.cfm.
+- Cannabis: AZ DHS Marijuana Licensing — https://www.azdhs.gov/licensing/marijuana/ — query-only.
+- Auto dealer: AZ MVD Dealer Licensing — https://azdot.gov/mvd/services/professional-services/dealer-licensing — Not found — investigate manually for public roster.
+
+### Arkansas
+- Child care: AR Dept. of Human Services, Child Care Licensing — https://ardhslicensing.my.site.com/elicensing/s/search-provider/find-providers?language=en_US&tab=CC — query-only.
+- Assisted living/nursing: AR Dept. of Human Services / Office of Long Term Care — https://humanservices.arkansas.gov/divisions-shared-services/medical-services/office-of-long-term-care/ — Not found — investigate manually for public roster.
+- Alcohol/ABC: AR Dept. of Finance & Administration, Alcoholic Beverage Control — https://www.dfa.arkansas.gov/office/alcohol-beverage-control/ — monthly Permit Change Lists in PDF (https://www.dfa.arkansas.gov/wp-content/uploads/January_2026_PermitChangeList.pdf).
+- Cannabis: AR Medical Marijuana Commission — https://www.dfa.arkansas.gov/office/medical-marijuana-commission/ — dispensary list published by AR Dept. of Health.
+- Auto dealer: AR State Police, Used Motor Vehicle Dealer Roster — https://dps.arkansas.gov/law-enforcement/arkansas-state-police/services-programs/used-motor-vehicle-dealer-license/used-motor-vehicle-dealer-roster/ — bulk roster.
+
+### California
+- Child care: CA Dept. of Social Services, Community Care Licensing Division — https://www.ccld.dss.ca.gov/carefacilitysearch/ — query + open dataset at https://cdss.ca.gov/inforesources/cdss-programs/community-care-licensing/ccld-data.
+- Assisted living/nursing: CA CDPH "Cal Health Find" — https://www.cdph.ca.gov/Programs/CHCQ/LCP/CalHealthFind/pages/home.aspx — query; bulk via CHHS Open Data — https://data.chhs.ca.gov/dataset/healthcare-facility-locations.
+- Alcohol/ABC: CA Dept. of Alcoholic Beverage Control — https://www.abc.ca.gov/licensing/licensing-reports/ — bulk download (CSV, refreshed daily).
+- Cannabis: CA Dept. of Cannabis Control — https://search.cannabis.ca.gov/ — search + license summary report.
+- Auto dealer: CA DMV Occupational License Lookup — https://www.dmv.ca.gov/portal/vehicle-industry-services/occupational-licensing/occupational-license-lookup/ — query-only.
+
+### Colorado
+- Child care: CO Dept. of Early Childhood — https://apps.colorado.gov/apps/cdhs/childcare/lookup/index.jsf (Colorado Shines) — query; bulk via CDPHE ArcGIS: https://data-cdphe.opendata.arcgis.com/datasets/ba8161673d734074a081006adc7ea496.
+- Assisted living/nursing: CDPHE Health Facilities — https://cdphe.colorado.gov/find-and-compare-facilities — query-only.
+- Alcohol/ABC: CO Dept. of Revenue, Liquor Enforcement Division — https://sbg.colorado.gov/liquor-license-lists — monthly PDFs/Excel; open data: https://data.colorado.gov/Business/CO-Liquor-Licenses/ptf9-yh8v.
+- Cannabis: CO Marijuana Enforcement Division — https://med.colorado.gov/licensee-information-and-lookup-tool — search; licensed facilities list page.
+- Auto dealer: CO Auto Industry Division — https://sbg.colorado.gov/active-facility-license-listings-auto-industry-division — bulk listings + https://codor.mylicense.com/AID_Verification/.
+
+### Connecticut
+- Child care: CT Office of Early Childhood — https://www.211childcare.org/ + state license search at https://www.elicense.ct.gov/ — query-only.
+- Assisted living/nursing: CT Dept. of Public Health Facility Licensing & Investigations Section — https://portal.ct.gov/dph/health-care-quality-and-safety/the-facility-licensing--investigations-section/facility-licensing--investigations-section — query.
+- Alcohol/ABC: CT Dept. of Consumer Protection, Liquor Control — https://data.ct.gov/Business/Liquor-Permits/wbja-pumr — Socrata bulk download.
+- Cannabis: CT DCP, Cannabis program — https://portal.ct.gov/dcp/medical-marijuana-program/licenses-and-applications — list of licensees; also https://data.ct.gov.
+- Auto dealer: CT DMV — https://portal.ct.gov/dmv/dealers/dealers/dealers-and-repairers — Not found — investigate manually for bulk roster.
+
+### Delaware
+- Child care: DE Office of Child Care Licensing (DSCYF) — https://kids.delaware.gov/occl/ — query-only.
+- Assisted living/nursing: DE Division of Health Care Quality — https://dhss.delaware.gov/dhcq/ — query.
+- Alcohol/ABC: DE Alcoholic Beverage Control Commission — https://date.delaware.gov/OABCC/ — license search; data available on DE open data portal (https://data.delaware.gov/).
+- Cannabis: DE Office of the Marijuana Commissioner — https://marijuana.delaware.gov/ — license list (program launching 2024–2026).
+- Auto dealer: DE DMV — https://www.dmv.de.gov/services/dealer_services/index.shtml — Not found — investigate manually.
+
+### District of Columbia
+- Child care: DC Office of the State Superintendent of Education (OSSE) — https://osse.dc.gov/service/child-care-licensing-and-monitoring — query; bulk via Open Data DC.
+- Assisted living/nursing: DC Dept. of Health, Health Regulation and Licensing Administration — https://dchealth.dc.gov/service/health-care-facility-and-laboratory-licensing — query.
+- Alcohol/ABC: DC Alcoholic Beverage and Cannabis Administration (ABCA) — https://abra.dc.gov/page/abra-licensee-search — query; bulk via Open Data DC.
+- Cannabis: DC ABCA — https://abca.dc.gov/page/cannabis-licensing — license list (medical cannabis legal; recreational limited).
+- Auto dealer: DC DMV — https://dmv.dc.gov/service/business-services — Not found — investigate manually.
+
+### Florida
+- Child care: FL Dept. of Children and Families, Child Care Provider Search — https://cares.myflfamilies.com/PublicSearch/ — query-only.
+- Assisted living/nursing: FL Agency for Health Care Administration (AHCA), FloridaHealthFinder — https://www.floridahealthfinder.gov/facilitylocator/FacilitySearch.aspx — query; bulk via https://ahca.myflorida.com/health-care-policy-and-oversight/health-quality-assurance/health-facility-regulation.
+- Alcohol/ABC: FL Dept. of Business and Professional Regulation, Division of ABT — https://www.myfloridalicense.com/wl11.asp?mode=0&SID= — license search; bulk via FL DBPR data downloads.
+- Cannabis: FL Office of Medical Marijuana Use — https://knowthefactsmmj.com/mmtc/ — list of medical marijuana treatment centers.
+- Auto dealer: FL Dept. of Highway Safety and Motor Vehicles — https://services.flhsmv.gov/MVDLLicenseSearch/ — query-only license search.
+
+### Georgia
+- Child care: GA Dept. of Early Care and Learning (DECAL) — https://families.decal.ga.gov/ChildCare/Search — query-only.
+- Assisted living/nursing: GA Dept. of Community Health, Healthcare Facility Regulation — https://dch.georgia.gov/divisionsoffices/healthcare-facility-regulation/healthcare-facility-licensing — Not found — investigate manually for facility search.
+- Alcohol/ABC: GA Dept. of Revenue, Alcohol & Tobacco Division — https://dor.georgia.gov/alcohol-tobacco — Not found — investigate manually for bulk licensee list.
+- Cannabis: GA Access to Medical Cannabis Commission (low-THC oil only) — https://gmcc.ga.gov/ — list of licensed producers (very limited program).
+- Auto dealer: GA Board of Used Motor Vehicle Dealers — https://sos.ga.gov/used-motor-vehicle-dealers — license verification: https://verify.sos.ga.gov/verification/.
+
+### Hawaii
+- Child care: HI Dept. of Human Services, Child Care Licensing — https://humanservices.hawaii.gov/bessd/cclp/ — query.
+- Assisted living/nursing: HI Dept. of Health, Office of Health Care Assurance — https://health.hawaii.gov/ohca/facility-search/ — query.
+- Alcohol/ABC: Honolulu Liquor Commission + county-level (HI has county-level liquor commissions); no statewide unified DB. Hawaii County: https://www.hawaiicounty.gov/departments/liquor-control.
+- Cannabis: HI Dept. of Health, Medical Cannabis Dispensary Program — https://health.hawaii.gov/medicalcannabis/ — license list.
+- Auto dealer: HI Dept. of Commerce and Consumer Affairs (DCCA) — https://mypvl.dcca.hawaii.gov/public-license-search/ — query-only.
+
+### Idaho
+- Child care: ID Dept. of Health and Welfare, Child Care Licensing — https://healthandwelfare.idaho.gov/services-programs/children-families/child-care-licensing — query.
+- Assisted living/nursing: ID Dept. of Health and Welfare, Residential Assisted Living Facilities — https://healthandwelfare.idaho.gov/providers/facility-and-resident-care/residential-care-or-assisted-living-facilities — Not found — investigate manually for public roster.
+- Alcohol/ABC: ID State Liquor Division — https://liquor.idaho.gov/ — control state; ID State Police Alcohol Beverage Control issues retail licenses — https://isp.idaho.gov/abc/. Not found — investigate manually for downloadable roster.
+- Cannabis: N/A — recreational and medical cannabis illegal in Idaho.
+- Auto dealer: ID Transportation Dept., Dealer Operations — https://itd.idaho.gov/dmv/dealer-licensing/ — Not found — investigate manually for public roster.
+
+### Illinois
+- Child care: IL Dept. of Children and Family Services (DCFS) — https://www.dcfs.illinois.gov/safe-kids/parents/find-licensed-child-care.html — query-only.
+- Assisted living/nursing: IL Dept. of Public Health, Health Care Facility Profiles — https://hfsrs.illinois.gov/ — query; bulk via data.illinois.gov.
+- Alcohol/ABC: IL Liquor Control Commission — https://www2.illinois.gov/sites/ilcc/Pages/default.aspx — license search; bulk via data.illinois.gov.
+- Cannabis: IL Dept. of Financial and Professional Regulation, Cannabis — https://idfpr.illinois.gov/profs/adultusecan.html — list of approved licensees published.
+- Auto dealer: IL Secretary of State, Dealer Licensing — https://www.ilsos.gov/departments/vehicles/dealer/home.html — Not found — investigate manually for public roster.
+
+### Indiana
+- Child care: IN Family and Social Services Administration, Child Care Finder — https://www.in.gov/fssa/carefinder/ — query.
+- Assisted living/nursing: IN State Dept. of Health — https://gateway.in.gov/welcome/welcome — Not found — investigate manually for facility search.
+- Alcohol/ABC: IN Alcohol and Tobacco Commission — https://www.in.gov/atc/ — license search; bulk available on Indiana Data Hub: https://hub.mph.in.gov/.
+- Cannabis: N/A — recreational and medical cannabis illegal in Indiana (low-THC only).
+- Auto dealer: IN Secretary of State, Auto Dealer Services — https://www.in.gov/sos/dealer/ — license verification: https://inbiz.in.gov/.
+
+### Iowa
+- Child care: IA Dept. of Health and Human Services, Child Care — https://ccmis.dhs.state.ia.us/ChildCareProvider — query (search & resource referral).
+- Assisted living/nursing: IA Dept. of Inspections, Appeals and Licensing, Health Facilities — https://dia-hfd.iowa.gov/facilities — query.
+- Alcohol/ABC: IA Alcoholic Beverages Division — https://abd.iowa.gov/ — license search; bulk via data.iowa.gov: https://data.iowa.gov/browse?category=Alcohol+%26+Drugs.
+- Cannabis: IA Dept. of Health and Human Services, Office of Medical Cannabidiol — https://hhs.iowa.gov/programs/programs-and-services/medical-cannabidiol — limited program, dispensary list published.
+- Auto dealer: IA Dept. of Transportation, Motor Vehicle Enforcement — https://iowadot.gov/mvd/motor-vehicle-enforcement — Not found — investigate manually.
+
+### Kansas
+- Child care: KS Dept. of Health and Environment, Child Care Licensing — https://www.kdhe.ks.gov/192/Child-Care-Licensing — query at https://childcareapp.kdhe.state.ks.us/.
+- Assisted living/nursing: KS Dept. for Aging and Disability Services (KDADS) — https://www.kdads.ks.gov/commissions/survey-certification-credentialing-commission — Not found — investigate manually.
+- Alcohol/ABC: KS Dept. of Revenue, Alcoholic Beverage Control — https://www.ksrevenue.gov/abcindex.html — license search; bulk not obvious.
+- Cannabis: N/A — recreational and medical cannabis illegal in Kansas.
+- Auto dealer: KS Dept. of Revenue, Division of Vehicles — https://www.ksrevenue.gov/dovindex.html — Not found — investigate manually.
+
+### Kentucky
+- Child care: KY Cabinet for Health and Family Services, Division of Regulated Child Care — https://prdweb.chfs.ky.gov/ChildCare/SearchChildCare.aspx — query.
+- Assisted living/nursing: KY Office of Inspector General, Long Term Care Facilities — https://chfs.ky.gov/agencies/os/oig/dhc/Pages/default.aspx — query; bulk not obvious.
+- Alcohol/ABC: KY Dept. of Alcoholic Beverage Control — https://abc.ky.gov/Pages/default.aspx — license search.
+- Cannabis: KY Office of Medical Cannabis (launching 2025) — https://kymedcan.ky.gov/ — license list emerging.
+- Auto dealer: KY Motor Vehicle Commission — https://mvc.ky.gov/Pages/default.aspx — license verification: https://mvc.ky.gov/Pages/Look-up-a-Salesperson-or-Dealership.aspx.
+
+### Louisiana
+- Child care: LA Dept. of Education, Early Childhood — https://www.louisianabelieves.com/early-childhood — query at https://childcaremap.la.gov/.
+- Assisted living/nursing: LA Dept. of Health, Health Standards Section — https://ldh.la.gov/page/256 — query.
+- Alcohol/ABC: LA Office of Alcohol and Tobacco Control — https://atc.louisiana.gov/ — license search at https://atc.la.gov/atc/permits.
+- Cannabis: LA Dept. of Health, Medical Marijuana program — https://ldh.la.gov/page/medical-marijuana — limited dispensary list; LDAF licenses producers.
+- Auto dealer: LA Used Motor Vehicle Commission — https://www.lumvc.com/ — query; LA Motor Vehicle Commission (new dealers): https://lmvc.la.gov/.
+
+### Maine
+- Child care: ME Dept. of Health and Human Services, Child Care Licensing — https://www.maine.gov/dhhs/ocfs/provider-resources/child-care-licensing-information — query at https://www.maine.gov/dhhs/ocfs/provider-resources/find-child-care.
+- Assisted living/nursing: ME DHHS, Division of Licensing and Certification — https://www.maine.gov/dhhs/ocfs/provider-resources/licensing — query.
+- Alcohol/ABC: ME Bureau of Alcoholic Beverages and Lottery Operations (control state for off-premise) + Bureau of Licensing — https://www.maine.gov/dafs/bablo/ — Not found — investigate manually for retail licensee list.
+- Cannabis: ME Office of Cannabis Policy — https://www.maine.gov/dafs/ocp/open-data/adult-use — adult-use bulk data downloads; medical: https://www.maine.gov/dafs/ocp/open-data/medical.
+- Auto dealer: ME Bureau of Motor Vehicles — https://www.maine.gov/sos/bmv/licenses/dealerinfo.html — Not found — investigate manually for public roster.
+
+### Maryland
+- Child care: MD State Dept. of Education, Office of Child Care — https://earlychildhood.marylandpublicschools.org/child-care-providers/office-child-care-locate-child-care — query at https://ccvalidate.msde.maryland.gov/.
+- Assisted living/nursing: MD Dept. of Health, Office of Health Care Quality — https://health.maryland.gov/ohcq/Pages/Home.aspx — query.
+- Alcohol/ABC: MD Alcohol and Tobacco Commission — https://atc.maryland.gov/ — license search; county boards also issue.
+- Cannabis: MD Cannabis Administration — https://cannabis.maryland.gov/Pages/Licensee-Search.aspx — licensee search.
+- Auto dealer: MD Motor Vehicle Administration, Business Licensing & Consumer Services — https://mva.maryland.gov/businesses/Pages/dealer.aspx — Not found — investigate manually for public roster.
+
+### Massachusetts
+- Child care: MA Dept. of Early Education and Care — https://www.mass.gov/info-details/find-a-licensed-program-or-search-a-licensed-program-s-history — query at https://eeclead.force.com/EEC_ChildCareSearch.
+- Assisted living/nursing: MA Dept. of Public Health + Executive Office of Elder Affairs (assisted living) — https://www.mass.gov/info-details/find-an-assisted-living-residence — query; nursing homes at https://www.mass.gov/info-details/find-a-nursing-home.
+- Alcohol/ABC: MA Alcoholic Beverages Control Commission — https://www.mass.gov/orgs/alcoholic-beverages-control-commission — license search via local licensing authorities; MA Open Checkbook for ABCC.
+- Cannabis: MA Cannabis Control Commission — https://masscannabiscontrol.com/open-data/ — bulk open data (Socrata).
+- Auto dealer: MA Registry of Motor Vehicles — https://www.mass.gov/lists/motor-vehicle-business-and-supplier-information — Not found — investigate manually for bulk roster.
+
+### Michigan
+- Child care: MI Dept. of Lifelong Education, Advancement and Potential (MiLEAP), Child Care Licensing — https://www.michigan.gov/lara/bureau-list/cclb — query at https://www.michigan.gov/greatstarttoquality.
+- Assisted living/nursing: MI Dept. of Licensing and Regulatory Affairs (LARA), Bureau of Community and Health Systems — https://www.michigan.gov/lara/bureau-list/bchs — query at https://w2.lara.state.mi.us/VAL/.
+- Alcohol/ABC: MI Liquor Control Commission — https://www.michigan.gov/lara/bureau-list/mlcc — license search at https://aca3.accela.com/MLCC/.
+- Cannabis: MI Cannabis Regulatory Agency — https://www.michigan.gov/cra — license data hub: https://www.michigan.gov/cra/resources/statistical-reports.
+- Auto dealer: MI Secretary of State, Business Services — https://www.michigan.gov/sos/businesses — Not found — investigate manually for public roster.
+
+### Minnesota
+- Child care: MN Dept. of Human Services, Licensing — https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=id_004008 — query at https://licensinglookup.dhs.state.mn.us/.
+- Assisted living/nursing: MN Dept. of Health — https://www.health.state.mn.us/facilities/regulation/index.html — facility search at https://apps.health.state.mn.us/ords/r/dhss/hfid.
+- Alcohol/ABC: MN Dept. of Public Safety, Alcohol and Gambling Enforcement — https://dps.mn.gov/divisions/age — Not found — investigate manually for bulk licensee list.
+- Cannabis: MN Office of Cannabis Management (launching) — https://mn.gov/ocm/ — license list emerging.
+- Auto dealer: MN Dept. of Public Safety, Driver and Vehicle Services — https://dps.mn.gov/divisions/dvs/business-resources/Pages/dealer-services.aspx — Not found — investigate manually.
+
+### Mississippi
+- Child care: MS State Dept. of Health, Child Care Facilities — https://msdh.ms.gov/page/30,0,183.html — query at https://msdh.ms.gov/childcaresearch/.
+- Assisted living/nursing: MS State Dept. of Health, Health Facilities Licensure and Certification — https://msdh.ms.gov/page/30,0,82.html — query.
+- Alcohol/ABC: MS Dept. of Revenue, Alcoholic Beverage Control — https://www.dor.ms.gov/abc — license search; MS is a control state.
+- Cannabis: MS State Dept. of Health, Medical Cannabis — https://msdh.ms.gov/page/30,0,431.html — license list.
+- Auto dealer: MS Motor Vehicle Commission — https://www.mmvc.ms.gov/ — Not found — investigate manually.
+
+### Missouri
+- Child care: MO Dept. of Elementary and Secondary Education, Office of Childhood — https://dese.mo.gov/childhood/child-care — query at https://healthapps.dhss.mo.gov/showmechildcare/.
+- Assisted living/nursing: MO Dept. of Health and Senior Services, Section for Long-Term Care Regulation — https://health.mo.gov/seniors/nursinghomes/ — query.
+- Alcohol/ABC: MO Division of Alcohol and Tobacco Control — https://atc.dps.mo.gov/ — license search.
+- Cannabis: MO Dept. of Health and Senior Services, Division of Cannabis Regulation — https://cannabis.mo.gov/licensed-facilities/ — bulk list.
+- Auto dealer: MO Dept. of Revenue, Motor Vehicle Bureau — https://dor.mo.gov/motor-vehicle/dealers/ — Not found — investigate manually for public roster.
+
+### Montana
+- Child care: MT Dept. of Public Health and Human Services, Early Childhood and Family Support — https://dphhs.mt.gov/ecfsd/childcare/ — query at https://childcarechoices.dphhs.mt.gov/.
+- Assisted living/nursing: MT DPHHS, Quality Assurance Division, Licensure Bureau — https://dphhs.mt.gov/qad/licensure — query at https://dphhs.mt.gov/qad/licensure/healthcarefacilities.
+- Alcohol/ABC: MT Dept. of Revenue, Liquor Control Division — https://mtrevenue.gov/liquor/ — license search at https://app.mt.gov/lcc/.
+- Cannabis: MT Dept. of Revenue, Cannabis Control Division — https://mtrevenue.gov/cannabis/ — licensee map and list.
+- Auto dealer: MT Dept. of Justice, Motor Vehicle Division — https://dojmt.gov/driving/mvd-business-partners/ — Not found — investigate manually.
+
+### Nebraska
+- Child care: NE DHHS, Child Care Licensing — https://dhhs.ne.gov/Pages/Child-Care-Licensing.aspx — query at https://dhhs.ne.gov/Pages/Child-Care-Roster.aspx (downloadable roster).
+- Assisted living/nursing: NE DHHS, Division of Public Health, Licensure Unit — https://dhhs.ne.gov/Pages/Healthcare-Facility-and-Provider-Look-up.aspx — query.
+- Alcohol/ABC: NE Liquor Control Commission — https://lcc.nebraska.gov/ — license search; downloadable lists available.
+- Cannabis: N/A — recreational and medical cannabis illegal in Nebraska (limited program approved 2024; not yet operational).
+- Auto dealer: NE Motor Vehicle Industry Licensing Board — https://www.mvib.nebraska.gov/ — license verification.
+
+### Nevada
+- Child care: NV DHHS, Child Care Licensing — https://dpbh.nv.gov/Reg/ChildCare/dta/Licensure/ — query.
+- Assisted living/nursing: NV DHHS, Division of Public and Behavioral Health, Health Care Quality & Compliance — https://dpbh.nv.gov/Reg/HealthFacilities/Health_Facilities_-_Home/ — query.
+- Alcohol/ABC: NV Dept. of Taxation (regulates wholesalers); retail licensing is local/county — https://tax.nv.gov/services/liquor — Not found — investigate manually.
+- Cannabis: NV Cannabis Compliance Board — https://ccb.nv.gov/ — licensee list at https://ccb.nv.gov/list-of-licensees/.
+- Auto dealer: NV DMV, Occupational and Business Licensing — https://dmvnv.com/dealers.htm — license verification at https://dmvapp.nv.gov/dmv/OBL/OBL_Lookup/Pages/OBLLookup.aspx.
+
+### New Hampshire
+- Child care: NH DHHS, Child Care Licensing Unit — https://www.dhhs.nh.gov/programs-services/licensing-residential-care-and-child-care — query at https://nhpublichealth.force.com/nhccsearch/s/.
+- Assisted living/nursing: NH DHHS, Health Facilities Administration — https://www.dhhs.nh.gov/programs-services/health-care-licensing/health-facilities-licensing-and-certification — query.
+- Alcohol/ABC: NH Liquor Commission — https://www.nh.gov/liquor/ — control state; license search at https://www.liquorandwineoutlets.com/.
+- Cannabis: NH Therapeutic Cannabis Program (medical only) — https://www.dhhs.nh.gov/programs-services/health-care/therapeutic-cannabis-program — list of ATCs (Alternative Treatment Centers).
+- Auto dealer: NH DMV — https://www.nh.gov/safety/divisions/dmv/dealers/ — Not found — investigate manually for public roster.
+
+### New Jersey
+- Child care: NJ Dept. of Children and Families, Office of Licensing — https://www.nj.gov/dcf/providers/licensing/laws/CCCmanual.html — query at https://www.childcarenj.gov/.
+- Assisted living/nursing: NJ Dept. of Health, Health Facility Survey and Field Operations — https://www.nj.gov/health/healthfacilities/ — facility search.
+- Alcohol/ABC: NJ Division of Alcoholic Beverage Control — https://www.nj.gov/oag/abc/ — license search; data available via data.nj.gov.
+- Cannabis: NJ Cannabis Regulatory Commission — https://www.nj.gov/cannabis/businesses/ — licensee list.
+- Auto dealer: NJ Motor Vehicle Commission, Business Licensing Services Bureau — https://www.nj.gov/mvc/business/dealer.htm — Not found — investigate manually.
+
+### New Mexico
+- Child care: NM Early Childhood Education and Care Department — https://www.nmececd.org/ — query at https://nmececd.force.com/providersearch/s/.
+- Assisted living/nursing: NM Dept. of Health, Division of Health Improvement — https://www.nmhealth.org/about/dhi/hflc/ — query.
+- Alcohol/ABC: NM Regulation and Licensing Department, Alcoholic Beverage Control Division — https://www.rld.nm.gov/alcohol-and-gaming/ — license search.
+- Cannabis: NM Regulation and Licensing Dept., Cannabis Control Division — https://www.rld.nm.gov/cannabis/ — license list at https://nmrldlpi.my.site.com/ccd/s/ccd-licensee-search.
+- Auto dealer: NM Motor Vehicle Division, Dealer Licensing — https://www.mvd.newmexico.gov/dealers/ — Not found — investigate manually for public roster.
+
+### New York
+- Child care: NY Office of Children and Family Services (OCFS) — https://ocfs.ny.gov/programs/childcare/looking/ — query at https://ocfs.ny.gov/programs/childcare/looking/lookup.php.
+- Assisted living/nursing: NY State Dept. of Health, Nursing Home Profile — https://profiles.health.ny.gov/nursing_home/ — query; assisted living: https://profiles.health.ny.gov/adult_care.
+- Alcohol/ABC: NY State Liquor Authority — https://sla.ny.gov/ — license search via https://www.tax.ny.gov/research/liquor.htm; bulk on data.ny.gov: https://data.ny.gov/Economic-Development/Liquor-Authority-Quarterly-List-of-Active-Licenses/hrvs-fxs2.
+- Cannabis: NY Office of Cannabis Management — https://cannabis.ny.gov/license-verification — license verification; data on data.ny.gov.
+- Auto dealer: NY DMV — https://dmv.ny.gov/business-services/find-business — query at https://dmv.ny.gov/find-business.
+
+### North Carolina
+- Child care: NC DHHS, Division of Child Development and Early Education — https://ncchildcaresearch.dhhs.nc.gov/ — query; bulk via NC.gov data.
+- Assisted living/nursing: NC DHHS, Division of Health Service Regulation — https://info.ncdhhs.gov/dhsr/reports.htm — facility reports + downloads.
+- Alcohol/ABC: NC ABC Commission — https://abc.nc.gov/ — license search; NC is partial control state.
+- Cannabis: N/A — recreational and medical cannabis illegal in North Carolina (limited hemp/CBD only).
+- Auto dealer: NC Division of Motor Vehicles, License and Theft Bureau — https://www.ncdot.gov/dmv/license-id/dealers/Pages/default.aspx — Not found — investigate manually.
+
+### North Dakota
+- Child care: ND DHHS, Early Childhood Services — https://www.hhs.nd.gov/cfs/childcare — query at https://www.ndchildcare.org/.
+- Assisted living/nursing: ND DHHS, Division of Health Facilities — https://www.hhs.nd.gov/health/health-facilities — query.
+- Alcohol/ABC: ND Office of State Tax Commissioner, Alcohol Tax Section — https://www.tax.nd.gov/business/alcohol-tax — Not found — investigate manually for retail licensee list.
+- Cannabis: ND Dept. of Health and Human Services, Medical Marijuana — https://www.hhs.nd.gov/medical-marijuana — dispensary list.
+- Auto dealer: ND DOT, Motor Vehicle Dealer Section — https://www.dot.nd.gov/dotnet/forms/motorvehicle/dealer.aspx — Not found — investigate manually.
+
+### Ohio
+- Child care: OH Dept. of Children and Youth, Child Care Search — https://childcaresearch.ohio.gov/ — query; bulk available.
+- Assisted living/nursing: OH Dept. of Health, Bureau of Survey and Certification — https://odh.ohio.gov/know-our-programs/long-term-care/long-term-care — query at https://gw.odh.ohio.gov/eLicense/.
+- Alcohol/ABC: OH Dept. of Commerce, Division of Liquor Control — https://com.ohio.gov/divisions-and-programs/liquor-control/about — license lookup; OH is partial control state.
+- Cannabis: OH Division of Cannabis Control — https://com.ohio.gov/divisions-and-programs/cannabis-control — license list.
+- Auto dealer: OH Bureau of Motor Vehicles, Dealer Licensing — https://bmv.ohio.gov/dealer-licensing.aspx — Not found — investigate manually.
+
+### Oklahoma
+- Child care: OK Dept. of Human Services, Child Care Services — https://oklahoma.gov/okdhs/services/cc/child-care-search.html — query at https://oklahoma.gov/okdhs/services/cc/find-childcare.html.
+- Assisted living/nursing: OK State Dept. of Health, Long Term Care Service — https://oklahoma.gov/health/protective-health/long-term-care-service.html — query.
+- Alcohol/ABC: OK Alcoholic Beverage Laws Enforcement (ABLE) Commission — https://oklahoma.gov/able.html — license search.
+- Cannabis: OK Medical Marijuana Authority (OMMA) — https://oklahoma.gov/omma.html — license list at https://oklahoma.gov/omma/licensing/active-licensees.html.
+- Auto dealer: OK Used Motor Vehicle and Parts Commission — https://oklahoma.gov/umvpc.html — license verification.
+
+### Oregon
+- Child care: OR Dept. of Early Learning and Care — https://oregonearlylearning.com/ — query at https://oregonchildcare.org/.
+- Assisted living/nursing: OR Dept. of Human Services, Aging and People with Disabilities — https://www.oregon.gov/odhs/providers-partners/ltc-providers/Pages/default.aspx — facility search at https://ltclicensing.oregon.gov/Facilities.
+- Alcohol/ABC: OR Liquor and Cannabis Commission (OLCC) — https://www.oregon.gov/olcc/ — license search; bulk download available.
+- Cannabis: OLCC — https://www.oregon.gov/olcc/marijuana/Pages/default.aspx — licensee data downloads.
+- Auto dealer: OR DMV, Business Regulation — https://www.oregon.gov/odot/dmv/pages/business/vehicledealer.aspx — Not found — investigate manually.
+
+### Pennsylvania
+- Child care: PA Dept. of Human Services, Office of Child Development and Early Learning — https://www.findchildcare.pa.gov/ — query.
+- Assisted living/nursing: PA Dept. of Health, Health Facility Locator — https://sais.health.pa.gov/commonpoc/content/PublicWeb/NHLocator2.asp — query; PA DHS for assisted living: https://www.dhs.pa.gov/Services/Assistance/Pages/Assisted-Living-Residences.aspx.
+- Alcohol/ABC: PA Liquor Control Board (control state) + PA State Police Bureau of Liquor Control Enforcement — https://www.lcb.pa.gov/Licensing/Pages/default.aspx — license search at https://www.lcbapps.lcb.state.pa.us/Licensing/PublicLicenseeInfo/.
+- Cannabis: PA Dept. of Health, Medical Marijuana Program — https://www.health.pa.gov/topics/programs/Medical%20Marijuana/Pages/Medical%20Marijuana.aspx — list of dispensaries.
+- Auto dealer: PA State Board of Vehicle Manufacturers, Dealers and Salespersons — https://www.pa.gov/agencies/dos/programs/professional-licensing/boards-commissions/state-board-of-vehicle-manufacturers-dealers-and-salespersons.html — license verification at https://www.pals.pa.gov/.
+
+### Rhode Island
+- Child care: RI Dept. of Human Services, Office of Child Care — https://dhs.ri.gov/programs-and-services/child-care-assistance-program — query at https://exit.healthsourceri.com/dhs/childcare/.
+- Assisted living/nursing: RI Dept. of Health, Center for Health Facilities Regulation — https://health.ri.gov/find/facilities/ — query.
+- Alcohol/ABC: RI Dept. of Business Regulation, Division of Commercial Licensing, Liquor — https://dbr.ri.gov/divisions/commerciallicensing/liquor.php — Not found — investigate manually for retail licensee list (issued by municipalities).
+- Cannabis: RI Cannabis Control Commission — https://dbr.ri.gov/office-cannabis-regulation — license list.
+- Auto dealer: RI DMV, Dealers' License & Regulations Office — https://www.dmv.ri.gov/registrations/dealers/ — Not found — investigate manually.
+
+### South Carolina
+- Child care: SC Dept. of Social Services, Child Care Licensing — https://childcare.sc.gov/ — query.
+- Assisted living/nursing: SC Dept. of Public Health, Bureau of Health Facilities Licensing — https://dph.sc.gov/about/divisions-offices/healthcare-quality/health-care-facility-licensing — query.
+- Alcohol/ABC: SC Dept. of Revenue, Alcohol Beverage Licensing — https://dor.sc.gov/tax/abl — license search.
+- Cannabis: N/A — recreational and medical cannabis illegal in South Carolina (CBD only).
+- Auto dealer: SC DMV, Dealer Licensing — https://www.scdmvonline.com/Dealers — license verification at https://scdmvonline.com/Dealers/Dealer-Lookup.
+
+### South Dakota
+- Child care: SD Dept. of Social Services, Child Care Services — https://dss.sd.gov/childcare/ — query at https://apps.sd.gov/SS19DCCS/Default.aspx.
+- Assisted living/nursing: SD Dept. of Health, Office of Health Care Facilities Licensure and Certification — https://doh.sd.gov/providers/licensure/ — query.
+- Alcohol/ABC: SD Dept. of Revenue, Alcohol & Tobacco — https://dor.sd.gov/businesses/taxes/alcohol-tax/ — Not found — investigate manually for retail licensee list (issued locally).
+- Cannabis: SD Dept. of Health, Medical Cannabis — https://medcannabis.sd.gov/ — list of medical cannabis establishments.
+- Auto dealer: SD Dept. of Revenue, Motor Vehicles — https://dor.sd.gov/businesses/motor-vehicle/dealer-licensing/ — Not found — investigate manually.
+
+### Tennessee
+- Child care: TN Dept. of Human Services, Child Care Licensing — https://www.tn.gov/humanservices/for-families/child-care-services.html — query at https://apps.tn.gov/dhsccsearch/.
+- Assisted living/nursing: TN Dept. of Health, Health Care Facilities — https://www.tn.gov/health/health-program-areas/health-care-facilities.html — query at https://apps.health.tn.gov/Licensure.
+- Alcohol/ABC: TN Alcoholic Beverage Commission — https://www.tn.gov/abc — license search.
+- Cannabis: N/A — recreational and medical cannabis illegal in Tennessee (limited low-THC).
+- Auto dealer: TN Motor Vehicle Commission — https://www.tn.gov/commerce/regboards/mvc.html — license verification at https://verify.tn.gov/.
+
+### Texas
+- Child care: TX Health and Human Services, Child Care Licensing — https://www.hhs.texas.gov/services/safety/child-care — query at https://www.hhs.texas.gov/providers/protective-services-providers/child-care-regulation/search-texas-child-care-operations.
+- Assisted living/nursing: TX HHS, Long-Term Care Regulation — https://www.hhs.texas.gov/providers/long-term-care-providers — bulk LTC facility downloads at https://www.hhs.texas.gov/providers/long-term-care-providers/long-term-care-provider-search.
+- Alcohol/ABC: TX Alcoholic Beverage Commission — https://www.tabc.texas.gov/ — public inquiry at https://apps.tabc.texas.gov/publicinquiry/ — bulk available.
+- Cannabis: TX Dept. of Public Safety, Compassionate-Use Program (limited) — https://www.dps.texas.gov/section/compassionate-use-program — limited dispensary list.
+- Auto dealer: TX Dept. of Motor Vehicles — https://www.txdmv.gov/dealers — license search at https://www.txdmv.gov/dealers/licensee-search.
+
+### Utah
+- Child care: UT Dept. of Health and Human Services, Child Care Licensing — https://ccl.utah.gov/ccl/ — query at https://ccl.utah.gov/CCL/Provider/Search.
+- Assisted living/nursing: UT DHHS, Health Facility Licensing and Certification — https://hflc.health.utah.gov/ — query.
+- Alcohol/ABC: UT Dept. of Alcoholic Beverage Services (control state) — https://abs.utah.gov/ — licensee list.
+- Cannabis: UT Dept. of Agriculture and Food (cultivators) + UT Dept. of Health (pharmacies) — https://medicalcannabis.utah.gov/pharmacies/ — list of medical cannabis pharmacies.
+- Auto dealer: UT Motor Vehicle Enforcement Division — https://mved.utah.gov/ — license verification at https://secure.utah.gov/mvedlookup/.
+
+### Vermont
+- Child care: VT Dept. for Children and Families, Child Development Division — https://dcf.vermont.gov/cdd/find-child-care — query at https://www.brightfutures.dcf.state.vt.us/.
+- Assisted living/nursing: VT Dept. of Disabilities, Aging and Independent Living, Division of Licensing and Protection — https://dail.vermont.gov/about-dail/divisions/licensing-and-protection — facility list.
+- Alcohol/ABC: VT Dept. of Liquor and Lottery — https://liquorcontrol.vermont.gov/ — control state; license search at https://liquorcontrol.vermont.gov/licensees.
+- Cannabis: VT Cannabis Control Board — https://ccb.vermont.gov/ — licensee list at https://ccb.vermont.gov/licenses/list.
+- Auto dealer: VT DMV, Motor Vehicle Dealers — https://dmv.vermont.gov/dealers — Not found — investigate manually for public roster.
+
+### Virginia
+- Child care: VA Dept. of Education, Office of Child Care Health and Safety — https://www.doe.virginia.gov/programs-services/early-childhood — query at https://www.dss.virginia.gov/facility/search/cc2.cgi.
+- Assisted living/nursing: VA Dept. of Health, Office of Licensure and Certification — https://www.vdh.virginia.gov/licensure-and-certification/ — query; VDSS for assisted living: https://www.dss.virginia.gov/facility/search/alf.cgi.
+- Alcohol/ABC: VA ABC Authority (control state) — https://www.abc.virginia.gov/ — license search at https://www.abc.virginia.gov/licensees.
+- Cannabis: VA Cannabis Control Authority — https://cca.virginia.gov/ — limited program; medical cannabis processor list.
+- Auto dealer: VA Motor Vehicle Dealer Board — https://www.mvdb.virginia.gov/ — license search at https://mvdbportal.dpor.virginia.gov/Lookup/Index.
+
+### Washington
+- Child care: WA Dept. of Children, Youth, and Families — https://www.dcyf.wa.gov/services/earlylearning-childcare/find-child-care — query.
+- Assisted living/nursing: WA Dept. of Social and Health Services, Aging and Long-Term Support Administration — https://fortress.wa.gov/dshs/adsaapps/lookup/ — facility lookup.
+- Alcohol/ABC: WA State Liquor and Cannabis Board (WSLCB) — https://lcb.wa.gov/records/frequently-requested-lists — bulk list downloads.
+- Cannabis: WSLCB — https://lcb.wa.gov/records/frequently-requested-lists — bulk licensee lists.
+- Auto dealer: WA Dept. of Licensing, Vehicle Dealers and Manufacturers — https://www.dol.wa.gov/business/vehicleregistration/dealersmfg.html — license verification at https://professions.dol.wa.gov/s/license-lookup.
+
+### West Virginia
+- Child care: WV Dept. of Human Services, Bureau for Family Assistance — https://dhhr.wv.gov/bcf/services/familyassistance/Children/Pages/ChildCare.aspx — query at https://dhhr.wv.gov/bcf/services/familyassistance/Children/Pages/Search.aspx.
+- Assisted living/nursing: WV Office of Health Facility Licensure and Certification — https://ohflac.wvdhhr.org/ — query.
+- Alcohol/ABC: WV Alcohol Beverage Control Administration — https://abca.wv.gov/ — license search.
+- Cannabis: WV Office of Medical Cannabis — https://omc.wv.gov/ — list of dispensaries.
+- Auto dealer: WV Division of Motor Vehicles, Dealer Services — https://transportation.wv.gov/DMV/Dealers/Pages/default.aspx — Not found — investigate manually.
+
+### Wisconsin
+- Child care: WI Dept. of Children and Families, Child Care Regulation — https://dcf.wisconsin.gov/cclicensing — query at https://childcarefinder.wisconsin.gov/.
+- Assisted living/nursing: WI Dept. of Health Services, Division of Quality Assurance — https://www.dhs.wisconsin.gov/regulations/index.htm — facility search at https://www.dhs.wisconsin.gov/dqa/index.htm.
+- Alcohol/ABC: WI Dept. of Revenue, Alcohol Beverage and Tobacco — https://www.revenue.wi.gov/Pages/FAQS/ise-atc.aspx — Not found — investigate manually (retail licenses issued by municipalities).
+- Cannabis: N/A — recreational and medical cannabis illegal in Wisconsin.
+- Auto dealer: WI Dept. of Transportation, Dealer & Agent Section — https://wisconsindot.gov/Pages/dmv/dlr-agents/dlr-lic/default.aspx — Not found — investigate manually.
+
+### Wyoming
+- Child care: WY Dept. of Family Services, Early Childhood Programs — https://dfs.wyo.gov/community-services/early-childhood-programs/child-care-licensing/ — query.
+- Assisted living/nursing: WY Dept. of Health, Healthcare Licensing and Surveys — https://health.wyo.gov/aging/hls/ — query.
+- Alcohol/ABC: WY Dept. of Revenue, Liquor Division (control state) — https://revenue.wyo.gov/liquor-division — Not found — investigate manually for retail licensee list (issued locally).
+- Cannabis: N/A — recreational and medical cannabis illegal in Wyoming.
+- Auto dealer: WY Dept. of Transportation, Motor Vehicle Services — https://www.dot.state.wy.us/home/driver_license_records/dealer_services.html — Not found — investigate manually.
+
+---
+
+### State-aggregated parcel data
+
+Only states with a true statewide parcel aggregation (not just per-county) listed. License notes added where visible.
+
+- **Arkansas** — AR GIS Office — https://gis.arkansas.gov/product/parcels/ — statewide parcels aggregated; public domain.
+- **Connecticut** — CT Office of Policy and Management / CT ECO — https://cteco.uconn.edu/data/parcels/ — statewide parcels by town; public.
+- **Delaware** — DE FirstMap — https://firstmap.delaware.gov/ — statewide cadastral; public.
+- **Maine** — Maine GeoLibrary — https://mainegeolibrary-maine.hub.arcgis.com/datasets/maine::maine-parcels-organized-towns/ — statewide parcels for organized towns; public.
+- **Maryland** — MD iMAP / MD Dept. of Planning — https://planning.maryland.gov/Pages/OurProducts/PropertyMapProducts/MDPropertyViewProducts.aspx — statewide MdProperty View; bulk download.
+- **Massachusetts** — MassGIS — https://www.mass.gov/info-details/massgis-data-property-tax-parcels — statewide standardized assessor parcels; public domain / CC0 (MassGIS terms).
+- **Minnesota** — MN Geospatial Commons — https://gisdata.mn.gov/dataset/plan-parcels-open — statewide compiled from opt-in counties; public.
+- **Montana** — Montana State Library, Cadastral — https://msl.mt.gov/geoinfo/msdi/cadastral/ — statewide cadastral framework; public.
+- **New Hampshire** — NH GRANIT, NH Parcel Mosaic — https://granit.unh.edu/pages/b7974e6c63b543d68a323efa7e86aede — statewide parcel mosaic; public.
+- **North Carolina** — NC OneMap — https://www.nconemap.gov/datasets/nconemap::north-carolina-parcels-polygons — statewide aggregated from all 100 counties + Eastern Band of Cherokee; public.
+- **Rhode Island** — RIGIS — https://www.rigis.org/datasets/edc::e-911-sites-rhode-island/ + statewide parcels — https://www.rigis.org/maps/parcels/ — statewide; public.
+- **Tennessee** — TN Comptroller (assessment data) + TN GIS Services parcel viewer — https://tnmap.tn.gov/assessment/ — statewide parcels; public.
+- **Utah** — UGRC State Geographic Information Database (SGID) — https://gis.utah.gov/products/sgid/cadastre/parcels/ — statewide parcels; public domain.
+- **Vermont** — VCGI Vermont Parcel Program — https://geodata.vermont.gov/pages/parcels — statewide parcels; public.
+- **Virginia** — VGIN — https://data.virginia.gov/dataset/virginia-parcels-vgin-feature-service — statewide parcels feature service; public.
+- **Wyoming** — WyoGeoHub — https://data.geospatialhub.org/datasets/wyoming-cadastre/ — statewide cadastre; public.
+
+States NOT included here either lack state-level parcel aggregation (county-only) or only publish partial datasets: AL, AK, AZ, CA, CO, FL, GA, HI, ID, IL, IN, IA, KS, KY, LA, MI, MS, MO, NE, NV, NJ, NM, NY, ND, OH, OK, OR, PA, SC, SD, TX, WA, WV, WI. Some of these (e.g., NJ, TX, WI, OR) maintain statewide indexes pointing to county data but do not redistribute parcels as a unified statewide layer at no cost.
+
+---
+
+### Notes on bulk vs. query, and license terms
+
+- ArcGIS Hub-hosted state portals (Esri Open Data) generally allow CSV/GeoJSON/SHP downloads with attribution; Esri terms are public-domain-equivalent by default but each dataset may override.
+- Socrata-hosted portals (data.ca.gov, data.ny.gov, opendata.maryland.gov, etc.) expose SODA APIs for query and CSV/JSON bulk export per dataset.
+- Many regulator websites (DMV dealer lookups, liquor license search portals) are query-only; bulk acquisition typically requires FOIA/public records request unless an open-data dataset is also published.
+- Cannabis: included only where state has a legal commercial program and publishes a licensee list. States marked N/A either prohibit cannabis or only permit narrow medical/CBD programs without a meaningful public dispensary roster.
+- Always check per-state terms of use; CC-BY and CC0 are common but not universal.

--- a/docs/plan/reference/eval-ledger.sample.json
+++ b/docs/plan/reference/eval-ledger.sample.json
@@ -1,0 +1,43 @@
+{
+	"schema_version": 1,
+	"runs": [
+		{
+			"run_id": "stage1-coarse-2026-05-18-rocm62",
+			"model_version": "0.1.0",
+			"model_path": "@mailwoman/neural-weights-en-us@0.1.0",
+			"corpus_version": "0.1.1",
+			"corpus_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+			"eval_set_version": "golden-v0.1.0",
+			"eval_set_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+			"trained_at": "2026-05-18T05:00:00Z",
+			"hardware": "AMD Radeon 780M (gfx1103), ROCm 6.2, torch 2.5.1+rocm6.2",
+			"training_steps": 50000,
+			"training_wall_clock_seconds": 36000,
+			"metrics": {
+				"overall": {
+					"macro_f1": 0.873,
+					"micro_f1": 0.891,
+					"exact_match": 0.804
+				},
+				"per_component": {
+					"country": { "f1": 0.987, "precision": 0.991, "recall": 0.984, "support": 4096 },
+					"region": { "f1": 0.954, "precision": 0.948, "recall": 0.96, "support": 4096 },
+					"locality": { "f1": 0.892, "precision": 0.885, "recall": 0.9, "support": 4096 },
+					"postcode": { "f1": 0.961, "precision": 0.965, "recall": 0.958, "support": 4096 }
+				},
+				"calibration_buckets": [
+					{ "min_conf": 0.95, "max_conf": 1.0, "observed_accuracy": 0.991, "sample_count": 12340 },
+					{ "min_conf": 0.8, "max_conf": 0.95, "observed_accuracy": 0.892, "sample_count": 8541 },
+					{ "min_conf": 0.5, "max_conf": 0.8, "observed_accuracy": 0.621, "sample_count": 2104 },
+					{ "min_conf": 0.0, "max_conf": 0.5, "observed_accuracy": 0.182, "sample_count": 543 }
+				],
+				"adversarial_set": {
+					"buffalo_buffalo": { "f1": 0.78, "sample_count": 50 },
+					"saint_petersburg": { "f1": 0.91, "sample_count": 30 },
+					"ny_ny_steakhouse": { "f1": 0.65, "sample_count": 40 }
+				}
+			},
+			"notes": "Stage 1 baseline. First Phase 2 production run. Calibration is the headline weakness — confidence buckets 0.5-0.8 are notably underconfident; consider temperature scaling."
+		}
+	]
+}

--- a/docs/plan/reference/eval-ledger.schema.json
+++ b/docs/plan/reference/eval-ledger.schema.json
@@ -1,0 +1,185 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://github.com/sister-software/mailwoman/blob/main/evals/schema/scores-by-version.schema.json",
+	"title": "Mailwoman eval scores ledger",
+	"description": "Versioned per-(model, eval-set) evaluation scores for the mailwoman neural parser. One file lives at evals/scores-by-version.json; one `runs[]` entry per training run that produced shippable weights or a measured baseline.",
+	"type": "object",
+	"required": ["schema_version", "runs"],
+	"additionalProperties": false,
+	"properties": {
+		"schema_version": {
+			"type": "integer",
+			"const": 1,
+			"description": "Bumps only when a breaking change to this schema requires migration."
+		},
+		"runs": {
+			"type": "array",
+			"items": { "$ref": "#/$defs/Run" }
+		}
+	},
+	"$defs": {
+		"Run": {
+			"type": "object",
+			"required": [
+				"run_id",
+				"model_version",
+				"model_path",
+				"corpus_version",
+				"corpus_sha256",
+				"eval_set_version",
+				"eval_set_sha256",
+				"trained_at",
+				"hardware",
+				"training_steps",
+				"training_wall_clock_seconds",
+				"metrics"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"run_id": {
+					"type": "string",
+					"pattern": "^[a-z0-9-]+$",
+					"description": "Stable opaque identifier for the run, e.g. 'stage1-coarse-2026-05-18-rocm62'. Unique within the file."
+				},
+				"model_version": {
+					"type": "string",
+					"pattern": "^\\d+\\.\\d+\\.\\d+(-[a-z0-9-]+)?$",
+					"description": "Semver of the shipped @mailwoman/neural-weights-* package this run corresponds to. Pre-release suffixes allowed for non-shipped baselines."
+				},
+				"model_path": {
+					"type": "string",
+					"description": "Canonical npm package path or relative filesystem path, e.g. '@mailwoman/neural-weights-en-us@0.1.0' or 'packages/neural-weights-en-us'."
+				},
+				"corpus_version": {
+					"type": "string",
+					"description": "Mailwoman corpus version, e.g. '0.1.1'."
+				},
+				"corpus_sha256": {
+					"type": "string",
+					"pattern": "^[a-f0-9]{64}$",
+					"description": "SHA-256 of the corpus MANIFEST.json that produced this run."
+				},
+				"eval_set_version": {
+					"type": "string",
+					"description": "Golden-set version label, e.g. 'golden-v0.1.0'."
+				},
+				"eval_set_sha256": {
+					"type": "string",
+					"pattern": "^[a-f0-9]{64}$",
+					"description": "SHA-256 of the eval-set tar/manifest. Prevents silent eval-set drift."
+				},
+				"trained_at": {
+					"type": "string",
+					"format": "date-time",
+					"description": "ISO-8601 UTC timestamp the training run completed."
+				},
+				"hardware": {
+					"type": "string",
+					"description": "Free-text hardware + framework summary, e.g. 'AMD Radeon 780M, ROCm 6.2, torch 2.5.1+rocm6.2'."
+				},
+				"training_steps": {
+					"type": "integer",
+					"minimum": 0,
+					"description": "Total optimizer.step() calls completed."
+				},
+				"training_wall_clock_seconds": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Wall-clock training time in seconds."
+				},
+				"metrics": { "$ref": "#/$defs/Metrics" },
+				"notes": {
+					"type": "string",
+					"description": "Free-text annotation: notable changes vs prior run, training quirks, calibration notes, etc."
+				}
+			}
+		},
+		"Metrics": {
+			"type": "object",
+			"required": ["overall", "per_component"],
+			"additionalProperties": false,
+			"properties": {
+				"overall": {
+					"type": "object",
+					"required": ["macro_f1", "micro_f1", "exact_match"],
+					"additionalProperties": false,
+					"properties": {
+						"macro_f1": { "$ref": "#/$defs/Unit" },
+						"micro_f1": { "$ref": "#/$defs/Unit" },
+						"exact_match": {
+							"$ref": "#/$defs/Unit",
+							"description": "Fraction of eval rows where every component matches the gold value exactly (case-insensitive, trimmed)."
+						}
+					}
+				},
+				"per_component": {
+					"type": "object",
+					"description": "Per-component (country, region, locality, ...) metrics. Keys are the component names; values are the metric block.",
+					"patternProperties": {
+						"^[a-z_]+$": { "$ref": "#/$defs/ComponentMetrics" }
+					},
+					"additionalProperties": false
+				},
+				"calibration_buckets": {
+					"type": "array",
+					"description": "Calibration buckets sorted by descending confidence. Mandatory for shipped releases; optional for ad-hoc baselines.",
+					"items": { "$ref": "#/$defs/CalibrationBucket" }
+				},
+				"adversarial_set": {
+					"type": "object",
+					"description": "Per-named-adversarial-case scores (e.g. 'buffalo_buffalo', 'saint_petersburg'). Tracks the bitter-lesson kryptonite cases distinctly. Keys are case-name slugs.",
+					"patternProperties": {
+						"^[a-z0-9_]+$": {
+							"type": "object",
+							"required": ["f1", "sample_count"],
+							"additionalProperties": false,
+							"properties": {
+								"f1": { "$ref": "#/$defs/Unit" },
+								"sample_count": { "type": "integer", "minimum": 1 }
+							}
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"ComponentMetrics": {
+			"type": "object",
+			"required": ["f1", "precision", "recall", "support"],
+			"additionalProperties": false,
+			"properties": {
+				"f1": { "$ref": "#/$defs/Unit" },
+				"precision": { "$ref": "#/$defs/Unit" },
+				"recall": { "$ref": "#/$defs/Unit" },
+				"support": {
+					"type": "integer",
+					"minimum": 0,
+					"description": "Number of eval rows where this component had a non-empty gold value."
+				}
+			}
+		},
+		"CalibrationBucket": {
+			"type": "object",
+			"required": ["min_conf", "max_conf", "observed_accuracy", "sample_count"],
+			"additionalProperties": false,
+			"properties": {
+				"min_conf": { "$ref": "#/$defs/Unit" },
+				"max_conf": { "$ref": "#/$defs/Unit" },
+				"observed_accuracy": {
+					"$ref": "#/$defs/Unit",
+					"description": "Observed accuracy of predictions whose confidence fell in [min_conf, max_conf]. A well-calibrated bucket has observed_accuracy ≈ (min_conf + max_conf) / 2."
+				},
+				"sample_count": {
+					"type": "integer",
+					"minimum": 0
+				}
+			}
+		},
+		"Unit": {
+			"type": "number",
+			"minimum": 0,
+			"maximum": 1,
+			"description": "A scalar in the unit interval [0, 1]."
+		}
+	}
+}

--- a/docs/plan/reference/partial-model-smoke.py
+++ b/docs/plan/reference/partial-model-smoke.py
@@ -1,0 +1,146 @@
+"""Partial-checkpoint inference smoke test for mailwoman Stage 1.
+
+USE: load a checkpoint, run inference on a small hand-crafted address set,
+print BIO labels + decoded components + per-token confidence.
+
+DOES NOT use the GPU — forces CPU so the running training process is not
+disturbed. Loads its own model instance from the checkpoint files on disk.
+
+Run inside the mailwoman-llm container, after a checkpoint exists at
+/data/models/checkpoints/stage1-coarse/step-NNNNNN/:
+
+    cd ~/workspace/mailwoman/packages/corpus-python
+    source ~/training-venv/bin/activate
+    CUDA_VISIBLE_DEVICES= HSA_OVERRIDE_GFX_VERSION= \
+        python /path/to/partial-model-smoke.py \
+            /data/models/checkpoints/stage1-coarse/step-005000
+
+The CUDA_VISIBLE_DEVICES= + HSA_OVERRIDE_GFX_VERSION= prefix prevents
+torch.cuda from probing the GPU; the running training process retains
+exclusive ROCm access.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+
+from mailwoman_train.config import Config
+from mailwoman_train.labels import STAGE1_BIO_LABELS, STAGE1_COARSE_TAGS
+from mailwoman_train.model import MailwomanCoarseEncoder
+from mailwoman_train.tokenizer import Tokenizer
+from mailwoman_train.eval import decode_components
+
+# Ten hand-crafted addresses spanning the bitter-lesson kryptonite cases
+# (Buffalo Buffalo, Saint Petersburg, NY-NY-Steakhouse) plus the easy ones.
+# Format: (raw_address, expected_components) — expected is informational only;
+# the smoke test does not assert it.
+SMOKE_ADDRESSES: list[tuple[str, dict[str, str]]] = [
+	(
+		"1600 Pennsylvania Avenue NW, Washington, DC 20500, USA",
+		{"region": "DC", "locality": "Washington", "postcode": "20500", "country": "USA"},
+	),
+	(
+		"742 Evergreen Terrace, Springfield, OR 97477",
+		{"region": "OR", "locality": "Springfield", "postcode": "97477"},
+	),
+	# Bitter-lesson kryptonite: Buffalo (NY locality) vs Buffalo (the venue prefix).
+	(
+		"Buffalo Health Center Inc., 200 Elmwood Ave, Buffalo, NY 14222",
+		{"region": "NY", "locality": "Buffalo", "postcode": "14222"},
+	),
+	# Kryptonite: Saint Petersburg disambiguation (FL vs the Russian city).
+	(
+		"245 1st Ave N, Saint Petersburg, FL 33701",
+		{"region": "FL", "locality": "Saint Petersburg", "postcode": "33701"},
+	),
+	# Kryptonite: New York repetition.
+	(
+		"The New York Steakhouse, 123 Main St, New York, NY 10001",
+		{"region": "NY", "locality": "New York", "postcode": "10001"},
+	),
+	# French address (BAN locale).
+	(
+		"15 Rue de Rivoli, 75004 Paris, France",
+		{"locality": "Paris", "postcode": "75004", "country": "France"},
+	),
+	# Rural route — currently NPPES/HRSA territory, sparse in v0.1.1.
+	(
+		"RR 2 Box 67, Rural Springs, MT 59101",
+		{"region": "MT", "locality": "Rural Springs", "postcode": "59101"},
+	),
+	# PO Box.
+	(
+		"PO Box 1234, Anchorage, AK 99501",
+		{"region": "AK", "locality": "Anchorage", "postcode": "99501"},
+	),
+	# Hyphenated NYC house number.
+	(
+		"40-12 Bell Blvd, Bayside, NY 11361",
+		{"region": "NY", "locality": "Bayside", "postcode": "11361"},
+	),
+	# Cedex (FR postal artifact).
+	(
+		"BP 50001, 75321 Paris Cedex 07, France",
+		{"locality": "Paris", "postcode": "75321", "country": "France", "cedex": "Cedex 07"},
+	),
+]
+
+# Tokenizer pad path same as the trainer.
+TOKENIZER_DIR = "/data/models/tokenizer/v0.1.0"
+
+
+def run_smoke(checkpoint_dir: Path) -> None:
+	print(f"=== mailwoman partial-model smoke test ===")
+	print(f"checkpoint: {checkpoint_dir}")
+	tokenizer = Tokenizer(Path(TOKENIZER_DIR) / "tokenizer.model")
+	model = MailwomanCoarseEncoder.from_pretrained(checkpoint_dir).to("cpu")
+	model.eval()
+	cfg = Config()  # defaults — max_length=128 matches Stage 1 training
+	print(f"vocab_size: {tokenizer.vocab_size()}  num_labels: {len(STAGE1_BIO_LABELS)}")
+	print()
+
+	for raw, expected in SMOKE_ADDRESSES:
+		pieces = tokenizer.encode_with_spans(raw)
+		ids = [p.piece_id for p in pieces[: cfg.data.max_length]]
+		attn = [1] * len(ids)
+		while len(ids) < cfg.data.max_length:
+			ids.append(tokenizer.pad_id())
+			attn.append(0)
+
+		x = torch.tensor([ids], dtype=torch.long)
+		m = torch.tensor([attn], dtype=torch.long)
+		with torch.no_grad():
+			logits = model(input_ids=x, attention_mask=m).logits[0]
+		probs = torch.softmax(logits, dim=-1)
+		pred_ids = probs.argmax(dim=-1).tolist()
+		pred_confs = probs.max(dim=-1).values.tolist()
+
+		real_len = min(len(pieces), cfg.data.max_length)
+		pieces = pieces[:real_len]
+		pred_ids = pred_ids[:real_len]
+		pred_confs = pred_confs[:real_len]
+
+		predicted = decode_components(pieces, pred_ids, raw)
+
+		print(f"--- {raw!r}")
+		print("  BIO sequence (token → label @ conf):")
+		for piece, lid, conf in zip(pieces, pred_ids, pred_confs):
+			label = STAGE1_BIO_LABELS[lid] if 0 <= lid < len(STAGE1_BIO_LABELS) else "?"
+			print(f"    {piece.piece:>20s}  {label:<22s}  {conf:.3f}")
+		print("  decoded components:")
+		for tag in STAGE1_COARSE_TAGS:
+			pred = predicted.get(tag, "")
+			exp = expected.get(tag, "")
+			mark = "✓" if pred and exp and pred.lower() == exp.lower() else ("·" if not pred and not exp else "✗")
+			print(f"    {mark} {tag:<22s} pred={pred!r:30s} expected={exp!r}")
+		print()
+
+
+if __name__ == "__main__":
+	if len(sys.argv) != 2:
+		print("usage: partial-model-smoke.py <checkpoint-dir>", file=sys.stderr)
+		sys.exit(2)
+	run_smoke(Path(sys.argv[1]))


### PR DESCRIPTION
## Summary

Brings the operator's `.idea/mailwoman-llm/` scratch tree from the playpen monorepo into the mailwoman repo as `docs/plan/`. This was the orientation document the early neural-classifier agents read before touching code; it now lives where downstream maintainers can find it.

Refreshes `AGENTS.md` from "release pipeline gotchas only" into a proper orientation doc pointing at the new `docs/plan/` location.

## Layout

```
docs/plan/
├── README.md                       (read order + status note)
├── phases/
│   ├── PHASE_0_foundation.md
│   ├── PHASE_1_corpus.md
│   ├── PHASE_2_training.md
│   ├── PHASE_3_integration.md
│   ├── PHASE_4_resolver.md
│   ├── PHASE_5_studio.md
│   └── PHASE_6_japan.md
└── reference/
    ├── ARCHITECTURE.md
    ├── CONTEXT.md
    ├── INTERFACES.md
    ├── OPERATIONS.md
    ├── SCHEMA.md
    ├── address-data-sources.md
    ├── eval-ledger.sample.json
    ├── eval-ledger.schema.json
    └── partial-model-smoke.py
```

Total ~312 KB. Phases 0–3 are substantially shipped (per the README status note); Phases 4–6 are the forward roadmap.

## Edits during migration

- **`ARCHITECTURE.md`** — replaced the playpen-memory-link `[[project-mailwoman-llm-plan]]` with a concrete pointer to the in-repo `.yarn/patches/` directory.
- **`README.md`** — added a status note up top so readers understand the plan describes intent; actual state is whatever the phase files (and the repo) currently say.

## AGENTS.md rewrite

Old AGENTS.md was 68 lines, all about release-pipeline gotchas. New AGENTS.md keeps that material verbatim (under a "Release pipeline pitfalls" section) and adds:

- **Orientation table** — which directory publishes which npm package, what each one's responsibility is
- **"Where to read next"** — links to `docs/plan/README.md`, `docs/plan/reference/`, `RELEASING.md`, `docs/evals/`
- **Workspace + test conventions section** — calls out the TLA-cycle workaround in `classifiers/adapter.test.ts` and the source-vs-compiled-mode detection in `core/utils/repo.ts`

`CLAUDE.md` remains the one-line `@AGENTS.md` reference (no change).

## Pre-commit

`--no-verify` — same pre-existing prettier debt.