### PR TITLE
phase-4.3: wire WOF resolver into the parser pipeline + --resolve CLI flag

### DIFF
--- a/core/decoder/serialize-xml.ts
+++ b/core/decoder/serialize-xml.ts
@@ -17,7 +17,11 @@
  *   - `src` — provenance for the assertion. Formatted as `<source>:<sourceId>` when both fields are
  *       present on the node, `<source>` when only the broad category is set, omitted when neither
  *       is. Phase 4.1 surfaces classifier provenance (`rule:whos_on_first`, `neural:v0.3.1-en-us`);
- *       Phase 4.3 will overlay resolver provenance (`wof-admin:101751113`).
+ *       Phase 4.3 overlays resolver provenance (`resolver:wof-admin:101751119`).
+ *   - `lat` / `lon` — resolver-supplied centroid (Phase 4.3). Emitted only when both are set.
+ *   - `place` — resolver-supplied normalized place URI like `wof:101751119` (Phase 4.3). Emitted only
+ *       when `node.placeId` is set; distinct from `src` so callers that want the bare place id
+ *       without the vendor prefix have a direct attribute to read.
  *   - Root `<address>` carries `raw` — the full input string for round-trip.
  *
  *   ⚠ DOM gotcha: `element.textContent` on a mixed-content node returns the concatenation of all
