### PR TITLE
feat(#154): v0.5.0 CE-only training — model.py gate, MANIFEST patch, configs, Modal wrapper

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0_5_0-classifier-ce-only-full.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_5_0-classifier-ce-only-full.yaml
@@ -1,0 +1,83 @@
+# v0.5.0 classifier CE-only FULL run — promoted from the smoke (val_macro_f1=0.444 at step 2000).
+#
+# CE-only = CRF NLL term dropped from training. CRF stays at inference via frozen mask + Viterbi.
+# This fixes the 9-run dual-loss curvature-conflict divergence (CRF gradient dominated CE by 8-20×
+# in the conflict regime below loss ~0.41; model was being dragged off its CE-preferred basin).
+#
+# Identical to v0_5_0-classifier-ce-only-smoke.yaml except:
+#   - max_steps: 2000 → 50000
+#   - eval_every_steps: 500 → 2500
+#   - save_every_steps: 2000 → 500 (gfx1103 GPU hang resilience)
+#   - log_every_steps: 50 → 100
+#   - train_rows_per_epoch: 1000000 (unchanged)
+#   - output_dir: ce-only-smoke → ce-only-full
+#
+# Launch command (from container, under watchdog for hang resilience):
+#
+#   nohup env HSA_OVERRIDE_GFX_VERSION=11.0.0 \
+#       ~/training-venv/bin/python -m mailwoman_train train \
+#           --config corpus-python/src/mailwoman_train/configs/v0_5_0-classifier-ce-only-full.yaml \
+#           --resume auto \
+#       > logs/c-train-ce-only-full.log 2>&1 &
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.5.0-a1
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+
+model:
+  hidden_size: 256
+  num_hidden_layers: 6
+  num_attention_heads: 4
+  intermediate_size: 1024
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  label_smoothing: 0.0
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0
+  use_phrase_priors: false
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/models/checkpoints/v0_5_0-classifier-ce-only-full
+  seed: 42
+  batch_size: 16
+  eval_batch_size: 16
+  grad_accum_steps: 8
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 500
+  grad_clip_norm: 1.0
+  max_steps: 50000
+  eval_every_steps: 2500
+  save_every_steps: 500
+  log_every_steps: 100
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/train_log.csv"
+  lr_schedule: constant
+
+eval:
+  golden_dir: ""
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/configs/v0_5_0-classifier-ce-only-smoke.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_5_0-classifier-ce-only-smoke.yaml
@@ -1,0 +1,104 @@
+# v0.5.0 classifier CE-only smoke — dual-loss removal experiment.
+#
+# Bisect 3 of the v0.5.0 divergence campaign. The first two bisects ruled out
+# hidden_size (h384 → h256) and phrase-prior conditioning (PR #128 input layer).
+# A gradient-norm ratio probe on diverged checkpoints then revealed CRF gradient
+# DOMINATES CE gradient by 8-20× — not the dual-loss collapse the original
+# DeepSeek synthesis predicted but the opposite: CRF as aggressor.
+#
+# Cooperative-vs-conflict regime model: above loss ~0.41 CE + CRF agree
+# directionally; below, they conflict and CRF's larger gradient wins. The
+# model is dragged off its CE-preferred basin toward a CRF-preferred attractor.
+#
+# Repair: drop CRF NLL from training entirely. CRF stays at inference via the
+# frozen transition mask + Viterbi (structural validity preserved, opposing-
+# curvature problem gone). One-line model.py change gated on
+# crf_loss_weight > 0 — backward-compatible.
+#
+# Diffs from v0_5_0-classifier-phrase-off-smoke.yaml:
+#   - crf_loss_weight: 0.05 → 0.0  (skips CRF forward entirely via the new gate)
+#   - max_steps: 1500 → 2000        (DeepSeek's promotion bar: pass step 2000)
+#   - eval_every_steps: 500 → 500   (unchanged; one extra eval @ 2000)
+#   - save_every_steps: 1500 → 2000 (single save at the gate)
+#   - log_every_steps: 50 → 50      (unchanged; per-tag F1 logging unchanged)
+#   - output_dir: -phrase-off-smoke → -ce-only-smoke
+#
+# Recipe history of the campaign:
+#   v1   h384 §1+§3 ON  LR=1.5e-4 priors=ON  crf_w=1.0   → diverged step ~700
+#   v2   h384 §1+§3 ON  LR=1e-4   priors=ON  crf_w=1.0   → diverged step ~1100
+#   v3   h384 §1+§3 OFF LR=1.5e-4 priors=ON  crf_w=0.05  → diverged step ~800
+#   bsk  h256 §1+§3 OFF LR=1.5e-4 priors=ON  crf_w=0.05  → diverged step ~1050
+#   p_off h256 §1+§3 OFF LR=1.5e-4 priors=OFF crf_w=0.05 → diverged step ~1100
+#   THIS h256 §1+§3 OFF LR=1.5e-4 priors=OFF crf_w=0.00 → ?
+#
+# Promotion bar (per DeepSeek round-2 conversation):
+#   - PASS: train_loss stable past step 2000 (no climb >20% from basin minimum)
+#     AND val_macro_F1 ≥ 0.35 at step 2000
+#     AND per-tag F1 trajectory shows no single-tag collapse.
+#   - FAIL: any of the above — diagnose tokenizer/corpus next, not recipe.
+#
+# See docs/articles/concepts/dual-loss-curvature-conflict.md for the full
+# technical write-up of the diagnostic + the cooperative-vs-conflict model.
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.5.0-a1
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+  train_rows_per_epoch: 1000000
+  val_rows: 256
+  coarse_filter: true
+
+model:
+  hidden_size: 256
+  num_hidden_layers: 6
+  num_attention_heads: 4
+  intermediate_size: 1024
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true # CRF stays for inference Viterbi (frozen mask); training skips it via the gate
+  label_smoothing: 0.0
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0 # NEW: triggers the crf_loss_weight > 0 gate to skip CRF forward
+  # class_weights omitted → uniform 1.0 per tag (v0.4.0-shipped configuration)
+  use_phrase_priors: false
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/models/checkpoints/v0_5_0-classifier-ce-only-smoke
+  seed: 42
+  batch_size: 16
+  eval_batch_size: 16
+  grad_accum_steps: 8
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 500
+  grad_clip_norm: 1.0
+  max_steps: 2000
+  eval_every_steps: 500
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/train_log.csv"
+  lr_schedule: constant
+
+eval:
+  golden_dir: ""
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -47,9 +47,19 @@ class EncodedExample:
 
 
 def _shard_paths(corpus_dir: Path, split: str) -> list[Path]:
+    """Resolve train/val/test shard paths via MANIFEST.json (adapter-addition corpora)
+    or legacy glob fallback (monolithic corpora)."""
+    import json
+    manifest = corpus_dir / "MANIFEST.json"
+    if manifest.exists():
+        data = json.loads(manifest.read_text())
+        shards = [Path(s["path"]) for s in data.get("shards", []) if s.get("split") == split]
+        if shards:
+            return sorted(shards)
+    # legacy fallback
     paths = sorted((corpus_dir / split).glob("*.parquet"))
     if not paths:
-        raise FileNotFoundError(f"no parquet shards under {corpus_dir / split}")
+        raise FileNotFoundError(f"no shards via MANIFEST or {corpus_dir / split}")
     return paths
 
 

--- a/corpus-python/src/mailwoman_train/model.py
+++ b/corpus-python/src/mailwoman_train/model.py
@@ -333,7 +333,7 @@ class MailwomanCoarseEncoder(nn.Module):
                 labels.view(-1),
                 **ce_kwargs,
             )
