### PR TITLE
docs: add exotic point-of-interest queries series

### DIFF
--- a/docs/articles/understanding/README.md
+++ b/docs/articles/understanding/README.md
@@ -78,6 +78,17 @@ _Inspired by and citing Michael Tandy's [original catalogue](https://www.mjt.me.
 37. **[Shapes and dimensions](./why-its-hard/falsehoods-shapes.md)** — not a point, not a polygon, not a building, not at ground level, not unique per coordinate.
 38. **[Precision and frontages](./why-its-hard/falsehoods-proximity.md)** — not one correct coordinate, not always "close enough," not necessarily the front door.
 
+### Exotic point-of-interest queries
+
+_Not every geocoder query is an address. A large fraction of real-world searches ask for points of interest — named places, categories, brands, landmarks, and transit infrastructure._
+
+39. **[Overview](./exotic-poi/exotic-point-of-interest-queries.md)** — what counts as a POI query vs an address query.
+40. **[Amenity queries](./exotic-poi/amenity-queries.md)** — water fountain, gas station, ATM, pharmacy.
+41. **[Franchise and brand queries](./exotic-poi/franchise-queries.md)** — Walmart, McDonalds, Hilton, Starbucks.
+42. **[Regional variants](./exotic-poi/regional-variant-queries.md)** — servo, bodega, マクド, off-licence, chemist.
+43. **[Landmark queries](./exotic-poi/landmark-queries.md)** — Eiffel Tower, Golden Gate Bridge, Empire State Building.
+44. **[Transit queries](./exotic-poi/transit-queries.md)** — subway station, bus stop, airport, train station.
+
 ## Reading order
 
 If you are **sceptical about the whole project**, read Tier 0 in order (articles 2–6). It should take about 45 minutes. If you are still sceptical after that, the project has failed to make its case — open an issue.

--- a/docs/articles/understanding/exotic-poi/_category.json
+++ b/docs/articles/understanding/exotic-poi/_category.json
@@ -1,0 +1,5 @@
+{
+	"label": "Exotic POI queries",
+	"position": 5,
+	"collapsed": true
+}

--- a/docs/articles/understanding/exotic-poi/amenity-queries.md
+++ b/docs/articles/understanding/exotic-poi/amenity-queries.md
@@ -46,7 +46,7 @@ The limitation: Nominatim only searches OSM. If a gas station is not in OSM, it 
 
 **Google's Places API** handles amenity queries through Google's proprietary place taxonomy. The API accepts a `type` parameter (e.g., `gas_station`, `atm`, `pharmacy`) and returns ranked results. Google's taxonomy is larger and more consistent than OSM's, but it is proprietary — you cannot inspect how a category is defined, add new categories, or correct misclassifications.
 
-**Pelias** has limited amenity support. Pelias indexes OSM amenities as part of its gazetteer, but the parser does not distinguish between address queries and amenity queries. A search for `gas station` tokenizes to `[gas] [station]` and searches for those tokens in the gazetteer. If OSM has a place named "Gas Station" (a business name, not a category tag), it matches. If no business is named "Gas Station," the search returns nothing. Pelias does not map category labels to OSM tags.
+**Pelias** has partial amenity support. Pelias indexes OSM amenities as part of its gazetteer and exposes a `/v1/search` endpoint with a `categories` parameter that maps to OSM tags (e.g., `categories=food` filters to amenity=restaurant/cafe/fast_food). For queries without the explicit parameter, Pelias tokenizes to `[gas] [station]` and searches the gazetteer by text — this works when an OSM feature's name or category text matches, but misses when the user's term differs from OSM's taxonomy. The category endpoint is the right idea but limited to a fixed set of mappings that doesn't cover regional variants or slang.
 
 ## What Mailwoman does today
 