@@ -37,6 +41,10 @@ export interface SerializeXmlOpts {
 	includeOffsets?: boolean
 	/** Include `src` provenance attribute when the node carries source info. Default true. */
 	includeSrc?: boolean
+	/** Include `lat` + `lon` resolver-supplied centroid attrs when set on the node. Default true. */
+	includeGeo?: boolean
+	/** Include `place` resolver-supplied normalized place URI when set. Default true. */
+	includePlace?: boolean
 }
 
 function escapeXml(s: string): string {
@@ -50,6 +58,12 @@ function srcAttrValue(node: AddressNode): string | null {
 	return null
 }
 
+/**
+ * Centroid precision for resolver-supplied lat/lon. 6 decimal places is ~11 cm at the equator —
+ * more than enough for any postal-address resolver and short enough to stay readable.
+ */
+const GEO_PRECISION = 6
+
 function attrs(node: AddressNode, opts: Required<SerializeXmlOpts>): string {
 	const parts: string[] = []
 	if (opts.includeOffsets) parts.push(`start="${node.start}"`, `end="${node.end}"`)
@@ -57,6 +71,14 @@ function attrs(node: AddressNode, opts: Required<SerializeXmlOpts>): string {
 	if (opts.includeSrc) {
 		const src = srcAttrValue(node)
 		if (src !== null) parts.push(`src="${escapeXml(src)}"`)
+	}
+	// Emit lat + lon together — a centroid is meaningless with only one coordinate. Resolvers that
+	// can produce one but not the other shouldn't decorate the node at all.
+	if (opts.includeGeo && node.lat !== undefined && node.lon !== undefined) {
+		parts.push(`lat="${node.lat.toFixed(GEO_PRECISION)}"`, `lon="${node.lon.toFixed(GEO_PRECISION)}"`)
+	}
+	if (opts.includePlace && node.placeId !== undefined) {
+		parts.push(`place="${escapeXml(node.placeId)}"`)
 	}
 	return parts.length === 0 ? "" : " " + parts.join(" ")
 }
@@ -82,6 +104,8 @@ export function decodeAsXml(tree: AddressTree, opts: SerializeXmlOpts = {}): str
 		includeConf: opts.includeConf ?? true,
 		includeOffsets: opts.includeOffsets ?? true,
 		includeSrc: opts.includeSrc ?? true,
+		includeGeo: opts.includeGeo ?? true,
+		includePlace: opts.includePlace ?? true,
 	}
 	const rawAttr = escapeXml(tree.raw)
 	const nl = full.pretty ? "\n" : ""

--- a/core/decoder/types.ts
+++ b/core/decoder/types.ts
@@ -67,15 +67,32 @@ export interface AddressNode {
 	children: AddressNode[]
 	/**
 	 * Broad category of the assertion's origin. `"rule"` and `"neural"` come from classifier
-	 * proposals; `"resolver"` will be added in Phase 4.3 when a resolver overwrites the attribution.
+	 * proposals; `"resolver"` is set by Phase 4.3's resolver when it overwrites the classifier
+	 * attribution (the displaced classifier source lands in `metadata.classifier_source`).
 	 */
 	source?: string
 	/**
 	 * Specific identifier within `source`: a rule classifier id like `"whos_on_first"`, a neural
-	 * model card version like `"neural-v0.3.1-en-us"`, or (Phase 4.3) a resolver place id like
-	 * `"wof-admin:101751113"`.
+	 * model card version like `"neural-v0.3.1-en-us"`, or a resolver-supplied place id like
+	 * `"wof-admin:101751119"`.
 	 */
 	sourceId?: string
+	/** Resolver-supplied centroid latitude (Phase 4.3). Optional — only set when a resolver wins. */
+	lat?: number
+	/** Resolver-supplied centroid longitude (Phase 4.3). Optional — only set when a resolver wins. */
+	lon?: number
+	/**
+	 * Resolver-supplied normalized place URI (Phase 4.3) — `"wof:101751119"` for a WOF place.
+	 * Distinct from `sourceId` (which includes the resolver vendor) so consumers that want the
+	 * canonical place id without the vendor prefix have one.
+	 */
+	placeId?: string
+	/**
+	 * Opaque per-node metadata bag. Phase 4.3 uses keys `classifier_source` and
+	 * `classifier_source_id` to preserve the displaced classifier attribution when a resolver wins.
+	 * Never consulted by the decoder or serializers — debugging + downstream telemetry only.
+	 */
+	metadata?: Record<string, unknown>
 }
 
 /**

--- a/core/package.json
+++ b/core/package.json
@@ -26,6 +26,7 @@
 		"./utils": "./out/utils/index.js",
 		"./locale": "./out/locale/index.js",
 		"./policy": "./out/policy/index.js",
+		"./resolver": "./out/resolver/index.js",
 		"./kysley/client": "./out/kysley/client.js",
 		"./kysley/dialect": "./out/kysley/dialect.js",
 		"./kysley/dialect-config": "./out/kysley/dialect-config.js",

--- a/core/resolver/index.ts
+++ b/core/resolver/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+export { createWofResolver } from "./resolve.js"
+export { DEFAULT_PLACETYPE_MAP } from "./types.js"
+export type { PlacetypeMap, ResolveOpts, ResolvedPlace, Resolver, ResolverBackend } from "./types.js"

--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -1,0 +1,310 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Unit tests for `resolveTree` — uses an in-memory `FakeResolverBackend` so the test exercises the
+ *   walk + decoration semantics without depending on any concrete WOF data.
+ */
+
+import { describe, expect, test, vi } from "vitest"
+
+import { decodeAsXml } from "../decoder/serialize-xml.js"
+import type { AddressNode, AddressTree, ComponentTag } from "../decoder/types.js"
+import { createWofResolver } from "./resolve.js"
+import type { ResolvedPlace, ResolverBackend } from "./types.js"
+
+function node(
+	tag: ComponentTag,
+	value: string,
+	start: number,
+	end: number,
+	children: AddressNode[] = [],
+	source?: string,
+	sourceId?: string
+): AddressNode {
+	const n: AddressNode = { tag, value, start, end, confidence: 0.9, children }
+	if (source) n.source = source
+	if (sourceId) n.sourceId = sourceId
+	return n
+}
+
+function tree(raw: string, roots: AddressNode[]): AddressTree {
+	return { raw, roots }
+}
+
+class FakeResolverBackend implements ResolverBackend {
+	readonly calls: Array<Parameters<ResolverBackend["findPlace"]>[0]> = []
+	readonly #places: ResolvedPlace[]
+
+	constructor(places: ResolvedPlace[]) {
+		this.#places = places
+	}
+
+	async findPlace(query: Parameters<ResolverBackend["findPlace"]>[0]): Promise<ResolvedPlace[]> {
+		this.calls.push(query)
+		const text = query.text.toLowerCase()
+		const types = Array.isArray(query.placetype) ? query.placetype : query.placetype ? [query.placetype] : null
+		return this.#places
+			.filter((p) => p.name.toLowerCase().includes(text))
+			.filter((p) => !types || types.includes(p.placetype))
+			.filter((p) => !query.country || p.country === query.country)
+			.filter((p) => query.parentId === undefined || p.parent_id === query.parentId)
+			.slice(0, query.limit ?? 5)
+	}
+}
+
+const FIXTURE_PLACES: ResolvedPlace[] = [
+	{ id: 85633147, name: "United States", placetype: "country", country: "US", lat: 39.5, lon: -98.0, score: 10 },
+	{ id: 85633723, name: "France", placetype: "country", country: "FR", lat: 46.5, lon: 2.5, score: 10 },
+	{
+		id: 85688489,
+		name: "Texas",
+		placetype: "region",
+		country: "US",
+		parent_id: 85633147,
+		lat: 31.0,
+		lon: -100.0,
+		score: 9,
+	},
+	{
+		id: 85688541,
+		name: "Illinois",
+		placetype: "region",
+		country: "US",
+		parent_id: 85633147,
+		lat: 40.0,
+		lon: -89.0,
+		score: 9,
+	},
+	{
+		id: 101715829,
+		name: "Paris",
+		placetype: "locality",
+		country: "US",
+		parent_id: 85688489,
+		lat: 33.66,
+		lon: -95.55,
+		score: 8,
+	},
+	{
+		id: 101727113,
+		name: "Springfield",
+		placetype: "locality",
+		country: "US",
+		parent_id: 85688541,
+		lat: 39.78,
+		lon: -89.65,
+		score: 8,
+	},
+	{
+		id: 101729437,
+		name: "Springfield",
+		placetype: "locality",
+		country: "US",
+		parent_id: 85688543, // Massachusetts — not in this fixture as a region
+		lat: 42.1,
+		lon: -72.59,
+		score: 8,
+	},
+]
+
+describe("resolveTree", () => {
+	test("decorates a matched node with resolver source + sourceId + lat/lon + placeId", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5)])
+		const result = await resolver.resolveTree(input)
+
+		expect(result.roots[0]).toMatchObject({
+			tag: "region",
+			value: "Texas",
+			source: "resolver",
+			sourceId: "region:85688489",
+			lat: 31.0,
+			lon: -100.0,
+			placeId: "wof:85688489",
+		})
+	})
+
+	test("preserves classifier attribution into metadata when it gets displaced", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5, [], "rule", "whos_on_first")])
+		const result = await resolver.resolveTree(input)
+
+		expect(result.roots[0]?.source).toBe("resolver")
+		expect(result.roots[0]?.metadata).toMatchObject({
+			classifier_source: "rule",
+			classifier_source_id: "whos_on_first",
+		})
+	})
+
+	test("leaves the node untouched when no candidates match", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Nowheresville", [node("locality", "Nowheresville", 0, 13, [], "neural", "v1")])
+		const result = await resolver.resolveTree(input)
+
+		expect(result.roots[0]?.source).toBe("neural")
+		expect(result.roots[0]?.sourceId).toBe("v1")
+		expect(result.roots[0]?.lat).toBeUndefined()
+		expect(result.roots[0]?.placeId).toBeUndefined()
+		expect(result.roots[0]?.metadata).toBeUndefined()
+	})
+
+	test("does NOT mutate the input tree", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5, [], "rule", "whos_on_first")])
+		const before = JSON.stringify(input)
+		await resolver.resolveTree(input)
+		expect(JSON.stringify(input)).toBe(before)
+	})
+
+	test("skips nodes whose tag isn't in the placetype map (street / house_number / etc)", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("123 Main St", [node("street", "Main St", 4, 11), node("house_number", "123", 0, 3)])
+		await resolver.resolveTree(input)
+		expect(backend.calls).toHaveLength(0)
+	})
+
+	test("inherits parent's country code into child queries", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas, Paris", [node("region", "Texas", 0, 5, [node("locality", "Paris", 7, 12)])])
+		await resolver.resolveTree(input)
+
+		// Parent (region) query: no country constraint.
+		expect(backend.calls[0]).toMatchObject({ text: "Texas", placetype: "region" })
+		expect(backend.calls[0]).not.toHaveProperty("country")
+		// Child (locality) query: country inherited from the parent's resolution (US).
+		expect(backend.calls[1]).toMatchObject({ text: "Paris", placetype: "locality", country: "US" })
+	})
+
+	test("inherits parent's id into child queries via parentId", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Illinois, Springfield", [
+			node("region", "Illinois", 0, 8, [node("locality", "Springfield", 10, 21)]),
+		])
+		const result = await resolver.resolveTree(input)
+
+		// The child lookup carries parentId = the resolved Illinois id (85688541).
+		expect(backend.calls[1]).toMatchObject({
+			text: "Springfield",
+			placetype: "locality",
+			parentId: 85688541,
+		})
+		// And the resolved locality is the IL Springfield, not the MA one.
+		expect(result.roots[0]?.children[0]?.placeId).toBe("wof:101727113")
+	})
+
+	test("respects maxLookups budget", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas, Illinois, Paris, Springfield", [
+			node("region", "Texas", 0, 5),
+			node("region", "Illinois", 7, 15),
+			node("locality", "Paris", 17, 22),
+			node("locality", "Springfield", 24, 35),
+		])
+		await resolver.resolveTree(input, { maxLookups: 2 })
+		expect(backend.calls).toHaveLength(2)
+	})
+
+	test("respects minWinningScore — low-score candidate doesn't win", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5, [], "rule", "whos_on_first")])
+		const result = await resolver.resolveTree(input, { minWinningScore: 100 })
+		// All fixture scores top out at 10; with a 100 floor, the resolver leaves classifier
+		// attribution in place.
+		expect(result.roots[0]?.source).toBe("rule")
+		expect(result.roots[0]?.sourceId).toBe("whos_on_first")
+		expect(result.roots[0]?.placeId).toBeUndefined()
+	})
+
+	test("placetypeMap override can disable a default mapping", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5)])
+		await resolver.resolveTree(input, { placetypeMap: { country: "country" } }) // omits region
+
+		// With region dropped, no backend call should fire.
+		expect(backend.calls).toHaveLength(0)
+	})
+
+	test("backend errors are caught and the node falls through unchanged", async () => {
+		const backend: ResolverBackend = {
+			async findPlace() {
+				throw new Error("backend boom")
+			},
+		}
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5, [], "rule", "whos_on_first")])
+		const result = await resolver.resolveTree(input)
+		expect(result.roots[0]?.source).toBe("rule")
+		expect(result.roots[0]?.placeId).toBeUndefined()
+	})
+
+	test("empty-value node doesn't issue a lookup", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("", [node("region", "  ", 0, 2)])
+		await resolver.resolveTree(input)
+		expect(backend.calls).toHaveLength(0)
+	})
+
+	test("emits lat/lon/place in XML serialization after resolve", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5)])
+		const result = await resolver.resolveTree(input)
+		const xml = decodeAsXml(result)
+
+		expect(xml).toContain(`src="resolver:region:85688489"`)
+		expect(xml).toContain(`lat="31.000000"`)
+		expect(xml).toContain(`lon="-100.000000"`)
+		expect(xml).toContain(`place="wof:85688489"`)
+	})
+
+	test("XML serializer can suppress geo + place via opts", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5)])
+		const result = await resolver.resolveTree(input)
+		const xml = decodeAsXml(result, { includeGeo: false, includePlace: false })
+
+		expect(xml).not.toContain("lat=")
+		expect(xml).not.toContain("lon=")
+		expect(xml).not.toContain("place=")
+		// `src` stays because includeSrc defaults to true.
+		expect(xml).toContain("src=")
+	})
+
+	test("backend call site receives candidatesPerLookup as `limit`", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES)
+		const findPlaceSpy = vi.spyOn(backend, "findPlace")
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Texas", [node("region", "Texas", 0, 5)])
+		await resolver.resolveTree(input, { candidatesPerLookup: 3 })
+		expect(findPlaceSpy).toHaveBeenCalledWith(expect.objectContaining({ limit: 3 }))
+	})
+})

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -1,0 +1,136 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `resolveTree` — walk an `AddressTree` top-down and decorate matched nodes with resolver- supplied
+ *   attribution + coordinates.
+ *
+ *   The walk is parent-constraint-aware: when a parent node resolves to a place id, its children's
+ *   lookups are scoped to descendants of that parent. This dramatically narrows the search space
+ *   for ambiguous names — `Springfield` under a resolved `Illinois` parent resolves to the IL one,
+ *   not the MA one.
+ */
+
+import type { AddressNode, AddressTree, ComponentTag } from "../decoder/types.js"
+import {
+	DEFAULT_PLACETYPE_MAP,
+	type PlacetypeMap,
+	type ResolvedPlace,
+	type ResolveOpts,
+	type Resolver,
+	type ResolverBackend,
+} from "./types.js"
+
+/**
+ * Build a `Resolver` backed by a `ResolverBackend`. The backend can be any concrete impl
+ * structurally compatible with `PlaceLookup` — e.g. `new WofSqlitePlaceLookup({ databasePath
+ * }).asResolverBackend()` or a fake for tests.
+ */
+export function createWofResolver(backend: ResolverBackend): Resolver {
+	return new WofResolver(backend)
+}
+
+interface ResolutionState {
+	lookupsRemaining: number
+	placetypeMap: PlacetypeMap
+	minWinningScore: number
+	candidatesPerLookup: number
+}
+
+class WofResolver implements Resolver {
+	readonly #backend: ResolverBackend
+
+	constructor(backend: ResolverBackend) {
+		this.#backend = backend
+	}
+
+	async resolveTree(tree: AddressTree, opts: ResolveOpts = {}): Promise<AddressTree> {
+		const state: ResolutionState = {
+			lookupsRemaining: opts.maxLookups ?? 10,
+			// Full replacement when `placetypeMap` is supplied — callers that want to extend rather
+			// than replace should spread DEFAULT_PLACETYPE_MAP themselves.
+			placetypeMap: opts.placetypeMap ?? DEFAULT_PLACETYPE_MAP,
+			minWinningScore: opts.minWinningScore ?? 0,
+			candidatesPerLookup: opts.candidatesPerLookup ?? 5,
+		}
+
+		const newRoots: AddressNode[] = []
+		for (const root of tree.roots) {
+			newRoots.push(await this.#walk(root, /* parentResolved */ null, state))
+		}
+		return { raw: tree.raw, roots: newRoots }
+	}
+
+	async #walk(node: AddressNode, parentResolved: ResolvedPlace | null, state: ResolutionState): Promise<AddressNode> {
+		// Always clone — never mutate input nodes.
+		const decorated: AddressNode = { ...node, children: [] }
+
+		const placetype = state.placetypeMap[node.tag as ComponentTag]
+		let resolved: ResolvedPlace | null = null
+		if (placetype && state.lookupsRemaining > 0 && node.value.trim().length > 0) {
+			resolved = await this.#lookupAndPick(node, placetype, parentResolved, state)
+			if (resolved) decorateNode(decorated, resolved)
+		}
+
+		const carryParent = resolved ?? parentResolved
+		for (const child of node.children) {
+			decorated.children.push(await this.#walk(child, carryParent, state))
+		}
+		return decorated
+	}
+
+	async #lookupAndPick(
+		node: AddressNode,
+		placetype: string,
+		parentResolved: ResolvedPlace | null,
+		state: ResolutionState
+	): Promise<ResolvedPlace | null> {
+		state.lookupsRemaining--
+
+		const query: Parameters<ResolverBackend["findPlace"]>[0] = {
+			text: node.value,
+			placetype,
+			limit: state.candidatesPerLookup,
+		}
+		// Pass the inherited parent constraint to the backend when available — both `parentId` and
+		// `country` are valid narrowing hints depending on what the parent resolved to.
+		if (parentResolved) {
+			if (typeof parentResolved.id === "number") query.parentId = parentResolved.id
+			if (parentResolved.country) query.country = parentResolved.country
+		}
+
+		let candidates: ResolvedPlace[]
+		try {
+			candidates = await this.#backend.findPlace(query)
+		} catch {
+			// Defensive: a backend failure should not abort the whole tree walk. Leave the node with
+			// its classifier attribution intact.
+			return null
+		}
+
+		if (candidates.length === 0) return null
+		const top = candidates[0]!
+		if (top.score < state.minWinningScore) return null
+		return top
+	}
+}
+
+/**
+ * Stamp a node with resolver-supplied attribution. Displaces any prior classifier `source` /
+ * `sourceId` into `metadata.classifier_source` / `metadata.classifier_source_id` so debugging tools
+ * can still see who made the original assertion.
+ */
+function decorateNode(node: AddressNode, resolved: ResolvedPlace): void {
+	if (node.source !== undefined || node.sourceId !== undefined) {
+		const meta = { ...(node.metadata ?? {}) }
+		if (node.source !== undefined) meta["classifier_source"] = node.source
+		if (node.sourceId !== undefined) meta["classifier_source_id"] = node.sourceId
+		node.metadata = meta
+	}
+	node.source = "resolver"
+	node.sourceId = `${resolved.placetype}:${resolved.id}`
+	node.lat = resolved.lat
+	node.lon = resolved.lon
+	node.placeId = `wof:${resolved.id}` // v1: only WOF resolvers; the URI scheme stays this simple
+}

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -1,0 +1,128 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Resolver interface for Phase 4.3 — wires the address-component decoder to a place-id / coordinate
+ *   lookup backend.
+ *
+ *   The interface is deliberately decoupled from any specific resolver implementation. The first
+ *   shipped impl is `@mailwoman/resolver-wof-sqlite`, but the same contract supports a future
+ *   `RemoteResolver` adapter (Phase 4.4 — Pelias / BAN / Nominatim) without a public-API break.
+ *
+ *   See `docs/plan/phases/PHASE_4_3_resolver_integration.md` for the design intent.
+ */
+
+import type { AddressTree, ComponentTag } from "../decoder/types.js"
+
+/**
+ * One candidate place returned by a resolver. Mirrors the shape used by
+ * `@mailwoman/resolver-wof-sqlite`'s `PlaceCandidate` — kept structurally compatible so a callsite
+ * holding a `PlaceCandidate` can be passed where a `ResolvedPlace` is expected.
+ */
+export interface ResolvedPlace {
+	/** Resolver-specific place identifier (e.g. WOF id). */
+	id: number | string
+	/** Canonical name of the place as the resolver knows it. */
+	name: string
+	/** Resolver's placetype taxonomy label (e.g. WOF's `country` / `region` / `locality`). */
+	placetype: string
+	/** ISO 3166-1 alpha-2 country code, if known. */
+	country: string
+	/** Centroid latitude in WGS-84 decimal degrees. */
+	lat: number
+	/** Centroid longitude in WGS-84 decimal degrees. */
+	lon: number
+	/** Parent place id within the resolver's hierarchy, if any. */
+	parent_id?: number | string
+	/**
+	 * Resolver-defined ranking score. Higher = better fit for the query. Scale is implementation-
+	 * defined; callers should treat as ordinal.
+	 */
+	score: number
+}
+
+/**
+ * Pull-based contract for a single resolver query. The resolver knows nothing about `AddressTree` —
+ * it just answers "what place is named X, optionally constrained by Y?"
+ *
+ * Structurally compatible with `PlaceLookup` from `@mailwoman/resolver-wof-sqlite` so the latter
+ * satisfies this interface without an adapter shim.
+ */
+export interface ResolverBackend {
+	findPlace(query: {
+		text: string
+		placetype?: string | string[]
+		country?: string
+		parentId?: number | string
+		limit?: number
+	}): Promise<ResolvedPlace[]>
+}
+
+/**
+ * Options for `resolveTree`. All optional with sensible defaults.
+ */
+export interface ResolveOpts {
+	/**
+	 * Hard cap on how many backend lookups one tree may issue. Default 10. Prevents a tree with
+	 * dozens of candidate nodes from triggering dozens of queries.
+	 */
+	maxLookups?: number
+	/**
+	 * Minimum candidate score before resolver attribution wins over the classifier's. Default 0. A
+	 * higher threshold makes the resolver more conservative — it leaves more nodes with classifier
+	 * provenance. Score scale is implementation-defined; tune per backend.
+	 */
+	minWinningScore?: number
+	/**
+	 * Maximum candidates to request from the backend per lookup. Default 5 — we only use the top
+	 * candidate after post-scoring, but the backend may benefit from over-fetching for ranking.
+	 */
+	candidatesPerLookup?: number
+	/**
+	 * Override the default ComponentTag → resolver-placetype mapping. When set, this map FULLY
+	 * REPLACES `DEFAULT_PLACETYPE_MAP` — start from the default by spreading it (`{
+	 * ...DEFAULT_PLACETYPE_MAP, ... }`) if you want to extend rather than replace. The fully-
+	 * replacing semantics let callers narrow the resolver scope (e.g. drop `locality` if the backend
+	 * doesn't ship locality data for the current locale) without awkward `undefined`-as-delete
+	 * tricks.
+	 */
+	placetypeMap?: PlacetypeMap
+	/**
+	 * Optional locale hint. Currently unused by the v1 resolver but reserved so the contract doesn't
+	 * break when locale-aware resolvers land in 4.4+.
+	 */
+	locale?: string
+}
+
+/**
+ * Mapping from mailwoman's address-component tags to the resolver's placetype taxonomy. Components
+ * not present in the map are NOT queried — the resolver pass leaves their classifier attribution
+ * untouched.
+ *
+ * Phase 4.3 default ships the obvious admin-level mappings; other tags (postcode, street, venue,
+ * dependent_locality, prefecture, etc.) are explicitly omitted because:
+ *
+ * - `postcode` lives in a separate WOF shard (Phase 4.3.x follow-up via the postalcode loader).
+ * - `street` / `house_number` aren't in WOF admin — would need OSM / OpenAddresses gazetteers and
+ *   license diligence (Phase 4.4 candidate).
+ * - Non-US JP-specific tags wait on a different shard entirely.
+ */
+export type PlacetypeMap = Partial<Record<ComponentTag, string>>
+
+export const DEFAULT_PLACETYPE_MAP: PlacetypeMap = {
+	country: "country",
+	region: "region",
+	locality: "locality",
+}
+
+/**
+ * The interface implemented by `createWofResolver` and any future resolver factories.
+ *
+ * `resolveTree` returns a NEW `AddressTree` rather than mutating — keeps the input safe to inspect
+ * after the call. The new tree's `roots` are fresh `AddressNode` objects; nodes the resolver didn't
+ * touch are structurally cloned with their classifier attribution preserved.
+ */
+export interface Resolver {
+	resolveTree(tree: AddressTree, opts?: ResolveOpts): Promise<AddressTree>
+}

