### PR TITLE
v0.5.0 thread F: harden verdict-smoke framework + sidecar audit

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,21 @@
 
 Open items not blocking the current ship. Promoted to issues / PRs as scope solidifies.
 
+## v0.5.0 fresh-slate threads (live)
+
+Per [Phase 8 — v0.5.0 fresh-slate](docs/articles/plan/phases/PHASE_8_v0_5_0_fresh_slate.md). Status at a glance:
+
+| Thread | Scope                                                         | Status                       |
+| ------ | ------------------------------------------------------------- | ---------------------------- |
+| A      | Tokenizer retrain — multi-script + adversarial coverage       | pending (blocked on B)       |
+| B      | Synthetic adversarial corpus expansion (corpus-v0.4.0)        | pending                      |
+| C      | Classifier with top-k output + phrase-prior conditioning      | pending (blocked on A, B, E) |
+| D      | Stage 5 reconcile — concordance matching via joint decoding   | pending (blocked on C, E)    |
+| E      | Stage 2.7 phrase grouper (rule-based first)                   | pending                      |
+| F      | Process improvements: verdict-smoke framework + sidecar audit | **shipped 2026-05-23**       |
+
+Thread F delivered: [`VERDICT_SMOKES.md`](docs/articles/plan/reference/VERDICT_SMOKES.md), `--smoke-mode constant\|long-tail` flag on `python -m mailwoman_train train` / `smoke`, sidecar audit (`corpus-audit`, `diagnose_regression.py`, decoder span-trim all verified in tree against `corpus-v0.3.0`), cross-links from [the knowledge ladder](docs/articles/concepts/the-knowledge-ladder.md) and PHASE_2 iteration log.
+
 ## CPU-bound work surfaced 2026-05-23 (parallel to v0.4.0 training window)
 
 Triaged during the v0.4.0 training prep — these can run while the GPU is occupied with

--- a/corpus-python/src/mailwoman_train/cli.py
+++ b/corpus-python/src/mailwoman_train/cli.py
@@ -46,8 +46,37 @@ def cmd_train(args: argparse.Namespace) -> int:
         cfg.train.output_dir = args.output_dir
     if args.max_steps is not None:
         cfg.train.max_steps = args.max_steps
+    _apply_smoke_mode(args, cfg)
     train(cfg, resume_from=args.resume)
     return 0
+
+
+def _apply_smoke_mode(args: argparse.Namespace, cfg) -> None:
+    """Translate the operator-facing ``--smoke-mode`` flag into ``cfg.train.lr_schedule``.
+
+    Lives here (not in config.py) because the policy is CLI-shaped: ``constant`` overrides
+    any config schedule, ``long-tail`` is a no-op modifier (cosine stays, just warn if
+    ``max_steps`` is short enough for the cosine tail to dominate the visible window).
+    See docs/articles/plan/reference/VERDICT_SMOKES.md for the rationale.
+    """
+    mode = getattr(args, "smoke_mode", None)
+    if mode is None:
+        return
+    if mode == "constant":
+        cfg.train.lr_schedule = "constant"
+        return
+    if mode == "long-tail":
+        # Cosine schedule, but the recipe must have a long enough max_steps that the
+        # cosine tail doesn't dominate the smoke-visible portion. The threshold is
+        # advisory — the operator may know what they're doing — so warn, don't error.
+        if cfg.train.max_steps < 10000:
+            sys.stderr.write(
+                f"warning: --smoke-mode long-tail expects max_steps>=10000; got "
+                f"{cfg.train.max_steps}. Cosine tail may mask divergence. See "
+                "docs/articles/plan/reference/VERDICT_SMOKES.md.\n"
+            )
+        return
+    raise ValueError(f"unknown --smoke-mode={mode!r}")
 
 
 def cmd_eval(args: argparse.Namespace) -> int:
@@ -220,6 +249,12 @@ def cmd_smoke(args: argparse.Namespace) -> int:
     from .train import train as train_fn
 
     cfg = load_config(args.config)
+    # Smokes default to constant-LR per the v0.5.0 verdict-smoke framework
+    # (docs/articles/plan/reference/VERDICT_SMOKES.md). Operator may opt into
+    # ``--smoke-mode long-tail`` for tweaks on a known-stable baseline.
+    if getattr(args, "smoke_mode", None) is None:
+        args.smoke_mode = "constant"
+    _apply_smoke_mode(args, cfg)
     started = time.time()
     train_fn(cfg)
     # Pick the latest checkpoint.
@@ -365,6 +400,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help='Resume from this checkpoint dir, or pass "auto" to use the latest step-* under output_dir.',
     )
+    p.add_argument(
+        "--smoke-mode",
+        choices=("constant", "long-tail"),
+        default=None,
+        help=(
+            "Override LR schedule for a verdict-smoke run. 'constant' = flat LR after "
+            "warmup so divergence isn't masked by cosine decay (default for new recipes). "
+            "'long-tail' = keep cosine but expect max_steps>=10000 so the tail doesn't "
+            "dominate the smoke window. See docs/articles/plan/reference/VERDICT_SMOKES.md."
+        ),
+    )
     p.set_defaults(func=cmd_train)
 
     p = sub.add_parser("eval", help="Eval a checkpoint against the golden set")
