### PR TITLE
feat: wire @mailwoman/locale-gate as default detectLocale in factory

### DIFF
--- a/mailwoman/runtime-pipeline.ts
+++ b/mailwoman/runtime-pipeline.ts
@@ -6,9 +6,10 @@
  *   Convenience factory that wires the default runtime-pipeline stages together.
  *
  *   Consumers who want the full happy-path (normalize → QueryShape → classify → resolve) can call
- *   `createRuntimePipeline({ classifier, resolver })` and get a one-call entry point. Stages with
- *   no production-ready implementation today (locale gate, kind classifier) use the coordinator's
- *   stubbed defaults.
+ *   `createRuntimePipeline({ classifier, resolver })` and get a one-call entry point. All stages
+ *   have production-ready defaults: normalize, QueryShape, locale-gate (rule-based v1), kind
+ *   classifier (rule-based), phrase grouper (rule-based). Only the neural classifier and resolver
+ *   need explicit injection.
  *
  *   See `docs/articles/plan/reference/STAGES.md` for the full contract.
  */
@@ -20,6 +21,7 @@ import {
 	type RuntimePipelineStages,
 } from "@mailwoman/core/pipeline"
 import { classifyKind as defaultClassifyKind } from "@mailwoman/kind-classifier"
+import { detectLocale as defaultDetectLocale } from "@mailwoman/locale-gate"
 import { normalize } from "@mailwoman/normalize"
 import { groupPhrases as defaultGroupPhrases } from "@mailwoman/phrase-grouper"
 import { computeQueryShape } from "@mailwoman/query-shape"
@@ -76,7 +78,10 @@ export function createRuntimePipeline(
 		groupPhrases: opts.groupPhrases ?? defaultGroupPhrases,
 		classifier: opts.classifier,
 		resolver: opts.resolver,
-		detectLocale: opts.detectLocale,
+		// Default locale gate: rule-based from @mailwoman/locale-gate. Derives locale from
+		// QueryShape character class (CJK→ja-JP, Cyrillic→ru-RU, Arabic→ar) + known-format
+		// hits (us_zip→en-US, fr_postcode→fr-FR, uk_postcode→en-GB). Caller-hint wins when set.
+		detectLocale: opts.detectLocale ?? defaultDetectLocale,
 	}
 
 	return (raw: string, runOpts?: PipelineOpts) => runPipeline(raw, stages, runOpts)


### PR DESCRIPTION
## Summary

The \`@mailwoman/locale-gate\` workspace already existed with a complete rule-based v1 implementation (16/16 tests passing) but wasn't wired as the default in \`createRuntimePipeline\` — the factory was still falling through to the coordinator's caller-trust stub (\`und\` at confidence 0.0 when no hint provided).

Now the factory imports \`detectLocale\` from \`@mailwoman/locale-gate\` and uses it as the default. Stage 2 is no longer a stub in the default pipeline path.

### What the locale-gate does

Derives locale from \`QueryShape\`:
- **Script class:** CJK → ja-JP, Cyrillic → ru-RU, Arabic → ar
- **Known-format hits:** us_zip/us_zip4 → en-US, fr_postcode → fr-FR, uk_postcode → en-GB
- **Caller-hint precedence:** when \`opts.locale\` is set, it wins at confidence 1.0; detector results surface as alternatives for diagnostics

Bitter-lesson-safe: only universal structural cues (script, postcode patterns), no place-name dictionaries.

### One-line change

\`\`\`ts
detectLocale: opts.detectLocale ?? defaultDetectLocale,
\`\`\`

## Test plan

- [x] \`vitest --run locale-gate/\` — 16/16 pass
- [x] \`vitest --run core/pipeline/\` — 57/57 pass (no regressions from the new default)
- [x] Factory JSDoc updated to reflect all stages having production-ready defaults

## Acceptance

Per TODO.md §1: STAGES.md Stage 2 "Today" line should flip from "caller-trust stub" to "\`@mailwoman/locale-gate\` (rule-based v1)". That doc update will follow once this PR merges.