### PR TITLE
phase-4.3.x: population-weighted ranking via wof:population

### DIFF
--- a/resolver-wof-sqlite/fts.ts
+++ b/resolver-wof-sqlite/fts.ts
@@ -30,6 +30,16 @@ export const PLACE_SEARCH_TABLE = "place_search"
 export const PLACE_BBOX_TABLE = "place_bbox"
 
 /**
+ * Name of the auxiliary table that mirrors `wof:population` extracted from each place's geojson
+ * body. Powers the population-weighted ranking boost. Sparse — WOF only populates this field for
+ * ~15% of localities (and mostly larger ones), so we don't insert NULL rows. Missing means no
+ * boost, never a penalty.
+ *
+ * Schema: `(id INTEGER PRIMARY KEY, population INTEGER NOT NULL)`. Plain table, not virtual.
+ */
+export const PLACE_POPULATION_TABLE = "place_population"
+
+/**
  * Counters for a single `buildPlaceSearchFts` run. Exposed so callers (CLI, lazy-build) can render
  * progress to the user.
  */
@@ -42,6 +52,10 @@ export interface BuildPlaceSearchFtsResult {
 	bboxCreated: boolean
 	/** Number of rows in the `place_bbox` R*Tree after the call. */
 	bboxIndexedRows: number
+	/** Whether the `place_population` table was created. */
+	populationCreated: boolean
+	/** Number of rows in the `place_population` table after the call. Sparse — only ~15% of WOF. */
+	populationIndexedRows: number
 	/** Wall-clock duration of the build step, in milliseconds. */
 	durationMs: number
 }
@@ -58,7 +72,16 @@ export interface BuildPlaceSearchFtsOpts {
 	 * builds where the INSERT step can take minutes.
 	 */
 	onProgress?: (
-		phase: "checking" | "dropping" | "creating" | "populating" | "creating-bbox" | "populating-bbox" | "done",
+		phase:
+			| "checking"
+			| "dropping"
+			| "creating"
+			| "populating"
+			| "creating-bbox"
+			| "populating-bbox"
+			| "creating-population"
+			| "populating-population"
+			| "done",
 		detail?: string
 	) => void
 }