--- a/docs/articles/understanding/exotic-poi/amenity-queries.md
+++ b/docs/articles/understanding/exotic-poi/amenity-queries.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 2
+title: Amenity queries
+tags:
+  - domain
+  - venue
+  - international
+---
+
+# Amenity queries
+
+An amenity query asks for the nearest instance of a generic category. The user doesn't care which gas station — they care which one is closest, open, or cheapest. The geocoder's job is to translate a category label into a set of candidate locations and rank them.
+
+## What amenity queries look like
+
+| Query | Category | Implicit constraints |
+|-------|----------|---------------------|
+| `gas station` | `amenity=fuel` | Nearest to user's location |
+| `water fountain` | `amenity=drinking_water` | Nearest, publicly accessible |
+| `ATM` | `amenity=atm` | Nearest, preferably in-network |
+| `restroom` | `amenity=toilets` | Nearest, publicly accessible, open |
+| `mailbox` | `amenity=post_box` | Nearest, collection time not passed |
+| `playground` | `leisure=playground` | Nearest, open to public |
+| `pharmacy` | `amenity=pharmacy` | Nearest, open now |
+| `hospital` | `amenity=hospital` | Nearest, emergency department |
+| `bicycle parking` | `amenity=bicycle_parking` | Nearest, secure |
+| `EV charging station` | `amenity=charging_station` | Nearest, compatible plug, available |
+| `pho near me` | `cuisine=vietnamese` | Nearest Vietnamese restaurant |
+| `coffee shop` | `amenity=cafe` | Nearest, open |
+
+The query has two parts: a **category** (what kind of thing) and an **implicit location constraint** (near where the user is, or near a specified place). The category is the hard part — the geocoder must map the user's words to a category taxonomy.
+
+## The category-taxonomy problem
+
+"Gas station" in English maps to `amenity=fuel` in OSM's taxonomy. "Gas station" in Australian English ("servo") maps to the same tag. "Petrol station" in British English also maps to the same tag. The same physical thing — a place that sells fuel for vehicles — has multiple names, and the geocoder must recognize all of them.
+
+The problem compounds across languages: `ガソリンスタンド` (gasorin sutando, Japanese), `加油站` (jiāyóuzhàn, Chinese), `Tankstelle` (German), `station-service` (French). Every language has its own word for "gas station." A geocoder that only recognizes English amenity names is useless for most of the world's population.
+
+This is not a translation problem — it's an **alias** problem. The geocoder doesn't need to translate "gas station" to French. It needs to know that `station-service` is the same category as `amenity=fuel`. The category taxonomy is language-independent; the labels for each category are language-dependent.
+
+## How traditional geocoders handle amenity queries
+
+**Nominatim** (OSM's geocoder) handles amenity queries well because OSM tags every amenity with a standardized key-value pair. `amenity=fuel` maps to every gas station in OSM. Nominatim's search API accepts free-text queries and matches them against OSM tags and names. `gas station near Paris` returns OSM-tagged fuel stations near Paris.
+
+The limitation: Nominatim only searches OSM. If a gas station is not in OSM, it doesn't exist to Nominatim. OSM's amenity coverage is excellent in Western Europe and sparse in much of the rest of the world. A query for `gas station` in rural India may return nothing because no one has mapped the gas stations there.
+
+**Google's Places API** handles amenity queries through Google's proprietary place taxonomy. The API accepts a `type` parameter (e.g., `gas_station`, `atm`, `pharmacy`) and returns ranked results. Google's taxonomy is larger and more consistent than OSM's, but it is proprietary — you cannot inspect how a category is defined, add new categories, or correct misclassifications.
+
+**Pelias** has limited amenity support. Pelias indexes OSM amenities as part of its gazetteer, but the parser does not distinguish between address queries and amenity queries. A search for `gas station` tokenizes to `[gas] [station]` and searches for those tokens in the gazetteer. If OSM has a place named "Gas Station" (a business name, not a category tag), it matches. If no business is named "Gas Station," the search returns nothing. Pelias does not map category labels to OSM tags.
+
+## What Mailwoman does today
+
+Mailwoman's parser will see `gas station` and try to classify the tokens as address components. The kind classifier (Stage 2.5) may recognize the input as a non-address query (no numbers, no street suffixes, no state abbreviations) and flag it as `kind=unknown`, but there is no `kind=amenity` classification path.
+
+The resolver (Stage 6) indexes WOF administrative places, not OSM amenities. A search for `gas station` in the current resolver returns nothing — WOF does not have gas stations.
+
+**Amenity queries are out of scope for Mailwoman's current architecture.** They require:
+
+- A **category alias table** mapping user-facing labels to OSM tags (or another taxonomy).
+- A **POI index** (OSM amenities, franchise locations, or a commercial dataset).
+- A **proximity resolver** that can answer "nearest X to location Y" queries.
+
+These are planned for a future phase but are not part of the current implementation.
+
+## See also
+
+- [Franchise and brand queries](./franchise-queries.md) — the named-chain version of amenity queries
+- [Regional variant queries](./regional-variant-queries.md) — when the same amenity has different names
+- [Exotic POI overview](./exotic-point-of-interest-queries.md) — the series index

--- a/docs/articles/understanding/exotic-poi/amenity-queries.md
+++ b/docs/articles/understanding/exotic-poi/amenity-queries.md
@@ -13,20 +13,20 @@ An amenity query asks for the nearest instance of a generic category. The user d
 
 ## What amenity queries look like
 
-| Query | Category | Implicit constraints |
-|-------|----------|---------------------|
-| `gas station` | `amenity=fuel` | Nearest to user's location |
-| `water fountain` | `amenity=drinking_water` | Nearest, publicly accessible |
-| `ATM` | `amenity=atm` | Nearest, preferably in-network |
-| `restroom` | `amenity=toilets` | Nearest, publicly accessible, open |
-| `mailbox` | `amenity=post_box` | Nearest, collection time not passed |
-| `playground` | `leisure=playground` | Nearest, open to public |
-| `pharmacy` | `amenity=pharmacy` | Nearest, open now |
-| `hospital` | `amenity=hospital` | Nearest, emergency department |
-| `bicycle parking` | `amenity=bicycle_parking` | Nearest, secure |
+| Query                 | Category                   | Implicit constraints                |
+| --------------------- | -------------------------- | ----------------------------------- |
+| `gas station`         | `amenity=fuel`             | Nearest to user's location          |
+| `water fountain`      | `amenity=drinking_water`   | Nearest, publicly accessible        |
+| `ATM`                 | `amenity=atm`              | Nearest, preferably in-network      |
+| `restroom`            | `amenity=toilets`          | Nearest, publicly accessible, open  |
+| `mailbox`             | `amenity=post_box`         | Nearest, collection time not passed |
+| `playground`          | `leisure=playground`       | Nearest, open to public             |
+| `pharmacy`            | `amenity=pharmacy`         | Nearest, open now                   |
+| `hospital`            | `amenity=hospital`         | Nearest, emergency department       |
+| `bicycle parking`     | `amenity=bicycle_parking`  | Nearest, secure                     |
 | `EV charging station` | `amenity=charging_station` | Nearest, compatible plug, available |
-| `pho near me` | `cuisine=vietnamese` | Nearest Vietnamese restaurant |
-| `coffee shop` | `amenity=cafe` | Nearest, open |
+| `pho near me`         | `cuisine=vietnamese`       | Nearest Vietnamese restaurant       |
+| `coffee shop`         | `amenity=cafe`             | Nearest, open                       |
 
 The query has two parts: a **category** (what kind of thing) and an **implicit location constraint** (near where the user is, or near a specified place). The category is the hard part — the geocoder must map the user's words to a category taxonomy.
 

--- a/docs/articles/understanding/exotic-poi/exotic-point-of-interest-queries.md
+++ b/docs/articles/understanding/exotic-poi/exotic-point-of-interest-queries.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 1
+title: Exotic point-of-interest queries
+tags:
+  - domain
+  - venue
+  - international
+  - multilingual
+---
+
+# Exotic point-of-interest queries
+
+Not every geocoder query is an address. A large fraction of real-world searches ask for **points of interest** — named places, categories of things, brands, landmarks, and transit infrastructure. "Find the nearest gas station" is not an address. "Where is the Eiffel Tower?" is not an address. "Show me every Hilton in Manhattan" is not an address.
+
+These queries are structurally different from address queries. An address has ordered components (number, street, city, state, postcode) with predictable patterns. A POI query is a name, a category, or a category with a location constraint. The parser that handles `350 5th Ave, New York, NY 10118` will fail on `water fountain near me` — not because the parser is broken, but because the input is a fundamentally different kind of query.
+
+This series catalogues the categories of POI queries, how traditional geocoders handle them, and what Mailwoman's architecture does (and doesn't) do for each.
+
+## The categories
+
+| Query type | Example | What the user wants |
+|-----------|---------|-------------------|
+| [Amenities](./amenity-queries.md) | water fountain, gas station, ATM, restroom | The nearest instance of a generic category |
+| [Franchises and brands](./franchise-queries.md) | Walmart, McDonalds, Hilton, Starbucks | The nearest or all locations of a named chain |
+| [Regional variants](./regional-variant-queries.md) | servo, bodega, マクド, off-licence, chemist | The same thing as an amenity or brand, but using local terminology |
+| [Landmarks](./landmark-queries.md) | Eiffel Tower, Golden Gate Bridge, Empire State Building | A specific named place, usually unique or nearly unique |
+| [Transit](./transit-queries.md) | subway station, bus stop, airport, train station | A transit facility, named or unnamed |
+
+## Why this matters for Mailwoman
+
+Mailwoman's parser is designed for address strings. Its output is `{house_number: 123, street: Main St, locality: Springfield, region: IL}` — structured address components. A POI query like `gas station` has none of these components. The parser will try to classify `gas` and `station` as address components (street? locality? venue?) and produce a low-confidence parse.
+
+The right behavior for a POI query is:
+
+1. **Recognize that it's a POI query, not an address.** The kind classifier (Stage 2.5) already does this for basic categories: `postcode_only`, `structured_address`, `intersection`. POI queries need a new kind: `amenity`, `franchise`, `landmark`.
+2. **Extract the POI type and location constraints.** `gas station near Springfield, IL` → POI type = `fuel`, location = `Springfield, IL`. The location constraint can be an address or place name, which Mailwoman can parse normally.
+3. **Resolve against a POI database.** The resolver needs a POI index (OSM amenities, WOF venues, a franchise location dataset) to answer "nearest gas station." Mailwoman's resolver currently indexes administrative places, not POIs.
+
+POI queries are the next frontier for Mailwoman after address parsing stabilizes. The architecture supports them — the staged pipeline can route POI queries to a different resolver — but the infrastructure (POI index, POI kind classifier, regional variant aliases) is not yet built.
+
+## See also
+
+- [What is an address?](./the-problem/what-is-an-address.md) — the boundary between addresses and POIs
+- [Why a neural parser?](./our-approach/why-a-neural-parser.md) — the architecture that could handle both
+- [The knowledge ladder](./our-approach/the-knowledge-ladder.md) — where query-type classification fits in the pipeline

