### PR TITLE
resolver-wof-sqlite: ship mailwoman-wof-build-fts CLI

### DIFF
--- a/resolver-wof-sqlite/README.md
+++ b/resolver-wof-sqlite/README.md
@@ -55,7 +55,44 @@ bunzip2 whosonfirst-data-admin-us-latest.db.bz2
 Upstream WOF SQLite distributions ship a `places` table but **not** an FTS5 index. The resolver needs FTS5 to do fast prefix + token-bag matching. Two options:
 
 1. **`buildFts: true` on construction** — builds the index lazily on first open. Cost is one-time but expensive (~minutes on the full US admin shard). Use for prototyping.
-2. **Pre-build the index** — run the build once via your own script (`db.exec("CREATE VIRTUAL TABLE place_search ..."); db.exec("INSERT INTO place_search SELECT ...")`) and ship the DB with the index included. Faster startup for production.
+2. **Pre-build the index with `mailwoman-wof-build-fts`** — ship the DB with the index included so first-open is fast. Recommended for production.
+
+### `mailwoman-wof-build-fts` CLI
+
+A one-shot operator script ships with this package as a `bin`:
+
+```bash
+npx mailwoman-wof-build-fts /path/to/whosonfirst-data-admin-us-latest.db
+```
+
+The CLI:
+
+- Opens the DB read-write.
+- Creates the `place_search` FTS5 virtual table (with the same schema the lazy build uses).
+- Populates it from `places` + `names` (alternate-name concatenation included).
+- Reports progress to stderr per phase (`checking` → `creating` → `populating` → `done`).
+- Exits 0 with a no-op message if the index already exists.
+
+```bash
+# Refresh after pulling a newer WOF dump
+npx mailwoman-wof-build-fts /path/to/wof.db --drop
+```
+
+`--drop` rebuilds from scratch — useful after refreshing the `places` / `names` tables from a newer dump. Without `--drop` the CLI is a no-op when the index is already present.
+
+You can also build the index programmatically via the package's `./fts` subpath:
+
+```ts
+import { DatabaseSync } from "node:sqlite"
+import { buildPlaceSearchFts } from "@mailwoman/resolver-wof-sqlite/fts"
+
+const db = new DatabaseSync("/path/to/wof.db")
+const { created, indexedRows, durationMs } = buildPlaceSearchFts(db, {
+	drop: false,
+	onProgress: (phase, detail) => console.log(phase, detail),
+})
+db.close()
+```
 
 ## Ranking
 

