### PR TITLE
phase-4.2: fix schema mismatch + add real-WOF integration tests

### DIFF
--- a/docs/plan/phases/PHASE_4_2_wof_sqlite.md
+++ b/docs/plan/phases/PHASE_4_2_wof_sqlite.md
@@ -19,7 +19,7 @@ Three independent reasons:
 ## What's in scope for 4.2
 
 - New workspace at `resolver-wof-sqlite/` (flat, no `packages/` nesting per the operator's monorepo convention).
-- Typed Kysely `Database` schema for the WOF tables we'll touch: `places`, `names`, `geojson`, `ancestors`, `fts` (the FTS5 virtual table).
+- Typed Kysely `Database` schema for the WOF tables we'll touch: `spr`, `names`, `geojson`, `ancestors`, `place_search` (the FTS5 virtual table we build ourselves).
 - `PlaceLookup` interface (the public surface).
 - `WofSqlitePlaceLookup` implementation: FTS5 `MATCH` over name + name_alts, placetype + country filters, BM25 + boosts.
 - A small fixture SQLite DB built inline in tests (no checked-in binary; tests `CREATE TABLE` + seed a handful of WOF-shaped rows).
@@ -122,15 +122,17 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 
 The Geocode Earth WOF SQLite distributions ship these tables that matter to us:
 
-| Table              | Use                                                                                                | Notes                                                                                                                 |
-| ------------------ | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `places`           | Core lookup. PK `id`. Columns: `id, parent_id, name, placetype, country, ...`                      | Indexed on `(placetype, country)`.                                                                                    |
-| `names`            | Alternate names per locale (`Paris` / `París` / `パリ`). One row per `(place_id, language, kind)`. | We query for `kind IN ('preferred', 'colloquial', 'variant')`.                                                        |
-| `geojson`          | Source GeoJSON blob per place. Contains lat/lon in the centroid property.                          | We extract `properties.geom:latitude` / `geom:longitude` via JSON path.                                               |
-| `ancestors`        | Adjacency: ancestor relationships per place.                                                       | Used for `parentId` filter — descendant lookup is `WHERE wof_id IN (SELECT id FROM ancestors WHERE ancestor_id = ?)`. |
-| FTS5 virtual table | NOT in the upstream WOF SQLite distro — we build it once on first open.                            | `CREATE VIRTUAL TABLE place_search USING fts5(name, alt_names, content=...)`.                                         |
+| Table          | Use                                                                                             | Notes                                                                                                                                                                                                |
+| -------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spr`          | Standard Places Response — the core lookup table. One row per place with all the lookup fields. | PK `id`. Carries `parent_id`, `name`, `placetype`, `country`, `latitude`, `longitude`, `min_*`/`max_*` bbox, and lifecycle flags. `is_current = -1` means "currently valid" (WOF's -1/0 convention). |
+| `names`        | Alternate names per place, keyed by BCP-47 language tag subfields.                              | Joins back to `spr.id` via `id` (NOT `place_id` — the column name is `id` on both tables, even though it's a FK on `names`). No `kind` column; FTS just concatenates ALL names.                      |
+| `geojson`      | Per-place GeoJSON blob.                                                                         | Not consulted by Phase 4.2 — lat/lon already live as `spr.latitude` / `spr.longitude`. Modeled in `schema.ts` for Phase 4.3+ where bbox or full geometry may be needed.                              |
+| `ancestors`    | Adjacency: ancestor relationships per place.                                                    | Used for `parentId` filter — descendant lookup is `WHERE spr.id IN (SELECT id FROM ancestors WHERE ancestor_id = ?)`.                                                                                |
+| `place_search` | FTS5 virtual table. NOT in the upstream WOF distro — we build it.                               | `CREATE VIRTUAL TABLE place_search USING fts5(wof_id UNINDEXED, name, alt_names, ...)`. Built by `buildPlaceSearchFts()` lazily or by the `mailwoman-wof-build-fts` CLI ahead-of-time.               |
 
-The Kysely `Database` interface declared in `resolver-wof-sqlite/schema.ts` types the columns we touch. Tables we don't touch (e.g. `spr`, `concordances`) are not modeled — we don't want to pretend we understand schema we haven't read.
+The Kysely `Database` interface declared in `resolver-wof-sqlite/schema.ts` types the columns we touch. Tables we don't touch (e.g. `concordances`, `spr` sibling tables) are not modeled — we don't want to pretend we understand schema we haven't read.
+
+**Schema-discovery note (2026-05-20):** the initial Phase 4.2 ship assumed a `places` table with names joined on `place_id`. Real WOF has none of that — it uses `spr`, names join on `id`, and lat/lon are direct columns. Caught during the first run against real data; fixed in a same-day follow-up. The fixture tests were correctly green against the made-up schema; only the integration tests against actual WOF caught the mismatch. **Always validate against the real artifact** before declaring a data-integration done.
 
 ## Ranking
 
@@ -165,3 +167,4 @@ Integration tests against a real WOF distribution will be added in a follow-up o
 ## Changelog
 
 - **2026-05-20** — opened. Picks the public API surface; defers the integration tests to follow-up once WOF data download is authorized.
+- **2026-05-20** (same day) — WOF download authorized; schema-discovery fix needed (`places` → `spr`, `place_id` → `id`, no JSON-extract for lat/lon). 10 integration tests added against the real US admin shard. FTS5 build on the full shard (142k rows) completes in ~0.81s — much faster than the ~minutes estimate in the original plan. No popularity signal in the current ranking (documented limitation; bare `findPlace({text: "Paris"})` returns small-town US Parises in unspecified order); `country` / `placetype` / `parentId` filters all behave as designed.

--- a/resolver-wof-sqlite/README.md
+++ b/resolver-wof-sqlite/README.md
@@ -121,6 +121,12 @@ Who's On First data is licensed [CC-BY 4.0](https://creativecommons.org/licenses
 
 This package itself is AGPL-3.0; the WOF data it indexes is CC-BY 4.0. The two licenses are separate — your application must comply with both.
 
+## Integration tests
+
+`resolver-wof-sqlite/integration.test.ts` exercises the resolver against a real WOF SQLite distribution. The suite is **skipped** when no DB is present — set `MAILWOMAN_WOF_DB` to override the lookup path, otherwise it defaults to `/mnt/playpen/mailwoman-data/wof/whosonfirst-data-admin-us-latest.db` (the canonical lab location). CI runs against the fixture-only suites; operators with real WOF data locally get an extra layer of validation.
+
+Coverage includes: placetype filtering, country filtering, the empty-result case, FTS5 special-character sanitization, Japanese alt-name resolution, parent-constrained lookup, and a performance budget (`findPlace` < 250 ms against the 142 k-row US admin shard).
+
 ## Concurrency model
 
 This package opens a single `node:sqlite` connection per `WofSqlitePlaceLookup` instance. SQLite is single-writer / many-reader; the Kysely wrapper around the connection serializes all queries through a mutex. For high-concurrency HTTP servers, instantiate one resolver per request handler or per pool slot — sharing a single instance across concurrent requests is fine (queries queue) but won't parallelize across cores.

--- a/resolver-wof-sqlite/build-fts-cli.test.ts
+++ b/resolver-wof-sqlite/build-fts-cli.test.ts
@@ -21,10 +21,13 @@ let scratch: string
 function buildFixtureDb(path: string): void {
 	const db = new DatabaseSync(path)
 	db.exec(`
-		CREATE TABLE places (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT NOT NULL, placetype TEXT NOT NULL, country TEXT);
-		CREATE TABLE names (rowid INTEGER PRIMARY KEY, place_id INTEGER, language TEXT, kind TEXT, name TEXT);
-		INSERT INTO places VALUES (1, NULL, 'Paris', 'locality', 'FR');
-		INSERT INTO places VALUES (2, NULL, 'Tokyo', 'locality', 'JP');
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+		INSERT INTO spr VALUES (1, NULL, 'Paris', 'locality', 'FR', -1, 0);
+		INSERT INTO spr VALUES (2, NULL, 'Tokyo', 'locality', 'JP', -1, 0);
 	`)
 	db.close()
 }

--- a/resolver-wof-sqlite/fts.test.ts
+++ b/resolver-wof-sqlite/fts.test.ts
@@ -14,26 +14,28 @@ import { buildPlaceSearchFts, PLACE_SEARCH_TABLE, placeSearchFtsExists } from ".
 
 function buildBaseSchema(): DatabaseSync {
 	const db = new DatabaseSync(":memory:")
+	// Mirror the real WOF SQLite schema subset that fts.ts queries.
 	db.exec(`
-		CREATE TABLE places (
+		CREATE TABLE spr (
 			id INTEGER PRIMARY KEY,
 			parent_id INTEGER,
-			name TEXT NOT NULL,
-			placetype TEXT NOT NULL,
-			country TEXT
+			name TEXT,
+			placetype TEXT,
+			country TEXT,
+			is_current INTEGER,
+			is_deprecated INTEGER
 		);
 		CREATE TABLE names (
-			rowid INTEGER PRIMARY KEY,
-			place_id INTEGER NOT NULL,
-			language TEXT NOT NULL,
-			kind TEXT NOT NULL,
+			rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+			id INTEGER NOT NULL,
+			language TEXT,
 			name TEXT NOT NULL
 		);
-		INSERT INTO places VALUES (1, NULL, 'Paris', 'locality', 'FR');
-		INSERT INTO places VALUES (2, NULL, 'Springfield', 'locality', 'US');
-		INSERT INTO places VALUES (3, NULL, 'London', 'locality', 'GB');
-		INSERT INTO names (place_id, language, kind, name) VALUES (1, 'und', 'variant', 'パリ');
-		INSERT INTO names (place_id, language, kind, name) VALUES (1, 'und', 'variant', 'París');
+		INSERT INTO spr VALUES (1, NULL, 'Paris', 'locality', 'FR', -1, 0);
+		INSERT INTO spr VALUES (2, NULL, 'Springfield', 'locality', 'US', -1, 0);
+		INSERT INTO spr VALUES (3, NULL, 'London', 'locality', 'GB', -1, 0);
+		INSERT INTO names (id, language, name) VALUES (1, 'und', 'パリ');
+		INSERT INTO names (id, language, name) VALUES (1, 'und', 'París');
 	`)
 	return db
 }
@@ -68,7 +70,7 @@ describe("buildPlaceSearchFts", () => {
 		buildPlaceSearchFts(db)
 
 		// Add a new place but don't reindex yet — count should still be the original 3.
-		db.exec(`INSERT INTO places VALUES (4, NULL, 'Tokyo', 'locality', 'JP');`)
+		db.exec(`INSERT INTO spr VALUES (4, NULL, 'Tokyo', 'locality', 'JP', -1, 0);`)
 		expect((db.prepare(`SELECT COUNT(*) AS n FROM ${PLACE_SEARCH_TABLE}`).get() as { n: number }).n).toBe(3)
 
 		const result = buildPlaceSearchFts(db, { drop: true })

--- a/resolver-wof-sqlite/fts.ts
+++ b/resolver-wof-sqlite/fts.ts
@@ -9,8 +9,9 @@
  *   `mailwoman-wof-build-fts` CLI (ahead-of-time build to avoid first-open latency in production).
  *
  *   Upstream WOF SQLite distributions do NOT ship FTS5. The index lives in a `place_search` virtual
- *   table whose rows mirror `(places.id, places.name, GROUP_CONCAT(names.name))` — one row per
- *   place, with all alternate names concatenated into a single search-token bag.
+ *   table whose rows mirror `(spr.id, spr.name, GROUP_CONCAT(names.name))` — one current,
+ *   non-deprecated place per row, with all alternate names concatenated into a single search-token
+ *   bag.
  */
 
 import type { DatabaseSync } from "node:sqlite"
@@ -90,13 +91,18 @@ export function buildPlaceSearchFts(db: DatabaseSync, opts: BuildPlaceSearchFtsO
 	`)
 
 	onProgress("populating")
+	// Excludes deprecated / superseded / non-current places. `is_current` uses a -1/0 convention in
+	// WOF — `-1` means "current"; anything else is historical.
 	db.exec(`
 		INSERT INTO ${PLACE_SEARCH_TABLE} (wof_id, name, alt_names)
 		SELECT
-			places.id,
-			places.name,
-			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM names WHERE names.place_id = places.id), '')
-		FROM places;
+			spr.id,
+			spr.name,
+			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM names WHERE names.id = spr.id), '')
+		FROM spr
+		WHERE spr.is_current = -1
+			AND spr.is_deprecated = 0
+			AND spr.name IS NOT NULL;
 	`)
 
 	const countRow = db.prepare(`SELECT COUNT(*) AS n FROM ${PLACE_SEARCH_TABLE}`).get() as { n: number }

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -6,7 +6,7 @@
 
 export type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WofPlacetype } from "./types.js"
 
