### PR TITLE
core+corpus+scripts: replace better-sqlite3 with node:sqlite

### DIFF
--- a/core/resources/whosonfirst/PlacetypeDataSource.ts
+++ b/core/resources/whosonfirst/PlacetypeDataSource.ts
@@ -10,7 +10,7 @@ import {
 	Alpha3bToAlpha2,
 	isAlpha3bLanguageCode,
 } from "@mailwoman/core/resources/languages"
-import sqlite, { type Options as SQLiteOptions } from "better-sqlite3"
+import { DatabaseSync, type DatabaseSyncOptions, type SQLInputValue } from "node:sqlite"
 import { PathBuilder, type PathBuilderLike } from "path-ts"
 import { tryWithBackoff } from "./DataSourceCache.js"
 import type { WhosOnFirstPlacetype } from "./placetypes/definition.js"
@@ -67,7 +67,7 @@ export interface PlacetypeRecord {
  * A data source for WhosOnFirst placetype records.
  */
 export class PlacetypeDataSource implements Disposable {
-	#db: sqlite.Database
+	#db: DatabaseSync
 
 	public static createPath<P extends WhosOnFirstPlacetype, L extends Alpha3bLanguageCode | Alpha2LanguageCode>({
 		placetype,
@@ -118,12 +118,13 @@ export class PlacetypeDataSource implements Disposable {
 		`)
 	}
 
-	constructor(databasePath: PathBuilderLike, dbOptions?: SQLiteOptions) {
-		this.#db = sqlite(databasePath.toString(), dbOptions)
+	constructor(databasePath: PathBuilderLike, dbOptions?: DatabaseSyncOptions) {
+		this.#db = new DatabaseSync(databasePath.toString(), dbOptions)
 
-		this.#db.pragma("busy_timeout = 10000")
-		this.#db.pragma("journal_mode = WAL")
-		this.#db.pragma("synchronous = OFF")
+		// node:sqlite has no .pragma() helper; pragmas are executed as plain SQL.
+		this.#db.exec("PRAGMA busy_timeout = 10000")
+		this.#db.exec("PRAGMA journal_mode = WAL")
+		this.#db.exec("PRAGMA synchronous = OFF")
 
 		this.prepareTables()
 		//this.prepareIndexes()
@@ -138,7 +139,7 @@ export class PlacetypeDataSource implements Disposable {
 	 */
 
 	public find(criteria: Partial<PlacetypeRecord>): IteratorObject<PlacetypeRecord> {
-		const statement = this.#db.prepare<[], PlacetypeRecord>(/* sql */ `
+		const statement = this.#db.prepare(/* sql */ `
 			SELECT *
 			FROM records
 			WHERE ${Object.keys(criteria)
@@ -146,7 +147,11 @@ export class PlacetypeDataSource implements Disposable {
 				.join(" OR ")}
 		`)
 
-		return Iterator.from(statement.iterate())
+		// node:sqlite's StatementSync.iterate() accepts named params via an object whose keys match
+		// the `@name` / `:name` / `$name` placeholders in the SQL.
+		return Iterator.from(
+			statement.iterate(criteria as unknown as Record<string, SQLInputValue>)
+		) as unknown as IteratorObject<PlacetypeRecord>
 	}
 
 	/**
@@ -156,7 +161,7 @@ export class PlacetypeDataSource implements Disposable {
 	 */
 	public async upsert(record: PlacetypeRecord): Promise<void> {
 		const perform = () => {
-			const statement = this.#db.prepare<PlacetypeRecord>(/* sql */ `
+			const statement = this.#db.prepare(/* sql */ `
 			INSERT INTO records
 			(id, src, name, preferred, variant, colloquial, abbr, short, parent_id)
 			VALUES (
@@ -180,7 +185,7 @@ export class PlacetypeDataSource implements Disposable {
 			parent_id = excluded.parent_id
 			`)
 
-			statement.run(record)
+			statement.run(record as unknown as Record<string, SQLInputValue>)
 		}
 
 		await tryWithBackoff(5, perform)

--- a/corpus/package.json
+++ b/corpus/package.json
@@ -19,7 +19,6 @@
 		"@dsnp/parquetjs": "1.7.0",
 		"@fragaria/address-formatter": "^6.3.0",
 		"@mailwoman/core": "workspace:*",
-		"better-sqlite3": "^11.5.0",
 		"csv-parse": "^5.5.6",
 		"fastest-levenshtein": "^1.0.16",
 		"lru-cache": "^10.0.1"

--- a/corpus/scripts/build-tiger-db.ts
+++ b/corpus/scripts/build-tiger-db.ts
@@ -544,9 +544,9 @@ async function buildDatabase(stateFipsList: string[]): Promise<void> {
 
 	// Build indexes
 	log("Building indexes...")
-	const Database = (await import("better-sqlite3")).default
-	const db = new Database(DB_PATH)
-	db.pragma("journal_mode = WAL")
+	const { DatabaseSync } = await import("node:sqlite")
+	const db = new DatabaseSync(DB_PATH)
+	db.exec("PRAGMA journal_mode = WAL")
 	db.exec("CREATE INDEX IF NOT EXISTS idx_tiger_streets_statefp ON tiger_streets(statefp)")
 	db.exec("CREATE INDEX IF NOT EXISTS idx_tiger_streets_linearid ON tiger_streets(linearid)")
 	try {

--- a/corpus/scripts/ingest-csv.ts
+++ b/corpus/scripts/ingest-csv.ts
@@ -250,12 +250,12 @@ async function ingestCSV(opts: IngestOptions): Promise<void> {
 	}
 
 	// --- Create database + import ---
-	const Database = (await import("better-sqlite3")).default
+	const { DatabaseSync } = await import("node:sqlite")
 	mkdirSync(dirname(opts.outputPath), { recursive: true })
 
-	const db = new Database(opts.outputPath)
-	db.pragma("journal_mode = OFF") // faster for bulk import
-	db.pragma("synchronous = OFF")
+	const db = new DatabaseSync(opts.outputPath)
+	db.exec("PRAGMA journal_mode = OFF") // faster for bulk import
+	db.exec("PRAGMA synchronous = OFF")
 
 	db.exec(createTableSQL)
 
@@ -284,11 +284,19 @@ async function ingestCSV(opts: IngestOptions): Promise<void> {
 	let imported = 0
 	let headerSkipped = false
 
-	const doInsert = db.transaction(() => {
-		for (const row of batch) {
-			insertStmt.run(row)
+	// node:sqlite has no `db.transaction(fn)` wrapper; use raw BEGIN/COMMIT around the batch.
+	const doInsert = () => {
+		db.exec("BEGIN")
+		try {
+			for (const row of batch) {
+				insertStmt.run(...row)
+			}
+			db.exec("COMMIT")
+		} catch (err) {
+			db.exec("ROLLBACK")
+			throw err
 		}
-	})
+	}
 
 	const batch: unknown[][] = []
 	const BATCH_SIZE = 10000

--- a/corpus/src/adapters/fcc-bdc/adapter.test.ts
+++ b/corpus/src/adapters/fcc-bdc/adapter.test.ts
@@ -4,10 +4,10 @@
  * @author Teffen Ellis, et al.
  */
 
-import Database from "better-sqlite3"
 import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
+import { DatabaseSync } from "node:sqlite"
 import { fileURLToPath } from "node:url"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { runAdapter } from "../../runner.js"
@@ -29,7 +29,7 @@ let dbPath: string
 async function buildFixtureDb(): Promise<string> {
 	const sql = await readFile(fixtureSqlPath, "utf8")
 	const path = join(scratch, "fcc-bdc-fixture.db")
-	const db = new Database(path)
+	const db = new DatabaseSync(path)
 	db.exec(sql)
 	db.close()
 	return path

--- a/corpus/src/adapters/fcc-bdc/adapter.ts
+++ b/corpus/src/adapters/fcc-bdc/adapter.ts
@@ -34,7 +34,7 @@
  *   re-stamp accordingly.
  */
 
-import Database from "better-sqlite3"
+import { DatabaseSync } from "node:sqlite"
 import { lookupStateAbbreviation } from "../../codex/us-fips-state.js"
 import { formatAddress, reconcileComponents } from "../../format.js"
 import type { AdapterOptions, CanonicalRow, CorpusAdapter } from "../../types.js"
@@ -115,16 +115,16 @@ export function createFccBdcAdapter(): CorpusAdapter {
 				throw new Error(`fcc-bdc adapter: only US supported, got country=${opts.country}`)
 			}
 
-			const db = new Database(opts.inputPath, { readonly: true, fileMustExist: true })
+			const db = new DatabaseSync(opts.inputPath, { readOnly: true })
 			let emitted = 0
 			try {
-				const stmt = db.prepare<[], BdcLocationRow>(
+				const stmt = db.prepare(
 					`SELECT location_id, address_primary, city, state, zip, zip_suffix
 					 FROM bdc_locations
 					 ORDER BY location_id`
 				)
 
-				for (const row of stmt.iterate()) {
+				for (const row of stmt.iterate() as IterableIterator<BdcLocationRow>) {
 					if (opts.signal?.aborted) return
 					if (opts.limit !== undefined && emitted >= opts.limit) return
 

--- a/corpus/src/adapters/tiger/adapter.test.ts
+++ b/corpus/src/adapters/tiger/adapter.test.ts
@@ -4,10 +4,10 @@
  * @author Teffen Ellis, et al.
  */
 
-import Database from "better-sqlite3"
 import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
+import { DatabaseSync } from "node:sqlite"
 import { fileURLToPath } from "node:url"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { runAdapter } from "../../runner.js"
@@ -23,7 +23,7 @@ let dbPath: string
 async function buildFixtureDb(): Promise<string> {
 	const sql = await readFile(fixtureSqlPath, "utf8")
 	const path = join(scratch, "tiger-fixture.db")
-	const db = new Database(path)
+	const db = new DatabaseSync(path)
 	db.exec(sql)
 	db.close()
 	return path
@@ -126,7 +126,7 @@ describe("tiger adapter against fixture.sql", () => {
 	it("zipl !== zipr produces two street variants (one per side)", async () => {
 		// Build a mini DB with one segment whose left and right ZIPs differ.
 		const inline = join(scratch, "split-zip.db")
-		const db = new Database(inline)
+		const db = new DatabaseSync(inline)
 		db.exec(`
 			CREATE TABLE tiger_streets (linearid TEXT PRIMARY KEY, fullname TEXT NOT NULL, zipl TEXT, zipr TEXT, statefp TEXT NOT NULL);
 			CREATE TABLE tiger_places (geoid TEXT PRIMARY KEY, name TEXT NOT NULL, statefp TEXT NOT NULL, lsad TEXT);
@@ -152,7 +152,7 @@ describe("tiger adapter against fixture.sql", () => {
 
 	it("street with no ZIPs emits a single zipless variant", async () => {
 		const inline = join(scratch, "no-zip.db")
-		const db = new Database(inline)
+		const db = new DatabaseSync(inline)
 		db.exec(`
 			CREATE TABLE tiger_streets (linearid TEXT PRIMARY KEY, fullname TEXT NOT NULL, zipl TEXT, zipr TEXT, statefp TEXT NOT NULL);
 			CREATE TABLE tiger_places (geoid TEXT PRIMARY KEY, name TEXT NOT NULL, statefp TEXT NOT NULL, lsad TEXT);
@@ -175,7 +175,7 @@ describe("tiger adapter against fixture.sql", () => {
 
 	it("rows with an unrecognized state FIPS code are dropped", async () => {
 		const inline = join(scratch, "bad-fips.db")
-		const db = new Database(inline)
+		const db = new DatabaseSync(inline)
 		db.exec(`
 			CREATE TABLE tiger_streets (linearid TEXT PRIMARY KEY, fullname TEXT NOT NULL, zipl TEXT, zipr TEXT, statefp TEXT NOT NULL);
 			CREATE TABLE tiger_places (geoid TEXT PRIMARY KEY, name TEXT NOT NULL, statefp TEXT NOT NULL, lsad TEXT);

--- a/corpus/src/adapters/tiger/adapter.ts
+++ b/corpus/src/adapters/tiger/adapter.ts
@@ -37,7 +37,7 @@
  *   needed — every row in TIGER is the same license.
  */
 
-import Database from "better-sqlite3"
+import { DatabaseSync } from "node:sqlite"
 import { lookupFipsState } from "../../codex/us-fips-state.js"
 import { formatAddress, reconcileComponents } from "../../format.js"
 import type { AdapterOptions, CanonicalRow, CorpusAdapter } from "../../types.js"
@@ -142,15 +142,13 @@ export function createTigerAdapter(): CorpusAdapter {
 				throw new Error(`tiger adapter: only US supported, got country=${opts.country}`)
 			}
 
-			const db = new Database(opts.inputPath, { readonly: true, fileMustExist: true })
+			const db = new DatabaseSync(opts.inputPath, { readOnly: true })
 			let emitted = 0
 			try {
-				const streetStmt = db.prepare<[], TigerStreetRow>(
-					`SELECT linearid, fullname, zipl, zipr, statefp FROM tiger_streets`
-				)
-				const placeStmt = db.prepare<[], TigerPlaceRow>(`SELECT geoid, name, statefp, lsad FROM tiger_places`)
+				const streetStmt = db.prepare(`SELECT linearid, fullname, zipl, zipr, statefp FROM tiger_streets`)
+				const placeStmt = db.prepare(`SELECT geoid, name, statefp, lsad FROM tiger_places`)
 
-				for (const row of streetStmt.iterate()) {
+				for (const row of streetStmt.iterate() as IterableIterator<TigerStreetRow>) {
 					if (opts.signal?.aborted) return
 					for (const variant of streetVariants(row)) {
 						if (opts.limit !== undefined && emitted >= opts.limit) return
@@ -173,7 +171,7 @@ export function createTigerAdapter(): CorpusAdapter {
 					}
 				}
 
-				for (const row of placeStmt.iterate()) {
+				for (const row of placeStmt.iterate() as IterableIterator<TigerPlaceRow>) {
 					if (opts.signal?.aborted) return
 					for (const variant of placeVariants(row)) {
 						if (opts.limit !== undefined && emitted >= opts.limit) return

--- a/mailwoman/package.json
+++ b/mailwoman/package.json
@@ -35,7 +35,6 @@
 		"@inkjs/ui": "^2.0.0",
 		"@mailwoman/classifiers": "workspace:*",
 		"@mailwoman/core": "workspace:*",
-		"better-sqlite3": "^11.5.0",
 		"change-case": "^5.4.4",
 		"core-js": "^3.49.0",
 		"express": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 		"@sister.software/eslint-config": "^8.0.1",
 		"@sister.software/prettier-config": "^8.0.1",
 		"@sister.software/tsconfig": "^8.0.1",
-		"@types/better-sqlite3": "^7.6.13",
 		"@types/core-js": "^2.5.8",
 		"@types/express": "^5.0.0",
 		"@types/geojson": "^7946.0.14",

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -15,7 +15,7 @@
  *   -fx resources/whosonfirst
  */
 
-import sqlite from "better-sqlite3"
+import { DatabaseSync } from "node:sqlite"
 // import { Presets, SingleBar } from "cli-progress"
 import { WhosOnFirstPlacetype } from "@mailwoman/core/resources/whosonfirst"
 import { resourceDictionaryPathBuilder } from "@mailwoman/core/utils"
@@ -52,9 +52,8 @@ if (process.argv.length !== 3) {
 const databasePath = process.argv[2]
 
 console.log(`Opening database... ${databasePath}`)
-const db = sqlite(databasePath, {
-	fileMustExist: true,
-	readonly: true,
+const db = new DatabaseSync(databasePath, {
+	readOnly: true,
 })
 
 console.log("Preparing statement...")
@@ -80,7 +79,7 @@ db.exec(/* sql */ `
 
 console.log("Preparing statement...")
 
-const stmt = db.prepare<[], WOFRow>(/* sql */ `
+const stmt = db.prepare(/* sql */ `
 	SELECT * FROM temp.introspection
 	WHERE (
 		fullkey IN (
@@ -106,7 +105,7 @@ const placetypeMap = new Map<string, PlacetypeData>()
 
 // const rowProgress = new SingleBar({}, Presets.shades_classic)
 
-for (const row of stmt.iterate()) {
+for (const row of stmt.iterate() as IterableIterator<WOFRow>) {
 	// rowProgress.increment()
 	// rowProgress.render()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,7 +1473,6 @@ __metadata:
     "@dsnp/parquetjs": "npm:1.7.0"
     "@fragaria/address-formatter": "npm:^6.3.0"
     "@mailwoman/core": "workspace:*"
-    better-sqlite3: "npm:^11.5.0"
     csv-parse: "npm:^5.5.6"
     fastest-levenshtein: "npm:^1.0.16"
     lru-cache: "npm:^10.0.1"
@@ -1511,7 +1510,6 @@ __metadata:
     "@sister.software/eslint-config": "npm:^8.0.1"
     "@sister.software/prettier-config": "npm:^8.0.1"
     "@sister.software/tsconfig": "npm:^8.0.1"
-    "@types/better-sqlite3": "npm:^7.6.13"
     "@types/core-js": "npm:^2.5.8"
     "@types/express": "npm:^5.0.0"
     "@types/geojson": "npm:^7946.0.14"
@@ -2236,15 +2234,6 @@ __metadata:
   version: 0.23.0
   resolution: "@tootallnate/quickjs-emscripten@npm:0.23.0"
   checksum: 10/95cbad451d195b9d8f312103abafcc010741eb9256e98d7953e7c026d4c1ed4abb2248a14018bf49e3201c350104fc643137b23aa0bbed2744c795c39dc48a28
-  languageName: node
-  linkType: hard
-
-"@types/better-sqlite3@npm:^7.6.13":
-  version: 7.6.13
-  resolution: "@types/better-sqlite3@npm:7.6.13"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/c74dafa3c550ac866737870016d7b1a735c7d450c16d40962eeb54510fa150e91752bfdf678f55e91894d8853771b95f909b0062122116cddac4d80491b74411
   languageName: node
   linkType: hard
 
@@ -3327,41 +3316,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^11.5.0":
-  version: 11.5.0
-  resolution: "better-sqlite3@npm:11.5.0"
-  dependencies:
-    bindings: "npm:^1.5.0"
-    node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-  checksum: 10/c76f450f6313b47317270dae9a641c41ca95b2be7b08024741298d019f0c453ebb0ac0707a33af558fcb41373026944dc8409871ee010c7ed08cab869a116371
-  languageName: node
-  linkType: hard
-
 "binary-searching@npm:^2.0.5":
   version: 2.0.5
   resolution: "binary-searching@npm:2.0.5"
   checksum: 10/8399941f7a7fe24093a41937fdb0fee6226887e376d5c01c766aee66a4058182b891c491c0de120af1aaa9c10c4637d325d56f6ca38883c66a2f0c7dcc81a6b3
-  languageName: node
-  linkType: hard
-
-"bindings@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "bindings@npm:1.5.0"
-  dependencies:
-    file-uri-to-path: "npm:1.0.0"
-  checksum: 10/593d5ae975ffba15fbbb4788fe5abd1e125afbab849ab967ab43691d27d6483751805d98cb92f7ac24a2439a8a8678cd0131c535d5d63de84e383b0ce2786133
-  languageName: node
-  linkType: hard
-
-"bl@npm:^4.0.3":
-  version: 4.1.0
-  resolution: "bl@npm:4.1.0"
-  dependencies:
-    buffer: "npm:^5.5.0"
-    inherits: "npm:^2.0.4"
-    readable-stream: "npm:^3.4.0"
-  checksum: 10/b7904e66ed0bdfc813c06ea6c3e35eafecb104369dbf5356d0f416af90c1546de3b74e5b63506f0629acf5e16a6f87c3798f16233dcff086e9129383aa02ab55
   languageName: node
   linkType: hard
 
@@ -3469,16 +3427,6 @@ __metadata:
   version: 6.7.0
   resolution: "bson@npm:6.7.0"
   checksum: 10/d4bc1d9514c67dbcb8451b7be95704e6e7cb262f0d11c938715c21297ab5550b0e2f3badf5480d53c4b3f899a84f2ed8708f3f46cad83ec52059f076aad8e1cd
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^5.5.0":
-  version: 5.7.1
-  resolution: "buffer@npm:5.7.1"
-  dependencies:
-    base64-js: "npm:^1.3.1"
-    ieee754: "npm:^1.1.13"
-  checksum: 10/997434d3c6e3b39e0be479a80288875f71cd1c07d75a3855e6f08ef848a3c966023f79534e22e415ff3a5112708ce06127277ab20e527146d55c84566405c7c6
   languageName: node
   linkType: hard
 
@@ -3725,13 +3673,6 @@ __metadata:
   dependencies:
     readdirp: "npm:^5.0.0"
   checksum: 10/a1c2a4ee6ee81ba6409712c295a47be055fb9de1186dfbab33c1e82f28619de962ba02fc5f9d433daaedc96c35747460d8b2079ac2907de2c95e3f7cce913113
-  languageName: node
-  linkType: hard
-
-"chownr@npm:^1.1.1":
-  version: 1.1.4
-  resolution: "chownr@npm:1.1.4"
-  checksum: 10/115648f8eb38bac5e41c3857f3e663f9c39ed6480d1349977c4d96c95a47266fcacc5a5aabf3cb6c481e22d72f41992827db47301851766c4fd77ac21a4f081d
   languageName: node
   linkType: hard
 
@@ -4239,15 +4180,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decompress-response@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "decompress-response@npm:6.0.0"
-  dependencies:
-    mimic-response: "npm:^3.1.0"
-  checksum: 10/d377cf47e02d805e283866c3f50d3d21578b779731e8c5072d6ce8c13cc31493db1c2f6784da9d1d5250822120cefa44f1deab112d5981015f2e17444b763812
-  languageName: node
-  linkType: hard
-
 "deep-eql@npm:^5.0.1":
   version: 5.0.2
   resolution: "deep-eql@npm:5.0.2"
@@ -4278,13 +4210,6 @@ __metadata:
     which-collection: "npm:^1.0.1"
     which-typed-array: "npm:^1.1.13"
   checksum: 10/1ce49d0b71d0f14d8ef991a742665eccd488dfc9b3cada069d4d7a86291e591c92d2589c832811dea182b4015736b210acaaebce6184be356c1060d176f5a05f
-  languageName: node
-  linkType: hard
-
-"deep-extend@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "deep-extend@npm:0.6.0"
-  checksum: 10/7be7e5a8d468d6b10e6a67c3de828f55001b6eb515d014f7aeb9066ce36bd5717161eb47d6a0f7bed8a9083935b465bc163ee2581c8b128d29bf61092fdf57a7
   languageName: node
   linkType: hard
 
@@ -4419,13 +4344,6 @@ __metadata:
   version: 7.0.2
   resolution: "detect-indent@npm:7.0.2"
   checksum: 10/ef215d1b55a14f677ce03e840973b25362b6f8cd3f566bc82831fa1abb2be6a95423729bc573dc2334b1371ad7be18d9ec67e1a9611b71a04cb6d63f0d8e54cc
-  languageName: node
-  linkType: hard
-
-"detect-libc@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "detect-libc@npm:2.0.3"
-  checksum: 10/b4ea018d623e077bd395f168a9e81db77370dde36a5b01d067f2ad7989924a81d31cb547ff764acb2aa25d50bb7fdde0b0a93bec02212b0cb430621623246d39
   languageName: node
   linkType: hard
 
@@ -4638,15 +4556,6 @@ __metadata:
   dependencies:
     iconv-lite: "npm:^0.6.2"
   checksum: 10/bb98632f8ffa823996e508ce6a58ffcf5856330fde839ae42c9e1f436cc3b5cc651d4aeae72222916545428e54fd0f6aa8862fd8d25bdbcc4589f1e3f3715e7f
-  languageName: node
-  linkType: hard
-
-"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
-  version: 1.4.4
-  resolution: "end-of-stream@npm:1.4.4"
-  dependencies:
-    once: "npm:^1.4.0"
-  checksum: 10/530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
   languageName: node
   linkType: hard
 
@@ -5523,13 +5432,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expand-template@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "expand-template@npm:2.0.3"
-  checksum: 10/588c19847216421ed92befb521767b7018dc88f88b0576df98cb242f20961425e96a92cbece525ef28cc5becceae5d544ae0f5b9b5e2aa05acb13716ca5b3099
-  languageName: node
-  linkType: hard
-
 "expect-type@npm:^1.2.0":
   version: 1.2.1
   resolution: "expect-type@npm:1.2.1"
@@ -5741,13 +5643,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-uri-to-path@npm:1.0.0":
-  version: 1.0.0
-  resolution: "file-uri-to-path@npm:1.0.0"
-  checksum: 10/b648580bdd893a008c92c7ecc96c3ee57a5e7b6c4c18a9a09b44fb5d36d79146f8e442578bc0e173dc027adf3987e254ba1dfd6e3ec998b7c282873010502144
-  languageName: node
-  linkType: hard
-
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
@@ -5862,13 +5757,6 @@ __metadata:
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10/64c88e489b5d08e2f29664eb3c79c705ff9a8eb15d3e597198ef76546d4ade295897a44abb0abd2700e7ef784b2e3cbf1161e4fbf16f59129193fd1030d16da1
-  languageName: node
-  linkType: hard
-
-"fs-constants@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fs-constants@npm:1.0.0"
-  checksum: 10/18f5b718371816155849475ac36c7d0b24d39a11d91348cfcb308b4494824413e03572c403c86d3a260e049465518c4f0d5bd00f0371cdfcad6d4f30a85b350d
   languageName: node
   linkType: hard
 
@@ -6135,13 +6023,6 @@ __metadata:
   dependencies:
     git-up: "npm:^8.1.0"
   checksum: 10/1522e86ce89bb854ac5eaab13e71f9a72e93c4eb9897559d9731e03b700a7e2d38d16a77dddede9f79c8dac6f50633e2e420702bb1677580e797312e9b55379d
-  languageName: node
-  linkType: hard
-
-"github-from-package@npm:0.0.0":
-  version: 0.0.0
-  resolution: "github-from-package@npm:0.0.0"
-  checksum: 10/2a091ba07fbce22205642543b4ea8aaf068397e1433c00ae0f9de36a3607baf5bcc14da97fbb798cfca6393b3c402031fca06d8b491a44206d6efef391c58537
   languageName: node
   linkType: hard
 
@@ -6486,7 +6367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
+"ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 10/d9f2557a59036f16c282aaeb107832dc957a93d73397d89bbad4eb1130560560eb695060145e8e6b3b498b15ab95510226649a0b8f52ae06583575419fe10fc4
@@ -6564,17 +6445,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
-  languageName: node
-  linkType: hard
-
-"ini@npm:~1.3.0":
-  version: 1.3.8
-  resolution: "ini@npm:1.3.8"
-  checksum: 10/314ae176e8d4deb3def56106da8002b462221c174ddb7ce0c49ee72c8cd1f9044f7b10cc555a7d8850982c3b9ca96fc212122749f5234bc2b6fb05fb942ed566
   languageName: node
   linkType: hard
 
@@ -7639,7 +7513,6 @@ __metadata:
     "@inkjs/ui": "npm:^2.0.0"
     "@mailwoman/classifiers": "workspace:*"
     "@mailwoman/core": "workspace:*"
-    better-sqlite3: "npm:^11.5.0"
     change-case: "npm:^5.4.4"
     core-js: "npm:^3.49.0"
     express: "npm:^5.0.1"
@@ -8132,13 +8005,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-response@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "mimic-response@npm:3.1.0"
-  checksum: 10/7e719047612411fe071332a7498cf0448bbe43c485c0d780046c76633a771b223ff49bd00267be122cedebb897037fdb527df72335d0d0f74724604ca70b37ad
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^10.2.2":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
@@ -8182,7 +8048,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.6, minimist@npm:^1.2.7, minimist@npm:^1.2.8":
+"minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.6, minimist@npm:^1.2.7, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10/908491b6cc15a6c440ba5b22780a0ba89b9810e1aea684e253e43c4e3b8d56ec1dcdd7ea96dde119c29df59c936cde16062159eae4225c691e19c70b432b6e6f
@@ -8273,13 +8139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
-  version: 0.5.3
-  resolution: "mkdirp-classic@npm:0.5.3"
-  checksum: 10/3f4e088208270bbcc148d53b73e9a5bd9eef05ad2cbf3b3d0ff8795278d50dd1d11a8ef1875ff5aea3fa888931f95bfcb2ad5b7c1061cfefd6284d199e6776ac
-  languageName: node
-  linkType: hard
-
 "mkdirp@npm:^1.0.3":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
@@ -8350,13 +8209,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"napi-build-utils@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "napi-build-utils@npm:1.0.2"
-  checksum: 10/276feb8e30189fe18718e85b6f82e4f952822baa2e7696f771cc42571a235b789dc5907a14d9ffb6838c3e4ff4c25717c2575e5ce1cf6e02e496e204c11e57f6
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -8398,15 +8250,6 @@ __metadata:
   version: 1.0.5
   resolution: "nice-try@npm:1.0.5"
   checksum: 10/0b4af3b5bb5d86c289f7a026303d192a7eb4417231fe47245c460baeabae7277bcd8fd9c728fb6bd62c30b3e15cd6620373e2cf33353b095d8b403d3e8a15aff
-  languageName: node
-  linkType: hard
-
-"node-abi@npm:^3.3.0":
-  version: 3.71.0
-  resolution: "node-abi@npm:3.71.0"
-  dependencies:
-    semver: "npm:^7.3.5"
-  checksum: 10/0a1cef5106c43d67f9f8a911b0c9d5ee08971eda002ba466606c8e6164964456f5211f37966717efc3d5d49bae32f0cf9290254b1286bf71f0ba158a4f8a9846
   languageName: node
   linkType: hard
 
@@ -8711,7 +8554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:1.4.0, once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
+"once@npm:1.4.0, once@npm:^1.3.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -9299,28 +9142,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.1.1":
-  version: 7.1.2
-  resolution: "prebuild-install@npm:7.1.2"
-  dependencies:
-    detect-libc: "npm:^2.0.0"
-    expand-template: "npm:^2.0.3"
-    github-from-package: "npm:0.0.0"
-    minimist: "npm:^1.2.3"
-    mkdirp-classic: "npm:^0.5.3"
-    napi-build-utils: "npm:^1.0.1"
-    node-abi: "npm:^3.3.0"
-    pump: "npm:^3.0.0"
-    rc: "npm:^1.2.7"
-    simple-get: "npm:^4.0.0"
-    tar-fs: "npm:^2.0.0"
-    tunnel-agent: "npm:^0.6.0"
-  bin:
-    prebuild-install: bin.js
-  checksum: 10/32d5c026cc978dd02762b9ad3c765178aee8383aeac4303fed3cd226eff53100db038d4791b03ae1ebc7d213a7af392d26e32095579cedb8dba1d00ad08ecd46
-  languageName: node
-  linkType: hard
-
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -9468,16 +9289,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pump@npm:^3.0.0":
-  version: 3.0.2
-  resolution: "pump@npm:3.0.2"
-  dependencies:
-    end-of-stream: "npm:^1.1.0"
-    once: "npm:^1.3.1"
-  checksum: 10/e0c4216874b96bd25ddf31a0b61a5613e26cc7afa32379217cf39d3915b0509def3565f5f6968fafdad2894c8bbdbd67d340e84f3634b2a29b950cffb6442d9f
-  languageName: node
-  linkType: hard
-
 "punycode@npm:^2.1.0, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -9534,20 +9345,6 @@ __metadata:
     defu: "npm:^6.1.4"
     destr: "npm:^2.0.3"
   checksum: 10/0694d2a80579983a5e4f0452092d9f6a06b785b104b32f48f3d6bb263f637e53d9ebd1fd77a41b157b84c1c7e8e4ecc87c3824907738653a296e6d2faf3d1844
-  languageName: node
-  linkType: hard
-
-"rc@npm:^1.2.7":
-  version: 1.2.8
-  resolution: "rc@npm:1.2.8"
-  dependencies:
-    deep-extend: "npm:^0.6.0"
-    ini: "npm:~1.3.0"
-    minimist: "npm:^1.2.0"
-    strip-json-comments: "npm:~2.0.1"
-  bin:
-    rc: ./cli.js
-  checksum: 10/5c4d72ae7eec44357171585938c85ce066da8ca79146b5635baf3d55d74584c92575fa4e2c9eac03efbed3b46a0b2e7c30634c012b4b4fa40d654353d3c163eb
   languageName: node
   linkType: hard
 
@@ -9667,17 +9464,6 @@ __metadata:
     string_decoder: "npm:~1.1.1"
     util-deprecate: "npm:~1.0.1"
   checksum: 10/8500dd3a90e391d6c5d889256d50ec6026c059fadee98ae9aa9b86757d60ac46fff24fafb7a39fa41d54cb39d8be56cc77be202ebd4cd8ffcf4cb226cbaa40d4
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
-  version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    string_decoder: "npm:^1.1.1"
-    util-deprecate: "npm:^1.0.1"
-  checksum: 10/d9e3e53193adcdb79d8f10f2a1f6989bd4389f5936c6f8b870e77570853561c362bee69feca2bbb7b32368ce96a85504aa4cedf7cf80f36e6a9de30d64244048
   languageName: node
   linkType: hard
 
@@ -10102,7 +9888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
@@ -10409,24 +10195,6 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
-  languageName: node
-  linkType: hard
-
-"simple-concat@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "simple-concat@npm:1.0.1"
-  checksum: 10/4d211042cc3d73a718c21ac6c4e7d7a0363e184be6a5ad25c8a1502e49df6d0a0253979e3d50dbdd3f60ef6c6c58d756b5d66ac1e05cda9cacd2e9fc59e3876a
-  languageName: node
-  linkType: hard
-
-"simple-get@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "simple-get@npm:4.0.1"
-  dependencies:
-    decompress-response: "npm:^6.0.0"
-    once: "npm:^1.3.1"
-    simple-concat: "npm:^1.0.0"
-  checksum: 10/93f1b32319782f78f2f2234e9ce34891b7ab6b990d19d8afefaa44423f5235ce2676aae42d6743fecac6c8dfff4b808d4c24fe5265be813d04769917a9a44f36
   languageName: node
   linkType: hard
 
@@ -10835,15 +10603,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
-  version: 1.3.0
-  resolution: "string_decoder@npm:1.3.0"
-  dependencies:
-    safe-buffer: "npm:~5.2.0"
-  checksum: 10/54d23f4a6acae0e93f999a585e673be9e561b65cd4cca37714af1e893ab8cd8dfa52a9e4f58f48f87b4a44918d3a9254326cb80ed194bf2e4c226e2b21767e56
-  languageName: node
-  linkType: hard
-
 "string_decoder@npm:~0.10.x":
   version: 0.10.31
   resolution: "string_decoder@npm:0.10.31"
@@ -10925,13 +10684,6 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10/492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
-  languageName: node
-  linkType: hard
-
-"strip-json-comments@npm:~2.0.1":
-  version: 2.0.1
-  resolution: "strip-json-comments@npm:2.0.1"
-  checksum: 10/1074ccb63270d32ca28edfb0a281c96b94dc679077828135141f27d52a5a398ef5e78bcf22809d23cadc2b81dfbe345eb5fd8699b385c8b1128907dec4a7d1e1
   languageName: node
   linkType: hard
 
@@ -11049,31 +10801,6 @@ __metadata:
   bin:
     tape: bin/tape
   checksum: 10/1003be11b38f3b006af75c569c1b724d847036bc50a5949c2dc87434198c44beef3ca569fd98fc3343836f38058f6b4a1eaab5d5e6f0e9fcf18d30c4b4b93edc
-  languageName: node
-  linkType: hard
-
-"tar-fs@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "tar-fs@npm:2.1.1"
-  dependencies:
-    chownr: "npm:^1.1.1"
-    mkdirp-classic: "npm:^0.5.2"
-    pump: "npm:^3.0.0"
-    tar-stream: "npm:^2.1.4"
-  checksum: 10/526deae025453e825f87650808969662fbb12eb0461d033e9b447de60ec951c6c4607d0afe7ce057defe9d4e45cf80399dd74bc15f9d9e0773d5e990a78ce4ac
-  languageName: node
-  linkType: hard
-
-"tar-stream@npm:^2.1.4":
-  version: 2.2.0
-  resolution: "tar-stream@npm:2.2.0"
-  dependencies:
-    bl: "npm:^4.0.3"
-    end-of-stream: "npm:^1.4.1"
-    fs-constants: "npm:^1.0.0"
-    inherits: "npm:^2.0.3"
-    readable-stream: "npm:^3.1.1"
-  checksum: 10/1a52a51d240c118cbcd30f7368ea5e5baef1eac3e6b793fb1a41e6cd7319296c79c0264ccc5859f5294aa80f8f00b9239d519e627b9aade80038de6f966fec6a
   languageName: node
   linkType: hard
 
@@ -11283,15 +11010,6 @@ __metadata:
   version: 2.8.0
   resolution: "tslib@npm:2.8.0"
   checksum: 10/1bc7c43937477059b4d26f2dbde7e49ef0fb4f38f3014e0603eaea76d6a885742c8b1762af45949145e5e7408a736d20ded949da99dabc8ccba1fc5531d2d927
-  languageName: node
-  linkType: hard
-
-"tunnel-agent@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "tunnel-agent@npm:0.6.0"
-  dependencies:
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10/7f0d9ed5c22404072b2ae8edc45c071772affd2ed14a74f03b4e71b4dd1a14c3714d85aed64abcaaee5fec2efc79002ba81155c708f4df65821b444abb0cfade
   languageName: node
   linkType: hard
 
@@ -11639,7 +11357,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
+"util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10/474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2


### PR DESCRIPTION
## Summary

Drops `better-sqlite3` (and its 30-package native build chain) in favor of Node's built-in `node:sqlite` (`DatabaseSync`), matching the pattern used in playpen's `repo-tools` workspace. This unblocks Phase 4.2 (WOF SQLite resolver) which builds on the Kysely + `node:sqlite` boilerplate landed in #82.

## API delta

Every callsite needed adjusting:

| Before (`better-sqlite3`) | After (`node:sqlite`) |
|---|---|
| `new Database(path, opts)` | `new DatabaseSync(path, opts)` |
| `{ readonly, fileMustExist }` | `{ readOnly }` (throw-on-missing is default) |
| `db.pragma("...")` | `db.exec("PRAGMA ...")` (no pragma helper) |
| `db.transaction(fn)` | raw `BEGIN`/`COMMIT`/`ROLLBACK` around the batch |
| `db.prepare<TParams, TRow>(...)` | untyped `prepare()`; callers cast `.iterate()`/`.all()`/`.run()` results |
| `stmt.run(arrayParams)` | `stmt.run(...arrayParams)` (positional spread) |
| `stmt.iterate({...namedParams})` | typed via `Record<string, SQLInputValue>` double-cast |

The `SQLInputValue` union (`null | number | bigint | string | Uint8Array`) is strict — for object types like `PlacetypeRecord` where every field is a valid input value, named-param call sites need `as unknown as Record<string, SQLInputValue>` rather than a direct cast.

## Files touched

| File | Notes |
|---|---|
| `core/resources/whosonfirst/PlacetypeDataSource.ts` | The trickiest migration — uses pragmas, named params, and is `Disposable`. |
| `corpus/src/adapters/tiger/adapter.ts` + `.test.ts` | Straightforward swap. |
| `corpus/src/adapters/fcc-bdc/adapter.ts` + `.test.ts` | Same shape as TIGER. |
| `corpus/scripts/build-tiger-db.ts` | Lazy-import preserved. |
| `corpus/scripts/ingest-csv.ts` | `db.transaction()` → manual `BEGIN`/`COMMIT`/`ROLLBACK`. |
| `scripts/generate.ts` | Codegen-time read; same swap. |
| `package.json` | Drop `@types/better-sqlite3` devDep. |
| `mailwoman/package.json` | Drop orphan `better-sqlite3` dep (no code in this workspace imports it). |
| `corpus/package.json` | Drop `better-sqlite3` runtime dep. |

## Test plan

- [x] `yarn install` — 30 packages removed (better-sqlite3 + native build chain).
- [x] `yarn compile` clean.
- [x] All 1198 tests pass (TIGER + FCC-BDC adapter tests exercise the real `node:sqlite` runtime via in-memory fixture DBs).
- [ ] CI green.

## Trade-offs

- ⚠ `node:sqlite` emits an `ExperimentalWarning: SQLite is an experimental feature` to stderr at runtime. Operator confirmed this is acceptable. Worth a README mention for downstream consumers eventually.
- Loss of typed `prepare()` generics — node:sqlite returns `unknown` for query results. Callers now do an `IterableIterator<TRow>` cast at the iteration site. Acceptable trade for losing the native build dep; can revisit if the Phase 4.2 Kysely layer needs more typing strictness.
- Loss of `db.transaction(fn)` wrapper — replaced with raw SQL in the one callsite that used it (`ingest-csv.ts`). The wrapper added value mainly via implicit savepoints; the bulk insert path doesn't need them.

## Disclosure

Triaged and authored end-to-end by an automated agent (Claude Opus 4.7) under operator supervision. Human reviewer: @GirlBossRush.