### PR TITLE
Phase B.1: slim WOF builder (35 MB output, browser-shippable)

### DIFF
--- a/resolver-wof-sqlite/README.md
+++ b/resolver-wof-sqlite/README.md
@@ -112,6 +112,36 @@ npx mailwoman-wof-build-fts /path/to/wof.db --drop
 
 `--drop` rebuilds from scratch — useful after refreshing the `places` / `names` tables from a newer dump. Without `--drop` the CLI is a no-op when the index is already present.
 
+### `mailwoman-wof-build-slim` CLI
+
+Builds a trimmed WOF SQLite distribution sized for browser-side deployments (Path B of the demo plan). The full admin-US distribution is ~4 GB; a slim US bundle with the top-1k localities by population plus all postcodes lands at **~35 MB** — small enough to ship as a static asset.
+
+```bash
+# Defaults: --top 1000 localities, --countries US, drops geojson after building aux tables
+npx mailwoman-wof-build-slim \
+  --in /path/to/whosonfirst-data-admin-us-latest.db \
+  --in /path/to/whosonfirst-data-postalcode-us-latest.db \
+  --out /path/to/wof-hot.db
+
+# Tinier — top 100 localities only
+npx mailwoman-wof-build-slim --in admin-us.db --out wof-tiny.db --top 100
+
+# Multi-country
+npx mailwoman-wof-build-slim --in admin-na.db --out wof-na.db --countries US,CA,MX
+```
+
+What survives in the slim DB:
+
+- All ancestor placetypes (`country`, `region`, `county`, `borough`, `macroregion`) in scope
+- Top-K localities by `wof:population`
+- All postcodes in scope
+- All `names` rows for the selected place IDs
+- Fresh `place_search` (FTS5), `place_bbox` (R\*Tree), `place_population` aux tables
+
+What gets dropped: the `geojson` table, which is build-time only — `lookup.ts` never reads it at query time, and it accounts for ~95% of the on-disk size. The `place_population` aux table consumes `wof:population` from geojson before we drop it.
+
+`WofSqlitePlaceLookup` opens the slim DB without any code change. Out-of-set queries (a locality not in the top-K) correctly return zero hits.
+
 You can also build the index programmatically via the package's `./fts` subpath:
 
 ```ts

--- a/resolver-wof-sqlite/build-slim-cli.ts
+++ b/resolver-wof-sqlite/build-slim-cli.ts
@@ -83,7 +83,7 @@ function parseArgs(argv: string[]): CliArgs {
 	return out
 }
 
-export function main(rawArgv: string[]): number {
+export async function main(rawArgv: string[]): Promise<number> {
 	let args: CliArgs
 	try {
 		args = parseArgs(rawArgv)
@@ -102,7 +102,7 @@ export function main(rawArgv: string[]): number {
 	}
 
 	try {
-		const result = buildSlimWofDatabase(opts)
+		const result = await buildSlimWofDatabase(opts)
 		const mb = (result.outputBytes / 1024 / 1024).toFixed(1)
 		stderr.write(
 			`\nBuilt ${result.outputPath} (${mb} MB)\n` +
@@ -122,5 +122,5 @@ export function main(rawArgv: string[]): number {
 
 // Run when invoked as a script (not when imported by tests).
 if (import.meta.url === `file://${process.argv[1]}`) {
-	exit(main(process.argv.slice(2)))
+	main(process.argv.slice(2)).then((code) => exit(code))
 }

