### PR TITLE
phase-4.3.x: FTS5 prefix queries via trailing-* sanitization

### DIFF
--- a/resolver-wof-sqlite/README.md
+++ b/resolver-wof-sqlite/README.md
@@ -181,6 +181,22 @@ new WofSqlitePlaceLookup({ databasePath }, { countryMatchBoost: 0.5 })
 
 Defaults are in `lookup.ts::DEFAULT_WEIGHTS`.
 
+## Query syntax
+
+`FindPlaceQuery.text` accepts free-text input — apostrophes / parens / accented characters / etc.
+are all stripped safely before going to FTS5. Per-token rules:
+
+- **Bare tokens** (`"Paris"`, `"62701"`) become FTS5 **phrase matches**: `"Paris"` matches places
+  named exactly "Paris", `"62701"` matches the postcode 62701 exactly.
+- **Trailing `*`** (`"627*"`, `"Pari*"`) becomes FTS5 **prefix syntax**: `627*` matches every
+  postcode starting with 627, `Pari*` matches Paris / Parishville / etc. The caller explicitly
+  signals "prefix"; bare tokens stay phrase-matched for safety.
+- **Multiple tokens** join with implicit AND: `"Pari* TX"` matches places whose name contains
+  both a `Pari*`-prefixed word AND the word `TX`.
+
+Example: `findPlace({ text: "902*", placetype: "postalcode" })` returns 90201, 90210, 90211, …
+matching the Los Angeles ZIP corridor.
+
 ## Attribution (CC-BY 4.0)
 
 Who's On First data is licensed [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/). Downstream applications shipping resolved results from this package **must** carry an attribution notice — for example:

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -416,20 +416,39 @@ function normalizePlacetypes(p: FindPlaceQuery["placetype"]): WofPlacetype[] | n
  * Make an arbitrary user-typed string safe for FTS5 MATCH.
  *
  * FTS5 has its own query syntax (`"phrase"`, `term1 OR term2`, `prefix*`, NEAR/N, etc.). Letting
- * raw user input through means a user typing `Paris's` or `St. (Petersburg)` causes a syntax error.
- * We strip everything but `[\p{L}\p{N} ]`, then quote each token as a phrase and join with implicit
- * AND. Conservative but predictable.
+ * raw user input through means a user typing `Paris's` or `St. (Petersburg)` causes a syntax
+ * error.
+ *
+ * Per-token rules:
+ *
+ * - Strip all punctuation except trailing `*` from each whitespace-separated token.
+ * - **Trailing `*`** is preserved as FTS5 **prefix syntax** — `627*` becomes the literal `627*`
+ *   (unquoted). The caller signaled they want a prefix; respect that.
+ * - All other tokens are wrapped in `"..."` as a single-word phrase. Conservative — handles
+ *   apostrophes, parens, accented input, etc. safely.
+ * - Multiple tokens join with implicit AND.
+ *
+ * Examples:
+ *
+ * - `"Paris"` → `"Paris"` (phrase)
+ * - `"627*"` → `627*` (prefix)
+ * - `"St. (Petersburg)"` → `"St" "Petersburg"` (two phrases, AND-joined)
+ * - `"Pari* TX"` → `Pari* "TX"` (mixed prefix + phrase)
+ * - `"*"` alone → `""` (no body → drop)
  */
 function sanitizeFtsQuery(text: string): string {
-	const tokens = text
-		.normalize("NFKC")
-		.replace(/[^\p{L}\p{N}\s]/gu, " ")
-		.split(/\s+/u)
-		.map((t) => t.trim())
-		.filter((t) => t.length > 0)
-
-	if (tokens.length === 0) return ""
-	return tokens.map((t) => `"${t.replace(/"/g, '""')}"`).join(" ")
+	const out: string[] = []
+	for (const rawToken of text.normalize("NFKC").split(/\s+/u)) {
+		const trimmed = rawToken.trim()
+		if (!trimmed) continue
+		const hasPrefixStar = trimmed.endsWith("*")
+		// Strip everything except letters + numbers from the token body. Apostrophes / hyphens /
+		// any embedded `*` all go. The trailing `*` (if any) is reapplied separately below.
+		const body = trimmed.replace(/[^\p{L}\p{N}]/gu, "")
+		if (!body) continue
+		out.push(hasPrefixStar ? `${body}*` : `"${body.replace(/"/g, '""')}"`)
+	}
+	return out.join(" ")
 }
 
 // `sql` is imported only because future Kysely-typed queries will use it; silence "unused" linting.