-            if self.crf is not None and attention_mask is not None:
+            if self.crf is not None and attention_mask is not None and self.crf_loss_weight > 0:
                 # CRF NLL needs a (B, S) float mask. attention_mask is long-typed; cast.
                 # Replace IGNORE_INDEX positions in labels with 0 so gather doesn't OOB
                 # — those positions are zeroed by the mask anyway.

--- a/scripts/modal/train_remote.py
+++ b/scripts/modal/train_remote.py
@@ -1,0 +1,262 @@
+"""
+Modal remote training wrapper for mailwoman v0.5.0 CE-only classifier.
+
+Pulls corpus + tokenizer + training code from Cloudflare R2 into a Modal Volume,
+then runs the full 50K-step CE-only train on an A100. Results (checkpoints, ONNX,
+model card, train log) are written back to the volume for download.
+
+Usage:
+    # First time: sync corpus from R2 (takes ~3 min at datacenter speed)
+    modal run scripts/modal/train_remote.py::sync_corpus
+
+    # Run the training (~1h on A100)
+    modal run scripts/modal/train_remote.py
+
+    # Download results
+    modal volume get mailwoman-training /output/ ./output/
+"""
+
+import os
+import subprocess
+import modal
+
+# ---------------------------------------------------------------------------
+# App + Volume + Image
+# ---------------------------------------------------------------------------
+
+app = modal.App("mailwoman-training")
+
+vol = modal.Volume.from_name("mailwoman-training")
+
+# Image with PyTorch (CUDA), rclone, sentencepiece, pyarrow, onnx
+training_image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("curl", "unzip")
+    .run_commands(
+        # Install rclone for R2 sync
+        "curl -sSL https://rclone.org/install.sh | bash",
+    )
+    .pip_install(
+        "torch",
+        "sentencepiece>=0.2.0",
+        "pyarrow>=15",
+        "pyyaml>=6",
+        "numpy>=1.26,<3",
+        "transformers>=4.41",
+        "datasets>=2.19",
+        "onnx>=1.16",
+        "onnxruntime>=1.18",
+        "onnxscript>=0.1",
+        "tqdm>=4.66",
+    )
+)
+
+# R2 credentials — reads from local .env at deploy time via dotenv fallback.
+# The script loads .env itself so `source .env` before `modal run` is NOT required.
+def _load_r2_env() -> dict[str, str]:
+    """Read RCLONE_S3_* from .env, falling back to os.environ."""
+    env: dict[str, str] = {}
+    env_file = os.path.join(os.path.dirname(__file__), "..", "..", ".env")
+    if os.path.isfile(env_file):
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    key, _, val = line.partition("=")
+                    if key.startswith("RCLONE_S3_"):
+                        env[key] = val
+    # os.environ overrides file values
+    for key in ["RCLONE_S3_PROVIDER", "RCLONE_S3_ACCESS_KEY_ID", "RCLONE_S3_SECRET_ACCESS_KEY",
+                "RCLONE_S3_ENDPOINT", "RCLONE_S3_REGION", "RCLONE_S3_NO_CHECK_BUCKET"]:
+        if key in os.environ:
+            env[key] = os.environ[key]
+    return env
+
+r2_secret = modal.Secret.from_dict(_load_r2_env())
+
+BUCKET = "mailwoman-assets"
+VOL_MOUNT = "/data"
+OUTPUT_DIR = "/data/output"
+
+# ---------------------------------------------------------------------------
+# Sync corpus from R2 into the volume
+# ---------------------------------------------------------------------------
+
+@app.function(
+    image=training_image,
+    volumes={VOL_MOUNT: vol},
+    secrets=[r2_secret],
+    timeout=3600,
+)
+def sync_corpus():
+    """Pull corpus + tokenizer + training code from R2 into the Modal volume."""
+    print("Syncing corpus from R2...")
+
+    commands = [
+        f"rclone copy :s3:{BUCKET}/corpus/v0.3.0/ {VOL_MOUNT}/corpus/versioned/v0.3.0/corpus-v0.3.0/ --transfers 16 --checkers 32 --stats 30s --stats-log-level NOTICE",
+        f"rclone copy :s3:{BUCKET}/corpus/v0.4.0/ {VOL_MOUNT}/corpus/versioned/v0.4.0/corpus-v0.4.0/ --transfers 8",
+        f"rclone copy :s3:{BUCKET}/models/tokenizer/ {VOL_MOUNT}/models/tokenizer/ --transfers 4",
+        f"rclone copy :s3:{BUCKET}/corpus-python/ {VOL_MOUNT}/corpus-python/ --transfers 4",
+    ]
+
+    for i, cmd in enumerate(commands):
+        print(f"\n[{i+1}/{len(commands)}] {cmd.split('/')[-1][:60]}...")
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"STDERR: {result.stderr[:500]}")
+            raise RuntimeError(f"rclone failed: {result.stderr[:200]}")
+        if result.stdout:
+            print(result.stdout[-300:])
+
+    vol.commit()
+    print("\nCorpus sync complete. Volume committed.")
+
+    # Verify
+    for d in ["corpus/versioned/v0.3.0", "corpus/versioned/v0.4.0", "models/tokenizer", "corpus-python"]:
+        path = f"{VOL_MOUNT}/{d}"
+        if os.path.isdir(path):
+            count = sum(1 for _ in os.scandir(path) if True)
+            print(f"  {d}: {count} entries")
+        else:
+            print(f"  {d}: MISSING")
+
+
+# ---------------------------------------------------------------------------
+# Training function
+# ---------------------------------------------------------------------------
+
+@app.function(
+    image=training_image,
+    volumes={VOL_MOUNT: vol},
+    gpu="A100",
+    timeout=14400,  # 4h max (training should take ~1h)
+    memory=32768,  # 32GB RAM
+)
+def train(
+    config_name: str = "v0_5_0-classifier-ce-only-full.yaml",
+    resume: str = "auto",
+):
+    """Run the CE-only classifier training on an A100."""
+    import sys
+    import torch
+
+    # Add training code to path
+    sys.path.insert(0, f"{VOL_MOUNT}/corpus-python/src")
+
+    print(f"PyTorch: {torch.__version__}")
+    print(f"CUDA available: {torch.cuda.is_available()}")
+    if torch.cuda.is_available():
+        print(f"GPU: {torch.cuda.get_device_name(0)}")
+        print(f"VRAM: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB")
+
+    # Verify corpus exists
+    train_dir = f"{VOL_MOUNT}/corpus/versioned/v0.3.0/corpus-v0.3.0/train"
+    if not os.path.isdir(train_dir):
+        raise RuntimeError(f"Corpus not found at {train_dir}. Run sync_corpus first.")
+
+    shard_count = len([f for f in os.listdir(train_dir) if f.endswith(".parquet")])
+    print(f"Corpus: {shard_count} train shards")
+
+    # The config file references paths relative to /data/ which matches our volume mount
+    config_path = f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/configs/{config_name}"
+    if not os.path.isfile(config_path):
+        raise RuntimeError(f"Config not found: {config_path}")
+
+    print(f"Config: {config_name}")
+    print(f"Resume: {resume}")
+    print("Starting training...\n")
+
+    # Import and run training
+    from mailwoman_train.config import Config, _merge
+    from mailwoman_train.train import train as run_train
+
+    import yaml
+    cfg = Config()
+    _merge(cfg, yaml.safe_load(open(config_path)))
+
+    # Override output dir to write to the volume
+    cfg.train.output_dir = f"{OUTPUT_DIR}/checkpoints"
+    cfg.train.csv_log_path = f"{OUTPUT_DIR}/train_log.csv"
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    if resume == "auto":
+        run_train(cfg, resume_from="auto")
+    else:
+        run_train(cfg)
+
+    vol.commit()
+    print(f"\nTraining complete. Output at {OUTPUT_DIR}/")
+
+    # List what we produced
+    for root, dirs, files in os.walk(OUTPUT_DIR):
+        for f in files:
+            path = os.path.join(root, f)
+            size = os.path.getsize(path)
+            print(f"  {os.path.relpath(path, OUTPUT_DIR)}: {size / 1e6:.1f} MB")
+
+
+# ---------------------------------------------------------------------------
+# Local entrypoint
+# ---------------------------------------------------------------------------
+
+@app.local_entrypoint()
+def main(
+    sync: bool = False,
+    config: str = "v0_5_0-classifier-ce-only-full.yaml",
+    resume: str = "auto",
+):
+    """
+    Run the mailwoman training pipeline on Modal.
+
+    --sync     Pull corpus from R2 first (only needed once)
+    --config   Training config YAML filename
+    --resume   Resume mode: 'auto' (find latest checkpoint) or 'none'
+    """
+    if sync:
+        print("Syncing corpus from R2 into Modal volume...")
+        sync_corpus.remote()
+        print("Corpus sync complete.")
+        print("\nTo train, run without --sync:")
+        print(f"  modal run scripts/modal/train_remote.py --config {config}")
+        return
+
+    print(f"Training with config={config}, resume={resume}...")
+    train.remote(config_name=config, resume=resume)
+    print("\nTraining complete!")
+    print(f"\nDownload results with:\n  modal volume get mailwoman-training /output/ ./output/")
+
+
+@app.function(
+    volumes={VOL_MOUNT: vol},
+    image=training_image,
+    timeout=600,
+)
+def export_onnx():
+    """Export the step-050000 checkpoint to ONNX."""
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, "/data/corpus-python/src")
+
+    from mailwoman_train.model import MailwomanCoarseEncoder
+    from mailwoman_train.export_onnx import export_to_onnx
+    from mailwoman_train.tokenizer import Tokenizer
+
+    import torch
+    ck_dir = Path("/data/output/checkpoints/step-050000")
+    tokenizer = Tokenizer(Path("/data/models/tokenizer/v0.5.0-a1/tokenizer.model"))
+
+    # Load on CPU — checkpoint was saved from CUDA, export function has no GPU
+    # Monkey-patch torch.load to force CPU before from_pretrained calls it
+    _orig_load = torch.load
+    torch.load = lambda *a, **kw: _orig_load(*a, **{**kw, "map_location": "cpu"})
+    model = MailwomanCoarseEncoder.from_pretrained(ck_dir)
+    torch.load = _orig_load
+
+    out_path = Path("/data/output/model.onnx")
+    print(f"Exporting {ck_dir} → {out_path}")
+    export_to_onnx(model, out_path, opset=17, max_length=128, pad_token_id=tokenizer.pad_id)
+    print(f"ONNX exported: {out_path} ({out_path.stat().st_size / 1e6:.1f} MB)")
+
+    vol.commit()
+    print("Committed to volume.")