@@ -407,6 +453,15 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("smoke", help="End-to-end smoke train + eval + export + quantize + package")
     common(p)
     p.add_argument("--golden-dir", default=None)
+    p.add_argument(
+        "--smoke-mode",
+        choices=("constant", "long-tail"),
+        default=None,
+        help=(
+            "LR schedule for the smoke train leg. Defaults to 'constant' per the v0.5.0 "
+            "verdict-smoke framework. See docs/articles/plan/reference/VERDICT_SMOKES.md."
+        ),
+    )
     p.set_defaults(func=cmd_smoke)
 
     p = sub.add_parser("verify-tokenizer", help="Re-tokenize a sample of corpus rows and assert OK")

--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -86,6 +86,13 @@ class TrainConfig:
     # Global-norm gradient clip. 0 disables clipping. Defaults to 1.0; the CRF NLL leg of
     # Stage 2 emits sharp gradients during warmup and diverged at the LR peak without it.
     grad_clip_norm: float = 1.0
+    # LR schedule after warmup. ``"cosine"`` = decay to 0 across max_steps (v0.4.0 default,
+    # right for full-length production runs). ``"constant"`` = hold ``learning_rate`` flat
+    # for the rest of the run after warmup — the smoke-window default per v0.5.0 process
+    # (see docs/articles/plan/reference/VERDICT_SMOKES.md). Cosine decay during a short
+    # smoke window masks divergence by collapsing LR before the loss curve shows it; the
+    # constant-LR mode keeps the signal visible. See the ref doc for when to pick which.
+    lr_schedule: str = "cosine"
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/train.py
+++ b/corpus-python/src/mailwoman_train/train.py
@@ -62,6 +62,29 @@ def _cosine_with_warmup(optimizer: AdamW, warmup_steps: int, max_steps: int) -> 
     return LambdaLR(optimizer, lr_lambda)
 
 
+def _constant_with_warmup(optimizer: AdamW, warmup_steps: int) -> LambdaLR:
+    # Linear warmup → constant. The verdict-smoke mode per v0.5.0 (see
+    # docs/articles/plan/reference/VERDICT_SMOKES.md): cosine decay over a short window
+    # collapses the LR before divergence shows in the loss curve.
+    def lr_lambda(step: int) -> float:
+        if step < warmup_steps:
+            return float(step) / float(max(1, warmup_steps))
+        return 1.0
+
+    return LambdaLR(optimizer, lr_lambda)
+
+
+def _build_scheduler(optim: AdamW, cfg_train) -> LambdaLR:
+    schedule = getattr(cfg_train, "lr_schedule", "cosine")
+    if schedule == "constant":
+        return _constant_with_warmup(optim, cfg_train.warmup_steps)
+    if schedule == "cosine":
+        return _cosine_with_warmup(optim, cfg_train.warmup_steps, cfg_train.max_steps)
+    raise ValueError(
+        f"unknown train.lr_schedule={schedule!r}; expected 'cosine' or 'constant'"
+    )
+
+
 def _precision_to_dtype(precision: str, device: torch.device) -> torch.dtype | None:
     if precision == "fp16":
         return torch.float16 if device.type == "cuda" else None
@@ -211,7 +234,8 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
         lr=cfg.train.learning_rate,
         weight_decay=cfg.train.weight_decay,
     )
-    scheduler = _cosine_with_warmup(optim, cfg.train.warmup_steps, cfg.train.max_steps)
+    scheduler = _build_scheduler(optim, cfg.train)
+    print(f"lr_schedule={getattr(cfg.train, 'lr_schedule', 'cosine')}")
     amp_dtype = _precision_to_dtype(cfg.train.precision, device)
     # On gfx1103 (Radeon 780M) autocast+bf16 has been observed to hang at batch≥64 with
     # nn.MultiheadAttention — the autocast fast-path picks a fused kernel that GPU hangs on.

--- a/docs/articles/concepts/the-knowledge-ladder.md
+++ b/docs/articles/concepts/the-knowledge-ladder.md
@@ -7,22 +7,22 @@ title: The knowledge ladder
 
 The staged pipeline is a contract for **decomposition by what each layer knows**. Every stage is the rightful home of a particular kind of information; pushing work to the wrong stage produces fragile systems that try to learn things from data that they could have looked up, or look up things that they could have learned. This article catalogues the layers, what each one knows, and the two layers we don't ship yet but should.
 
-Read [The pipeline contract](./staged-pipeline-contract.md) first for the runtime mechanics. This article is the conceptual companion — *why* the layers are arranged this way, and where the design has gaps.
+Read [The pipeline contract](./staged-pipeline-contract.md) first for the runtime mechanics. This article is the conceptual companion — _why_ the layers are arranged this way, and where the design has gaps.
 
 ## The full ladder
 
 Each layer adds one kind of knowledge the layers below it cannot easily derive:
 
