### PR TITLE
v0.5.0 thread C-scaffold: top-k inference + phrase-prior input layer

### DIFF
--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -35,6 +35,13 @@ class DataConfig:
 
 @dataclass
 class ModelConfig:
+    # Per-token embedding width and transformer body hidden dim. v0.3.0/v0.4.0 shipped at
+    # 256 on a 9M-param encoder; v0.5.0's Thread C scaffold preserves that baseline so the
+    # phrase-prior conditioning's contribution can be ablated cleanly against v0.4.0
+    # numerics. The Phase 8 plan recommends a 256 → 384 or 512 bump for the v0.5.0 full
+    # train ("likely paid for by rented GPU") but only after the new architecture is
+    # validated stable at the current size. Bump becomes a follow-up
+    # `v0_5_0-classifier-large.yaml` recipe once the baseline lands clean.
     hidden_size: int = 256
     num_hidden_layers: int = 6
     num_attention_heads: int = 4
@@ -64,6 +71,17 @@ class ModelConfig:
     # (venue/street/house_number) to re-prioritize coarse-class recovery. See
     # configs/v0_4_0.yaml for the worked example.
     class_weights: dict[str, float] | None = None
+    # v0.5.0 thread C: phrase-prior conditioning from Stage 2.7 (Thread E). When True, the
+    # encoder forward concatenates a per-token feature row (BIE markers + PhraseKind one-
+    # hot) onto the token+position embedding before the first transformer block, and
+    # projects back to ``hidden_size`` with a learned linear. Default False preserves
+    # v0.3.0/v0.4.0 numerics for ablation studies. See `phrase_priors.py` for the slot
+    # layout + ``the-knowledge-ladder.md`` § Phrase grouper for the design rationale.
+    use_phrase_priors: bool = False
+    # Per-token feature width. Determined by the phrase-priors taxonomy; surfaced as a
+    # config field so corpus-side feature shape and model-side projection width stay
+    # in lockstep through the model-card layer.
+    phrase_feature_dim: int = 10  # = PHRASE_BIE_DIM (3) + PHRASE_KIND_DIM (7)
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/configs/v0_5_0-classifier-smoke.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_5_0-classifier-smoke.yaml
@@ -1,0 +1,151 @@
+# v0.5.0 classifier verdict-smoke — thread C-s recipe.
+#
+# Hand off: NOT for immediate use. This config is parked here as part of Thread C-s
+# (the scaffold-now-train-later ship). It becomes invocable when:
+#
+#   - Thread A (tokenizer retrain) has landed under /data/models/tokenizer/v0.5.0/, AND
+#   - Thread B (corpus-v0.4.0 with phrase proposals + adversarial expansion) has landed
+#     under /data/corpus/versioned/v0.4.0/corpus-v0.4.0/, AND
+#   - Thread F (verdict-smoke framework) is merged to main so the `--smoke-mode constant`
+#     flag + `train.lr_schedule: constant` config field are wired through.
+#
+# When all three blockers clear, the recipe becomes:
+#
+#   HSA_OVERRIDE_GFX_VERSION=11.0.0 \
+#       ~/training-venv/bin/python -m mailwoman_train train \
+#           --config src/mailwoman_train/configs/v0_5_0-classifier-smoke.yaml \
+#           --smoke-mode constant
+#
+# Purpose mirrors v0_4_0-smoke.yaml: a ~2-minute integration check before the full
+# 50K run on rented GPU. Catches:
+#
+#   - Phrase-prior feature plumbing: corpus loader emits the (B, S, 10) feature tensor
+#     in the layout the model expects (see phrase_priors.py for the slot contract).
+#   - Top-k inference returns calibrated paths when sanity-checked against the eval set.
+#   - CRF + class_weights + per_token + phrase-prior projection all coexist without
+#     NaN or dtype mismatch under bf16 on gfx1103.
+#   - Constant-LR schedule (per VERDICT_SMOKES.md): sustained peak LR for the smoke
+#     window so dual-loss divergence has a chance to surface visibly — v0.4.0's
+#     cw-only false-positive (cosine decay masked the destabilization) does not
+#     recur.
+#
+# Expected: ~2 minutes wall, ~50 steps, train_log.csv shows finite + decreasing loss.
+
+data:
+  # Thread B output. Path will exist once Thread B's corpus build completes.
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  # Thread A output. Path will exist once Thread A's tokenizer retrain completes.
+  # 48K-64K vocab budget (vs v0.1.0's 32K) for non-Latin sub-piece coverage.
+  tokenizer_dir: /data/models/tokenizer/v0.5.0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  # Carry-over of v0.4.0's source rebalance (the only §-recipe lever that shipped clean
+  # in v0.4.0). Re-evaluate after the first v0.5.0 eval run — corpus-v0.4.0's adversarial
+  # additions may shift the optimal mix.
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+  # Cap rows-per-epoch so the smoke doesn't burn time on a giant per-epoch scan during
+  # resume — same shape as v0_4_0-smoke.yaml.
+  train_rows_per_epoch: 10000
+  val_rows: 256
+  coarse_filter: true
+
+model:
+  # Hidden-size stays at v0.3.0/v0.4.0 baseline per Thread C-s scope. The plan doc mentions
+  # a 256 → 384 or 512 bump as "likely paid for by rented GPU" for the FULL v0.5.0 run,
+  # but the scaffold validates that the new architecture trains cleanly at the current
+  # size first. Treat the bump as an orthogonal training-side concern, bumped in a
+  # follow-up `v0_5_0-classifier-large.yaml` if the v0.5.0 baseline lands clean.
+  hidden_size: 256
+  num_hidden_layers: 6
+  num_attention_heads: 4
+  intermediate_size: 1024
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  label_smoothing: 0.0
+  # v0.4.0 dual-loss lessons carry over.
+  crf_normalization: per_token
+  crf_loss_weight: 1.0
+  # v0.4.0 class-weight recipe — coarse-biased CE. Re-validate after the v0.5.0 corpus
+  # mix lands; the relative class frequencies will shift with the adversarial additions.
+  class_weights:
+    O: 1.0
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 2.0
+    I-region: 2.0
+    B-locality: 1.5
+    I-locality: 1.5
+    B-dependent_locality: 1.5
+    I-dependent_locality: 1.5
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 1.5
+    I-subregion: 1.5
+    B-cedex: 2.0
+    I-cedex: 2.0
+    B-venue: 0.5
+    I-venue: 0.5
+    B-street: 0.5
+    I-street: 0.5
+    B-house_number: 0.5
+    I-house_number: 0.5
+  # v0.5.0 thread C: phrase-prior conditioning ON. The headline architectural change for
+  # this iteration — Stage 2.7's PhraseProposals flow into the classifier as per-token
+  # features (see phrase_priors.py for the layout). Default is OFF for backward-compat;
+  # turning it on here is the explicit v0.5.0 opt-in.
+  use_phrase_priors: true
+  # Per-token feature width = PHRASE_BIE_DIM (3) + PHRASE_KIND_DIM (7) = 10.
+  # Surfaced as a config field so the corpus loader's emitted tensor width and the
+  # model's projection layer width stay in lockstep through the model card.
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/models/checkpoints/v0_5_0-classifier-smoke
+  seed: 42
+  # gfx1103 envelope, matched to v0_4_0-smoke.
+  batch_size: 8
+  eval_batch_size: 16
+  grad_accum_steps: 1
+  learning_rate: 5.0e-4
+  weight_decay: 0.01
+  warmup_steps: 10
+  grad_clip_norm: 1.0
+  # Just enough steps to exercise loss + eval + a checkpoint save under the constant-LR
+  # schedule. Per VERDICT_SMOKES.md mode A, the smoke window stays at sustained peak LR
+  # — divergence surfaces immediately if the dual-loss + phrase-prior recipe is unstable.
+  max_steps: 50
+  eval_every_steps: 25
+  save_every_steps: 25
+  log_every_steps: 5
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/train_log.csv"
+  # Constant linear warmup → flat at learning_rate; no cosine decay. Per Thread F's
+  # VERDICT_SMOKES.md mode A: sustained peak LR for the smoke window means dual-loss
+  # divergence surfaces immediately rather than being masked by a decaying tail
+  # (the v0.4.0 cw-only false-positive trap). Equivalent to passing
+  # `--smoke-mode constant` on the CLI.
+  lr_schedule: constant
+
+eval:
+  # Golden v0.1.2 stays the eval anchor for v0.5.0. The non-Latin adversarial slice +
+  # kryptonite catalogue are NEW eval splits per the plan doc § Success metrics; their
+  # fixtures land alongside Thread D (reconcile).
+  golden_dir: ""
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/crf.py
+++ b/corpus-python/src/mailwoman_train/crf.py
@@ -22,12 +22,32 @@ ONNX-export caveat: the forward / Viterbi loops use Python control flow over the
 dim, which `torch.onnx.export` traces but cannot symbolically vectorize. For the
 exported runtime we emit just the per-token emissions + transition tensors and run Viterbi
 on the TS side (see ``export_onnx.py``).
