### PR TITLE
docs: synthetic-corpus validation + DeepSeek reasoning-budget gotchas (B/B2 takeaways)

### DIFF
--- a/docs/articles/concepts/deepseek-reasoning-budget.md
+++ b/docs/articles/concepts/deepseek-reasoning-budget.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 19
+title: DeepSeek — max_tokens covers reasoning, not just output
+---
+
+# DeepSeek — max_tokens covers reasoning, not just output
+
+A short article on one DeepSeek API quirk that has burned every mailwoman thread that called it with reasoning enabled. Worth knowing before you write the next one.
+
+## The trap
+
+DeepSeek's chat-completions API takes a `max_tokens` parameter. The natural reading is "stop after this many output tokens." The actual semantic is "stop after this many **reasoning + output** tokens." With `reasoning_effort=low`, the model's internal reasoning happily consumes 75% of the budget before any output is emitted.
+
+Thread B2's first run was configured with `max_tokens=20000` and `reasoning_effort=low`. The model's reasoning ate ~15K tokens per response, leaving ~5K for output. Most transliteration responses needed more than 5K (multi-script transliteration of an address row plus its annotation is large). Every truncated response was returned with `finish_reason=length` and a partial body.
+
+If the worker treats `finish_reason=length` as a successful completion (most starter implementations do), the partial body is fed into downstream parsing and the row is silently malformed. Throughput appears fine — the worker is consuming responses at the API's nominal rate — but the corpus that lands on disk is partial.
+
+## How to detect it
+
+The single best signal is the rejection-pipeline log. If the substring validator (see [Synthetic corpus — alignment validation](./synthetic-corpus-validation.md)) starts rejecting rows in batches, with reasons like `not-in-raw:postcode` clustered at end-of-row positions, the LLM responses are being truncated. The validator is doing the right thing — it would silently corrupt the corpus without it.
+
+The second signal is `finish_reason` itself. Logging the distribution per batch shows the truncation rate directly. A healthy run is `finish_reason=stop` >99% of the time; truncation rates above 1% are a configuration bug.
+
+## The fix
+
+Three changes to the worker:
+
+1. **Bump `max_tokens`** generously enough that reasoning + output fits. For mailwoman's address-transliteration prompts, B2 settled on `max_tokens=60000`. Pure-output tasks can stay lower (~5K) but anything with reasoning should err well above what feels comfortable.
+2. **Retry on `finish_reason=length`** rather than accepting the partial response. The B2 patch added a one-shot retry with `max_tokens` bumped to 90K (1.5× the configured value). If the retry also truncates, the row is dropped with a structured rejection reason — the validator never sees malformed input.
+3. **Log truncation rate per batch**. Surfaces the problem before it can poison the corpus. The B2 worker writes a per-batch summary line; the `truncated=` counter is the headline.
+
+## Why the API does it this way
+
+Reasoning models are still pricing in compute differently than vanilla generation. Reasoning tokens cost the same as output tokens but are not returned to the caller. Charging them against the same budget is the simple model — one number, predictable cost ceiling. The trap is that the parameter name does not advertise the semantic.
+
+DeepSeek's documentation does state this, in a sentence buried under the reasoning-effort overview. If you discover the trap by reading the docs, well done. If you discover it by watching your corpus get silently truncated, you are in good company — Thread B2's first run was the first time we hit it inside the playpen workflow, and the patch took longer than the original generation would have if we had set the budget right at the start.
+
+## Carry forward
+
+When writing the next DeepSeek-driven worker:
+
+1. Default `max_tokens` to 3× the natural output ceiling, not 1×.
+2. Wire `finish_reason=length` as a retry, never a success.
+3. Surface truncation rate in the per-batch summary line.
+4. Run a 50-row smoke pass first and verify `finish_reason=stop` rate before committing to the full run.
+
+## See also
+
+- [Synthetic corpus — alignment validation is load-bearing](./synthetic-corpus-validation.md) — why the validator caught this even when the worker silently accepted truncated responses
+- [`CORPUS_V0_4_0_GENERATION.md`](../plan/reference/CORPUS_V0_4_0_GENERATION.md) — the operational record, including B2's actual prompt-engineering decisions and rate parameters

