### PR TITLE
fix(docs): escape `<5%`, `<1%`, `<5K` in CORPUS_V0_4_0_GENERATION.md

### DIFF
--- a/docs/articles/plan/reference/CORPUS_V0_4_0_GENERATION.md
+++ b/docs/articles/plan/reference/CORPUS_V0_4_0_GENERATION.md
@@ -22,7 +22,7 @@ Thread B's commit (`d8a6bae`), transliteration in this commit (Thread B2).
 
 The kryptonite slice is what unblocks Stage 5 reconcile (Thread D) and the Stage 2.5
 kind-classifier's joint-decoding test surface. Transliteration is what unblocks Thread A's
-<5% byte-fallback target on non-Latin scripts. See
+`<5%` byte-fallback target on non-Latin scripts. See
 [PHASE_8 §B](../phases/PHASE_8_v0_5_0_fresh_slate.md) for the threading rationale.
 
 PHASE_8 §B originally enumerated eight scripts (CJK + Cyrillic + Armenian + Greek + Arabic +
@@ -143,7 +143,7 @@ filename-prefix inference fallback.
 
 Quarantined rows (alignment failures) are logged to `quarantine-kryptonite.tsv`
 alongside the new shard. Surface-form validation already happens in the Python
-generator, so the alignment step should reject <1% — anything above 5% indicates a
+generator, so the alignment step should reject `<1%` — anything above 5% indicates a
 prompt or substring-match regression and should be investigated before commit.
 
 ## Split policy
@@ -233,7 +233,7 @@ the production 75K pass.
 DeepSeek-v4-flash with `reasoning_effort=low` still consumes a non-trivial reasoning budget
 on transliteration batches. Thread B2's first launch ran at `max_tokens=20000` (the same knob
 that worked for kryptonite) and saw 30/32 batches hit `finish_reason=length` because
-reasoning ate 12–15K of the 20K budget, leaving <5K for the 50-row JSONL output. Truncated
+reasoning ate 12–15K of the 20K budget, leaving `<5K` for the 50-row JSONL output. Truncated
 responses produced ~8 rows per batch instead of 50.
 
 The validated production knob is **`max_tokens=60000`**: empirically reasoning peaks around


### PR DESCRIPTION
## Summary

Three places in \`docs/articles/plan/reference/CORPUS_V0_4_0_GENERATION.md\` use \`<5%\` / \`<1%\` / \`<5K\` as inequalities in prose. The MDX compiler reads these as a JSX element opening tag, hits the digit immediately after \`<\`, and fails with:

\`\`\`
Unexpected character \`5\` (U+0035) before name, expected a character that can start a name, such as a letter, \`$\`, or \`_\`
\`\`\`

This has been silently blocking \`mailwoman-docs-build.service\` since Thread B2's PR #136 merged 2026-05-24. The site has been stale all day.

Fix is mechanical: wrap each inequality in backticks so MDX treats it as inline code rather than JSX. Three call sites, three backticks per side.

## Test plan

- [x] Three patterns changed; no prose meaning altered
- [x] Local prettier passed (the issue was MDX-specific, not markdown syntax)
- [ ] CI confirms (this is the one that actually matters here)
- [ ] \`sudo systemctl start mailwoman-docs-build.service\` succeeds after merge

## Disclosure

Triaged and authored end-to-end by Claude Code running host-side under operator supervision, after triggering the docs build to publish today's v0.5.0 blog post and discovering the pre-existing build failure.