-export type { AncestorsTable, GeojsonTable, NamesTable, PlaceSearchTable, PlacesTable, WofDatabase } from "./schema.js"
+export type { AncestorsTable, GeojsonTable, NamesTable, PlaceSearchTable, SprTable, WofDatabase } from "./schema.js"
 
 export { WofSqlitePlaceLookup, type RankingWeights, type WofSqlitePlaceLookupOpts } from "./lookup.js"
 

--- a/resolver-wof-sqlite/integration.test.ts
+++ b/resolver-wof-sqlite/integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Integration tests for `WofSqlitePlaceLookup` against a real Who's On First SQLite distribution.
+ *
+ *   These are gated on the WOF DB being present on disk — the suite SKIPS (with a clear stderr
+ *   message) if the path doesn't exist. CI runs against the fixture-only suites; operators with the
+ *   real DB locally get an extra layer of validation.
+ *
+ *   Resolution order for the DB path:
+ *
+ *   1. `MAILWOMAN_WOF_DB` env var (explicit operator override).
+ *   2. `/mnt/playpen/mailwoman-data/wof/whosonfirst-data-admin-us-latest.db` (the canonical lab location
+ *        documented in the README + handover doc).
+ *
+ *   Assumes the `place_search` FTS5 table is already built (run `mailwoman-wof-build-fts` ahead of
+ *   time). The resolver throws a clear error if missing — that's a sufficient signal.
+ */
+
+import { existsSync } from "node:fs"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+import { WofSqlitePlaceLookup } from "./lookup.js"
+
+const DEFAULT_WOF_PATH = "/mnt/playpen/mailwoman-data/wof/whosonfirst-data-admin-us-latest.db"
+const wofPath = process.env["MAILWOMAN_WOF_DB"] ?? DEFAULT_WOF_PATH
+const hasWofDb = existsSync(wofPath)
+
+// vitest's describe.skipIf prints a helpful message at suite runtime.
+const describeIfWof = describe.skipIf(!hasWofDb)
+
+describeIfWof(`WofSqlitePlaceLookup integration against ${wofPath}`, () => {
+	let lookup: WofSqlitePlaceLookup
+
+	beforeAll(() => {
+		lookup = new WofSqlitePlaceLookup({ databasePath: wofPath })
+	})
+
+	afterAll(() => {
+		lookup?.close()
+	})
+
+	describe("lookup smoke tests", () => {
+		test("`Paris` with locality filter returns >0 candidates, all containing Paris in US", async () => {
+			// FTS5 token-match — `Saint Paris` is a legitimate hit, so the assertion is on substring
+			// match rather than exact equality.
+			const candidates = await lookup.findPlace({ text: "Paris", placetype: "locality", limit: 20 })
+			expect(candidates.length).toBeGreaterThan(0)
+			for (const c of candidates) {
+				expect(c.name).toMatch(/Paris/)
+				expect(c.placetype).toBe("locality")
+				expect(c.country).toBe("US")
+				expect(c.lat).toBeGreaterThan(0)
+				expect(c.lon).toBeLessThan(0)
+				expect(c.wof_id).toBeGreaterThan(0)
+			}
+			// At least one of the candidates IS plain "Paris" (not "Saint Paris" / "South Paris" / etc).
+			expect(candidates.some((c) => c.name === "Paris")).toBe(true)
+		})
+
+		test("`Springfield` with locality filter returns several distinct candidates", async () => {
+			const candidates = await lookup.findPlace({ text: "Springfield", placetype: "locality", limit: 50 })
+			// The US has dozens of Springfields — admin-us has many.
+			expect(candidates.length).toBeGreaterThan(5)
+			// All distinct wof_ids
+			const ids = new Set(candidates.map((c) => c.wof_id))
+			expect(ids.size).toBe(candidates.length)
+		})
+
+		test("placetype: 'neighbourhood' actually narrows to neighbourhoods", async () => {
+			const candidates = await lookup.findPlace({ text: "Mission", placetype: "neighbourhood", limit: 10 })
+			expect(candidates.length).toBeGreaterThan(0)
+			for (const c of candidates) {
+				expect(c.placetype).toBe("neighbourhood")
+			}
+		})
+
+		test("country: 'FR' filter returns empty against the US-only admin shard", async () => {
+			const candidates = await lookup.findPlace({ text: "Paris", country: "FR" })
+			expect(candidates).toEqual([])
+		})
+
+		test("country: 'US' filter passes through all admin-us rows", async () => {
+			const candidates = await lookup.findPlace({ text: "Springfield", country: "US", placetype: "locality", limit: 5 })
+			expect(candidates.length).toBeGreaterThan(0)
+			for (const c of candidates) {
+				expect(c.country).toBe("US")
+			}
+		})
+
+		test("empty / non-token text returns []", async () => {
+			expect(await lookup.findPlace({ text: "" })).toEqual([])
+			expect(await lookup.findPlace({ text: "   " })).toEqual([])
+			expect(await lookup.findPlace({ text: "()" })).toEqual([])
+		})
+
+		test("query with FTS5-special characters doesn't crash", async () => {
+			// FTS5 reserves quotes / parens / colons / etc. Our sanitizer strips all non-alphanumeric.
+			await expect(lookup.findPlace({ text: "St. (Petersburg)" })).resolves.toBeInstanceOf(Array)
+		})
+	})
+
+	describe("alt-name matching", () => {
+		test("Japanese alternate-name query resolves to the underlying English place", async () => {
+			// Ashley (US, IL) — admin-us ships a jpn alt: アシュリー (id 1108979833).
+			const candidates = await lookup.findPlace({ text: "アシュリー", placetype: "locality", limit: 10 })
+			expect(candidates.length).toBeGreaterThan(0)
+			const ashley = candidates.find((c) => c.wof_id === 1108979833)
+			expect(ashley).toBeDefined()
+			expect(ashley!.name).toBe("Ashley")
+		})
+	})
+
+	describe("parent-constrained lookup", () => {
+		test("parentId narrows children to direct + transitive descendants", async () => {
+			// Pick the first Springfield candidate, then look up children of its parent.
+			const springfields = await lookup.findPlace({ text: "Springfield", placetype: "locality", limit: 1 })
+			expect(springfields.length).toBe(1)
+			const parentId = springfields[0]!.parent_id
+			expect(parentId).toBeDefined()
+
+			// Now query for that Springfield by name, scoped to its parent. Should include itself plus
+			// possibly other places under the same parent.
+			const constrained = await lookup.findPlace({
+				text: "Springfield",
+				placetype: "locality",
+				parentId: parentId!,
+				limit: 50,
+			})
+			expect(constrained.length).toBeGreaterThan(0)
+			expect(constrained.find((c) => c.wof_id === springfields[0]!.wof_id)).toBeDefined()
+		})
+	})
+
+	describe("performance budget", () => {
+		test("`findPlace` against the full US admin shard returns in <250ms", async () => {
+			const start = Date.now()
+			await lookup.findPlace({ text: "Springfield", placetype: "locality", limit: 10 })
+			const elapsed = Date.now() - start
+			expect(elapsed).toBeLessThan(250)
+		})
+	})
+})
+
+if (!hasWofDb) {
+	describe.skip("WofSqlitePlaceLookup integration", () => {
+		test(`skipped (WOF DB not present at ${wofPath} — set MAILWOMAN_WOF_DB or download via the README)`, () => {})
+	})
+}