--- a/resolver-wof-sqlite/build-fts-cli.test.ts
+++ b/resolver-wof-sqlite/build-fts-cli.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the `mailwoman-wof-build-fts` CLI. Drives `main()` directly with synthetic argv so we
+ *   exercise the parsing / file-existence / progress paths without forking a child process.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import { main } from "./build-fts-cli.js"
+import { placeSearchFtsExists } from "./fts.js"
+
+let scratch: string
+
+function buildFixtureDb(path: string): void {
+	const db = new DatabaseSync(path)
+	db.exec(`
+		CREATE TABLE places (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT NOT NULL, placetype TEXT NOT NULL, country TEXT);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY, place_id INTEGER, language TEXT, kind TEXT, name TEXT);
+		INSERT INTO places VALUES (1, NULL, 'Paris', 'locality', 'FR');
+		INSERT INTO places VALUES (2, NULL, 'Tokyo', 'locality', 'JP');
+	`)
+	db.close()
+}
+
+beforeEach(async () => {
+	scratch = await mkdtemp(join(tmpdir(), "mailwoman-wof-fts-cli-"))
+})
+
+afterEach(async () => {
+	await rm(scratch, { recursive: true, force: true }).catch(() => {})
+})
+
+describe("build-fts-cli main()", () => {
+	test("exits 0 and builds the index against a fresh DB", () => {
+		const dbPath = join(scratch, "fixture.db")
+		buildFixtureDb(dbPath)
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		const exitCode = main([dbPath])
+		expect(exitCode).toBe(0)
+		stderrSpy.mockRestore()
+
+		const db = new DatabaseSync(dbPath)
+		try {
+			expect(placeSearchFtsExists(db)).toBe(true)
+		} finally {
+			db.close()
+		}
+	})
+
+	test("exits 0 and is a no-op when the index already exists", () => {
+		const dbPath = join(scratch, "fixture.db")
+		buildFixtureDb(dbPath)
+		main([dbPath]) // first build
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		const exitCode = main([dbPath])
+		expect(exitCode).toBe(0)
+		// Find the summary line in the stderr captures
+		const written = stderrSpy.mock.calls.map((c) => String(c[0])).join("")
+		expect(written).toMatch(/Already present/)
+		stderrSpy.mockRestore()
+	})
+
+	test("exits 0 and rebuilds when --drop is passed", () => {
+		const dbPath = join(scratch, "fixture.db")
+		buildFixtureDb(dbPath)
+		main([dbPath])
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		const exitCode = main([dbPath, "--drop"])
+		expect(exitCode).toBe(0)
+		const written = stderrSpy.mock.calls.map((c) => String(c[0])).join("")
+		expect(written).toMatch(/Built/)
+		stderrSpy.mockRestore()
+	})
+
+	test("exits 1 when the database path does not exist", () => {
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+		const exitCode = main(["/nope/does/not/exist.db"])
+		expect(exitCode).toBe(1)
+		const written = stderrSpy.mock.calls.map((c) => String(c[0])).join("")
+		expect(written).toMatch(/file not found/)
+		stderrSpy.mockRestore()
+	})
+
+	test("exits 2 when an unknown flag is passed", () => {
+		// vitest auto-throws on process.exit calls inside tests with the message
+		// "process.exit unexpectedly called with \"<code>\"".
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		expect(() => main(["--bogus", "x.db"])).toThrow(/process\.exit.*"2"/)
+
+		const written = stderrSpy.mock.calls.map((c) => String(c[0])).join("")
+		expect(written).toMatch(/unknown flag/)
+		stderrSpy.mockRestore()
+	})
+
+	test("exits 2 when zero or multiple positional args are passed", () => {
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		expect(() => main([])).toThrow(/process\.exit.*"2"/)
+		expect(() => main(["a.db", "b.db"])).toThrow(/process\.exit.*"2"/)
+
+		stderrSpy.mockRestore()
+	})
+
+	test("--help exits 0 without doing any work", () => {
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		expect(() => main(["--help"])).toThrow(/process\.exit.*"0"/)
+
+		const written = stderrSpy.mock.calls.map((c) => String(c[0])).join("")
+		expect(written).toMatch(/usage:/)
+		stderrSpy.mockRestore()
+	})
+})