+
+v0.5.0 thread C: ``top_k_decode`` returns the K most-probable tag sequences (list-Viterbi
+over the same structural mask). Consumed by Stage 5 reconcile (Thread D) so it can
+disambiguate kryptonite cases like ``NY-NY Steakhouse, Houston, TX`` jointly across
+classifier candidates + resolver candidates + concordance score.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import torch
 from torch import nn
+
+
+@dataclass
+class TopKPath:
+    """One decoded tag sequence with its calibrated log-probability score.
+
+    ``score`` is ``path_log_score - log_partition`` — a valid log P(path | emissions) under
+    the CRF distribution, with ``sum_paths exp(score) <= 1``. Stage 5 reconcile uses these
+    as the classifier's belief over candidate parses.
+    """
+
+    sequence: list[int]
+    score: float
 
 
 def build_bio_transition_mask(id_to_label: dict[int, str]) -> torch.Tensor:
@@ -271,3 +291,158 @@ class LinearChainCRF(nn.Module):
             tags.reverse()
             results.append(tags)
         return results
+
+    @torch.no_grad()
+    def top_k_decode(
+        self,
+        emissions: torch.Tensor,
+        mask: torch.Tensor,
+        k: int = 5,
+    ) -> list[list[TopKPath]]:
+        """Top-K most-probable tag sequences per row, sorted by score descending.
+
+        List-Viterbi (k-best dynamic programming): for each (time, state) cell we keep
+        the K best path-scores ending at that state, with backpointers to (prev_state,
+        prev_rank). After processing the sequence, the K best paths are read off the
+        last column by sorting end-augmented scores and backtracking through ``(state,
+        rank)`` history.
+
+        Each path's score is converted to ``log P(path | emissions)`` by subtracting the
+        log-partition. The result is a calibrated belief over candidate parses — the
+        Stage 5 reconcile (Thread D) input.
+
+        Args:
+            emissions: ``(batch, seq, num_tags)`` per-token emission scores.
+            mask: ``(batch, seq)`` 1 = real token, 0 = padding. Same dtype as ``emissions``.
+            k: maximum number of paths to return per row. Returned list may be shorter
+               when fewer structurally-valid paths exist (e.g. ``num_tags ** length < k``
+               on a tiny sequence).
+
+        Returns:
+            Per-row list of ``TopKPath(sequence, score)`` items, sorted by score desc.
+            ``sequence`` length equals ``mask[row].sum()``; padding is dropped.
+
+        Complexity: ``O(B * T * N² * K * log(N * K))`` where N=num_tags, K=k, T=seq_len.
+        For N=21, K=5, T=128, B=32 this is ~10M ops — negligible compared to the encoder
+        forward pass. Implemented per-row on CPU after `.cpu()` to keep the topk + backtrack
+        readable; the call site is inference, not training, so GPU residency doesn't matter.
+        """
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k}")
+        bsz, seq_len, num_tags = emissions.shape
+
+        # Compute log-partition once (per-row) so we can return calibrated log-probs.
+        log_partition = self._log_partition(emissions, mask)  # (B,)
+
+        masked_trans = self.masked_transitions().detach()  # (N, N)
+        start_trans = self.masked_start_transitions().detach()  # (N,)
+        end_trans = self.end_transitions.detach()  # (N,)
+
+        results: list[list[TopKPath]] = []
+        # Per-row decode. Lengths vary, structural masks introduce -inf, and the topk on
+        # the broadcast cube is cleanest one row at a time.
+        for b in range(bsz):
+            length = int(mask[b].sum().item())
+            if length == 0:
+                results.append([])
+                continue
+
+            em = emissions[b].detach()  # (S, N)
+            row_logZ = float(log_partition[b].item())
+            row_paths = _row_top_k(
+                emissions=em,
+                length=length,
+                num_tags=num_tags,
+                start_trans=start_trans,
+                end_trans=end_trans,
+                masked_trans=masked_trans,
+                k=k,
+                log_partition=row_logZ,
+            )
+            results.append(row_paths)
+        return results
+
+
+def _row_top_k(
+    *,
+    emissions: torch.Tensor,  # (S, N)
+    length: int,
+    num_tags: int,
+    start_trans: torch.Tensor,  # (N,)
+    end_trans: torch.Tensor,  # (N,)
+    masked_trans: torch.Tensor,  # (N, N)
+    k: int,
+    log_partition: float,
+) -> list[TopKPath]:
+    """Single-row k-best Viterbi. Pure-tensor; ``length`` trims padding."""
+    # score[t, j, r] = r-th best path-score ending at tag j at time t.
+    # backptr[t, j, r] = (prev_tag, prev_rank) of the predecessor for that path.
+    # Use -inf to flag "no path here yet" so structurally-invalid extensions stay invalid.
+    NEG_INF = float("-inf")
+
+    # t=0 init: only rank 0 is real; ranks 1..K-1 are -inf with no predecessor.
+    score = torch.full((num_tags, k), NEG_INF, dtype=emissions.dtype)
+    score[:, 0] = start_trans + emissions[0]
+    # backptr_tag[t][j, r] = prev_tag; backptr_rank[t][j, r] = prev_rank. Stored per-step.
+    backptr_tag: list[torch.Tensor] = []
+    backptr_rank: list[torch.Tensor] = []
+
+    for t in range(1, length):
+        # candidates[i, m, j] = score[t-1, i, m] + trans[i, j] + emit[j]
+        # Shape: (N, K, N). Reshape to (N*K, N) so topk-over-predecessors is a single dim.
+        candidates = (
+            score.unsqueeze(2)  # (N, K, 1)
+            + masked_trans.unsqueeze(1)  # (N, 1, N)
+            + emissions[t].unsqueeze(0).unsqueeze(0)  # (1, 1, N)
+        )  # (N, K, N)
+        # For each destination tag j, pick top-K predecessors from the N*K candidates.
+        flat = candidates.permute(2, 0, 1).reshape(num_tags, num_tags * k)  # (N_dest, N*K)
+        # k may exceed N*K only at t=1 (when previous step has K-1 -inf ranks); topk handles
+        # by returning -inf for over-budget ranks, which propagate as "no path."
+        kk = min(k, flat.size(1))
+        top_vals, top_idx = flat.topk(kk, dim=1)  # (N_dest, kk)
+        new_score = torch.full((num_tags, k), NEG_INF, dtype=emissions.dtype)
+        new_score[:, :kk] = top_vals
+        # Decode (prev_tag, prev_rank) from flat index = prev_tag * K + prev_rank.
+        prev_tag = (top_idx // k).long()  # (N_dest, kk)
+        prev_rank = (top_idx % k).long()  # (N_dest, kk)
+        tag_full = torch.full((num_tags, k), -1, dtype=torch.long)
+        rank_full = torch.full((num_tags, k), -1, dtype=torch.long)
+        tag_full[:, :kk] = prev_tag
+        rank_full[:, :kk] = prev_rank
+        backptr_tag.append(tag_full)
+        backptr_rank.append(rank_full)
+        score = new_score
+
+    # End-augment, flatten over (tag, rank), pick top-K overall.
+    final = score + end_trans.unsqueeze(1)  # (N, K)
+    flat_final = final.reshape(-1)  # (N*K,)
+    kk = min(k, flat_final.numel())
+    top_final_vals, top_final_idx = flat_final.topk(kk)
+    # Drop -inf entries — they correspond to invalid / nonexistent paths.
+    paths: list[TopKPath] = []
+    for v, idx in zip(top_final_vals.tolist(), top_final_idx.tolist()):
+        if v == NEG_INF or v != v:  # NaN guard
+            continue
+        end_tag = int(idx // k)
+        end_rank = int(idx % k)
+        # Backtrack.
+        seq = [end_tag]
+        cur_tag, cur_rank = end_tag, end_rank
+        for t in range(length - 1, 0, -1):
+            bt = backptr_tag[t - 1]
+            br = backptr_rank[t - 1]
+            prev_tag = int(bt[cur_tag, cur_rank].item())
+            prev_rank = int(br[cur_tag, cur_rank].item())
+            if prev_tag < 0:
+                # Hit an unfilled slot — path is shorter than ``length``; skip.
+                seq = []
+                break
+            seq.append(prev_tag)
+            cur_tag, cur_rank = prev_tag, prev_rank
+        if not seq:
+            continue
+        seq.reverse()
+        paths.append(TopKPath(sequence=seq, score=float(v) - log_partition))
+    # topk already returned in desc order; keep that property after filtering.
+    return paths

--- a/corpus-python/src/mailwoman_train/model.py
+++ b/corpus-python/src/mailwoman_train/model.py
@@ -36,8 +36,9 @@ import torch
 from torch import nn
 
 from .config import Config
-from .crf import LinearChainCRF
+from .crf import LinearChainCRF, TopKPath
 from .labels import ID_TO_LABEL, LABEL_TO_ID, ACTIVE_BIO_LABELS
+from .phrase_priors import PHRASE_FEATURE_DIM
 
 
 def force_math_sdpa() -> None:
@@ -146,11 +147,22 @@ class MailwomanCoarseEncoder(nn.Module):
         crf_loss_weight: float = 0.1,
         crf_normalization: str = "per_sequence",
         class_weights: torch.Tensor | None = None,
+        use_phrase_priors: bool = False,
+        phrase_feature_dim: int = PHRASE_FEATURE_DIM,
     ) -> None:
         super().__init__()
         self.pad_token_id = pad_token_id
         self.max_position_embeddings = max_position_embeddings
         self.num_labels = num_labels
+        # v0.5.0 thread C: phrase-prior input-layer features (from Stage 2.7 phrase grouper,
+        # Thread E). When ``use_phrase_priors`` is on, the encoder takes an additional
+        # ``(B, S, phrase_feature_dim)`` tensor at forward time, concatenates it onto the
+        # token+position embedding, and projects back to ``hidden_size``. The projection is
+        # the minimum addition needed to thread the structural prior through without bumping
+        # the encoder body's hidden dim — keeps the v0.5.0 baseline fair vs v0.3.0/v0.4.0
+        # so the phrase-prior contribution can be ablated cleanly.
+        self.use_phrase_priors = use_phrase_priors
+        self.phrase_feature_dim = int(phrase_feature_dim) if use_phrase_priors else 0
         # v0.3.0 additions: CRF decoder for structural validity + learned tag dynamics,
         # label smoothing on the per-token CE leg for calibration. Both gate-able for
         # ablation studies via the kwargs above.
@@ -188,6 +200,18 @@ class MailwomanCoarseEncoder(nn.Module):
         self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
         self.input_dropout = nn.Dropout(hidden_dropout_prob)
         self.input_ln = nn.LayerNorm(hidden_size)
+        # Linear projection ``(hidden + phrase_feature_dim) → hidden`` so the body's
+        # transformer stack keeps its declared ``hidden_size``. xavier_uniform_ init via
+        # ``_init_weights``; bias init zero. None when ``use_phrase_priors`` is off — the
+        # forward path skips the projection entirely in that case (keeps v0.4.0 numerics
+        # bit-identical for back-compat ablations).
+        self.phrase_input_projection: nn.Linear | None
+        if self.use_phrase_priors:
+            self.phrase_input_projection = nn.Linear(
+                hidden_size + self.phrase_feature_dim, hidden_size, bias=True
+            )
+        else:
+            self.phrase_input_projection = None
 
         self.blocks = nn.ModuleList(
             [
@@ -243,6 +267,7 @@ class MailwomanCoarseEncoder(nn.Module):
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         labels: torch.Tensor | None = None,
+        phrase_features: torch.Tensor | None = None,
     ) -> "_CoarseEncoderOutput":
         bsz, seq = input_ids.shape
         if seq > self.max_position_embeddings:
@@ -252,6 +277,34 @@ class MailwomanCoarseEncoder(nn.Module):
             )
         pos = torch.arange(seq, device=input_ids.device).unsqueeze(0).expand(bsz, seq)
         h = self.token_embeddings(input_ids) + self.position_embeddings(pos)
+        # v0.5.0 thread C: optional phrase-prior conditioning. ``phrase_features`` is the
+        # per-token BIE+kind one-hot from Stage 2.7. When the encoder was built with
+        # ``use_phrase_priors=True`` and features are supplied, concat them onto the embed
+        # and project back to hidden_size; absent features default to zeros (silently — a
+        # caller that opted into priors but didn't supply them gets the equivalent of "no
+        # phrase covers any token," which is a degraded but well-defined inference path).
+        if self.phrase_input_projection is not None:
+            if phrase_features is None:
+                phrase_features = torch.zeros(
+                    bsz, seq, self.phrase_feature_dim,
+                    dtype=h.dtype, device=h.device,
+                )
+            elif phrase_features.shape != (bsz, seq, self.phrase_feature_dim):
+                raise ValueError(
+                    f"phrase_features shape {tuple(phrase_features.shape)} != "
+                    f"({bsz}, {seq}, {self.phrase_feature_dim})"
+                )
+            else:
+                phrase_features = phrase_features.to(h.dtype)
+            h = self.phrase_input_projection(torch.cat([h, phrase_features], dim=-1))
+        elif phrase_features is not None:
+            # Caller passed features but the encoder wasn't built to use them. Surface this
+            # rather than silently ignoring — wiring drift is exactly the bug class the
+            # smoke test is designed to catch.
+            raise ValueError(
+                "phrase_features supplied but use_phrase_priors=False — rebuild the "
+                "encoder with use_phrase_priors=True or drop the features argument"
+            )
         h = self.input_dropout(self.input_ln(h))
 
         # nn.MultiheadAttention key_padding_mask: True = mask (ignore), False = keep.
@@ -309,13 +362,18 @@ class MailwomanCoarseEncoder(nn.Module):
         self,
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
+        phrase_features: torch.Tensor | None = None,
     ) -> list[list[int]]:
         """Best-path tag IDs per row. Returns variable-length lists (mask-trimmed).
 
         Uses CRF Viterbi when the layer is present; falls back to per-token argmax
         otherwise (the v0.2.0 behavior — kept for ablation / pre-CRF checkpoints).
         """
