### PR TITLE
openaddresses: document share-alike filter in adapter README

### DIFF
--- a/corpus/src/adapters/openaddresses/README.md
+++ b/corpus/src/adapters/openaddresses/README.md
@@ -48,6 +48,41 @@ adapter falls back to:
 Downstream training code can stratify or exclude by license via the
 `license` field on every row.
 
+## Share-alike filter (default-on)
+
+OpenAddresses includes a non-trivial fraction of **ODbL** and
+**CC-BY-SA** rows (notably parts of Canada and several European
+countries) that — per the licensing strategy in [#26][licensing] —
+must NOT enter the training corpus for the proprietary
+`@mailwoman/neural-weights-*` packages. Training on share-alike data
+would create a copyleft obligation on the weights themselves.
+
+The adapter drops rows whose `license` matches the share-alike pattern:
+
+- `ODbL` / `Open Database License` (any version suffix)
+- `CC-BY-SA-*` (any version)
+- `CC-SA-*`
+
+Filter is **on by default**. The adapter logs a one-line stderr summary
+of dropped vs. kept rows at end of run so operators can see how much
+data the filter excluded.
+
+To bypass — for operator-driven open-weights experiments — construct
+the adapter with `allowShareAlike: true`:
+
+```ts
+import { createOpenaddressesAdapter } from "@mailwoman/corpus"
+
+const adapter = createOpenaddressesAdapter({ allowShareAlike: true })
+```
+
+A CLI `--allow-share-alike` flag is **not yet wired through
+`mailwoman corpus run`** — it lands with the global corpus-build
+filter from [#26][licensing]. Until then, override via a custom
+build script that calls `createOpenaddressesAdapter()` directly.
+
+[licensing]: https://github.com/sister-software/mailwoman/issues/26
+
 ## Properties consumed
 
 | OA property             | Mailwoman component                            |
@@ -95,4 +130,6 @@ One `CanonicalRow` per usable Feature:
 `fixtures/openaddresses/sample-us.geojson` — 6 hand-crafted Features
 covering NY, OR, CA, WA, TX with a mix of per-row licenses (CC-BY-4.0,
 PDDL-1.0, CC0-1.0, CC-BY-SA-4.0) plus one row with no `LICENSE`
-property to exercise the default-fallback path.
+property to exercise the default-fallback path. The CC-BY-SA-4.0 row
+exercises the share-alike filter — it's absent from the default run and
+present when `allowShareAlike: true`.


### PR DESCRIPTION
## Summary

Closes #32. The runtime share-alike filter, opt-out option, stderr summary log, and full test coverage are all already shipped. Gap was that the per-adapter README didn't surface the share-alike behavior or link back to the licensing strategy in #26.

## Changes

- New **"Share-alike filter (default-on)"** section in `corpus/src/adapters/openaddresses/README.md` documenting:
  - Which licenses are blocked (`ODbL`, `CC-BY-SA-*`, `CC-SA-*`)
  - That the filter is on by default with a stderr summary at end of run
  - How to bypass programmatically via `createOpenaddressesAdapter({ allowShareAlike: true })`
  - That a CLI `--allow-share-alike` flag lands with **#26**'s global corpus-build filter (not yet wired through `mailwoman corpus run`)
- Fixture section updated to call out that the `CC-BY-SA-4.0` row exercises the filter path.
- Link back to #26 (licensing strategy umbrella).

## Test plan

- [x] Docs-only change; existing test coverage already exercises the filter path (`filters share-alike licenses (ODbL, CC-BY-SA, CC-SA) by default` and `passes share-alike rows through when allowShareAlike is set` in `corpus/src/adapters/openaddresses/adapter.test.ts`)
- [x] All 1198 tests pass
- [ ] CI green

## Out of scope

- Wiring `--allow-share-alike` through `mailwoman corpus run` — lands with **#26** when the global build-level filter is implemented.

## Disclosure

Triaged and authored end-to-end by an automated agent (Claude Opus 4.7) under operator supervision. Human reviewer: @GirlBossRush.