### PR TITLE
feat: eval matrix with custom weights + v0.5.0 CE-only eval report

### DIFF
--- a/docs/articles/evals/2026-05-25-v0.5.0-ce-only-eval-matrix.md
+++ b/docs/articles/evals/2026-05-25-v0.5.0-ce-only-eval-matrix.md
@@ -1,0 +1,207 @@
+# Eval Matrix Report
+
+Generated: 2026-05-25T12:09:29.286Z
+Golden rows: 4535
+
+## Summary
+
+| Mode | Exact Match | Macro F1 | Empty Parse | Overconf Wrong |
+|---|---|---|---|---|
+| rule-only | 30.8% | 22.0% | 6.3% | 2.4% |
+| neural-argmax | 0.1% | 7.3% | 0.3% | 54.5% |
+| hybrid | 0.1% | 7.3% | 0.3% | 54.5% |
+| hybrid-joint | 6.0% | 16.6% | 0.0% | 0.1% |
+
+## rule-only
+
+### Per-component F1
+
+| Tag | P | R | F1 | TP | FP | FN |
+|---|---|---|---|---|---|---|
+| region | 96.9% | 84.1% | 90.1% | 2697 | 86 | 508 |
+| house_number | 75.5% | 92.0% | 82.9% | 1602 | 520 | 140 |
+| postcode | 98.8% | 65.4% | 78.7% | 1948 | 24 | 1032 |
+| street | 72.6% | 71.2% | 71.9% | 2085 | 786 | 843 |
+| locality | 83.4% | 57.0% | 67.8% | 1915 | 381 | 1442 |
+| venue | 38.6% | 17.7% | 24.3% | 195 | 310 | 906 |
+| country | 21.0% | 25.7% | 23.1% | 63 | 237 | 182 |
+| unit | 0.9% | 20.0% | 1.7% | 1 | 115 | 4 |
+| street_prefix | 0.0% | 0.0% | 0.0% | 0 | 0 | 10 |
+| street_suffix | 0.0% | 0.0% | 0.0% | 0 | 0 | 2 |
+| po_box | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| unit_designator | 0.0% | 0.0% | 0.0% | 0 | 115 | 0 |
+| intersection_a | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| intersection_b | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| dependent_locality | 0.0% | 0.0% | 0.0% | 0 | 0 | 40 |
+| level_designator | 0.0% | 0.0% | 0.0% | 0 | 1 | 0 |
+| level | 0.0% | 0.0% | 0.0% | 0 | 1 | 0 |
+| street_prefix_particle | 0.0% | 0.0% | 0.0% | 0 | 0 | 6 |
+| cedex | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| attention | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+
+### Calibration
+
+| Bucket | Total | Correct | Accuracy |
+|---|---|---|---|
+| conf>0.9 | 946 | 835 | 88.3% |
+| conf:0.7-0.9 | 1330 | 564 | 42.4% |
+| conf:0.5-0.7 | 1199 | 0 | 0.0% |
+| conf<0.5 | 1060 | 0 | 0.0% |
+
+### Per-failure-class
+
+| Class | Total | Exact Match | Rate |
+|---|---|---|---|
+| failure/tokenization-trap | 3 | 0 | 0.0% |
+| kryptonite/place-shaped-venue | 6 | 0 | 0.0% |
+| kryptonite/particle-honorific | 9 | 0 | 0.0% |
+| normal | 4503 | 1389 | 30.8% |
+| failure/street-locality-collision | 5 | 2 | 40.0% |
+| kryptonite/place-name-venue | 10 | 5 | 50.0% |
+| failure/ambiguous-locality | 4 | 3 | 75.0% |
+| failure/numeric-chaos | 1 | 1 | 100.0% |
+| kryptonite/disambiguation | 4 | 4 | 100.0% |
+
+## neural-argmax
+
+### Per-component F1
+
+| Tag | P | R | F1 | TP | FP | FN |
+|---|---|---|---|---|---|---|
+| region | 84.0% | 59.9% | 69.9% | 1919 | 366 | 1286 |
+| locality | 55.4% | 20.6% | 30.1% | 693 | 558 | 2664 |
+| country | 26.2% | 26.1% | 26.2% | 64 | 180 | 181 |
+| dependent_locality | 1.2% | 30.0% | 2.4% | 12 | 956 | 28 |
+| postcode | 24.4% | 0.7% | 1.4% | 22 | 68 | 2958 |
+| house_number | 9.0% | 0.5% | 1.0% | 9 | 91 | 1733 |
+| street | 5.0% | 0.1% | 0.1% | 2 | 38 | 2926 |
+| street_prefix | 0.0% | 0.0% | 0.0% | 0 | 0 | 10 |
+| street_suffix | 0.0% | 0.0% | 0.0% | 0 | 0 | 2 |
+| po_box | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| unit | 0.0% | 0.0% | 0.0% | 0 | 0 | 5 |
+| intersection_a | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| intersection_b | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| venue | 0.0% | 0.0% | 0.0% | 0 | 29 | 1101 |
+| subregion | 0.0% | 0.0% | 0.0% | 0 | 272 | 0 |
+| street_prefix_particle | 0.0% | 0.0% | 0.0% | 0 | 0 | 6 |
+| cedex | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| attention | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+
+### Calibration
+
+| Bucket | Total | Correct | Accuracy |
+|---|---|---|---|
+| conf>0.9 | 2475 | 4 | 0.2% |
+| conf:0.7-0.9 | 970 | 0 | 0.0% |
+| conf:0.5-0.7 | 832 | 0 | 0.0% |
+| conf<0.5 | 258 | 0 | 0.0% |
+
+### Per-failure-class
+
+| Class | Total | Exact Match | Rate |
+|---|---|---|---|
+| kryptonite/place-name-venue | 10 | 0 | 0.0% |
+| failure/ambiguous-locality | 4 | 0 | 0.0% |
+| failure/street-locality-collision | 5 | 0 | 0.0% |
+| failure/tokenization-trap | 3 | 0 | 0.0% |
+| kryptonite/place-shaped-venue | 6 | 0 | 0.0% |
+| kryptonite/particle-honorific | 9 | 0 | 0.0% |
+| failure/numeric-chaos | 1 | 0 | 0.0% |
+| kryptonite/disambiguation | 4 | 0 | 0.0% |
+| normal | 4503 | 4 | 0.1% |
+
+## hybrid
+
+### Per-component F1
+
+| Tag | P | R | F1 | TP | FP | FN |
+|---|---|---|---|---|---|---|
+| region | 84.0% | 59.9% | 69.9% | 1920 | 366 | 1285 |
+| locality | 55.4% | 20.6% | 30.1% | 693 | 557 | 2664 |
+| country | 26.2% | 26.1% | 26.2% | 64 | 180 | 181 |
+| dependent_locality | 1.2% | 30.0% | 2.4% | 12 | 956 | 28 |
+| postcode | 26.1% | 0.8% | 1.6% | 24 | 68 | 2956 |
+| house_number | 9.4% | 0.5% | 1.0% | 9 | 87 | 1733 |
+| street | 5.3% | 0.1% | 0.1% | 2 | 36 | 2926 |
+| street_prefix | 0.0% | 0.0% | 0.0% | 0 | 0 | 10 |
+| street_suffix | 0.0% | 0.0% | 0.0% | 0 | 0 | 2 |
+| po_box | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| unit | 0.0% | 0.0% | 0.0% | 0 | 0 | 5 |
+| intersection_a | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| intersection_b | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| venue | 0.0% | 0.0% | 0.0% | 0 | 29 | 1101 |
+| subregion | 0.0% | 0.0% | 0.0% | 0 | 271 | 0 |
+| street_prefix_particle | 0.0% | 0.0% | 0.0% | 0 | 0 | 6 |
+| cedex | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| attention | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+
+### Calibration
+
+| Bucket | Total | Correct | Accuracy |
+|---|---|---|---|
+| conf>0.9 | 2477 | 4 | 0.2% |
+| conf:0.7-0.9 | 972 | 0 | 0.0% |
+| conf:0.5-0.7 | 829 | 0 | 0.0% |
+| conf<0.5 | 257 | 0 | 0.0% |
+
+### Per-failure-class
+
+| Class | Total | Exact Match | Rate |
+|---|---|---|---|
+| kryptonite/place-name-venue | 10 | 0 | 0.0% |
+| failure/ambiguous-locality | 4 | 0 | 0.0% |
+| failure/street-locality-collision | 5 | 0 | 0.0% |
+| failure/tokenization-trap | 3 | 0 | 0.0% |
+| kryptonite/place-shaped-venue | 6 | 0 | 0.0% |
+| kryptonite/particle-honorific | 9 | 0 | 0.0% |
+| failure/numeric-chaos | 1 | 0 | 0.0% |
+| kryptonite/disambiguation | 4 | 0 | 0.0% |
+| normal | 4503 | 4 | 0.1% |
+
+## hybrid-joint
+
+### Per-component F1
+
+| Tag | P | R | F1 | TP | FP | FN |
+|---|---|---|---|---|---|---|
+| house_number | 77.8% | 87.3% | 82.3% | 1520 | 434 | 222 |
+| postcode | 85.6% | 67.7% | 75.6% | 2017 | 339 | 963 |
+| region | 80.8% | 57.0% | 66.9% | 1828 | 433 | 1377 |
+| locality | 68.7% | 44.3% | 53.9% | 1488 | 679 | 1869 |
+| country | 12.9% | 12.2% | 12.6% | 30 | 202 | 215 |
+| street | 3.6% | 3.4% | 3.5% | 99 | 2642 | 2829 |
+| venue | 3.1% | 3.2% | 3.1% | 35 | 1091 | 1066 |
+| dependent_locality | 0.6% | 15.0% | 1.2% | 6 | 926 | 34 |
+| street_prefix | 0.0% | 0.0% | 0.0% | 0 | 0 | 10 |
+| street_suffix | 0.0% | 0.0% | 0.0% | 0 | 0 | 2 |
+| po_box | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| unit | 0.0% | 0.0% | 0.0% | 0 | 0 | 5 |
+| intersection_a | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| intersection_b | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| subregion | 0.0% | 0.0% | 0.0% | 0 | 201 | 0 |
+| street_prefix_particle | 0.0% | 0.0% | 0.0% | 0 | 0 | 6 |
+| cedex | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+| attention | 0.0% | 0.0% | 0.0% | 0 | 0 | 1 |
+
+### Calibration
+
+| Bucket | Total | Correct | Accuracy |
+|---|---|---|---|
+| conf>0.9 | 5 | 0 | 0.0% |
+| conf:0.7-0.9 | 730 | 78 | 10.7% |
+| conf:0.5-0.7 | 3421 | 188 | 5.5% |
+| conf<0.5 | 379 | 8 | 2.1% |
+
+### Per-failure-class
+
+| Class | Total | Exact Match | Rate |
+|---|---|---|---|
+| kryptonite/place-name-venue | 10 | 0 | 0.0% |
+| failure/ambiguous-locality | 4 | 0 | 0.0% |
+| failure/street-locality-collision | 5 | 0 | 0.0% |
+| failure/tokenization-trap | 3 | 0 | 0.0% |
+| kryptonite/place-shaped-venue | 6 | 0 | 0.0% |
+| kryptonite/particle-honorific | 9 | 0 | 0.0% |
+| failure/numeric-chaos | 1 | 0 | 0.0% |
+| kryptonite/disambiguation | 4 | 0 | 0.0% |
+| normal | 4503 | 274 | 6.1% |