@@ -80,6 +103,8 @@ export function buildPlaceSearchFts(db: DatabaseSync, opts: BuildPlaceSearchFtsO
 	onProgress("checking")
 	const ftsExisting = tableExists(db, PLACE_SEARCH_TABLE)
 	const bboxExisting = tableExists(db, PLACE_BBOX_TABLE)
+	const populationExisting = tableExists(db, PLACE_POPULATION_TABLE)
+	const hasGeojsonTable = tableExists(db, "geojson")
 
 	// ─── FTS5 phase ──────────────────────────────────────────────────
 	let ftsCreated = false
@@ -161,16 +186,60 @@ export function buildPlaceSearchFts(db: DatabaseSync, opts: BuildPlaceSearchFtsO
 	}
 	const bboxCountRow = db.prepare(`SELECT COUNT(*) AS n FROM ${PLACE_BBOX_TABLE}`).get() as { n: number }
 
+	// ─── Population aux-table phase ──────────────────────────────────
+	// Sparse. WOF only populates `wof:population` for ~15% of localities (the bigger ones). Missing
+	// is silent — the ranking boost is 0 for absent rows, never a penalty.
+	// Some fixtures don't carry a `geojson` table at all (it's modeled in schema.ts but not always
+	// populated in tests). Skip the population step gracefully in that case — it's only useful when
+	// we have geojson bodies to extract from.
+	let populationCreated = false
+	let populationCount = 0
+	if (hasGeojsonTable) {
+		if (populationExisting && opts.drop) {
+			onProgress("dropping", PLACE_POPULATION_TABLE)
+			db.exec(`DROP TABLE ${PLACE_POPULATION_TABLE}`)
+		}
+		if (!populationExisting || opts.drop) {
+			onProgress("creating-population")
+			db.exec(`
+				CREATE TABLE ${PLACE_POPULATION_TABLE} (
+					id INTEGER PRIMARY KEY,
+					population INTEGER NOT NULL
+				);
+			`)
+			onProgress("populating-population")
+			// Extract `wof:population` from the geojson body. CAST to INTEGER, drop NULLs (sparse) and
+			// any non-positive sentinels.
+			db.exec(`
+				INSERT INTO ${PLACE_POPULATION_TABLE} (id, population)
+				SELECT
+					spr.id,
+					CAST(json_extract(geojson.body, '$.properties."wof:population"') AS INTEGER) AS population
+				FROM spr
+				JOIN geojson ON geojson.id = spr.id
+				WHERE spr.is_current != 0
+					AND spr.is_deprecated = 0
+					AND json_extract(geojson.body, '$.properties."wof:population"') IS NOT NULL
+					AND CAST(json_extract(geojson.body, '$.properties."wof:population"') AS INTEGER) > 0;
+			`)
+			populationCreated = true
+		}
+		populationCount = (db.prepare(`SELECT COUNT(*) AS n FROM ${PLACE_POPULATION_TABLE}`).get() as { n: number }).n
+	}
+
 	onProgress(
 		"done",
-		`${ftsCountRow.n} FTS rows + ${bboxCountRow.n} bbox rows ` +
-			`(${ftsCreated ? "built" : "preexisting"} / ${bboxCreated ? "built" : "preexisting"})`
+		`${ftsCountRow.n} FTS rows + ${bboxCountRow.n} bbox rows + ${populationCount} pop rows ` +
+			`(${ftsCreated ? "built" : "preexisting"} / ${bboxCreated ? "built" : "preexisting"} / ` +
+			`${populationCreated ? "built" : hasGeojsonTable ? "preexisting" : "skipped-no-geojson"})`
 	)
 	return {
 		created: ftsCreated,
 		indexedRows: ftsCountRow.n,
 		bboxCreated,
 		bboxIndexedRows: bboxCountRow.n,
+		populationCreated,
+		populationIndexedRows: populationCount,
 		durationMs: Date.now() - start,
 	}
 }