--- a/docs/articles/concepts/synthetic-corpus-validation.md
+++ b/docs/articles/concepts/synthetic-corpus-validation.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 18
+title: Synthetic corpus — alignment validation is load-bearing
+---
+
+# Synthetic corpus — alignment validation is load-bearing
+
+Both v0.5.0 corpus threads (B kryptonite and B2 transliteration) used an LLM (DeepSeek) to generate annotated training rows. Both surfaced the same lesson: **the substring-match alignment check is not a quality filter you can drop later — it is structural infrastructure.** This article explains why.
+
+## What alignment validation does
+
+After the LLM generates a row, the validator confirms that every annotated component literally appears in the surface string. For example, if the LLM returns:
+
+```json
+{
+  "surface": "350 5th Avenue, New York, NY 10118",
+  "house_number": "350",
+  "street": "5th Avenue",
+  "locality": "New York",
+  "region": "NY",
+  "postcode": "10118"
+}
+```
+
+the validator checks: does `350` substring-match the surface? Does `5th Avenue`? Does `New York`? Does `NY`? Does `10118`? If any one fails, the row is rejected before it reaches the training corpus.
+
+The implementation is unglamorous (`generate_deepseek_corpus.py::align_or_reject` if you want to read it) but the contract it enforces is what makes the corpus trustworthy.
+
+## What goes wrong without it
+
+LLMs hallucinate around component boundaries. The B and B2 reject logs catalogue the common failure modes:
+
+- **Component embedded in another component**. `house_number=350, street=350 5th Avenue` — the street contains the house number. A naïve trainer would see `350` as both a house number and as the first token of a street, and learn an incoherent BIO labelling.
+- **Hallucinated transliteration fragments**. For B2's Cyrillic / Japanese / Hangul output, the LLM sometimes added a transliterated suffix or prefix that does not appear in the source surface. The annotated component would substring-match against itself but not against the surface — silently misaligned data.
+- **Component missing from surface**. The LLM produced a `venue` field for a string that had no venue in it (model imagined one). No substring match → reject.
+- **Off-by-one in the annotation**. `house_number=35` for a surface starting `350 5th Avenue` — close but wrong. Substring match fails because `35` does appear, but the validator can be made stricter to demand the full token (and was).
+
+Reject rates from the two runs:
+
+| Run | Total generated | Rejected | Rate |
+|---|---|---|---|
+| B (kryptonite) | 4,872 | 101 | 2.1% |
+| B2 (transliteration) | 74,140 | 821 | 1.1% |
+
+Neither approaches zero. The 1–2% range is the **floor** for DeepSeek-as-corpus at the prompt quality we shipped with. Better prompting drops it further but does not eliminate it. The validator is permanent infrastructure.
+
+## Why this matters more for synthetic data than for real data
+
+For corpora harvested from real sources (NPPES, NAD, WOF, BAN), alignment problems are bugs in the harvester or in the source — rare, deterministic, fixable by a one-line ETL patch. A 0.01% reject rate is plausible.
+
+For LLM-generated corpora, alignment problems are inherent to the generation process. The model is producing both the surface and the annotation in the same forward pass; nothing forces internal consistency. Even with temperature=0 and `reasoning_effort=low`, the 1–2% rate persists.
+
+This shifts the validator from "quality filter" to "trust boundary". Without it, you are training on data the LLM only thinks it generated correctly. With it, every row in the corpus is provably consistent with its annotation.
+
+## What the validator does not catch
+
+The substring check enforces structural consistency but not semantic correctness. A row where the LLM annotated `street=Main` for the surface `123 Main Street` will pass — `Main` substring-matches. But the correct annotation is `street=Main Street`. The check confirms _what is annotated_ exists in the surface; it does not confirm _what should be annotated_ matches what _is_ annotated.
+
+Three things bridge the gap:
+
+1. **Prompt engineering** — the prompts for B and B2 included explicit examples showing full-token annotations. This moves the LLM toward the right behaviour at generation time.
+2. **`corpus-audit`** — runs over the assembled corpus and checks distributional invariants (component balance, surface length distribution, character-set coverage). It catches "annotations are technically consistent but pathological" classes of bug.
+3. **Held-out eval** — the golden eval set (`v0.1.2`) catches the model learning bad patterns from systematically-skewed synthetic data, even when each row is individually consistent.
+
+The validator is the first line of defence. Audit and eval are the second and third.
+
+## Pattern to carry forward
+
+Any future synthetic-corpus pipeline should ship with:
+
+1. **A substring-match validator** that runs per-row before the row reaches the corpus. Reject reasons logged with structured tags so the reject-rate breakdown is greppable (`reject:not-in-raw:street` etc., the shape B and B2 use).
+2. **A reject-rate floor expectation** in the pipeline's README. If you see reject rate drop to zero, that is a bug in the validator, not a quality breakthrough.
+3. **A `corpus-audit` pass before declaring done** — the validator is necessary but not sufficient.
+
+The cost is low (a few hundred lines of Python). The value is high (the corpus you train on is the corpus you think you have).
+
+## See also
+
+- [`CORPUS_V0_4_0_GENERATION.md`](../plan/reference/CORPUS_V0_4_0_GENERATION.md) — the operational record for the v0.5.0 corpus generation, including the actual prompts used
+- [v0.5.0 — as shipped](../plan/v0-5-0-shipped.md) — context for where corpus-v0.4.0 fits
+- [The knowledge ladder](./the-knowledge-ladder.md) — why we keep generation honest at this layer rather than trying to fix it downstream