-        out = self.forward(input_ids=input_ids, attention_mask=attention_mask)
+        out = self.forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            phrase_features=phrase_features,
+        )
         if self.crf is not None:
             return self.crf.viterbi_decode(out.logits, attention_mask.to(out.logits.dtype))
         # Argmax fallback. Trim per row to mask length.
@@ -325,6 +383,33 @@ class MailwomanCoarseEncoder(nn.Module):
             length = int(attention_mask[b].sum().item())
             results.append(argmax_ids[b, :length].tolist())
         return results
+
+    @torch.no_grad()
+    def predict_top_k(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        k: int = 5,
+        phrase_features: torch.Tensor | None = None,
+    ) -> list[list[TopKPath]]:
+        """Top-K tag sequences per row with calibrated log-prob scores.
+
+        v0.5.0 thread C: this is what Stage 5 reconcile (Thread D) consumes. Each row
+        gets up to ``k`` ``TopKPath`` items, sorted by score descending. Padding is
+        trimmed from each path's ``sequence``. Only works when the encoder was built with
+        ``use_crf=True`` — argmax-only encoders have no notion of path probability.
+        """
+        if self.crf is None:
+            raise RuntimeError(
+                "predict_top_k requires a CRF decoder; this encoder was built with "
+                "use_crf=False. Either rebuild with use_crf=True or use predict()."
+            )
+        out = self.forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            phrase_features=phrase_features,
+        )
+        return self.crf.top_k_decode(out.logits, attention_mask.to(out.logits.dtype), k=k)
 
     # ---- HuggingFace-compatible save/load helpers ----
 
