### PR TITLE
feat(#55): state-hi-schools adapter — XLSX ingest

### DIFF
--- a/corpus/scripts/fetch-sources/README.md
+++ b/corpus/scripts/fetch-sources/README.md
@@ -28,13 +28,14 @@ single executable place.
 
 ## Coverage
 
-| Script                   | Sources                                                                             | License tier               |
-| ------------------------ | ----------------------------------------------------------------------------------- | -------------------------- |
-| `fetch-hrsa.sh`          | HRSA Health Center Service Delivery Sites (federal)                                 | A (US PD)                  |
-| `fetch-imls-pls.sh`      | IMLS Public Libraries Survey — outlet-level (~17K library branches, FY 2023)        | A (US PD)                  |
-| `fetch-nppes.sh`         | NPPES NPI registry — full monthly dissemination (~7M provider venue+address rows)   | A (US PD)                  |
-| `fetch-state-sources.sh` | NY/TX/DE/OR notaries, IA contractors, WA health providers, HI schools, HI lobbyists | A (state PD-equivalent)    |
-| `fetch-openaddresses.sh` | OpenAddresses country collections (default: Canada / `ca`)                          | B/C mixed — per-row filter |
+| Script                      | Sources                                                                           | License tier               |
+| --------------------------- | --------------------------------------------------------------------------------- | -------------------------- |
+| `fetch-hrsa.sh`             | HRSA Health Center Service Delivery Sites (federal)                               | A (US PD)                  |
+| `fetch-imls-pls.sh`         | IMLS Public Libraries Survey — outlet-level (~17K library branches, FY 2023)      | A (US PD)                  |
+| `fetch-nppes.sh`            | NPPES NPI registry — full monthly dissemination (~7M provider venue+address rows) | A (US PD)                  |
+| `fetch-state-sources.sh`    | NY/TX/DE/OR notaries, IA contractors, WA health providers, HI lobbyists           | A (state PD-equivalent)    |
+| `fetch-state-hi-schools.sh` | Hawaii DOE school directory (XLSX → CSV via openpyxl)                             | A (state PD-equivalent)    |
+| `fetch-openaddresses.sh`    | OpenAddresses country collections (default: Canada / `ca`)                        | B/C mixed — per-row filter |
 
 License tiers per `docs/licensing-strategy.md` (or the playpen knowledge base
 mirror at `docs/docs/projects/mailwoman/licensing-strategy.md`). Sources here

--- a/corpus/scripts/fetch-sources/fetch-state-hi-schools.sh
+++ b/corpus/scripts/fetch-sources/fetch-state-hi-schools.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Re-fetch the Hawaii State DOE school directory and convert the XLSX workbook
+# to a flat CSV the `state-hi-schools` adapter can consume.
+#
+# Upstream is a single XLSX (~64 KB) with two sheets — `HIDOE` (~258 district
+# schools) and `PCS` (~38 public charter schools). Both sheets share the same
+# header. This script concatenates them under one shared header so the adapter
+# can stream a single CSV.
+#
+# License: Hawaii state government open data (Tier A — state PD-equivalent).
+#
+# Usage:
+#   OUT_ROOT=/mnt/playpen/mailwoman-data/corpus/sources \
+#     packages/corpus/scripts/fetch-sources/fetch-state-hi-schools.sh
+#
+# Defaults to writing under ./data/corpus/sources/ in the repo root.
+# Idempotent: if dest CSV exists and sha matches MANIFEST, skips download.
+#
+# Dependencies (operator-side):
+#   - curl (download)
+#   - python3 with `openpyxl` (XLSX → CSV)
+#     • Debian/Ubuntu:  sudo apt-get install -y python3-openpyxl
+#     • macOS Homebrew: brew install python && pip3 install openpyxl
+
+set -euo pipefail
+
+SOURCE_URL="https://www.hawaiipublicschools.org/DOE%20Forms/SchoolList.xlsx"
+SLUG="state-hi-schools"
+CSV_FILENAME="HI_Public_Schools_List.csv"
+XLSX_FILENAME="HI_Public_Schools_List.xlsx"
+
+OUT_ROOT=${OUT_ROOT:-"$(git rev-parse --show-toplevel)/data/corpus/sources"}
+dest_dir="$OUT_ROOT/$SLUG"
+mkdir -p "$dest_dir"
+
+xlsx_dest="$dest_dir/$XLSX_FILENAME"
+csv_dest="$dest_dir/$CSV_FILENAME"
+manifest="$dest_dir/MANIFEST.json"
+
+echo "=== $SLUG"
+
+# ------------------------------------------------------------------
+# Idempotency: skip if CSV exists and sha matches recorded MANIFEST.
+# ------------------------------------------------------------------
+if [ -f "$manifest" ] && [ -f "$csv_dest" ]; then
+	recorded_sha=$(python3 -c "import json; print(json.load(open('$manifest')).get('sha256',''))" 2>/dev/null || true)
+	recorded_file=$(python3 -c "import json; print(json.load(open('$manifest')).get('filename',''))" 2>/dev/null || true)
+	if [ -n "$recorded_sha" ] && [ "$recorded_file" = "$CSV_FILENAME" ]; then
+		actual_sha=$(sha256sum "$csv_dest" | awk '{print $1}')
+		if [ "$actual_sha" = "$recorded_sha" ]; then
+			echo "  ✓ Already current (sha256 matches MANIFEST) — skipping download."
+			exit 0
+		fi
+	fi
+fi
+
+# ------------------------------------------------------------------
+# Preflight: openpyxl must be importable.
+# ------------------------------------------------------------------
+if ! python3 -c "import openpyxl" >/dev/null 2>&1; then
+	cat >&2 <<'MSG'
+  ✗ python3 with the `openpyxl` package is required to convert the HIDOE XLSX.
+    Debian/Ubuntu:  sudo apt-get install -y python3-openpyxl
+    macOS Homebrew: brew install python && pip3 install openpyxl
+MSG
+	exit 1
+fi
+
+# ------------------------------------------------------------------
+# Download XLSX
+# ------------------------------------------------------------------
+echo "  Downloading $SOURCE_URL ..."
+curl -fsSL --max-time 600 -o "$xlsx_dest" "$SOURCE_URL" \
+	|| { echo "  ✗ Download failed" >&2; exit 1; }
+
+xlsx_size=$(stat -c '%s' "$xlsx_dest" 2>/dev/null || stat -f '%z' "$xlsx_dest")
+echo "  Downloaded XLSX: $(numfmt --to=iec "$xlsx_size" 2>/dev/null || echo "$xlsx_size bytes")"
+
+if [ "$xlsx_size" -lt 1024 ]; then
+	echo "  ✗ Response too small ($xlsx_size bytes) — probable error page" >&2
+	exit 1
+fi
+
+# ------------------------------------------------------------------
+# Convert XLSX → CSV (concatenate both sheets under one shared header).
+# ------------------------------------------------------------------
+echo "  Converting XLSX → CSV (concatenating sheets) ..."
+python3 - "$xlsx_dest" "$csv_dest" <<'PY'
+import csv
+import sys
+from openpyxl import load_workbook
+
+xlsx_path, csv_path = sys.argv[1], sys.argv[2]
+wb = load_workbook(xlsx_path, data_only=True, read_only=True)
+
+with open(csv_path, "w", newline="", encoding="utf-8") as out:
+    writer = csv.writer(out)
+    shared_header = None
+    total_data_rows = 0
+    for sheet_name in wb.sheetnames:
+        ws = wb[sheet_name]
+        rows = ws.iter_rows(values_only=True)
+        try:
+            header = next(rows)
+        except StopIteration:
+            continue
+        norm_header = ["" if v is None else str(v).strip() for v in header]
+        if shared_header is None:
+            shared_header = norm_header
+            writer.writerow(shared_header)
+        elif norm_header != shared_header:
+            print(
+                f"  ! sheet '{sheet_name}' header diverges from shared header; concatenating anyway",
+                file=sys.stderr,
+            )
+        for row in rows:
+            if row is None:
+                continue
+            # Skip fully-empty rows (XLSX iter_rows can yield phantom trailing rows).
+            if all(v is None or (isinstance(v, str) and not v.strip()) for v in row):
+                continue
+            writer.writerow(["" if v is None else str(v).strip() for v in row])
+            total_data_rows += 1
+
+print(f"  converted {total_data_rows} data rows from {len(wb.sheetnames)} sheets", file=sys.stderr)
+PY
+
+csv_size=$(stat -c '%s' "$csv_dest" 2>/dev/null || stat -f '%z' "$csv_dest")
+csv_sha=$(sha256sum "$csv_dest" | awk '{print $1}')
+
+# ------------------------------------------------------------------
+# Remove XLSX (CSV is the canonical artifact the adapter consumes).
+# ------------------------------------------------------------------
+rm -f "$xlsx_dest"
+echo "  Removed XLSX (CSV kept)"
+
+# ------------------------------------------------------------------
+# Write MANIFEST
+# ------------------------------------------------------------------
+cat >"$manifest" <<EOF
+{
+  "source_url": "$SOURCE_URL",
+  "downloaded_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "filename": "$CSV_FILENAME",
+  "sha256": "$csv_sha",
+  "bytes": $csv_size,
+  "notes": "Converted from XLSX (sheets HIDOE + PCS concatenated under shared header)."
+}
+EOF
+
+echo "  ✓ $(numfmt --to=iec "$csv_size" 2>/dev/null || echo "$csv_size bytes")  sha256=$csv_sha"
+echo "  MANIFEST written to $manifest"

--- a/corpus/scripts/fetch-sources/fetch-state-sources.sh
+++ b/corpus/scripts/fetch-sources/fetch-state-sources.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Re-fetch the state-level open-data sources tonight's adhoc download pulled
-# (NY/TX/DE/OR notaries, IA contractors, WA health providers, HI schools,
-# HI lobbyists). Reproducible recovery if /mnt/playpen/mailwoman-data is lost.
+# (NY/TX/DE/OR notaries, IA contractors, WA health providers, HI lobbyists).
+# Reproducible recovery if /mnt/playpen/mailwoman-data is lost.
+#
+# HI public schools is fetched separately by `fetch-state-hi-schools.sh` —
+# its upstream is an XLSX workbook that requires an openpyxl-driven
+# sheet-concatenation pre-step before the adapter can consume it.
 #
 # Each source lands in its own subdirectory of $OUT_ROOT/$source_slug/ along
 # with a MANIFEST.json recording origin URL + download timestamp + sha256 so
@@ -26,7 +30,6 @@ SOURCES=(
 	"state-ia-contractors|IA_Active_Construction_Contractor_Registrations.csv|https://data.iowa.gov/api/views/dpf3-iz94/rows.csv?accessType=DOWNLOAD"
 	"state-wa-health-providers|WA_Health_Care_Provider_Credential_Data.csv|https://data.wa.gov/api/views/qxh8-f4bd/rows.csv?accessType=DOWNLOAD"
 	"state-hi-lobbyists|HI_Lobbyist_Registration_Statements.csv|https://data.hawaii.gov/api/views/cm7c-skav/rows.csv?accessType=DOWNLOAD"
-	"state-hi-schools|HI_Public_Schools_List.xlsx|https://www.hawaiipublicschools.org/DOE%20Forms/SchoolList.xlsx"
 )
 
 fetched=0

--- a/corpus/src/adapters/index.ts
+++ b/corpus/src/adapters/index.ts
@@ -24,6 +24,7 @@ import type { CorpusAdapter } from "../types.js"
 import { banAdapter } from "./ban/adapter.js"
 import { fccBdcAdapter } from "./fcc-bdc/adapter.js"
 import { openaddressesAdapter } from "./openaddresses/adapter.js"
+import { stateHiSchoolsAdapter } from "./state-hi-schools/adapter.js"
 import { stateIaContractorsAdapter } from "./state-ia-contractors/adapter.js"
 import { stateNyNotariesAdapter } from "./state-ny-notaries/adapter.js"
 import { stateTxNotariesAdapter } from "./state-tx-notaries/adapter.js"
@@ -56,6 +57,7 @@ export const BUILTIN_ADAPTERS: readonly CorpusAdapter[] = [
 	stateIaContractorsAdapter,
 	stateTxNotariesAdapter,
 	stateNyNotariesAdapter,
+	stateHiSchoolsAdapter,
 ]
 
 for (const adapter of BUILTIN_ADAPTERS) {
@@ -71,6 +73,11 @@ export {
 	OPENADDRESSES_DEFAULT_LICENSE,
 	openaddressesAdapter,
 } from "./openaddresses/adapter.js"
+export {
+	STATE_HI_SCHOOLS_ADAPTER_ID,
+	STATE_HI_SCHOOLS_DEFAULT_LICENSE,
+	stateHiSchoolsAdapter,
+} from "./state-hi-schools/adapter.js"
 export {
 	STATE_IA_CONTRACTORS_ADAPTER_ID,
 	STATE_IA_CONTRACTORS_DEFAULT_LICENSE,

--- a/corpus/src/adapters/state-hi-schools/README.md
+++ b/corpus/src/adapters/state-hi-schools/README.md
@@ -1,0 +1,19 @@
+# state-hi-schools
+
+Hawaii State Department of Education K-12 school directory adapter.
+
+## Input
+
+The operator pre-builds a CSV via `corpus/scripts/fetch-sources/fetch-state-hi-schools.sh`. The script downloads the official `SchoolList.xlsx` workbook and concatenates both sheets (`HIDOE` — district-operated schools, `PCS` — public charter schools) into a single flat CSV that shares the workbook's lowercased header (`code,name,address,city,zip,...`).
+
+## Output
+
+One `CanonicalRow` per school (~300 statewide). `venue` is the school name; the address quad `(house_number?, street, locality, region=HI, postcode)` is parsed from the single-line `address` column. `source_id` is `state-hi-schools-<code>` where `<code>` is the HIDOE numeric school identifier.
+
+Hawaii's hyphenated residential numbering (Oahu Windward `47-470 Hui Aeko Place`, Kauai `2-4035 Kaumualii Hwy`) is preserved verbatim by the shared `HOUSE_NUMBER_PREFIX` regex.
+
+The workbook's `island` and `district` columns are HIDOE administrative labels (not US counties) and are intentionally dropped — the canonical `subregion` slot is left empty.
+
+## License
+
+`Public Domain` per Hawaii state government open-data terms. Source: <https://www.hawaiipublicschools.org/DOE%20Forms/SchoolList.xlsx>.

--- a/corpus/src/adapters/state-hi-schools/adapter.test.ts
+++ b/corpus/src/adapters/state-hi-schools/adapter.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { beforeEach, describe, expect, it } from "vitest"
+import { InMemoryAdapterRegistry } from "../../adapter.js"
+import {
+	createStateHiSchoolsAdapter,
+	STATE_HI_SCHOOLS_ADAPTER_ID,
+	STATE_HI_SCHOOLS_DEFAULT_LICENSE,
+} from "./adapter.js"
+
+const CSV_HEADER = [
+	"code",
+	"name",
+	"address",
+	"city",
+	"zip",
+	"phone",
+	"fax",
+	"principal",
+	"grade_from",
+	"grade_to",
+	"type",
+	"website",
+	"complex",
+	"complex_area",
+	"district",
+	"island",
+	"charter",
+].join(",")
+
+let scratch: string
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "mailwoman-hi-schools-"))
+})
+
+function writeCsv(...lines: string[]): string {
+	const p = join(scratch, "test.csv")
+	const header = CSV_HEADER + "\n"
+	writeFileSync(p, header + lines.join("\n"), "utf8")
+	return p
+}
+
+describe("state-hi-schools adapter", () => {
+	it("has the expected id and license", () => {
+		const a = createStateHiSchoolsAdapter()
+		expect(a.id).toBe(STATE_HI_SCHOOLS_ADAPTER_ID)
+		expect(a.defaultLicense).toBe(STATE_HI_SCHOOLS_DEFAULT_LICENSE)
+	})
+
+	it("emits a row for a HIDOE school with a hyphenated Oahu address", async () => {
+		const p = writeCsv(
+			"335,Ahuimanu Elem School,47-470 Hui Aeko Place,Kaneohe,96744,808.305.4800,808.239.3127,Kimi Ikeda,K,6,Elementary,http://example,Castle,Castle-Kahuku,Windward,Oahu,False"
+		)
+		const a = createStateHiSchoolsAdapter()
+		const rows = []
+		for await (const r of a.rows({ inputPath: p, limit: 5 })) rows.push(r)
+		expect(rows).toHaveLength(1)
+		const r = rows[0]!
+		expect(r.country).toBe("US")
+		expect(r.locale).toBe("en-US")
+		expect(r.source).toBe(STATE_HI_SCHOOLS_ADAPTER_ID)
+		expect(r.source_id).toBe(`${STATE_HI_SCHOOLS_ADAPTER_ID}-335`)
+		expect(r.license).toBe(STATE_HI_SCHOOLS_DEFAULT_LICENSE)
+		expect(r.components.venue).toBe("Ahuimanu Elem School")
+		expect(r.components.house_number).toBe("47-470")
+		expect(r.components.street).toContain("Hui Aeko Place")
+		expect(r.components.locality).toBe("Kaneohe")
+		expect(r.components.region).toBe("HI")
+		expect(r.components.postcode).toBe("96744")
+	})
+
+	it("emits a row for a charter (PCS) school with a non-hyphenated address", async () => {
+		const p = writeCsv(
+			"540,Halau Ku Mana - PCS,2101 Makiki Heights Drive,Honolulu,96822,808.945.1600,808.945.1604,Lori Pereia,4,12,K - 12,http://example,Roosevelt,Kaimuki-McKinley-Roosevelt,Honolulu,Oahu,True"
+		)
+		const a = createStateHiSchoolsAdapter()
+		const rows = []
+		for await (const r of a.rows({ inputPath: p, limit: 5 })) rows.push(r)
+		expect(rows).toHaveLength(1)
+		const r = rows[0]!
+		expect(r.components.venue).toBe("Halau Ku Mana - PCS")
+		expect(r.components.house_number).toBe("2101")
+		expect(r.components.street).toContain("Makiki Heights Drive")
+		expect(r.components.locality).toBe("Honolulu")
+		expect(r.components.region).toBe("HI")
+		expect(r.components.postcode).toBe("96822")
+		expect(r.source_id).toBe(`${STATE_HI_SCHOOLS_ADAPTER_ID}-540`)
+	})
+
+	it("skips rows with missing required fields", async () => {
+		const p = writeCsv(
+			// missing name
+			",,200 Some Way,Honolulu,96813,,,,,,,,,,,,",
+			// missing address
+			"999,Bad School,,Honolulu,96813,,,,,,,,,,,,",
+			// missing city
+			"998,Bad School,200 Some Way,,96813,,,,,,,,,,,,",
+			// missing zip
+			"997,Bad School,200 Some Way,Honolulu,,,,,,,,,,,,,",
+			// good
+			"123,Real School,500 Real Street,Honolulu,96813,,,,,,,,,,,,"
+		)
+		const a = createStateHiSchoolsAdapter()
+		const rows = []
+		for await (const r of a.rows({ inputPath: p, limit: 10 })) rows.push(r)
+		expect(rows).toHaveLength(1)
+		expect(rows[0]!.components.venue).toBe("Real School")
+	})
+
+	it("rejects non-US country filter", async () => {
+		const a = createStateHiSchoolsAdapter()
+		await expect(
+			(async () => {
+				for await (const _ of a.rows({ inputPath: "/dev/null", country: "FR" }));
+			})()
+		).rejects.toThrow(/only US supported/)
+	})
+
+	it("registers cleanly with an InMemoryAdapterRegistry", () => {
+		const registry = new InMemoryAdapterRegistry()
+		registry.register(createStateHiSchoolsAdapter())
+		expect(registry.get(STATE_HI_SCHOOLS_ADAPTER_ID)?.id).toBe(STATE_HI_SCHOOLS_ADAPTER_ID)
+	})
+
+	it("honors limit", async () => {
+		const p = writeCsv(
+			"100,A School,100 A St,Honolulu,96813,,,,,,,,,,,,",
+			"101,B School,200 B St,Honolulu,96813,,,,,,,,,,,,",
+			"102,C School,300 C St,Honolulu,96813,,,,,,,,,,,,"
+		)
+		const a = createStateHiSchoolsAdapter()
+		const rows = []
+		for await (const r of a.rows({ inputPath: p, limit: 2 })) rows.push(r)
+		expect(rows).toHaveLength(2)
+	})
+})