### PR DESCRIPTION
## Summary

Ships the training infrastructure and results for v0.5.0 CE-only weights. Closes #154.

### The fix: CE-only training

Nine dual-loss (CE + CRF NLL) runs diverged with the same fingerprint. A gradient-norm probe revealed CRF gradient dominates CE by 8-20×, pulling the model off its CE-preferred basin. Fix: set \`crf_loss_weight: 0.0\` — CRF at inference stays (frozen structural mask + Viterbi), CRF at training goes.

### Results (Modal A100-SXM4-40GB, 2h wall)

\`\`\`
val_macro_f1: 0.605 final (0.621 peak at step 35K)
train_loss:   0.068 final
Rate:         6.94 sps sustained
Divergence:   zero across 50K steps
Cost:         ~$5 of A100 time (Modal free credits)
\`\`\`

**+68% relative improvement** over v0.4.0-shipped (macro_f1 0.36).

### Code changes

| File | Change |
|---|---|
| \`model.py\` | Gate CRF forward on \`crf_loss_weight > 0\`. One line, backward-compatible. |
| \`data_loader.py\` | \`_shard_paths\` reads MANIFEST.json for adapter-addition corpora. Fallback to legacy glob. |
| \`v0_5_0-classifier-ce-only-smoke.yaml\` | 2000-step verdict-smoke config |
| \`v0_5_0-classifier-ce-only-full.yaml\` | 50K-step full train config |
| \`scripts/modal/train_remote.py\` | Modal wrapper: R2 sync → A100 train → ONNX export |

### ONNX model

Exported on Modal (CPU): 66 MB. Loads via \`NeuralAddressClassifier.loadFromWeights({ modelPath, tokenizerPath })\`. Smoke test confirms it classifies.

Weights + ONNX are on the Modal volume (\`mailwoman-training\`) and locally at \`output/output/\`. The npm publish of \`@mailwoman/neural-weights-en-us@v0.5.0\` is a separate step pending the full eval matrix run.

## Test plan

- [x] CE-only smoke passed (val_macro_f1=0.444 at step 2000, no divergence)
- [x] Full 50K train completed (val_macro_f1=0.605, zero divergence)
- [x] ONNX export succeeded (66 MB, loads in TS runtime)
- [x] Smoke test: \`NeuralAddressClassifier\` loads new ONNX + classifies an address
- [ ] Full eval matrix run with new weights (blocked on eval script accepting custom paths — next PR)

Refs: #154