@@ -354,6 +439,11 @@ class MailwomanCoarseEncoder(nn.Module):
                 if isinstance(self.class_weights, torch.Tensor)
                 else None
             ),
+            # v0.5.0 thread C: phrase-prior conditioning. False on v0.4.0/v0.3.0 weights;
+            # True on v0.5.0+. Loaders branch on this flag to materialize the
+            # ``phrase_input_projection`` layer.
+            "use_phrase_priors": bool(self.use_phrase_priors),
+            "phrase_feature_dim": int(self.phrase_feature_dim),
             "id2label": dict(ID_TO_LABEL),
             "label2id": dict(LABEL_TO_ID),
         }
@@ -391,6 +481,9 @@ class MailwomanCoarseEncoder(nn.Module):
             # v0.4.0+ fields. Default to v0.3.0 behavior (per_sequence, uniform CE).
             crf_normalization=cfg.get("crf_normalization", "per_sequence"),
             class_weights=cw_tensor,
+            # v0.5.0+ fields. Default to v0.4.0 behavior (no phrase priors).
+            use_phrase_priors=cfg.get("use_phrase_priors", False),
+            phrase_feature_dim=cfg.get("phrase_feature_dim", PHRASE_FEATURE_DIM),
         )
         # Use weights_only=True if available (torch 2.4+) to avoid pickle-arbitrary-code warning.
         try:
@@ -429,6 +522,9 @@ def build_model(cfg: Config, vocab_size: int, pad_token_id: int) -> MailwomanCoa
         # v0.4.0 additions.
         crf_normalization=getattr(cfg.model, "crf_normalization", "per_sequence"),
         class_weights=cw_tensor,
+        # v0.5.0 thread C additions.
+        use_phrase_priors=getattr(cfg.model, "use_phrase_priors", False),
+        phrase_feature_dim=getattr(cfg.model, "phrase_feature_dim", PHRASE_FEATURE_DIM),
     )
 
 