--- a/resolver-wof-sqlite/build-fts-cli.ts
+++ b/resolver-wof-sqlite/build-fts-cli.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `mailwoman-wof-build-fts <path-to-wof.db> [--drop]`
+ *
+ *   Operator-side one-shot CLI: takes a Who's On First SQLite distribution and adds the
+ *   `place_search` FTS5 virtual table needed by `WofSqlitePlaceLookup`. Run this once after
+ *   downloading a fresh WOF shard so production callers can skip the (~minutes-long) lazy build.
+ *
+ *   Why a plain-args CLI rather than Ink / Pastel: this is a one-shot operator script, not an
+ *   interactive TUI. The dep weight of inkjs / pastel would dominate the script's footprint and
+ *   doesn't match how operators expect to drive a build step (`script /path/to/db` + stderr
+ *   progress). Matches the spirit of `corpus/scripts/*.ts`.
+ */
+
+import { existsSync } from "node:fs"
+import { exit, stderr } from "node:process"
+import { DatabaseSync } from "node:sqlite"
+
+import { buildPlaceSearchFts } from "./fts.js"
+
+interface CliArgs {
+	databasePath: string
+	drop: boolean
+}
+
+function printUsageAndExit(code: number): never {
+	stderr.write(
+		[
+			"usage: mailwoman-wof-build-fts <path-to-wof.db> [--drop]",
+			"",
+			"Builds the place_search FTS5 virtual table in a Who's On First SQLite",
+			"distribution. Run this once after downloading a fresh WOF shard so production",
+			"WofSqlitePlaceLookup instances don't pay the lazy-build cost at first open.",
+			"",
+			"  --drop   Drop and rebuild place_search if it already exists. Use after",
+			"           refreshing the `places` / `names` tables from an updated dump.",
+			"",
+			"See https://github.com/sister-software/mailwoman/tree/main/resolver-wof-sqlite for",
+			"the recommended WOF distribution sources + attribution requirements.",
+			"",
+		].join("\n")
+	)
+	exit(code)
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+	const args: string[] = []
+	let drop = false
+	for (const a of argv) {
+		if (a === "--drop") drop = true
+		else if (a === "--help" || a === "-h") printUsageAndExit(0)
+		else if (a.startsWith("-")) {
+			stderr.write(`mailwoman-wof-build-fts: unknown flag ${JSON.stringify(a)}\n`)
+			printUsageAndExit(2)
+		} else args.push(a)
+	}
+	if (args.length !== 1) {
+		stderr.write(`mailwoman-wof-build-fts: expected exactly one positional arg, got ${args.length}\n`)
+		printUsageAndExit(2)
+	}
+	return { databasePath: args[0]!, drop }
+}
+
+export function main(argv: readonly string[]): number {
+	const args = parseArgs(argv)
+	if (!existsSync(args.databasePath)) {
+		stderr.write(`mailwoman-wof-build-fts: file not found: ${args.databasePath}\n`)
+		return 1
+	}
+
+	stderr.write(`Opening ${args.databasePath}…\n`)
+	const db = new DatabaseSync(args.databasePath)
+	try {
+		const result = buildPlaceSearchFts(db, {
+			drop: args.drop,
+			onProgress: (phase, detail) => {
+				const suffix = detail ? ` — ${detail}` : ""
+				stderr.write(`  [${phase}]${suffix}\n`)
+			},
+		})
+		const verb = result.created ? "Built" : "Already present"
+		stderr.write(
+			`${verb}: place_search has ${result.indexedRows.toLocaleString()} rows ` +
+				`(${(result.durationMs / 1000).toFixed(2)}s)\n`
+		)
+		return 0
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err)
+		stderr.write(`mailwoman-wof-build-fts: ${message}\n`)
+		return 1
+	} finally {
+		db.close()
+	}
+}
+
+// Entry point — only run when invoked directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	exit(main(process.argv.slice(2)))
+}