--- a/resolver-wof-sqlite/sanitize.test.ts
+++ b/resolver-wof-sqlite/sanitize.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the FTS5 sanitizer. The function isn't exported (it lives inside `lookup.ts`), so we
+ *   drive it through real `findPlace` calls against a tiny fixture DB and assert on the
+ *   `place_search MATCH` behavior. This also catches the case where the sanitizer produces SQL
+ *   that's syntactically valid but logically wrong.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { WofSqlitePlaceLookup } from "./lookup.js"
+
+function buildFixtureDb(): DatabaseSync {
+	const db = new DatabaseSync(":memory:")
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+		CREATE TABLE ancestors (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT);
+		INSERT INTO spr VALUES (1, NULL, '62701', 'postalcode', 'US', 39.80, -89.65, 39.78, 39.82, -89.67, -89.63, -1, 0);
+		INSERT INTO spr VALUES (2, NULL, '62702', 'postalcode', 'US', 39.82, -89.63, 39.80, 39.84, -89.65, -89.61, -1, 0);
+		INSERT INTO spr VALUES (3, NULL, '62721', 'postalcode', 'US', 39.78, -89.66, 39.76, 39.80, -89.68, -89.64, -1, 0);
+		INSERT INTO spr VALUES (4, NULL, '90210', 'postalcode', 'US', 34.07, -118.41, 34.05, 34.09, -118.43, -118.39, -1, 0);
+		INSERT INTO spr VALUES (5, NULL, 'Paris', 'locality', 'FR', 48.85, 2.34, 48.81, 48.90, 2.22, 2.46, -1, 0);
+		INSERT INTO spr VALUES (6, NULL, 'St. Petersburg', 'locality', 'US', 27.77, -82.64, 27.66, 27.85, -82.78, -82.51, -1, 0);
+	`)
+	return db
+}
+
+let lookup: WofSqlitePlaceLookup
+
+beforeEach(() => {
+	lookup = new WofSqlitePlaceLookup({ database: buildFixtureDb(), buildFts: true })
+})
+
+afterEach(() => {
+	lookup.close()
+})
+
+describe("sanitizeFtsQuery — trailing-* prefix support", () => {
+	test("exact-match (no trailing *) still works (phrase)", async () => {
+		const r = await lookup.findPlace({ text: "62701", placetype: "postalcode" })
+		expect(r.length).toBe(1)
+		expect(r[0]?.name).toBe("62701")
+	})
+
+	test("trailing * returns all postcodes starting with the prefix", async () => {
+		const r = await lookup.findPlace({ text: "627*", placetype: "postalcode", limit: 10 })
+		const names = new Set(r.map((c) => c.name))
+		expect(names).toContain("62701")
+		expect(names).toContain("62702")
+		expect(names).toContain("62721")
+		// 90210 starts with 9; should NOT match
+		expect(names).not.toContain("90210")
+	})
+
+	test("longer prefix narrows the result set", async () => {
+		const r627 = await lookup.findPlace({ text: "627*", placetype: "postalcode", limit: 10 })
+		const r6270 = await lookup.findPlace({ text: "6270*", placetype: "postalcode", limit: 10 })
+		expect(r627.length).toBeGreaterThan(r6270.length)
+		expect(r6270.length).toBeGreaterThan(0)
+	})
+
+	test("prefix that matches nothing returns empty", async () => {
+		expect(await lookup.findPlace({ text: "999*", placetype: "postalcode" })).toEqual([])
+	})
+
+	test('phrase + prefix in one query (mixed): `Pari* TX` is `Pari* AND "TX"`', async () => {
+		// The fixture has Paris (FR) but no TX; the AND of `Pari*` (matches Paris) AND `"TX"` (matches
+		// nothing in the fixture) returns empty.
+		const r = await lookup.findPlace({ text: "Pari* TX", placetype: "locality" })
+		expect(r).toEqual([])
+		// But bare `Pari*` matches Paris.
+		const justPrefix = await lookup.findPlace({ text: "Pari*", placetype: "locality" })
+		expect(justPrefix.length).toBe(1)
+		expect(justPrefix[0]?.name).toBe("Paris")
+	})
+})
+
+describe("sanitizeFtsQuery — punctuation stripping (existing behavior, regression backstop)", () => {
+	test("apostrophes are stripped — `St. (Petersburg)` becomes two phrases AND-joined", async () => {
+		// Both `St` and `Petersburg` (as standalone tokens) must match the name `St. Petersburg`.
+		// FTS5 tokenizes the name on whitespace (after stripping punctuation by the unicode61
+		// tokenizer), so `St` matches `St.` and `Petersburg` matches `Petersburg`.
+		const r = await lookup.findPlace({ text: "St. (Petersburg)", placetype: "locality" })
+		expect(r.length).toBe(1)
+		expect(r[0]?.name).toBe("St. Petersburg")
+	})
+
+	test("lone `*` is dropped (no body — no tokens emitted)", async () => {
+		expect(await lookup.findPlace({ text: "*", placetype: "postalcode" })).toEqual([])
+	})
+
+	test("`abc*xyz*` strips embedded * and keeps trailing → prefix `abcxyz*`", async () => {
+		// Confirm no crash from embedded asterisks; assertion is just "no SQL error". Result depends on
+		// fixture; here the prefix doesn't match anything.
+		await expect(lookup.findPlace({ text: "abc*xyz*", placetype: "postalcode" })).resolves.toBeInstanceOf(Array)
+	})
+})


### PR DESCRIPTION
## Summary

Closes the FTS5 prefix-query gap surfaced in #93's multi-shard PR where `627*` queries silently returned nothing. The old `sanitizeFtsQuery` wrapped every token in `"..."` quotes — `627*` became the literal phrase `"627*"` which matches the literal string with a star (nothing). Now: trailing `*` is preserved as **FTS5 prefix syntax** while bare tokens keep phrase-match semantics for safety.

## Per-token rules

| Input | Output | Notes |
|---|---|---|
| `Paris` | `"Paris"` | bare token → phrase (existing) |
| `62701` | `"62701"` | bare → phrase (existing — exact-match still works) |
| `627*` | `627*` | trailing `*` → prefix (NEW) |
| `Pari*` | `Pari*` | trailing `*` → prefix (NEW) |
| `Pari* TX` | `Pari* "TX"` | mixed — joined with implicit AND (NEW) |
| `St. (Petersburg)` | `"St" "Petersburg"` | punctuation stripped, two phrases AND-joined (existing) |
| `*` alone | (empty) | no body → token dropped (no FTS5 error) |
| `abc*xyz*` | `abcxyz*` | embedded `*` stripped, trailing preserved |

## End-to-end smoke (real WOF admin + postcode)

```
=== 627* prefix postcodes near IL ===
  554735275 62701 dist: 2.3km
  554735281 62703 dist: 2.6km
  554735283 62704 dist: 3.0km
  554735279 62702 dist: 5.0km
  554756907 62712 dist: 6.7km

=== 902* prefix (LA ZIP corridor) ===
  554783989 90201
  554783991 90210   ← Beverly Hills
  554783993 90211
  554783995 90212
  554783997 90220

=== exact 62701 (regression — phrase still works) ===
  554735275 62701
```

## Test plan

- [x] `sanitize.test.ts` (NEW) — 8 tests covering exact-match regression, prefix matching, longer-prefix narrowing, no-match empty, mixed prefix+phrase AND semantics, punctuation stripping regression, lone-asterisk drop, embedded-asterisk handling
- [x] All 1317 tests pass (was 1309; +8 new)
- [x] `yarn compile` clean
- [x] End-to-end smoke against real WOF confirms the original failure case (`627*`) now works
- [ ] CI green

## Out of scope

- Other FTS5 operators (`OR`, `NEAR`, parenthesized groups). Caller can compose multiple `findPlace` calls if needed; explicit AST mode would be a separate larger PR.
- Wildcards anywhere other than trailing position. Trailing-only matches FTS5's native prefix-only support; SQLite doesn't ship trigram or middle-wildcard indexing out of the box.

## Disclosure

Triaged and authored end-to-end by an automated agent (Claude Opus 4.7) under operator supervision. Human reviewer: @GirlBossRush.