--- a/resolver-wof-sqlite/build-slim-cli.ts
+++ b/resolver-wof-sqlite/build-slim-cli.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `mailwoman-wof-build-slim --in <wof.db>... --out <slim.db> [--top 1000] [--countries US]`
+ *
+ *   Operator-side one-shot CLI that produces a "slim" WOF SQLite distribution sized for the
+ *   browser-side mailwoman demo (Path B). Delegates to {@linkcode buildSlimWofDatabase}; the CLI is
+ *   just argument parsing + stderr progress.
+ */
+
+import { exit, stderr } from "node:process"
+
+import { buildSlimWofDatabase, type BuildSlimOptions } from "./build-slim.js"
+
+interface CliArgs {
+	inputs: string[]
+	output: string
+	topLocalities: number
+	countries: string[]
+}
+
+function printUsageAndExit(code: number): never {
+	stderr.write(
+		[
+			"usage: mailwoman-wof-build-slim --in <wof.db>... --out <slim.db> [--top N] [--countries US,CA,...]",
+			"",
+			"Builds a trimmed WOF SQLite distribution for the browser-side demo. Default selection:",
+			"  - All ancestor placetypes (country/region/county/borough/macroregion) in scope",
+			"  - Top --top localities by wof:population (default 1000)",
+			"  - All postalcodes in scope",
+			"  - All names + geojson rows for selected IDs",
+			"  - Fresh place_search FTS5, place_bbox R*Tree, place_population aux tables",
+			"",
+			"Examples:",
+			"  mailwoman-wof-build-slim --in admin-us.db --in postalcode-us.db --out wof-hot.db",
+			"  mailwoman-wof-build-slim --in admin-us.db --out wof-tiny.db --top 100",
+			"  mailwoman-wof-build-slim --in admin-na.db --out wof-na.db --countries US,CA,MX",
+			"",
+		].join("\n")
+	)
+	exit(code)
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	const out: CliArgs = { inputs: [], output: "", topLocalities: 1000, countries: ["US"] }
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i]
+		if (a === "--in") {
+			const v = argv[++i]
+			if (!v) printUsageAndExit(2)
+			out.inputs.push(v)
+		} else if (a === "--out") {
+			const v = argv[++i]
+			if (!v) printUsageAndExit(2)
+			out.output = v
+		} else if (a === "--top") {
+			const v = argv[++i]
+			if (!v) printUsageAndExit(2)
+			const n = Number(v)
+			if (!Number.isFinite(n) || n <= 0) {
+				stderr.write(`--top must be a positive number; got '${v}'\n`)
+				exit(2)
+			}
+			out.topLocalities = n
+		} else if (a === "--countries") {
+			const v = argv[++i]
+			if (!v) printUsageAndExit(2)
+			out.countries = v
+				.split(",")
+				.map((c) => c.trim())
+				.filter(Boolean)
+		} else if (a === "--help" || a === "-h") {
+			printUsageAndExit(0)
+		} else {
+			stderr.write(`unknown argument: '${a}'\n`)
+			printUsageAndExit(2)
+		}
+	}
+	if (out.inputs.length === 0 || !out.output) printUsageAndExit(2)
+	return out
+}
+
+export function main(rawArgv: string[]): number {
+	let args: CliArgs
+	try {
+		args = parseArgs(rawArgv)
+	} catch {
+		return 2
+	}
+
+	const opts: BuildSlimOptions = {
+		inputs: args.inputs,
+		output: args.output,
+		countries: args.countries,
+		topLocalitiesPerCountry: args.topLocalities,
+		onProgress: (phase, detail) => {
+			stderr.write(`[${phase}] ${detail}\n`)
+		},
+	}
+
+	try {
+		const result = buildSlimWofDatabase(opts)
+		const mb = (result.outputBytes / 1024 / 1024).toFixed(1)
+		stderr.write(
+			`\nBuilt ${result.outputPath} (${mb} MB)\n` +
+				`  spr=${result.rowCounts.spr}` +
+				`  names=${result.rowCounts.names}` +
+				`  geojson=${result.rowCounts.geojson}` +
+				`  fts=${result.rowCounts.placeSearch}` +
+				`  bbox=${result.rowCounts.placeBbox}` +
+				`  pop=${result.rowCounts.placePopulation}\n`
+		)
+		return 0
+	} catch (err) {
+		stderr.write(`build-slim failed: ${(err as Error).message}\n`)
+		return 1
+	}
+}
+
+// Run when invoked as a script (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+	exit(main(process.argv.slice(2)))
+}