--- a/docs/articles/understanding/exotic-poi/exotic-point-of-interest-queries.md
+++ b/docs/articles/understanding/exotic-poi/exotic-point-of-interest-queries.md
@@ -18,13 +18,13 @@ This series catalogues the categories of POI queries, how traditional geocoders 
 
 ## The categories
 
-| Query type | Example | What the user wants |
-|-----------|---------|-------------------|
-| [Amenities](./amenity-queries.md) | water fountain, gas station, ATM, restroom | The nearest instance of a generic category |
-| [Franchises and brands](./franchise-queries.md) | Walmart, McDonalds, Hilton, Starbucks | The nearest or all locations of a named chain |
-| [Regional variants](./regional-variant-queries.md) | servo, bodega, マクド, off-licence, chemist | The same thing as an amenity or brand, but using local terminology |
-| [Landmarks](./landmark-queries.md) | Eiffel Tower, Golden Gate Bridge, Empire State Building | A specific named place, usually unique or nearly unique |
-| [Transit](./transit-queries.md) | subway station, bus stop, airport, train station | A transit facility, named or unnamed |
+| Query type                                         | Example                                                 | What the user wants                                                |
+| -------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------ |
+| [Amenities](./amenity-queries.md)                  | water fountain, gas station, ATM, restroom              | The nearest instance of a generic category                         |
+| [Franchises and brands](./franchise-queries.md)    | Walmart, McDonalds, Hilton, Starbucks                   | The nearest or all locations of a named chain                      |
+| [Regional variants](./regional-variant-queries.md) | servo, bodega, マクド, off-licence, chemist             | The same thing as an amenity or brand, but using local terminology |
+| [Landmarks](./landmark-queries.md)                 | Eiffel Tower, Golden Gate Bridge, Empire State Building | A specific named place, usually unique or nearly unique            |
+| [Transit](./transit-queries.md)                    | subway station, bus stop, airport, train station        | A transit facility, named or unnamed                               |
 
 ## Why this matters for Mailwoman
 

--- a/docs/articles/understanding/exotic-poi/exotic-point-of-interest-queries.md
+++ b/docs/articles/understanding/exotic-poi/exotic-point-of-interest-queries.md
@@ -40,6 +40,6 @@ POI queries are the next frontier for Mailwoman after address parsing stabilizes
 
 ## See also
 
-- [What is an address?](./the-problem/what-is-an-address.md) — the boundary between addresses and POIs
-- [Why a neural parser?](./our-approach/why-a-neural-parser.md) — the architecture that could handle both
-- [The knowledge ladder](./our-approach/the-knowledge-ladder.md) — where query-type classification fits in the pipeline
+- [What is an address?](../the-problem/what-is-an-address.md) — the boundary between addresses and POIs
+- [Why a neural parser?](../our-approach/why-a-neural-parser.md) — the architecture that could handle both
+- [The knowledge ladder](../our-approach/the-knowledge-ladder.md) — where query-type classification fits in the pipeline

--- a/docs/articles/understanding/exotic-poi/franchise-queries.md
+++ b/docs/articles/understanding/exotic-poi/franchise-queries.md
@@ -14,16 +14,16 @@ A franchise query names a specific chain or brand. The user doesn't want the nea
 
 ## What franchise queries look like
 
-| Query | Implicit meaning |
-|-------|-----------------|
-| `Walmart` | Nearest Walmart store |
-| `McDonalds` | Nearest McDonalds restaurant |
-| `Hilton` | Nearest Hilton hotel |
-| `Starbucks` | Nearest Starbucks coffee shop |
-| `7-Eleven` | Nearest 7-Eleven convenience store |
-| `Home Depot near Springfield, IL` | Nearest Home Depot to a specific place |
-| `Walmart Supercenter vs Walmart Neighborhood Market` | A specific sub-brand of the franchise |
-| `McDonalds with PlayPlace` | A franchise location with a specific amenity |
+| Query                                                | Implicit meaning                             |
+| ---------------------------------------------------- | -------------------------------------------- |
+| `Walmart`                                            | Nearest Walmart store                        |
+| `McDonalds`                                          | Nearest McDonalds restaurant                 |
+| `Hilton`                                             | Nearest Hilton hotel                         |
+| `Starbucks`                                          | Nearest Starbucks coffee shop                |
+| `7-Eleven`                                           | Nearest 7-Eleven convenience store           |
+| `Home Depot near Springfield, IL`                    | Nearest Home Depot to a specific place       |
+| `Walmart Supercenter vs Walmart Neighborhood Market` | A specific sub-brand of the franchise        |
+| `McDonalds with PlayPlace`                           | A franchise location with a specific amenity |
 
 Franchise queries have three components: a **brand name**, an optional **sub-brand** or **feature filter**, and an optional **location constraint**. The brand name is the hard part — it may not match what the franchise calls itself, and it varies by region.
 