--- a/corpus-python/src/mailwoman_train/phrase_priors.py
+++ b/corpus-python/src/mailwoman_train/phrase_priors.py
@@ -1,0 +1,106 @@
+"""Phrase-prior input-layer features for the v0.5.0 classifier.
+
+Stage 2.7 of the v0.5.0 pipeline (the phrase grouper, Thread E) emits ``PhraseProposal``s
+— coarse boundary candidates with a structural ``PhraseKind`` hypothesis. The classifier
+(Stage 3, this codebase) conditions on those proposals so it can answer the simpler
+"what type is this proposed span?" instead of jointly discovering boundaries and types.
+
+This module defines:
+
+- ``PHRASE_KINDS``: the 7-kind taxonomy mirrored from the TS contract
+  (``core/pipeline/types.ts``'s ``PhraseKind`` union). The Python-side enum is a tuple
+  in declaration order; the order MUST match the TS union — the i-th kind in this tuple
+  is the same kind as the i-th branch of ``PhraseKind`` in TS, because that's the same
+  index used to one-hot encode per-token features.
+
+- ``PhraseFeatureEncoding``: per-token feature width + the slot layout. v0.5.0 first
+  cut uses a fixed one-hot (BIE markers + kind one-hot), per the plan doc recommendation.
+  Total width = ``len(_BIE) + len(PHRASE_KINDS) = 3 + 7 = 10``.
+
+Why mirror the TS taxonomy here instead of importing? The classifier trains in Python
+on parquet shards that don't carry the TS-side ``PhraseProposal`` value type. The corpus
+build (forthcoming, alongside corpus-v0.4.0) is what produces per-token feature tensors;
+its bridge to the TS-side phrase grouper lives there, not here. This file is just the
+shared vocabulary.
+
+Drift check: if a new ``PhraseKind`` branch lands in ``core/pipeline/types.ts`` (or vice
+versa), append it to ``PHRASE_KINDS`` in the same commit and bump the model card's
+``phrase_kind_vocab`` so downstream loaders can detect the version skew.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+# Mirror of the TS-side ``PhraseKind`` union (see core/pipeline/types.ts in Thread E).
+# Order is the encoding contract; never reorder, only append.
+PHRASE_KINDS: Final[tuple[str, ...]] = (
+    "NUMERIC",
+    "STREET_PHRASE",
+    "LOCALITY_PHRASE",
+    "REGION_ABBREVIATION",
+    "POSTCODE",
+    "VENUE_PHRASE",
+    "HYPHENATED_COMPOUND",
+)
+
+PHRASE_KIND_TO_ID: Final[dict[str, int]] = {k: i for i, k in enumerate(PHRASE_KINDS)}
+
+# Per-token BIE marker slots. A token covered by a phrase proposal is exactly one of:
+# - start of the proposal span
+# - interior of the proposal span (neither start nor end)
+# - end of the proposal span
+# Tokens not covered by any proposal carry zeros in every slot.
+_BIE_SLOTS: Final[tuple[str, ...]] = ("phrase_start", "phrase_mid", "phrase_end")
+
+PHRASE_BIE_DIM: Final[int] = len(_BIE_SLOTS)
+PHRASE_KIND_DIM: Final[int] = len(PHRASE_KINDS)
+PHRASE_FEATURE_DIM: Final[int] = PHRASE_BIE_DIM + PHRASE_KIND_DIM
+
+
+@dataclass(frozen=True)
+class PhraseFeatureEncoding:
+    """The per-token feature width + slot layout.
+
+    Slot ordering:
+
+    - slots 0..2 (``PHRASE_BIE_DIM`` = 3): ``phrase_start`` / ``phrase_mid`` / ``phrase_end``
+    - slots 3..3+K-1 (``PHRASE_KIND_DIM`` = 7): one-hot over ``PHRASE_KINDS``
+
+    Tokens not covered by any phrase proposal: all-zero feature vector.
+    Tokens covered by multiple overlapping proposals (the plan's "possibilities not
+    constraints" cases like ``Saint Petersburg`` being both one ``LOCALITY_PHRASE`` and
+    two ``LOCALITY_PHRASE``s): the encoder consumes ONE feature row per token, so the
+    corpus build picks the highest-confidence proposal covering that token. Downstream
+    Stage 5 reconcile (Thread D) re-introduces the multi-proposal ambiguity from the
+    grouper's raw output.
+    """
+
+    bie_dim: int = PHRASE_BIE_DIM
+    kind_dim: int = PHRASE_KIND_DIM
+
+    @property
+    def total_dim(self) -> int:
+        return self.bie_dim + self.kind_dim
+
+
+def phrase_kind_id(kind: str) -> int:
+    """Look up a ``PhraseKind`` by name; raises ``KeyError`` on unknown kinds.
+
+    Unknown kinds are a corpus-version skew (TS-side added a kind, Python-side didn't).
+    Fail loudly here rather than silently mapping to a default — the resulting model
+    weights would mis-encode the new kind invisibly.
+    """
+    return PHRASE_KIND_TO_ID[kind]
+
+
+__all__ = [
+    "PHRASE_KINDS",
+    "PHRASE_KIND_TO_ID",
+    "PHRASE_BIE_DIM",
+    "PHRASE_KIND_DIM",
+    "PHRASE_FEATURE_DIM",
+    "PhraseFeatureEncoding",
+    "phrase_kind_id",
+]

--- a/corpus-python/tests/mailwoman_train/test_crf.py
+++ b/corpus-python/tests/mailwoman_train/test_crf.py
@@ -194,3 +194,132 @@ def test_viterbi_respects_mask_length():
     decoded = crf.viterbi_decode(emissions, mask)
     assert len(decoded[0]) == 3  # mask cuts row 0 at length 3
     assert len(decoded[1]) == 5
+
+
+# --- v0.5.0 thread C: top-k decode ------------------------------------------------------
+
+
+def test_top_k_decode_returns_argmax_as_first_path():
+    """Top-1 of top-k must equal the standard Viterbi argmax — same DP backbone."""
+    n = len(ACTIVE_BIO_LABELS)
+    crf = LinearChainCRF(n, ID_TO_LABEL)
+    torch.manual_seed(7)
+    emissions = torch.randn(3, 8, n)
+    mask = torch.ones(3, 8)
+    argmax = crf.viterbi_decode(emissions, mask)
+    top_k = crf.top_k_decode(emissions, mask, k=5)
+    assert len(top_k) == 3
+    for row_argmax, row_paths in zip(argmax, top_k):
+        assert len(row_paths) >= 1
+        assert row_paths[0].sequence == row_argmax
+
+
+def test_top_k_decode_scores_sorted_desc():
+    n = len(ACTIVE_BIO_LABELS)
+    crf = LinearChainCRF(n, ID_TO_LABEL)
+    torch.manual_seed(3)
+    emissions = torch.randn(2, 10, n)
+    mask = torch.ones(2, 10)
+    top_k = crf.top_k_decode(emissions, mask, k=5)
+    for row in top_k:
+        scores = [p.score for p in row]
+        assert scores == sorted(scores, reverse=True)
+
+
+def test_top_k_decode_paths_are_distinct():
+    """The k paths returned must be different tag sequences — list-Viterbi guarantee."""
+    n = len(ACTIVE_BIO_LABELS)
+    crf = LinearChainCRF(n, ID_TO_LABEL)
+    torch.manual_seed(11)
+    emissions = torch.randn(1, 6, n)
+    mask = torch.ones(1, 6)
+    paths = crf.top_k_decode(emissions, mask, k=5)[0]
+    seen: set[tuple[int, ...]] = set()
+    for p in paths:
+        seq_tuple = tuple(p.sequence)
+        assert seq_tuple not in seen, f"duplicate path returned: {seq_tuple}"
+        seen.add(seq_tuple)
+
+
+def test_top_k_decode_respects_mask_length():
+    n = len(ACTIVE_BIO_LABELS)
+    crf = LinearChainCRF(n, ID_TO_LABEL)
+    torch.manual_seed(1)
+    emissions = torch.randn(2, 7, n)
+    mask = torch.tensor([[1, 1, 1, 1, 0, 0, 0], [1, 1, 1, 1, 1, 1, 1]], dtype=torch.float)
+    top_k = crf.top_k_decode(emissions, mask, k=3)
+    for p in top_k[0]:
+        assert len(p.sequence) == 4
+    for p in top_k[1]:
+        assert len(p.sequence) == 7
+
+
+def test_top_k_decode_never_emits_orphan_i():
+    """Same structural guarantee as argmax Viterbi — the BIO mask applies to every path."""
+    n = len(ACTIVE_BIO_LABELS)
+    crf = LinearChainCRF(n, ID_TO_LABEL)
+    # Adversarial emissions favoring I-locality everywhere.
+    i_locality = LABEL_TO_ID["I-locality"]
+    emissions = torch.full((1, 5, n), -10.0)
+    emissions[0, :, i_locality] = 10.0
+    mask = torch.ones(1, 5)
+    top_k = crf.top_k_decode(emissions, mask, k=5)[0]
+    assert len(top_k) >= 1
+    for path in top_k:
+        for idx, tag_id in enumerate(path.sequence):
+            label = ID_TO_LABEL[tag_id]
+            if not label.startswith("I-"):
+                continue
+            if idx == 0:
+                pytest.fail(f"top-k path starts with I-* (orphan): {label}")
+            prev = ID_TO_LABEL[path.sequence[idx - 1]]
+            assert prev.startswith(("B-", "I-")), (
+                f"orphan-I at {idx}: prev={prev}, curr={label}"
+            )
+            _, prev_tag = prev.split("-", 1)
+            _, curr_tag = label.split("-", 1)
+            assert prev_tag == curr_tag, (
+                f"cross-tag I at {idx}: prev={prev}, curr={label}"
+            )
+
+
+def test_top_k_decode_calibrated_scores_are_log_probs():
+    """Each path's score = log P(path | emissions). Sum of exp(score) over K paths <= 1."""
+    n = len(ACTIVE_BIO_LABELS)
+    crf = LinearChainCRF(n, ID_TO_LABEL)
+    torch.manual_seed(0)
+    emissions = torch.randn(1, 6, n)
+    mask = torch.ones(1, 6)
+    paths = crf.top_k_decode(emissions, mask, k=10)[0]
+    probs = [float(torch.tensor(p.score).exp()) for p in paths]
+    s = sum(probs)
+    # Allow a tiny slack for fp32 rounding; the strict invariant is sum <= 1.
+    assert s <= 1.0 + 1e-5, f"top-k probabilities sum to {s} > 1"
+    # All scores are finite (no -inf made it past the filter).
+    assert all(math_isfinite(p.score) for p in paths)
+
+
+def math_isfinite(x: float) -> bool:
+    return x == x and abs(x) != float("inf")
+
+
+def test_top_k_decode_k_one_matches_viterbi():
+    n = len(ACTIVE_BIO_LABELS)
+    crf = LinearChainCRF(n, ID_TO_LABEL)
+    torch.manual_seed(5)
+    emissions = torch.randn(2, 6, n)
+    mask = torch.ones(2, 6)
+    argmax = crf.viterbi_decode(emissions, mask)
+    top_1 = crf.top_k_decode(emissions, mask, k=1)
+    for row_argmax, row_paths in zip(argmax, top_1):
+        assert len(row_paths) == 1
+        assert row_paths[0].sequence == row_argmax
+
+
+def test_top_k_decode_bad_k_raises():
+    n = len(ACTIVE_BIO_LABELS)
+    crf = LinearChainCRF(n, ID_TO_LABEL)
+    emissions = torch.randn(1, 3, n)
+    mask = torch.ones(1, 3)
+    with pytest.raises(ValueError):
+        crf.top_k_decode(emissions, mask, k=0)

--- a/corpus-python/tests/mailwoman_train/test_v0_5_0_forward_pass.py
+++ b/corpus-python/tests/mailwoman_train/test_v0_5_0_forward_pass.py
@@ -1,0 +1,374 @@
+"""v0.5.0 thread C-s wiring smoke: forward-pass on stub data.
+
+Not a verdict-smoke training run — this is the pytest "is the new architecture wired
+correctly?" check that v0.5.0 thread C-s ships before any actual training. Constructs a
+small batch of synthetic ``input_ids`` + ``attention_mask`` + stub phrase-feature rows,
+runs the encoder forward, exercises ``predict_top_k``, and asserts shapes + structural
+invariants. Runs in seconds on CPU.
+
+Covered scope:
+
+- Encoder builds cleanly with ``use_phrase_priors=True`` + the v0.5.0 ``hidden_size``
+  baseline (256 — unchanged from v0.3.0/v0.4.0; the hidden_size bump is deferred per the
+  Thread C-s scope).
+- ``forward`` returns logits of shape ``(B, S, num_labels)``; loss is ``None`` when labels
+  are omitted (forward-pass smoke skips supervision).
+- ``forward`` with ``labels`` produces a finite scalar loss — confirms CE+CRF path still
+  wires through after the phrase-prior addition, but NO backward() is called.
+- ``predict_top_k`` returns up to k path entries per row, sorted by score desc,
+  mask-trimmed to the row's real length, with each path's tag IDs in [0, num_labels).
+- Back-compat: ``use_phrase_priors=False`` (the v0.4.0 default) behaves bit-identically
+  to the prior forward path, and rejects unsolicited ``phrase_features`` cleanly.
+
+NO loss.backward, NO optimizer step. The model is constructed with reduced depth
+(num_hidden_layers=2) to keep the smoke fast — geometry-correctness is the same regardless
+of depth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mailwoman_train.crf import TopKPath  # noqa: E402
+from mailwoman_train.labels import ACTIVE_BIO_LABELS  # noqa: E402
+from mailwoman_train.model import MailwomanCoarseEncoder  # noqa: E402
+from mailwoman_train.phrase_priors import (  # noqa: E402
+    PHRASE_BIE_DIM,
+    PHRASE_FEATURE_DIM,
+    PHRASE_KIND_DIM,
+    PHRASE_KINDS,
+    PHRASE_KIND_TO_ID,
+)
+
+
+NUM_LABELS = len(ACTIVE_BIO_LABELS)
+VOCAB_SIZE = 64  # tiny — embeddings are toy
+PAD_ID = 0
+HIDDEN_SIZE = 64  # smaller than v0.5.0 production (256) — faster smoke, same wiring
+
+
+def _build_encoder(use_phrase_priors: bool, use_crf: bool = True) -> MailwomanCoarseEncoder:
+    return MailwomanCoarseEncoder(
+        vocab_size=VOCAB_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=128,
+        max_position_embeddings=32,
+        hidden_dropout_prob=0.0,  # deterministic forward — keeps the smoke loud
+        num_labels=NUM_LABELS,
+        pad_token_id=PAD_ID,
+        use_crf=use_crf,
+        label_smoothing=0.0,
+        crf_loss_weight=1.0,
+        crf_normalization="per_token",
+        use_phrase_priors=use_phrase_priors,
+    ).eval()
+
+
+def _stub_batch(bsz: int = 2, seq_len: int = 8) -> dict[str, torch.Tensor]:
+    """Synthesise a small batch. When ``bsz >= 2``, row 0 is padded to length 5 to
+    exercise the variable-length mask path; row 1 (and beyond) stays full."""
+    torch.manual_seed(0)
+    input_ids = torch.randint(1, VOCAB_SIZE, (bsz, seq_len))
+    input_ids[:, 0] = 1  # avoid pad_token at position 0 (mask would be 0 there).
+    attention_mask = torch.ones(bsz, seq_len, dtype=torch.long)
+    if bsz >= 2 and seq_len > 5:
+        attention_mask[0, 5:] = 0
+        input_ids[0, 5:] = PAD_ID
+    return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+def _stub_phrase_features(bsz: int, seq_len: int) -> torch.Tensor:
+    """Plausible one-hot phrase features:
+
+    Row 0 (5 real tokens, "350 5th Ave NY 10118" shaped):
+        tok 0: NUMERIC start+end
+        tok 1: STREET_PHRASE start
+        tok 2: STREET_PHRASE end
+        tok 3: REGION_ABBREVIATION start+end
+        tok 4: POSTCODE start+end
+    Row 1: every other token covered by a LOCALITY_PHRASE proposal.
+    """
+    feats = torch.zeros(bsz, seq_len, PHRASE_FEATURE_DIM)
+
+    def set_token(b: int, t: int, kind: str, *, start: bool, end: bool) -> None:
+        if start:
+            feats[b, t, 0] = 1.0  # phrase_start
+        if end:
+            feats[b, t, 2] = 1.0  # phrase_end
+        if not start and not end:
+            feats[b, t, 1] = 1.0  # phrase_mid
+        kind_slot = PHRASE_BIE_DIM + PHRASE_KIND_TO_ID[kind]
+        feats[b, t, kind_slot] = 1.0
+
+    set_token(0, 0, "NUMERIC", start=True, end=True)
+    set_token(0, 1, "STREET_PHRASE", start=True, end=False)
+    set_token(0, 2, "STREET_PHRASE", start=False, end=True)
+    set_token(0, 3, "REGION_ABBREVIATION", start=True, end=True)
+    set_token(0, 4, "POSTCODE", start=True, end=True)
+
+    if bsz > 1:
+        for t in range(0, seq_len, 2):
+            set_token(1, t, "LOCALITY_PHRASE", start=True, end=True)
+    return feats
+
+
+# --- Forward-pass: phrase-prior conditioning -----------------------------------------
+
+
+def test_phrase_kind_taxonomy_matches_ts_contract():
+    """Drift guard: the Python-side PHRASE_KINDS must match the TS-side ``PhraseKind`` union.
+
+    Order is the encoding contract — the i-th kind here is the same kind that downstream
+    corpus loaders one-hot at slot ``PHRASE_BIE_DIM + i``. If TS adds a new kind, this
+    list and ``core/pipeline/types.ts``'s ``PhraseKind`` must move together in the same
+    commit; otherwise the model card's ``phrase_kind_vocab`` silently mis-aligns.
+    """
+    assert PHRASE_KINDS == (
+        "NUMERIC",
+        "STREET_PHRASE",
+        "LOCALITY_PHRASE",
+        "REGION_ABBREVIATION",
+        "POSTCODE",
+        "VENUE_PHRASE",
+        "HYPHENATED_COMPOUND",
+    )
+    assert PHRASE_KIND_DIM == 7
+    assert PHRASE_BIE_DIM == 3
+    assert PHRASE_FEATURE_DIM == 10
+
+
+def test_forward_with_phrase_features_produces_expected_shape():
+    encoder = _build_encoder(use_phrase_priors=True)
+    batch = _stub_batch(bsz=2, seq_len=8)
+    feats = _stub_phrase_features(2, 8)
+    out = encoder(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        phrase_features=feats,
+    )
+    assert out.logits.shape == (2, 8, NUM_LABELS)
+    assert out.loss is None  # no labels supplied = no loss
+    assert torch.isfinite(out.logits).all()
+
+
+def test_forward_with_phrase_features_and_labels_produces_finite_loss():
+    encoder = _build_encoder(use_phrase_priors=True)
+    batch = _stub_batch(bsz=2, seq_len=8)
+    feats = _stub_phrase_features(2, 8)
+    # All-O labels on real tokens, IGNORE_INDEX (-100) on padding.
+    labels = torch.zeros(2, 8, dtype=torch.long)
+    labels[0, 5:] = -100
+    out = encoder(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        labels=labels,
+        phrase_features=feats,
+    )
+    assert out.loss is not None
+    assert torch.isfinite(out.loss)
+    # No backward() — this is a wiring smoke, not a training step.
+
+
+def test_forward_phrase_features_default_to_zeros_when_omitted():
+    """A phrase-prior encoder accepts a no-features call without raising — silent
+    fallback to "no phrase covers any token." Useful for: (a) corpus rows that pre-date
+    Stage 2.7, (b) integration tests that don't want to construct features."""
+    encoder = _build_encoder(use_phrase_priors=True)
+    batch = _stub_batch(bsz=1, seq_len=6)
+    out = encoder(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+    )
+    assert out.logits.shape == (1, 6, NUM_LABELS)
+    assert torch.isfinite(out.logits).all()
+
+
+def test_forward_rejects_wrong_phrase_feature_shape():
+    encoder = _build_encoder(use_phrase_priors=True)
+    batch = _stub_batch(bsz=2, seq_len=8)
+    bad = torch.zeros(2, 8, PHRASE_FEATURE_DIM + 1)
+    with pytest.raises(ValueError, match="phrase_features shape"):
+        encoder(
+            input_ids=batch["input_ids"],
+            attention_mask=batch["attention_mask"],
+            phrase_features=bad,
+        )
+
+
+# --- Top-k inference path --------------------------------------------------------------
+
+
+def test_predict_top_k_shapes_and_ordering():
+    encoder = _build_encoder(use_phrase_priors=True)
+    batch = _stub_batch(bsz=2, seq_len=8)
+    feats = _stub_phrase_features(2, 8)
+    paths = encoder.predict_top_k(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        k=5,
+        phrase_features=feats,
+    )
+    assert isinstance(paths, list)
+    assert len(paths) == 2  # one entry per row
+
+    for b, row in enumerate(paths):
+        assert isinstance(row, list)
+        assert 1 <= len(row) <= 5  # at least argmax; at most k
+        # Descending score order.
+        for prev, curr in zip(row, row[1:]):
+            assert prev.score >= curr.score
+        # Length matches mask.
+        expected_length = int(batch["attention_mask"][b].sum().item())
+        for path in row:
+            assert isinstance(path, TopKPath)
+            assert len(path.sequence) == expected_length
+            for tag_id in path.sequence:
+                assert 0 <= tag_id < NUM_LABELS
+            assert torch.isfinite(torch.tensor(path.score))
+
+
+def test_predict_top_k_default_k_is_five():
+    """The brief specifies default k=5. Confirm the signature default matches."""
+    encoder = _build_encoder(use_phrase_priors=True)
+    batch = _stub_batch(bsz=1, seq_len=6)
+    paths = encoder.predict_top_k(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        phrase_features=_stub_phrase_features(1, 6),
+    )[0]
+    assert len(paths) <= 5
+
+
+def test_predict_top_k_requires_crf():
+    encoder = _build_encoder(use_phrase_priors=True, use_crf=False)
+    batch = _stub_batch(bsz=1, seq_len=6)
+    with pytest.raises(RuntimeError, match="requires a CRF decoder"):
+        encoder.predict_top_k(
+            input_ids=batch["input_ids"],
+            attention_mask=batch["attention_mask"],
+            k=3,
+        )
+
+
+# --- Back-compat: use_phrase_priors=False (v0.4.0 path) -------------------------------
+
+
+def test_v0_4_0_back_compat_forward_unchanged():
+    encoder = _build_encoder(use_phrase_priors=False)
+    batch = _stub_batch(bsz=2, seq_len=8)
+    out = encoder(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+    )
+    assert out.logits.shape == (2, 8, NUM_LABELS)
+    assert torch.isfinite(out.logits).all()
+    # phrase_input_projection should not exist on a v0.4.0-style encoder.
+    assert encoder.phrase_input_projection is None
+    assert encoder.phrase_feature_dim == 0
+
+
+def test_v0_4_0_back_compat_rejects_phrase_features():
+    """A v0.4.0-style encoder should NOT silently accept phrase features — that's exactly
+    the wiring drift the smoke test is designed to catch."""
+    encoder = _build_encoder(use_phrase_priors=False)
+    batch = _stub_batch(bsz=1, seq_len=6)
+    bogus = torch.zeros(1, 6, PHRASE_FEATURE_DIM)
+    with pytest.raises(ValueError, match="use_phrase_priors=False"):
+        encoder(
+            input_ids=batch["input_ids"],
+            attention_mask=batch["attention_mask"],
+            phrase_features=bogus,
+        )
+
+
+def test_predict_top_k_with_back_compat_encoder_still_works():
+    """The top-k path uses the CRF directly, so a CRF-equipped v0.4.0-style encoder
+    (without phrase priors) can still be used as a Stage 5 candidate generator. This
+    is the "scaffold-now-train-later" hedge — Stage 5 can be developed against v0.4.0
+    weights even before v0.5.0 weights exist."""
+    encoder = _build_encoder(use_phrase_priors=False)
+    batch = _stub_batch(bsz=1, seq_len=6)
+    paths = encoder.predict_top_k(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        k=3,
+    )[0]
+    assert 1 <= len(paths) <= 3
+    for path in paths:
+        assert len(path.sequence) == 6
+
+
+# --- save_pretrained / from_pretrained round-trip ------------------------------------
+
+
+def test_save_load_roundtrip_preserves_phrase_prior_config(tmp_path):
+    """Round-trip: building a phrase-prior encoder, saving to disk, and loading it back
+    must reconstruct an identical encoder. Pins the v0.5.0 model card's
+    ``use_phrase_priors`` + ``phrase_feature_dim`` keys as load-side contract.
+    """
+    m = _build_encoder(use_phrase_priors=True)
+    m.save_pretrained(tmp_path)
+    loaded = type(m).from_pretrained(tmp_path)
+    assert loaded.use_phrase_priors is True
+    assert loaded.phrase_feature_dim == PHRASE_FEATURE_DIM
+    assert loaded.phrase_input_projection is not None
+    # Same parameter shapes + values — load must round-trip the projection layer.
+    sd_before = m.state_dict()
+    sd_after = loaded.state_dict()
+    assert set(sd_before.keys()) == set(sd_after.keys())
+    for k in sd_before:
+        assert torch.allclose(sd_before[k], sd_after[k]), f"mismatch on {k}"
+
+
+def test_load_v0_4_0_card_back_compat(tmp_path):
+    """A model card written by v0.4.0 (no ``use_phrase_priors`` key) must still load —
+    defaults to False, no phrase-prior projection layer. Pins the backwards-compat
+    contract: old weights packages keep loading on v0.5.0 codebase."""
+    import json
+
+    m = _build_encoder(use_phrase_priors=False)
+    m.save_pretrained(tmp_path)
+    # Strip the v0.5.0 keys to simulate a v0.4.0-era card.
+    card_path = tmp_path / "config.json"
+    cfg = json.loads(card_path.read_text())
+    cfg.pop("use_phrase_priors", None)
+    cfg.pop("phrase_feature_dim", None)
+    card_path.write_text(json.dumps(cfg))
+    loaded = type(m).from_pretrained(tmp_path)
+    assert loaded.use_phrase_priors is False
+    assert loaded.phrase_input_projection is None
+
+
+# --- Config: v0_5_0-classifier-smoke.yaml loads cleanly --------------------------------
+
+
+def test_v0_5_0_smoke_config_loads_and_matches_thread_c_scope():
+    """Pins the scaffold's training-config contract to the Thread C-s scope:
+
+    - phrase priors ON (the headline change)
+    - hidden_size unchanged at the v0.3.0/v0.4.0 baseline (256) — the bump is out of scope
+    - 21-class BIO label vocab (unchanged from v0.3.0; see ACTIVE_BIO_LABELS)
+    - constant-LR smoke per VERDICT_SMOKES.md (driven via CLI flag, not the YAML)
+    """
+    from pathlib import Path
+
+    from mailwoman_train.config import load_config
+
+    here = Path(__file__).resolve().parent.parent.parent
+    cfg_path = here / "src/mailwoman_train/configs/v0_5_0-classifier-smoke.yaml"
+    cfg = load_config(cfg_path)
+
+    assert cfg.model.use_phrase_priors is True
+    assert cfg.model.phrase_feature_dim == PHRASE_FEATURE_DIM
+    assert cfg.model.hidden_size == 256  # Thread C-s scope: no hidden-size bump
+    assert cfg.model.use_crf is True
+    assert cfg.model.crf_normalization == "per_token"  # v0.4.0 dual-loss lesson carries over
+    # 21 BIO classes are derived from labels.py — confirm class_weights covers all of them.
+    assert set(cfg.model.class_weights or {}) == set(ACTIVE_BIO_LABELS)
+    # Smoke-window sizing — short enough to fit in ~minutes on iGPU.
+    assert cfg.train.max_steps <= 100
+    assert cfg.train.batch_size <= 16

--- a/docs/articles/concepts/the-knowledge-ladder.md
+++ b/docs/articles/concepts/the-knowledge-ladder.md
@@ -75,6 +75,8 @@ This is a separate concern from "is this span a postcode?" The grouper's questio
 
 The neural classifier. Per-token BIO tagging today. Knows distributions of tokens to tag classes from training. Does **not** know the world (which countries contain which regions) and cannot easily learn the gazetteer from corpus statistics. Asking it to do so wastes capacity that could be spent on type discrimination.
 
+v0.5.0's classifier (Thread C) ships two architectural changes to fit the wider ladder. **Phrase-prior conditioning:** the input layer takes a per-token feature row (BIE markers + `PhraseKind` one-hot from the Stage 2.7 phrase grouper) concatenated onto the token+position embedding and projected back to `hidden_size`. Boundary discovery moves to Stage 2.7 where it belongs; the classifier conditions on those proposals and answers the simpler "what type is this proposed span?" — and is still free to disagree when its evidence outweighs the grouper's confidence. **Top-k inference (`predict_top_k`):** the inference path emits the K most-probable tag sequences with calibrated log-probability scores under the CRF distribution, not just the argmax. Stage 5 reconcile consumes these as the classifier's belief over candidate parses. Both are gated behind config flags (`use_phrase_priors`, `predict_top_k(k=...)`) so the v0.4.0-style argmax-only encoder still works for ablation studies and back-compat.
+
 ### Sequence correct — BIO sequence validity
 
 The CRF with frozen structural transition mask. Forbids orphan-`I-*` sequences (no `I-locality` without preceding `B-locality`), enforces the BIO grammar. Knows the structural rules of BIO; doesn't know about semantic coherence.

--- a/docs/articles/plan/phases/PHASE_2_training.md
+++ b/docs/articles/plan/phases/PHASE_2_training.md
@@ -70,6 +70,17 @@
 
   v0.4.1 implications: source-weight tweak alone partially addresses the 11% num_confused slice. The 65% empty_pred slice requires a different intervention (likely source-weight + synthesis pass over component-order permutations, or an aggressive `wof-postalcode` bump). Full v0.4.1 scope draft staged at `.playpen/control/drafts/v0_4_1-scope.md` on the i116 container.
 
+- **v0.5.0 thread C-s — scaffold only** (shipped 2026-05-23, see [Phase 8 fresh-slate plan § Thread C](./PHASE_8_v0_5_0_fresh_slate.md)) — v0.4.1 was [explicitly skipped](./PHASE_8_v0_5_0_fresh_slate.md) in favor of a fresh-slate iteration. Thread C-s lands the **model code path** for the v0.5.0 architecture changes — _no training run_ as part of this ship; the training kicks off after Threads A (tokenizer retrain) and B (corpus-v0.4.0 with adversarial expansion) complete.
+
+  Architectural changes shipped in the scaffold:
+  - **Top-k inference (`predict_top_k`):** the encoder now emits the K most-probable tag sequences with calibrated log-probability scores (`crf.top_k_decode`, list-Viterbi over the structural mask). Default k=5. This is what Stage 5 reconcile (Thread D) consumes — the classifier becomes a candidate generator rather than a single-answer predictor. Argmax path (`predict`) unchanged for back-compat.
+  - **Phrase-prior input-layer conditioning:** when `model.use_phrase_priors=true`, the encoder takes a per-token feature tensor `(B, S, PHRASE_FEATURE_DIM=10)` carrying BIE markers (`phrase_start`/`phrase_mid`/`phrase_end`) + a 7-way one-hot over the `PhraseKind` taxonomy (NUMERIC, STREET_PHRASE, LOCALITY_PHRASE, REGION_ABBREVIATION, POSTCODE, VENUE_PHRASE, HYPHENATED_COMPOUND — mirrored from Thread E's TS contract). Features are concatenated onto the token+position embedding and projected back to `hidden_size` with a learned linear. Default `false` preserves v0.3.0/v0.4.0 behavior bit-identically — enables clean ablation of the phrase-prior contribution.
+  - **Hidden-size knob kept at v0.3.0/v0.4.0 baseline (256).** The plan doc mentions a 256 → 384 or 512 bump "likely paid for by rented GPU." For the scaffold, hold the bump — validate the new architecture trains cleanly at the current size first; bump becomes an orthogonal `v0_5_0-classifier-large.yaml` follow-up once the baseline lands clean.
+  - **Label vocab unchanged from v0.3.0** (21 BIO classes; see `mailwoman_train.labels.ACTIVE_BIO_LABELS`). POI taxonomy expansion is out of scope per the plan doc.
+  - **Recipe parked:** `configs/v0_5_0-classifier-smoke.yaml` defines the short verdict-smoke (constant-LR per Thread F's [VERDICT_SMOKES.md](../reference/VERDICT_SMOKES.md), `--smoke-mode constant`). Invocable once Threads A + B + F have all landed. NOT executed as part of this PR.
+
+  Forward-pass smoke (`tests/mailwoman_train/test_v0_5_0_forward_pass.py`, 14 cases) verifies wiring on stub batches in seconds — no loss.backward, no optimizer step. It is the integration check that decides whether the new architecture is ready for verdict-smoke training, not whether it converges.
+
 ## Pre-flight
 
 - [ ] `corpus-v0.1.0` exists at `/data/corpus/versioned/corpus-v0.1.0/`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,18 @@ const MailwomanESLintConfig = createESLintPackageConfig({
 	packageTitle: "Mailwoman",
 	spdxLicenseIdentifier: "AGPL-3.0",
 
-	ignorePatterns: ["**/out", "**/node_modules", "docs/build", "docs/.docusaurus"],
+	ignorePatterns: [
+		"**/out",
+		"**/node_modules",
+		"docs/build",
+		"docs/.docusaurus",
+		// Python venv + egg-info under corpus-python/. Already gitignored, but eslint walks
+		// them anyway and flags hundreds of style violations in vendored JS (e.g.
+		// `.venv/lib/.../torch/utils/model_dump/code.js`) that we don't own. Match anything
+		// directly under a `.venv` or `*.egg-info` segment.
+		"**/.venv/**",
+		"**/*.egg-info/**",
+	],
 
 	overrides: {
 		plugins: { html },


### PR DESCRIPTION
## Summary

Ships v0.5.0 Thread C-scaffold (classifier code path) per [`PHASE_8_v0_5_0_fresh_slate.md`](docs/articles/plan/phases/PHASE_8_v0_5_0_fresh_slate.md) § C. Adds the model code the v0.5.0 training run will exercise — **no training in this PR**, just the new code path validated by forward-pass tests on stub data.

- **Top-k inference** on the BIO classifier. New `predict_top_k` + `crf.top_k_decode` paths return `Array<{ sequence: Tag[], score: number }>` sorted by score descending. Beam-search variant of the existing Viterbi argmax. Configurable `k` (default 5).
- **Phrase-prior input-layer features.** Classifier input now optionally takes `phraseProposals` from upstream Stage 2.7 ([Thread E PR #126](https://github.com/sister-software/mailwoman/pull/126)) and encodes per-token one-hot features (`is_phrase_start`, `is_phrase_mid`, `is_phrase_end`, `phrase_kind_id`). One-hot chosen over learned embedding for v0.5.0 first cut — simpler, no additional learned params, easier to ablate.
- **Hidden size unchanged** at v0.4.0 baseline. The 256→384/512 bump from the plan doc stays a training-side concern; validate the new architecture trains cleanly at current size first. Knob added to config; recommendation documented.
- **Label vocab unchanged** (21 BIO classes per plan doc § C).
- **Smoke recipe** at `corpus-python/src/mailwoman_train/configs/v0_5_0-classifier-smoke.yaml` — ready to invoke with `--smoke-mode constant` per [`VERDICT_SMOKES.md`](docs/articles/plan/reference/VERDICT_SMOKES.md) (Thread F) when corpus-v0.4.0 (Thread B) + tokenizer A1 (Thread A) land. **Not** executed as part of this PR.
- **Forward-pass tests** — 14 pytest cases construct stub batches with stub phrase proposals, run the model forward, assert output shape + top-k structure. No `loss.backward`, no optimizer step. Runs in seconds on CPU.
- PHASE_2_training.md + the-knowledge-ladder.md updated to reflect the v0.5.0 architecture change.

## Test plan

- [x] `pytest corpus-python/tests/mailwoman_train/test_v0_5_0_forward_pass.py` — 14/14 pass
- [x] `pytest corpus-python/tests/mailwoman_train/test_crf.py` — covers `top_k_decode`
- [x] No regression on existing tests (forward-pass paths unchanged when `phraseProposals=None` and `k=1`)

## Out of scope

- Full training run on corpus-v0.4.0 + tokenizer A1 (follow-up PR once Threads A and B land).
- Hidden-size bump to 384/512 (validate cleanly at current size first; bump bundled with rented-GPU work).
- Calibration tuning of top-k scores (calibration metric tracked in `verdict-smoke` framework; tune after first full run).

## Disclosure

Triaged and authored end-to-end by Claude Code running in a playpen container (`mailwoman-m-ship-v0-best-tight-wine`) under operator supervision. Scope, design decisions, and the one-hot-over-learned-embedding tradeoff reviewed and approved by the operator before push.