-| Layer | Knows | Shipped today |
-|---|---|---|
-| **1. Normalize** | input preprocessing rules | Yes |
-| **2. Locale gate** | language / script family | Yes (rule-based) |
-| **2.5. Kind classifier** | overall query category (postcode_only, structured_address, …) | Yes (rule-based) |
-| **2.7. Phrase grouper** | **coherent input units (boundary discovery)** | **No — missing rung** |
-| **3. Token classify** | per-token semantic type | Yes (neural) |
-| **4. Sequence correct** | per-token BIO sequence validity | Yes (CRF with structural mask) |
-| **5. Reconcile** | **joint-coherent interpretation across candidates** | **Partial — needs concordance work** |
-| **6. Resolve** | world hierarchy (gazetteer) | Yes (WOF SQLite) |
+| Layer                    | Knows                                                         | Shipped today                        |
+| ------------------------ | ------------------------------------------------------------- | ------------------------------------ |
+| **1. Normalize**         | input preprocessing rules                                     | Yes                                  |
+| **2. Locale gate**       | language / script family                                      | Yes (rule-based)                     |
+| **2.5. Kind classifier** | overall query category (postcode_only, structured_address, …) | Yes (rule-based)                     |
+| **2.7. Phrase grouper**  | **coherent input units (boundary discovery)**                 | **No — missing rung**                |
+| **3. Token classify**    | per-token semantic type                                       | Yes (neural)                         |
+| **4. Sequence correct**  | per-token BIO sequence validity                               | Yes (CRF with structural mask)       |
+| **5. Reconcile**         | **joint-coherent interpretation across candidates**           | **Partial — needs concordance work** |
+| **6. Resolve**           | world hierarchy (gazetteer)                                   | Yes (WOF SQLite)                     |
 
 The two emphasized rows are the layers that v0.4.0's mixed result exposed as missing. They're complementary: the phrase grouper feeds cleaner spans IN to the classifier; the expanded reconciler picks coherent assignments OUT of the classifier's candidates.
 
@@ -38,7 +38,7 @@ Detects whether input is en-US, fr-FR, ja-JP, etc. Today this is a rule-based sc
 
 ### Kind classifier — overall query category
 
-Bare postcode? Single locality? Full structured address? PO box? Landmark? Intersection? This is a coarse taxonomy of input *shape* — bitter-lesson-safe (purely structural cues, no place-name dictionaries). The kind decision enables the fast-path routing in the coordinator. Knows the high-level question being asked; doesn't know the answer.
+Bare postcode? Single locality? Full structured address? PO box? Landmark? Intersection? This is a coarse taxonomy of input _shape_ — bitter-lesson-safe (purely structural cues, no place-name dictionaries). The kind decision enables the fast-path routing in the coordinator. Knows the high-level question being asked; doesn't know the answer.
 
 ### Phrase grouper — coherent input units (boundary discovery) — MISSING
 
@@ -52,7 +52,7 @@ The neural classifier (Stage 3) is asked to learn three things simultaneously vi
 
 These are coupled in BIO. A wrong boundary makes the type prediction wrong — even when the model "knew" the right type. v0.4.0's bio_slip cases (`", 22220"` for `22220`) are exactly this: type was right, boundary was off.
 