@@ -186,6 +255,11 @@ export function placeSearchFtsExists(db: DatabaseSync): boolean {
 /** Returns true iff the `place_bbox` R*Tree table exists. Used for opt-in proximity lookup checks. */
 export function placeBboxExists(db: DatabaseSync): boolean {
 	return tableExists(db, PLACE_BBOX_TABLE)
+}
+
+/** Returns true iff the `place_population` table exists. Used for opt-in population-ranking checks. */
+export function placePopulationExists(db: DatabaseSync): boolean {
+	return tableExists(db, PLACE_POPULATION_TABLE)
 }
 
 function tableExists(db: DatabaseSync, name: string): boolean {

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -15,7 +15,14 @@ import { DatabaseSync, type SQLInputValue } from "node:sqlite"
 
 import { SqliteDialect } from "@mailwoman/core/kysley/dialect"
 
-import { buildPlaceSearchFts, PLACE_BBOX_TABLE, placeBboxExists, placeSearchFtsExists } from "./fts.js"
+import {
+	buildPlaceSearchFts,
+	PLACE_BBOX_TABLE,
+	PLACE_POPULATION_TABLE,
+	placeBboxExists,
+	placePopulationExists,
+	placeSearchFtsExists,
+} from "./fts.js"
 import { bboxAround, haversineKm } from "./geo.js"
 import type { WofDatabase } from "./schema.js"
 import { pickShardForPlacetype, resolveShards, type ResolvedShard, type ShardConfig } from "./sharding.js"
@@ -80,6 +87,20 @@ export interface RankingWeights {
 	proximityBoost: number
 	/** Distance (km) at which the proximity boost halves. Tune to the typical query radius. */
 	proximityScaleKm: number
+	/**
+	 * Magnitude of the population boost when the candidate has a known `wof:population`. The
+	 * contribution is `populationBoost * log10(1 + population) / populationScaleLog10`, capped at
+	 * `populationBoost`. WOF only carries population for ~15% of localities (mostly larger ones);
+	 * places without it get +0 (never a penalty). Default tuned so the famous Springfield, IL (pop
+	 * ~112k) gets ~0.42 boost — enough to nudge past tiny same-name peers.
+	 */
+	populationBoost: number
+	/**
+	 * Population (in log10) at which the boost reaches its full magnitude. Default 6 — i.e. a
+	 * population of 1,000,000 gives `populationBoost` exactly. Larger populations cap at the same
+	 * value (no compounding effect for megacities).
+	 */
+	populationScaleLog10: number
 }
 
 const DEFAULT_WEIGHTS: RankingWeights = {
@@ -91,6 +112,14 @@ const DEFAULT_WEIGHTS: RankingWeights = {
 	lengthPenaltyWeight: 0.1,
 	proximityBoost: 0.8,
 	proximityScaleKm: 100,
+	// populationBoost is intentionally large — empirical tuning against real WOF showed BM25 gaps
+	// of 1.5-3.0 between famous places and tiny same-name peers (because the famous ones have
+	// hundreds of alt-name entries that hurt their FTS document score). To consistently surface
+	// "the famous one" for unambiguous queries like "New York" or "Chicago", the population signal
+	// needs to dominate. Callers wanting a more conservative balance can drop this in the
+	// RankingWeights override.
+	populationBoost: 4.0,
+	populationScaleLog10: 6,
 }
 
 interface RawSearchRow {
@@ -102,6 +131,7 @@ interface RawSearchRow {
 	rank: number // BM25 (lower = better in SQLite); we negate to get higher-is-better
 	lat: number | null
 	lon: number | null
+	population: number | null // from the place_population aux table; null when missing
 }
 
 export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
@@ -117,6 +147,12 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 * Per-shard: a shard is only considered to have the bbox index if its own R*Tree table exists.
 	 */
 	readonly #hasBboxIndex: Map<string, boolean>
+	/**
+	 * Per-shard probe for the `place_population` aux table. When false, the LEFT JOIN is omitted from
+	 * the SELECT and population boost is 0 for every row — preserves compatibility with DBs built
+	 * before this feature shipped.
+	 */
+	readonly #hasPopulationIndex: Map<string, boolean>
 	/**
 	 * Resolved shard list. Always at least one entry; first is `main`. Multi-shard adds extras with
 	 * their own derived (or override) schema names.
@@ -161,20 +197,26 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		})
 		this.#weights = { ...DEFAULT_WEIGHTS, ...(weights ?? {}) }
 
-		// Probe each shard's bbox index presence — driven by per-shard `place_bbox` table existence.
+		// Probe each shard's aux-table presence — driven by per-shard table existence in
+		// sqlite_master. Cached at construction so findPlace doesn't query sqlite_master per call.
 		this.#hasBboxIndex = new Map()
+		this.#hasPopulationIndex = new Map()
 		for (const s of this.#shards) {
-			this.#hasBboxIndex.set(s.schemaName, this.#shardHasBbox(s.schemaName))
+			this.#hasBboxIndex.set(s.schemaName, this.#shardHasTable(s.schemaName, PLACE_BBOX_TABLE))
+			this.#hasPopulationIndex.set(s.schemaName, this.#shardHasTable(s.schemaName, PLACE_POPULATION_TABLE))
 		}
 	}
 
-	#shardHasBbox(schemaName: string): boolean {
-		// For main, the existing helper works directly. For attached shards we have to ask via the
+	#shardHasTable(schemaName: string, tableName: string): boolean {
+		// For main, the existing helpers work directly. For attached shards we have to ask via the
 		// schema-qualified `sqlite_master` view.
-		if (schemaName === "main") return placeBboxExists(this.#db)
+		if (schemaName === "main") {
+			if (tableName === PLACE_BBOX_TABLE) return placeBboxExists(this.#db)
+			if (tableName === PLACE_POPULATION_TABLE) return placePopulationExists(this.#db)
+		}
 		const row = this.#db
 			.prepare(`SELECT name FROM ${schemaName}.sqlite_master WHERE type = 'table' AND name = ?`)
-			.get(PLACE_BBOX_TABLE) as { name: string } | undefined
+			.get(tableName) as { name: string } | undefined
 		return Boolean(row)
 	}
 
@@ -230,6 +272,27 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			params.push(filterBox.maxLat, filterBox.minLat, filterBox.maxLon, filterBox.minLon)
 		}
 
+		// LEFT JOIN the population aux table when present. Missing-on-this-shard means the SELECT
+		// just doesn't include the population column; the post-scoring loop treats it as 0.
+		const shardHasPopulation = this.#hasPopulationIndex.get(sch) === true
+		const populationSelect = shardHasPopulation
+			? `${PLACE_POPULATION_TABLE}.population AS population`
+			: `NULL AS population`
+		const populationJoin = shardHasPopulation
+			? `LEFT JOIN ${sch}.${PLACE_POPULATION_TABLE} ON ${PLACE_POPULATION_TABLE}.id = spr.id`
+			: ""
+
+		// Push the population boost into the ORDER BY when the index is available, so famous places
+		// (whose long alt-name lists hurt BM25) actually make it into the over-fetch window. The TS
+		// post-scoring will still compute the same boost for the final score; this just ensures the
+		// candidate set is right.
+		//
+		// Formula: rank_adjusted = bm25 - populationBoost * min(1.0, log10(1 + pop) / scaleLog10)
+		// Lower rank_adjusted = better (matches SQLite's bm25 convention of "more negative = better").
+		const orderByExpr = shardHasPopulation
+			? `(bm25(place_search) - ? * MIN(1.0, COALESCE(log10(1.0 + ${PLACE_POPULATION_TABLE}.population), 0) / ?))`
+			: "bm25(place_search)"
+
 		// Schema-qualified FROM with bare-name MATCH — required syntax for FTS5 on attached schemas.
 		// See sharding.ts header for the gotcha that drove this design.
 		const stmt = this.#db.prepare(`
@@ -241,13 +304,18 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 				spr.parent_id,
 				bm25(place_search) AS rank,
 				spr.latitude AS lat,
-				spr.longitude AS lon
+				spr.longitude AS lon,
+				${populationSelect}
 			FROM ${sch}.place_search
 			${joinClause}
+			${populationJoin}
 			WHERE ${where.join(" AND ")}
-			ORDER BY rank ASC
+			ORDER BY ${orderByExpr} ASC
 			LIMIT ?
 		`)
+		if (shardHasPopulation) {
+			params.push(this.#weights.populationBoost, this.#weights.populationScaleLog10)
+		}
 		params.push(ftsLimit)
 
 		const rawRows = stmt.all(...params) as unknown as RawSearchRow[]
@@ -285,6 +353,14 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 				score += this.#weights.proximityBoost / (1 + distanceKm / this.#weights.proximityScaleKm)
 			}
 
+			// Population boost: capped at `populationBoost` magnitude at `10^populationScaleLog10`
+			// people. Missing population → no contribution. Never penalizes.
+			if (row.population !== null && row.population > 0 && this.#weights.populationScaleLog10 > 0) {
+				const popLog = Math.log10(1 + row.population)
+				const popFraction = Math.min(1, popLog / this.#weights.populationScaleLog10)
+				score += this.#weights.populationBoost * popFraction
+			}
+
 			const candidate: PlaceCandidate = {
 				id: row.id,
 				name: row.name,
@@ -296,6 +372,7 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 				score,
 			}
 			if (distanceKm !== undefined) candidate.distanceKm = distanceKm
+			if (row.population !== null && row.population > 0) candidate.population = row.population
 			return candidate
 		})
 

--- a/resolver-wof-sqlite/population.test.ts
+++ b/resolver-wof-sqlite/population.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Population-weighted ranking tests. Builds an in-memory fixture DB with a geojson body that
+ *   carries `wof:population`, exercises buildPlaceSearchFts() so the place_population aux table
+ *   gets populated, then verifies the boost behaves as documented.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { buildPlaceSearchFts, placePopulationExists } from "./fts.js"
+import { WofSqlitePlaceLookup } from "./lookup.js"
+
+interface FixturePlace {
+	id: number
+	name: string
+	country: string
+	lat: number
+	lon: number
+	population?: number
+}
+
+const FIXTURE: FixturePlace[] = [
+	// Three Springfields with realistic populations
+	{ id: 1001, name: "Springfield", country: "US", lat: 39.8, lon: -89.65, population: 112_544 }, // IL
+	{ id: 1002, name: "Springfield", country: "US", lat: 42.1, lon: -72.54, population: 153_672 }, // MA
+	{ id: 1003, name: "Springfield", country: "US", lat: 37.2, lon: -93.28, population: 171_589 }, // MO
+	// Tiny Springfield with no population data
+	{ id: 1004, name: "Springfield", country: "US", lat: 33.5, lon: -81.28, population: undefined }, // SC, no pop
+	// A huge unrelated city for sanity (mega-population bound check)
+	{ id: 1100, name: "Tokyo", country: "JP", lat: 35.68, lon: 139.69, population: 13_500_000 },
+]
+
+function buildFixtureDb(): DatabaseSync {
+	const db = new DatabaseSync(":memory:")
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+		CREATE TABLE ancestors (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT);
+		CREATE TABLE geojson (id INTEGER PRIMARY KEY, body TEXT);
+	`)
+	const insertSpr = db.prepare(`
+		INSERT INTO spr (id, parent_id, name, placetype, country,
+		                 latitude, longitude,
+		                 min_latitude, max_latitude, min_longitude, max_longitude,
+		                 is_current, is_deprecated)
+		VALUES (?, NULL, ?, 'locality', ?, ?, ?, ?, ?, ?, ?, -1, 0)
+	`)
+	const insertGeo = db.prepare(`INSERT INTO geojson (id, body) VALUES (?, ?)`)
+	for (const p of FIXTURE) {
+		insertSpr.run(p.id, p.name, p.country, p.lat, p.lon, p.lat - 0.05, p.lat + 0.05, p.lon - 0.05, p.lon + 0.05)
+		const properties: Record<string, unknown> = {
+			"geom:latitude": p.lat,
+			"geom:longitude": p.lon,
+		}
+		if (p.population !== undefined) properties["wof:population"] = p.population
+		insertGeo.run(p.id, JSON.stringify({ properties }))
+	}
+	return db
+}
+
+let lookup: WofSqlitePlaceLookup
+
+beforeEach(() => {
+	lookup = new WofSqlitePlaceLookup({ database: buildFixtureDb(), buildFts: true })
+})
+
+afterEach(() => {
+	lookup.close()
+})
+
+describe("buildPlaceSearchFts — place_population aux table", () => {
+	test("creates the place_population table when geojson is present", () => {
+		const db = buildFixtureDb()
+		expect(placePopulationExists(db)).toBe(false)
+		const result = buildPlaceSearchFts(db)
+		expect(result.populationCreated).toBe(true)
+		expect(placePopulationExists(db)).toBe(true)
+		db.close()
+	})
+
+	test("populates only places with wof:population — sparse coverage", () => {
+		const db = buildFixtureDb()
+		const result = buildPlaceSearchFts(db)
+		// Fixture has 5 places, 4 with population. One Springfield has undefined population.
+		expect(result.populationIndexedRows).toBe(4)
+		db.close()
+	})
+
+	test("done-phase summary mentions all three table counts", () => {
+		const db = buildFixtureDb()
+		let doneDetail: string | undefined
+		buildPlaceSearchFts(db, {
+			onProgress: (phase, detail) => {
+				if (phase === "done") doneDetail = detail
+			},
+		})
+		expect(doneDetail).toMatch(/FTS rows/)
+		expect(doneDetail).toMatch(/bbox rows/)
+		expect(doneDetail).toMatch(/pop rows/)
+		db.close()
+	})
+
+	test("DB without geojson table → population step skipped, no crash", () => {
+		const db = new DatabaseSync(":memory:")
+		db.exec(`
+			CREATE TABLE spr (
+				id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+				latitude REAL, longitude REAL,
+				min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+				is_current INTEGER, is_deprecated INTEGER
+			);
+			CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+			INSERT INTO spr VALUES (1, NULL, 'NoPop', 'locality', 'US', 0, 0, 0, 0, 0, 0, -1, 0);
+		`)
+		const result = buildPlaceSearchFts(db)
+		expect(result.populationCreated).toBe(false)
+		expect(result.populationIndexedRows).toBe(0)
+		db.close()
+	})
+})
+
+describe("findPlace — population boost", () => {
+	test("returns population on candidates when present", async () => {
+		const candidates = await lookup.findPlace({ text: "Springfield", placetype: "locality", limit: 10 })
+		const springfieldMA = candidates.find((c) => c.id === 1002)
+		expect(springfieldMA?.population).toBe(153_672)
+		// Springfield, SC has no population → field absent
+		const springfieldSC = candidates.find((c) => c.id === 1004)
+		expect(springfieldSC?.population).toBeUndefined()
+	})
+
+	test("orders Springfields by population — MO (172k) > MA (153k) > IL (112k) > SC (no pop)", async () => {
+		const candidates = await lookup.findPlace({ text: "Springfield", placetype: "locality", limit: 10 })
+		// Filter to just the Springfields (Tokyo also has population but isn't a Springfield match)
+		const springfields = candidates.filter((c) => c.name === "Springfield")
+		expect(springfields.length).toBe(4)
+		const ids = springfields.map((c) => c.id)
+		// MO has highest pop → first. SC has none → last. MA and IL in between in pop order.
+		expect(ids[0]).toBe(1003) // MO
+		expect(ids[1]).toBe(1002) // MA
+		expect(ids[2]).toBe(1001) // IL
+		expect(ids[3]).toBe(1004) // SC (no population data)
+	})
+
+	test("the population boost can be tuned to 0 — falls back to BM25-only ordering", async () => {
+		const dbg = new WofSqlitePlaceLookup({ database: buildFixtureDb(), buildFts: true }, { populationBoost: 0 })
+		try {
+			const candidates = await dbg.findPlace({ text: "Springfield", placetype: "locality", limit: 10 })
+			const springfields = candidates.filter((c) => c.name === "Springfield")
+			expect(springfields.length).toBe(4)
+			// With boost=0, the four Springfields tie on BM25 + everything else. Ordering is
+			// implementation-defined but ALL should have identical scores.
+			const scores = new Set(springfields.map((c) => c.score.toFixed(6)))
+			expect(scores.size).toBe(1)
+		} finally {
+			dbg.close()
+		}
+	})
+
+	test("population boost caps at populationBoost magnitude (Tokyo doesn't exceed it)", async () => {
+		// Tokyo has 13.5M people — log10 ≈ 7.13. With populationScaleLog10 = 6 default, the raw
+		// fraction is 7.13/6 = 1.19, capped at 1. So Tokyo's boost = exactly populationBoost.
+		const candidates = await lookup.findPlace({ text: "Tokyo", placetype: "locality" })
+		expect(candidates.length).toBe(1)
+		expect(candidates[0]?.population).toBe(13_500_000)
+		// We can't easily isolate the population boost from BM25, but we can check the boost
+		// caps logic by tuning the weight to a sentinel + comparing the score delta to a
+		// no-population control. Skipped for now — the formula caps deterministically in code.
+	})
+
+	test("DB without place_population table → no boost, lookup still works", async () => {
+		// Build the fixture but drop the aux table before opening the lookup.
+		const db = buildFixtureDb()
+		buildPlaceSearchFts(db)
+		db.exec(`DROP TABLE place_population`)
+		const fallback = new WofSqlitePlaceLookup({ database: db })
+		try {
+			const candidates = await fallback.findPlace({ text: "Springfield", placetype: "locality", limit: 10 })
+			// All 4 Springfields returned, none with `population` field (the aux table was dropped).
+			const springfields = candidates.filter((c) => c.name === "Springfield")
+			expect(springfields.length).toBe(4)
+			for (const c of springfields) expect(c.population).toBeUndefined()
+			// Their scores should all be equal (no population boost differentiation).
+			const scores = new Set(springfields.map((c) => c.score.toFixed(6)))
+			expect(scores.size).toBe(1)
+		} finally {
+			fallback.close()
+		}
+	})
+})

--- a/resolver-wof-sqlite/types.ts
+++ b/resolver-wof-sqlite/types.ts
@@ -57,6 +57,12 @@ export interface PlaceCandidate {
 	parent_id?: number
 	score: number
 	distanceKm?: number
+	/**
+	 * Population from WOF's `wof:population` property. Only present when the candidate has it on
+	 * record — WOF carries population for ~15% of localities (mostly larger ones). Absent does NOT
+	 * mean zero, just unknown.
+	 */
+	population?: number
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the "famous places lose to obscure peers because BM25 punishes their long alt-name lists" problem documented in #91 (supplemental-data half). NYC, LA, Chicago, Boston, Miami all now resolve to their famous self at top of `findPlace({ text, placetype: "locality" })`.

**The mechanism:**

1. `mailwoman-wof-build-fts` now also builds `place_population` — a sparse INTEGER aux table extracted from `geojson.body` JSON at index time via SQLite's `json_extract`. Only ~15% of WOF localities have `wof:population` (the bigger places); missing rows just don't get the boost (never a penalty).

2. The boost is **pushed into SQL `ORDER BY`**:
   ```sql
   ORDER BY bm25(place_search)
          - populationBoost * MIN(1.0, COALESCE(log10(1 + pop), 0) / scaleLog10)
   ```
   This makes famous places — whose long alt-name lists hurt BM25 — actually appear in the FTS over-fetch window. Without it, the post-fetch re-rank never sees them.

3. `PlaceCandidate.population` exposed to callers (when known). `RankingWeights.populationBoost` (default **4.0**) and `populationScaleLog10` (default 6 → 1M people = full boost) tunable per instance.

**Why the high default boost.** Empirical tuning against real WOF showed BM25 gaps of 1.5–3.0 between famous places and tiny same-name peers, so the population signal needs to dominate for the "NYC means NYC" expectation. Callers wanting subtler behavior can dial it down.

## End-to-end smoke (real WOF admin-US, 97,432 population rows indexed)

| Query | Result |
|---|---|
| `New York` | famous NYC (pop **8,840,134**) ★ |
| `Los Angeles` | famous LA (pop **3,820,914**) ★ |
| `Chicago` | famous Chicago (pop **2,750,534**) ★ |
| `Boston` | famous Boston (pop **653,833**) ★ |
| `Miami` | famous Miami (pop **455,924**) ★ |
| `Springfield` | still ambiguous (60+ candidates) — Springfield, MA (pop 153k) now #4 of 60+, Springfield, IL (pop 112k) now #11. Both improved from "not in top 20." For deeply ambiguous names, `near` or `parentId` hints are still needed. |

## Backwards compatibility

- DBs built before this PR (without `place_population`) get the old behavior — no boost, no crash. The LEFT JOIN and ORDER BY expression are both omitted per-shard when the aux table is absent.
- Same DBs can be upgraded via `mailwoman-wof-build-fts --drop`.
- Multi-shard aware — per-shard probe decides whether to include the JOIN.

## Test plan

- [x] `population.test.ts` (NEW) — 9 tests covering aux-table build, sparse coverage, done-phase summary, no-geojson skip, candidate.population populated, Springfield rank-by-population, populationBoost=0 zero-contribution, missing-aux-table fallback
- [x] All existing tests (fts/lookup/multi-shard/proximity/integration) continue to pass — the LEFT JOIN is conditional on the shard having the aux table
- [x] All 1309 tests pass (was 1300; +9 new)
- [x] `yarn compile` clean
- [x] End-to-end smoke on real WOF admin-US confirms the famous-cities expectation
- [ ] CI green

## Out of scope

- **Springfield-level deep ambiguity** — population alone can't beat 60+ identically-named US places. The path forward is proximity / parentId hints, which Phase 4.3.x already supports.
- **Use `wof:population_rank`** as a secondary signal — the bucketed version (0-13) is more sparsely populated than raw population, less useful.
- **FTS5 prefix sanitization** — next PR in the queue.

## Disclosure

Triaged and authored end-to-end by an automated agent (Claude Opus 4.7) under operator supervision. Human reviewer: @GirlBossRush.