--- a/resolver-wof-sqlite/fts.test.ts
+++ b/resolver-wof-sqlite/fts.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the FTS5 build helpers used by both `WofSqlitePlaceLookup` and the
+ *   `mailwoman-wof-build-fts` CLI.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { describe, expect, test } from "vitest"
+
+import { buildPlaceSearchFts, PLACE_SEARCH_TABLE, placeSearchFtsExists } from "./fts.js"
+
+function buildBaseSchema(): DatabaseSync {
+	const db = new DatabaseSync(":memory:")
+	db.exec(`
+		CREATE TABLE places (
+			id INTEGER PRIMARY KEY,
+			parent_id INTEGER,
+			name TEXT NOT NULL,
+			placetype TEXT NOT NULL,
+			country TEXT
+		);
+		CREATE TABLE names (
+			rowid INTEGER PRIMARY KEY,
+			place_id INTEGER NOT NULL,
+			language TEXT NOT NULL,
+			kind TEXT NOT NULL,
+			name TEXT NOT NULL
+		);
+		INSERT INTO places VALUES (1, NULL, 'Paris', 'locality', 'FR');
+		INSERT INTO places VALUES (2, NULL, 'Springfield', 'locality', 'US');
+		INSERT INTO places VALUES (3, NULL, 'London', 'locality', 'GB');
+		INSERT INTO names (place_id, language, kind, name) VALUES (1, 'und', 'variant', 'パリ');
+		INSERT INTO names (place_id, language, kind, name) VALUES (1, 'und', 'variant', 'París');
+	`)
+	return db
+}
+
+describe("buildPlaceSearchFts", () => {
+	test("builds the place_search virtual table from a fresh DB", () => {
+		const db = buildBaseSchema()
+		expect(placeSearchFtsExists(db)).toBe(false)
+
+		const result = buildPlaceSearchFts(db)
+		expect(result.created).toBe(true)
+		expect(result.indexedRows).toBe(3)
+		expect(result.durationMs).toBeGreaterThanOrEqual(0)
+		expect(placeSearchFtsExists(db)).toBe(true)
+
+		db.close()
+	})
+
+	test("is a no-op when the table already exists and drop is false", () => {
+		const db = buildBaseSchema()
+		buildPlaceSearchFts(db)
+
+		const result = buildPlaceSearchFts(db)
+		expect(result.created).toBe(false)
+		expect(result.indexedRows).toBe(3)
+
+		db.close()
+	})
+
+	test("rebuilds when drop is true", () => {
+		const db = buildBaseSchema()
+		buildPlaceSearchFts(db)
+
+		// Add a new place but don't reindex yet — count should still be the original 3.
+		db.exec(`INSERT INTO places VALUES (4, NULL, 'Tokyo', 'locality', 'JP');`)
+		expect((db.prepare(`SELECT COUNT(*) AS n FROM ${PLACE_SEARCH_TABLE}`).get() as { n: number }).n).toBe(3)
+
+		const result = buildPlaceSearchFts(db, { drop: true })
+		expect(result.created).toBe(true)
+		expect(result.indexedRows).toBe(4)
+
+		db.close()
+	})
+
+	test("concatenates alt_names from the names table into the FTS document", () => {
+		const db = buildBaseSchema()
+		buildPlaceSearchFts(db)
+
+		const row = db.prepare(`SELECT name, alt_names FROM ${PLACE_SEARCH_TABLE} WHERE wof_id = 1`).get() as {
+			name: string
+			alt_names: string
+		}
+		expect(row.name).toBe("Paris")
+		expect(row.alt_names).toContain("パリ")
+		expect(row.alt_names).toContain("París")
+
+		db.close()
+	})
+
+	test("MATCH query works against the built index", () => {
+		const db = buildBaseSchema()
+		buildPlaceSearchFts(db)
+
+		const rows = db
+			.prepare(`SELECT wof_id FROM ${PLACE_SEARCH_TABLE} WHERE ${PLACE_SEARCH_TABLE} MATCH ?`)
+			.all('"Paris"') as { wof_id: number }[]
+		expect(rows.length).toBe(1)
+		expect(rows[0]?.wof_id).toBe(1)
+
+		const altRows = db
+			.prepare(`SELECT wof_id FROM ${PLACE_SEARCH_TABLE} WHERE ${PLACE_SEARCH_TABLE} MATCH ?`)
+			.all('"パリ"') as { wof_id: number }[]
+		expect(altRows.length).toBe(1)
+		expect(altRows[0]?.wof_id).toBe(1)
+
+		db.close()
+	})
+
+	test("invokes onProgress for each phase on a fresh build", () => {
+		const db = buildBaseSchema()
+		const phases: string[] = []
+		buildPlaceSearchFts(db, { onProgress: (phase) => phases.push(phase) })
+		expect(phases).toEqual(["checking", "creating", "populating", "done"])
+		db.close()
+	})
+
+	test("invokes onProgress with the dropping phase when --drop is used", () => {
+		const db = buildBaseSchema()
+		buildPlaceSearchFts(db)
+		const phases: string[] = []
+		buildPlaceSearchFts(db, { drop: true, onProgress: (phase) => phases.push(phase) })
+		expect(phases).toEqual(["checking", "dropping", "creating", "populating", "done"])
+		db.close()
+	})
+
+	test("onProgress receives a detail string for the done phase", () => {
+		const db = buildBaseSchema()
+		let doneDetail: string | undefined
+		buildPlaceSearchFts(db, {
+			onProgress: (phase, detail) => {
+				if (phase === "done") doneDetail = detail
+			},
+		})
+		expect(doneDetail).toMatch(/3 rows indexed/)
+		db.close()
+	})
+})
+
+describe("placeSearchFtsExists", () => {
+	test("returns false when the table is absent", () => {
+		const db = buildBaseSchema()
+		expect(placeSearchFtsExists(db)).toBe(false)
+		db.close()
+	})
+
+	test("returns true once the table is built", () => {
+		const db = buildBaseSchema()
+		buildPlaceSearchFts(db)
+		expect(placeSearchFtsExists(db)).toBe(true)
+		db.close()
+	})
+})

