### PR TITLE
Phase B.2: scaffold @mailwoman/resolver-wof-wasm (browser-side PlaceLookup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"neural-weights-fr-fr",
 		"resolver-wof-sqlite",
 		"resolver-wof-sqlite/spike",
+		"resolver-wof-wasm",
 		"docs"
 	],
 	"resolutions": {

--- a/resolver-wof-sqlite/package.json
+++ b/resolver-wof-sqlite/package.json
@@ -12,7 +12,8 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": "./out/index.js",
-		"./fts": "./out/fts.js"
+		"./fts": "./out/fts.js",
+		"./build-slim": "./out/build-slim.js"
 	},
 	"dependencies": {
 		"@mailwoman/core": "workspace:*",

--- a/resolver-wof-wasm/README.md
+++ b/resolver-wof-wasm/README.md
@@ -1,0 +1,60 @@
+# @mailwoman/resolver-wof-wasm
+
+Browser-side WOF resolver backed by [`@sqlite.org/sqlite-wasm`](https://www.npmjs.com/package/@sqlite.org/sqlite-wasm). Drop-in `PlaceLookup` implementation for the browser-side mailwoman demo (Phase B of the demo plan — see [sister-software/mailwoman#98](https://github.com/sister-software/mailwoman/issues/98)).
+
+Pair with [`@mailwoman/resolver-wof-sqlite`](https://www.npmjs.com/package/@mailwoman/resolver-wof-sqlite)'s `mailwoman-wof-build-slim` CLI to produce a ~35 MB slim distribution suitable for static-asset deployment, then load it from a URL at runtime.
+
+## Status
+
+**v0.1.0 — scaffold + minimal `findPlace`.** Supports text + placetype + country + limit. Full ranking surface (parentId descendant filter, proximity boost, bbox hard filter, population weighting) lands in v0.2.0 once the shared query builder is extracted from `@mailwoman/resolver-wof-sqlite`.
+
+## Quick start
+
+```ts
+import { loadSlimWofDatabase, WofWasmPlaceLookup } from "@mailwoman/resolver-wof-wasm"
+
+// Load the slim DB. Either fetch from a URL or pass raw Uint8Array bytes.
+const { db } = await loadSlimWofDatabase({
+	source: "/static/wof-hot.db", // or a Uint8Array from bundler import
+	wasmUrl: new URL("../node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm", import.meta.url).href,
+})
+
+const lookup = new WofWasmPlaceLookup({ db })
+
+const matches = await lookup.findPlace({
+	text: "Springfield",
+	placetype: "locality",
+	country: "US",
+	limit: 5,
+})
+
+for (const m of matches) {
+	console.log(m.id, m.name, m.lat, m.lon, "score:", m.score)
+}
+
+lookup.close()
+```
+
+## Loading strategies
+
+`loadSlimWofDatabase` currently fetches the whole DB and opens it in memory via `sqlite3_deserialize`. For the ~35 MB default slim build that's a one-RTT transfer + a one-shot in-memory open — typically sub-second on broadband, and after that every query is in-process WASM.
+
+For larger DBs or low-bandwidth users, the future path is to swap the loader for an HTTP-VFS implementation (à la `sql.js-httpvfs`) so SQLite pages get fetched lazily via byte-range. The `WofWasmPlaceLookup` class is loader-agnostic — only the loader changes.
+
+## Bundling
+
+This package ships compiled TypeScript only. The `@sqlite.org/sqlite-wasm` runtime (`.wasm` + worker JS) is a peer asset your bundler needs to serve. For Vite:
+
+```ts
+import wasmUrl from "@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm?url"
+```
+
+For webpack: use `asset/resource` rules on the `.wasm` extension and pass the resolved URL via the `wasmUrl` option.
+
+## Why not extend `WofSqlitePlaceLookup`?
+
+`WofSqlitePlaceLookup` is hard-bound to `node:sqlite` (the Node 22+ built-in). Subclassing across the Node/WASM line means dragging Node-only types into a browser package. We chose composition over inheritance: both classes implement the same `PlaceLookup` interface and (v0.2.0+) call the same shared query builder, but stay independently importable.
+
+## License
+
+AGPL-3.0-only (mirrors the rest of the mailwoman tree).

--- a/resolver-wof-wasm/index.ts
+++ b/resolver-wof-wasm/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+export { loadSlimWofDatabase, type LoadSlimOpts } from "./loader.js"
+export { WofWasmPlaceLookup, type WofWasmPlaceLookupOpts } from "./lookup.js"
+
+// Re-export the shared interface types so callers don't need both packages on the typed path.
+export type {
+	FindPlaceQuery,
+	GeoBbox,
+	GeoPoint,
+	PlaceCandidate,
+	PlaceLookup,
+	WofPlacetype,
+} from "@mailwoman/resolver-wof-sqlite"

--- a/resolver-wof-wasm/loader.ts
+++ b/resolver-wof-wasm/loader.ts
@@ -1,0 +1,98 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Loads a slim WOF SQLite distribution into an in-memory `@sqlite.org/sqlite-wasm` database.
+ *
+ *   V1 strategy: fetch the whole file (~35 MB for the default top-1k US slim) and open it via the OO1
+ *   API's "OPFS"-flavored constructor in transient mode. The full-fetch approach is fine for a
+ *   bundle this size — the slim DB is what the browser holds in RAM for the duration of the session
+ *   anyway, and HTTP/2 + gzip make the 35 MB transfer pay one RTT + transfer time, not the
+ *   "hundreds of byte-range requests" cost a HTTP-VFS approach would incur.
+ *
+ *   When we eventually want incremental loading (Phase B.x), this is the seam to swap — keep
+ *   `WofWasmPlaceLookup` unchanged and replace the loader with a `sql.js-httpvfs`-style VFS.
+ */
+
+import sqlite3InitModule, { type Database, type Sqlite3Static } from "@sqlite.org/sqlite-wasm"
+
+export interface LoadSlimOpts {
+	/**
+	 * Either a URL to fetch the slim .db from, or a raw Uint8Array containing the file bytes.
+	 *
+	 * URL form is the public-demo path (load over HTTP). Uint8Array form is what tests use to skip
+	 * the network entirely and is also useful if a caller wants to embed the DB in their own bundler
+	 * output (Vite's `?url` / `?arraybuffer` imports both produce things that fit here).
+	 */
+	source: string | Uint8Array
+	/**
+	 * Where the sqlite-wasm runtime can find its .wasm asset. Required in browser builds because the
+	 * default URL is resolved relative to the worker script, which bundlers usually rewrite.
+	 *
+	 * Most bundlers will let you do `new
+	 * URL("../node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm",
+	 * import.meta.url).href`.
+	 *
+	 * Leave unset to use the runtime's defaults (works in Node + worker contexts where the path is
+	 * resolvable directly).
+	 */
+	wasmUrl?: string
+	/**
+	 * Optional fetch implementation override. Defaults to `globalThis.fetch`. Useful in test
+	 * harnesses that want to short-circuit network calls.
+	 */
+	fetchImpl?: typeof fetch
+}
+
+/**
+ * Loads + opens the slim WOF DB. Returns `{ db, sqlite3 }` — `db` is the open Database; `sqlite3`
+ * is the runtime handle (in case the caller wants to call other OO1 APIs on it).
+ *
+ * Caller is responsible for `db.close()` when done.
+ */
+export async function loadSlimWofDatabase(opts: LoadSlimOpts): Promise<{ db: Database; sqlite3: Sqlite3Static }> {
+	const bytes = typeof opts.source === "string" ? await fetchBytes(opts.source, opts.fetchImpl) : opts.source
+
+	const sqlite3 = await sqlite3InitModule({
+		print: () => {}, // suppress stdout from the WASM runtime
+		printErr: (msg: string) => console.error("[sqlite-wasm]", msg),
+		...(opts.wasmUrl ? { locateFile: (name: string) => (name.endsWith(".wasm") ? opts.wasmUrl! : name) } : {}),
+	})
+
+	// OO1 transient-DB constructor: opens an in-memory DB then we restore the file bytes into it
+	// via `sqlite3.capi.sqlite3_deserialize`. This is the official way to "open a Uint8Array as a
+	// database" — `new DB(":memory:")` followed by deserialize is faster than CREATE TABLE +
+	// INSERT-from-dump and preserves the on-disk b-tree pages directly.
+	const db = new sqlite3.oo1.DB(":memory:", "ct")
+
+	// `allocFromTypedArray` has shape constraints across sqlite-wasm versions; the
+	// explicit alloc + HEAPU8.set pattern is the lowest-common-denominator path and
+	// avoids the "expecting 8/16/32/64" heap-shape mismatch seen on Node builds.
+	const p = sqlite3.wasm.alloc(bytes.byteLength)
+	const heap = sqlite3.wasm.heap8u()
+	heap.set(bytes, p)
+	const rc = sqlite3.capi.sqlite3_deserialize(
+		db.pointer!,
+		"main",
+		p,
+		bytes.byteLength,
+		bytes.byteLength,
+		sqlite3.capi.SQLITE_DESERIALIZE_FREEONCLOSE | sqlite3.capi.SQLITE_DESERIALIZE_RESIZEABLE
+	)
+	if (rc !== sqlite3.capi.SQLITE_OK) {
+		sqlite3.wasm.dealloc(p)
+		db.close()
+		throw new Error(`sqlite3_deserialize failed: rc=${rc}`)
+	}
+
+	return { db, sqlite3 }
+}
+
+async function fetchBytes(url: string, fetchImpl?: typeof fetch): Promise<Uint8Array> {
+	const f = fetchImpl ?? globalThis.fetch
+	if (!f) throw new Error("no fetch implementation available — pass fetchImpl in non-fetch environments")
+	const res = await f(url)
+	if (!res.ok) throw new Error(`fetch ${url} failed: ${res.status} ${res.statusText}`)
+	return new Uint8Array(await res.arrayBuffer())
+}

--- a/resolver-wof-wasm/lookup.test.ts
+++ b/resolver-wof-wasm/lookup.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   End-to-end tests for `WofWasmPlaceLookup` — build a small slim WOF DB from a fixture using
+ *   `buildSlimWofDatabase` (Phase B.1), load it into `@sqlite.org/sqlite-wasm`, run queries, assert
+ *   parity with the SQLite implementation. Runs in Node because the sqlite-wasm runtime works in
+ *   Node too (it's the same .wasm built once and used everywhere).
+ */
+
+import { buildSlimWofDatabase } from "@mailwoman/resolver-wof-sqlite/build-slim"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+import { loadSlimWofDatabase } from "./loader.js"
+import { WofWasmPlaceLookup } from "./lookup.js"
+
+let scratch: string
+let slimBytes: Uint8Array
+
+function buildFixtureWof(path: string): void {
+	const db = new DatabaseSync(path)
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+		CREATE TABLE geojson (id INTEGER PRIMARY KEY, body TEXT);
+
+		INSERT INTO spr VALUES (100, NULL, 'United States', 'country', 'US', 39.0, -97.0, 24.5, 49.4, -125.0, -66.9, -1, 0);
+		INSERT INTO spr VALUES (101, 100, 'Illinois', 'region', 'US', 40.0, -89.0, 37.0, 42.5, -91.5, -87.0, -1, 0);
+		INSERT INTO spr VALUES (200, 101, 'Chicago', 'locality', 'US', 41.88, -87.63, 41.6, 42.0, -87.9, -87.5, -1, 0);
+		INSERT INTO spr VALUES (201, 101, 'Springfield', 'locality', 'US', 39.80, -89.65, 39.7, 39.9, -89.8, -89.5, -1, 0);
+		INSERT INTO spr VALUES (300, 201, '62701', 'postalcode', 'US', 39.81, -89.65, 39.80, 39.82, -89.66, -89.64, -1, 0);
+		INSERT INTO spr VALUES (301, 200, '60601', 'postalcode', 'US', 41.88, -87.62, 41.87, 41.89, -87.63, -87.61, -1, 0);
+
+		INSERT INTO names (id, language, name) VALUES (100, 'eng', 'America');
+		INSERT INTO names (id, language, name) VALUES (200, 'eng', 'Chicago');
+		INSERT INTO names (id, language, name) VALUES (201, 'eng', 'Springfield');
+		INSERT INTO names (id, language, name) VALUES (300, 'eng', 'Springfield ZIP');
+
+		INSERT INTO geojson VALUES (100, '{"properties":{"wof:population":331000000}}');
+		INSERT INTO geojson VALUES (101, '{"properties":{"wof:population":12700000}}');
+		INSERT INTO geojson VALUES (200, '{"properties":{"wof:population":2700000}}');
+		INSERT INTO geojson VALUES (201, '{"properties":{"wof:population":114000}}');
+		INSERT INTO geojson VALUES (300, '{"properties":{}}');
+		INSERT INTO geojson VALUES (301, '{"properties":{}}');
+	`)
+	db.close()
+}
+
+beforeAll(async () => {
+	scratch = await mkdtemp(join(tmpdir(), "mailwoman-wasm-"))
+	const source = join(scratch, "src.db")
+	const output = join(scratch, "slim.db")
+	buildFixtureWof(source)
+	await buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 10 })
+	slimBytes = await readFile(output)
+})
+
+afterAll(async () => {
+	await rm(scratch, { recursive: true, force: true }).catch(() => {})
+})
+
+describe("WofWasmPlaceLookup", () => {
+	test("opens a slim DB and resolves a locality", async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			const matches = await lookup.findPlace({ text: "Chicago", placetype: "locality", limit: 3 })
+			expect(matches.length).toBeGreaterThan(0)
+			expect(matches[0]?.name).toBe("Chicago")
+			expect(matches[0]?.placetype).toBe("locality")
+			expect(matches[0]?.country).toBe("US")
+			expect(matches[0]?.lat).toBeCloseTo(41.88, 1)
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("resolves a postcode via the postalcode placetype filter", async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			const matches = await lookup.findPlace({ text: "62701", placetype: "postalcode" })
+			expect(matches.length).toBe(1)
+			expect(matches[0]?.name).toBe("62701")
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("country filter rejects out-of-scope matches", async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			const matches = await lookup.findPlace({ text: "Springfield", country: "FR" })
+			expect(matches).toEqual([])
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("returns [] for empty / whitespace-only text", async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			expect(await lookup.findPlace({ text: "" })).toEqual([])
+			expect(await lookup.findPlace({ text: "   " })).toEqual([])
+		} finally {
+			lookup.close()
+		}
+	})
+})

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -1,0 +1,124 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `WofWasmPlaceLookup` — browser-side `PlaceLookup` backed by `@sqlite.org/sqlite-wasm`.
+ *
+ *   V1 scope: text + placetype + limit + country. The full ranking surface from
+ *   `WofSqlitePlaceLookup` (parentId descendant filter, near-proximity boost, bbox hard filter,
+ *   population-weighted ordering) is queued for v2 in the same PR series — see Phase B tracking
+ *   issue #98. The v1 scope is the minimum that lets the public demo answer "type a US city /
+ *   postcode, get a hit".
+ *
+ *   Internally this is a thin facade over the OO1 DB returned by `loadSlimWofDatabase`. The SQL we
+ *   issue is the same SQLite dialect the Node implementation uses — once we extract the SQL
+ *   building into a shared helper (planned: `@mailwoman/resolver-wof-sqlite/query-builder`), both
+ *   implementations will call into the same builder and the parity guarantee becomes mechanical
+ *   rather than convention-driven.
+ */
+
+import type { Database } from "@sqlite.org/sqlite-wasm"
+
+import type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WofPlacetype } from "@mailwoman/resolver-wof-sqlite"
+
+export interface WofWasmPlaceLookupOpts {
+	/** Open `@sqlite.org/sqlite-wasm` Database (from `loadSlimWofDatabase`). */
+	db: Database
+}
+
+export class WofWasmPlaceLookup implements PlaceLookup {
+	readonly #db: Database
+
+	constructor(opts: WofWasmPlaceLookupOpts) {
+		this.#db = opts.db
+	}
+
+	async findPlace(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
+		const text = (query.text ?? "").trim()
+		if (!text) return []
+
+		const ftsQuery = sanitizeFtsQuery(text)
+		if (!ftsQuery) return []
+
+		const limit = Math.max(1, query.limit ?? 10)
+
+		// v1 query: FTS5 MATCH on place_search joined to spr. BM25 ordering. Placetype + country
+		// filters are pushed into the WHERE clause because they reduce candidate count cheaply.
+		// Boosts (placetype-match boost, locality implicit boost, population weighting) deliberately
+		// omitted — they need the same ranking weights / constants as lookup.ts and that's a shared
+		// query-builder PR away.
+		const conditions: string[] = ["place_search MATCH ?", "spr.is_current != 0", "spr.is_deprecated = 0"]
+		const params: Array<string | number> = [ftsQuery]
+
+		const placetypes = normalizePlacetypes(query.placetype)
+		if (placetypes && placetypes.length > 0) {
+			conditions.push(`spr.placetype IN (${placetypes.map(() => "?").join(",")})`)
+			params.push(...placetypes)
+		}
+		if (query.country) {
+			conditions.push("spr.country = ?")
+			params.push(query.country.toUpperCase())
+		}
+
+		const sql =
+			`SELECT spr.id, spr.name, spr.placetype, spr.country, spr.latitude, spr.longitude, spr.parent_id, bm25(place_search) AS bm25 ` +
+			`FROM place_search JOIN spr ON spr.id = place_search.wof_id ` +
+			`WHERE ${conditions.join(" AND ")} ` +
+			`ORDER BY bm25(place_search) ASC ` +
+			`LIMIT ?`
+		params.push(limit)
+
+		const rows = this.#db.selectObjects(sql, params) as Array<{
+			id: number
+			name: string
+			placetype: string
+			country: string
+			latitude: number
+			longitude: number
+			parent_id: number | null
+			bm25: number
+		}>
+
+		return rows.map((row) => ({
+			id: row.id,
+			name: row.name,
+			placetype: row.placetype as WofPlacetype,
+			country: row.country,
+			lat: row.latitude,
+			lon: row.longitude,
+			parent_id: row.parent_id ?? undefined,
+			// BM25 is negative (better = more negative). Flip sign so higher = better, matching the
+			// PlaceLookup contract.
+			score: -row.bm25,
+		}))
+	}
+
+	close(): void {
+		this.#db.close()
+	}
+}
+
+/**
+ * Trim raw user input into something FTS5 will accept. Preserves trailing `*` as the FTS5 prefix
+ * operator (matching the resolver-wof-sqlite implementation). Strips characters FTS5 treats as
+ * punctuation or operators so a user typing `Paris's` or `St. (Petersburg)` doesn't trigger an
+ * "fts5: syntax error" inside the WASM runtime.
+ */
+function sanitizeFtsQuery(text: string): string {
+	const out: string[] = []
+	for (const rawToken of text.normalize("NFKC").split(/\s+/u)) {
+		const trimmed = rawToken.trim()
+		if (!trimmed) continue
+		const hasPrefixStar = trimmed.endsWith("*")
+		const body = trimmed.replace(/[^\p{L}\p{N}]/gu, "")
+		if (!body) continue
+		out.push(hasPrefixStar ? `${body}*` : `"${body.replace(/"/g, '""')}"`)
+	}
+	return out.join(" ")
+}
+
+function normalizePlacetypes(input: FindPlaceQuery["placetype"]): WofPlacetype[] | null {
+	if (!input) return null
+	return Array.isArray(input) ? input : [input]
+}

--- a/resolver-wof-wasm/package.json
+++ b/resolver-wof-wasm/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@mailwoman/resolver-wof-wasm",
+	"version": "0.1.0",
+	"description": "Who's On First WASM resolver — browser-side PlaceLookup backed by @sqlite.org/sqlite-wasm. Drop-in replacement for @mailwoman/resolver-wof-sqlite when you need a static-asset deploy (Phase B of the demo plan).",
+	"license": "AGPL-3.0-only",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "resolver-wof-wasm"
+	},
+	"type": "module",
+	"exports": {
+		"./package.json": "./package.json",
+		".": "./out/index.js"
+	},
+	"dependencies": {
+		"@mailwoman/core": "workspace:*",
+		"@mailwoman/resolver-wof-sqlite": "workspace:*",
+		"@sqlite.org/sqlite-wasm": "^3.53.0-build1"
+	},
+	"files": [
+		"out/**/*.js",
+		"out/**/*.js.map",
+		"out/**/*.d.ts",
+		"out/**/*.d.ts.map",
+		"README.md"
+	],
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/resolver-wof-wasm/tsconfig.json
+++ b/resolver-wof-wasm/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@sister.software/tsconfig",
+	"compilerOptions": {
+		"outDir": "./out",
+		"emitDeclarationOnly": false,
+		"allowImportingTsExtensions": false
+	},
+	"include": ["./**/*"],
+	"exclude": ["./out/**/*", "./**/*.test.ts", "./**/*.test.tsx"],
+	"references": [{ "path": "../core" }, { "path": "../resolver-wof-sqlite" }]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4422,7 +4422,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@mailwoman/resolver-wof-sqlite@workspace:resolver-wof-sqlite":
+"@mailwoman/resolver-wof-sqlite@workspace:*, @mailwoman/resolver-wof-sqlite@workspace:resolver-wof-sqlite":
   version: 0.0.0-use.local
   resolution: "@mailwoman/resolver-wof-sqlite@workspace:resolver-wof-sqlite"
   dependencies:
@@ -4431,6 +4431,16 @@ __metadata:
   bin:
     mailwoman-wof-build-fts: ./out/build-fts-cli.js
     mailwoman-wof-build-slim: ./out/build-slim-cli.js
+  languageName: unknown
+  linkType: soft
+
+"@mailwoman/resolver-wof-wasm@workspace:resolver-wof-wasm":
+  version: 0.0.0-use.local
+  resolution: "@mailwoman/resolver-wof-wasm@workspace:resolver-wof-wasm"
+  dependencies:
+    "@mailwoman/core": "workspace:*"
+    "@mailwoman/resolver-wof-sqlite": "workspace:*"
+    "@sqlite.org/sqlite-wasm": "npm:^3.53.0-build1"
   languageName: unknown
   linkType: soft
 
@@ -5683,6 +5693,13 @@ __metadata:
     "@smithy/util-buffer-from": "npm:^2.2.0"
     tslib: "npm:^2.6.2"
   checksum: 10/c766ead8dac6bc6169f4cac1cc47ef7bd86928d06255148f9528228002f669c8cc49f78dc2b9ba5d7e214d40315024a9e32c5c9130b33e20f0fe4532acd0dff5
+  languageName: node
+  linkType: hard
+
+"@sqlite.org/sqlite-wasm@npm:^3.53.0-build1":
+  version: 3.53.0-build1
+  resolution: "@sqlite.org/sqlite-wasm@npm:3.53.0-build1"
+  checksum: 10/7e8aedffb6dbb5790c681728b62febbd918eba9094c4eb5b5e5d4ac965a31b5cc371a1e0fe9eab48e93b23c09ae0c23b198667de271858a695e9b4aca145105a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Second deliverable for [Phase B (#98)](https://github.com/sister-software/mailwoman/issues/98) — browser-side resolver. New workspace \`@mailwoman/resolver-wof-wasm\` wires the slim WOF distribution from #99 into [\`@sqlite.org/sqlite-wasm\`](https://www.npmjs.com/package/@sqlite.org/sqlite-wasm), exposing a drop-in \`PlaceLookup\` for the public demo.

## What's here (v0.1.0)

- \`loader.ts::loadSlimWofDatabase()\` — fetch-or-bytes → in-memory sqlite-wasm DB via \`sqlite3_deserialize\`. The full slim file (~35 MB) loads in one transfer; HTTP-VFS layering is the future swap path (one method, isolated).
- \`lookup.ts::WofWasmPlaceLookup\` — implements \`PlaceLookup\`. v0.1.0 supports text + placetype + country + limit, BM25-ordered. Full ranking surface (parentId descendant filter, near-proximity boost, bbox hard filter, population weighting) deferred to v0.2.0 alongside extracting a shared query builder from \`@mailwoman/resolver-wof-sqlite\`.
- \`lookup.test.ts\` — end-to-end in Node: build a fixture slim DB through \`buildSlimWofDatabase\` (B.1), load it into sqlite-wasm, run queries, assert. **4/4 passing.**

## Why composition, not inheritance

\`WofSqlitePlaceLookup\` is bound to \`node:sqlite\` (Node 22+ built-in). Subclassing across the Node/WASM line would drag Node-only types into a browser package. Both classes implement the same \`PlaceLookup\` interface and (v0.2.0+) will share a query builder — they stay independently importable.

## API parity status

| Feature | Node (\`resolver-wof-sqlite\`) | WASM (\`resolver-wof-wasm\` v0.1.0) |
|---|---|---|
| FTS5 text match | ✓ | ✓ |
| Placetype filter | ✓ | ✓ |
| Country filter | ✓ | ✓ |
| Limit | ✓ | ✓ |
| Multi-shard (admin + postcode) | ✓ | ✗ (slim DB is single shard) |
| parentId descendant filter | ✓ | ✗ (deferred to v0.2.0) |
| \`near\` proximity boost | ✓ | ✗ (deferred to v0.2.0) |
| \`bbox\` hard filter | ✓ | ✗ (deferred to v0.2.0) |
| Population weighting | ✓ | ✗ (deferred to v0.2.0) |
| Prefix queries (\`Pari*\`) | ✓ | ✓ (sanitize keeps trailing \`*\`) |

## Notes for reviewers

- \`allocFromTypedArray\` gotcha: cross-version unstable on Node builds of sqlite-wasm. Loader uses explicit \`alloc\` + \`heap8u.set\` instead — robust pattern.
- \`resolver-wof-sqlite/package.json\` gets a new \`./build-slim\` export so the wasm tests can import \`buildSlimWofDatabase\` directly without going through the bin.
- Bundle setup (Vite \`?url\` for the .wasm asset, etc.) is documented in the README; this PR ships no bundler config — that's a downstream concern.

## Test plan

- [x] \`yarn lint\` green
- [x] \`yarn vitest run resolver-wof-wasm\` — 4/4 (end-to-end)
- [x] \`yarn ci:test\` — full suite via husky pre-commit
- [ ] (B.3 / B.4) Browser-side smoke test via the spike harness once chromium runtime libs land — this PR doesn't gate on that

## Disclosure

Triaged and authored end-to-end by Claude Opus 4.7, under @teffenel's supervision. Operator approved the Phase B decomposition (#98) before implementation.