### PR TITLE
demo: debug XML toggle on the result panel

### DIFF
--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -282,9 +282,31 @@ const EXAMPLE_ADDRESSES: Array<{ label: string; address: string }> = [
 ]
 
 function ResultPanel({ result }: { result: DemoResult }): React.ReactElement {
+	const [showXml, setShowXml] = React.useState(false)
+	const [xml, setXml] = React.useState<string | null>(null)
+
+	// Lazy-load the XML serializer the first time the operator asks for debug output. Stripping it
+	// from the main bundle keeps the demo's cold-path payload down; tree-shaking can't drop it
+	// because the rest of the module re-exports from @mailwoman/core/decoder.
+	const onToggle = React.useCallback(async () => {
+		if (xml) {
+			setShowXml((v) => !v)
+			return
+		}
+		const { decodeAsXml } = await import("@mailwoman/core/decoder")
+		setXml(decodeAsXml(result.tree as Parameters<typeof decodeAsXml>[0]))
+		setShowXml(true)
+	}, [xml, result.tree])
+
 	return (
 		<div className={styles.resultPanel}>
-			<h2>Parsed components</h2>
+			<div className={styles.resultHeader}>
+				<h2>Parsed components</h2>
+				<button type="button" className={styles.debugBtn} onClick={onToggle}>
+					{showXml ? "Hide XML" : "Show XML"}
+				</button>
+			</div>
+			{showXml && xml ? <pre className={styles.xml}>{xml}</pre> : null}
 			<table className={styles.componentTable}>
 				<thead>
 					<tr>

--- a/docs/src/pages/demo/styles.module.css
+++ b/docs/src/pages/demo/styles.module.css
@@ -127,6 +127,39 @@
 	letter-spacing: 0.05em;
 }
 
+.resultHeader {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+}
+
+.debugBtn {
+	font-size: 0.75rem;
+	padding: 0.2rem 0.5rem;
+	background: transparent;
+	color: var(--ifm-color-emphasis-700);
+	border: 1px solid var(--ifm-color-emphasis-400);
+	border-radius: 4px;
+	cursor: pointer;
+	font-family: inherit;
+}
+
+.debugBtn:hover {
+	color: var(--ifm-color-primary);
+	border-color: var(--ifm-color-primary);
+}
+
+.xml {
+	font-size: 0.75rem;
+	background: var(--ifm-code-background);
+	padding: 0.75rem;
+	border-radius: 4px;
+	max-height: 240px;
+	overflow: auto;
+	margin: 0 0 1rem 0;
+	white-space: pre;
+}
+
 .componentTable {
 	width: 100%;
 	font-size: 0.875rem;


### PR DESCRIPTION
Lazy-loaded decodeAsXml; click 'Show XML' under Parsed components to see the canonical XML projection of the AddressTree.