### PR TITLE
docs: dual-loss curvature conflict — KB doc + synthesis review postscript

### DIFF
--- a/docs/articles/concepts/dual-loss-curvature-conflict.md
+++ b/docs/articles/concepts/dual-loss-curvature-conflict.md
@@ -1,0 +1,129 @@
+---
+sidebar_position: 18
+title: Dual-loss curvature conflict — when CRF is the aggressor
+---
+
+# Dual-loss curvature conflict — when CRF is the aggressor
+
+A specific failure mode of CE + CRF dual-loss training that surfaced across nine of mailwoman's v0.5.0 attempts. Documented here because the diagnostic technique generalises and the fix is simple once you know what's happening.
+
+If you haven't read [the v0.4.0 ablation retrospective](../retrospectives/v0-4-0-ablation-campaign.md) and the [bisect-by-elimination blog post](/blog/v0-5-0-bisect-by-elimination), do those first — they set up the failure pattern this article diagnoses.
+
+## The failure fingerprint
+
+Across every recipe variant tried — different learning rates, hidden sizes, with and without class weights, with and without per-token CRF normalisation, with and without phrase-prior input features — training showed the same shape:
+
+1. **Clean descent through warmup.** Loss drops monotonically as expected.
+2. **Brief plateau near loss 0.41** (the deepest point any run reached).
+3. **Sharp climb back to the starting magnitude** over the next 100-300 steps.
+
+Validation macro-F1 mirrored the train loss curve — peaked when loss bottomed, collapsed to roughly random-baseline as loss climbed. The collapse step shifted with learning rate (lower LR → later collapse), but a factor-2 LR drop only delayed the collapse by ~1.3× — too sub-linear for "we just picked too high an LR" to explain.
+
+The bisect ruled out: learning rate, per-token CRF normalisation (§1), class-weighted cross-entropy (§3), hidden size (h384 vs h256), phrase-prior input features. That left two suspects — the tokenizer / corpus pair — and one we hadn't named: the dual loss itself.
+
+## The diagnostic technique
+
+For any model trained with a sum of two loss terms (here CE + `λ`×CRF NLL), the question "which loss is dominating the optimisation right before divergence?" has a cheap answer. Take a checkpoint from the just-before-climb step. Run one forward, then two backwards — once with CE only, once with CRF only — and compare gradient norms.
+
+```python
+# CE-only backward
+ce_loss = F.cross_entropy(logits.view(-1, num_labels), labels.view(-1), ...)
+ce_loss.backward(retain_graph=True)
+ce_norm = sum(p.grad.detach().pow(2).sum() for p in model.parameters() if p.grad is not None) ** 0.5
+
+# CRF-only backward
+model.zero_grad()
+crf_loss = model.crf(emissions=logits, tags=labels.clamp(min=0), mask=crf_mask, reduction=crf_reduction)
+crf_loss.backward()
+crf_norm = sum(p.grad.detach().pow(2).sum() for p in model.parameters() if p.grad is not None) ** 0.5
+
+ratio = crf_norm / max(ce_norm, 1e-12)
+```
+
+The whole probe runs in a few minutes against an existing checkpoint. No retraining, no instrumentation in the train loop, no special-mode flag — just two backwards on a stored set of weights.
+
+## What the probe revealed
+
+Two checkpoints sampled — one at the inflection point (loss settled at 0.63, about to climb) and one deep in the climb (loss 1.92):
+
+| Checkpoint | Phase | `‖∇_CE‖` | `‖∇_CRF‖` | **ratio** |
+|---|---|---|---|---|
+| v3-ablation step-500 | settled, about to climb | 7-17 | 149-275 | **median 16.2** |
+| phrase-off step-1500 | deep in climb | 4-5 | 30-46 | **median 8.0** |
+
+Two conclusions, both unexpected before the probe:
+
+1. **The CRF gradient is 8-20× larger than the CE gradient.** With `crf_loss_weight=0.05`, that means the effective contribution to backward is roughly 1:0.8 CE:CRF — close to 1:1 weighted, dominated by CRF. The hand-tuned `crf_loss_weight` knob did not produce the gentle CRF regularisation it was supposed to.
+2. **The ratio shrinks during divergence (16 → 8).** Not because CRF is collapsing — CRF gradient is still 30-45 in magnitude — but because CE is growing relative to CRF as the model gets dragged off its basin. CE is fighting back and losing.
+
+## The cooperative vs conflict regime model
+
+The probe results are consistent with a specific story about why dual-loss training survives early and breaks late:
+
+**Above loss ~0.41 (cooperative regime).** The model starts at high entropy — random predictions, no structural understanding. Both loss surfaces slope downhill toward the same broad basin: "become less random." CE wants to refine per-token accuracy from random. CRF wants to maximise transition-probability coherence from random. Both objectives direct the optimiser the same way. Training descends cleanly.
+
+**Below loss ~0.41 (conflict regime).** The model exits the high-entropy basin and starts making fine-grained decisions — specific per-token trade-offs between similar tags, structural patterns the CRF can score. CE and CRF stop agreeing. CE wants to refine per-token accuracy. CRF wants transition-probability shapes that may push individual tokens toward technically-coherent but locally-wrong tags. The two objectives now point in opposing directions on this data.
+
+The optimiser follows whichever loss has the larger gradient. With CRF at 16× CE magnitude, the CRF wins. The model gets dragged off its CE-preferred basin toward a CRF-preferred attractor that CE actively disagrees with. CE loss climbs as collateral damage.
+
+The "below 0.41" boundary isn't a magic constant — it's the level at which the cooperative-vs-conflict transition happens on this specific data and architecture. Different corpora, different label spaces, different model sizes would shift it. The structure of the failure is the load-bearing observation.
+
+## Why the standard repairs don't help
+
+Several recipe knobs that ought to address this all failed in mailwoman's v0.5.0 attempts:
+
+- **Lowering `crf_loss_weight`** from 0.1 to 0.05 produced the v0.4.0-shipped weights, which still showed early signs of the same fingerprint (postcode regressed, full-parse exact match fell). The gradient-norm asymmetry is large enough that lowering the weight knob doesn't keep up — at `crf_loss_weight=0.05`, CRF still contributes 0.05 × 16 = 0.8× CE in optimization.
+- **Per-token CRF normalisation** (§1) — was meant to make CRF NLL magnitude comparable to per-token CE. The probe shows the *gradient* magnitudes are still wildly different even when *loss* magnitudes were normalised. Loss-magnitude balance does not imply gradient-magnitude balance.
+- **Global gradient clipping** to norm 1.0 — applied to the combined gradient after the dual-loss sum. Doesn't address the *relative* dominance; CRF's 16× share of the budget is preserved through clipping.
+
+The pattern: knobs that *scale* loss values don't fix asymmetric *curvature*. Below the cooperative-regime boundary, CRF NLL has a loss surface where small parameter changes produce large gradients on this data — and no amount of multiplicative weighting will rebalance that against CE's gentler surface.
+
+## The repair
+
+Drop the CRF NLL loss term entirely during training. Keep the CRF as an inference-time structural decoder, with its frozen transition mask + Viterbi.
+
+The structural benefits the CRF was supposed to provide — no orphan I-tags, no `Saint → Petersburg` clipping bugs from BIO-invalid spans — come from the **transition mask**, not from training the transition matrix via NLL. The mask is hand-encoded in `crf.py`: it forbids `O → I-locality` and every other BIO-invalid transition by setting those entries to `-inf` at initialisation. The training-side NLL was layered on top as a learned refinement; it's that learned refinement that fights with CE.
+
+```python
+# Before — the v0.4.0 train loop
+loss = ce_loss + self.crf_loss_weight * crf_loss
+
+# After — CE-only training, CRF stays at inference via frozen mask + Viterbi
+if self.crf is not None and attention_mask is not None and self.crf_loss_weight > 0:
+    crf_loss = self.crf(emissions=logits, tags=labels.clamp(min=0), mask=crf_mask, reduction=crf_reduction)
+    loss = ce_loss + self.crf_loss_weight * crf_loss
+else:
+    loss = ce_loss
+```
+
+Gated on `self.crf_loss_weight > 0` so the change is backward-compatible: existing recipes that ship with `crf_loss_weight: 0.05` still compute CRF; the new behaviour activates only when a recipe explicitly sets `crf_loss_weight: 0.0`. No new config field, no coordination bugs between flags.
+
+Inference unchanged. The runtime still calls `model.crf.decode(emissions, mask)` for Viterbi over the frozen mask. Structural validity preserved; opposing-curvature problem gone.
+
+## What to measure when validating the repair
+
+A CE-only smoke run that has to convince you the repair works:
+
+- **Loss stable past step 2000.** Every prior dual-loss run diverged by step 2000. If CE-only stays at or below its basin minimum past that point, the repair holds.
+- **val_macro_F1 ≥ 0.35 at step 2000.** v0.4.0-shipped is 0.36; h256-bisect peaked at 0.40 before diverging. 0.35 says "stable AND nearly as good as the best dual-loss checkpoint ever reached" — and the stability is the win that matters.
+- **Per-tag F1 trajectory.** Total macro_F1 hides tag-level collapse. If `venue` F1 drops from 0.39 to 0.05 while `house_number` climbs, you have a quality redistribution problem CE-only hasn't fixed. Cost: zero — confusion matrices for per-tag F1 are already computed during eval.
+
+If the smoke passes those gates, promote to a full 50K-step CE-only training run. Quality refinements (class weights, source weights, longer schedules) become safe to layer on top — they were unsafe under dual-loss because they amplified whichever loss was already aggressive.
+
+## What this technique generalises to
+
+Any training setup where you sum two loss terms with a hand-tuned weight, and observe a "trains fine then catastrophically diverges" pattern, has the same diagnostic available:
+
+1. Take a checkpoint from the just-before-divergence step.
+2. Compute per-loss gradient norms via separate backwards.
+3. Read the ratio. Far-from-one means one loss is dominating; the loss-value-weighted multiplier you set may not produce the gradient-magnitude balance you assumed.
+
+The bug shape is symmetric — it could be the auxiliary loss dominating (mailwoman's case) or the primary loss dominating (rarer; would look like the auxiliary loss being ignored). Either way the diagnostic is the same and so is the repair frame: if a loss term is destabilising training, drop it from training and reintroduce it at inference if its structural contribution justifies the integration cost.
+
+## See also
+
+- [v0.4.0 ablation campaign retrospective](../retrospectives/v0-4-0-ablation-campaign.md) — first appearance of the divergence fingerprint, before the diagnostic was named
+- [Bisect-by-elimination blog post](/blog/v0-5-0-bisect-by-elimination) — the bisect ladder that narrowed the suspects before the probe ran
+- [Synthesis review](../../reviews/2026-05-24-claude-deepseek-followup-synthesis.md) — the multi-agent conversation that produced both the dual-loss hypothesis and its falsification
+- [`VERDICT_SMOKES.md`](../plan/reference/VERDICT_SMOKES.md) — the smoke discipline that catches this class of divergence (constant-LR, full-eff-batch)
+- [CRF decoder](./crf-decoder.md) — the frozen-mask Viterbi the runtime keeps using even when training drops the NLL

--- a/docs/reviews/2026-05-24-claude-deepseek-followup-synthesis.md
+++ b/docs/reviews/2026-05-24-claude-deepseek-followup-synthesis.md
@@ -122,6 +122,76 @@ A few principles worth carrying forward beyond this specific sprint:
 - **Cheap diagnostics first.** A 5-minute gradient-norm probe answers more about the v0.5.0 divergence than a 25-hour retrain. Always exhaust the zero-GPU diagnostic ladder before any retrain.
 - **The integration test is the architectural test.** v0.5.0's thesis is that joint decoding beats argmax on kryptonite. That thesis can be measured today, against v0.4.0 weights, with zero GPU time. There is no good reason to defer it behind any training experiment.
 
+## Postscript — what the probe revealed (and how the plan changed)
+
+The gradient-norm ratio probe ran a few hours after this synthesis was written. The result falsified the dual-loss decoupling hypothesis at its centre — and falsified it in an unexpected direction.
+
+### The probe numbers
+
+Two v0.5.0-diverged checkpoints sampled, five batches each, eff_batch=128, same loader the production training uses:
+
+| Checkpoint | Training phase | `‖∇_CE‖` | `‖∇_CRF‖` | **ratio** |
+| --- | --- | --- | --- | --- |
+| `v3-ablation/step-500` | settled at loss 0.63, right before climb | 7.2–17.0 | 149–275 | **median 16.2** |
+| `phrase-off/step-1500` | deep in climb at loss 1.92 | 3.9–5.3 | 30–46 | **median 8.0** |
+
+DeepSeek's predicted signature: ratio drops below ~0.01 → CRF gradient has collapsed → CE-only training is the repair.
+
+**Reality**: ratio is 8–20× the other way. CRF gradient _dominates_ CE gradient by an order of magnitude at the inflection point, and is still 8× larger deep in the climb. The ratio shrinks during divergence (16 → 8) because CE grows relative to CRF — not because CRF weakens.
+
+### The refined picture (round-2 DeepSeek conversation)
+
+A second six-turn conversation reframed the diagnosis: not "dual-loss decoupling" but **"CRF as aggressor"**. The story that fits all the data:
+
+- **Cooperative regime, loss > 0.41.** Model starts at high entropy; both CE and CRF point downhill toward the same broad basin ("become less random"). Training descends cleanly.
+- **Conflict regime, loss < 0.41.** Model exits the high-entropy basin and enters fine-grained per-token decisions. CE and CRF now point in opposing directions on this data. CRF's 8–20× gradient magnitude wins. The optimiser follows CRF; CE is dragged uphill.
+
+The 0.41 boundary isn't a magic number — it's where the cooperative-vs-conflict transition happens on this specific architecture + corpus. The structure of the failure is the load-bearing observation, not the threshold.
+
+### Why standard repairs don't fix this
+
+- **Lowering `crf_loss_weight`** scales loss values, not gradient magnitudes. At `crf_loss_weight=0.05` with the observed ratio, the effective optimiser mix is still roughly 1:0.8 CE:CRF.
+- **Per-token CRF normalisation (§1)** made the _loss_ magnitudes comparable. The probe shows _gradient_ magnitudes are still wildly asymmetric.
+- **Global gradient clipping** preserves the relative dominance — CRF's 16× share survives clipping.
+
+Knobs that scale loss values cannot fix asymmetric curvature.
+
+### The actual repair
+
+Drop the CRF NLL loss term entirely during training. Keep the CRF as an inference-time structural decoder (frozen transition mask + Viterbi). The structural benefits that protect against orphan I-tags + BIO-invalid spans come from the **mask**, which is hand-encoded — not from the trained transition matrix. The training-side NLL was layered on as a learned refinement and that refinement is what fights with CE.
+
+One-line model.py change, gated on `crf_loss_weight > 0`. Backward-compatible: existing recipes ship CRF; the new behaviour activates only when a recipe explicitly sets `crf_loss_weight: 0.0`.
+
+This is the same destination DeepSeek's earlier review pointed at, with a sharper reason.
+
+### Promotion bar for CE-only
+
+- Loss stable past step 2000 (no climb &gt; 20% from basin minimum).
+- val_macro_F1 ≥ 0.35 at step 2000.
+- Per-tag F1 trajectory does not show single-tag collapse.
+
+If all three pass, promote to a full 50K-step CE-only training run. **Stability is the win**; any quality improvements come from recipe knobs (class weights, source rebalance, longer schedules) that were unsafe under dual-loss but become safe once the aggressive loss term is gone.
+
+### Updated 24-hour ordered plan
+
+Replaces the "validation sprint plan" earlier in this document.
+
+| Phase | Time | Action |
+| --- | --- | --- |
+| 1 (now, ~2 h, parallel) | t0 | WOF parent_id spot-check + model.py one-line gate + CE-only smoke YAML + launch CE-only smoke (~2 h on the iGPU) |
+| 2 (parallel with smoke) | t0 | Reconciler integration via per-span logit aggregation against v0.4.0 weights; eval against kryptonite ∪ golden via the ±15pp / ≤1pt matrix |
+| 3 (gate at smoke step 2000) | ~t+2 h | Read CE-only smoke result; both stability + quality gates pass → promote |
+| 4 (gated on Phase 3) | ~t+2 h | Full 50K-step CE-only C-train (~6–8 h); parallel: act on reconciler matrix result |
+| 4.1 (post-train) | ~t+10 h | Eval CE-only checkpoint against product-level matrix; if ≥2-axis improvement vs v0.4.0 → ship v0.5.0 |
+
+### Additional discipline note
+
+A fifth principle worth keeping with the four above:
+
+- **Hypotheses are tested in the direction the data points, not the direction you expected.** The probe predicted ratio &lt; 0.01 (CRF collapsed) and found ratio &gt; 8 (CRF dominant) — opposite direction, same repair. The original hypothesis was a useful scaffold for designing the experiment; falsifying it cleanly was more valuable than confirming it would have been. Build experiments around what would change your mind, not around what would confirm what you already believe.
+
+The full technical write-up of the diagnostic, the cooperative-vs-conflict regime model, and the repair is at [`docs/articles/concepts/dual-loss-curvature-conflict.md`](../articles/concepts/dual-loss-curvature-conflict.md).
+
 ## See also
 
 - [`./2026-05-24-codex-project-direction-review.md`](./2026-05-24-codex-project-direction-review.md) — the first independent review


### PR DESCRIPTION
## Summary

The gradient-norm ratio probe (the cheap diagnostic the [synthesis review](https://github.com/sister-software/mailwoman/blob/main/docs/reviews/2026-05-24-claude-deepseek-followup-synthesis.md) named) ran a few hours after the synthesis was written. It falsified DeepSeek's dual-loss decoupling hypothesis in an unexpected direction — the ratio doesn't collapse below 0.01 → 8-20× *the other way*, CRF gradient dominates CE by an order of magnitude.

The repair direction (CE-only training) is the same as the original prediction. The reason is sharper.

This PR ships two documents:

### \`docs/articles/concepts/dual-loss-curvature-conflict.md\`

A technical concept article aimed at the same engineer audience as the rest of \`concepts/\`. Covers:

- The divergence fingerprint (clean descent → plateau near 0.41 → sharp climb) across 9 v0.5.0 attempts.
- The gradient-norm ratio probe as a generalisable diagnostic — runs in minutes against any existing checkpoint, no retraining, no train-loop instrumentation.
- What the probe revealed (8-20× ratio in the wrong direction).
- The cooperative-vs-conflict regime model: above loss 0.41, CE and CRF agree directionally; below it, they conflict, and CRF's larger gradient magnitude wins.
- Why standard repairs (lower \`crf_loss_weight\`, per-token CRF normalisation §1, global gradient clipping) don't help — they all scale loss values, not gradient magnitudes.
- The one-line repair gated on \`crf_loss_weight > 0\`, backward-compatible.
- What to measure when validating the repair (stability past step 2000, val_macro_F1 ≥ 0.35, per-tag F1 trajectory).
- How the diagnostic generalises beyond mailwoman.

### \`docs/reviews/2026-05-24-claude-deepseek-followup-synthesis.md\` (postscript)

Appended a 'Postscript — what the probe revealed' section documenting:

- The probe numbers (two checkpoints, five batches each, falsified hypothesis).
- The refined CRF-as-aggressor picture from the round-2 DeepSeek conversation.
- The updated 24-hour ordered plan (Phase 1 + 2 in parallel: WOF spot-check, model.py gate, CE-only smoke launch, reconciler integration; gate at smoke step 2000; full 50K only after stability + quality gates pass).
- A fifth discipline note: hypotheses are tested in the direction the data points, not the direction you expected. Falsifying cleanly is more valuable than confirming would have been.
- Cross-link to the new concept article as the canonical technical write-up.

## Test plan

- [x] Frontmatter present on the concept article (sidebar_position: 18, title)
- [x] All inline links resolve (v0-4-0-ablation-campaign retrospective, bisect-by-elimination blog, synthesis review, VERDICT_SMOKES, CRF decoder concept)
- [x] Backward-compat preserved (the proposed fix is gated on \`crf_loss_weight > 0\`, existing recipes unchanged)
- [x] No new dependencies

## Disclosure

Triaged and authored end-to-end by Claude Code running host-side under operator supervision. Probe numbers are lifted directly from the live diagnostic run against C-train container's preserved checkpoints; the cooperative-vs-conflict regime model is from the round-2 DeepSeek conversation captured in the synthesis review's postscript.