### PR TITLE
demo: protomaps theme + marker CSS + bbox boundary + lookup cascade

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,7 @@
 		"clsx": "^2.1.1",
 		"maplibre-gl": "^5.0.0",
 		"prism-react-renderer": "^2.4.1",
+		"protomaps-themes-base": "^4.5.0",
 		"react": "^19.2.6",
 		"react-dom": "^19.2.6"
 	},

--- a/docs/src/pages/demo/_cartography.ts
+++ b/docs/src/pages/demo/_cartography.ts
@@ -1,0 +1,164 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Ported from sister-software/isp-nexus's `cartographer` module (under the same AGPL terms).
+ *   Provides:
+ *
+ *   - `MailwomanDarkTheme` — the Nexus dark Protomaps palette (suitable for dark-mode pages).
+ *   - `MailwomanLightTheme` — protomaps-themes-base's default `light` (no Nexus light theme exists).
+ *   - `buildMapStyle(theme)` — composes a full MapLibre style with self-hosted glyphs + sprites
+ *
+ *       - Terrain DEM source + sky spec.
+ *
+ *   Self-hosting: glyphs + sprites are served from public.sister.software/protomaps/* so the demo
+ *   doesn't depend on protomaps.github.io's static-site availability.
+ */
+
+import * as protomapsThemes from "protomaps-themes-base"
+
+const SOURCE_NAME = "protomaps"
+const TILE_URL = "https://tiles.sister.software/basemap/{z}/{x}/{y}.mvt"
+const GLYPHS_URL = "https://public.sister.software/protomaps/fonts/{fontstack}/{range}.pbf"
+const SPRITE_URL_BASE = "https://public.sister.software/protomaps/sprites/v3"
+const TERRAIN_SOURCE = "terrain"
+const TERRAIN_URL = "https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png"
+const ATTRIBUTION = '<a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>'
+
+export type MapTheme = "light" | "dark"
+
+/** Nexus dark theme — full Protomaps palette in HSL dark tones. */
+const MailwomanDarkTheme: Parameters<typeof protomapsThemes.layersWithCustomTheme>[1] = {
+	background: "hsl(0deg 10% 5%)",
+	earth: "hsl(0deg 10% 5%)",
+	park_a: "hsl(120deg 45.75% 1%)",
+	park_b: "hsl(120deg 65.75% 10%)",
+	hospital: "#252424",
+	industrial: "#222222",
+	school: "#262323",
+	wood_a: "#202121",
+	wood_b: "#202121",
+	pedestrian: "#1e1e1e",
+	scrub_a: "#222323",
+	scrub_b: "#222323",
+	glacier: "#1c1c1c",
+	sand: "#212123",
+	beach: "hsl(44.24deg 100% 20% / 0.1)",
+	aerodrome: "#1e1e1e",
+	runway: "#333333",
+	water: "hsl(194deg 100% 10%)",
+	pier: "#222222",
+	zoo: "#222323",
+	military: "#242323",
+	tunnel_other_casing: "#141414",
+	tunnel_minor_casing: "#141414",
+	tunnel_link_casing: "#141414",
+	tunnel_medium_casing: "#141414",
+	tunnel_major_casing: "#141414",
+	tunnel_highway_casing: "#141414",
+	tunnel_other: "#292929",
+	tunnel_minor: "#292929",
+	tunnel_link: "#292929",
+	tunnel_medium: "#292929",
+	tunnel_major: "#292929",
+	tunnel_highway: "#292929",
+	transit_pier: "#333333",
+	buildings: "#111111",
+	minor_service_casing: "#1f1f1f",
+	minor_casing: "#1f1f1f",
+	link_casing: "#1f1f1f",
+	medium_casing: "#1f1f1f",
+	major_casing_late: "#1f1f1f",
+	highway_casing_late: "#1f1f1f",
+	other: "#333333",
+	minor_service: "#333333",
+	minor_a: "#3d3d3d",
+	minor_b: "#333333",
+	link: "#3d3d3d",
+	medium: "#3d3d3d",
+	major_casing_early: "#1f1f1f",
+	major: "#3d3d3d",
+	highway_casing_early: "#1f1f1f",
+	highway: "hsl(36deg 10% 50%)",
+	railway: "#000000",
+	boundaries: "hsl(240deg 100% 90%)",
+	waterway_label: "#717784",
+	bridges_other_casing: "#2b2b2b",
+	bridges_minor_casing: "#1f1f1f",
+	bridges_link_casing: "#1f1f1f",
+	bridges_medium_casing: "#1f1f1f",
+	bridges_major_casing: "#1f1f1f",
+	bridges_highway_casing: "#1f1f1f",
+	bridges_other: "#333333",
+	bridges_minor: "#333333",
+	bridges_link: "#3d3d3d",
+	bridges_medium: "#3d3d3d",
+	bridges_major: "#3d3d3d",
+	bridges_highway: "#474747",
+	roads_label_minor: "hsl(240deg 100% 90%)",
+	roads_label_minor_halo: "#1f1f1f",
+	roads_label_major: "hsl(240deg 100% 90%)",
+	roads_label_major_halo: "#1f1f1f",
+	ocean_label: "#717784",
+	peak_label: "#898080",
+	subplace_label: "hsl(50deg 50% 70%)",
+	subplace_label_halo: "hsl(40deg 100% 10%)",
+	city_label: "hsl(50deg 100% 90%)",
+	city_label_halo: "hsl(240deg 100% 10%)",
+	state_label: "hsl(240deg 100% 90%)",
+	state_label_halo: "#1f1f1f",
+	country_label: "hsl(240deg 50% 80% / 0.5)",
+}
+
+/**
+ * Compose a MapLibre style. Light mode uses protomaps-themes-base's stock `light` theme; dark mode
+ * uses the ported Nexus palette via `layersWithCustomTheme`. Terrain DEM source (Mapzen's
+ * publicly-hosted terrarium tiles on AWS S3) is wired in so callers can toggle 3D terrain via
+ * map.setTerrain({ source: "terrain", exaggeration: 1 }).
+ */
+export function buildMapStyle(theme: MapTheme): unknown {
+	const layers =
+		theme === "dark"
+			? protomapsThemes.layersWithCustomTheme(SOURCE_NAME, MailwomanDarkTheme, "en")
+			: protomapsThemes.default(SOURCE_NAME, theme, "en")
+
+	return {
+		version: 8,
+		glyphs: GLYPHS_URL,
+		sprite: `${SPRITE_URL_BASE}/${theme}`,
+		sky: {
+			"sky-color": theme === "dark" ? "#000535" : "#9bcef0",
+			"horizon-color": theme === "dark" ? "hsl(54deg 100% 16%)" : "#dfe6ed",
+			"fog-color": theme === "dark" ? "hsl(54deg 100% 5%)" : "#ffffff",
+			"sky-horizon-blend": 0.75,
+			"horizon-fog-blend": 0.75,
+			"fog-ground-blend": 0.1,
+		},
+		sources: {
+			[SOURCE_NAME]: {
+				type: "vector",
+				tiles: [TILE_URL],
+				maxzoom: 15,
+				attribution: ATTRIBUTION,
+			},
+			[TERRAIN_SOURCE]: {
+				type: "raster-dem",
+				encoding: "terrarium",
+				tiles: [TERRAIN_URL],
+				tileSize: 256,
+				maxzoom: 15,
+			},
+		},
+		layers,
+	}
+}
+
+/**
+ * Read the current map theme from Docusaurus's `data-theme` attribute on <html>. Returns "light"
+ * when unset / SSR — initial render matches the light default until the client hydrates.
+ */
+export function currentMapTheme(): MapTheme {
+	if (typeof document === "undefined") return "light"
+	return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
+}

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -22,6 +22,9 @@
 
 import BrowserOnly from "@docusaurus/BrowserOnly"
 import Layout from "@theme/Layout"
