### PR TITLE
phase-4.3.x: multi-shard ATTACH + postcode resolver routing

### DIFF
--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -114,6 +114,10 @@ export const DEFAULT_PLACETYPE_MAP: PlacetypeMap = {
 	country: "country",
 	region: "region",
 	locality: "locality",
+	// `postcode` (mailwoman tag) maps to WOF's `postalcode` placetype. Resolves only when the
+	// backend has the postcode shard available — `WofSqlitePlaceLookup` auto-routes `postalcode`
+	// queries to a `postalcode_us` (or similarly-named) shard, falling back to main if absent.
+	postcode: "postalcode",
 }
 
 /**

--- a/resolver-wof-sqlite/README.md
+++ b/resolver-wof-sqlite/README.md
@@ -35,6 +35,35 @@ for (const c of candidates) {
 lookup.close()
 ```
 
+## Multi-shard (admin + postcode in one connection)
+
+Pass an array of paths to open multiple WOF shards on a single connection — each is opened as a
+separate SQLite schema via `ATTACH DATABASE`. Schema names auto-derive from filenames
+(`whosonfirst-data-admin-us-latest.db` → `admin_us`, `whosonfirst-data-postalcode-us-latest.db` →
+`postalcode_us`). Queries route by `placetype` — a `postalcode` query goes to the
+`postalcode_us` shard automatically, everything else hits main.
+
+```ts
+const lookup = new WofSqlitePlaceLookup({
+	databasePath: ["/data/wof/whosonfirst-data-admin-us-latest.db", "/data/wof/whosonfirst-data-postalcode-us-latest.db"],
+})
+
+await lookup.findPlace({ text: "Springfield", placetype: "locality" }) // → admin shard
+await lookup.findPlace({ text: "62701", placetype: "postalcode" }) // → postcode shard
+```
+
+Override schema names or routing explicitly when needed:
+
+```ts
+new WofSqlitePlaceLookup({
+	databasePath: ["/data/wof/admin.db", { path: "/data/oddly-named.db", schemaName: "pc", placetypes: ["postalcode"] }],
+})
+```
+
+Cross-shard `UNION` queries are not supported in one `findPlace` call — BM25 scores aren't
+comparable across separately-indexed corpora. Issue two `findPlace` calls and merge in your
+caller if you need that.
+
 ## Getting the WOF SQLite distribution
 
 The Geocode Earth team mirrors WOF SQLite distributions at <https://data.geocode.earth/wof/dist/sqlite/>. The two relevant shards for v1:

--- a/resolver-wof-sqlite/build-fts-cli.test.ts
+++ b/resolver-wof-sqlite/build-fts-cli.test.ts
@@ -108,12 +108,32 @@ describe("build-fts-cli main()", () => {
 		stderrSpy.mockRestore()
 	})
 
-	test("exits 2 when zero or multiple positional args are passed", () => {
+	test("exits 2 when zero positional args are passed", () => {
 		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
-
 		expect(() => main([])).toThrow(/process\.exit.*"2"/)
-		expect(() => main(["a.db", "b.db"])).toThrow(/process\.exit.*"2"/)
+		stderrSpy.mockRestore()
+	})
 
+	test("accepts multiple positional args (variadic — one DB per arg)", () => {
+		// Build two real fixture DBs and pass them both. Both should land with indexes.
+		const dbA = join(scratch, "a.db")
+		const dbB = join(scratch, "b.db")
+		buildFixtureDb(dbA)
+		buildFixtureDb(dbB)
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+		expect(main([dbA, dbB])).toBe(0)
+		const written = stderrSpy.mock.calls.map((c) => String(c[0])).join("")
+		// One "Built" line per DB.
+		expect(written.match(/Built:/g)?.length).toBe(2)
+		stderrSpy.mockRestore()
+	})
+
+	test("multi-DB invocation surfaces the worst exit code (missing file → 1)", () => {
+		const dbOK = join(scratch, "ok.db")
+		buildFixtureDb(dbOK)
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+		// Good DB succeeds, missing DB fails. Worst-of-both = 1.
+		expect(main([dbOK, "/nope/missing.db"])).toBe(1)
 		stderrSpy.mockRestore()
 	})
 

--- a/resolver-wof-sqlite/build-fts-cli.ts
+++ b/resolver-wof-sqlite/build-fts-cli.ts
@@ -4,11 +4,15 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   `mailwoman-wof-build-fts <path-to-wof.db> [--drop]`
+ *   `mailwoman-wof-build-fts <path-to-wof.db>... [--drop]`
  *
- *   Operator-side one-shot CLI: takes a Who's On First SQLite distribution and adds the
- *   `place_search` FTS5 virtual table needed by `WofSqlitePlaceLookup`. Run this once after
- *   downloading a fresh WOF shard so production callers can skip the (~minutes-long) lazy build.
+ *   Operator-side one-shot CLI: takes one or more Who's On First SQLite distributions and adds the
+ *   `place_search` FTS5 + `place_bbox` R*Tree virtual tables needed by `WofSqlitePlaceLookup`. Run
+ *   this once per downloaded WOF shard so production callers can skip the (~minutes-long) lazy
+ *   build.
+ *
+ *   Multiple positional args process each DB in sequence — useful when you've just pulled the admin +
+ *   postcode shards in one go.
  *
  *   Why a plain-args CLI rather than Ink / Pastel: this is a one-shot operator script, not an
  *   interactive TUI. The dep weight of inkjs / pastel would dominate the script's footprint and
@@ -23,21 +27,26 @@ import { DatabaseSync } from "node:sqlite"
 import { buildPlaceSearchFts } from "./fts.js"
 
 interface CliArgs {
-	databasePath: string
+	databasePaths: string[]
 	drop: boolean
 }
 
 function printUsageAndExit(code: number): never {
 	stderr.write(
 		[
-			"usage: mailwoman-wof-build-fts <path-to-wof.db> [--drop]",
+			"usage: mailwoman-wof-build-fts <path-to-wof.db>... [--drop]",
 			"",
-			"Builds the place_search FTS5 virtual table in a Who's On First SQLite",
-			"distribution. Run this once after downloading a fresh WOF shard so production",
-			"WofSqlitePlaceLookup instances don't pay the lazy-build cost at first open.",
+			"Builds the place_search FTS5 + place_bbox R*Tree virtual tables in one or more",
+			"Who's On First SQLite distributions. Run this once per downloaded WOF shard so",
+			"production WofSqlitePlaceLookup instances skip the lazy-build cost at first open.",
 			"",
-			"  --drop   Drop and rebuild place_search if it already exists. Use after",
-			"           refreshing the `places` / `names` tables from an updated dump.",
+			"  --drop   Drop and rebuild place_search + place_bbox if they already exist.",
+			"           Apply after refreshing the spr / names tables from a newer dump.",
+			"",
+			"Examples:",
+			"  mailwoman-wof-build-fts /data/wof/admin-us.db",
+			"  mailwoman-wof-build-fts /data/wof/admin-us.db /data/wof/postalcode-us.db",
+			"  mailwoman-wof-build-fts /data/wof/admin-us.db --drop",
 			"",
 			"See https://github.com/sister-software/mailwoman/tree/main/resolver-wof-sqlite for",
 			"the recommended WOF distribution sources + attribution requirements.",
@@ -58,25 +67,27 @@ function parseArgs(argv: readonly string[]): CliArgs {
 			printUsageAndExit(2)
 		} else args.push(a)
 	}
-	if (args.length !== 1) {
-		stderr.write(`mailwoman-wof-build-fts: expected exactly one positional arg, got ${args.length}\n`)
+	if (args.length === 0) {
+		stderr.write(`mailwoman-wof-build-fts: expected at least one positional arg\n`)
 		printUsageAndExit(2)
 	}
-	return { databasePath: args[0]!, drop }
+	return { databasePaths: args, drop }
 }
 
-export function main(argv: readonly string[]): number {
-	const args = parseArgs(argv)
-	if (!existsSync(args.databasePath)) {
-		stderr.write(`mailwoman-wof-build-fts: file not found: ${args.databasePath}\n`)
+/**
+ * Build indexes on a single DB. Returns 0 on success, 1 on failure. Errors are written to stderr
+ * but the call doesn't throw — `main()` aggregates the exit code across multi-DB invocations.
+ */
+function buildOne(path: string, drop: boolean): number {
+	if (!existsSync(path)) {
+		stderr.write(`mailwoman-wof-build-fts: file not found: ${path}\n`)
 		return 1
 	}
-
-	stderr.write(`Opening ${args.databasePath}…\n`)
-	const db = new DatabaseSync(args.databasePath)
+	stderr.write(`Opening ${path}…\n`)
+	const db = new DatabaseSync(path)
 	try {
 		const result = buildPlaceSearchFts(db, {
-			drop: args.drop,
+			drop,
 			onProgress: (phase, detail) => {
 				const suffix = detail ? ` — ${detail}` : ""
 				stderr.write(`  [${phase}]${suffix}\n`)
@@ -95,6 +106,17 @@ export function main(argv: readonly string[]): number {
 	} finally {
 		db.close()
 	}
+}
+
+export function main(argv: readonly string[]): number {
+	const args = parseArgs(argv)
+	// Process every DB; if any fail, the worst exit code wins (so CI / scripts see failure).
+	let worst = 0
+	for (const path of args.databasePaths) {
+		const rc = buildOne(path, args.drop)
+		if (rc > worst) worst = rc
+	}
+	return worst
 }
 
 // Entry point — only run when invoked directly, not when imported by tests.

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -21,3 +21,11 @@ export {
 } from "./fts.js"
 
 export { bboxAround, haversineKm, type Bbox } from "./geo.js"
+
+export {
+	deriveSchemaName,
+	pickShardForPlacetype,
+	resolveShards,
+	type ResolvedShard,
+	type ShardConfig,
+} from "./sharding.js"

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -18,14 +18,28 @@ import { SqliteDialect } from "@mailwoman/core/kysley/dialect"
 import { buildPlaceSearchFts, PLACE_BBOX_TABLE, placeBboxExists, placeSearchFtsExists } from "./fts.js"
 import { bboxAround, haversineKm } from "./geo.js"
 import type { WofDatabase } from "./schema.js"
+import { pickShardForPlacetype, resolveShards, type ResolvedShard, type ShardConfig } from "./sharding.js"
 import type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WofPlacetype } from "./types.js"
 
 export interface WofSqlitePlaceLookupOpts {
-	/** Path to the WOF SQLite distribution on disk. Mutually exclusive with `database`. */
-	databasePath?: string
+	/**
+	 * Path to the WOF SQLite distribution on disk. Mutually exclusive with `database`.
+	 *
+	 * **Single string** — opens that one DB as the main shard.
+	 *
+	 * **Array** — opens the first entry as main, then ATTACHes each subsequent entry as a separate
+	 * SQLite schema. Schema names are derived from the filename (`whosonfirst-data-postalcode-
+	 * us-latest.db` → `postalcode_us`); override with `ShardConfig.schemaName` when the filename
+	 * doesn't follow WOF convention. See `sharding.ts` for the derivation rules.
+	 *
+	 * Routing: queries with a `placetype` matching a shard's name (or explicit `placetypes` hint) are
+	 * sent to that shard; everything else hits main. Cross-shard UNION is NOT done — BM25 isn't
+	 * comparable across separately-indexed corpora.
+	 */
+	databasePath?: string | ReadonlyArray<string | ShardConfig>
 	/**
 	 * Pre-opened DatabaseSync — primarily for tests against an inline fixture DB. Mutually exclusive
-	 * with `databasePath`.
+	 * with `databasePath`. Multi-shard requires `databasePath` (so the lookup owns the ATTACH).
 	 */
 	database?: DatabaseSync
 	/**
@@ -33,6 +47,9 @@ export interface WofSqlitePlaceLookupOpts {
 	 * exist. The upstream WOF distribution does NOT ship FTS5, so callers either set this once on
 	 * first open or pre-build it via the operator-side CLI documented in the README. Default false —
 	 * the resolver assumes the index already exists and errors loudly if it doesn't.
+	 *
+	 * With multi-shard, `buildFts: true` builds the index on the **main** shard only. Other shards
+	 * must be pre-built via `mailwoman-wof-build-fts` — operator script for predictable cost.
 	 */
 	buildFts?: boolean
 }
@@ -96,8 +113,15 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 * Cached at construction so we don't `sqlite_master` query on every findPlace call. Bbox + near-
 	 * with-radius queries fall back to no-filter when this is false, preserving compatibility with
 	 * DBs that were FTS-built before the R*Tree shipped.
+	 *
+	 * Per-shard: a shard is only considered to have the bbox index if its own R*Tree table exists.
 	 */
-	readonly #hasBboxIndex: boolean
+	readonly #hasBboxIndex: Map<string, boolean>
+	/**
+	 * Resolved shard list. Always at least one entry; first is `main`. Multi-shard adds extras with
+	 * their own derived (or override) schema names.
+	 */
+	readonly #shards: ResolvedShard[]
 
 	constructor(opts: WofSqlitePlaceLookupOpts, weights?: Partial<RankingWeights>) {
 		if (opts.database && opts.databasePath) {
@@ -110,9 +134,17 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		if (opts.database) {
 			this.#db = opts.database
 			this.#ownsDb = false
+			this.#shards = [{ path: ":memory:", schemaName: "main", placetypes: [] }]
 		} else {
-			this.#db = new DatabaseSync(opts.databasePath!, { readOnly: false })
+			const shards = resolveShards(opts.databasePath!)
+			this.#shards = shards
+			this.#db = new DatabaseSync(shards[0]!.path, { readOnly: false })
 			this.#ownsDb = true
+			// ATTACH each non-main shard. Schema names were validated by resolveShards, so safe to
+			// interpolate directly (SQLite ATTACH doesn't accept parameters for the schema name).
+			for (const s of shards.slice(1)) {
+				this.#db.exec(`ATTACH DATABASE '${s.path.replace(/'/g, "''")}' AS ${s.schemaName}`)
+			}
 		}
 
 		// node:sqlite has no .pragma() helper; pragmas are executed as plain SQL.
@@ -128,7 +160,22 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			dialect: new SqliteDialect({ database: this.#db }),
 		})
 		this.#weights = { ...DEFAULT_WEIGHTS, ...(weights ?? {}) }
-		this.#hasBboxIndex = placeBboxExists(this.#db)
+
+		// Probe each shard's bbox index presence — driven by per-shard `place_bbox` table existence.
+		this.#hasBboxIndex = new Map()
+		for (const s of this.#shards) {
+			this.#hasBboxIndex.set(s.schemaName, this.#shardHasBbox(s.schemaName))
+		}
+	}
+
+	#shardHasBbox(schemaName: string): boolean {
+		// For main, the existing helper works directly. For attached shards we have to ask via the
+		// schema-qualified `sqlite_master` view.
+		if (schemaName === "main") return placeBboxExists(this.#db)
+		const row = this.#db
+			.prepare(`SELECT name FROM ${schemaName}.sqlite_master WHERE type = 'table' AND name = ?`)
+			.get(PLACE_BBOX_TABLE) as { name: string } | undefined
+		return Boolean(row)
 	}
 
 	async findPlace(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
@@ -139,9 +186,18 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		const ftsQuery = sanitizeFtsQuery(query.text)
 		if (!ftsQuery) return []
 
+		// Pick the shard for this query. Multi-shard routing is placetype-driven; a query without
+		// `placetype` always goes to main. (Mixed-placetype queries with multiple shards aren't
+		// supported in v1 — caller can issue two findPlace calls and merge in TS if needed.)
+		const firstPlacetype = placetypes?.[0]
+		const shard = pickShardForPlacetype(this.#shards, firstPlacetype)
+		const sch = shard.schemaName // bare schema name; safe to interpolate (validated at construction)
+
 		// Filter out historical / superseded / deprecated places by default — they live in the same
 		// spr table but should never win a contemporary lookup. `is_current = 0` is the only WOF
 		// value that means "not current"; both `-1` (modern) and `1` (legacy) mean current. See #91.
+		// Note: with schema-qualified FROM the bare `place_search` reference in MATCH resolves to
+		// the FROM table — required by FTS5 parser, see sharding.ts header comment.
 		const where: string[] = ["place_search MATCH ?", "spr.is_current != 0", "spr.is_deprecated = 0"]
 		const params: SQLInputValue[] = [ftsQuery]
 
@@ -154,17 +210,18 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			params.push(query.country)
 		}
 		if (query.parentId !== undefined) {
-			where.push("(spr.parent_id = ? OR spr.id IN (SELECT id FROM ancestors WHERE ancestor_id = ?))")
+			where.push(`(spr.parent_id = ? OR spr.id IN (SELECT id FROM ${sch}.ancestors WHERE ancestor_id = ?))`)
 			params.push(query.parentId, query.parentId)
 		}
 
 		// Bbox + near-with-radius are SQL-level filters via the R*Tree. We only emit the JOIN when
-		// the R*Tree is actually present; missing-but-requested is silently treated as no-bbox-filter
-		// so callers without the index don't crash. (Verbose mode could log here — defer.)
-		const useBboxJoin = (query.bbox || query.near?.maxDistanceKm !== undefined) && this.#hasBboxIndex
-		let joinClause = "JOIN spr ON spr.id = place_search.wof_id"
+		// the active shard has the R*Tree; missing-but-requested is silently treated as no-bbox-
+		// filter so legacy DBs / shards-without-bbox don't crash.
+		const shardHasBbox = this.#hasBboxIndex.get(sch) === true
+		const useBboxJoin = (query.bbox || query.near?.maxDistanceKm !== undefined) && shardHasBbox
+		let joinClause = `JOIN ${sch}.spr ON spr.id = place_search.wof_id`
 		if (useBboxJoin) {
-			joinClause += ` JOIN ${PLACE_BBOX_TABLE} bbox ON bbox.id = spr.id`
+			joinClause += ` JOIN ${sch}.${PLACE_BBOX_TABLE} bbox ON bbox.id = spr.id`
 			// AABB intersection — both bbox sides must overlap. R*Tree handles this in O(log n).
 			const filterBox = query.bbox
 				? query.bbox
@@ -173,6 +230,8 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			params.push(filterBox.maxLat, filterBox.minLat, filterBox.maxLon, filterBox.minLon)
 		}
 
+		// Schema-qualified FROM with bare-name MATCH — required syntax for FTS5 on attached schemas.
+		// See sharding.ts header for the gotcha that drove this design.
 		const stmt = this.#db.prepare(`
 			SELECT
 				spr.id AS id,
@@ -183,7 +242,7 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 				bm25(place_search) AS rank,
 				spr.latitude AS lat,
 				spr.longitude AS lon
-			FROM place_search
+			FROM ${sch}.place_search
 			${joinClause}
 			WHERE ${where.join(" AND ")}
 			ORDER BY rank ASC

--- a/resolver-wof-sqlite/multi-shard.test.ts
+++ b/resolver-wof-sqlite/multi-shard.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Multi-shard ATTACH tests for `WofSqlitePlaceLookup`.
+ *
+ *   Uses on-disk fixture DBs because ATTACH requires file paths. Tests run unconditionally (the
+ *   fixture DBs are built in-test via the same shape the real WOF distribution uses), so this
+ *   doesn't gate on the real WOF being present.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { buildPlaceSearchFts } from "./fts.js"
+import { WofSqlitePlaceLookup } from "./lookup.js"
+
+let scratch: string
+
+function buildAdminShard(path: string): void {
+	const db = new DatabaseSync(path)
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+		CREATE TABLE ancestors (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT);
+		INSERT INTO spr VALUES (101, NULL, 'Springfield', 'locality', 'US', 39.80, -89.65, 39.75, 39.85, -89.70, -89.60, -1, 0);
+		INSERT INTO spr VALUES (102, NULL, 'Beverly Hills', 'locality', 'US', 34.07, -118.40, 34.05, 34.09, -118.42, -118.38, 1, 0);
+		INSERT INTO spr VALUES (103, NULL, 'Paris', 'locality', 'FR', 48.85, 2.34, 48.81, 48.90, 2.22, 2.46, -1, 0);
+	`)
+	buildPlaceSearchFts(db)
+	db.close()
+}
+
+function buildPostcodeShard(path: string): void {
+	const db = new DatabaseSync(path)
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+		CREATE TABLE ancestors (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT);
+		INSERT INTO spr VALUES (201, 101, '62701', 'postalcode', 'US', 39.80, -89.65, 39.78, 39.82, -89.67, -89.63, 1, 0);
+		INSERT INTO spr VALUES (202, 102, '90210', 'postalcode', 'US', 34.10, -118.41, 34.08, 34.12, -118.43, -118.39, -1, 0);
+		INSERT INTO spr VALUES (203, 101, '62702', 'postalcode', 'US', 39.82, -89.63, 39.80, 39.84, -89.65, -89.61, 1, 0);
+	`)
+	buildPlaceSearchFts(db)
+	db.close()
+}
+
+beforeEach(async () => {
+	scratch = await mkdtemp(join(tmpdir(), "mailwoman-multi-shard-"))
+})
+
+afterEach(async () => {
+	await rm(scratch, { recursive: true, force: true }).catch(() => {})
+})
+
+describe("WofSqlitePlaceLookup — multi-shard ATTACH", () => {
+	test("opens a single shard via string path (backwards compatible)", async () => {
+		const adminPath = join(scratch, "whosonfirst-data-admin-us-latest.db")
+		buildAdminShard(adminPath)
+		const lookup = new WofSqlitePlaceLookup({ databasePath: adminPath })
+		try {
+			const r = await lookup.findPlace({ text: "Springfield", placetype: "locality" })
+			expect(r.length).toBeGreaterThan(0)
+			expect(r[0]?.name).toBe("Springfield")
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("opens admin + postcode shards via array, auto-routes by placetype", async () => {
+		const adminPath = join(scratch, "whosonfirst-data-admin-us-latest.db")
+		const pcPath = join(scratch, "whosonfirst-data-postalcode-us-latest.db")
+		buildAdminShard(adminPath)
+		buildPostcodeShard(pcPath)
+
+		const lookup = new WofSqlitePlaceLookup({ databasePath: [adminPath, pcPath] })
+		try {
+			// Locality query → admin shard
+			const localities = await lookup.findPlace({ text: "Springfield", placetype: "locality" })
+			expect(localities.length).toBe(1)
+			expect(localities[0]?.placetype).toBe("locality")
+			expect(localities[0]?.id).toBe(101)
+
+			// Postcode query → postalcode shard
+			const postcodes = await lookup.findPlace({ text: "62701", placetype: "postalcode" })
+			expect(postcodes.length).toBe(1)
+			expect(postcodes[0]?.placetype).toBe("postalcode")
+			expect(postcodes[0]?.id).toBe(201)
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("ShardConfig.schemaName override + explicit placetypes hint", async () => {
+		const adminPath = join(scratch, "admin.db")
+		const oddlyNamed = join(scratch, "wherever-they-put-postcodes.db")
+		buildAdminShard(adminPath)
+		buildPostcodeShard(oddlyNamed)
+
+		const lookup = new WofSqlitePlaceLookup({
+			databasePath: [adminPath, { path: oddlyNamed, schemaName: "pc", placetypes: ["postalcode"] }],
+		})
+		try {
+			// Even though the filename derives `wherever_they_put_postcodes`, the override gave it
+			// a `pc` schema name with explicit `postalcode` routing.
+			const postcodes = await lookup.findPlace({ text: "90210", placetype: "postalcode" })
+			expect(postcodes.length).toBe(1)
+			expect(postcodes[0]?.name).toBe("90210")
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("postcode bbox + proximity work via R*Tree on the attached shard", async () => {
+		const adminPath = join(scratch, "whosonfirst-data-admin-us-latest.db")
+		const pcPath = join(scratch, "whosonfirst-data-postalcode-us-latest.db")
+		buildAdminShard(adminPath)
+		buildPostcodeShard(pcPath)
+
+		const lookup = new WofSqlitePlaceLookup({ databasePath: [adminPath, pcPath] })
+		try {
+			// "62701" near Illinois coords with a 10km hard filter — only 62701 and 62702 in fixture
+			// are near these coords, but the FTS phrase exact-match on "62701" picks just one.
+			const r = await lookup.findPlace({
+				text: "62701",
+				placetype: "postalcode",
+				near: { lat: 39.8, lon: -89.65, maxDistanceKm: 10 },
+			})
+			expect(r.length).toBeGreaterThan(0)
+			expect(r[0]?.distanceKm).toBeDefined()
+			expect(r[0]?.distanceKm).toBeLessThan(5)
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("query without placetype routes to main (admin) regardless of shards", async () => {
+		const adminPath = join(scratch, "whosonfirst-data-admin-us-latest.db")
+		const pcPath = join(scratch, "whosonfirst-data-postalcode-us-latest.db")
+		buildAdminShard(adminPath)
+		buildPostcodeShard(pcPath)
+
+		const lookup = new WofSqlitePlaceLookup({ databasePath: [adminPath, pcPath] })
+		try {
+			// No placetype → main only. "62701" won't match (it's in postcode shard); Springfield will.
+			const r = await lookup.findPlace({ text: "Springfield" })
+			expect(r.length).toBe(1)
+			expect(r[0]?.placetype).toBe("locality")
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("placetype with no matching shard falls back to main", async () => {
+		const adminPath = join(scratch, "whosonfirst-data-admin-us-latest.db")
+		buildAdminShard(adminPath)
+		// Only admin shard — no postcode shard. A postalcode query falls back to main, returns
+		// nothing because admin has no postalcodes.
+		const lookup = new WofSqlitePlaceLookup({ databasePath: [adminPath] })
+		try {
+			const r = await lookup.findPlace({ text: "62701", placetype: "postalcode" })
+			expect(r).toEqual([])
+		} finally {
+			lookup.close()
+		}
+	})
+})

--- a/resolver-wof-sqlite/sharding.test.ts
+++ b/resolver-wof-sqlite/sharding.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Schema-name derivation + shard routing tests.
+ */
+
+import { describe, expect, test } from "vitest"
+
+import { deriveSchemaName, pickShardForPlacetype, resolveShards } from "./sharding.js"
+
+describe("deriveSchemaName", () => {
+	test("strips whosonfirst-data prefix and -latest.db suffix", () => {
+		expect(deriveSchemaName("whosonfirst-data-admin-us-latest.db")).toBe("admin_us")
+		expect(deriveSchemaName("whosonfirst-data-postalcode-us-latest.db")).toBe("postalcode_us")
+		expect(deriveSchemaName("whosonfirst-data-admin-latest.db")).toBe("admin")
+	})
+
+	test("handles full paths (basename only)", () => {
+		expect(deriveSchemaName("/mnt/playpen/mailwoman-data/wof/whosonfirst-data-admin-us-latest.db")).toBe("admin_us")
+	})
+
+	test("replaces non-identifier chars with underscores", () => {
+		expect(deriveSchemaName("my-custom.db")).toBe("my_custom")
+		expect(deriveSchemaName("places (2024).db")).toBe("places__2024_")
+	})
+
+	test("throws when the result is empty", () => {
+		expect(() => deriveSchemaName(".db")).toThrow(/could not derive/)
+		expect(() => deriveSchemaName("whosonfirst-data-.db")).toThrow(/could not derive/)
+	})
+})
+
+describe("resolveShards", () => {
+	test("single string → one shard named main", () => {
+		expect(resolveShards("/tmp/whosonfirst-data-admin-us-latest.db")).toEqual([
+			{ path: "/tmp/whosonfirst-data-admin-us-latest.db", schemaName: "main", placetypes: [] },
+		])
+	})
+
+	test("array of strings: first becomes main, rest derive", () => {
+		const r = resolveShards([
+			"/tmp/whosonfirst-data-admin-us-latest.db",
+			"/tmp/whosonfirst-data-postalcode-us-latest.db",
+		])
+		expect(r).toEqual([
+			{ path: "/tmp/whosonfirst-data-admin-us-latest.db", schemaName: "main", placetypes: [] },
+			{ path: "/tmp/whosonfirst-data-postalcode-us-latest.db", schemaName: "postalcode_us", placetypes: [] },
+		])
+	})
+
+	test("ShardConfig.schemaName overrides derivation", () => {
+		const r = resolveShards([
+			"/tmp/whosonfirst-data-admin-us-latest.db",
+			{ path: "/tmp/weird-name.db", schemaName: "postalcode_us" },
+		])
+		expect(r[1]?.schemaName).toBe("postalcode_us")
+	})
+
+	test("placetypes hint passes through", () => {
+		const r = resolveShards([
+			"/tmp/whosonfirst-data-admin-us-latest.db",
+			{ path: "/tmp/whosonfirst-data-postalcode-us-latest.db", placetypes: ["postalcode"] },
+		])
+		expect(r[1]?.placetypes).toEqual(["postalcode"])
+	})
+
+	test("rejects shard name collisions on non-main shards", () => {
+		// The first shard is always "main" regardless of its derived name; collisions only matter
+		// across the non-first entries. Two postcode shards in a row collide.
+		expect(() =>
+			resolveShards([
+				"/tmp/whosonfirst-data-admin-us-latest.db",
+				"/tmp/whosonfirst-data-postalcode-us-latest.db",
+				"/tmp/whosonfirst-data-postalcode-us-latest.db",
+			])
+		).toThrow(/collides/)
+	})
+
+	test("rejects schema names that aren't valid SQLite identifiers", () => {
+		expect(() =>
+			resolveShards([
+				"/tmp/whosonfirst-data-admin-us-latest.db",
+				{ path: "/tmp/weird.db", schemaName: "1nvalid-start" },
+			])
+		).toThrow(/not a valid SQLite identifier/)
+	})
+
+	test("non-main shard cannot use the reserved name `main`", () => {
+		expect(() => resolveShards(["/tmp/a.db", { path: "/tmp/b.db", schemaName: "main" }])).toThrow(/collides/)
+	})
+
+	test("empty input rejects", () => {
+		expect(() => resolveShards([])).toThrow(/at least one shard/)
+	})
+})
+
+describe("pickShardForPlacetype", () => {
+	const shards = resolveShards([
+		"/tmp/whosonfirst-data-admin-us-latest.db",
+		"/tmp/whosonfirst-data-postalcode-us-latest.db",
+	])
+
+	test("undefined placetype → main", () => {
+		expect(pickShardForPlacetype(shards, undefined).schemaName).toBe("main")
+	})
+
+	test("postalcode → postalcode_us (substring match on schema name)", () => {
+		expect(pickShardForPlacetype(shards, "postalcode").schemaName).toBe("postalcode_us")
+	})
+
+	test("locality → main (no postalcode-shard hit, falls back)", () => {
+		expect(pickShardForPlacetype(shards, "locality").schemaName).toBe("main")
+	})
+
+	test("explicit placetypes hint wins over substring match", () => {
+		const explicit = resolveShards([
+			"/tmp/whosonfirst-data-admin-us-latest.db",
+			{ path: "/tmp/whosonfirst-data-postalcode-us-latest.db", placetypes: ["postalcode", "region"] },
+		])
+		// `region` doesn't substring-match `postalcode_us`, but the explicit hint claims it.
+		expect(pickShardForPlacetype(explicit, "region").schemaName).toBe("postalcode_us")
+	})
+
+	test("conservative substring match — does NOT false-positive on `region` matching `arboregion`", () => {
+		const odd = resolveShards(["/tmp/whosonfirst-data-admin-us-latest.db", { path: "/tmp/arboregion.db" }])
+		expect(pickShardForPlacetype(odd, "region").schemaName).toBe("main")
+	})
+})

--- a/resolver-wof-sqlite/sharding.ts
+++ b/resolver-wof-sqlite/sharding.ts
@@ -1,0 +1,168 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Multi-shard support for `WofSqlitePlaceLookup` — opens multiple WOF SQLite distributions on one
+ *   connection via `ATTACH DATABASE`, and routes queries to the right shard based on placetype.
+ *
+ *   ## The FTS5 syntax rule that drove this design
+ *
+ *   The naive `SELECT … FROM pc.place_search WHERE pc.place_search MATCH ?` fails — SQLite parses the
+ *   schema-qualified table on the left of MATCH as "column place_search of table pc". Discovered in
+ *   the spike at PR review time; documented as `_SHARD_RULE.md` should it ever bite again.
+ *
+ *   The working form: schema-qualified in FROM, bare table name in MATCH:
+ *
+ *   ```sql
+ *   SELECT … FROM pc.place_search WHERE place_search MATCH ?
+ * ```
+ *
+ *   Identical table names across attached shards (which is what we have — every shard ships its own
+ *   `place_search` + `place_bbox`) are fine because the bare-name MATCH resolves against FROM
+ *   scope.
+ */
+
+import { basename } from "node:path"
+
+/**
+ * Derive a SQL-safe schema name from a WOF distribution filename. Used by `ATTACH DATABASE … AS
+ * <name>` so each shard gets a stable, predictable handle.
+ *
+ * Convention strips the `whosonfirst-data-` prefix and the `-latest.db` (or just `.db`) suffix,
+ * then replaces `-` with `_` for SQL identifier safety.
+ *
+ * Examples:
+ *
+ * - `whosonfirst-data-admin-us-latest.db` → `admin_us`
+ * - `whosonfirst-data-postalcode-us-latest.db` → `postalcode_us`
+ * - `whosonfirst-data-admin-latest.db` → `admin`
+ * - `my-custom.db` → `my_custom`
+ *
+ * Callers can override the derived name explicitly via `ShardConfig.schemaName` when the filename
+ * doesn't follow WOF convention.
+ */
+export function deriveSchemaName(path: string): string {
+	const stem = basename(path)
+		.replace(/^whosonfirst-data-/u, "")
+		.replace(/-latest\.db$/u, "")
+		.replace(/\.db$/u, "")
+		.replace(/[^a-zA-Z0-9_]/g, "_")
+	if (!stem) {
+		throw new Error(`deriveSchemaName: could not derive a SQL schema name from path ${JSON.stringify(path)}`)
+	}
+	return stem
+}
+
+/**
+ * Per-shard configuration. The simple form is just a path string — the schema name is derived from
+ * it. The object form lets callers override the derived schema name (useful when a filename doesn't
+ * follow WOF convention) or attach an extra hint about which placetypes route here.
+ */
+export interface ShardConfig {
+	path: string
+	/**
+	 * Override the auto-derived schema name. Useful when the filename doesn't match WOF convention or
+	 * when you want a memorable handle. Must be a valid SQLite identifier —
+	 * `[a-zA-Z_][a-zA-Z0-9_]*`.
+	 */
+	schemaName?: string
+	/**
+	 * Optional explicit list of placetypes this shard serves. When set, queries against any listed
+	 * placetype are routed to this shard. When omitted, routing falls back to a name-match heuristic:
+	 * a shard whose `schemaName` contains the placetype as a substring (e.g. `postalcode_us` for
+	 * `postalcode` queries) is preferred for that placetype.
+	 */
+	placetypes?: readonly string[]
+}
+
+/**
+ * Resolved post-derivation: paired path + chosen schema name + (possibly empty) placetypes hint.
+ * Used internally by `WofSqlitePlaceLookup` so the routing logic operates on uniform structures.
+ */
+export interface ResolvedShard {
+	path: string
+	schemaName: string
+	placetypes: readonly string[]
+}
+
+/** SQLite identifier regex — `[A-Za-z_][A-Za-z0-9_]*`. */
+const SQLITE_IDENT_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u
+
+/**
+ * Normalize the user-provided `databasePath` opt (which may be a single string, an array of
+ * strings, or an array of `ShardConfig` objects) into a uniform `ResolvedShard[]`.
+ *
+ * The first shard becomes `main` regardless of its derived schema name — that's the SQLite
+ * convention. Subsequent shards keep their derived (or override) schema name.
+ */
+export function resolveShards(input: string | ReadonlyArray<string | ShardConfig>): ResolvedShard[] {
+	const list = typeof input === "string" ? [input] : input
+	if (list.length === 0) throw new Error("resolveShards: at least one shard is required")
+
+	const seen = new Set<string>()
+	const out: ResolvedShard[] = []
+	for (let i = 0; i < list.length; i++) {
+		const entry = list[i]!
+		const cfg: ShardConfig = typeof entry === "string" ? { path: entry } : entry
+		const derived = cfg.schemaName ?? deriveSchemaName(cfg.path)
+		if (!SQLITE_IDENT_RE.test(derived)) {
+			throw new Error(
+				`resolveShards: schema name ${JSON.stringify(derived)} is not a valid SQLite identifier ` +
+					`(derived from path ${JSON.stringify(cfg.path)}). Pass an explicit ` +
+					`{ path, schemaName } to override.`
+			)
+		}
+		// The first shard is always main per SQLite semantics — its derived name is informational
+		// only. Subsequent shards must have unique non-main names.
+		const schemaName = i === 0 ? "main" : derived
+		if (i > 0 && (schemaName === "main" || seen.has(schemaName))) {
+			throw new Error(
+				`resolveShards: schema name ${JSON.stringify(schemaName)} collides ` +
+					`(either with "main" or another shard). Pass an explicit { path, schemaName }.`
+			)
+		}
+		seen.add(schemaName)
+		out.push({
+			path: cfg.path,
+			schemaName,
+			placetypes: cfg.placetypes ?? [],
+		})
+	}
+	return out
+}
+
+/**
+ * Pick the shard to route a query to given the requested placetype(s).
+ *
+ * Routing rules, in order:
+ *
+ * 1. If any shard has explicit `placetypes` that includes the requested placetype, use it.
+ * 2. Otherwise, if a non-main shard's `schemaName` matches the placetype (e.g. `postalcode_us` matches
+ *    `postalcode`), use it.
+ * 3. Otherwise, fall back to `main`.
+ *
+ * This deliberately doesn't UNION across shards — BM25 scores aren't comparable across separately-
+ * indexed corpora, and the typical mailwoman query has a single placetype anyway. If a caller needs
+ * cross-shard results they can issue two `findPlace` calls.
+ */
+export function pickShardForPlacetype(shards: ResolvedShard[], placetype: string | undefined): ResolvedShard {
+	if (!placetype) return shards[0]!
+	for (const s of shards) {
+		if (s.placetypes.includes(placetype)) return s
+	}
+	for (const s of shards) {
+		if (s.schemaName === "main") continue
+		// Substring match: `postalcode_us` matches `postalcode`. Conservative — requires the
+		// placetype to appear at a word boundary in the schema name to avoid false hits like
+		// `region` matching `arboregion`.
+		if (
+			s.schemaName === placetype ||
+			s.schemaName.startsWith(`${placetype}_`) ||
+			s.schemaName.endsWith(`_${placetype}`)
+		) {
+			return s
+		}
+	}
+	return shards[0]!
+}


### PR DESCRIPTION
## Summary

`WofSqlitePlaceLookup` now opens multiple WOF SQLite distributions on a single connection via `ATTACH DATABASE` and auto-routes queries by `placetype`. The classic flow:

```ts
const lookup = new WofSqlitePlaceLookup({
  databasePath: [
    "/data/wof/whosonfirst-data-admin-us-latest.db",
    "/data/wof/whosonfirst-data-postalcode-us-latest.db",
  ],
})

await lookup.findPlace({ text: "Springfield", placetype: "locality" }) // → admin shard
await lookup.findPlace({ text: "62701", placetype: "postalcode" })     // → postcode shard auto-routed
```

The schema-qualified-FROM + bare-name-MATCH syntax rule from the earlier spike pays off here — single connection, multiple FTS5 indexes, all the existing query shapes (bbox / proximity / parent-constrained / placetype filter) carry over to attached shards unchanged.

Closes the multi-shard half of "roll with C" — proximity ranking shipped in #90, this is the second half.

## End-to-end smoke against real WOF (admin + postcode)

```
=== locality query (auto → admin shard) ===
  85940429 Springfield US 39.80,-89.65 dist: 2.0km
=== postcode query (auto → postalcode shard) ===
  554735275 62701 US lat: 39.80 lon: -89.65
=== postcode 90210 (Beverly Hills) ===
  554783991 90210 US lat: 34.10 lon: -118.41
```

## What's in

**`sharding.ts`** (new, 168 lines):
- `deriveSchemaName(path)` — `whosonfirst-data-postalcode-us-latest.db` → `postalcode_us`
- `resolveShards(input)` — normalize the user opt into a `ResolvedShard[]`; first entry is always `main`; validates SQL identifier safety + collision-free non-main names
- `pickShardForPlacetype(shards, placetype)` — routing logic: explicit `ShardConfig.placetypes` hint wins, then substring match against schema names, fall back to main

**`WofSqlitePlaceLookupOpts.databasePath`** now accepts `string | ReadonlyArray<string | ShardConfig>`. Backwards compatible — string form preserves the old behavior bit-for-bit.

**All `findPlace` SQL now schema-qualifies** the FROM tables (`<sch>.spr`, `<sch>.place_search`, `<sch>.place_bbox`, `<sch>.ancestors`). MATCH stays using the bare table name — that's the FTS5 syntax requirement we found in the spike. Bbox-index probe runs per-shard; missing-on-some-shards is silently handled.

**`DEFAULT_PLACETYPE_MAP`** in `@mailwoman/core/resolver` gains `postcode: "postalcode"` — so the resolver pass now decorates postcode-tagged nodes when the postalcode shard is available.

**`mailwoman-wof-build-fts`** CLI: variadic positional args. Builds indexes on each DB sequentially. Worst exit code wins:

```
$ mailwoman-wof-build-fts \
    /data/wof/whosonfirst-data-admin-us-latest.db \
    /data/wof/whosonfirst-data-postalcode-us-latest.db
```

## Known limitation (out of scope)

FTS5 prefix queries (`627*`) don't work yet — `sanitizeFtsQuery` wraps every token in `"..."` which forces phrase-search semantics. Exact-match works (`62701`, `90210` return correct rows). The sanitizer needs an opt-in prefix mode; filing a separate follow-up.

## Test plan

- [x] `sharding.test.ts` (NEW) — 17 tests for `deriveSchemaName`, `resolveShards` (including collision + invalid-identifier paths), `pickShardForPlacetype` (explicit hints, substring matching, conservative-bounds rule)
- [x] `multi-shard.test.ts` (NEW) — 6 integration tests via on-disk fixture DBs (ATTACH requires file paths). Covers single-shard backwards compat, two-shard routing, schemaName + placetypes overrides, bbox+proximity on attached shards, no-placetype-falls-back-to-main, no-matching-shard-falls-back
- [x] `build-fts-cli.test.ts` — variadic test added + multi-DB worst-exit-code test
- [x] All 1300 tests pass (was 1275; +25 new)
- [x] `yarn compile` clean
- [x] End-to-end smoke on real WOF (admin-US + postcode-US) returns correct results for known places
- [ ] CI green

## Disclosure

Triaged and authored end-to-end by an automated agent (Claude Opus 4.7) under operator supervision. Human reviewer: @GirlBossRush.