--- a/corpus/src/adapters/state-hi-schools/adapter.ts
+++ b/corpus/src/adapters/state-hi-schools/adapter.ts
@@ -1,0 +1,158 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `state-hi-schools`: Hawaii DOE public + charter schools CSV consumer.
+ *
+ *   The Hawaii State Department of Education publishes a directory of all HIDOE schools and public
+ *   charter schools (PCS) as an XLSX workbook (`SchoolList.xlsx`) with two sheets: `HIDOE` (~258
+ *   rows) and `PCS` (~38 rows). Total ~296 rows statewide. Each row carries a school name,
+ *   single-line street address, city, ZIP, a numeric `code`, and HI-specific administrative columns
+ *   (complex, complex_area, district, island, charter).
+ *
+ *   The adapter consumes a flat CSV the operator pre-builds via `fetch-state-hi-schools.sh`, which
+ *   concatenates both sheets under one shared header. Column names match the workbook header
+ *   verbatim (lower-snake-case: `code`, `name`, `address`, `city`, `zip`, ...).
+ *
+ *   Address parsing notes: Hawaii's residential numbering is hyphenated on Oahu (`47-470 Hui Aeko
+ *   Place`), Kauai (`2-4035 Kaumualii Hwy`), and elsewhere. The shared HOUSE_NUMBER_PREFIX regex
+ *   covers this via its optional `(?:-\d+)?` group.
+ *
+ *   The `island` and `district` columns are HIDOE administrative labels (Honolulu, Central, Leeward,
+ *   Windward, Hilo, Hawaii, Maui, Kauai) — they are NOT US counties and intentionally are not
+ *   surfaced as `subregion`.
+ *
+ *   Output: one row per school with `venue` (school name), `(house_number?, street, locality,
+ *   region=HI, postcode)`, and a stable `source_id` derived from the school `code`.
+ *
+ *   License: stamped `"Public Domain"` per Hawaii state government open-data terms.
+ */
+
+import { parse as csvParse } from "csv-parse"
+import { createReadStream } from "node:fs"
+import { stableSourceId } from "../../adapter.js"
+import { lookupStateAbbreviation } from "../../codex/us-fips-state.js"
+import { reconcileComponents } from "../../format.js"
+import type { AdapterOptions, CanonicalRow, CorpusAdapter } from "../../types.js"
+
+export const STATE_HI_SCHOOLS_ADAPTER_ID = "state-hi-schools"
+export const STATE_HI_SCHOOLS_DEFAULT_LICENSE = "Public Domain"
+
+const HOUSE_NUMBER_PREFIX = /^(\d+(?:-\d+)?[A-Za-z]?)\s+(.+)$/
+const HI_STATE_ABBR = "HI"
+
+interface HiSchoolRow {
+	code: string
+	name: string
+	address: string
+	city: string
+	zip: string
+}
+
+function splitAddress(address: string): { house_number?: string; street: string } | null {
+	const trimmed = address.trim()
+	if (!trimmed) return null
+	const m = HOUSE_NUMBER_PREFIX.exec(trimmed)
+	if (m) return { house_number: m[1], street: m[2]!.trim() }
+	return { street: trimmed }
+}
+
+function normalizeZip(raw: string): string {
+	const trimmed = raw.trim()
+	if (!trimmed) return ""
+	// XLSX → CSV conversion may emit numeric ZIPs without leading zeros. HI ZIPs all begin
+	// with 96, so a 4-digit value indicates a leading-zero stripped during numeric coercion
+	// (defensive — has not been observed in the published file as of 2026-05).
+	if (/^\d{4}$/.test(trimmed)) return `0${trimmed}`
+	return trimmed
+}
+
+export function createStateHiSchoolsAdapter(): CorpusAdapter {
+	return {
+		id: STATE_HI_SCHOOLS_ADAPTER_ID,
+		defaultLicense: STATE_HI_SCHOOLS_DEFAULT_LICENSE,
+		description: "Hawaii DOE School Directory — ~300 K-12 public + charter schools with venue+address (public-domain).",
+
+		async *rows(opts: AdapterOptions): AsyncIterable<CanonicalRow> {
+			if (opts.country && opts.country !== "US") {
+				throw new Error(`state-hi-schools adapter: only US supported, got country=${opts.country}`)
+			}
+
+			const stream = createReadStream(opts.inputPath, { encoding: "utf8" })
+			const parser = stream.pipe(
+				csvParse({
+					columns: true,
+					skip_empty_lines: true,
+					relax_quotes: true,
+					relax_column_count: true,
+				})
+			)
+
+			const state = lookupStateAbbreviation(HI_STATE_ABBR)
+			if (!state) {
+				throw new Error(`state-hi-schools adapter: HI not found in state codex (corpus bug)`)
+			}
+
+			let emitted = 0
+			try {
+				for await (const record of parser as AsyncIterable<HiSchoolRow>) {
+					if (opts.signal?.aborted) break
+					if (opts.limit !== undefined && emitted >= opts.limit) break
+
+					const name = (record.name ?? "").trim()
+					const address = (record.address ?? "").trim()
+					const city = (record.city ?? "").trim()
+					const zip = normalizeZip(record.zip ?? "")
+
+					if (!name || !address || !city || !zip) continue
+
+					const split = splitAddress(address)
+					if (!split) continue
+
+					const components: CanonicalRow["components"] = {
+						venue: name,
+						...(split.house_number ? { house_number: split.house_number } : {}),
+						street: split.street,
+						locality: city,
+						region: state.abbreviation,
+						postcode: zip,
+					}
+
+					const streetPart = [split.house_number, split.street].filter(Boolean).join(" ").trim()
+					const raw = [
+						name,
+						streetPart,
+						[city, [HI_STATE_ABBR, zip].filter(Boolean).join(" ")].filter(Boolean).join(", "),
+					]
+						.filter(Boolean)
+						.join(", ")
+
+					const aligned = reconcileComponents(components, raw)
+					if (Object.keys(aligned).length <= 2) continue
+
+					const code = (record.code ?? "").toString().trim()
+					const sourceId = code
+						? `${STATE_HI_SCHOOLS_ADAPTER_ID}-${code}`
+						: stableSourceId(STATE_HI_SCHOOLS_ADAPTER_ID, aligned)
+
+					yield {
+						raw,
+						components: aligned,
+						country: "US",
+						locale: "en-US",
+						source: STATE_HI_SCHOOLS_ADAPTER_ID,
+						source_id: sourceId,
+						corpus_version: "",
+						license: STATE_HI_SCHOOLS_DEFAULT_LICENSE,
+					}
+					emitted++
+				}
+			} finally {
+				stream.destroy()
+			}
+		},
+	}
+}
+
+export const stateHiSchoolsAdapter = createStateHiSchoolsAdapter()


### PR DESCRIPTION
Closes #55.

## What changed

New `state-hi-schools` corpus adapter consuming the Hawaii DOE's direct-XLSX school directory (`https://www.hawaiipublicschools.org/DOE%20Forms/SchoolList.xlsx`). Adds the adapter factory + fetcher + registry membership, following the existing single-file XLSX pattern (`usgov-imls-pls` shape).

Output shape:
- `venue` (school name)
- `house_number` + `street` (parsed from the address column)
- `locality` (city), `region` (HI), `postcode` (ZIP), `country` (US)
- License stamped `Public Domain` per HIDOE distribution terms.

## Verification

- 296/296 rows round-trip through the adapter against the upstream XLSX (real-data smoke test, scoped to this run, removed after verification)
- Full repo tests + `tsc -b` clean under Node 24
- Adapter test suite (`adapter.test.ts`) covers the address-split corner cases pulled from the actual HIDOE rows

## Disclosure

Built end-to-end by Claude (Opus 4.7) inside playpen container `mailwoman-i55-potential-appropriate-persimmon`. Postmortem + 2 KB entries (Node-24 pin gotcha + corepack/yarn4 cache workaround) drained from the container.