### PR TITLE
v0.5.0 thread A0: SentencePiece tokenizer trainer harness + multi-script eval fixture

### DIFF
--- a/corpus-python/src/mailwoman_train/cli.py
+++ b/corpus-python/src/mailwoman_train/cli.py
@@ -10,6 +10,8 @@ Subcommands:
 - ``smoke`` — run the entire pipeline at tiny scale on CPU. Validates the wiring; does
   NOT produce shippable weights.
 - ``verify-tokenizer`` — re-tokenize a sample of corpus rows and assert the SP encoder works.
+- ``tokenizer`` — train a versioned SentencePiece tokenizer from a corpus shard tree, with
+  byte-fallback measurement + model card. v0.5.0 Thread A harness.
 """
 
 from __future__ import annotations
@@ -336,6 +338,94 @@ def cmd_smoke(args: argparse.Namespace) -> int:
     return 0
 
 
+_CORPUS_VERSIONED_ROOT = Path("/data/corpus/versioned")
+
+
+def _resolve_corpus_dir(spec: str) -> Path:
+    """Resolve a ``--corpus`` argument into a concrete shard-tree path.
+
+    Accepts three forms:
+
+    1. ``vX.Y.Z`` (or ``X.Y.Z``) — looks under ``/data/corpus/versioned/vX.Y.Z/corpus-vX.Y.Z/``.
+    2. An absolute or relative path that already contains ``train/*.parquet``.
+    3. An absolute or relative path one level up (with ``corpus-v*`` child).
+    """
+    p = Path(spec)
+    if p.is_absolute() and (p / "train").is_dir():
+        return p
+    if p.exists() and (p / "train").is_dir():
+        return p.resolve()
+    # Path one level up — accept ``/data/corpus/versioned/v0.3.0`` and resolve inward.
+    if p.exists() and p.is_dir():
+        candidates = sorted(p.glob("corpus-v*"))
+        if len(candidates) == 1 and (candidates[0] / "train").is_dir():
+            return candidates[0].resolve()
+    # Version-string form: ``v0.3.0`` or ``0.3.0``.
+    ver = spec.lstrip("v")
+    candidate = _CORPUS_VERSIONED_ROOT / f"v{ver}" / f"corpus-v{ver}"
+    if (candidate / "train").is_dir():
+        return candidate
+    raise FileNotFoundError(
+        f"could not resolve --corpus={spec!r}; tried {candidate}/train and direct path forms"
+    )
+
+
+def cmd_tokenizer(args: argparse.Namespace) -> int:
+    """Train a SentencePiece tokenizer from a corpus version (v0.5.0 Thread A harness)."""
+    import logging
+
+    from .tokenizer_train import (
+        DEFAULT_USER_DEFINED_SYMBOLS,
+        TrainerConfig,
+        parse_user_defined_symbols_file,
+        train_tokenizer,
+    )
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    corpus_dir = _resolve_corpus_dir(args.corpus)
+    output_dir = Path(args.output)
+    countries = tuple(c.strip() for c in args.countries.split(",") if c.strip())
+
+    uds: list[str] = []
+    if not args.no_default_user_defined_symbols:
+        uds.extend(DEFAULT_USER_DEFINED_SYMBOLS)
+    if args.user_defined_symbols_file:
+        uds.extend(parse_user_defined_symbols_file(Path(args.user_defined_symbols_file)))
+
+    cfg = TrainerConfig(
+        corpus_dir=corpus_dir,
+        output_dir=output_dir,
+        corpus_version=args.corpus_version or _infer_corpus_version(corpus_dir),
+        vocab_size=args.vocab,
+        character_coverage=args.character_coverage,
+        model_type=args.model_type,
+        byte_fallback=not args.no_byte_fallback,
+        split_digits=args.split_digits,
+        allow_whitespace_only_pieces=False,
+        per_country_sample=args.per_country_sample,
+        countries=countries,
+        mine_postcode_literals=args.mine_postcode_literals,
+        user_defined_symbols=tuple(uds),
+        eval_fixture=Path(args.eval_fixture) if args.eval_fixture else None,
+        seed=args.seed,
+    )
+    card = train_tokenizer(cfg)
+    print(json.dumps(card, indent=2))
+    return 0
+
+
+def _infer_corpus_version(corpus_dir: Path) -> str:
+    """Best-effort: pull ``v0.3.0`` out of ``.../v0.3.0/corpus-v0.3.0`` paths."""
+    name = corpus_dir.name
+    if name.startswith("corpus-"):
+        return name[len("corpus-"):]
+    return name
+
+
 def cmd_verify_tokenizer(args: argparse.Namespace) -> int:
     from .config import load_config
     from .data_loader import verify_tokenizer_alignment
@@ -413,6 +503,63 @@ def build_parser() -> argparse.ArgumentParser:
     common(p)
     p.add_argument("--sample", type=int, default=100)
     p.set_defaults(func=cmd_verify_tokenizer)
+
+    p = sub.add_parser(
+        "tokenizer",
+        help="Train a SentencePiece tokenizer from a corpus version (v0.5.0 Thread A).",
+    )
+    p.add_argument(
+        "--corpus",
+        required=True,
+        help='Corpus to train on. Accepts "v0.3.0" / "0.3.0" (resolves under '
+        '/data/corpus/versioned/vX.Y.Z/corpus-vX.Y.Z/) or an explicit shard-tree path '
+        "(parent of train/, val/, test/).",
+    )
+    p.add_argument(
+        "--corpus-version",
+        default=None,
+        help="Override the corpus_version stamp in the model card (auto-inferred from path).",
+    )
+    p.add_argument("--output", required=True, help="Output dir for tokenizer.model + model_card.json")
+    p.add_argument("--vocab", type=int, default=48000, help="Vocabulary size (v0.5.0 default 48000)")
+    p.add_argument(
+        "--character-coverage",
+        type=float,
+        default=0.9999,
+        help="SP character_coverage. v0.5.0 bumps to 0.9999 (from v0.1.0's 0.9995) for better non-Latin coverage.",
+    )
+    p.add_argument("--model-type", default="unigram", choices=["unigram", "bpe", "char", "word"])
+    p.add_argument("--no-byte-fallback", action="store_true", help="Disable SP byte_fallback (default: enabled)")
+    p.add_argument("--split-digits", action="store_true", help="Pass SP split_digits=true (default: false)")
+    p.add_argument(
+        "--countries",
+        default="US,FR",
+        help="Comma-separated country codes to sample raws from (default: US,FR)",
+    )
+    p.add_argument("--per-country-sample", type=int, default=500_000)
+    p.add_argument(
+        "--mine-postcode-literals",
+        type=int,
+        default=0,
+        help="If > 0, mine the top-N postcode literals from the corpus and add them as user_defined_symbols.",
+    )
+    p.add_argument(
+        "--user-defined-symbols-file",
+        default=None,
+        help="One literal per line (blank + ``#``-comments skipped). Appended to the default UDS list.",
+    )
+    p.add_argument(
+        "--no-default-user-defined-symbols",
+        action="store_true",
+        help="Skip the built-in DEFAULT_USER_DEFINED_SYMBOLS list (US states + country abbrevs + postal markers).",
+    )
+    p.add_argument(
+        "--eval-fixture",
+        default=None,
+        help="Path to a JSONL or text file of held-out lines. Used to compute the byte-fallback rate recorded in the model card.",
+    )
+    p.add_argument("--seed", type=int, default=42)
+    p.set_defaults(func=cmd_tokenizer)
 
     return parser
 

--- a/corpus-python/src/mailwoman_train/tokenizer_train.py
+++ b/corpus-python/src/mailwoman_train/tokenizer_train.py
@@ -1,0 +1,551 @@
+"""SentencePiece tokenizer training harness (v0.5.0 Thread A).
+
+A reproducible trainer that produces a versioned tokenizer + model card from a corpus
+shard tree. Used to train ``tokenizer-v0.5.0-a0`` on ``corpus-v0.3.0`` and (once Thread B
+lands) ``tokenizer-v0.5.0-a1`` on ``corpus-v0.4.0`` via the same code path.
+
+The runtime wrapper lives in ``mailwoman_train.tokenizer`` — that's the SP encoder + label
+realigner the Phase 2 train loop consumes. This module is *only* about producing the SP
+model file from a corpus version. The two are kept separate so the heavy parquet/sampling
+imports don't load when the train loop just wants to encode.
+
+Why a new module (not extending ``scripts/train_tokenizer.py``)?
+
+- The legacy script is stdin-or-file driven; the harness contract is "give me a corpus
+  version + vocab budget, do the sampling and training and measurement end-to-end."
+- The harness writes a richer ``model_card.json`` (sentencepiece flags, UDS preview,
+  byte-fallback rate per script) the legacy ``META.json`` doesn't carry.
+- A0 / A1 retrain is a single re-invocation: same harness, new ``--corpus``.
+
+Default sampling strategy: per-country reservoir over the train split, taking ``raw``
+strings only (whitespace tokens / BIO labels are irrelevant to SP training). Countries
+default to ``US`` + ``FR`` to match corpus-v0.3.0's mass; pass ``--countries`` to widen
+once Thread B's adversarial transliteration corpus is in the mix.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import random
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pyarrow.parquet as pq
+import sentencepiece as spm  # type: ignore[import-not-found]
+
+logger = logging.getLogger(__name__)
+
+# Byte-fallback pieces in a SentencePiece model are surface-form ``<0xNN>`` (one literal
+# token per byte). Matching the surface form is more robust than matching piece id ranges:
+# the id range depends on where SP placed the byte block in the unigram vocab.
+_BYTE_FALLBACK_RE = re.compile(r"^<0x[0-9A-Fa-f]{2}>$")
+
+# Default user-defined symbols ("must keep whole"). SentencePiece UDS are literal strings
+# that bypass unigram inference and are always emitted as a single piece. We use them for
+# anchor patterns that should never fragment across sub-pieces:
+#
+# - **Country abbreviations** the corpus mentions but the unigram model might split.
+# - **US state codes** (50 + DC) — short two-letter chunks adjacent to postcodes; without
+#   UDS the unigram tokenizer can fragment ``NY 10001`` into ``N`` + ``Y`` + `` 10001``
+#   under some merges. Keeping state codes atomic preserves the region→postcode adjacency
+#   the classifier relies on.
+# - **Common postal markers** (PO Box, Cedex, BP) — fixed surface forms; cheaper to put in
+#   the vocab once than to learn them from frequency.
+# - **JP postcode hyphen anchor** (``-``) we don't include here because ``-`` already
+#   tokenizes as a single piece; the JP 100-0005 *whole-postcode* coverage comes from
+#   corpus-mined postcode literals (see ``mine_postcode_literals``).
+#
+# Callers can extend or replace this set via ``--user-defined-symbols-file`` (one literal
+# per line, blank lines + ``#``-comments ignored).
+DEFAULT_USER_DEFINED_SYMBOLS: tuple[str, ...] = (
+    # US states
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+    "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+    "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+    "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+    "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+    "DC", "PR", "VI", "GU", "AS", "MP",
+    # Country abbreviations / common names
+    "USA", "US", "U.S.", "U.S.A.", "FR", "FRA", "France",
+    "JP", "JPN", "Japan", "GB", "UK", "U.K.",
+    "DE", "DEU", "Germany", "IT", "ITA", "Italy",
+    "ES", "ESP", "Spain", "NL", "NLD", "Netherlands",
+    "CA", "CAN", "Canada", "AU", "AUS", "Australia",
+    "CH", "CHE", "Switzerland", "BE", "BEL", "Belgium",
+    "AT", "AUT", "Austria", "SE", "SWE", "Sweden",
+    "RU", "RUS",
+    # Postal-form anchors
+    "PO Box", "P.O. Box", "P.O.Box", "POB",
+    "Apt", "Apt.", "Suite", "Ste",
+    "Cedex", "CEDEX",
+    "BP",
+)
+
+
+@dataclass
+class TrainerConfig:
+    """Inputs to ``train_tokenizer``. Keep fields flat — they round-trip into the model card."""
+
+    corpus_dir: Path
+    output_dir: Path
+    corpus_version: str
+    vocab_size: int = 48000
+    character_coverage: float = 0.9999
+    model_type: str = "unigram"
+    byte_fallback: bool = True
+    split_digits: bool = False
+    allow_whitespace_only_pieces: bool = False
+    per_country_sample: int = 500_000
+    countries: tuple[str, ...] = ("US", "FR")
+    mine_postcode_literals: int = 0
+    user_defined_symbols: tuple[str, ...] = ()
+    eval_fixture: Path | None = None
+    seed: int = 42
+    extra_sp_kwargs: dict = field(default_factory=dict)
+
+
+def iter_raws_by_country(corpus_dir: Path, country: str) -> Iterable[str]:
+    """Yield ``raw`` strings from every train shard whose row matches ``country``."""
+    train_dir = corpus_dir / "train"
+    shards = sorted(train_dir.glob("*.parquet"))
+    if not shards:
+        raise FileNotFoundError(f"no parquet shards under {train_dir}")
+    for shard in shards:
+        # Column-projected read keeps RSS low.
+        t = pq.read_table(shard, columns=["raw", "country"])
+        raws = t["raw"]
+        countries = t["country"]
+        for i in range(t.num_rows):
+            if countries[i].as_py() == country:
+                yield raws[i].as_py()
+
+
+def reservoir_sample(it: Iterable[str], k: int, rng: random.Random) -> list[str]:
+    """Algorithm-R reservoir sampler. Single pass, memory ≤ ``k``."""
+    out: list[str] = []
+    for i, x in enumerate(it):
+        if i < k:
+            out.append(x)
+        else:
+            j = rng.randint(0, i)
+            if j < k:
+                out[j] = x
+    return out
+
+
+def sample_balanced_raws(
+    corpus_dir: Path,
+    *,
+    countries: Sequence[str],
+    per_country: int,
+    seed: int,
+) -> list[str]:
+    """Per-country reservoir sample, concatenated + shuffled."""
+    rng = random.Random(seed)
+    out: list[str] = []
+    for cc in countries:
+        picked = reservoir_sample(iter_raws_by_country(corpus_dir, cc), per_country, rng)
+        logger.info("sampled %d lines for country=%s", len(picked), cc)
+        out.extend(picked)
+    rng.shuffle(out)
+    return out
+
+
+def mine_postcode_literals(
+    corpus_dir: Path,
+    *,
+    top_k: int,
+    countries: Sequence[str] | None = None,
+    max_shards: int | None = None,
+) -> list[str]:
+    """Return the top-``top_k`` postcode literals in the train split by frequency.
+
+    Reads each shard's ``labels`` column and pulls out tokens whose BIO label endswith
+    ``-postcode``. The unigram trainer will not always keep these whole on its own; adding
+    them as UDS guarantees one piece per common postcode literal.
+
+    ``countries``: when given, only count postcodes from rows whose ``country`` matches.
+    ``max_shards``: for unit tests; in production leave ``None`` to scan everything.
+    """
+    counter: Counter[str] = Counter()
+    train_dir = corpus_dir / "train"
+    shards = sorted(train_dir.glob("*.parquet"))
+    if max_shards is not None:
+        shards = shards[:max_shards]
+    if not shards:
+        raise FileNotFoundError(f"no parquet shards under {train_dir}")
+    for shard in shards:
+        cols = ["tokens", "labels"]
+        if countries is not None:
+            cols.append("country")
+        t = pq.read_table(shard, columns=cols)
+        tokens_col = t["tokens"]
+        labels_col = t["labels"]
+        countries_col = t["country"] if countries is not None else None
+        country_filter = set(countries) if countries is not None else None
+        for i in range(t.num_rows):
+            if country_filter is not None and countries_col[i].as_py() not in country_filter:
+                continue
+            toks = tokens_col[i].as_py()
+            labs = labels_col[i].as_py()
+            for tok, lab in zip(toks, labs):
+                if lab.endswith("-postcode"):
+                    # Strip trailing punctuation like ``75008,`` so the literal we add to
+                    # the vocab is the bare postcode form. Anything else is unsafe to mine.
+                    cleaned = tok.strip(" ,;:.()[]\"'")
+                    if cleaned:
+                        counter[cleaned] += 1
+    return [w for w, _ in counter.most_common(top_k)]
+
+
+def detect_script(text: str) -> str:
+    """Return a coarse script tag for a string: ``latin``, ``cjk``, ``cyrillic``, ``armenian``,
+    ``arabic``, ``greek``, ``hebrew``, ``devanagari``, ``thai``, ``mixed``, or ``other``.
+
+    Used to bucket the byte-fallback eval into per-script rates so the model card surfaces
+    *where* the tokenizer hits byte fallback, not just the overall headline number.
+    """
+    blocks: Counter[str] = Counter()
+    for ch in text:
+        if ch.isspace() or unicodedata.category(ch).startswith(("N", "P", "Z", "S")):
+            continue
+        name = unicodedata.name(ch, "")
+        if not name:
+            blocks["other"] += 1
+            continue
+        if name.startswith(("LATIN", "FULLWIDTH LATIN")):
+            blocks["latin"] += 1
+        elif name.startswith(("CJK", "HIRAGANA", "KATAKANA", "HANGUL")):
+            blocks["cjk"] += 1
+        elif name.startswith("CYRILLIC"):
+            blocks["cyrillic"] += 1
+        elif name.startswith("ARMENIAN"):
+            blocks["armenian"] += 1
+        elif name.startswith("ARABIC"):
+            blocks["arabic"] += 1
+        elif name.startswith("GREEK"):
+            blocks["greek"] += 1
+        elif name.startswith("HEBREW"):
+            blocks["hebrew"] += 1
+        elif name.startswith("DEVANAGARI"):
+            blocks["devanagari"] += 1
+        elif name.startswith("THAI"):
+            blocks["thai"] += 1
+        else:
+            blocks["other"] += 1
+    if not blocks:
+        return "other"
+    if len(blocks) == 1:
+        return next(iter(blocks))
+    # If 90%+ of letter chars are in one block, call it that block (latin punctuation around
+    # a CJK address shouldn't make it ``mixed``). Otherwise call it ``mixed``.
+    total = sum(blocks.values())
+    top, n = blocks.most_common(1)[0]
+    return top if n / total >= 0.9 else "mixed"
+
+
+def measure_byte_fallback(
+    sp: spm.SentencePieceProcessor, lines: Iterable[str]
+) -> dict:
+    """Encode each line and tally byte-fallback piece rate, overall + per script.
+
+    Returns a dict shaped::
+
+        {
+          "overall": {"lines": n, "pieces": p, "byte_fallback_pieces": b, "rate": b/p},
+          "per_script": {
+              "latin":   {"lines": ..., "pieces": ..., "byte_fallback_pieces": ..., "rate": ...},
+              "cjk":     {...},
+              ...
+          }
+        }
+
+    The "rate" denominator is piece count, not line count — a byte-fallback piece is a
+    *piece*, not a *line*, so the rate that matters for downstream model wastage is the
+    fraction of pieces that landed on the byte block.
+    """
+    overall = {"lines": 0, "pieces": 0, "byte_fallback_pieces": 0}
+    per_script: dict[str, dict[str, int]] = {}
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        script = detect_script(line)
+        bucket = per_script.setdefault(
+            script, {"lines": 0, "pieces": 0, "byte_fallback_pieces": 0}
+        )
+        pieces = sp.encode_as_pieces(line)
+        npieces = len(pieces)
+        nfb = sum(1 for p in pieces if _BYTE_FALLBACK_RE.match(p))
+
+        overall["lines"] += 1
+        overall["pieces"] += npieces
+        overall["byte_fallback_pieces"] += nfb
+        bucket["lines"] += 1
+        bucket["pieces"] += npieces
+        bucket["byte_fallback_pieces"] += nfb
+
+    def _attach_rate(d: dict[str, int]) -> dict[str, float | int]:
+        rate = d["byte_fallback_pieces"] / d["pieces"] if d["pieces"] > 0 else 0.0
+        return {**d, "rate": rate}
+
+    return {
+        "overall": _attach_rate(overall),
+        "per_script": {k: _attach_rate(v) for k, v in per_script.items()},
+    }
+
+
+def load_fixture_lines(path: Path) -> list[str]:
+    """Load raws from a JSONL eval fixture, falling back to plain-text if not JSON."""
+    lines: list[str] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            raw_line = raw_line.rstrip("\n")
+            if not raw_line:
+                continue
+            if raw_line.lstrip().startswith("{"):
+                obj = json.loads(raw_line)
+                v = obj.get("raw") or obj.get("text") or obj.get("input")
+                if v:
+                    lines.append(str(v))
+            else:
+                lines.append(raw_line)
+    return lines
+
+
+def git_commit(workdir: Path | None = None) -> str | None:
+    """Best-effort: return the current HEAD SHA, or None outside a git checkout."""
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=workdir or Path(__file__).parent,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode("utf-8").strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def sha256_of_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_user_defined_symbols_file(path: Path) -> list[str]:
+    """One literal per line; blank lines + ``#``-comments ignored. Whitespace stripped only
+    at line ends (a UDS may itself contain spaces like ``PO Box``)."""
+    out: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        s = line.rstrip()
+        if not s or s.lstrip().startswith("#"):
+            continue
+        out.append(s)
+    return out
+
+
+# U+2581 LOWER ONE EIGHTH BLOCK is SentencePiece's whitespace placeholder. UDS literals
+# that contain ASCII spaces must use this codepoint instead — SP normalizes all whitespace
+# to ▁ before matching, so a UDS like ``"PO Box"`` would never fire (the encoder sees
+# ``"PO▁Box"`` internally but the UDS in the vocab is still ``"PO Box"``). We substitute
+# transparently so callers can write natural strings.
+_SP_WHITESPACE = "▁"
+
+
+def _normalize_uds_for_sp(s: str) -> str:
+    """Convert ASCII spaces to SentencePiece's ``▁`` whitespace placeholder."""
+    return s.replace(" ", _SP_WHITESPACE)
+
+
+def _dedupe_keep_order(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for x in items:
+        if x and x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+
+def train_tokenizer(cfg: TrainerConfig) -> dict:
+    """End-to-end SentencePiece training + byte-fallback measurement.
+
+    Steps:
+
+    1. Sample per-country raws into a temp text file.
+    2. (Optional) Mine top-N postcode literals from the corpus and union with the supplied
+       UDS list.
+    3. Invoke ``spm.SentencePieceTrainer.train`` with the assembled flags.
+    4. (Optional) Encode the eval fixture and compute overall + per-script byte-fallback.
+    5. Persist ``tokenizer.model``, ``tokenizer.vocab``, ``model_card.json``.
+
+    Returns the model card dict.
+    """
+    started = time.time()
+
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
+    model_prefix = cfg.output_dir / "tokenizer"
+
+    # 1. Sample.
+    raws = sample_balanced_raws(
+        cfg.corpus_dir,
+        countries=cfg.countries,
+        per_country=cfg.per_country_sample,
+        seed=cfg.seed,
+    )
+    if not raws:
+        raise RuntimeError(
+            f"sampled zero lines from corpus_dir={cfg.corpus_dir} countries={cfg.countries}"
+        )
+
+    # 2. Resolve UDS: caller's list, deduped + intersected with sane limits.
+    uds = list(cfg.user_defined_symbols)
+    if cfg.mine_postcode_literals > 0:
+        mined = mine_postcode_literals(
+            cfg.corpus_dir,
+            top_k=cfg.mine_postcode_literals,
+            countries=cfg.countries,
+        )
+        uds.extend(mined)
+    uds = _dedupe_keep_order(uds)
+    # SentencePiece's vocab budget MUST be > UDS count + reserved special-tokens — otherwise
+    # the trainer aborts. Cap UDS at min(uds, vocab_size // 4) defensively so a misconfigured
+    # caller (e.g. asking for 30K UDS with vocab=48K) doesn't poison the training pass.
+    uds_cap = max(0, cfg.vocab_size // 4)
+    if len(uds) > uds_cap:
+        logger.warning(
+            "user_defined_symbols (%d) exceeds vocab_size/4 cap (%d); truncating",
+            len(uds), uds_cap,
+        )
+        uds = uds[:uds_cap]
+    # SP needs ASCII spaces in UDS literals translated to its ``▁`` placeholder so they
+    # actually match user input. See ``_normalize_uds_for_sp`` for the rationale.
+    uds_for_sp = [_normalize_uds_for_sp(s) for s in uds]
+
+    # 3. Materialize sampled raws to a temp file (SP wants a path on disk).
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False, encoding="utf-8"
+    ) as tmp:
+        tmp_path = Path(tmp.name)
+        for line in raws:
+            tmp.write(line.replace("\n", " "))
+            tmp.write("\n")
+
+    try:
+        sp_flags = {
+            "input": str(tmp_path),
+            "model_prefix": str(model_prefix),
+            "vocab_size": cfg.vocab_size,
+            "character_coverage": cfg.character_coverage,
+            "model_type": cfg.model_type,
+            "byte_fallback": cfg.byte_fallback,
+            "split_digits": cfg.split_digits,
+            "allow_whitespace_only_pieces": cfg.allow_whitespace_only_pieces,
+            "pad_id": 0,
+            "unk_id": 1,
+            "bos_id": 2,
+            "eos_id": 3,
+            "user_defined_symbols": uds_for_sp,
+            **cfg.extra_sp_kwargs,
+        }
+        logger.info(
+            "training sentencepiece: vocab=%d, type=%s, char_cov=%.4f, byte_fb=%s, lines=%d, uds=%d",
+            cfg.vocab_size,
+            cfg.model_type,
+            cfg.character_coverage,
+            cfg.byte_fallback,
+            len(raws),
+            len(uds),
+        )
+        spm.SentencePieceTrainer.train(**sp_flags)
+    finally:
+        # Clean up the sampling temp file regardless of training success.
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    elapsed = time.time() - started
+    model_path = model_prefix.with_suffix(".model")
+    vocab_path = model_prefix.with_suffix(".vocab")
+    if not model_path.exists():
+        raise RuntimeError(f"sentencepiece training finished without writing {model_path}")
+
+    # 4. Byte-fallback measurement.
+    sp = spm.SentencePieceProcessor(model_file=str(model_path))
+    byte_fb: dict | None = None
+    if cfg.eval_fixture is not None:
+        fixture_lines = load_fixture_lines(cfg.eval_fixture)
+        byte_fb = measure_byte_fallback(sp, fixture_lines)
+
+    # 5. Persist model card. Drop the absolute ``input`` path from sp_flags before writing
+    # so the card stays portable across machines; keep everything else.
+    portable_flags = {k: v for k, v in sp_flags.items() if k not in ("input",)}
+    portable_flags["user_defined_symbols_count"] = len(uds)
+    # Keep a preview of the UDS list; the full list is mostly mined postcodes, redundant in
+    # the card. The full list is recoverable from ``tokenizer.vocab`` (UDS shows up as
+    # `<surface>\t0` entries adjacent to the special tokens).
+    portable_flags["user_defined_symbols_preview"] = uds[:64]
+    portable_flags.pop("user_defined_symbols", None)
+
+    card = {
+        "tokenizer_version": cfg.output_dir.name,
+        "corpus_version": cfg.corpus_version,
+        "vocab_size": int(sp.get_piece_size()),
+        "training_lines": len(raws),
+        "training_duration_seconds": round(elapsed, 3),
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "git_commit": git_commit(),
+        "model_sha256": sha256_of_file(model_path),
+        "model_path": str(model_path),
+        "vocab_path": str(vocab_path),
+        "sentencepiece_flags": portable_flags,
+        "sampling": {
+            "countries": list(cfg.countries),
+            "per_country": cfg.per_country_sample,
+            "seed": cfg.seed,
+        },
+        "byte_fallback_eval": byte_fb,
+    }
+    card_path = cfg.output_dir / "model_card.json"
+    card_path.write_text(json.dumps(card, indent=2) + "\n", encoding="utf-8")
+    # Keep a META.json compatibility shim — older Phase 1 scripts looked for this name.
+    (cfg.output_dir / "META.json").write_text(
+        json.dumps(card, indent=2) + "\n", encoding="utf-8"
+    )
+
+    logger.info(
+        "wrote %s (vocab=%d, byte_fb_overall=%s)",
+        model_path,
+        card["vocab_size"],
+        f"{byte_fb['overall']['rate']:.4f}" if byte_fb else "n/a",
+    )
+    return card
+
+
+__all__ = [
+    "DEFAULT_USER_DEFINED_SYMBOLS",
+    "TrainerConfig",
+    "detect_script",
+    "iter_raws_by_country",
+    "load_fixture_lines",
+    "measure_byte_fallback",
+    "mine_postcode_literals",
+    "parse_user_defined_symbols_file",
+    "reservoir_sample",
+    "sample_balanced_raws",
+    "train_tokenizer",
+]

--- a/corpus-python/tests/mailwoman_train/test_tokenizer_train.py
+++ b/corpus-python/tests/mailwoman_train/test_tokenizer_train.py
@@ -1,0 +1,264 @@
+"""Trainer-harness unit tests.
+
+These tests cover the pieces of ``mailwoman_train.tokenizer_train`` that don't need a
+corpus on disk: script detection, byte-fallback measurement, UDS file parsing, and the
+postcode-shape preservation invariant when UDS literals are present in the SP model.
+
+The full ``train_tokenizer`` end-to-end (with parquet input) is exercised by hand from the
+CLI; covering it here would require committing a parquet fixture or training on the real
+30 GB shard tree, neither of which is appropriate for fast unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import sentencepiece as spm  # type: ignore[import-not-found]
+
+from mailwoman_train.tokenizer_train import (
+    DEFAULT_USER_DEFINED_SYMBOLS,
+    detect_script,
+    load_fixture_lines,
+    measure_byte_fallback,
+    parse_user_defined_symbols_file,
+    reservoir_sample,
+)
+
+
+def test_detect_script_pure_blocks():
+    assert detect_script("1600 Pennsylvania Avenue NW") == "latin"
+    assert detect_script("東京都新宿区西新宿") == "cjk"
+    assert detect_script("Москва, ул. Тверская") == "cyrillic"
+    assert detect_script("Երեւան, Աբովյան") == "armenian"
+    assert detect_script("Αθήνα") == "greek"
+    assert detect_script("القاهرة") == "arabic"
+    assert detect_script("ירושלים") == "hebrew"
+    assert detect_script("नई दिल्ली") == "devanagari"
+    assert detect_script("กรุงเทพมหานคร") == "thai"
+
+
+def test_detect_script_handles_mixed_majority():
+    # Numbers + Latin punctuation around CJK still counts as cjk (90% threshold).
+    assert detect_script("〒100-0005 東京都千代田区丸の内") == "cjk"
+    # Half-Latin / half-CJK is mixed.
+    assert detect_script("Tokyo 東京 City") == "mixed"
+
+
+def test_detect_script_falls_back_to_other_for_unknown_blocks():
+    # Georgian Mkhedruli isn't in our enumerated list — should land on ``other``.
+    assert detect_script("თბილისი") == "other"
+
+
+def test_default_user_defined_symbols_includes_postal_anchors():
+    # Sanity: the default list should cover the four format families called out in the
+    # v0.5.0 plan plus the postal markers that appear adjacent to postcodes in corpus.
+    assert "NY" in DEFAULT_USER_DEFINED_SYMBOLS
+    assert "CA" in DEFAULT_USER_DEFINED_SYMBOLS
+    assert "USA" in DEFAULT_USER_DEFINED_SYMBOLS
+    assert "France" in DEFAULT_USER_DEFINED_SYMBOLS
+    assert "Cedex" in DEFAULT_USER_DEFINED_SYMBOLS
+    assert "PO Box" in DEFAULT_USER_DEFINED_SYMBOLS
+
+
+def test_parse_user_defined_symbols_file(tmp_path: Path):
+    p = tmp_path / "uds.txt"
+    p.write_text(
+        "\n".join(
+            [
+                "# comment",
+                "75008",
+                "10001",
+                "",
+                "SW1A 1AA",
+                "  ",  # blank-ish; trimmed to nothing, skipped
+                "100-0005",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out = parse_user_defined_symbols_file(p)
+    assert out == ["75008", "10001", "SW1A 1AA", "100-0005"]
+
+
+def test_reservoir_sample_size_and_determinism():
+    import random as _r
+
+    pool = [str(i) for i in range(1000)]
+    rng1 = _r.Random(42)
+    rng2 = _r.Random(42)
+    s1 = reservoir_sample(iter(pool), 50, rng1)
+    s2 = reservoir_sample(iter(pool), 50, rng2)
+    assert len(s1) == 50
+    assert s1 == s2
+    # With a different seed, the sample changes.
+    s3 = reservoir_sample(iter(pool), 50, _r.Random(7))
+    assert s3 != s1
+
+
+def test_load_fixture_lines_handles_jsonl_and_text(tmp_path: Path):
+    jsonl = tmp_path / "f.jsonl"
+    jsonl.write_text(
+        '{"raw": "foo"}\n'
+        '{"text": "bar"}\n'
+        '{"input": "baz"}\n'
+        "\n"
+        '{"raw": "qux"}\n',
+        encoding="utf-8",
+    )
+    assert load_fixture_lines(jsonl) == ["foo", "bar", "baz", "qux"]
+
+    txt = tmp_path / "f.txt"
+    txt.write_text("hello\n\nworld\n", encoding="utf-8")
+    assert load_fixture_lines(txt) == ["hello", "world"]
+
+
+_SP_WS = "▁"
+
+
+def _train_tiny_sp(tmp_path: Path, uds: list[str] | None = None) -> spm.SentencePieceProcessor:
+    """Train a deliberately-tiny SP model on a one-shot synthetic corpus for unit tests."""
+    sample = tmp_path / "raws.txt"
+    # Seed the corpus with enough material that SP can hit the tiny vocab budget while still
+    # exposing the postcodes we want to keep whole.
+    lines = []
+    # SP's vocab_size floor = required_chars (1 per byte fallback = 256) + 4 specials +
+    # corpus alphabet. Lower bound is ~300, upper bound = pieces SP can extract. Generate a
+    # rich-enough synthetic corpus with varied tokens so SP has > 600 candidate pieces.
+    import string
+    base_addresses = [
+        "1600 Pennsylvania Avenue NW Washington DC 20500",
+        "350 Fifth Avenue New York NY 10118",
+        "1 Apple Park Way Cupertino CA 95014",
+        "15 Rue de Rivoli 75004 Paris France",
+        "Paris 75008",
+        "PO Box 1234 Anchorage AK 99501",
+        "742 Evergreen Terrace Springfield OR 97477",
+        "Buffalo Health Center 200 Elmwood Ave Buffalo NY 14222",
+        "Saint Petersburg FL 33701",
+        "Brooklyn NY 11201",
+        "Marais Paris 75004",
+        "Lyon 69001 France",
+        "Bordeaux 33000",
+        "Lille 59000",
+    ]
+    # Extra filler so the unigram trainer has plenty of distinct pieces to choose from.
+    filler_streets = [
+        "Main Street", "Oak Avenue", "Maple Road", "Cedar Lane",
+        "Elm Boulevard", "Pine Drive", "Birch Court", "Walnut Place",
+        "Sunset Park", "Lakeshore Way", "Highland Plaza", "Riverside Path",
+    ]
+    for _ in range(200):
+        for a in base_addresses:
+            lines.append(a)
+        for s in filler_streets:
+            lines.append(f"{s}, Demo Town, ZZ 00000")
+    sample.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    prefix = tmp_path / "tk"
+    kwargs = dict(
+        input=str(sample),
+        model_prefix=str(prefix),
+        # 512 leaves room for 256 byte-fallback pieces + 4 specials + ~50-char alphabet +
+        # UDS literals, with headroom for actual unigram pieces. 256 is below the floor.
+        vocab_size=512,
+        character_coverage=1.0,
+        # The synthetic corpus may not contain enough distinct pieces to fill vocab_size;
+        # this lets SP cap at the extractable count instead of erroring out.
+        hard_vocab_limit=False,
+        model_type="unigram",
+        byte_fallback=True,
+        pad_id=0,
+        unk_id=1,
+        bos_id=2,
+        eos_id=3,
+        # Match the harness's space → ▁ substitution so UDS with embedded whitespace fire.
+        user_defined_symbols=[u.replace(" ", _SP_WS) for u in (uds or [])],
+    )
+    spm.SentencePieceTrainer.train(**kwargs)
+    return spm.SentencePieceProcessor(model_file=str(prefix.with_suffix(".model")))
+
+
+def test_user_defined_postcode_kept_whole(tmp_path: Path):
+    """Sentencepiece UDS literals must appear as a single piece in the encoding."""
+    sp = _train_tiny_sp(tmp_path, uds=["75008", "10118", "SW1A 1AA", "100-0005"])
+    # In-corpus postcode that is also a UDS literal.
+    pieces = sp.encode_as_pieces("Paris 75008")
+    assert "75008" in pieces
+
+    # UDS literal that did NOT appear in training data — should still be guaranteed-whole.
+    pieces2 = sp.encode_as_pieces("Tokyo 100-0005")
+    assert "100-0005" in pieces2
+
+    # UDS with internal whitespace (UK postcode style). SP renders the whitespace as ``▁``
+    # internally — the literal lands as ``SW1A▁1AA`` in the piece stream, which is what the
+    # downstream realigner expects (it joins pieces back to chars via byte offsets).
+    pieces3 = sp.encode_as_pieces("London SW1A 1AA UK")
+    assert f"SW1A{_SP_WS}1AA" in pieces3
+
+
+def test_measure_byte_fallback_buckets_per_script(tmp_path: Path):
+    """Byte-fallback measurement should bucket by detected script and compute rates."""
+    sp = _train_tiny_sp(tmp_path)
+    # CJK + Cyrillic lines aren't in the tiny synthetic corpus, so they'll byte-fallback;
+    # Latin lines are in-corpus and won't.
+    lines = [
+        "Paris 75008",  # latin, in-vocab
+        "Washington DC 20500",  # latin, in-vocab
+        "東京都新宿区",  # cjk, will byte-fallback
+        "Москва Тверская",  # cyrillic, will byte-fallback
+    ]
+    r = measure_byte_fallback(sp, lines)
+    assert r["overall"]["lines"] == 4
+    assert r["overall"]["pieces"] > 0
+    # Latin rows should not contribute byte-fallback pieces.
+    assert r["per_script"]["latin"]["byte_fallback_pieces"] == 0
+    # CJK + Cyrillic rows should contribute byte-fallback pieces.
+    assert r["per_script"]["cjk"]["byte_fallback_pieces"] > 0
+    assert r["per_script"]["cyrillic"]["byte_fallback_pieces"] > 0
+    # Per-script rates land in [0, 1].
+    for bucket in r["per_script"].values():
+        assert 0.0 <= bucket["rate"] <= 1.0
+
+
+def test_measure_byte_fallback_empty_input(tmp_path: Path):
+    sp = _train_tiny_sp(tmp_path)
+    r = measure_byte_fallback(sp, [])
+    assert r["overall"]["lines"] == 0
+    assert r["overall"]["pieces"] == 0
+    assert r["overall"]["byte_fallback_pieces"] == 0
+    assert r["overall"]["rate"] == 0.0
+
+
+def test_committed_multi_script_fixture_loads_and_has_balanced_scripts():
+    """Sanity-check the in-tree multi-script eval fixture is wellformed."""
+    # Resolve relative to the repo root via the test file's own location.
+    fixture = (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "data"
+        / "eval"
+        / "multi-script"
+        / "v0.5.0-a0.jsonl"
+    )
+    assert fixture.exists(), f"missing fixture: {fixture}"
+    lines = load_fixture_lines(fixture)
+    assert len(lines) >= 30
+    # Every line should also have a script tag declared. Re-read raw lines to validate the
+    # declared script field matches the detector's call for at least 80% of rows (the slack
+    # absorbs the ``other`` / ``mixed`` edge cases the fixture intentionally includes).
+    matches = 0
+    total = 0
+    with fixture.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            raw = raw.strip()
+            if not raw:
+                continue
+            obj = json.loads(raw)
+            declared = obj.get("script")
+            assert declared is not None
+            total += 1
+            if detect_script(obj["raw"]) == declared:
+                matches += 1
+    assert matches / total >= 0.80, f"only {matches}/{total} fixture rows match detected script"

--- a/data/eval/multi-script/README.md
+++ b/data/eval/multi-script/README.md
@@ -1,0 +1,44 @@
+# Multi-script tokenizer eval fixtures
+
+Held-out lines used to measure SentencePiece **byte-fallback rate** per script. Consumed
+by `python -m mailwoman_train tokenizer --eval-fixture …`, which records the rate (overall
+and per-script) in the trained tokenizer's `model_card.json`.
+
+These are **not** parser-output gold (no `components` field) — they exercise the tokenizer
+only. Lines are hand-curated rather than corpus-sampled so the per-script slices stay
+balanced and so the file is small enough to keep in git.
+
+## File
+
+- `v0.5.0-a0.jsonl` — the fixture used to grade `tokenizer-v0.5.0-a0`. Lines cover CJK
+  (Japanese / Chinese / Korean), Cyrillic (Russian / Ukrainian / Bulgarian / Serbian /
+  Belarusian / Georgian-via-Russian), Armenian, Greek, Arabic, Hebrew, Devanagari, Thai,
+  and a Latin baseline including Polish / Czech / Hungarian / Turkish / Icelandic /
+  Faroese diacritics. Plus one Georgian-script row that the script detector tags `other`,
+  as a sanity check on the fallthrough path.
+
+## Schema (one JSON object per line)
+
+```json
+{
+  "raw":     "<address text>",
+  "script":  "latin|cjk|cyrillic|armenian|greek|arabic|hebrew|devanagari|thai|other",
+  "country": "<ISO 3166-1 alpha-2>",
+  "notes":   "<free-form annotation>"
+}
+```
+
+`script` is informational — the harness independently re-detects script per line via
+`tokenizer_train.detect_script` and buckets the byte-fallback rate accordingly. The
+authored value is for human readability.
+
+## Rationale
+
+A0 trains on `corpus-v0.3.0`, which is en-US + fr-FR mass with effectively zero non-Latin
+content. **Byte-fallback on this fixture is expected to be high** — that's the *point*:
+the rate measured here is the A0 baseline, and the A1 retrain on `corpus-v0.4.0` (with
+Thread B's synthetic transliterations) should drive it down. The A0→A1 delta is the
+headline tokenizer KPI for v0.5.0.
+
+Target: <5% byte-fallback overall on the fixture **after** A1 lands. If A0 misses 5%, that
+is expected; A0's job is to establish the baseline + validate the harness.

--- a/data/eval/multi-script/v0.5.0-a0.jsonl
+++ b/data/eval/multi-script/v0.5.0-a0.jsonl
@@ -1,0 +1,43 @@
+{"raw":"東京都新宿区西新宿2-8-1","script":"cjk","country":"JP","notes":"Tokyo Metropolitan Government building"}
+{"raw":"〒100-0005 東京都千代田区丸の内","script":"cjk","country":"JP","notes":"Imperial Palace area with JP postcode marker 〒"}
+{"raw":"〒530-0001 大阪府大阪市北区梅田3-1-3","script":"cjk","country":"JP","notes":"Osaka Umeda with hyphenated chome-banchi-go"}
+{"raw":"北京市朝阳区建国门外大街1号","script":"cjk","country":"CN","notes":"Beijing Chaoyang district CITIC tower address"}
+{"raw":"上海市浦东新区世纪大道100号","script":"cjk","country":"CN","notes":"Shanghai Pudong Century Avenue"}
+{"raw":"广东省深圳市福田区福华路1号","script":"cjk","country":"CN","notes":"Shenzhen Futian district"}
+{"raw":"서울특별시 종로구 세종대로 175","script":"cjk","country":"KR","notes":"Seoul Jongno-gu Sejongno"}
+{"raw":"부산광역시 해운대구 우동 1411-3","script":"cjk","country":"KR","notes":"Busan Haeundae"}
+{"raw":"г. Москва, ул. Тверская, д. 1","script":"cyrillic","country":"RU","notes":"Moscow Tverskaya St 1"}
+{"raw":"Санкт-Петербург, Невский проспект 28","script":"cyrillic","country":"RU","notes":"Saint Petersburg Nevsky Prospekt 28"}
+{"raw":"Новосибирск, ул. Ленина 10, 630099","script":"cyrillic","country":"RU","notes":"Novosibirsk with RU postcode"}
+{"raw":"Київ, вул. Хрещатик, 22","script":"cyrillic","country":"UA","notes":"Kyiv Khreshchatyk St 22"}
+{"raw":"Львів, площа Ринок, 6","script":"cyrillic","country":"UA","notes":"Lviv Rynok Square 6"}
+{"raw":"Минск, проспект Независимости 11","script":"cyrillic","country":"BY","notes":"Minsk Independence Avenue 11"}
+{"raw":"Белград, улица Кнеза Михаила 42","script":"cyrillic","country":"RS","notes":"Belgrade Knez Mihailova 42 (Serbian Cyrillic)"}
+{"raw":"София, бул. Витоша 89","script":"cyrillic","country":"BG","notes":"Sofia Vitosha Boulevard 89"}
+{"raw":"Երևան, Աբովյան փողոց 5","script":"armenian","country":"AM","notes":"Yerevan Abovyan St 5"}
+{"raw":"Գյումրի, Ռիժկովի փողոց 12","script":"armenian","country":"AM","notes":"Gyumri Rizhkov St 12"}
+{"raw":"Երևան, Մաշտոցի պողոտա 28","script":"armenian","country":"AM","notes":"Yerevan Mashtots Avenue 28"}
+{"raw":"Αθήνα, οδός Ερμού 12","script":"greek","country":"GR","notes":"Athens Ermou St 12"}
+{"raw":"Θεσσαλονίκη, λεωφόρος Νίκης 21","script":"greek","country":"GR","notes":"Thessaloniki Nikis Avenue 21"}
+{"raw":"شارع الملك فهد، الرياض 11564","script":"arabic","country":"SA","notes":"King Fahd Road Riyadh with postcode"}
+{"raw":"شارع الجمهورية، القاهرة","script":"arabic","country":"EG","notes":"Republic St Cairo"}
+{"raw":"רחוב הרצל 50, תל אביב","script":"hebrew","country":"IL","notes":"Herzl St 50 Tel Aviv"}
+{"raw":"רחוב יפו 15, ירושלים","script":"hebrew","country":"IL","notes":"Jaffa Road 15 Jerusalem"}
+{"raw":"कनॉट प्लेस, नई दिल्ली 110001","script":"devanagari","country":"IN","notes":"Connaught Place New Delhi with IN postcode"}
+{"raw":"मुंबई, मरीन ड्राइव","script":"devanagari","country":"IN","notes":"Mumbai Marine Drive"}
+{"raw":"ถนนสุขุมวิท, กรุงเทพมหานคร 10110","script":"thai","country":"TH","notes":"Sukhumvit Road Bangkok with TH postcode"}
+{"raw":"1600 Pennsylvania Avenue NW, Washington, DC 20500","script":"latin","country":"US","notes":"Latin baseline: White House (well-formed US)"}
+{"raw":"15 Rue de Rivoli, 75004 Paris, France","script":"latin","country":"FR","notes":"Latin baseline: well-formed FR with accent in Rue"}
+{"raw":"München, Marienplatz 8, 80331","script":"latin","country":"DE","notes":"Latin baseline: German with umlaut"}
+{"raw":"København, Nyhavn 12, 1051","script":"latin","country":"DK","notes":"Latin baseline: Danish with ø"}
+{"raw":"Reykjavík, Laugavegur 50, 101","script":"latin","country":"IS","notes":"Latin baseline: Icelandic with þ-block letters and accented í"}
+{"raw":"Tórshavn, Niels Finsens gøta 21, 100","script":"latin","country":"FO","notes":"Latin baseline: Faroese with ó and ø"}
+{"raw":"Kraków, ul. Floriańska 41, 31-019","script":"latin","country":"PL","notes":"Latin baseline: Polish with diacritics, hyphenated PL postcode"}
+{"raw":"Praha 1, Václavské náměstí 28","script":"latin","country":"CZ","notes":"Latin baseline: Czech with háček + carons"}
+{"raw":"Budapest, Andrássy út 60, 1062","script":"latin","country":"HU","notes":"Latin baseline: Hungarian with accents"}
+{"raw":"Istanbul, İstiklal Caddesi 145","script":"latin","country":"TR","notes":"Latin baseline: Turkish with dotted/dotless I"}
+{"raw":"東京都港区六本木6-10-1 六本木ヒルズ","script":"cjk","country":"JP","notes":"Roppongi Hills (CJK with venue + Roman-digit chome-banchi-go)"}
+{"raw":"重庆市渝中区解放碑步行街","script":"cjk","country":"CN","notes":"Chongqing Yuzhong Jiefangbei pedestrian street"}
+{"raw":"г. Тбилиси, проспект Руставели 12","script":"cyrillic","country":"GE","notes":"Tbilisi Rustaveli Avenue 12 (Georgian addr written in Russian Cyrillic)"}
+{"raw":"თბილისი, რუსთაველის გამზირი 14","script":"other","country":"GE","notes":"Tbilisi Rustaveli Avenue 14 (Georgian/Mkhedruli script)"}
+{"raw":"제주특별자치도 제주시 첨단로 242","script":"cjk","country":"KR","notes":"Jeju Island Cheomdan-ro 242 (Hangul)"}


### PR DESCRIPTION
## Summary

Ships v0.5.0 Thread A0 (SentencePiece tokenizer trainer harness) per [`PHASE_8_v0_5_0_fresh_slate.md`](docs/articles/plan/phases/PHASE_8_v0_5_0_fresh_slate.md) § A. **Schedule reframe**: A0 = train against existing `corpus-v0.3.0` now to validate the harness and establish a byte-fallback baseline; A1 will follow as a separate PR retraining on corpus-v0.4.0 once Thread B's synthetic transliterations land.

- **`corpus-python/src/mailwoman_train/tokenizer_train.py`** — `TrainerConfig` + `train_tokenizer()` end-to-end pipeline: per-country reservoir sampling → optional postcode-literal mining → SentencePiece training with user-defined symbols → byte-fallback measurement → `model_card.json` + `META.json` shim. Deterministic with `--seed 42` default.
- **`python -m mailwoman_train tokenizer` CLI** — invokes the harness; resolves `--corpus v0.3.0` → `/data/corpus/versioned/v0.3.0/corpus-v0.3.0/`.
- **Multi-script eval fixture** at `data/eval/multi-script/v0.5.0-a0.jsonl` — 43 hand-curated lines covering CJK / Cyrillic / Armenian / Greek / Arabic / Hebrew / Devanagari / Thai / Latin-with-diacritics. This is the byte-fallback eval slice; **A0 vs A1 delta on this fixture is the headline KPI** the plan doc targets.
- **11 unit tests** covering script detection, byte-fallback bucketing, UDS file parsing, postcode-whole invariant, and fixture wellformedness. All pass.

### v0.1.0 baseline against the new fixture

```
overall: 18.0% byte-fallback (144/801 pieces)
  cjk:        51.6%  (141/273 pieces)
  cyrillic:    0.0%  (0/141)
  armenian:    0.0%  (0/53)
  greek:       0.0%  (0/37)
  arabic:      0.0%  (0/31)
  hebrew:      0.0%  (0/33)
  devanagari:  0.0%  (0/31)
  thai:       10.0%  (3/30)
  latin:       0.0%  (0/151)
  other:       0.0%  (0/21)
```

A0 trains on the same en-US + fr-FR mass as v0.1.0 (just corpus-v0.3.0 instead of v0.1.0); byte-fallback is **expected to be similar or marginally better** on most scripts. The A0 number is the baseline; A1 (after Thread B's synthetic transliterations) is where the < 5% target lands.

### Known non-obvious findings (KB-worthy)

- **SP UDS literals containing ASCII space silently don't match.** SP normalizes whitespace to U+2581 before vocab lookup; without substitution, `"PO Box"` as a UDS never fires. The harness substitutes `" "` → `"▁"` transparently in `_normalize_uds_for_sp`. Legacy `scripts/train_tokenizer.py` passed an empty UDS list, so this failure mode never surfaced before.
- **SP `hard_vocab_limit=False`** is the right knob for tiny test corpora — production A0 (vocab=48K, ~1M lines) doesn't need it, but it makes the test suite robust.
- **Reservoir sampling is slow at v0.3.0 scale** (~11 min/country for a full shard scan). Trivial parallelization opportunity via `ThreadPoolExecutor` against pyarrow reads — out of scope for this PR.

## A0 weights — status

The trainer is currently mid-run in the source container (background pid `2677`, log `/tmp/a0-train.log`) with:

```
python -m mailwoman_train tokenizer \
    --corpus v0.3.0 --vocab 48000 \
    --output /data/models/tokenizer/v0.5.0-a0 \
    --per-country-sample 500000 \
    --mine-postcode-literals 2000 \
    --eval-fixture data/eval/multi-script/v0.5.0-a0.jsonl
```

Expected wall-clock: 4-8h in the reservoir-sampling phase, then ~30-60min for the unigram SP pass. Output (`tokenizer.model`, `tokenizer.vocab`, `model_card.json`, `META.json`) lands under `/data/` (outside the repo). The `model_card.json` numbers will be posted as a follow-up comment on this PR.

## Test plan

- [x] `cd corpus-python && python -m pytest tests/mailwoman_train/test_tokenizer_train.py -q` — 11/11 pass
- [x] CLI invocation works against corpus-v0.3.0 (run currently in-flight)
- [ ] A0 byte-fallback measurement vs v0.1.0 baseline — follow-up comment when train completes

## Out of scope

- A1 retrain on corpus-v0.4.0 — separate PR once Thread B lands
- Reservoir-sampling parallelization (~5x speedup possible) — separate PR if A1 turnaround matters
- Vocab budget tuning (48K → 64K) — defer until A0 vs A1 byte-fallback delta justifies

## Disclosure

Triaged and authored end-to-end by Claude Code running in a playpen container (`mailwoman-m-ship-v0-northern-constant-soap`) under operator supervision. Scope, design decisions, and the schedule reframe (A0-now / A1-on-B) reviewed and approved by the operator before push.