+// MapLibre's marker / control / popup positioning depends on the bundled stylesheet. Without it,
+// .maplibregl-marker collapses to a zero-sized inline element and the SVG never paints.
+import "maplibre-gl/dist/maplibre-gl.css"
 import React from "react"
 
 import styles from "./styles.module.css"
@@ -102,9 +105,10 @@ function DemoApp(): React.ReactElement {
 
 				if (cancelled) return
 				if (mapContainerRef.current) {
+					const style = await buildMapStyle(currentMapTheme())
 					const map = new maplibre.Map({
 						container: mapContainerRef.current,
-						style: buildMapStyle(currentMapTheme()),
+						style: style as maplibre.StyleSpecification,
 						center: [-95.7129, 37.0902],
 						zoom: 3,
 						attributionControl: false,
@@ -143,10 +147,12 @@ function DemoApp(): React.ReactElement {
 	React.useEffect(() => {
 		if (typeof document === "undefined") return
 		const observer = new MutationObserver(() => {
-			const map = mapRef.current as { setStyle?: (s: unknown) => void } | null
-			if (map?.setStyle) {
-				map.setStyle(buildMapStyle(currentMapTheme()))
-			}
+			const map = mapRef.current as MaplibreMapLike | null
+			if (!map?.setStyle) return
+			void (async () => {
+				const style = await buildMapStyle(currentMapTheme())
+				map.setStyle?.(style)
+			})()
 		})
 		observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
 		return () => observer.disconnect()
@@ -190,26 +196,19 @@ function DemoApp(): React.ReactElement {
 				}
 
 				let resolved: ResolvedHit | null = null
-				const queryString =
-					(postcodeNode?.value as string | undefined) ?? (localityNode?.value as string | undefined) ?? text
-				const placetype: "locality" | "postalcode" | undefined = postcodeNode
-					? "postalcode"
-					: localityNode
-						? "locality"
-						: undefined
-				const candidates = await wofLookup.findPlace({
-					text: queryString,
-					placetype,
-					country: "US",
-					limit: 5,
-				})
-				// Clear any stale marker from a prior submit before deciding whether to drop a new one —
-				// otherwise a "Pier 39" lookup followed by an unresolvable address would leave the SF
-				// marker hovering over a mismatched input.
+				// Cascade: postcode first (most precise), fall back to locality if the postcode hit lacks
+				// usable coords (WOF ships ~22% of US postcodes with placeholder lat=0/lon=0 — postcode
+				// 20500 is one of them, ironically the White House). Final fallback: the raw input string,
+				// which lets the FTS5 index pick up whatever placename it can.
+				const candidates = await runCascade(wofLookup, postcodeNode, localityNode, text)
+				// Clear any stale marker + bbox from a prior submit before deciding whether to draw a new
+				// one — otherwise a "Pier 39" lookup followed by an unresolvable address would leave the
+				// SF marker hovering over a mismatched input.
 				if (markerRef.current) {
 					;(markerRef.current as { remove: () => void }).remove()
 					markerRef.current = null
 				}
+				if (mapRef.current) clearBbox(mapRef.current as MaplibreMapLike)
 
 				if (candidates.length > 0) {
 					const best = candidates[0]!
@@ -220,20 +219,30 @@ function DemoApp(): React.ReactElement {
 						lat: best.lat,
 						lon: best.lon,
 						score: best.score,
+						bbox: best.bbox,
 					}
 					// Drop a fresh marker + fly to the resolved coords.
 					const maplibre = await import("maplibre-gl")
 					if (mapRef.current && resolved) {
-						type MapLike = {
-							flyTo: (opts: { center: [number, number]; zoom: number }) => void
-							getCenter: () => unknown
-						}
-						const map = mapRef.current as MapLike
-						const marker = new maplibre.Marker({ color: "#e0367c" })
-							.setLngLat([resolved.lon, resolved.lat])
-							.addTo(map as unknown as maplibre.Map)
+						const map = mapRef.current as MaplibreMapLike & maplibre.Map
+						const marker = new maplibre.Marker({ color: "#e0367c" }).setLngLat([resolved.lon, resolved.lat]).addTo(map)
 						markerRef.current = marker
-						map.flyTo({ center: [resolved.lon, resolved.lat], zoom: 10 })
+						// If the lookup returned a bbox AND it's non-trivial (postcodes can be tiny —
+						// fit-bounds zooms way too far in), use fitBounds so the operator sees the whole
+						// place extent. Otherwise just flyTo the centroid with a reasonable city-level zoom.
+						const b = resolved.bbox
+						if (b && Math.max(b.maxLat - b.minLat, b.maxLon - b.minLon) > 0.001) {
+							drawBbox(map, b)
+							map.fitBounds?.(
+								[
+									[b.minLon, b.minLat],
+									[b.maxLon, b.maxLat],
+								],
+								{ padding: 40 }
+							)
+						} else {
+							map.flyTo?.({ center: [resolved.lon, resolved.lat], zoom: 12 })
+						}
 					}
 				}
 
@@ -396,6 +405,7 @@ interface MailwomanLookupLike {
 			lat: number
 			lon: number
 			score: number
+			bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
 		}>
 	>
 }
@@ -414,121 +424,159 @@ interface ResolvedHit {
 	lat: number
 	lon: number
 	score: number
+	bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
 }
 
-/**
- * Color palettes for the synthesized MapLibre style. Light + dark variants match Docusaurus's
- * data-theme; the page-level hook below swaps map.setStyle() when the operator toggles theme.
- */
-const MAP_PALETTES = {
-	light: {
-		background: "#f7f5f0",
-		earth: "#fafaf7",
-		water: "#cfdfec",
-		landuse: "#eef0e3",
-		roadsMajor: "#d0c8b8",
-		roadsMinor: "#e0d8c8",
-		boundaries: "#9aa0a6",
-	},
-	dark: {
-		background: "#1a1d22",
-		earth: "#23272d",
-		water: "#1d2a3a",
-		landuse: "#2a2e35",
-		roadsMajor: "#52576a",
-		roadsMinor: "#3a3f4a",
-		boundaries: "#6a7280",
-	},
-} as const
+type MapTheme = "light" | "dark"
 
-type MapTheme = keyof typeof MAP_PALETTES
+const SOURCE_NAME = "protomaps"
+const TILE_URL = "https://tiles.sister.software/basemap/{z}/{x}/{y}.mvt"
+const GLYPHS_URL = "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf"
+const SPRITE_URL_BASE = "https://protomaps.github.io/basemaps-assets/sprites/v4"
+const ATTRIBUTION = '<a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>'
 
 /**
- * Build a minimal MapLibre style document pointing at the Protomaps basemap vector tiles served by
- * `tiles.sister.software`. The host endpoint exposes only TileJSON (data-source metadata), not a
- * full MapLibre style — so we synthesize one here with the layers we care about for an address
- * demo. Visual styling stays deliberately plain so the marker pops.
+ * Build a full MapLibre style by composing the upstream protomaps-themes-base layers (which ship
+ * city / state / road labels for free) over our own tile source. Returns a Promise because the
+ * themes package is dynamically imported to keep the cold-path bundle small.
  */
-function buildMapStyle(theme: MapTheme = "light"): unknown {
-	const p = MAP_PALETTES[theme]
-	const tileUrl = "https://tiles.sister.software/basemap/{z}/{x}/{y}.mvt"
-	const attribution =
-		'<a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>'
+async function buildMapStyle(theme: MapTheme): Promise<unknown> {
+	const themes = await import("protomaps-themes-base")
+	const layers = themes.default(SOURCE_NAME, theme, "en")
 	return {
 		version: 8,
-		glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
+		glyphs: GLYPHS_URL,
+		sprite: `${SPRITE_URL_BASE}/${theme}`,
 		sources: {
-			protomaps: {
+			[SOURCE_NAME]: {
 				type: "vector",
-				tiles: [tileUrl],
+				tiles: [TILE_URL],
 				maxzoom: 15,
-				attribution,
+				attribution: ATTRIBUTION,
 			},
 		},
-		layers: [
-			{ id: "background", type: "background", paint: { "background-color": p.background } },
-			{
-				id: "earth",
-				type: "fill",
-				source: "protomaps",
-				"source-layer": "earth",
-				paint: { "fill-color": p.earth },
-			},
-			{
-				id: "water",
-				type: "fill",
-				source: "protomaps",
-				"source-layer": "water",
-				paint: { "fill-color": p.water },
-			},
-			{
-				id: "landuse",
-				type: "fill",
-				source: "protomaps",
-				"source-layer": "landuse",
-				minzoom: 4,
-				paint: { "fill-color": p.landuse, "fill-opacity": 0.5 },
-			},
-			{
-				id: "roads-major",
-				type: "line",
-				source: "protomaps",
-				"source-layer": "roads",
-				minzoom: 5,
-				filter: ["in", "pmap:kind", "highway", "major_road"],
-				paint: { "line-color": p.roadsMajor, "line-width": ["interpolate", ["linear"], ["zoom"], 5, 0.5, 14, 3] },
-			},
-			{
-				id: "roads-minor",
-				type: "line",
-				source: "protomaps",
-				"source-layer": "roads",
-				minzoom: 11,
-				paint: { "line-color": p.roadsMinor, "line-width": ["interpolate", ["linear"], ["zoom"], 11, 0.3, 16, 1.5] },
-			},
-			{
-				id: "boundaries",
-				type: "line",
-				source: "protomaps",
-				"source-layer": "boundaries",
-				paint: {
-					"line-color": p.boundaries,
-					"line-width": ["interpolate", ["linear"], ["zoom"], 0, 0.4, 6, 0.8],
-					"line-dasharray": [2, 2],
-				},
-			},
-		],
+		layers,
 	}
 }
 
 /**
- * Read the current map theme from Docusaurus's `data-theme` attribute on <html>. We can't use
- * `useColorMode` here because this file runs at module scope before any hook can be called; the
- * effect-driven swap below handles the dynamic side.
+ * Read the current map theme from Docusaurus's `data-theme` attribute on <html>. Returns "light"
+ * when unset / SSR — initial render matches the light default until the client hydrates.
  */
 function currentMapTheme(): MapTheme {
 	if (typeof document === "undefined") return "light"
 	return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
+}
+
+const BBOX_SOURCE = "mailwoman-bbox"
+const BBOX_FILL_LAYER = "mailwoman-bbox-fill"
+const BBOX_LINE_LAYER = "mailwoman-bbox-line"
+
+/**
+ * Draw / update a rectangle showing the resolved place's bounding box on the map. The slim WOF
+ * distribution ships bbox columns on `spr` but not the full polygon geometry — bbox is the best
+ * outline we can render without re-shipping the 1.5 GB geojson table.
+ */
+function drawBbox(
+	map: MaplibreMapLike,
+	bbox: { minLat: number; maxLat: number; minLon: number; maxLon: number }
+): void {
+	const ring: Array<[number, number]> = [
+		[bbox.minLon, bbox.minLat],
+		[bbox.maxLon, bbox.minLat],
+		[bbox.maxLon, bbox.maxLat],
+		[bbox.minLon, bbox.maxLat],
+		[bbox.minLon, bbox.minLat],
+	]
+	const geojson = {
+		type: "FeatureCollection" as const,
+		features: [
+			{
+				type: "Feature" as const,
+				geometry: { type: "Polygon" as const, coordinates: [ring] },
+				properties: {},
+			},
+		],
+	}
+	const existing = map.getSource?.(BBOX_SOURCE)
+	if (existing && typeof (existing as { setData?: unknown }).setData === "function") {
+		;(existing as { setData: (g: unknown) => void }).setData(geojson)
+		return
+	}
+	map.addSource?.(BBOX_SOURCE, { type: "geojson", data: geojson })
+	map.addLayer?.({
+		id: BBOX_FILL_LAYER,
+		type: "fill",
+		source: BBOX_SOURCE,
+		paint: { "fill-color": "#e0367c", "fill-opacity": 0.12 },
+	})
+	map.addLayer?.({
+		id: BBOX_LINE_LAYER,
+		type: "line",
+		source: BBOX_SOURCE,
+		paint: { "line-color": "#e0367c", "line-width": 2 },
+	})
+}
+
+function clearBbox(map: MaplibreMapLike): void {
+	if (map.getLayer?.(BBOX_FILL_LAYER)) map.removeLayer?.(BBOX_FILL_LAYER)
+	if (map.getLayer?.(BBOX_LINE_LAYER)) map.removeLayer?.(BBOX_LINE_LAYER)
+	if (map.getSource?.(BBOX_SOURCE)) map.removeSource?.(BBOX_SOURCE)
+}
+
+interface MaplibreMapLike {
+	flyTo?: (opts: { center: [number, number]; zoom: number }) => void
+	fitBounds?: (bounds: [[number, number], [number, number]], opts?: { padding?: number }) => void
+	getSource?: (id: string) => unknown
+	addSource?: (id: string, source: unknown) => void
+	addLayer?: (layer: unknown) => void
+	removeLayer?: (id: string) => void
+	removeSource?: (id: string) => void
+	getLayer?: (id: string) => unknown
+	setStyle?: (style: unknown) => void
+	on?: (event: string, cb: () => void) => void
+}
+
+type ParsedNode = { tag: string; value?: unknown; confidence?: number }
+
+/**
+ * Try increasingly broad WOF queries until something with usable coords surfaces. Drops (lat=0,
+ * lon=0) hits — WOF carries placeholder zeros on ~22% of US postcodes (including 20500), so the raw
+ * "best BM25 hit" is sometimes geographically meaningless.
+ */
+async function runCascade(
+	lookup: MailwomanLookupLike,
+	postcodeNode: ParsedNode | undefined,
+	localityNode: ParsedNode | undefined,
+	rawText: string
+): Promise<Awaited<ReturnType<MailwomanLookupLike["findPlace"]>>> {
+	const usable = (
+		cs: Awaited<ReturnType<MailwomanLookupLike["findPlace"]>>
+	): Awaited<ReturnType<MailwomanLookupLike["findPlace"]>> => cs.filter((c) => !(c.lat === 0 && c.lon === 0))
+
+	if (postcodeNode?.value) {
+		const cs = usable(
+			await lookup.findPlace({
+				text: String(postcodeNode.value),
+				placetype: "postalcode",
+				country: "US",
+				limit: 5,
+			})
+		)
+		if (cs.length > 0) return cs
+	}
+	if (localityNode?.value) {
+		const cs = usable(
+			await lookup.findPlace({
+				text: String(localityNode.value),
+				placetype: "locality",
+				country: "US",
+				limit: 5,
+			})
+		)
+		if (cs.length > 0) return cs
+	}
+	return usable(await lookup.findPlace({ text: rawText, country: "US", limit: 5 }))
 }
 
 /** Walk the AddressTree, returning a flat list of leaf component nodes. */

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -27,6 +27,7 @@ import Layout from "@theme/Layout"
 import "maplibre-gl/dist/maplibre-gl.css"
 import React from "react"
 
+import { buildMapStyle, currentMapTheme } from "./_cartography"
 import styles from "./styles.module.css"
 
 export default function DemoPage(): React.ReactElement {
@@ -105,7 +106,7 @@ function DemoApp(): React.ReactElement {
 
 				if (cancelled) return
 				if (mapContainerRef.current) {
-					const style = await buildMapStyle(currentMapTheme())
+					const style = buildMapStyle(currentMapTheme())
 					const map = new maplibre.Map({
 						container: mapContainerRef.current,
 						style: style as maplibre.StyleSpecification,
@@ -115,6 +116,15 @@ function DemoApp(): React.ReactElement {
 					})
 					map.addControl(new maplibre.AttributionControl({ compact: true }))
 					mapRef.current = map
+					// Wire 3D terrain once the style + DEM source are loaded.
+					map.on("load", () => {
+						try {
+							map.setTerrain({ source: "terrain", exaggeration: 1 })
+						} catch {
+							// Some browsers / WebGL contexts reject terrain (no GL_OES_element_index_uint, etc.);
+							// fall through to flat rendering rather than breaking the page.
+						}
+					})
 				}
 
 				if (cancelled) return
@@ -149,10 +159,7 @@ function DemoApp(): React.ReactElement {
 		const observer = new MutationObserver(() => {
 			const map = mapRef.current as MaplibreMapLike | null
 			if (!map?.setStyle) return
-			void (async () => {
-				const style = await buildMapStyle(currentMapTheme())
-				map.setStyle?.(style)
-			})()
+			map.setStyle(buildMapStyle(currentMapTheme()))
 		})
 		observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] })
 		return () => observer.disconnect()
@@ -425,47 +432,6 @@ interface ResolvedHit {
 	lon: number
 	score: number
 	bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
-}
-
-type MapTheme = "light" | "dark"
-
-const SOURCE_NAME = "protomaps"
-const TILE_URL = "https://tiles.sister.software/basemap/{z}/{x}/{y}.mvt"
-const GLYPHS_URL = "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf"
-const SPRITE_URL_BASE = "https://protomaps.github.io/basemaps-assets/sprites/v4"
-const ATTRIBUTION = '<a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>'
-
-/**
- * Build a full MapLibre style by composing the upstream protomaps-themes-base layers (which ship
- * city / state / road labels for free) over our own tile source. Returns a Promise because the
- * themes package is dynamically imported to keep the cold-path bundle small.
- */
-async function buildMapStyle(theme: MapTheme): Promise<unknown> {
-	const themes = await import("protomaps-themes-base")
-	const layers = themes.default(SOURCE_NAME, theme, "en")
-	return {
-		version: 8,
-		glyphs: GLYPHS_URL,
-		sprite: `${SPRITE_URL_BASE}/${theme}`,
-		sources: {
-			[SOURCE_NAME]: {
-				type: "vector",
-				tiles: [TILE_URL],
-				maxzoom: 15,
-				attribution: ATTRIBUTION,
-			},
-		},
-		layers,
-	}
-}
-
-/**
- * Read the current map theme from Docusaurus's `data-theme` attribute on <html>. Returns "light"
- * when unset / SSR — initial render matches the light default until the client hydrates.
- */
-function currentMapTheme(): MapTheme {
-	if (typeof document === "undefined") return "light"
-	return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
 }
 
 const BBOX_SOURCE = "mailwoman-bbox"

--- a/resolver-wof-sqlite/types.ts
+++ b/resolver-wof-sqlite/types.ts
@@ -63,6 +63,13 @@ export interface PlaceCandidate {
 	 * mean zero, just unknown.
 	 */
 	population?: number
+	/**
+	 * Bounding box from WOF's `spr.{min,max}_{latitude,longitude}` columns. Coarse outline for the
+	 * place — a city's bbox is the city's full extent, a postcode's is roughly the postcode polygon's
+	 * envelope. Optional because not all callers ask for it; implementations are free to omit when
+	 * the underlying schema lacks the columns.
+	 */
+	bbox?: GeoBbox
 }
 
 /**

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -62,7 +62,8 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 		}
 
 		const sql =
-			`SELECT spr.id, spr.name, spr.placetype, spr.country, spr.latitude, spr.longitude, spr.parent_id, bm25(place_search) AS bm25 ` +
+			`SELECT spr.id, spr.name, spr.placetype, spr.country, spr.latitude, spr.longitude, spr.parent_id, ` +
+			`spr.min_latitude, spr.max_latitude, spr.min_longitude, spr.max_longitude, bm25(place_search) AS bm25 ` +
 			`FROM place_search JOIN spr ON spr.id = place_search.wof_id ` +
 			`WHERE ${conditions.join(" AND ")} ` +
 			`ORDER BY bm25(place_search) ASC ` +
@@ -77,6 +78,10 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 			latitude: number
 			longitude: number
 			parent_id: number | null
+			min_latitude: number | null
+			max_latitude: number | null
+			min_longitude: number | null
+			max_longitude: number | null
 			bm25: number
 		}>
 
@@ -88,6 +93,15 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 			lat: row.latitude,
 			lon: row.longitude,
 			parent_id: row.parent_id ?? undefined,
+			bbox:
+				row.min_latitude != null && row.max_latitude != null && row.min_longitude != null && row.max_longitude != null
+					? {
+							minLat: row.min_latitude,
+							maxLat: row.max_latitude,
+							minLon: row.min_longitude,
+							maxLon: row.max_longitude,
+						}
+					: undefined,
 			// BM25 is negative (better = more negative). Flip sign so higher = better, matching the
 			// PlaceLookup contract.
 			score: -row.bm25,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5270,6 +5270,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     maplibre-gl: "npm:^5.0.0"
     prism-react-renderer: "npm:^2.4.1"
+    protomaps-themes-base: "npm:^4.5.0"
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
     typescript: "npm:^6.0.3"
@@ -18680,6 +18681,13 @@ __metadata:
   version: 2.0.2
   resolution: "protocols@npm:2.0.2"
   checksum: 10/031cc068eb800468a50eb7c1e1c528bf142fb8314f5df9b9ea3c3f9df1697a19f97b9915b1229cef694d156812393172d9c3051ef7878d26eaa8c6faa5cccec4
+  languageName: node
+  linkType: hard
+
+"protomaps-themes-base@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "protomaps-themes-base@npm:4.5.0"
+  checksum: 10/9dc8a2089414494b43d62ccfb5ae641aeea8f31e4ceaab2cc2ba56c3d9b333374b05f0c428c6fff74abcfd0e452c3e1d1925beea44787857da8f525d71495a02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Operator-reported polish: maplibre CSS for marker rendering, protomaps-themes-base for labels, bbox rectangle for resolved place (slim WOF dropped geojson but kept bbox columns on spr), cascade for placeholder-coord postcodes.