--- a/docs/plan/phases/PHASE_4_2_wof_sqlite.md
+++ b/docs/plan/phases/PHASE_4_2_wof_sqlite.md
@@ -2,7 +2,7 @@
 
 **Parent:** [`PHASE_4_resolver.md`](./PHASE_4_resolver.md) (Option B picked: SQLite FTS5 + WOF SQLite).
 
-**Goal:** ship `@mailwoman/resolver-wof-sqlite` — a small standalone package that loads a Who's On First SQLite distribution and exposes a typed `PlaceLookup` interface backed by FTS5 full-text matching. Independently useful: callers can resolve `"Paris, FR"` → `wof_id: 101751119, lat: 48.85, lon: 2.34` without going through the full mailwoman parser.
+**Goal:** ship `@mailwoman/resolver-wof-sqlite` — a small standalone package that loads a Who's On First SQLite distribution and exposes a typed `PlaceLookup` interface backed by FTS5 full-text matching. Independently useful: callers can resolve `"Paris, FR"` → `id: 101751119, lat: 48.85, lon: 2.34` without going through the full mailwoman parser.
 
 **Branch:** `feature/phase-4-2-wof-sqlite` (this PR).
 
@@ -65,7 +65,7 @@ Three independent reasons:
 // resolver-wof-sqlite/index.ts
 
 export interface PlaceCandidate {
-	wof_id: number
+	id: number
 	name: string
 	placetype: WofPlacetype
 	country: string // ISO 3166-1 alpha-2

--- a/docs/plan/phases/PHASE_4_3_resolver_integration.md
+++ b/docs/plan/phases/PHASE_4_3_resolver_integration.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-**Not started.** This document is the design intent so the operator can review the shape before implementation begins.
+**Shipped (2026-05-20).** Implementation matches the design below, with three deviations called out in the changelog. The `Resolver` interface + `resolveTree` live in `@mailwoman/core/resolver`; the WOF backing is provided through `@mailwoman/resolver-wof-sqlite` as an **optional peer dep** that the CLI dynamic-imports only when `--resolve` is set.
 
 ## What "integration" means here
 
@@ -128,3 +128,7 @@ mailwoman parse --resolve --resolve-db /path/to/wof.db --format xml "..."
 ## Changelog
 
 - **2026-05-20** — written as design intent during the autonomous night shift. Not yet started; awaits operator review.
+- **2026-05-20** (same day, post-sync) — shipped. Three deviations from the original plan:
+  1. **`@mailwoman/resolver-wof-sqlite` is an optional peer dep, not a hard dep.** The CLI dynamic-imports it inside `withResolver()` so callers who never set `--resolve` don't pay the kysely + resolver bundle cost. Honors the Phase 4.2 plan's "optional dep" intent.
+  2. **`PlaceCandidate.wof_id` → `id` rename.** Phase 4.2 shipped the WOF candidate with a `wof_id` field; that was structurally incompatible with `core/resolver`'s generic `ResolvedPlace.id`. Renamed in this PR so `WofSqlitePlaceLookup` satisfies `ResolverBackend` without an adapter shim. No external consumers yet so the breakage was free.
+  3. **Pre-existing locale-casing bug fix bundled.** `resolveWeights` was forming `@mailwoman/neural-weights-en-US` (uppercase region) but the package is lowercase. The CLI accepts canonical `en-US` casing; `weights.ts` now lowercases before forming the package name. Surfaced on the first end-to-end smoke test; fix shipped alongside Phase 4.3.

--- a/mailwoman/commands/parse.tsx
+++ b/mailwoman/commands/parse.tsx
@@ -5,13 +5,15 @@
  */
 
 import { Spinner } from "@inkjs/ui"
-import { decodeAsJson, decodeAsTuples, decodeAsXml, proposalsToTree } from "@mailwoman/core/decoder"
+import { type AddressTree, decodeAsJson, decodeAsTuples, decodeAsXml, proposalsToTree } from "@mailwoman/core/decoder"
 import { collectProposals, filterByPolicy } from "@mailwoman/core/parser"
 import { InMemoryPolicyRegistry, type PolicyMode } from "@mailwoman/core/policy"
+import { createWofResolver, type Resolver, type ResolverBackend } from "@mailwoman/core/resolver"
 import type { ComponentTag, Section } from "@mailwoman/core/types"
 import { createNeuralProposalClassifier, NeuralAddressClassifier } from "@mailwoman/neural"
 import { Text } from "ink"
 import { createAddressParser, createDiagnosticReport } from "mailwoman"
+import { setImmediate } from "node:timers/promises"
 import { useEffect, useState } from "react"
 import zod from "zod"
 import type { CommandComponent } from "../sdk/cli.js"
@@ -53,6 +55,19 @@ const ParseConfigSchema = zod.object({
 				POLICY_MODES.join(", ") +
 				". Requires --neural."
 		),
+	resolve: zod
+		.boolean()
+		.optional()
+		.default(false)
+		.describe(
+			"Run the parsed tree through the WOF resolver (Phase 4.3) — decorates matched nodes with wof:<id> + lat/lon. Requires --neural."
+		),
+	resolveDb: zod
+		.string()
+		.optional()
+		.describe(
+			"Path to a WOF SQLite distribution for --resolve. Defaults to $MAILWOMAN_WOF_DB; errors if neither is set."
+		),
 })
 
 interface PolicyOverride {
@@ -79,11 +94,28 @@ const ParseCommand: CommandComponent<typeof ParseConfigSchema, typeof ArgumentsS
 	const [error, setError] = useState<string>()
 
 	useEffect(() => {
+		if (error) {
+			// Render the error once, then exit non-zero so callers (scripts, CI) see the failure.
+			// Mirrors the pattern in corpus/run.tsx — setImmediate() yields so the React render flushes
+			// to stderr/stdout before the process tears down.
+			setImmediate().then(() => process.exit(1))
+		}
+	}, [error])
+
+	useEffect(() => {
 		const input = args[0]!
 
 		if (options.policy && options.policy.length > 0 && !options.neural) {
 			// eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot mount validation; refactor pending
 			setError("--policy requires --neural in this version (rule-side policy integration is a follow-up).")
+			return
+		}
+
+		if (options.resolve && !options.neural) {
+			// eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot mount validation; refactor pending
+			setError(
+				"--resolve requires --neural. The rule-based parser doesn't produce the AddressTree shape the resolver needs."
+			)
 			return
 		}
 
@@ -119,6 +151,8 @@ const ParseCommand: CommandComponent<typeof ParseConfigSchema, typeof ArgumentsS
 		options.model,
 		options.tokenizer,
 		options.policy,
+		options.resolve,
+		options.resolveDb,
 	])
 
 	if (error) {
@@ -132,6 +166,56 @@ const ParseCommand: CommandComponent<typeof ParseConfigSchema, typeof ArgumentsS
 	return <Text>{output}</Text>
 }
 
+function resolveWofPath(options: zod.infer<typeof ParseConfigSchema>): string {
+	const path = options.resolveDb ?? process.env["MAILWOMAN_WOF_DB"]
+	if (!path) {
+		throw new Error(
+			"--resolve needs a WOF SQLite path. Set $MAILWOMAN_WOF_DB or pass --resolve-db <path>. " +
+				"Download from https://data.geocode.earth/wof/dist/sqlite/ and pre-build the FTS5 index " +
+				"with `npx mailwoman-wof-build-fts <path>`."
+		)
+	}
+	return path
+}
+
+async function withResolver<T>(
+	options: zod.infer<typeof ParseConfigSchema>,
+	fn: (resolver: Resolver) => Promise<T>
+): Promise<T> {
+	// Dynamic import so `@mailwoman/resolver-wof-sqlite` stays a true optional peer dep — users who
+	// never set --resolve don't pay for kysely + the resolver bundle.
+	let mod: typeof import("@mailwoman/resolver-wof-sqlite")
+	try {
+		mod = await import("@mailwoman/resolver-wof-sqlite")
+	} catch {
+		throw new Error(
+			"--resolve requires `@mailwoman/resolver-wof-sqlite` to be installed. " +
+				"Run `npm install @mailwoman/resolver-wof-sqlite` and try again."
+		)
+	}
+
+	const lookup = new mod.WofSqlitePlaceLookup({ databasePath: resolveWofPath(options) })
+	try {
+		// PlaceLookup is structurally compatible with ResolverBackend — the cast is just to satisfy
+		// the type, no runtime conversion.
+		const resolver = createWofResolver(lookup as unknown as ResolverBackend)
+		return await fn(resolver)
+	} finally {
+		lookup.close()
+	}
+}
+
+function serializeTree(tree: AddressTree, format: "json" | "tuple" | "xml"): string {
+	switch (format) {
+		case "xml":
+			return decodeAsXml(tree)
+		case "tuple":
+			return JSON.stringify(decodeAsTuples(tree), null, 2)
+		default:
+			return JSON.stringify(decodeAsJson(tree), null, 2)
+	}
+}
+
 async function runNeural(
 	input: string,
 	options: zod.infer<typeof ParseConfigSchema>,
@@ -143,8 +227,9 @@ async function runNeural(
 		tokenizerPath: options.tokenizer,
 	})
 
-	// Fast path: no policy → use the existing direct projection, preserves containment nesting.
-	if (policyOverrides.length === 0) {
+	// Fast path: no policy AND no resolve → preserve containment nesting via NeuralAddressClassifier
+	// 's direct projection helpers (returns the serialized string in one call).
+	if (policyOverrides.length === 0 && !options.resolve) {
 		switch (options.format) {
 			case "xml":
 				return neural.parseXml(input)
@@ -155,33 +240,36 @@ async function runNeural(
 		}
 	}
 
-	// Policy path: run the proposal pipeline so per-component overrides are honored. Containment
-	// nesting is lost in this projection — see proposals-to-tree.ts for why.
-	const proposalCls = createNeuralProposalClassifier({ id: `neural-cli-${options.locale}`, classifier: neural })
-	// Without rule classifiers in the CLI loop, the registry's default rule_only would drop every
-	// neural proposal and produce empty output. Default every component to neural_only when
-	// --neural --policy is used, then layer the user's overrides on top.
-	const policy = InMemoryPolicyRegistry.withDefaults()
-	for (const entry of policy.entries()) {
-		policy.set({ component: entry.component, mode: "neural_only" })
-	}
-	for (const o of policyOverrides) {
-		policy.set({ component: o.component, mode: o.mode })
+	// Slow paths build the tree explicitly so we can resolve / re-project before serialization.
+	let tree: AddressTree
+	if (policyOverrides.length > 0) {
+		// Policy path: containment nesting is lost — see proposals-to-tree.ts for why.
+		const proposalCls = createNeuralProposalClassifier({ id: `neural-cli-${options.locale}`, classifier: neural })
+		// Without rule classifiers in the CLI loop, the registry's default rule_only would drop every
+		// neural proposal and produce empty output. Default every component to neural_only when
+		// --neural --policy is used, then layer the user's overrides on top.
+		const policy = InMemoryPolicyRegistry.withDefaults()
+		for (const entry of policy.entries()) {
+			policy.set({ component: entry.component, mode: "neural_only" })
+		}
+		for (const o of policyOverrides) {
+			policy.set({ component: o.component, mode: o.mode })
+		}
+
+		const wholeInputSection = { body: input, start: 0, end: input.length } as unknown as Section
+		const proposals = await collectProposals([wholeInputSection], [proposalCls], { locale: options.locale })
+		const filtered = filterByPolicy(proposals, policy, options.locale)
+		tree = proposalsToTree(input, filtered)
+	} else {
+		// Resolve path without policy — keep containment by going through the decoder directly.
+		tree = await neural.parse(input)
 	}
 
-	const wholeInputSection = { body: input, start: 0, end: input.length } as unknown as Section
-	const proposals = await collectProposals([wholeInputSection], [proposalCls], { locale: options.locale })
-	const filtered = filterByPolicy(proposals, policy, options.locale)
-	const tree = proposalsToTree(input, filtered)
-
-	switch (options.format) {
-		case "xml":
-			return decodeAsXml(tree)
-		case "tuple":
-			return JSON.stringify(decodeAsTuples(tree), null, 2)
-		default:
-			return JSON.stringify(decodeAsJson(tree), null, 2)
+	if (options.resolve) {
+		tree = await withResolver(options, (resolver) => resolver.resolveTree(tree))
 	}
+
+	return serializeTree(tree, options.format)
 }
 
 export default ParseCommand

--- a/mailwoman/package.json
+++ b/mailwoman/package.json
@@ -50,6 +50,9 @@
 		"spliterator": "^2.0.0",
 		"zod": "^4.1.12"
 	},
+	"peerDependencies": {
+		"@mailwoman/resolver-wof-sqlite": "workspace:*"
+	},
 	"files": [
 		"!out/test/**/*",
 		"!**/*.ts",
@@ -69,6 +72,9 @@
 	"bin": "./out/cli.js",
 	"peerDependenciesMeta": {
 		"@inkjs/ui": {
+			"optional": true
+		},
+		"@mailwoman/resolver-wof-sqlite": {
 			"optional": true
 		},
 		"core-js": {

--- a/mailwoman/test/resolve-flag.test.ts
+++ b/mailwoman/test/resolve-flag.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   CLI integration tests for `parse --neural --resolve` (Phase 4.3).
+ *
+ *   Schema-level tests run unconditionally. End-to-end tests gate on a real WOF SQLite distribution
+ *   being on disk (skip-if-missing via `describe.skipIf`), matching the pattern in
+ *   `resolver-wof-sqlite/integration.test.ts`.
+ */
+
+import { execFile } from "node:child_process"
+import { existsSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+import { describe, expect, test } from "vitest"
+import { options as parseOptions } from "../commands/parse.js"
+
+const exec = promisify(execFile)
+const repoRoot = resolve(fileURLToPath(import.meta.url), "../..")
+const cliBin = resolve(repoRoot, "out", "cli.js")
+
+const DEFAULT_WOF_PATH = "/mnt/playpen/mailwoman-data/wof/whosonfirst-data-admin-us-latest.db"
+const wofPath = process.env["MAILWOMAN_WOF_DB"] ?? DEFAULT_WOF_PATH
+const hasWofDb = existsSync(wofPath)
+const describeIfWof = describe.skipIf(!hasWofDb)
+
+describe("--resolve schema validation", () => {
+	test("--resolve defaults to false", () => {
+		expect(parseOptions.parse({}).resolve).toBe(false)
+	})
+
+	test("--resolve accepts true", () => {
+		expect(parseOptions.parse({ resolve: true, neural: true }).resolve).toBe(true)
+	})
+
+	test("--resolve-db accepts an arbitrary path string", () => {
+		expect(parseOptions.parse({ resolveDb: "/tmp/wof.db" }).resolveDb).toBe("/tmp/wof.db")
+	})
+})
+
+describe("npx mailwoman parse --resolve error paths", () => {
+	test("--resolve without --neural exits non-zero with a clear message", async () => {
+		await expect(exec("node", [cliBin, "parse", "--resolve", "123 Main St"])).rejects.toMatchObject({
+			stdout: expect.stringMatching(/--resolve requires --neural/),
+		})
+	})
+})
+
+describeIfWof(`npx mailwoman parse --neural --resolve against ${wofPath}`, () => {
+	test("emits resolver-decorated XML for a known US locality", async () => {
+		const result = await exec(
+			"node",
+			[cliBin, "parse", "--neural", "--resolve", "--format", "xml", "Springfield, Illinois"],
+			{ env: { ...process.env, MAILWOMAN_WOF_DB: wofPath, NODE_NO_WARNINGS: "1" }, maxBuffer: 4 * 1024 * 1024 }
+		)
+		// The XML root is always present.
+		expect(result.stdout).toContain("<address raw=")
+		// At least one node gained resolver attribution. The exact wof id varies by FTS ranking, but
+		// the `place="wof:<digits>"` shape + the `lat=` / `lon=` attrs are stable.
+		expect(result.stdout).toMatch(/src="resolver:[a-z_]+:\d+"/)
+		expect(result.stdout).toMatch(/place="wof:\d+"/)
+		expect(result.stdout).toMatch(/lat="-?\d+\.\d+"/)
+		expect(result.stdout).toMatch(/lon="-?\d+\.\d+"/)
+	}, 30_000)
+
+	test("respects --resolve-db explicit path override (matches env default)", async () => {
+		// Use the same input as the first test — the neural classifier needs enough context to tag
+		// component spans; bare single-token names like "Houston" alone often parse to nothing.
+		const result = await exec(
+			"node",
+			[cliBin, "parse", "--neural", "--resolve", "--resolve-db", wofPath, "--format", "xml", "Springfield, Illinois"],
+			{ env: { ...process.env, NODE_NO_WARNINGS: "1" }, maxBuffer: 4 * 1024 * 1024 }
+		)
+		expect(result.stdout).toContain("<address raw=")
+		expect(result.stdout).toMatch(/src="resolver:/)
+	}, 30_000)
+
+	test("works without --resolve (regression check — flag default is off)", async () => {
+		const result = await exec("node", [cliBin, "parse", "--neural", "--format", "xml", "Springfield, Illinois"], {
+			env: { ...process.env, NODE_NO_WARNINGS: "1" },
+			maxBuffer: 4 * 1024 * 1024,
+		})
+		expect(result.stdout).toContain("<address raw=")
+		// Without --resolve, no resolver attribution.
+		expect(result.stdout).not.toMatch(/src="resolver:/)
+		expect(result.stdout).not.toMatch(/place="wof:/)
+	}, 30_000)
+})
+
+if (!hasWofDb) {
+	describe.skip("--resolve end-to-end", () => {
+		test(`skipped (WOF DB not present at ${wofPath} — set MAILWOMAN_WOF_DB)`, () => {})
+	})
+}

--- a/mailwoman/tsconfig.json
+++ b/mailwoman/tsconfig.json
@@ -7,5 +7,11 @@
 	},
 	"include": ["./**/*"],
 	"exclude": ["./out/**/*", "./**/*.test.ts", "./**/*.test.tsx", "./test/**/*", "./server/static/**"],
-	"references": [{ "path": "../core" }, { "path": "../classifiers" }, { "path": "../corpus" }, { "path": "../neural" }]
+	"references": [
+		{ "path": "../core" },
+		{ "path": "../classifiers" },
+		{ "path": "../corpus" },
+		{ "path": "../neural" },
+		{ "path": "../resolver-wof-sqlite" }
+	]
 }

--- a/neural/weights.ts
+++ b/neural/weights.ts
@@ -53,7 +53,10 @@ export function resolveWeights(opts: ResolveWeightsOpts): ResolvedWeights {
 		return { modelPath: opts.modelPath, tokenizerPath: opts.tokenizerPath, source: "explicit" }
 	}
 
-	const locale = opts.locale ?? "en-us"
+	// Package names follow the all-lowercase BCP-47 convention (`neural-weights-en-us`,
+	// `neural-weights-fr-fr`). The CLI's locale validation accepts canonical `en-US` / `fr-FR`
+	// casing, so we normalize here rather than at the callsite.
+	const locale = (opts.locale ?? "en-us").toLowerCase()
 	const packageName = `@mailwoman/neural-weights-${locale}`
 	let packageDir: string
 	try {

--- a/resolver-wof-sqlite/README.md
+++ b/resolver-wof-sqlite/README.md
@@ -29,7 +29,7 @@ const candidates = await lookup.findPlace({
 })
 
 for (const c of candidates) {
-	console.log(c.wof_id, c.name, c.country, c.lat, c.lon, "score:", c.score)
+	console.log(c.id, c.name, c.country, c.lat, c.lon, "score:", c.score)
 }
 
 lookup.close()

--- a/resolver-wof-sqlite/integration.test.ts
+++ b/resolver-wof-sqlite/integration.test.ts
@@ -54,7 +54,7 @@ describeIfWof(`WofSqlitePlaceLookup integration against ${wofPath}`, () => {
 				expect(c.country).toBe("US")
 				expect(c.lat).toBeGreaterThan(0)
 				expect(c.lon).toBeLessThan(0)
-				expect(c.wof_id).toBeGreaterThan(0)
+				expect(c.id).toBeGreaterThan(0)
 			}
 			// At least one of the candidates IS plain "Paris" (not "Saint Paris" / "South Paris" / etc).
 			expect(candidates.some((c) => c.name === "Paris")).toBe(true)
@@ -64,8 +64,8 @@ describeIfWof(`WofSqlitePlaceLookup integration against ${wofPath}`, () => {
 			const candidates = await lookup.findPlace({ text: "Springfield", placetype: "locality", limit: 50 })
 			// The US has dozens of Springfields — admin-us has many.
 			expect(candidates.length).toBeGreaterThan(5)
-			// All distinct wof_ids
-			const ids = new Set(candidates.map((c) => c.wof_id))
+			// All distinct ids
+			const ids = new Set(candidates.map((c) => c.id))
 			expect(ids.size).toBe(candidates.length)
 		})
 
@@ -107,7 +107,7 @@ describeIfWof(`WofSqlitePlaceLookup integration against ${wofPath}`, () => {
 			// Ashley (US, IL) — admin-us ships a jpn alt: アシュリー (id 1108979833).
 			const candidates = await lookup.findPlace({ text: "アシュリー", placetype: "locality", limit: 10 })
 			expect(candidates.length).toBeGreaterThan(0)
-			const ashley = candidates.find((c) => c.wof_id === 1108979833)
+			const ashley = candidates.find((c) => c.id === 1108979833)
 			expect(ashley).toBeDefined()
 			expect(ashley!.name).toBe("Ashley")
 		})
@@ -130,7 +130,7 @@ describeIfWof(`WofSqlitePlaceLookup integration against ${wofPath}`, () => {
 				limit: 50,
 			})
 			expect(constrained.length).toBeGreaterThan(0)
-			expect(constrained.find((c) => c.wof_id === springfields[0]!.wof_id)).toBeDefined()
+			expect(constrained.find((c) => c.id === springfields[0]!.id)).toBeDefined()
 		})
 	})
 

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -65,7 +65,7 @@ const DEFAULT_WEIGHTS: RankingWeights = {
 }
 
 interface RawSearchRow {
-	wof_id: number
+	id: number
 	name: string
 	placetype: string
 	country: string | null
@@ -140,7 +140,7 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 
 		const stmt = this.#db.prepare(`
 			SELECT
-				spr.id AS wof_id,
+				spr.id AS id,
 				spr.name,
 				spr.placetype,
 				spr.country,
@@ -183,7 +183,7 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			score -= (this.#weights.lengthPenaltyWeight * extraLen) / 10
 
 			return {
-				wof_id: row.wof_id,
+				id: row.id,
 				name: row.name,
 				placetype: row.placetype as WofPlacetype,
 				country: row.country ?? "",

--- a/resolver-wof-sqlite/types.ts
+++ b/resolver-wof-sqlite/types.ts
@@ -38,9 +38,13 @@ export type WofPlacetype =
  *
  * `score` is the post-boost ranking number — higher is better, but the scale is implementation-
  * defined. Callers should treat it as ordinal, not absolute.
+ *
+ * `id` is the WOF place id. It's named generically (not `wof_id`) so the shape stays structurally
+ * compatible with `@mailwoman/core/resolver`'s `ResolvedPlace` — `WofSqlitePlaceLookup` satisfies
+ * the generic `ResolverBackend` contract without an adapter shim.
  */
 export interface PlaceCandidate {
-	wof_id: number
+	id: number
 	name: string
 	placetype: WofPlacetype
 	/** ISO 3166-1 alpha-2 country code. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -7538,8 +7538,12 @@ __metadata:
     regenerate: "npm:^1.4.2"
     spliterator: "npm:^2.0.0"
     zod: "npm:^4.1.12"
+  peerDependencies:
+    "@mailwoman/resolver-wof-sqlite": "workspace:*"
   peerDependenciesMeta:
     "@inkjs/ui":
+      optional: true
+    "@mailwoman/resolver-wof-sqlite":
       optional: true
     core-js:
       optional: true


### PR DESCRIPTION
## Summary

Phase 4.3 closes the resolver loop. After this PR, `mailwoman parse --neural --resolve --format xml "Springfield, Illinois"` returns an `<address>` tree whose `<locality>` carries:

```xml
<locality start="0" end="11" conf="0.96"
          src="resolver:locality:1125884535"
          lat="39.930670" lon="-75.320190"
          place="wof:1125884535">Springfield</locality>
```

The resolver overlays its attribution on top of Phase 4.1's classifier-derived `src`, displacing the classifier source into `metadata.classifier_source` for debugging.

Closes the design in #86.

## Key pieces

**`core/resolver/` (new)** — `Resolver`, `ResolverBackend`, `ResolvedPlace`, `ResolveOpts`, `PlacetypeMap` interfaces. Decoupled from any specific backend so a future `RemoteResolver` (Phase 4.4) drops in without a public-API break. `createWofResolver(backend)` builds the impl. `resolveTree()` walks top-down with **parent-constraint inheritance** — when a parent resolves, child queries inherit `parentId` + `country` to narrow the FTS search space dramatically.

**`mailwoman/commands/parse.tsx`** — `--resolve` flag (default false) + `--resolve-db <path>` override. Falls back to `$MAILWOMAN_WOF_DB`. Dynamic-imports `@mailwoman/resolver-wof-sqlite` so callers without `--resolve` never pay the kysely + resolver bundle cost. Errors now exit non-zero (was: rendered red text + exit 0 — UX bug fixed in passing).

**`core/decoder/types.ts` + `serialize-xml.ts`** — `AddressNode` gains optional `lat`/`lon`/`placeId`/`metadata` fields; XML serializer emits new `lat`/`lon`/`place` attributes (6-decimal precision on coords).

## Three deviations from the plan

1. **Optional peer dep instead of hard dep.** Honors the Phase 4.2 plan's "Not every mailwoman user wants geocoding" intent. Dynamic import inside `withResolver()`.
2. **`PlaceCandidate.wof_id` → `id` rename in Phase 4.2's package.** Required for structural compatibility with `core/resolver`'s generic `ResolvedPlace`. No external consumers yet so the breakage was free.
3. **`PlacetypeMap` opt fully REPLACES the default** (not merge-on-default) — clearer semantics, lets callers narrow without `undefined`-as-delete tricks.

## Bonus fix bundled

Pre-existing locale-casing bug in `neural/weights.ts`: CLI accepts canonical `en-US` but `resolveWeights` was forming `@mailwoman/neural-weights-en-US` (uppercase region; package is lowercase). Surfaced on the first end-to-end smoke test. Fix: lowercase the locale before forming the package name. Two-line change.

## Test plan

- [x] 15 new resolveTree unit tests (fake backend) — covers decoration, metadata preservation, immutability, placetype-map skipping, country + parentId inheritance, maxLookups budget, minWinningScore, backend error fall-through, XML projection
- [x] 7 new CLI integration tests in `mailwoman/test/resolve-flag.test.ts` — 3 schema, 1 error-path (unconditional), 3 end-to-end gated on real WOF presence via `describe.skipIf`
- [x] All 1259 tests pass (was 1237 after #88; +22 new)
- [x] `yarn compile` clean
- [x] End-to-end smoke against real WOF admin-US: known-good output shape
- [ ] CI green

## Known limitation (Phase 4.3.x follow-up territory)

The admin-us shard has no `region`-placetype rows for US states, so `Illinois` doesn't resolve and `Springfield` falls through to an unconstrained FTS lookup — picks an arbitrary Springfield. Adding the full planet admin shard or a US-states gazetteer would unlock the full parent-constrained resolution path. Doesn't block the integration; the **mechanism** works correctly (verified by the unit tests with a fake backend that DOES return Illinois).

## Disclosure

Triaged and authored end-to-end by an automated agent (Claude Opus 4.7) under operator supervision. Human reviewer: @GirlBossRush.