### PR TITLE
demo: scope primary-button styling to the form

### DIFF
--- a/docs/src/pages/demo/styles.module.css
+++ b/docs/src/pages/demo/styles.module.css
@@ -54,7 +54,11 @@
 	opacity: 0.5;
 }
 
-.controls button {
+/* Scope the primary submit-button styling to the form so secondary buttons (example chips, debug
+ * toggle) keep their own visual weight. Without this scope, `.controls button` outranked the more
+ * specific `.exampleBtn` selector via SVN (0,1,1 vs 0,1,0) and example buttons rendered as
+ * filled primary buttons — misleading the visual hierarchy. */
+.controls form button {
 	padding: 0.5rem 0.75rem;
 	background: var(--ifm-color-primary);
 	color: white;
@@ -64,7 +68,7 @@
 	cursor: pointer;
 }
 
-.controls button:disabled {
+.controls form button:disabled {
 	background: var(--ifm-color-emphasis-400);
 	cursor: not-allowed;
 }

--- a/resolver-wof-sqlite/spike/demo-mobile-test.mjs
+++ b/resolver-wof-sqlite/spike/demo-mobile-test.mjs
@@ -1,0 +1,48 @@
+/**
+ * Mobile-viewport smoke for https://mailwoman.sister.software/demo/. Emulates iPhone 12 + a desktop
+ * viewport, screenshots both, checks for layout overflow.
+ */
+
+import { chromium, devices } from "playwright"
+
+const url = process.argv[2] ?? "https://mailwoman.sister.software/demo/"
+
+const browser = await chromium.launch({ headless: true })
+
+const cases = [
+	{ name: "mobile", device: devices["iPhone 12"] },
+	{ name: "desktop", viewport: { width: 1280, height: 800 } },
+]
+
+for (const c of cases) {
+	const ctx = await browser.newContext(c.device ? c.device : { viewport: c.viewport })
+	const page = await ctx.newPage()
+	console.log(`\n=== ${c.name} ===`)
+	await page.goto(url, { waitUntil: "networkidle", timeout: 120_000 })
+	await page.waitForFunction(
+		() => {
+			const btn = document.querySelector("button[type='submit']")
+			return btn && !btn.disabled
+		},
+		{ timeout: 120_000 }
+	)
+	// Capture document overflow.
+	const overflow = await page.evaluate(() => {
+		const docW = document.documentElement.scrollWidth
+		const viewW = document.documentElement.clientWidth
+		return { docW, viewW, horizontalScroll: docW > viewW }
+	})
+	console.log(
+		`document width ${overflow.docW}px / viewport ${overflow.viewW}px — horizontal scroll: ${overflow.horizontalScroll}`
+	)
+	const mapBox = await page.locator("section >> nth=1").boundingBox()
+	const ctrlBox = await page.locator("section >> nth=0").boundingBox()
+	console.log(`controls: ${JSON.stringify(ctrlBox)}`)
+	console.log(`map: ${JSON.stringify(mapBox)}`)
+	const screenshot = `/tmp/demo-${c.name}.png`
+	await page.screenshot({ path: screenshot, fullPage: true })
+	console.log(`screenshot → ${screenshot}`)
+	await ctx.close()
+}
+
+await browser.close()


### PR DESCRIPTION
Bugfix — example chips were inheriting the primary submit-button style; scoping the rule to `.controls form button` restores the muted secondary look.