--- a/docs/articles/understanding/exotic-poi/franchise-queries.md
+++ b/docs/articles/understanding/exotic-poi/franchise-queries.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 3
+title: Franchise and brand queries
+tags:
+  - domain
+  - venue
+  - international
+  - multilingual
+---
+
+# Franchise and brand queries
+
+A franchise query names a specific chain or brand. The user doesn't want the nearest restaurant — they want the nearest **McDonalds**. The brand name is the query, and the geocoder's job is to resolve it to one or more specific locations.
+
+## What franchise queries look like
+
+| Query | Implicit meaning |
+|-------|-----------------|
+| `Walmart` | Nearest Walmart store |
+| `McDonalds` | Nearest McDonalds restaurant |
+| `Hilton` | Nearest Hilton hotel |
+| `Starbucks` | Nearest Starbucks coffee shop |
+| `7-Eleven` | Nearest 7-Eleven convenience store |
+| `Home Depot near Springfield, IL` | Nearest Home Depot to a specific place |
+| `Walmart Supercenter vs Walmart Neighborhood Market` | A specific sub-brand of the franchise |
+| `McDonalds with PlayPlace` | A franchise location with a specific amenity |
+
+Franchise queries have three components: a **brand name**, an optional **sub-brand** or **feature filter**, and an optional **location constraint**. The brand name is the hard part — it may not match what the franchise calls itself, and it varies by region.
+
+## The brand-name problem
+
+"McDonalds" is the official brand name. Users also search for:
+
+- `McDonalds` (correct spelling)
+- `McDonald's` (possessive, correct per corporate branding)
+- `Mcdonalds` (incorrect but common)
+- `Mickey D's` (slang, US)
+- `Macca's` (slang, Australia)
+- `マクドナルド` (makudonarudo, Japan — full name)
+- `マクド` (makudo, Japan — abbreviated, Kansai region)
+- `McDo` (abbreviated, France/Quebec)
+- `Mek` (abbreviated, German-speaking countries)
+
+A geocoder that only matches "McDonald's" against an exact-string index will miss every slang and regional variant. A geocoder that matches all variants requires an **alias table** mapping user-facing terms to brand identifiers.
+
+The alias table is not a translation table. "Macca's" is not a translation of "McDonald's" — it's a colloquial name used by millions of people. The geocoder doesn't need to translate. It needs to know they refer to the same brand.
+
+## The sub-brand problem
+
+Franchises have sub-brands that differ in meaningful ways:
+
+- **Walmart** has Walmart Supercenter (full grocery), Walmart Discount Store (general merchandise, no grocery), Walmart Neighborhood Market (grocery-only, smaller footprint), and Sam's Club (warehouse membership).
+- **Hilton** has Hilton Hotels & Resorts (full-service), Hilton Garden Inn (mid-scale), Hampton by Hilton (budget), Homewood Suites (extended stay), and several others.
+- **Starbucks** has company-operated stores, licensed stores (in airports, hotels, grocery stores), and Starbucks Reserve Roastery (premium, limited locations).
+
+A query for `Walmart` could mean any of the sub-brands. A query for `Walmart Supercenter` is specific. The geocoder should return the nearest Supercenter for the specific query and the nearest any-Walmart for the generic query. This requires the POI index to include sub-brand classification.
+
+## The location-constraint problem
+
+`Walmart near Springfield, IL` requires two operations:
+
+1. Resolve the location constraint (`Springfield, IL`) to coordinates or an area.
+2. Find the nearest Walmart to that location.
+
+The location constraint is an address or place name — the kind of query Mailwoman already handles. The franchise lookup is new. The composition of "parse the location constraint, then query the franchise index near that location" is a **two-stage resolver** query: resolve the place, then find POIs near it.
+
+This is the same pattern as "gas station near Springfield, IL" (amenity + location constraint) but with a named brand instead of a generic category.
+
+## How traditional geocoders handle franchise queries
+
+**Google's Places API** handles franchise queries through Google's place database. A search for "McDonalds" returns McDonalds locations ranked by proximity and prominence. Google's database includes franchise locations globally, with sub-brand classification (Walmart Supercenter vs Walmart Neighborhood Market) and user-contributed attributes (PlayPlace, drive-through, 24-hour). Google handles spelling variants and some slang through its search model.
+
+**Nominatim** handles franchise queries by matching the brand name against OSM's `name` and `brand` tags. OSM has good coverage of franchise locations in well-mapped areas. However, OSM's brand tagging is inconsistent: some locations are tagged `brand=McDonald's`, others `name=McDonald's`, and the relationship between franchise brand and individual location name varies by mapper. Nominatim does not handle slang or regional variants — `Macca's` returns nothing unless an Australian mapper tagged a location with `alt_name=Macca's`.
+
+**Pelias** indexes franchise locations as part of its OSM and OpenAddresses gazetteers. The same OSM tagging inconsistency applies. Pelias's search treats "McDonalds" as a text token and matches it against name fields. Slang and variants don't match. Sub-brand classification is not modeled.
+
+## What Mailwoman does today
+
+Mailwoman's parser will see `Walmart` and try to classify it as an address component. A lone brand name with no other tokens is a one-token address — the parser may classify it as `locality` (there are towns named Walmart) or `venue` (the venue classifier exists but is weak). The resolver will search WOF for "Walmart" and return nothing — WOF does not index franchise locations as venues.
+
+**Franchise queries are out of scope for Mailwoman's current architecture**, for the same reasons as amenity queries: they require a POI index and a brand alias table. The address parser can handle the location-constraint part (`near Springfield, IL`) but the franchise lookup requires different infrastructure.
+
+## See also
+
+- [Amenity queries](./amenity-queries.md) — the generic-category version
+- [Regional variant queries](./regional-variant-queries.md) — when the same brand has different local names
+- [Exotic POI overview](./exotic-point-of-interest-queries.md) — the series index