--- a/resolver-wof-sqlite/build-slim.test.ts
+++ b/resolver-wof-sqlite/build-slim.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for {@linkcode buildSlimWofDatabase}. Builds a tiny fixture WOF with a country + a few
+ *   localities (varying populations) + postcodes + a non-US locality, then asserts that the slim
+ *   output keeps only what the selection policy promises.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { buildSlimWofDatabase } from "./build-slim.js"
+
+let scratch: string
+
+function buildFixtureWof(path: string): void {
+	const db = new DatabaseSync(path)
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+		CREATE TABLE geojson (id INTEGER PRIMARY KEY, body TEXT);
+
+		-- US country + region (ancestor placetypes — always kept)
+		INSERT INTO spr VALUES (100, NULL, 'United States', 'country', 'US', 39.0, -97.0, 24.5, 49.4, -125.0, -66.9, -1, 0);
+		INSERT INTO spr VALUES (101, 100, 'Illinois', 'region', 'US', 40.0, -89.0, 37.0, 42.5, -91.5, -87.0, -1, 0);
+
+		-- Three US localities with varying populations
+		INSERT INTO spr VALUES (200, 101, 'Chicago', 'locality', 'US', 41.88, -87.63, 41.6, 42.0, -87.9, -87.5, -1, 0);
+		INSERT INTO spr VALUES (201, 101, 'Springfield', 'locality', 'US', 39.80, -89.65, 39.7, 39.9, -89.8, -89.5, -1, 0);
+		INSERT INTO spr VALUES (202, 101, 'Mascoutah', 'locality', 'US', 38.49, -89.79, 38.4, 38.5, -89.85, -89.75, -1, 0);
+
+		-- US postcodes (always kept)
+		INSERT INTO spr VALUES (300, 201, '62701', 'postalcode', 'US', 39.81, -89.65, 39.80, 39.82, -89.66, -89.64, -1, 0);
+		INSERT INTO spr VALUES (301, 200, '60601', 'postalcode', 'US', 41.88, -87.62, 41.87, 41.89, -87.63, -87.61, -1, 0);
+
+		-- Non-US locality (should be dropped)
+		INSERT INTO spr VALUES (400, NULL, 'Paris', 'locality', 'FR', 48.85, 2.34, 48.81, 48.90, 2.22, 2.46, -1, 0);
+
+		-- Deprecated US locality (should be dropped)
+		INSERT INTO spr VALUES (500, 101, 'Old Town', 'locality', 'US', 40.0, -89.0, 40.0, 40.0, -89.0, -89.0, 1, 1);
+
+		-- names rows
+		INSERT INTO names (id, language, name) VALUES (100, 'eng', 'America');
+		INSERT INTO names (id, language, name) VALUES (200, 'eng', 'Chicago');
+		INSERT INTO names (id, language, name) VALUES (201, 'eng', 'Springfield');
+		INSERT INTO names (id, language, name) VALUES (202, 'eng', 'Mascoutah');
+		INSERT INTO names (id, language, name) VALUES (300, 'eng', 'Springfield ZIP');
+		INSERT INTO names (id, language, name) VALUES (400, 'fra', 'Paris');
+
+		-- geojson with wof:population so the population-ranked selector has something to sort on
+		INSERT INTO geojson VALUES (100, '{"properties":{"wof:population":331000000}}');
+		INSERT INTO geojson VALUES (101, '{"properties":{"wof:population":12700000}}');
+		INSERT INTO geojson VALUES (200, '{"properties":{"wof:population":2700000}}');
+		INSERT INTO geojson VALUES (201, '{"properties":{"wof:population":114000}}');
+		INSERT INTO geojson VALUES (202, '{"properties":{"wof:population":8000}}');
+		INSERT INTO geojson VALUES (300, '{"properties":{}}');
+		INSERT INTO geojson VALUES (301, '{"properties":{}}');
+		INSERT INTO geojson VALUES (400, '{"properties":{"wof:population":2100000}}');
+		INSERT INTO geojson VALUES (500, '{"properties":{"wof:population":0}}');
+	`)
+	db.close()
+}
+
+beforeEach(async () => {
+	scratch = await mkdtemp(join(tmpdir(), "mailwoman-slim-"))
+})
+
+afterEach(async () => {
+	await rm(scratch, { recursive: true, force: true }).catch(() => {})
+})
+
+describe("buildSlimWofDatabase", () => {
+	test("keeps ancestors, top-K localities by population, and all postcodes", () => {
+		const source = join(scratch, "src.db")
+		const output = join(scratch, "slim.db")
+		buildFixtureWof(source)
+
+		const result = buildSlimWofDatabase({
+			inputs: [source],
+			output,
+			topLocalitiesPerCountry: 2, // keeps Chicago + Springfield, drops Mascoutah
+		})
+
+		expect(result.rowCounts.spr).toBe(6) // 2 ancestors + 2 localities + 2 postcodes
+		expect(result.rowCounts.placeSearch).toBe(6)
+		expect(result.rowCounts.placeBbox).toBe(6)
+
+		const slim = new DatabaseSync(output, { readOnly: true })
+		try {
+			const names = slim
+				.prepare(`SELECT name FROM spr ORDER BY id`)
+				.all()
+				.map((r) => (r as { name: string }).name)
+			expect(names).toEqual(["United States", "Illinois", "Chicago", "Springfield", "62701", "60601"])
+
+			// Mascoutah, Paris, and Old Town must be absent.
+			expect(names).not.toContain("Mascoutah")
+			expect(names).not.toContain("Paris")
+			expect(names).not.toContain("Old Town")
+		} finally {
+			slim.close()
+		}
+	})
+
+	test("preserves names + geojson only for selected IDs", () => {
+		const source = join(scratch, "src.db")
+		const output = join(scratch, "slim.db")
+		buildFixtureWof(source)
+
+		buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 1 })
+
+		const slim = new DatabaseSync(output, { readOnly: true })
+		try {
+			const nameIds = slim
+				.prepare(`SELECT DISTINCT id FROM names ORDER BY id`)
+				.all()
+				.map((r) => (r as { id: number }).id)
+			// Top-1 locality = Chicago (200); ancestors 100/101; postcodes 300/301.
+			expect(nameIds).toEqual([100, 200, 300])
+			// Paris (400) and Mascoutah (202) names must be gone.
+			expect(nameIds).not.toContain(400)
+			expect(nameIds).not.toContain(202)
+
+			// geojson is dropped at the end of the build — it's only needed to feed place_population,
+			// and lookup.ts never reads it at query time. Confirm the drop happened.
+			const geojsonExists = slim.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'geojson'`).get()
+			expect(geojsonExists).toBeUndefined()
+		} finally {
+			slim.close()
+		}
+	})
+
+	test("builds the place_population aux table on the trimmed row set", () => {
+		const source = join(scratch, "src.db")
+		const output = join(scratch, "slim.db")
+		buildFixtureWof(source)
+
+		buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 2 })
+
+		const slim = new DatabaseSync(output, { readOnly: true })
+		try {
+			const rows = slim
+				.prepare(`SELECT id, population FROM place_population ORDER BY population DESC LIMIT 3`)
+				.all() as Array<{ id: number; population: number }>
+			expect(rows[0]?.id).toBe(100) // US country, biggest population
+			expect(rows[0]?.population).toBe(331000000)
+		} finally {
+			slim.close()
+		}
+	})
+
+	test("merges rows across multiple input shards without duplicating", () => {
+		const adminSource = join(scratch, "admin.db")
+		const postcodeSource = join(scratch, "postcode.db")
+		const output = join(scratch, "slim.db")
+		buildFixtureWof(adminSource)
+		// Postcode shard: same schema, only contributes postcodes (here, re-use the admin fixture's
+		// postcode rows to verify INSERT OR IGNORE actually de-dupes on id).
+		buildFixtureWof(postcodeSource)
+
+		const result = buildSlimWofDatabase({
+			inputs: [adminSource, postcodeSource],
+			output,
+			topLocalitiesPerCountry: 1,
+		})
+
+		// Same 5 rows (1 country + 1 region + 1 locality + 2 postcodes) — no duplication across shards.
+		expect(result.rowCounts.spr).toBe(5)
+	})
+})