### PR DESCRIPTION
## Summary

Two concept articles distilling the cross-cutting lessons from v0.5.0 Thread B (kryptonite) and Thread B2 (transliteration), aimed at the next contributor writing a synthetic-corpus worker so they find the lessons before paying the debugging cost.

### \`docs/articles/concepts/synthetic-corpus-validation.md\`

Substring-match alignment is **structural infrastructure**, not a quality filter to drop later. Documents the reject rates (B: 2.1%, B2: 1.1%) as the floor for DeepSeek-as-corpus, the four failure modes the validator caught, what the validator does NOT catch (semantic correctness — needs prompt engineering, corpus-audit, and held-out eval as the second and third lines of defence), and the carry-forward pattern for the next synthetic-corpus pipeline.

### \`docs/articles/concepts/deepseek-reasoning-budget.md\`

DeepSeek's \`max_tokens\` covers reasoning + output, not output alone. Thread B2's first run truncated at \`max_tokens=20000\` because reasoning_effort=low still ate ~75% of the budget. Documents the trap, how to detect it (substring validator rejections clustered at end-of-row positions; finish_reason distribution per batch), the three-part fix (bump max_tokens, retry on \`finish_reason=length\`, log truncation rate), and why the API works this way.

## Test plan

- [x] Frontmatter present (\`sidebar_position: 18\` / \`19\`, titles)
- [x] All inline links resolve (cross-referenced to CORPUS_V0_4_0_GENERATION, knowledge-ladder, v0-5-0-shipped, and to each other)
- [x] No new dependencies

## Disclosure

Triaged and authored end-to-end by Claude Code running host-side under operator supervision. Source material is the postmortems from Thread B (\`mailwoman-m-ship-v0-reduced-achievable-fire\`) and Thread B2 (\`mailwoman-m-ship-v0-experienced-little-chrome\`); adaptation for the published docs reviewed before push.