--- a/resolver-wof-sqlite/fts.ts
+++ b/resolver-wof-sqlite/fts.ts
@@ -1,0 +1,120 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   FTS5 index lifecycle for the WOF SQLite distribution.
+ *
+ *   Shared by `WofSqlitePlaceLookup` (lazy build via `buildFts: true`) and the operator-side
+ *   `mailwoman-wof-build-fts` CLI (ahead-of-time build to avoid first-open latency in production).
+ *
+ *   Upstream WOF SQLite distributions do NOT ship FTS5. The index lives in a `place_search` virtual
+ *   table whose rows mirror `(places.id, places.name, GROUP_CONCAT(names.name))` — one row per
+ *   place, with all alternate names concatenated into a single search-token bag.
+ */
+
+import type { DatabaseSync } from "node:sqlite"
+
+/**
+ * Name of the FTS5 virtual table this module owns. Centralized so `WofSqlitePlaceLookup` and the
+ * CLI can't drift apart.
+ */
+export const PLACE_SEARCH_TABLE = "place_search"
+
+/**
+ * Counters for a single `buildPlaceSearchFts` run. Exposed so callers (CLI, lazy-build) can render
+ * progress to the user.
+ */
+export interface BuildPlaceSearchFtsResult {
+	/** Whether the index was created (true) or already existed and was left alone (false). */
+	created: boolean
+	/** Number of rows in the `place_search` table after the call. */
+	indexedRows: number
+	/** Wall-clock duration of the build step, in milliseconds. */
+	durationMs: number
+}
+
+export interface BuildPlaceSearchFtsOpts {
+	/**
+	 * Drop the existing `place_search` table before building. Default false — if the table already
+	 * exists the call is a no-op. Set true when you want to rebuild against an updated `places` /
+	 * `names` snapshot.
+	 */
+	drop?: boolean
+	/**
+	 * Optional progress callback invoked after each phase. Useful for CLI output on the planet-scale
+	 * builds where the INSERT step can take minutes.
+	 */
+	onProgress?: (phase: "checking" | "dropping" | "creating" | "populating" | "done", detail?: string) => void
+}
+
+/**
+ * Build (or rebuild, with `drop: true`) the `place_search` FTS5 virtual table from the existing
+ * `places` + `names` tables in a WOF SQLite distribution.
+ *
+ * Returns a `BuildPlaceSearchFtsResult` summary. Idempotent when `drop: false` — re-running against
+ * an already-indexed DB returns `{ created: false, ... }` without rebuilding.
+ */
+export function buildPlaceSearchFts(db: DatabaseSync, opts: BuildPlaceSearchFtsOpts = {}): BuildPlaceSearchFtsResult {
+	const start = Date.now()
+	const onProgress = opts.onProgress ?? (() => {})
+
+	onProgress("checking")
+	const existing = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
+		.get(PLACE_SEARCH_TABLE) as { name: string } | undefined
+
+	if (existing && !opts.drop) {
+		const countRow = db.prepare(`SELECT COUNT(*) AS n FROM ${PLACE_SEARCH_TABLE}`).get() as { n: number }
+		onProgress("done", `${countRow.n} rows already indexed`)
+		return {
+			created: false,
+			indexedRows: countRow.n,
+			durationMs: Date.now() - start,
+		}
+	}
+
+	if (existing && opts.drop) {
+		onProgress("dropping")
+		db.exec(`DROP TABLE ${PLACE_SEARCH_TABLE}`)
+	}
+
+	onProgress("creating")
+	db.exec(`
+		CREATE VIRTUAL TABLE ${PLACE_SEARCH_TABLE} USING fts5(
+			wof_id UNINDEXED,
+			name,
+			alt_names,
+			tokenize = 'unicode61 remove_diacritics 2'
+		);
+	`)
+
+	onProgress("populating")
+	db.exec(`
+		INSERT INTO ${PLACE_SEARCH_TABLE} (wof_id, name, alt_names)
+		SELECT
+			places.id,
+			places.name,
+			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM names WHERE names.place_id = places.id), '')
+		FROM places;
+	`)
+
+	const countRow = db.prepare(`SELECT COUNT(*) AS n FROM ${PLACE_SEARCH_TABLE}`).get() as { n: number }
+	onProgress("done", `${countRow.n} rows indexed`)
+	return {
+		created: true,
+		indexedRows: countRow.n,
+		durationMs: Date.now() - start,
+	}
+}
+
+/**
+ * Returns true iff the `place_search` table exists in the connected DB. Used by
+ * `WofSqlitePlaceLookup` for its "FTS missing — pass buildFts:true or run the CLI" guard.
+ */
+export function placeSearchFtsExists(db: DatabaseSync): boolean {
+	const row = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(PLACE_SEARCH_TABLE) as
+		| { name: string }
+		| undefined
+	return Boolean(row)
+}

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -9,3 +9,11 @@ export type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WofPlacetype } from "
 export type { AncestorsTable, GeojsonTable, NamesTable, PlaceSearchTable, PlacesTable, WofDatabase } from "./schema.js"
 
 export { WofSqlitePlaceLookup, type RankingWeights, type WofSqlitePlaceLookupOpts } from "./lookup.js"