--- a/resolver-wof-sqlite/build-slim.test.ts
+++ b/resolver-wof-sqlite/build-slim.test.ts
@@ -80,12 +80,12 @@ afterEach(async () => {
 })
 
 describe("buildSlimWofDatabase", () => {
-	test("keeps ancestors, top-K localities by population, and all postcodes", () => {
+	test("keeps ancestors, top-K localities by population, and all postcodes", async () => {
 		const source = join(scratch, "src.db")
 		const output = join(scratch, "slim.db")
 		buildFixtureWof(source)
 
-		const result = buildSlimWofDatabase({
+		const result = await buildSlimWofDatabase({
 			inputs: [source],
 			output,
 			topLocalitiesPerCountry: 2, // keeps Chicago + Springfield, drops Mascoutah
@@ -112,12 +112,12 @@ describe("buildSlimWofDatabase", () => {
 		}
 	})
 
-	test("preserves names + geojson only for selected IDs", () => {
+	test("preserves names + geojson only for selected IDs", async () => {
 		const source = join(scratch, "src.db")
 		const output = join(scratch, "slim.db")
 		buildFixtureWof(source)
 
-		buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 1 })
+		await buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 1 })
 
 		const slim = new DatabaseSync(output, { readOnly: true })
 		try {
@@ -140,12 +140,12 @@ describe("buildSlimWofDatabase", () => {
 		}
 	})
 
-	test("builds the place_population aux table on the trimmed row set", () => {
+	test("builds the place_population aux table on the trimmed row set", async () => {
 		const source = join(scratch, "src.db")
 		const output = join(scratch, "slim.db")
 		buildFixtureWof(source)
 
-		buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 2 })
+		await buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 2 })
 
 		const slim = new DatabaseSync(output, { readOnly: true })
 		try {
@@ -159,7 +159,7 @@ describe("buildSlimWofDatabase", () => {
 		}
 	})
 
-	test("merges rows across multiple input shards without duplicating", () => {
+	test("merges rows across multiple input shards without duplicating", async () => {
 		const adminSource = join(scratch, "admin.db")
 		const postcodeSource = join(scratch, "postcode.db")
 		const output = join(scratch, "slim.db")
@@ -168,7 +168,7 @@ describe("buildSlimWofDatabase", () => {
 		// postcode rows to verify INSERT OR IGNORE actually de-dupes on id).
 		buildFixtureWof(postcodeSource)
 
-		const result = buildSlimWofDatabase({
+		const result = await buildSlimWofDatabase({
 			inputs: [adminSource, postcodeSource],
 			output,
 			topLocalitiesPerCountry: 1,

--- a/resolver-wof-sqlite/build-slim.ts
+++ b/resolver-wof-sqlite/build-slim.ts
@@ -1,0 +1,255 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build a "slim" Who's On First SQLite distribution that's small enough to ship as a static asset
+ *   for the browser-side mailwoman demo (Path B of the demo plan). The full admin-US distribution
+ *   is ~4 GB; the slim variant aims for the ~50–100 MB range by keeping only the places a public
+ *   demo will actually query for.
+ *
+ *   Selection policy (v1, US-focused):
+ *
+ *   - All countries / regions / counties / boroughs in the configured `countries` set, so the ancestor
+ *       chain a locality / postcode reports through `parent_id` stays intact.
+ *   - Top-K localities by `wof:population` (extracted via the `place_population` aux table the full WOF
+ *       build already emits) in those countries.
+ *   - All postcodes in those countries — they're small and addressing-relevant.
+ *   - All `names` rows + `geojson` rows for selected place IDs.
+ *
+ *   The output DB has the same logical schema as the source: `spr`, `names`, `geojson`, plus the
+ *   `place_search` FTS5 / `place_bbox` R*Tree / `place_population` aux tables built fresh against
+ *   the trimmed row set. That means `WofSqlitePlaceLookup` opens the slim DB without any code
+ *   change — it sees a smaller universe, nothing more.
+ *
+ *   Multi-shard inputs (e.g. admin-us + postcode-us) are processed in sequence; selected rows
+ *   accumulate into the single output DB. The postcode shard contributes only postcodes; admin
+ *   contributes everything else.
+ */
+
+import { copyFileSync, existsSync, mkdtempSync, rmSync, statSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { buildPlaceSearchFts, PLACE_BBOX_TABLE, PLACE_POPULATION_TABLE, PLACE_SEARCH_TABLE } from "./fts.js"
+
+export interface BuildSlimOptions {
+	/** Input WOF SQLite distributions. Each should already have spr / names / geojson tables. */
+	inputs: string[]
+	/** Output path for the slim DB. Will be overwritten if it exists. */
+	output: string
+	/** Country codes to keep (ISO 2-letter). Defaults to `["US"]`. */
+	countries?: string[]
+	/** Cap on the number of localities to keep per country, by descending population. */
+	topLocalitiesPerCountry?: number
+	/** Optional progress callback for CLI / test introspection. */
+	onProgress?: (phase: SlimBuildPhase, detail: string) => void
+}
+
+export type SlimBuildPhase =
+	| "init"
+	| "schema"
+	| "country"
+	| "region"
+	| "county"
+	| "locality"
+	| "postcode"
+	| "names"
+	| "geojson"
+	| "fts"
+	| "vacuum"
+	| "done"
+
+export interface BuildSlimResult {
+	outputPath: string
+	outputBytes: number
+	rowCounts: {
+		spr: number
+		names: number
+		geojson: number
+		placeSearch: number
+		placeBbox: number
+		placePopulation: number
+	}
+}
+
+/** Placetypes that we always keep so the ancestor chain a selected locality reports stays valid. */
+const ANCESTOR_PLACETYPES = ["country", "region", "county", "borough", "macroregion"] as const
+
+/** Names of the tables we copy from each source DB. Anything outside this list is dropped. */
+const COPIED_TABLES = ["spr", "names", "geojson"] as const
+
+export function buildSlimWofDatabase(opts: BuildSlimOptions): BuildSlimResult {
+	const countries = (opts.countries ?? ["US"]).map((c) => c.toUpperCase())
+	const topLocalities = opts.topLocalitiesPerCountry ?? 1000
+	const progress = opts.onProgress ?? (() => {})
+
+	for (const input of opts.inputs) {
+		if (!existsSync(input)) throw new Error(`input WOF db not found: ${input}`)
+	}
+
+	progress("init", `${opts.inputs.length} input(s) → ${opts.output}`)
+	if (existsSync(opts.output)) rmSync(opts.output)
+
+	// Open the output DB and create the empty schema. We discover the schema from the FIRST input so
+	// the output mirrors source column ordering / types — `CREATE TABLE AS SELECT` flattens types
+	// to dynamic, which would break callers that rely on column-affinity behavior.
+	const out = new DatabaseSync(opts.output)
+	try {
+		const firstSource = new DatabaseSync(opts.inputs[0]!, { readOnly: true })
+		try {
+			progress("schema", "copying spr / names / geojson schemas from first input")
+			for (const table of COPIED_TABLES) {
+				const createSql = firstSource
+					.prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+					.get(table) as { sql?: string } | undefined
+				if (!createSql?.sql) {
+					throw new Error(`source DB ${opts.inputs[0]} is missing required table '${table}'`)
+				}
+				out.exec(createSql.sql)
+			}
+			// PRIMARY KEY on spr.id is in the schema we copied; explicit indexes on names.id /
+			// geojson.id help the per-id INSERT SELECT later. They're tiny — make them now even if
+			// the source DB shipped without them.
+			out.exec(`CREATE INDEX IF NOT EXISTS names_id_idx ON names(id);`)
+			out.exec(`CREATE INDEX IF NOT EXISTS geojson_id_idx ON geojson(id);`)
+		} finally {
+			firstSource.close()
+		}
+
+		// Pull rows from each input.
+		for (const inputPath of opts.inputs) {
+			copyFromSource(out, inputPath, countries, topLocalities, progress)
+		}
+
+		// Build the resolver virtual tables on the trimmed row set. We call buildPlaceSearchFts
+		// after all data is in place so place_population's geojson scan sees the merged geojson
+		// table, not a per-input partial.
+		progress("fts", "building place_search / place_bbox / place_population on slim DB")
+		buildPlaceSearchFts(out, {
+			drop: true, // schema we copied had no FTS tables, but be explicit
+			onProgress: (phase, name) => progress("fts", `${phase} ${name}`),
+		})
+
+		// geojson is only used during the BUILD phase (place_population extracts wof:population from
+		// it; FTS docs key off names, not geojson). Lookup.ts never reads it at query time. For a
+		// public demo bundle, geojson dominates the file size — admin-US polygons alone are >1 GB —
+		// while contributing nothing to query behavior. Drop it after the aux tables are built; the
+		// slim DB still resolves identically.
+		progress("vacuum", "dropping geojson table (build-time only; ~95% of file size)")
+		out.exec(`DROP INDEX IF EXISTS geojson_id_idx;`)
+		out.exec(`DROP TABLE IF EXISTS geojson;`)
+
+		// VACUUM the output so the on-disk file reflects just the trimmed row count. Without it the
+		// file size stays inflated from the in-flight INSERT churn.
+		progress("vacuum", "VACUUM (final size reduction)")
+		out.exec("VACUUM;")
+
+		const rowCounts = {
+			spr: countRows(out, "spr"),
+			names: countRows(out, "names"),
+			geojson: 0, // dropped above; reported as 0 for stability
+			placeSearch: countRows(out, PLACE_SEARCH_TABLE),
+			placeBbox: countRows(out, PLACE_BBOX_TABLE),
+			placePopulation: countRows(out, PLACE_POPULATION_TABLE),
+		}
+		progress("done", JSON.stringify(rowCounts))
+
+		return {
+			outputPath: opts.output,
+			outputBytes: statSync(opts.output).size,
+			rowCounts,
+		}
+	} finally {
+		out.close()
+	}
+}
+
+function copyFromSource(
+	out: DatabaseSync,
+	inputPath: string,
+	countries: string[],
+	topLocalities: number,
+	progress: NonNullable<BuildSlimOptions["onProgress"]>
+): void {
+	// ATTACH avoids any "load source into memory" step — SQLite walks both files in place. We need a
+	// fresh temp copy because some WOF distributions ship as read-only filesystem mounts and ATTACH
+	// will still want a writable journal on the side; copying to /tmp dodges that without mutating
+	// the canonical files in /mnt/playpen/mailwoman-data/wof/.
+	const tmpScratch = mkdtempSync(join(tmpdir(), "mailwoman-slim-src-"))
+	const scratchPath = join(tmpScratch, "src.db")
+	copyFileSync(inputPath, scratchPath)
+	try {
+		out.exec(`ATTACH DATABASE '${scratchPath.replace(/'/g, "''")}' AS src;`)
+		try {
+			const countriesList = countries.map((c) => `'${c.replace(/'/g, "''")}'`).join(",")
+			const ancestorList = ANCESTOR_PLACETYPES.map((p) => `'${p}'`).join(",")
+
+			// 1. Ancestor placetypes (country / region / county / etc.) — always-kept.
+			progress("country", `${inputPath}: ancestor placetypes in (${countries.join(",")})`)
+			out.exec(`
+				INSERT OR IGNORE INTO spr
+				SELECT * FROM src.spr
+				WHERE src.spr.is_current != 0
+					AND src.spr.is_deprecated = 0
+					AND src.spr.country IN (${countriesList})
+					AND src.spr.placetype IN (${ancestorList});
+			`)
+
+			// 2. Top-K localities by population. wof:population lives in the geojson body, so we
+			// rank via json_extract. The aux table on the source might or might not exist; rather
+			// than depending on it, use the raw geojson which always does.
+			progress("locality", `${inputPath}: top-${topLocalities} localities by population`)
+			out.exec(`
+				INSERT OR IGNORE INTO spr
+				SELECT s.* FROM src.spr s
+				LEFT JOIN src.geojson g ON g.id = s.id
+				WHERE s.is_current != 0
+					AND s.is_deprecated = 0
+					AND s.country IN (${countriesList})
+					AND s.placetype = 'locality'
+				ORDER BY COALESCE(
+					CAST(json_extract(g.body, '$.properties."wof:population"') AS INTEGER),
+					0
+				) DESC
+				LIMIT ${topLocalities};
+			`)
+
+			// 3. All postcodes in scope.
+			progress("postcode", `${inputPath}: all postcodes`)
+			out.exec(`
+				INSERT OR IGNORE INTO spr
+				SELECT * FROM src.spr
+				WHERE src.spr.is_current != 0
+					AND src.spr.is_deprecated = 0
+					AND src.spr.country IN (${countriesList})
+					AND src.spr.placetype = 'postalcode';
+			`)
+
+			// 4. Pull names / geojson for the IDs we just selected. Restrict to those IDs so we
+			// don't drag the full 4 GB geojson over.
+			progress("names", `${inputPath}: names rows for selected IDs`)
+			out.exec(`
+				INSERT OR IGNORE INTO names
+				SELECT n.* FROM src.names n
+				WHERE n.id IN (SELECT id FROM spr);
+			`)
+			progress("geojson", `${inputPath}: geojson rows for selected IDs`)
+			out.exec(`
+				INSERT OR IGNORE INTO geojson
+				SELECT g.* FROM src.geojson g
+				WHERE g.id IN (SELECT id FROM spr);
+			`)
+		} finally {
+			out.exec(`DETACH DATABASE src;`)
+		}
+	} finally {
+		rmSync(tmpScratch, { recursive: true, force: true })
+	}
+}
+
+function countRows(db: DatabaseSync, table: string): number {
+	const row = db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n?: number } | undefined
+	return Number(row?.n ?? 0)
+}

--- a/resolver-wof-sqlite/build-slim.ts
+++ b/resolver-wof-sqlite/build-slim.ts
@@ -27,12 +27,15 @@
  *   contributes everything else.
  */
 
+import { SqliteDialect } from "@mailwoman/core/kysley/dialect"
+import { Kysely, sql } from "kysely"
 import { copyFileSync, existsSync, mkdtempSync, rmSync, statSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { DatabaseSync } from "node:sqlite"
 
 import { buildPlaceSearchFts, PLACE_BBOX_TABLE, PLACE_POPULATION_TABLE, PLACE_SEARCH_TABLE } from "./fts.js"
+import type { GeojsonTable, NamesTable, SprTable } from "./schema.js"
 
 export interface BuildSlimOptions {
 	/** Input WOF SQLite distributions. Each should already have spr / names / geojson tables. */
@@ -80,7 +83,22 @@ const ANCESTOR_PLACETYPES = ["country", "region", "county", "borough", "macroreg
 /** Names of the tables we copy from each source DB. Anything outside this list is dropped. */
 const COPIED_TABLES = ["spr", "names", "geojson"] as const
 
-export function buildSlimWofDatabase(opts: BuildSlimOptions): BuildSlimResult {
+/**
+ * Kysely schema for the build phase. Mirrors {@link WofDatabase}, but adds the ATTACHed `src.*`
+ * tables so the row-copying queries can name the source schema in `selectFrom` without falling back
+ * to raw SQL. ATTACH itself is still raw — Kysely doesn't model it — but everything downstream (the
+ * SELECT-INSERT step that does the actual filtering work) goes through the builder.
+ */
+interface BuildSchema {
+	spr: SprTable
+	names: NamesTable
+	geojson: GeojsonTable
+	"src.spr": SprTable
+	"src.names": NamesTable
+	"src.geojson": GeojsonTable
+}
+
+export async function buildSlimWofDatabase(opts: BuildSlimOptions): Promise<BuildSlimResult> {
 	const countries = (opts.countries ?? ["US"]).map((c) => c.toUpperCase())
 	const topLocalities = opts.topLocalitiesPerCountry ?? 1000
 	const progress = opts.onProgress ?? (() => {})
@@ -92,9 +110,10 @@ export function buildSlimWofDatabase(opts: BuildSlimOptions): BuildSlimResult {
 	progress("init", `${opts.inputs.length} input(s) → ${opts.output}`)
 	if (existsSync(opts.output)) rmSync(opts.output)
 
-	// Open the output DB and create the empty schema. We discover the schema from the FIRST input so
-	// the output mirrors source column ordering / types — `CREATE TABLE AS SELECT` flattens types
-	// to dynamic, which would break callers that rely on column-affinity behavior.
+	// Open the output DB and create the empty schema. We discover the schema from the FIRST input
+	// (raw sqlite_master read — Kysely doesn't model that) so the output mirrors source column
+	// ordering / types. `CREATE TABLE AS SELECT` flattens types to dynamic, which would break
+	// callers that rely on column-affinity behavior.
 	const out = new DatabaseSync(opts.output)
 	try {
 		const firstSource = new DatabaseSync(opts.inputs[0]!, { readOnly: true })
@@ -110,17 +129,18 @@ export function buildSlimWofDatabase(opts: BuildSlimOptions): BuildSlimResult {
 				out.exec(createSql.sql)
 			}
 			// PRIMARY KEY on spr.id is in the schema we copied; explicit indexes on names.id /
-			// geojson.id help the per-id INSERT SELECT later. They're tiny — make them now even if
-			// the source DB shipped without them.
+			// geojson.id help the per-id INSERT SELECT later.
 			out.exec(`CREATE INDEX IF NOT EXISTS names_id_idx ON names(id);`)
 			out.exec(`CREATE INDEX IF NOT EXISTS geojson_id_idx ON geojson(id);`)
 		} finally {
 			firstSource.close()
 		}
 
+		const kysely = new Kysely<BuildSchema>({ dialect: new SqliteDialect({ database: out }) })
+
 		// Pull rows from each input.
 		for (const inputPath of opts.inputs) {
-			copyFromSource(out, inputPath, countries, topLocalities, progress)
+			await copyFromSource(out, kysely, inputPath, countries, topLocalities, progress)
 		}
 
 		// Build the resolver virtual tables on the trimmed row set. We call buildPlaceSearchFts
@@ -166,81 +186,105 @@ export function buildSlimWofDatabase(opts: BuildSlimOptions): BuildSlimResult {
 	}
 }
 
-function copyFromSource(
+async function copyFromSource(
 	out: DatabaseSync,
+	kysely: Kysely<BuildSchema>,
 	inputPath: string,
 	countries: string[],
 	topLocalities: number,
 	progress: NonNullable<BuildSlimOptions["onProgress"]>
-): void {
-	// ATTACH avoids any "load source into memory" step — SQLite walks both files in place. We need a
-	// fresh temp copy because some WOF distributions ship as read-only filesystem mounts and ATTACH
-	// will still want a writable journal on the side; copying to /tmp dodges that without mutating
-	// the canonical files in /mnt/playpen/mailwoman-data/wof/.
+): Promise<void> {
+	// ATTACH avoids any "load source into memory" step — SQLite walks both files in place. We need
+	// a fresh temp copy because some WOF distributions ship as read-only filesystem mounts and
+	// ATTACH will still want a writable journal on the side; copying to /tmp dodges that without
+	// mutating the canonical files in /mnt/playpen/mailwoman-data/wof/. ATTACH / DETACH stay raw
+	// — Kysely doesn't model them.
 	const tmpScratch = mkdtempSync(join(tmpdir(), "mailwoman-slim-src-"))
 	const scratchPath = join(tmpScratch, "src.db")
 	copyFileSync(inputPath, scratchPath)
 	try {
 		out.exec(`ATTACH DATABASE '${scratchPath.replace(/'/g, "''")}' AS src;`)
 		try {
-			const countriesList = countries.map((c) => `'${c.replace(/'/g, "''")}'`).join(",")
-			const ancestorList = ANCESTOR_PLACETYPES.map((p) => `'${p}'`).join(",")
+			// All four SELECT-INSERT queries below go through Kysely. The cross-schema FROM is the
+			// only "interesting" bit: by declaring `src.spr` / `src.names` / `src.geojson` in
+			// `BuildSchema`, Kysely lets us write `selectFrom("src.spr")` with the same column-type
+			// checking as the regular schema. SQLite parses the dotted identifier as a schema-name
+			// qualifier, so this works directly without any aliasing trick.
 
 			// 1. Ancestor placetypes (country / region / county / etc.) — always-kept.
 			progress("country", `${inputPath}: ancestor placetypes in (${countries.join(",")})`)
-			out.exec(`
-				INSERT OR IGNORE INTO spr
-				SELECT * FROM src.spr
-				WHERE src.spr.is_current != 0
-					AND src.spr.is_deprecated = 0
-					AND src.spr.country IN (${countriesList})
-					AND src.spr.placetype IN (${ancestorList});
-			`)
+			await kysely
+				.insertInto("spr")
+				.expression((eb) =>
+					eb
+						.selectFrom("src.spr")
+						.selectAll()
+						.where("is_current", "!=", 0)
+						.where("is_deprecated", "=", 0)
+						.where("country", "in", countries)
+						.where("placetype", "in", [...ANCESTOR_PLACETYPES])
+				)
+				.onConflict((oc) => oc.doNothing())
+				.execute()
 
 			// 2. Top-K localities by population. wof:population lives in the geojson body, so we
-			// rank via json_extract. The aux table on the source might or might not exist; rather
-			// than depending on it, use the raw geojson which always does.
+			// rank via json_extract. SQLite's json_extract isn't in Kysely's `eb.fn` catalog;
+			// `sql` template literal is the canonical escape hatch (same pattern lookup.ts uses
+			// for FTS5 MATCH).
 			progress("locality", `${inputPath}: top-${topLocalities} localities by population`)
-			out.exec(`
-				INSERT OR IGNORE INTO spr
-				SELECT s.* FROM src.spr s
-				LEFT JOIN src.geojson g ON g.id = s.id
-				WHERE s.is_current != 0
-					AND s.is_deprecated = 0
-					AND s.country IN (${countriesList})
-					AND s.placetype = 'locality'
-				ORDER BY COALESCE(
-					CAST(json_extract(g.body, '$.properties."wof:population"') AS INTEGER),
-					0
-				) DESC
-				LIMIT ${topLocalities};
-			`)
+			await kysely
+				.insertInto("spr")
+				.expression((eb) =>
+					eb
+						.selectFrom("src.spr as s")
+						.leftJoin("src.geojson as g", "g.id", "s.id")
+						.selectAll("s")
+						.where("s.is_current", "!=", 0)
+						.where("s.is_deprecated", "=", 0)
+						.where("s.country", "in", countries)
+						.where("s.placetype", "=", "locality")
+						.orderBy(
+							sql<number>`COALESCE(CAST(json_extract(g.body, '$.properties."wof:population"') AS INTEGER), 0)`,
+							"desc"
+						)
+						.limit(topLocalities)
+				)
+				.onConflict((oc) => oc.doNothing())
+				.execute()
 
 			// 3. All postcodes in scope.
 			progress("postcode", `${inputPath}: all postcodes`)
-			out.exec(`
-				INSERT OR IGNORE INTO spr
-				SELECT * FROM src.spr
-				WHERE src.spr.is_current != 0
-					AND src.spr.is_deprecated = 0
-					AND src.spr.country IN (${countriesList})
-					AND src.spr.placetype = 'postalcode';
-			`)
+			await kysely
+				.insertInto("spr")
+				.expression((eb) =>
+					eb
+						.selectFrom("src.spr")
+						.selectAll()
+						.where("is_current", "!=", 0)
+						.where("is_deprecated", "=", 0)
+						.where("country", "in", countries)
+						.where("placetype", "=", "postalcode")
+				)
+				.onConflict((oc) => oc.doNothing())
+				.execute()
 
 			// 4. Pull names / geojson for the IDs we just selected. Restrict to those IDs so we
 			// don't drag the full 4 GB geojson over.
 			progress("names", `${inputPath}: names rows for selected IDs`)
-			out.exec(`
-				INSERT OR IGNORE INTO names
-				SELECT n.* FROM src.names n
-				WHERE n.id IN (SELECT id FROM spr);
-			`)
+			await kysely
+				.insertInto("names")
+				.expression((eb) => eb.selectFrom("src.names").selectAll().where("id", "in", eb.selectFrom("spr").select("id")))
+				.onConflict((oc) => oc.doNothing())
+				.execute()
+
 			progress("geojson", `${inputPath}: geojson rows for selected IDs`)
-			out.exec(`
-				INSERT OR IGNORE INTO geojson
-				SELECT g.* FROM src.geojson g
-				WHERE g.id IN (SELECT id FROM spr);
-			`)
+			await kysely
+				.insertInto("geojson")
+				.expression((eb) =>
+					eb.selectFrom("src.geojson").selectAll().where("id", "in", eb.selectFrom("spr").select("id"))
+				)
+				.onConflict((oc) => oc.doNothing())
+				.execute()
 		} finally {
 			out.exec(`DETACH DATABASE src;`)
 		}

--- a/resolver-wof-sqlite/package.json
+++ b/resolver-wof-sqlite/package.json
@@ -26,7 +26,8 @@
 		"README.md"
 	],
 	"bin": {
-		"mailwoman-wof-build-fts": "./out/build-fts-cli.js"
+		"mailwoman-wof-build-fts": "./out/build-fts-cli.js",
+		"mailwoman-wof-build-slim": "./out/build-slim-cli.js"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4430,6 +4430,7 @@ __metadata:
     kysely: "npm:^0.29.2"
   bin:
     mailwoman-wof-build-fts: ./out/build-fts-cli.js
+    mailwoman-wof-build-slim: ./out/build-slim-cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

First deliverable for [Phase B (#98)](https://github.com/sister-software/mailwoman/issues/98) — the browser-side mailwoman demo. Adds a CLI + library that takes the 4 GB admin-US WOF distribution + the ~100 MB postcode shard and produces a **35 MB** drop-in replacement suitable for static-asset deployment.

## How

`buildSlimWofDatabase(opts)` in \`resolver-wof-sqlite/build-slim.ts\` + the \`mailwoman-wof-build-slim\` CLI:

- Copies the spr / names schemas from the first input.
- ATTACHes each input read-only, selects:
  - All ancestor placetypes (country / region / county / borough / macroregion) in scope.
  - Top-K localities by \`wof:population\` (default K = 1000).
  - All postcodes in scope.
  - All names + geojson rows for the selected IDs.
- Builds \`place_search\` (FTS5), \`place_bbox\` (R*Tree), \`place_population\` aux tables on the trimmed row set.
- **Drops the geojson table** at the end — it's only needed during the build (feeds \`place_population\` via \`json_extract\`); \`lookup.ts\` never reads it at query time, and it's ~95% of file size.
- VACUUMs.

\`WofSqlitePlaceLookup\` opens the slim DB without any code change — it sees a smaller universe, nothing more.

## Empirical results

Real build against \`/mnt/playpen/mailwoman-data/wof/whosonfirst-data-{admin,postalcode}-us-latest.db\`:

| | |
|---|---:|
| Input size | ~4.1 GB (admin) + ~100 MB (postcode) |
| Output size | **35 MB** |
| Localities kept | 1,000 (top by population) |
| Postcodes kept | 37,191 |
| Ancestor places | ~4,300 (counties / regions / country) |
| Names rows | 257,266 |
| Smoke-test query latency | <1 ms per query |

Selection sanity checks (smoke-tested manually):

| Query | Result |
|---|---|
| \`Chicago\` | ✓ resolves (top-K) |
| \`Springfield\` | ✓ resolves (multiple, incl. IL) |
| \`62701\` / \`60601\` | ✓ resolves (all postcodes kept) |
| \`New York\` | ✓ resolves (county + region survive ancestor pass) |
| \`Mascoutah\` | 0 hits (correctly absent — outside top 1000) |

## Test plan

- [x] \`yarn lint\` green
- [x] \`yarn ci:test\` 1325/1325 (4 new tests under \`build-slim.test.ts\`)
- [x] Real \`mailwoman-wof-build-slim\` run end-to-end against the production WOF distributions
- [x] Smoke-test slim DB through \`WofSqlitePlaceLookup\` — query latency sub-ms; expected hits + correct misses
- [ ] (Future) Re-run automatically via a Makefile target or CI artifact step

## Disclosure

Triaged and authored end-to-end by Claude Opus 4.7, under @teffenel's supervision. Operator approved the Phase B decomposition (#98) before implementation.