--- a/resolver-wof-sqlite/lookup.test.ts
+++ b/resolver-wof-sqlite/lookup.test.ts
@@ -159,48 +159,46 @@ const FIXTURE: FixturePlace[] = [
 
 function buildFixtureDb(): DatabaseSync {
 	const db = new DatabaseSync(":memory:")
+	// Schema mirrors the real WOF SQLite distribution at data.geocode.earth (subset of columns we
+	// actually read; full schema is documented in `schema.ts`). Note the WOF lifecycle-flag
+	// convention: `is_current = -1` means "currently valid".
 	db.exec(`
-		CREATE TABLE places (
+		CREATE TABLE spr (
 			id INTEGER PRIMARY KEY,
 			parent_id INTEGER,
-			name TEXT NOT NULL,
-			placetype TEXT NOT NULL,
-			country TEXT
+			name TEXT,
+			placetype TEXT,
+			country TEXT,
+			latitude REAL,
+			longitude REAL,
+			is_current INTEGER,
+			is_deprecated INTEGER
 		);
 		CREATE TABLE names (
-			rowid INTEGER PRIMARY KEY,
-			place_id INTEGER NOT NULL,
-			language TEXT NOT NULL,
-			kind TEXT NOT NULL,
+			rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+			id INTEGER NOT NULL,
+			language TEXT,
 			name TEXT NOT NULL
 		);
-		CREATE TABLE geojson (
-			id INTEGER PRIMARY KEY,
-			body TEXT NOT NULL
-		);
 		CREATE TABLE ancestors (
-			rowid INTEGER PRIMARY KEY,
+			rowid INTEGER PRIMARY KEY AUTOINCREMENT,
 			id INTEGER NOT NULL,
 			ancestor_id INTEGER NOT NULL,
 			ancestor_placetype TEXT
 		);
 	`)
 
-	const insertPlace = db.prepare(`INSERT INTO places (id, parent_id, name, placetype, country) VALUES (?, ?, ?, ?, ?)`)
-	const insertName = db.prepare(`INSERT INTO names (place_id, language, kind, name) VALUES (?, ?, ?, ?)`)
-	const insertGeo = db.prepare(`INSERT INTO geojson (id, body) VALUES (?, ?)`)
+	const insertSpr = db.prepare(
+		`INSERT INTO spr (id, parent_id, name, placetype, country, latitude, longitude, is_current, is_deprecated)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, -1, 0)`
+	)
+	const insertName = db.prepare(`INSERT INTO names (id, language, name) VALUES (?, ?, ?)`)
 	const insertAncestor = db.prepare(`INSERT INTO ancestors (id, ancestor_id, ancestor_placetype) VALUES (?, ?, ?)`)
 
 	for (const p of FIXTURE) {
-		insertPlace.run(p.id, p.parent_id, p.name, p.placetype, p.country)
-		insertGeo.run(
-			p.id,
-			JSON.stringify({
-				properties: { "geom:latitude": p.lat, "geom:longitude": p.lon },
-			})
-		)
+		insertSpr.run(p.id, p.parent_id, p.name, p.placetype, p.country, p.lat, p.lon)
 		for (const alt of p.alt_names ?? []) {
-			insertName.run(p.id, "und", "variant", alt)
+			insertName.run(p.id, "und", alt)
 		}
 		for (const aid of p.ancestor_ids ?? []) {
 			insertAncestor.run(p.id, aid, "ancestor")
@@ -292,7 +290,7 @@ describe("WofSqlitePlaceLookup against an inline WOF fixture", () => {
 		}
 		// After the using block: querying via the original db handle should still work because we
 		// don't own it.
-		const after = db.prepare(`SELECT COUNT(*) AS n FROM places`).get() as { n: number }
+		const after = db.prepare(`SELECT COUNT(*) AS n FROM spr`).get() as { n: number }
 		expect(after.n).toBe(FIXTURE.length)
 		db.close()
 	})

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -120,35 +120,36 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		const ftsQuery = sanitizeFtsQuery(query.text)
 		if (!ftsQuery) return []
 
-		const where: string[] = ["place_search MATCH ?"]
+		// Filter out historical / superseded / deprecated places by default — they live in the same
+		// spr table but should never win a contemporary lookup.
+		const where: string[] = ["place_search MATCH ?", "spr.is_current = -1", "spr.is_deprecated = 0"]
 		const params: SQLInputValue[] = [ftsQuery]
 
 		if (placetypes && placetypes.length > 0) {
-			where.push(`places.placetype IN (${placetypes.map(() => "?").join(", ")})`)
+			where.push(`spr.placetype IN (${placetypes.map(() => "?").join(", ")})`)
 			params.push(...placetypes)
 		}
 		if (query.country) {
-			where.push("places.country = ?")
+			where.push("spr.country = ?")
 			params.push(query.country)
 		}
 		if (query.parentId !== undefined) {
-			where.push("(places.parent_id = ? OR places.id IN (SELECT id FROM ancestors WHERE ancestor_id = ?))")
+			where.push("(spr.parent_id = ? OR spr.id IN (SELECT id FROM ancestors WHERE ancestor_id = ?))")
 			params.push(query.parentId, query.parentId)
 		}
 
 		const stmt = this.#db.prepare(`
 			SELECT
-				places.id AS wof_id,
-				places.name,
-				places.placetype,
-				places.country,
-				places.parent_id,
+				spr.id AS wof_id,
+				spr.name,
+				spr.placetype,
+				spr.country,
+				spr.parent_id,
 				bm25(place_search) AS rank,
-				CAST(json_extract(geojson.body, '$.properties."geom:latitude"') AS REAL) AS lat,
-				CAST(json_extract(geojson.body, '$.properties."geom:longitude"') AS REAL) AS lon
+				spr.latitude AS lat,
+				spr.longitude AS lon
 			FROM place_search
-			JOIN places ON places.id = place_search.wof_id
-			LEFT JOIN geojson ON geojson.id = places.id
+			JOIN spr ON spr.id = place_search.wof_id
 			WHERE ${where.join(" AND ")}
 			ORDER BY rank ASC
 			LIMIT ?

--- a/resolver-wof-sqlite/schema.ts
+++ b/resolver-wof-sqlite/schema.ts
@@ -5,7 +5,7 @@
  *
  *   Kysely table types for the subset of the Who's On First SQLite schema we touch in Phase 4.2.
  *
- *   The full upstream distribution at data.geocode.earth/wof/dist/sqlite/ ships ~20 tables; this file
+ *   The full upstream distribution at data.geocode.earth/wof/dist/sqlite/ ships ~7 tables; this file
  *   models only the ones we read. Pretending to model the others would be misleading — we haven't
  *   verified their shapes and they're not part of the resolver's contract.
  *
@@ -19,7 +19,7 @@
  * The FTS5 virtual table built by this package on first open (NOT shipped by upstream WOF).
  *
  * `content` is unindexed — it's there so we can roundtrip the original name back to the caller
- * without a second SELECT. The actual FTS rebuild happens in `lookup.ts::ensureFts`.
+ * without a second SELECT. The actual FTS rebuild happens in `fts.ts::buildPlaceSearchFts`.
  */
 export interface PlaceSearchTable {
 	rowid: number
@@ -29,38 +29,72 @@ export interface PlaceSearchTable {
 }
 
 /**
- * One row per WOF place.
+ * `spr` — the Who's On First "Standard Places Response": a denormalized lightweight summary of one
+ * row per place. The resolver's main lookup table.
  *
- * Real distribution has many more columns (`is_current`, `is_deprecated`, `superseded_by`, etc.).
- * We surface only what the resolver actually queries.
+ * Lifecycle flags use a `-1 / 0` convention (not the more common `1 / 0`): `is_current = -1` means
+ * "currently valid", `0` means "no longer current". Filters in `lookup.ts` exclude `is_current !=
+ * -1` and `is_deprecated != 0`.
+ *
+ * Lat/lon live directly on this row — no GeoJSON extraction needed for centroid resolution. `min_*`
+ * / `max_*` form a bounding box if callers want one (Phase 4.3 candidate).
  */
-export interface PlacesTable {
+export interface SprTable {
 	id: number
 	parent_id: number | null
-	name: string
-	placetype: string
+	name: string | null
+	placetype: string | null
 	country: string | null
+	latitude: number
+	longitude: number
+	min_latitude: number
+	min_longitude: number
+	max_latitude: number
+	max_longitude: number
+	is_current: number
+	is_deprecated: number
+	is_ceased: number
+	is_superseded: number
+	is_superseding: number
+	superseded_by: string | null
+	supersedes: string | null
+	lastmodified: number
 }
 
 /**
- * Alternate names per place, keyed by language + kind. Joins back to `places.id` via `place_id`.
+ * Alternate names per place, keyed by language tag subfields (BCP-47 components). Joins back to
+ * `spr.id` via `id` (NOT `place_id` — the real WOF schema uses the same column name as the spr
+ * primary key; this is a normal join across two tables with the same FK column name).
+ *
+ * No `kind` column in real WOF — the FTS build just concatenates ALL names per id.
  */
 export interface NamesTable {
-	rowid: number
-	place_id: number
-	language: string // ISO-639 alpha-3
-	kind: string // 'preferred' / 'colloquial' / 'variant' / etc.
+	id: number
+	placetype: string | null
+	country: string | null
+	language: string | null // ISO-639 alpha-3
+	extlang: string | null
+	script: string | null
+	region: string | null
+	variant: string | null
+	extension: string | null
+	privateuse: string | null
 	name: string
+	lastmodified: number
 }
 
 /**
- * Per-place GeoJSON blob. Centroid lives at `properties."geom:latitude"` /
- * `properties."geom:longitude"`. The resolver uses SQLite's json_extract() rather than parsing the
- * blob in TS.
+ * Per-place GeoJSON blob. Centroid lat/lon are already exposed via `spr.{latitude,longitude}` so
+ * the resolver doesn't need to parse this; we keep the table modeled in case Phase 4.3 wants the
+ * full geometry for bbox / polygon work.
  */
 export interface GeojsonTable {
 	id: number
 	body: string
+	source: string | null
+	alt_label: string | null
+	is_alt: number
+	lastmodified: number
 }
 
 /**
@@ -70,7 +104,8 @@ export interface GeojsonTable {
 export interface AncestorsTable {
 	id: number
 	ancestor_id: number
-	ancestor_placetype: string
+	ancestor_placetype: string | null
+	lastmodified: number
 }
 
 /**
@@ -79,7 +114,7 @@ export interface AncestorsTable {
  */
 export interface WofDatabase {
 	place_search: PlaceSearchTable
-	places: PlacesTable
+	spr: SprTable
 	names: NamesTable
 	geojson: GeojsonTable
 	ancestors: AncestorsTable


### PR DESCRIPTION
## Summary

The fixture-only Phase 4.2 ship (#84) passed all 12 unit tests but turned out to be based on a **wrong assumption about the WOF SQLite schema**. The fixture used a made-up `places` table; real Geocode Earth distributions use `spr` (Standard Places Response), names join on `id` not `place_id`, and lat/lon are direct `spr` columns rather than JSON-extracted from a `geojson` body.

Caught on the first run against real data, immediately after you authorized the WOF download. This PR is the same-day follow-up: fixes the lookup code, refits the fixture tests to match the real schema, adds an integration test suite that runs against actual WOF, and updates the plan + README with what we now know.

## Schema fix

| Before (made-up) | After (real WOF) |
|---|---|
| `places` table | `spr` table |
| `names.place_id` FK | `names.id` (same column name on both tables) |
| `CAST(json_extract(geojson.body, '$.properties."geom:latitude"') AS REAL)` | `spr.latitude` (direct column) |
| (no lifecycle filter) | `WHERE spr.is_current = -1 AND spr.is_deprecated = 0` |

WOF's lifecycle flags use a **-1/0 convention** (not the usual 1/0): `-1` means "currently valid." Documented in `schema.ts`.

## Integration tests (new file)

`resolver-wof-sqlite/integration.test.ts` — 10 tests, **`describe.skipIf` gated** on the real WOF DB being present.

Path resolution: `MAILWOMAN_WOF_DB` env var → `/mnt/playpen/mailwoman-data/wof/whosonfirst-data-admin-us-latest.db` (canonical lab location). CI runs against the fixture-only suites (no behaviour change); operators with the real DB get the extra layer.

Coverage:
- Placetype filter narrows (`locality` / `neighbourhood`)
- Country filter (`US` passes; `FR` returns empty against the US-only admin shard)
- Empty / non-token / FTS-special-character inputs all return `[]` without crashing
- **Japanese alt-name resolution** — `findPlace({ text: "アシュリー" })` resolves to `Ashley` (wof_id `1108979833`)
- Parent-constrained lookup via `parentId`
- Perf budget: `findPlace` < 250 ms against the 142 k-row US admin shard

## Test plan

- [x] 29/29 fixture tests still pass (after schema-refit)
- [x] 10/10 new integration tests pass against the real US admin shard
- [x] All 1237 tests pass (was 1227 before)
- [x] `yarn compile` clean
- [x] `mailwoman-wof-build-fts` works end-to-end on real data: **142,383 rows indexed in 0.81 seconds** — substantially faster than the "~minutes" estimate in the original Phase 4.2 plan
- [ ] CI green

## Lesson captured

Added a **"Schema-discovery note"** to `docs/plan/phases/PHASE_4_2_wof_sqlite.md`:

> The fixture tests were correctly green against the made-up schema; only the integration tests against actual WOF caught the mismatch. **Always validate against the real artifact** before declaring a data-integration done.

The Phase 4.2 plan and README are both updated with the corrected schema-mapping table.

## Disclosure

Triaged and authored end-to-end by an automated agent (Claude Opus 4.7) under operator supervision. Human reviewer: @GirlBossRush.