### PR TITLE
fix: default R2 bucket → mailwoman-assets

### DIFF
--- a/mailwoman/commands/corpus/download.tsx
+++ b/mailwoman/commands/corpus/download.tsx
@@ -18,7 +18,7 @@ import { $ } from "zx"
 import zod from "zod"
 import type { CommandComponent } from "../../sdk/cli.js"
 
-const DEFAULT_BUCKET = "mailwoman-corpus"
+const DEFAULT_BUCKET = "mailwoman-assets"
 
 const OptionsSchema = zod.object({
 	bucket: zod.string().optional().default(DEFAULT_BUCKET).describe("R2 bucket name"),

--- a/mailwoman/commands/corpus/upload.tsx
+++ b/mailwoman/commands/corpus/upload.tsx
@@ -17,7 +17,7 @@ import { $ } from "zx"
 import zod from "zod"
 import type { CommandComponent } from "../../sdk/cli.js"
 
-const DEFAULT_BUCKET = "mailwoman-corpus"
+const DEFAULT_BUCKET = "mailwoman-assets"
 const DEFAULT_CORPUS_DIR = "/data/corpus/versioned"
 const DEFAULT_TOKENIZER_DIR = "/data/models/tokenizer"
 


### PR DESCRIPTION
One-line fix — the R2 API token is scoped to `mailwoman-assets`.