-A phrase grouper proposes coherent units with confidence *before* the classifier runs:
+A phrase grouper proposes coherent units with confidence _before_ the classifier runs:
 
 ```
 input:     "350 5th Ave, New York, NY 10118"
@@ -86,10 +86,12 @@ The CRF with frozen structural transition mask. Forbids orphan-`I-*` sequences (
 Stage 5's purpose is cross-component reconciliation: take everything the upstream layers produced and pick the joint interpretation that maximizes coherence.
 
 Today the inputs to Stage 5 are:
+
 - One tag sequence (Viterbi argmax from CRF)
 - A flat list of spans
 
 What Stage 5 needs to be useful:
+
 - **Top-k tag interpretations** from the classifier (model's beliefs ranked)
 - **Top-k span proposals** from the phrase grouper (boundary candidates ranked)
 - **Top-k resolver candidates** per span from Stage 6 (world's beliefs ranked)
@@ -126,11 +128,14 @@ The campaign's failure modes mapped almost cleanly to the missing layers:
 - **Several kryptonite cases** (`NY-NY Steakhouse`, `Paris, Texas`, `St. Petersburg`) — every one needs joint decoding across (input shape, classifier output, world hierarchy). Stage 5 reconcile is the layer.
 - **92% adversarial transliteration** on country FN — this is the tokenizer layer (different concern), not a missing rung.
 
-The missing rungs are *information layers*. We weren't doing the joint reasoning the architecture's contract implied we should.
+The missing rungs are _information layers_. We weren't doing the joint reasoning the architecture's contract implied we should.
+
+There was also a _process-side_ lesson — the verdict-smoke framework reported `cw-only` as stable when sustained-peak-LR would have diverged it, because the smoke's cosine schedule decayed LR before the loss curve showed the divergence. That's about reading the layers, not building them; the redesigned smoke framework that closes that gap lives in [`VERDICT_SMOKES.md`](../plan/reference/VERDICT_SMOKES.md).
 
 ## See also
 
 - [The pipeline contract](./staged-pipeline-contract.md) — runtime mechanics for integrators
 - [The staged pipeline](./the-staged-pipeline.md) — narrative framing
 - [`STAGES.md`](../plan/reference/STAGES.md) — formal per-stage type contracts
+- [`VERDICT_SMOKES.md`](../plan/reference/VERDICT_SMOKES.md) — the process-side companion: how to read smoke runs without the cosine-LR meta-bug
 - [v0.4.0 ablation campaign retrospective](../retrospectives/v0-4-0-ablation-campaign.md) — the failures that exposed the missing rungs

--- a/docs/articles/plan/phases/PHASE_2_training.md
+++ b/docs/articles/plan/phases/PHASE_2_training.md
@@ -21,52 +21,52 @@
 - **v0.4.0** (shipped to packaged artifacts 2026-05-23, NOT npm-published — issue [#116](https://github.com/sister-software/mailwoman/issues/116)) — six planned work areas: (1) per-token CRF NLL normalization; (2) longer training (reach step-5000+ before judging); (3) class-weighted CE biased toward coarse classes; (4) source-weight rebalance away from NAD-heavy fine-label mix; (5) JS-side Viterbi decode + model-card label loading (landed 2026-05-22, see entry above); (6) reuse `corpus-v0.3.0`. **Shipped recipe is §4 + §5 only**; §1 and §3 deferred to v0.4.1 after destabilizing the dual-loss training.
 
   **Ablation campaign (2026-05-23, 5 divergence runs + 3 verdict smokes + 1 full 50K + 1 successful full run):**
-    1. The full §1+§3+§4 recipe diverged at **all three tested LRs** (lr=5e-4 step 750, lr=3e-4 step 1000, lr=1.5e-4 step 2000). LR delays divergence proportionally — destabilizer is in the recipe, not LR.
-    2. At `lr=5e-4`, both single-knob ablations failed identically (ablate-§1: 0.35 → 0.11; ablate-§3: 0.35 → 0.14). `lr=5e-4` is structurally unreachable for this codebase's dual-loss landscape regardless of which §1/§3 knob is active.
-    3. Switched to lr=1.5e-4 (v0.3.0-stable) verdict-smoke matrix at max_steps=3000:
-        - source-only (§4): PASS, peak 0.4190 step 2250
-        - cw-only (§3+§4): PASS, peak 0.4279 step 2250
-        - crf-only (§1+§4): FAIL, train_loss=1.24 at step 3000
-    4. **Verdict-smoke framework had a false-positive on cw-only**: the smoke's cosine LR decayed to ~0 by step 2750, masking sustained-peak-LR divergence. When promoted to the full 50K run, cw-only diverged at step 2250 (macro_f1 collapse 0.41 → 0.29). Process improvement for v0.4.1: verdict smokes should use a constant LR or much longer max_steps.
-    5. **Math sanity-check** of `model.py` + `crf.py` found no implementation bug — `per_token` reduction is `nll.sum() / total_tokens.clamp(min=1)`; class_weights enter via `cross_entropy(weight=...)`. Destabilization is a real recipe interaction, not a coding artifact.
-    6. **Shipped checkpoint**: `v0_4_0-stableLR-source-only/step-002200` — §4 source rebalance + v0.3.0 dual-loss base + lr=1.5e-4. Only recipe that stayed clean AND outperformed cw-only on golden v0.1.2 eval.
+  1. The full §1+§3+§4 recipe diverged at **all three tested LRs** (lr=5e-4 step 750, lr=3e-4 step 1000, lr=1.5e-4 step 2000). LR delays divergence proportionally — destabilizer is in the recipe, not LR.
+  2. At `lr=5e-4`, both single-knob ablations failed identically (ablate-§1: 0.35 → 0.11; ablate-§3: 0.35 → 0.14). `lr=5e-4` is structurally unreachable for this codebase's dual-loss landscape regardless of which §1/§3 knob is active.
+  3. Switched to lr=1.5e-4 (v0.3.0-stable) verdict-smoke matrix at max_steps=3000:
+     - source-only (§4): PASS, peak 0.4190 step 2250
+     - cw-only (§3+§4): PASS, peak 0.4279 step 2250
+     - crf-only (§1+§4): FAIL, train_loss=1.24 at step 3000
+  4. **Verdict-smoke framework had a false-positive on cw-only**: the smoke's cosine LR decayed to ~0 by step 2750, masking sustained-peak-LR divergence. When promoted to the full 50K run, cw-only diverged at step 2250 (macro_f1 collapse 0.41 → 0.29). Process improvement for v0.4.1: verdict smokes should use a constant LR or much longer max_steps. (Landed in v0.5.0 Thread F as `--smoke-mode constant|long-tail`; framework + decision matrix in [`VERDICT_SMOKES.md`](../reference/VERDICT_SMOKES.md).)
+  5. **Math sanity-check** of `model.py` + `crf.py` found no implementation bug — `per_token` reduction is `nll.sum() / total_tokens.clamp(min=1)`; class_weights enter via `cross_entropy(weight=...)`. Destabilization is a real recipe interaction, not a coding artifact.
+  6. **Shipped checkpoint**: `v0_4_0-stableLR-source-only/step-002200` — §4 source rebalance + v0.3.0 dual-loss base + lr=1.5e-4. Only recipe that stayed clean AND outperformed cw-only on golden v0.1.2 eval.
 
   **Golden v0.1.2 eval (4535 entries) — mixed result, issue #116 success metric NOT cleanly met:**
 
-  | tag | v0.4.0 shipped | v0.3.0 | Δ |
-  |---|---:|---:|---:|
-  | country | 0.21 | 0.28 | **-0.07 regression** |
-  | region | 0.19 | 0.18 | +0.01 |
-  | locality | 0.27 | 0.27 | flat |
-  | postcode | 0.69 | 0.76 | **-0.07 regression** |
-  | venue | 0.39 | 0.39 | flat |
-  | street | 0.30 | 0.27 | **+0.03 improvement** |
-  | house_number | 0.79 | 0.78 | +0.01 (issue #57 floor held) |
+  | tag          | v0.4.0 shipped | v0.3.0 |                            Δ |
+  | ------------ | -------------: | -----: | ---------------------------: |
+  | country      |           0.21 |   0.28 |         **-0.07 regression** |
+  | region       |           0.19 |   0.18 |                        +0.01 |
+  | locality     |           0.27 |   0.27 |                         flat |
+  | postcode     |           0.69 |   0.76 |         **-0.07 regression** |
+  | venue        |           0.39 |   0.39 |                         flat |
+  | street       |           0.30 |   0.27 |        **+0.03 improvement** |
+  | house_number |           0.79 |   0.78 | +0.01 (issue #57 floor held) |
 
   Macro F1 raw average: 0.357 vs 0.293. Mean token confidence: 0.806 vs 0.857. Full-parse exact match: 0.082 vs 0.107 (regression — better per-component agreement, worse full-address agreement).
 
   Issue #116 asked for "clear progress on at least two of (coarse F1, fine F1, calibration, training stability)":
-    - coarse F1: NEGATIVE (country/postcode each -0.07)
-    - fine F1: SMALL POSITIVE (street +0.03, house_number +0.01)
-    - calibration: FLAT
-    - training stability: NEGATIVE (recipe destabilization is the campaign's central finding)
+  - coarse F1: NEGATIVE (country/postcode each -0.07)
+  - fine F1: SMALL POSITIVE (street +0.03, house_number +0.01)
+  - calibration: FLAT
+  - training stability: NEGATIVE (recipe destabilization is the campaign's central finding)
 
   Only one clean improvement axis. §1 (per_token CRF) and §3 (class_weights) deferred to v0.4.1 after a corpus-side investigation of why the full recipe destabilizes past step 2000.
 
   **Post-hoc regression diagnostic (categorized, 4535 entries, 1217 postcode FNs + 194 country FNs):**
 
-  | error class | postcode FN | country FN |
-  |---|---:|---:|
-  | empty_pred (model emits nothing) | 789 (65%) | 9 (5%) |
-  | non-Latin transliteration (v0.3.0 pre-existing) | 213 (18%) | **178 (92%)** |
-  | num_confused (house# picked instead of postcode) | 136 (11%) | n/a |
-  | bio_slip (boundary off ±1 sentencepiece) | 73 (6%) | small |
-  | other | 6 (0.5%) | ~5% |
+  | error class                                      | postcode FN |    country FN |
+  | ------------------------------------------------ | ----------: | ------------: |
+  | empty_pred (model emits nothing)                 |   789 (65%) |        9 (5%) |
+  | non-Latin transliteration (v0.3.0 pre-existing)  |   213 (18%) | **178 (92%)** |
+  | num_confused (house# picked instead of postcode) |   136 (11%) |           n/a |
+  | bio_slip (boundary off ±1 sentencepiece)         |     73 (6%) |         small |
+  | other                                            |    6 (0.5%) |           ~5% |
 
   Headline takeaways:
-    - The dominant postcode FN is **empty_pred (65%)** on mid-position / short-form postcodes (`Paris 75008`, `47110 Sainte-Livrade-sur-Lot`). v0.4.0's source rebalance traded structured-address postcode exposure for coarse-only `10118`-style forms.
-    - Country FN is **92% adversarial transliteration** (CJK/Cyrillic raw input → English country gold). This is a v0.3.0 pre-existing failure mode; after excluding adversarials, country FN drops 194 → ~16. **The country -0.07 F1 regression is mostly a golden-set adversarial-weighting artifact, not a real recipe regression.**
-    - Decoder span-trim sidecar (commit `c72ab4c`, no retrain required) addresses the 6% bio_slip slice + an unmeasured share of FP rate. Material impact on the headline numbers is smaller than the initial diagnostic suggested but the trim is still a correct decoder bug fix.
+  - The dominant postcode FN is **empty_pred (65%)** on mid-position / short-form postcodes (`Paris 75008`, `47110 Sainte-Livrade-sur-Lot`). v0.4.0's source rebalance traded structured-address postcode exposure for coarse-only `10118`-style forms.
+  - Country FN is **92% adversarial transliteration** (CJK/Cyrillic raw input → English country gold). This is a v0.3.0 pre-existing failure mode; after excluding adversarials, country FN drops 194 → ~16. **The country -0.07 F1 regression is mostly a golden-set adversarial-weighting artifact, not a real recipe regression.**
+  - Decoder span-trim sidecar (commit `c72ab4c`, no retrain required) addresses the 6% bio_slip slice + an unmeasured share of FP rate. Material impact on the headline numbers is smaller than the initial diagnostic suggested but the trim is still a correct decoder bug fix.
 
   v0.4.1 implications: source-weight tweak alone partially addresses the 11% num_confused slice. The 65% empty_pred slice requires a different intervention (likely source-weight + synthesis pass over component-order permutations, or an aggressive `wof-postalcode` bump). Full v0.4.1 scope draft staged at `.playpen/control/drafts/v0_4_1-scope.md` on the i116 container.
 

--- a/docs/articles/plan/phases/PHASE_8_v0_5_0_fresh_slate.md
+++ b/docs/articles/plan/phases/PHASE_8_v0_5_0_fresh_slate.md
@@ -91,19 +91,21 @@ Six work areas, each with its own thread. Cross-thread dependencies noted.
 - **Blocks:** Thread C (classifier conditioning), Thread D (reconcile consumes proposals).
 - **Blocked by:** nothing — rule-based version can start immediately.
 
-### F. Process improvements landed during v0.4.0 to harden
+### F. Process improvements landed during v0.4.0 to harden — **SHIPPED**
 
+- **Status:** shipped 2026-05-23 (branch `feat/v0.5.0-thread-f-verdict-smokes`).
 - **What:** carry the v0.4.0 sidecars + diagnostic tools into the v0.5.0 process from day one.
-  - `corpus-audit` already in tree — use it to verify Thread B's corpus mix before tokenizer training and before classifier training.
-  - `diagnose_regression.py` already in tree — use it for v0.5.0 eval bucketing, not just post-hoc.
-  - Verdict-smoke framework redesigned: **constant LR for the smoke window**, OR `max_steps >= 10000` so the cosine tail doesn't dominate. Documented in a new `docs/articles/plan/reference/VERDICT_SMOKES.md`.
-  - Decoder span-trim sidecar (commit `c72ab4c`) stays in main — covers the long tail of bio_slip cases the phrase grouper might miss.
+  - `corpus-audit` already in tree (`corpus/scripts/audit.ts`) — runs cleanly against `corpus-v0.3.0`. Use it to verify Thread B's corpus mix before tokenizer training and before classifier training.
+  - `diagnose_regression.py` already in tree (`corpus-python/scripts/diagnose_regression.py`) — use it for v0.5.0 eval bucketing, not just post-hoc.
+  - Verdict-smoke framework redesigned: **constant LR for the smoke window**, OR `max_steps >= 10000` so the cosine tail doesn't dominate. Documented in [`VERDICT_SMOKES.md`](../reference/VERDICT_SMOKES.md). Code enforcement: `--smoke-mode constant|long-tail` on `python -m mailwoman_train train` and `smoke` subcommands; defaults to constant for end-to-end smokes.
+  - Decoder span-trim sidecar (commit `c72ab4c`, `core/decoder/build-tree.ts:58`) stays in main — covers the long tail of bio_slip cases the phrase grouper might miss.
 - **Why:** v0.4.0's process meta-bug (cosine LR masking divergence) cost real iteration cycles. Document the lesson so v0.5.0 doesn't repeat it.
-- **Output:** new `VERDICT_SMOKES.md` reference doc + updated TODO.md.
+- **Output:** new [`VERDICT_SMOKES.md`](../reference/VERDICT_SMOKES.md) + `--smoke-mode` CLI flag + updated TODO.md.
 
 ## Cross-thread execution order
 
 Critical path (must complete sequentially):
+
 ```
 B (corpus expansion) → A (tokenizer) → C (classifier)
                                           ↘