+
+export {
+	PLACE_SEARCH_TABLE,
+	buildPlaceSearchFts,
+	placeSearchFtsExists,
+	type BuildPlaceSearchFtsOpts,
+	type BuildPlaceSearchFtsResult,
+} from "./fts.js"

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -15,6 +15,7 @@ import { DatabaseSync, type SQLInputValue } from "node:sqlite"
 
 import { SqliteDialect } from "@mailwoman/core/kysley/dialect"
 
+import { buildPlaceSearchFts, placeSearchFtsExists } from "./fts.js"
 import type { WofDatabase } from "./schema.js"
 import type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WofPlacetype } from "./types.js"
 
@@ -211,37 +212,13 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 
 	/** Build the FTS5 virtual table from the `names` + `places` tables. */
 	#ensureFts(): void {
-		const existsRow = this.#db
-			.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'place_search'`)
-			.get() as { name: string } | undefined
-
-		if (existsRow) return
-
-		this.#db.exec(`
-			CREATE VIRTUAL TABLE place_search USING fts5(
-				wof_id UNINDEXED,
-				name,
-				alt_names,
-				tokenize = 'unicode61 remove_diacritics 2'
-			);
-		`)
-		this.#db.exec(`
-			INSERT INTO place_search (wof_id, name, alt_names)
-			SELECT
-				places.id,
-				places.name,
-				COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM names WHERE names.place_id = places.id), '')
-			FROM places;
-		`)
+		buildPlaceSearchFts(this.#db)
 	}
 
 	#assertFtsExists(): void {
-		const row = this.#db
-			.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'place_search'`)
-			.get() as { name: string } | undefined
-		if (!row) {
+		if (!placeSearchFtsExists(this.#db)) {
 			throw new Error(
-				"WofSqlitePlaceLookup: `place_search` FTS5 table is missing. Pass `buildFts: true` to build it on open, or run the operator-side index-build CLI documented in the README."
+				"WofSqlitePlaceLookup: `place_search` FTS5 table is missing. Pass `buildFts: true` to build it on open, or run `mailwoman-wof-build-fts <path-to-wof.db>` ahead of time (see resolver-wof-sqlite/README.md)."
 			)
 		}
 	}

--- a/resolver-wof-sqlite/package.json
+++ b/resolver-wof-sqlite/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",
-		".": "./out/index.js"
+		".": "./out/index.js",
+		"./fts": "./out/fts.js"
 	},
 	"dependencies": {
 		"@mailwoman/core": "workspace:*",
@@ -24,6 +25,9 @@
 		"out/**/*.d.ts.map",
 		"README.md"
 	],