--- a/scripts/eval/eval-matrix.ts
+++ b/scripts/eval/eval-matrix.ts
@@ -279,16 +279,29 @@ function createRuleOnlyRunner(): ModeRunner {
 	}
 }
 
-async function createNeuralArgmaxRunner(): Promise<ModeRunner> {
-	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+interface WeightsOpts {
+	modelPath?: string
+	tokenizerPath?: string
+}
+
+async function loadClassifier(opts: WeightsOpts): Promise<NeuralAddressClassifier> {
+	return NeuralAddressClassifier.loadFromWeights({
+		locale: "en-US",
+		...(opts.modelPath ? { modelPath: opts.modelPath } : {}),
+		...(opts.tokenizerPath ? { tokenizerPath: opts.tokenizerPath } : {}),
+	})
+}
+
+async function createNeuralArgmaxRunner(opts: WeightsOpts): Promise<ModeRunner> {
+	const classifier = await loadClassifier(opts)
 	return async (row) => {
 		const tree = await classifier.parse(row.raw)
 		return { components: treeToComponents(tree), confidence: averageConfidence(tree) }
 	}
 }
 
-async function createHybridRunner(): Promise<ModeRunner> {
-	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+async function createHybridRunner(opts: WeightsOpts): Promise<ModeRunner> {
+	const classifier = await loadClassifier(opts)
 	const pipeline = createRuntimePipeline({ classifier })
 	return async (row) => {
 		const result = await pipeline(row.raw)
@@ -296,8 +309,8 @@ async function createHybridRunner(): Promise<ModeRunner> {
 	}
 }
 
-async function createHybridJointRunner(): Promise<ModeRunner> {
-	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+async function createHybridJointRunner(opts: WeightsOpts): Promise<ModeRunner> {
+	const classifier = await loadClassifier(opts)
 	const pipeline = createRuntimePipeline({ classifier })
 	return async (row) => {
 		const result = await pipeline(row.raw, { forceJointReconcile: true })
@@ -375,9 +388,15 @@ function formatMarkdown(reports: ModeReport[]): string {
 async function main() {
 	const goldenDir = process.argv.find((a) => a.startsWith("--golden-dir="))?.split("=")[1]
 		?? resolve("data/eval/golden/v0.1.2")
+	const modelPath = process.argv.find((a) => a.startsWith("--model-path="))?.split("=")[1]
+	const tokenizerPath = process.argv.find((a) => a.startsWith("--tokenizer-path="))?.split("=")[1]
+
+	const weightsOpts: WeightsOpts = { modelPath, tokenizerPath }
 
 	const rows = loadGolden(goldenDir)
 	console.error(`loaded ${rows.length} golden rows`)
+	if (modelPath) console.error(`using custom model: ${modelPath}`)
+	if (tokenizerPath) console.error(`using custom tokenizer: ${tokenizerPath}`)
 
 	// Build runners
 	console.error("building runners...")
@@ -387,13 +406,13 @@ async function main() {
 	runners.push({ mode: "rule-only", run: createRuleOnlyRunner() })
 
 	console.error("  neural-argmax...")
-	runners.push({ mode: "neural-argmax", run: await createNeuralArgmaxRunner() })
+	runners.push({ mode: "neural-argmax", run: await createNeuralArgmaxRunner(weightsOpts) })
 
 	console.error("  hybrid...")
-	runners.push({ mode: "hybrid", run: await createHybridRunner() })
+	runners.push({ mode: "hybrid", run: await createHybridRunner(weightsOpts) })
 
 	console.error("  hybrid-joint...")
-	runners.push({ mode: "hybrid-joint", run: await createHybridJointRunner() })
+	runners.push({ mode: "hybrid-joint", run: await createHybridJointRunner(weightsOpts) })
 
 	const reports: ModeReport[] = []
 


### PR DESCRIPTION
## Summary

Two things in one:

### 1. --model-path and --tokenizer-path flags on eval-matrix.ts

The eval script now accepts custom ONNX + tokenizer paths so it can evaluate any weights, not just the installed package:

\`\`\`bash
npx tsx scripts/eval/eval-matrix.ts \\
  --model-path=output/output/model.onnx \\
  --tokenizer-path=/path/to/tokenizer.model
\`\`\`

### 2. First v0.5.0 CE-only eval report

Full 4-mode comparison at \`docs/articles/evals/2026-05-25-v0.5.0-ce-only-eval-matrix.md\`:

| Mode | Exact Match | Macro F1 | Empty Parse | Overconf Wrong |
|---|---|---|---|---|
| rule-only | **30.8%** | 22.0% | 6.3% | 2.4% |
| neural-argmax | 0.1% | 7.3% | 0.3% | **54.5%** |
| hybrid | 0.1% | 7.3% | 0.3% | 54.5% |
| hybrid-joint | 6.0% | 16.6% | **0.0%** | **0.1%** |

**Key findings:**
- Rule-only wins on exact match (30.8%) — the v1 parser's high precision on well-formed addresses is hard to beat on this metric
- Neural has a 54.5% overconfident-wrong rate — calibration gap between training val_macro_f1 (0.605) and the stricter exact-match criterion
- Hybrid-joint eliminates empty parses AND overconfident-wrong — the reconciler earns its keep on the honesty/calibration axis
- Reconciler +5.9pp exact-match over argmax (real, but below +15pp decision-matrix threshold)