@@ -112,6 +114,7 @@ E (phrase grouper, rule-based)             → D (Stage 5 reconcile)
 ```
 
 Parallel-safe:
+
 - F (process improvements) ships independently throughout
 - E rule-based version can ship as a standalone improvement before A/C complete (slot it into the existing v0.4.0 pipeline as an opt-in stage; backward-compatible)
 

--- a/docs/articles/plan/reference/VERDICT_SMOKES.md
+++ b/docs/articles/plan/reference/VERDICT_SMOKES.md
@@ -1,0 +1,104 @@
+# Verdict-smoke framework
+
+A **verdict smoke** is a short (few-hundred-to-few-thousand-step) training run whose only job is to decide whether a full-length training run is worth launching. The full run is expensive (rented GPU, ~6–10h); the smoke runs in minutes and is supposed to surface divergence, NaN, sampler starvation, and other recipe-level bugs before they cost a full-run.
+
+This document captures the v0.4.0 meta-bug that made the framework unreliable, and the redesigned framework v0.5.0 (and onward) uses.
+
+## The cosine-LR meta-bug
+
+The v0.4.0 ablation campaign (issue [#116](https://github.com/sister-software/mailwoman/issues/116), retrospective [v0-4-0-ablation-campaign](../../retrospectives/v0-4-0-ablation-campaign.md)) ran a verdict-smoke matrix at `max_steps=3000` over the §1/§3/§4 single-knob ablations. The `cw-only` smoke (§3 class-weighted CE + §4 source rebalance) passed with peak `macro_f1=0.4279` at step 2250 — clean curve, no warning signs.
+
+Promoted to the full 50K run, **`cw-only` diverged at step 2250** — `macro_f1` collapsed 0.41 → 0.29.
+
+Why the smoke missed it: the smoke ran cosine LR decay over `warmup_steps=1000` → `max_steps=3000`. By step 2250 the cosine schedule had decayed the learning rate to roughly `0.5 * (1 + cos(π * 0.625))` ≈ **30% of peak**, and by step 2750 to ~6%. The destabilizing dynamics needed sustained peak LR to manifest, and the cosine tail collapsed the LR before the loss curve made the divergence visible.
+
+The smoke was reporting "this recipe is stable at this hparam slice" when what it had actually demonstrated was "this recipe is stable when LR is decaying off". Two different statements; the smoke conflated them.
+
+This cost a 6h rented-GPU full-train cycle.
+
+## The redesigned framework
+
+Pick one of two modes for every smoke. Default is **constant-LR** for any new or unstable recipe.
+
+### Mode A — Constant-LR (default)
+
+Linear warmup from 0 → `learning_rate` over `warmup_steps`, then **flat at `learning_rate` for the entire smoke window.** No decay.
+
+- Divergence shows up immediately because nothing is masking it.
+- The smoke window is a "would this recipe survive at sustained peak LR" probe — which is exactly the question that matters for "will the full run blow up."
+- Use this for any recipe that introduces a new loss term, a new normalization scheme, new class weights, a tokenizer change, or any other lever that hasn't been validated at full LR before.
+
+### Mode B — Long-tail cosine
+
+Cosine schedule, but `max_steps >= 10000` so the cosine tail does not dominate the visible portion of the smoke window. By step 3000, with `max_steps=10000`, LR is still at ~84% of peak — close enough to peak that destabilization can still surface.
+
+- Use this when the recipe is a tweak on a known-stable baseline (a small source-weight nudge, a tiny class-weight adjustment within a previously-stable family) AND when the full-train cosine dynamics matter for the verdict you're trying to reach.
+- Costs more wall-clock than constant-LR smokes (a 10K-step smoke is ~6× the wall-clock of a 1.5K-step constant-LR smoke).
+
+### Which to pick
+
+| Situation                                                                  | Mode                                                    |
+| -------------------------------------------------------------------------- | ------------------------------------------------------- |
+| New recipe (new loss, new normalization, new tokenizer, new class weights) | **A — constant-LR**                                     |
+| First time exercising a knob at a new LR                                   | **A — constant-LR**                                     |
+| Tweak on a known-stable baseline (`±20%` source weight, etc.)              | **B — long-tail** if cosine dynamics matter; else **A** |
+| Pre-flight integration check (wiring, dtype, sampler) — not a verdict      | Either; constant-LR is faster                           |
+| Reproducing a known divergence to characterize it                          | **A — constant-LR**                                     |
+
+When in doubt: pick constant-LR. The false-positive cost (a stable recipe gets flagged at sustained peak LR when it would actually survive cosine decay) is small — you just promote it to the full run anyway. The false-negative cost (a divergent recipe passes the smoke and burns a full run) is what the v0.4.0 campaign paid.
+
+## How to invoke
+
+The CLI accepts `--smoke-mode {constant,long-tail}` on both `train` and `smoke` subcommands.
+
+```bash
+# New recipe — default constant-LR smoke (recommended)
+python -m mailwoman_train train \
+    --config corpus-python/src/mailwoman_train/configs/<recipe>-smoke.yaml \
+    --smoke-mode constant
+
+# Tweak on a known-stable baseline — long-tail cosine
+python -m mailwoman_train train \
+    --config corpus-python/src/mailwoman_train/configs/<recipe>-smoke.yaml \
+    --smoke-mode long-tail   # requires max_steps >= 10000 in the config
+
+# End-to-end pipeline smoke (train → eval → export → quantize → package)
+# Defaults to --smoke-mode constant.
+python -m mailwoman_train smoke --config <recipe>-smoke.yaml
+```
+
+The flag overrides `cfg.train.lr_schedule`. Non-smoke (full) runs continue to use whatever the config declares — by default cosine, unchanged from v0.4.0.
+
+Long-tail mode does not change `max_steps`; it asserts the recipe already has it sized correctly and warns when `max_steps < 10000`.
+
+## Reading a smoke result
+
+A smoke is **only** answering "would this recipe survive sustained peak LR for the smoke window?" — it is not predicting full-run F1, full-run convergence step, or anything else.
+
+- **Loss is finite and trending down / sideways across the full smoke window** → promote to full run.
+- **Loss spikes, NaN, or trends up at any point in the smoke window** → recipe is unstable at this LR. Reduce LR or revisit the recipe.
+- **Loss looks fine until the cosine tail (constant-LR mode disabled)** → you've reproduced the v0.4.0 meta-bug. Re-run in constant-LR mode.
+- **Val F1 peaks early and decays** in a constant-LR smoke → may still be fine in the full run (early-stopping or full-cosine recovers it), but the smoke is not the layer that decides this. Promote and let the full run be the verdict.
+
+## Sidecars that ride alongside
+
+Three v0.4.0 diagnostic tools that should run against every v0.5.0 smoke / full-run pair. Each is in the tree as of 2026-05-23.
+
+- **`corpus-audit`** ([`corpus/scripts/audit.ts`](https://github.com/sister-software/mailwoman/blob/main/corpus/scripts/audit.ts)) — per-source shard-count × source-weight diagnostic. Run before training to verify the sampled mix matches intent. Catches the v0.3.0 "NAD = 35% effective sample" class of footgun before it costs a training cycle.
+
+  ```bash
+  npx tsx corpus/scripts/audit.ts /data/corpus/versioned/<rev>/corpus-<rev> \
+      --config corpus-python/src/mailwoman_train/configs/<recipe>.yaml
+  ```
+
+- **`diagnose_regression.py`** ([`corpus-python/scripts/diagnose_regression.py`](https://github.com/sister-software/mailwoman/blob/main/corpus-python/scripts/diagnose_regression.py)) — post-eval FP/FN bucketing (`non_latin` / `case_only` / `bio_slip` / `empty_pred` / `num_confused` / `other`). Use it on every eval pass, not just post-hoc — bucket distributions are how recipe choices get debugged. The v0.4.0 retrospective entry documents reference distributions for calibration.
+
+- **Decoder span-trim** (commit [`c72ab4c`](https://github.com/sister-software/mailwoman/commit/c72ab4c), `core/decoder/build-tree.ts:58`) — `trimBoundary(raw, start, end)` shrinks BIO span bounds past leading / trailing non-`/[\p{L}\p{N}]/u` characters. No retrain required; covers the `bio_slip` long tail the phrase grouper (Thread E) hasn't been designed to catch yet.
+
+## See also
+
+- [The knowledge ladder](../../concepts/the-knowledge-ladder.md) — why v0.4.0's failure modes mapped to missing pipeline rungs (the smoke meta-bug is the process-side companion).
+- [Phase 8 — v0.5.0 fresh-slate](../phases/PHASE_8_v0_5_0_fresh_slate.md) — Thread F lands this framework before B/C/E start training.
+- [Phase 2 — training](../phases/PHASE_2_training.md) iteration log — v0.4.0 entry has the original false-positive case.
+- [v0.4.0 ablation campaign retrospective](../../retrospectives/v0-4-0-ablation-campaign.md) — full incident write-up.
+- [Operations](./OPERATIONS.md) — working norms; smokes commit at the unit boundary like any other change.


### PR DESCRIPTION
## Summary

Ship Thread F of the v0.5.0 fresh-slate plan ([PHASE_8_v0_5_0_fresh_slate.md](docs/articles/plan/phases/PHASE_8_v0_5_0_fresh_slate.md)). Hardens v0.4.0's process meta-bug (cosine-LR masking divergence in verdict smokes) into a documented discipline + small CLI enforcement.

- New [`docs/articles/plan/reference/VERDICT_SMOKES.md`](docs/articles/plan/reference/VERDICT_SMOKES.md) — design + decision matrix for constant-LR vs long-tail smoke modes, with the v0.4.0 cw-only cosine-mask false-positive as the motivating example.
- `--smoke-mode {constant,long-tail}` flag on `python -m mailwoman_train train` and `smoke` subcommands. Defaults to constant-LR; overrides `cfg.train.lr_schedule` for the smoke window only. Full (non-smoke) runs unchanged from v0.4.0.
- Sidecar audit: verified `corpus-audit`, `diagnose_regression.py`, decoder span-trim (commit `c72ab4c`) all present in tree against `corpus-v0.3.0`.
- Cross-links from [the knowledge ladder](docs/articles/concepts/the-knowledge-ladder.md) and the PHASE_2 iteration log so new contributors find the discipline from either entry point.
- TODO.md updated to mark F shipped.

This is the pre-flight ship for the v0.5.0 thread bundle (A tokenizer / B corpus / C classifier / D reconcile / E phrase grouper). Threads B, E, A0 spin up next; the verdict-smoke discipline lands before any of them touch the training loop.

## Test plan

- [ ] \`python -m mailwoman_train train --help\` shows \`--smoke-mode\` flag
- [ ] \`python -m mailwoman_train smoke --help\` shows \`--smoke-mode\` flag
- [ ] Constant-LR smoke against a known-stable recipe passes; default mode is constant
- [ ] Long-tail smoke warns when \`max_steps < 10000\`
- [ ] No regression on existing non-smoke training paths (full runs read \`cfg.train.lr_schedule\` unchanged)

## Disclosure

Triaged and authored end-to-end by Claude Code running in a playpen container (\`mailwoman-m-ship-v0-likely-weekly-eminence\`) under operator supervision. Scope, design decisions, and the v0.4.0-derived discipline framing reviewed and approved by the operator before push.