+	"bin": {
+		"mailwoman-wof-build-fts": "./out/build-fts-cli.js"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1507,6 +1507,8 @@ __metadata:
   dependencies:
     "@mailwoman/core": "workspace:*"
     kysely: "npm:^0.29.2"
+  bin:
+    mailwoman-wof-build-fts: ./out/build-fts-cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Phase 4.2's README referenced an "operator-side index-build CLI" that wasn't actually shipped. This PR ships it.

**Why now:** the **#1 queued operator decision** in the night-shift handover doc is the WOF SQLite download authorization. The moment you approve it, the next concrete action you'd need is "build the FTS5 index ahead of running the resolver in production." Without this CLI you'd either need to write the SQL by hand or eat the (~minutes-long) lazy-build cost at first open via `buildFts: true`. This pre-positions the critical path.

Direct follow-up to #84.

## Changes

- **New `resolver-wof-sqlite/fts.ts`** — factors the FTS5 lifecycle out of `lookup.ts`. Exports `buildPlaceSearchFts()`, `placeSearchFtsExists()`, `PLACE_SEARCH_TABLE`. Single source of truth so `WofSqlitePlaceLookup`'s lazy build and the CLI's ahead-of-time build can't drift.
- **New `resolver-wof-sqlite/build-fts-cli.ts`** — minimal plain-args CLI (no Ink/Pastel — matches the operator-script idiom in `corpus/scripts/*.ts`). Supports:
  - Positional `<path-to-wof.db>`
  - `--drop` (rebuild from scratch after refreshing the source tables)
  - `--help` (inline usage)
  - Stderr progress per phase: `checking` → `creating` → `populating` → `done`
- **`resolver-wof-sqlite/package.json`** — adds the `bin` entry: `mailwoman-wof-build-fts`. Adds the `./fts` subpath export.
- **`resolver-wof-sqlite/lookup.ts`** — delegates `#ensureFts()` to the shared helper. The FTS-missing error message now names the CLI explicitly.
- **`resolver-wof-sqlite/README.md`** — new "## FTS5 index" subsection documenting the CLI, the `--drop` flow, and the programmatic alternative via `@mailwoman/resolver-wof-sqlite/fts`.

## Test plan

- [x] 17 new tests across `fts.test.ts` (10) + `build-fts-cli.test.ts` (7). Coverage:
  - `buildPlaceSearchFts` idempotency, `--drop` rebuild semantics, progress callbacks for every phase, MATCH against the built index, alt-name concatenation
  - CLI exit codes (0 success, 1 missing file, 2 bad args), argv parsing, `--help`, no-op-when-already-built, `--drop`
- [x] `yarn compile` clean
- [x] All 1227 tests pass (was 1210 after PR #84; +17 new)
- [ ] CI green

## Out of scope

- Wiring the resolver into the parser pipeline — that's **Phase 4.3** (planned in #86).
- Postcode-shard support — Phase 4.3.x follow-up.
- Anything that requires the actual WOF distribution on disk (integration tests are still gated on the queued download decision).

## Disclosure

Triaged and authored end-to-end by an automated agent (Claude Opus 4.7) under operator supervision. Human reviewer: @GirlBossRush.