--- a/docs/articles/understanding/exotic-poi/franchise-queries.md
+++ b/docs/articles/understanding/exotic-poi/franchise-queries.md
@@ -72,7 +72,7 @@ This is the same pattern as "gas station near Springfield, IL" (amenity + locati
 
 **Nominatim** handles franchise queries by matching the brand name against OSM's `name` and `brand` tags. OSM has good coverage of franchise locations in well-mapped areas. However, OSM's brand tagging is inconsistent: some locations are tagged `brand=McDonald's`, others `name=McDonald's`, and the relationship between franchise brand and individual location name varies by mapper. Nominatim does not handle slang or regional variants — `Macca's` returns nothing unless an Australian mapper tagged a location with `alt_name=Macca's`.
 
-**Pelias** indexes franchise locations as part of its OSM and OpenAddresses gazetteers. The same OSM tagging inconsistency applies. Pelias's search treats "McDonalds" as a text token and matches it against name fields. Slang and variants don't match. Sub-brand classification is not modeled.
+**Pelias** indexes franchise locations as part of its OSM and OpenAddresses gazetteers. The same OSM tagging inconsistency applies. Pelias's search matches "McDonalds" against name and brand fields, and its `categories` parameter can filter by broad types (e.g., `food`), but it has no brand-alias resolution — slang and variants don't match unless the exact text appears in the data. Sub-brand classification is not modeled.
 
 ## What Mailwoman does today
 

--- a/docs/articles/understanding/exotic-poi/landmark-queries.md
+++ b/docs/articles/understanding/exotic-poi/landmark-queries.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 5
+title: Landmark queries
+tags:
+  - domain
+  - venue
+  - international
+---
+
+# Landmark queries
+
+A landmark query names a specific, usually unique, place. The user doesn't want the nearest instance of a category — they want **the** Eiffel Tower, **the** Golden Gate Bridge, **the** Empire State Building. The geocoder's job is to recognize the landmark name and resolve it to a single coordinate or small candidate set.
+
+## What landmark queries look like
+
+| Query | Type |
+|-------|------|
+| Eiffel Tower | Named landmark — globally unique |
+| Golden Gate Bridge | Named landmark — unique, but spans a distance |
+| Empire State Building | Named landmark — unique, has a street address |
+| Taj Mahal | Named landmark — unique, well-known |
+| Sydney Opera House | Named landmark — unique, well-known |
+| the White House | Named landmark — unique, politically sensitive |
+| Wrigley Field | Named venue — unique, has a street address |
+| Grand Central Terminal | Named transit + landmark — unique, transit hub |
+| Central Park | Named area — large, multiple entrances |
+| The High Line | Named linear feature — spans a distance |
+| The Las Vegas Strip | Named area — not a single point, not a polygon |
+| Stonehenge | Named landmark — remote, well-known |
+| Mount Everest | Natural feature — summit vs base camp are different locations |
+
+Landmark queries differ from address queries in that the user knows the name of the place but not (or doesn't care about) its address. The geocoder must map the name to a coordinate without the structured components (`street`, `city`, `state`) that address queries provide.
+
+## The landmark taxonomy
+
+### Named structures
+
+Buildings, bridges, towers, monuments: Eiffel Tower, Empire State Building, Big Ben, Colosseum, CN Tower. These are the easiest landmarks to geocode — they typically exist in gazetteers (WOF, OSM, GeoNames) with a single name and coordinate.
+
+The complication: some named structures have the same name in multiple cities. There are replica Eiffel Towers in Las Vegas, Paris (Texas), and Tokyo. The user searching for "Eiffel Tower" from Paris, France wants the real one. The user in Las Vegas wants the replica. The geocoder needs a **prominence signal** — the original Eiffel Tower is more prominent than the replica, and users searching without a location constraint probably mean the prominent one.
+
+### Named natural features
+
+Mountains, rivers, lakes, forests: Mount Everest, the Amazon, Lake Tahoe, Central Park. These are areas or linear features, not points. A geocode for "Central Park" could be the park's centroid, the main entrance, or the Park's visitor center — all different coordinates. A geocode for "the Amazon" is meaningless as a point — the Amazon rainforest spans 5.5 million square kilometers across 9 countries.
+
+The geocoder should return the feature's centroid for map display and the most relevant entrance or access point for navigation. Which one to return depends on the use case, and the geocoder cannot know the use case from the query alone.
+
+### Named venues
+
+Stadiums, theaters, museums, arenas: Wrigley Field, Sydney Opera House, the Louvre, Madison Square Garden. These are easier — they are buildings with street addresses, and gazetteers typically have them. But a venue may have multiple entrances (main entrance, box office, VIP entrance, loading dock), and the geocoder's single coordinate is an implicit choice about which entrance matters.
+
+### Named areas
+
+Neighborhoods, districts, informal regions: SoHo, Shibuya, the French Quarter, Silicon Valley. These are areas, not points, with fuzzy boundaries that change over time and vary by who you ask. A geocode for "SoHo" places a pin at an arbitrary point within a neighborhood whose boundaries are contested.
+
+WOF models neighborhoods as `neighbourhood` placetypes with a representative coordinate and a parent chain (Soho → Manhattan → New York City → New York → United States). The coordinate is approximate. The boundary is not modeled. This is acceptable for most use cases — "find SoHo on a map" — but not for use cases that need boundary-level precision (delivery zones, real estate searches, neighborhood statistics).
+
+### Named linear features
+
+Trails, parkways, pedestrian paths: the High Line, the Appalachian Trail, Route 66, the Las Vegas Strip. These are paths, not points. A geocode at the midpoint of the High Line places the pin in the middle of the park — useful for map display, useless for navigation (the nearest entrance might be a mile away). Linear features need a **point-set representation** (the path as a polyline) and a way to answer "where is the nearest access point?"
+
+## How traditional geocoders handle landmark queries
+
+**Google's Places API** handles landmark queries through its place database. Landmarks are a `type` in the Places taxonomy. Google's results include a `location` (coordinate), `viewport` (bounding box for area landmarks), and `types` (what kind of landmark). Google handles disambiguation through user context (the user searching from Paris gets the real Eiffel Tower; the user in Las Vegas gets the replica).
+
+**Nominatim** handles landmarks through OSM's tagging. Named buildings (`building=yes` + `name=Eiffel Tower`), monuments (`historic=monument`), parks (`leisure=park`), and natural features (`natural=peak`) all appear in OSM. Nominatim's search matches the landmark name against OSM's name tags and returns the best match. The limitation is OSM coverage — well-known landmarks in well-mapped areas are covered; lesser-known landmarks in unmapped areas are not.
+
+**Pelias** indexes WOF venues and landmarks. WOF has good coverage of globally prominent landmarks (Eiffel Tower, Taj Mahal) but spotty coverage of local landmarks (the neighborhood park, the local statue). Pelias's search matches the landmark name against WOF's name fields and returns the best placetype match.
+
+## What Mailwoman does today
+
+Mailwoman's resolver indexes WOF administrative places plus a limited set of WOF venues. Well-known landmarks that exist in WOF as `venue` or `neighbourhood` records are resolvable. Lesser-known landmarks are not.
+
+The parser handles landmark queries as venue queries: a query with no address-format tokens (no numbers, no street suffixes, no state abbreviations) and a known venue name is classified as `kind=venue` and routed to the venue resolver. The venue classifier is weak (F1 ≈ 0.39 in v0.4.0) and improving it is part of the v0.5.0+ roadmap.
+
+**Landmark queries are partially in scope.** The architecture supports them through the venue classifier and WOF venue records. The limitation is data coverage (WOF's venue catalogue is not comprehensive) and classifier quality (the venue classifier needs more training data). Both are being addressed in the current development cycle.
+
+## See also
+
+- [Amenity queries](./amenity-queries.md) — the generic-category version
+- [Transit queries](./transit-queries.md) — transit stations as landmarks
+- [Exotic POI overview](./exotic-point-of-interest-queries.md) — the series index
+- [Resolver and Who's On First](../concepts/resolver-and-wof.md) — the gazetteer that stores landmarks

--- a/docs/articles/understanding/exotic-poi/landmark-queries.md
+++ b/docs/articles/understanding/exotic-poi/landmark-queries.md
@@ -13,21 +13,21 @@ A landmark query names a specific, usually unique, place. The user doesn't want 
 
 ## What landmark queries look like
 
-| Query | Type |
-|-------|------|
-| Eiffel Tower | Named landmark — globally unique |
-| Golden Gate Bridge | Named landmark — unique, but spans a distance |
-| Empire State Building | Named landmark — unique, has a street address |
-| Taj Mahal | Named landmark — unique, well-known |
-| Sydney Opera House | Named landmark — unique, well-known |
-| the White House | Named landmark — unique, politically sensitive |
-| Wrigley Field | Named venue — unique, has a street address |
-| Grand Central Terminal | Named transit + landmark — unique, transit hub |
-| Central Park | Named area — large, multiple entrances |
-| The High Line | Named linear feature — spans a distance |
-| The Las Vegas Strip | Named area — not a single point, not a polygon |
-| Stonehenge | Named landmark — remote, well-known |
-| Mount Everest | Natural feature — summit vs base camp are different locations |
+| Query                  | Type                                                          |
+| ---------------------- | ------------------------------------------------------------- |
+| Eiffel Tower           | Named landmark — globally unique                              |
+| Golden Gate Bridge     | Named landmark — unique, but spans a distance                 |
+| Empire State Building  | Named landmark — unique, has a street address                 |
+| Taj Mahal              | Named landmark — unique, well-known                           |
+| Sydney Opera House     | Named landmark — unique, well-known                           |
+| the White House        | Named landmark — unique, politically sensitive                |
+| Wrigley Field          | Named venue — unique, has a street address                    |
+| Grand Central Terminal | Named transit + landmark — unique, transit hub                |
+| Central Park           | Named area — large, multiple entrances                        |
+| The High Line          | Named linear feature — spans a distance                       |
+| The Las Vegas Strip    | Named area — not a single point, not a polygon                |
+| Stonehenge             | Named landmark — remote, well-known                           |
+| Mount Everest          | Natural feature — summit vs base camp are different locations |
 
 Landmark queries differ from address queries in that the user knows the name of the place but not (or doesn't care about) its address. The geocoder must map the name to a coordinate without the structured components (`street`, `city`, `state`) that address queries provide.
 

--- a/docs/articles/understanding/exotic-poi/landmark-queries.md
+++ b/docs/articles/understanding/exotic-poi/landmark-queries.md
@@ -80,4 +80,4 @@ The parser handles landmark queries as venue queries: a query with no address-fo
 - [Amenity queries](./amenity-queries.md) — the generic-category version
 - [Transit queries](./transit-queries.md) — transit stations as landmarks
 - [Exotic POI overview](./exotic-point-of-interest-queries.md) — the series index
-- [Resolver and Who's On First](../concepts/resolver-and-wof.md) — the gazetteer that stores landmarks
+- [Resolver and Who's On First](../../concepts/resolver-and-wof.md) — the gazetteer that stores landmarks

--- a/docs/articles/understanding/exotic-poi/regional-variant-queries.md
+++ b/docs/articles/understanding/exotic-poi/regional-variant-queries.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 4
+title: Regional variant queries
+tags:
+  - domain
+  - venue
+  - international
+  - multilingual
+---
+
+# Regional variant queries
+
+A regional variant is a local term for an amenity, brand, or category that differs from the global or standard name. "Servo" means gas station in Australia. "Bodega" means corner store in New York City. "マクド" (makudo) means McDonalds in the Kansai region of Japan. These are not errors, slang to be corrected, or alternate spellings — they are the **primary term** used by millions of people in their region.
+
+A geocoder that only recognizes the global standard name ("gas station," "convenience store," "McDonald's") is useless for users who search with regional variants. The geocoder doesn't need to translate the variant — it needs to recognize it as equivalent to the standard category.
+
+## The variant taxonomy
+
+Regional variants fall into several categories:
+
+### Amenity variants
+
+| Standard term | Regional variant | Region |
+|--------------|-----------------|--------|
+| gas station | servo | Australia |
+| gas station | petrol station | UK, Ireland, Commonwealth |
+| convenience store | bodega | NYC, parts of US Northeast |
+| convenience store | corner shop | UK |
+| convenience store | depanneur (dépanneur) | Quebec |
+| convenience store | milk bar | Australia (declining) |
+| liquor store | off-licence | UK, Ireland |
+| liquor store | bottle shop | Australia |
+| liquor store | package store (packie) | New England, US |
+| pharmacy | chemist | UK, Australia |
+| pharmacy | apothecary | Historical, some US regions |
+| restaurant (delivery only) | takeaway | UK, Australia |
+| restaurant (delivery only) | takeout | US, Canada |
+| public restroom | loo | UK |
+| public restroom | washroom | Canada |
+| garbage can | rubbish bin | UK, Australia |
+| garbage can | dustbin | UK (older) |
+| residential building | flat | UK |
+| residential building | apartment | US |
+| elevator | lift | UK |
+
+### Brand variants
+
+| Brand | Regional variant | Region |
+|-------|-----------------|--------|
+| McDonald's | Macca's | Australia |
+| McDonald's | マクド (makudo) | Kansai, Japan |
+| McDonald's | マック (makku) | Kantō, Japan |
+| McDonald's | McDo | France, Quebec |
+| McDonald's | Mek | Germany, Austria |
+| McDonald's | Mickey D's | US (slang) |
+| KFC | PFK (Poulet Frit Kentucky) | Quebec (legal name) |
+| Burger King | Hungry Jack's | Australia (trademark issue) |
+| 7-Eleven | セブンイレブン (sebun irebun) | Japan |
+| Starbucks | スタバ (sutaba) | Japan (slang) |
+
+### Japanese brand abbreviation patterns
+
+Japanese brand name variants follow predictable patterns that a geocoder could learn:
+
+- **Truncation to 2 mora**: マクドナルド → マクド (first 2 kanas of the loanword). スターバックス → スタバ. セブンイレブン → セブイレ or セブン. ファミリーマート → ファミマ.
+- **Regional variation**: The same brand can have different abbreviations in different regions. マクド (Kansai) vs マック (Kantō) for McDonalds. This is a known linguistic phenomenon — Kansai speakers prefer the first two mora of the first word, Kantō speakers prefer the full first word.
+- **Loanword adaptation**: Brand names borrowed into Japanese are adapted to Japanese phonology. "McDonald's" → マクドナルド (makudonarudo). "Starbucks" → スターバックス (sutābakkusu). These are not variants — they are the standard name in Japanese.
+
+### Code-switching queries
+
+Some queries mix languages: `スタバ near Shibuya Station`. The brand name is in Japanese slang. The location constraint is in English and Japanese. The geocoder must handle the code-switch — recognize スタバ as Starbucks, parse `Shibuya Station` as a transit location, and compose the query.
+
+## How traditional geocoders handle regional variants
+
+**Google** handles regional variants through its search model, trained on global query logs. "Servo" returns gas stations in Australia because Google's Australian users search for "servo" and click on gas station results. The mapping is learned from user behavior, not hand-curated.
+
+This is the right approach for a global-scale geocoder with query log data. It does not work for a geocoder without query logs — you cannot learn that "servo" means gas station if you've never seen an Australian user search for it.
+
+**Nominatim** does not handle regional variants. The search is against OSM tags and names, which use standard English categories. "Servo" returns nothing unless an Australian mapper added `alt_name=servo` to a gas station — which almost none have.
+
+**Pelias** has the same limitation. The search matches text tokens against name fields. Regional variants don't match unless they appear in the data.
+
+## What a variant-aware geocoder needs
+
+1. **An alias table.** A mapping from regional terms to standard categories and brands. This is hand-curated data — about 200-500 entries for major global variants, maintained as a data file. It's the same kind of maintenance burden as a state abbreviation dictionary, just larger.
+
+2. **A locale signal.** The geocoder needs to know where the user is to disambiguate variants. "Chemist" means pharmacy in the UK and Australia but not in the US. The locale gate (Stage 2) provides this signal for Mailwoman — it detects the script and format of the query, which is a proxy for the user's region.
+
+3. **Fuzzy matching.** Some variants are informal and appear nowhere in formal databases. "Mickey D's" for McDonalds, "packie" for liquor store. Exact alias matching won't catch these. A fuzzy-matching layer that handles common informal variants requires training data — either query logs or hand-curated examples.
+
+## What Mailwoman does today
+
+Mailwoman's locale gate (Stage 2) can detect the query's language/script family. A query in Japanese (kanji/kana) can trigger Japanese-specific alias matching. A query in English with an Australian IP (if available) can trigger Australian variant matching. But the alias table and fuzzy-matching layer do not exist.
+
+Regional variants are in the same category as amenity and franchise queries: **the infrastructure to handle them is planned but not yet built.** The architecture supports them — the kind classifier can route variant queries to a variant-aware resolver — but the data and resolver work remain.
+
+## See also
+
+- [Amenity queries](./amenity-queries.md) — the generic-category version of what variants refer to
+- [Franchise and brand queries](./franchise-queries.md) — the brand-name version of what variants refer to
+- [Exotic POI overview](./exotic-point-of-interest-queries.md) — the series index

--- a/docs/articles/understanding/exotic-poi/regional-variant-queries.md
+++ b/docs/articles/understanding/exotic-poi/regional-variant-queries.md
@@ -20,43 +20,43 @@ Regional variants fall into several categories:
 
 ### Amenity variants
 
-| Standard term | Regional variant | Region |
-|--------------|-----------------|--------|
-| gas station | servo | Australia |
-| gas station | petrol station | UK, Ireland, Commonwealth |
-| convenience store | bodega | NYC, parts of US Northeast |
-| convenience store | corner shop | UK |
-| convenience store | depanneur (dépanneur) | Quebec |
-| convenience store | milk bar | Australia (declining) |
-| liquor store | off-licence | UK, Ireland |
-| liquor store | bottle shop | Australia |
-| liquor store | package store (packie) | New England, US |
-| pharmacy | chemist | UK, Australia |
-| pharmacy | apothecary | Historical, some US regions |
-| restaurant (delivery only) | takeaway | UK, Australia |
-| restaurant (delivery only) | takeout | US, Canada |
-| public restroom | loo | UK |
-| public restroom | washroom | Canada |
-| garbage can | rubbish bin | UK, Australia |
-| garbage can | dustbin | UK (older) |
-| residential building | flat | UK |
-| residential building | apartment | US |
-| elevator | lift | UK |
+| Standard term              | Regional variant      | Region                      |
+| -------------------------- | --------------------- | --------------------------- |
+| gas station                | servo                 | Australia                   |
+| gas station                | petrol station        | UK, Ireland, Commonwealth   |
+| convenience store          | bodega                | NYC, parts of US Northeast  |
+| convenience store          | corner shop           | UK                          |
+| convenience store          | depanneur (dépanneur) | Quebec                      |
+| convenience store          | milk bar              | Australia (declining)       |
+| liquor store               | off-licence           | UK, Ireland                 |
+| liquor store               | bottle shop           | Australia                   |
+| liquor store               | package store         | New England, US             |
+| pharmacy                   | chemist               | UK, Australia               |
+| pharmacy                   | apothecary            | Historical, some US regions |
+| restaurant (delivery only) | takeaway              | UK, Australia               |
+| restaurant (delivery only) | takeout               | US, Canada                  |
+| public restroom            | loo                   | UK                          |
+| public restroom            | washroom              | Canada                      |
+| garbage can                | rubbish bin           | UK, Australia               |
+| garbage can                | dustbin               | UK (older)                  |
+| residential building       | flat                  | UK                          |
+| residential building       | apartment             | US                          |
+| elevator                   | lift                  | UK                          |
 
 ### Brand variants
 
-| Brand | Regional variant | Region |
-|-------|-----------------|--------|
-| McDonald's | Macca's | Australia |
-| McDonald's | マクド (makudo) | Kansai, Japan |
-| McDonald's | マック (makku) | Kantō, Japan |
-| McDonald's | McDo | France, Quebec |
-| McDonald's | Mek | Germany, Austria |
-| McDonald's | Mickey D's | US (slang) |
-| KFC | PFK (Poulet Frit Kentucky) | Quebec (legal name) |
-| Burger King | Hungry Jack's | Australia (trademark issue) |
-| 7-Eleven | セブンイレブン (sebun irebun) | Japan |
-| Starbucks | スタバ (sutaba) | Japan (slang) |
+| Brand       | Regional variant              | Region                      |
+| ----------- | ----------------------------- | --------------------------- |
+| McDonald's  | Macca's                       | Australia                   |
+| McDonald's  | マクド (makudo)               | Kansai, Japan               |
+| McDonald's  | マック (makku)                | Kantō, Japan                |
+| McDonald's  | McDo                          | France, Quebec              |
+| McDonald's  | Mek                           | Germany, Austria            |
+| McDonald's  | Mickey D's                    | US (slang)                  |
+| KFC         | PFK (Poulet Frit Kentucky)    | Quebec (legal name)         |
+| Burger King | Hungry Jack's                 | Australia (trademark issue) |
+| 7-Eleven    | セブンイレブン (sebun irebun) | Japan                       |
+| Starbucks   | スタバ (sutaba)               | Japan (slang)               |
 
 ### Japanese brand abbreviation patterns
 
@@ -86,7 +86,7 @@ This is the right approach for a global-scale geocoder with query log data. It d
 
 2. **A locale signal.** The geocoder needs to know where the user is to disambiguate variants. "Chemist" means pharmacy in the UK and Australia but not in the US. The locale gate (Stage 2) provides this signal for Mailwoman — it detects the script and format of the query, which is a proxy for the user's region.
 
-3. **Fuzzy matching.** Some variants are informal and appear nowhere in formal databases. "Mickey D's" for McDonalds, "packie" for liquor store. Exact alias matching won't catch these. A fuzzy-matching layer that handles common informal variants requires training data — either query logs or hand-curated examples.
+3. **Fuzzy matching.** Some variants are informal and appear nowhere in formal databases. "Mickey D's" for McDonalds, regional colloquialisms for common amenities. Exact alias matching won't catch these. A fuzzy-matching layer that handles common informal variants requires training data — either query logs or hand-curated examples.
 
 ## What Mailwoman does today
 

--- a/docs/articles/understanding/exotic-poi/transit-queries.md
+++ b/docs/articles/understanding/exotic-poi/transit-queries.md
@@ -13,19 +13,19 @@ A transit query names a station, stop, airport, terminal, or interchange. The us
 
 ## What transit queries look like
 
-| Query | Type |
-|-------|------|
-| Grand Central Terminal | Named station — unique, well-known |
-| Shibuya Station | Named station — major hub, multiple exits |
-| Heathrow Airport | Named airport — large area, multiple terminals |
-| bus stop #4521 | Numbered stop — not a name, a route identifier |
-| Metro Center (DC Metro) | Named station — multiple cities have a "Metro Center" |
-| Tokyo Station | Named station — massive complex, underground city |
-| Port Authority Bus Terminal | Named terminal — multiple carriers, multiple levels |
-| ferry terminal | Generic — which one? |
-| JFK | Airport code — three letters, globally unique |
-| LHR T5 | Airport code + terminal — specific part of a larger facility |
-| the train station | Implicit — "the" train station where the user is |
+| Query                       | Type                                                         |
+| --------------------------- | ------------------------------------------------------------ |
+| Grand Central Terminal      | Named station — unique, well-known                           |
+| Shibuya Station             | Named station — major hub, multiple exits                    |
+| Heathrow Airport            | Named airport — large area, multiple terminals               |
+| bus stop #4521              | Numbered stop — not a name, a route identifier               |
+| Metro Center (DC Metro)     | Named station — multiple cities have a "Metro Center"        |
+| Tokyo Station               | Named station — massive complex, underground city            |
+| Port Authority Bus Terminal | Named terminal — multiple carriers, multiple levels          |
+| ferry terminal              | Generic — which one?                                         |
+| JFK                         | Airport code — three letters, globally unique                |
+| LHR T5                      | Airport code + terminal — specific part of a larger facility |
+| the train station           | Implicit — "the" train station where the user is             |
 
 Transit queries have more structural variety than amenity queries. They can be named (Grand Central), coded (JFK), numbered (bus stop #4521), or implicit ("the train station"). The geocoder must handle all of these forms.
 

--- a/docs/articles/understanding/exotic-poi/transit-queries.md
+++ b/docs/articles/understanding/exotic-poi/transit-queries.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 6
+title: Transit queries
+tags:
+  - domain
+  - venue
+  - international
+---
+
+# Transit queries
+
+A transit query names a station, stop, airport, terminal, or interchange. The user wants to find the transit facility — to depart from it, arrive at it, or navigate near it. Transit queries sit between landmark queries (named stations are landmarks) and amenity queries (unnamed bus stops are amenities).
+
+## What transit queries look like
+
+| Query | Type |
+|-------|------|
+| Grand Central Terminal | Named station — unique, well-known |
+| Shibuya Station | Named station — major hub, multiple exits |
+| Heathrow Airport | Named airport — large area, multiple terminals |
+| bus stop #4521 | Numbered stop — not a name, a route identifier |
+| Metro Center (DC Metro) | Named station — multiple cities have a "Metro Center" |
+| Tokyo Station | Named station — massive complex, underground city |
+| Port Authority Bus Terminal | Named terminal — multiple carriers, multiple levels |
+| ferry terminal | Generic — which one? |
+| JFK | Airport code — three letters, globally unique |
+| LHR T5 | Airport code + terminal — specific part of a larger facility |
+| the train station | Implicit — "the" train station where the user is |
+
+Transit queries have more structural variety than amenity queries. They can be named (Grand Central), coded (JFK), numbered (bus stop #4521), or implicit ("the train station"). The geocoder must handle all of these forms.
+
+## The station-as-multi-point problem
+
+A major transit station is not a point. It is a complex with multiple entrances, exits, platforms, and often an entire underground or above-ground city:
+
+- **Shibuya Station** (Tokyo) has 6 exits, multiple train and subway lines, a bus terminal, and a surrounding commercial district. The "station" is a neighborhood-scale complex. A single coordinate for "Shibuya Station" is wrong for any specific use — the Hachikō exit is 200 meters from the New South exit, and the wrong exit can mean a 10-minute walk in the wrong direction.
+- **Tokyo Station** has an underground city with shopping, dining, and office space. The Marunouchi exit faces the Imperial Palace; the Yaesu exit faces the business district. Same station, different worlds.
+- **Heathrow Airport** has 5 terminals connected by train. A query for "Heathrow" could mean any terminal. A query for "Heathrow T5" is specific. The geocoder should return the airport centroid for the former and Terminal 5's coordinates for the latter.
+- **Port Authority Bus Terminal** (New York) has multiple levels, multiple carriers, and gates numbered by floor. The "station" is a building; the "gate" is a specific point within it.
+
+Transit stations need a **hierarchical model**: station → entrance/exit → platform/gate. Most geocoders only model the station level. A user searching for "Shibuya Station Hachikō exit" needs entrance-level precision. Most geocoders return the station centroid.
+
+## The station-name ambiguity problem
+
+Many cities have stations with the same name:
+
+- "Union Station" exists in Washington DC, Los Angeles, Chicago, Toronto, and dozens of other cities.
+- "Central Station" exists in most major cities worldwide.
+- "Metro Center" is a station name in the DC Metro, but "metro center" is also a generic term for a transit hub.
+
+The station name alone is not unique. The geocoder needs the city context to disambiguate — "Union Station, Washington DC" vs "Union Station, Los Angeles." This is the same problem as "Springfield" ambiguity, but for transit infrastructure.
+
+Airport codes (JFK, LHR, NRT, CDG, DXB) are globally unique three-letter IATA codes. A query for "JFK" unambiguously means John F. Kennedy International Airport in New York. Airport codes are the most machine-friendly transit identifiers — short, globally unique, and standardized.
+
+## The implicit-station problem
+
+"The train station" without a city name implies "the train station where the user is." The geocoder needs the user's location to resolve this. This is not a parsing problem — it's a context problem. The parser correctly identifies "train station" as a transit query. The resolver needs a location to search near. Without one, the query is unresolvable.
+
+"Subway station near me" is the same pattern: transit category + implicit location. The geocoder needs the user's location to answer it.
+
+## How traditional geocoders handle transit queries
+
+**Google's Places API** handles transit queries well. Stations, airports, and transit hubs are first-class place types. Google's transit data includes station entrances and exits (where available from local transit agencies) and airport terminal coordinates. "Shibuya Station" returns a coordinate for the station; Google Maps shows individual exits as separate markers.
+
+**Nominatim** handles transit through OSM's transit tagging (`railway=station`, `aeroway=aerodrome`, `public_transport=station`). OSM station data is excellent in well-mapped areas — individual platforms, entrances, and exits are often tagged. Station name ambiguity is handled through the OSM hierarchy: the station's containing city is part of the OSM record.
+
+**Pelias** indexes transit stations through OSM and WOF. WOF has transit stations as `venue` or `campus` placetypes. The data is as good as the underlying OSM contribution in each area. Station entrance data is sparse outside of major cities.
+
+## What Mailwoman does today
+
+Mailwoman's resolver indexes WOF administrative places plus a limited set of WOF venues. Transit stations that exist in WOF are resolvable; stations that don't are not. Airport codes (JFK, LHR) are not in WOF's name index — WOF uses full names ("John F. Kennedy International Airport"), not codes.
+
+The parser handles transit queries as a mixed case: a named station like "Grand Central Terminal" looks like a venue query. An unnamed transit query like "bus stop" looks like an amenity query. The kind classifier should route transit queries to a transit-aware resolver, but this routing does not exist.
+
+**Transit queries are partially in scope** (same as landmarks) but underserved. The venue classifier and WOF venue records cover named stations in well-populated WOF regions. Station entrance data, airport code resolution, and numbered-stop resolution are not supported.
+
+## See also
+
+- [Landmark queries](./landmark-queries.md) — named stations as landmarks
+- [Amenity queries](./amenity-queries.md) — unnamed stops as amenities
+- [Exotic POI overview](./exotic-point-of-interest-queries.md) — the series index


### PR DESCRIPTION
## Summary

Adds a six-article series on non-address geocoder queries — named places, categories, brands, landmarks, and transit infrastructure that users search for but that don't fit the address-parsing model.

### Articles

| Article | Covers |
|---------|--------|
| **Overview** | What counts as a POI query vs an address query. Taxonomy of 5 categories. How the staged pipeline handles routing. |
| **Amenity queries** | Generic categories: gas station, ATM, water fountain, pharmacy. The category-taxonomy problem (OSM tags, language aliases). What Mailwoman can and can't do today. |
| **Franchise/brand queries** | Named chains: Walmart, McDonalds, Hilton, Starbucks. Brand-name problem (spelling variants, slang, abbreviations across languages). Sub-brand classification. |
| **Regional variants** | Local terminology: servo, bodega, マクド, off-licence, chemist. Japanese brand abbreviation patterns (truncation to 2 mora, Kansai vs Kantō regional variation). Code-switching queries. |
| **Landmark queries** | Named places: Eiffel Tower, Golden Gate Bridge, Central Park. Landmark taxonomy: structures, natural features, venues, areas, linear features. Prominence-based disambiguation. |
| **Transit queries** | Stations, airports, stops, terminals. Station-as-multi-point problem, station-name ambiguity (Union Station), airport code resolution (JFK, LHR, NRT). |

### Structure

Each article follows the same pattern as the falsehoods and simple-geocoders series:
1. What these queries look like (with examples)
2. How traditional geocoders handle them (Google, Nominatim, Pelias)
3. What Mailwoman does today (mostly out of scope — architecture ready, POI index not yet built)
4. See also cross-references

Placed in `understanding/exotic-poi/` directory. Autogenerated sidebar picks them up.