### PR TITLE
feat(train): v0.5.2 rebalanced recipe — WOF downweight + augmentation + cosine decay

### DIFF
--- a/corpus-python/src/mailwoman_train/augment.py
+++ b/corpus-python/src/mailwoman_train/augment.py
@@ -1,0 +1,174 @@
+"""Training-time augmentation: expand abbreviations to teach token equivalence.
+
+Two augmentations, applied independently with configurable probability:
+
+1. **Directional expansion**: "NW" → "Northwest", "SE" → "Southeast", etc.
+   Teaches the model that both abbreviated and expanded directionals are the same
+   component, without requiring inference-time normalization.
+
+2. **Region-abbreviation expansion**: "NY" → "New York", "CA" → "California", etc.
+   Only US state abbreviations for now. Teaches the model that "NY" and "New York"
+   are both B-region, improving locality/region disambiguation.
+
+Both augmentations replace the token in the raw text AND update the tokens + labels
+lists to match. The expanded form inherits the original token's BIO label (B- for
+the first word, I- for continuation words).
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Iterator
+
+# US directional abbreviations → expanded forms.
+DIRECTIONALS: dict[str, str] = {
+    "N": "North",
+    "S": "South",
+    "E": "East",
+    "W": "West",
+    "NE": "Northeast",
+    "NW": "Northwest",
+    "SE": "Southeast",
+    "SW": "Southwest",
+}
+
+# US state abbreviations → full names. Only unambiguous 2-letter codes.
+US_STATES: dict[str, str] = {
+    "AL": "Alabama",
+    "AK": "Alaska",
+    "AZ": "Arizona",
+    "AR": "Arkansas",
+    "CA": "California",
+    "CO": "Colorado",
+    "CT": "Connecticut",
+    "DE": "Delaware",
+    "FL": "Florida",
+    "GA": "Georgia",
+    "HI": "Hawaii",
+    "ID": "Idaho",
+    "IL": "Illinois",
+    "IN": "Indiana",
+    "IA": "Iowa",
+    "KS": "Kansas",
+    "KY": "Kentucky",
+    "LA": "Louisiana",
+    "ME": "Maine",
+    "MD": "Maryland",
+    "MA": "Massachusetts",
+    "MI": "Michigan",
+    "MN": "Minnesota",
+    "MS": "Mississippi",
+    "MO": "Missouri",
+    "MT": "Montana",
+    "NE": "Nebraska",
+    "NV": "Nevada",
+    "NH": "New Hampshire",
+    "NJ": "New Jersey",
+    "NM": "New Mexico",
+    "NY": "New York",
+    "NC": "North Carolina",
+    "ND": "North Dakota",
+    "OH": "Ohio",
+    "OK": "Oklahoma",
+    "OR": "Oregon",
+    "PA": "Pennsylvania",
+    "RI": "Rhode Island",
+    "SC": "South Carolina",
+    "SD": "South Dakota",
+    "TN": "Tennessee",
+    "TX": "Texas",
+    "UT": "Utah",
+    "VT": "Vermont",
+    "VA": "Virginia",
+    "WA": "Washington",
+    "WV": "West Virginia",
+    "WI": "Wisconsin",
+    "WY": "Wyoming",
+    "DC": "District of Columbia",
+}
+
+
+def _expand_token(
+    tokens: list[str],
+    labels: list[str],
+    idx: int,
+    expansion: str,
+) -> tuple[list[str], list[str]]:
+    """Replace token at `idx` with a multi-word expansion, updating labels with B-/I- continuation."""
+    orig_label = labels[idx]
+    expansion_words = expansion.split()
+
+    if len(expansion_words) == 1:
+        new_tokens = tokens[:idx] + [expansion_words[0]] + tokens[idx + 1 :]
+        new_labels = labels[:]
+        return new_tokens, new_labels
+
+    # Multi-word: first word keeps the original label, rest get I- version.
+    if orig_label.startswith("B-"):
+        tag = orig_label[2:]
+        new_labels_for_expansion = [orig_label] + [f"I-{tag}"] * (len(expansion_words) - 1)
+    elif orig_label.startswith("I-"):
+        new_labels_for_expansion = [orig_label] * len(expansion_words)
+    else:
+        # O label — all expansion words are O
+        new_labels_for_expansion = ["O"] * len(expansion_words)
+
+    new_tokens = tokens[:idx] + expansion_words + tokens[idx + 1 :]
+    new_labels = labels[:idx] + new_labels_for_expansion + labels[idx + 1 :]
+    return new_tokens, new_labels
+
+
+def augment_row(
+    row: dict,
+    rng: random.Random,
+    directional_prob: float = 0.3,
+    region_prob: float = 0.3,
+) -> Iterator[dict]:
+    """Yield the original row, then optionally an augmented copy.
+
+    Each augmentation fires independently with its configured probability. When an
+    augmentation fires, a COPY of the row is yielded with the expansion applied.
+    The original row is always yielded first, unchanged.
+    """
+    yield row
+
+    tokens: list[str] = row["tokens"]
+    labels: list[str] = row["labels"]
+
+    # Directional expansion: find directional tokens and expand one.
+    if rng.random() < directional_prob:
+        directional_indices = [
+            i for i, t in enumerate(tokens) if t in DIRECTIONALS
+        ]
+        if directional_indices:
+            idx = rng.choice(directional_indices)
+            new_tokens, new_labels = _expand_token(
+                tokens, labels, idx, DIRECTIONALS[tokens[idx]]
+            )
+            new_raw = " ".join(new_tokens)
+            yield {
+                **row,
+                "raw": new_raw,
+                "tokens": new_tokens,
+                "labels": new_labels,
+            }
+
+    # Region-abbreviation expansion: find region-labeled abbreviations and expand one.
+    if rng.random() < region_prob:
+        region_indices = [
+            i
+            for i, (t, l) in enumerate(zip(tokens, labels))
+            if t in US_STATES and l in ("B-region", "I-region")
+        ]
+        if region_indices:
+            idx = rng.choice(region_indices)
+            new_tokens, new_labels = _expand_token(
+                tokens, labels, idx, US_STATES[tokens[idx]]
+            )
+            new_raw = " ".join(new_tokens)
+            yield {
+                **row,
+                "raw": new_raw,
+                "tokens": new_tokens,
+                "labels": new_labels,
+            }

--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -31,6 +31,10 @@ class DataConfig:
     val_rows: int | None = 4096
     # Filter: keep only rows with country + at least one of (region, locality, postcode).
     coarse_filter: bool = True
+    # Training augmentation: expand abbreviations to teach token equivalence.
+    # Probability (0-1) that each augmentation fires per row. 0 = disabled.
+    augment_directional_prob: float = 0.0
+    augment_region_prob: float = 0.0
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/configs/v0_5_2-classifier-rebalanced.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_5_2-classifier-rebalanced.yaml
@@ -1,0 +1,102 @@
+# v0.5.2 classifier — "rebalanced" iteration.
+#
+# Addresses the locality/region confusion diagnosed in DEMO_PRESET_DIAGNOSIS.md:
+#   - wof-admin: 2.0 → 0.3 (counters bare-name frequency dominance)
+#   - wof-postalcode: 2.0 → 1.0 (still useful, but not overrepresented)
+#   - label_smoothing: 0.0 → 0.1 (softens overconfident predictions)
+#   - lr_schedule: constant → cosine (decay after step 50K prevents overfitting)
+#
+# Everything else carries from v0.5.1 unchained:
+#   - h384, batch=128 direct, CE-only, phrase priors ON, class weights tuned
+#
+# Expected improvement: model learns positional "locality precedes region abbreviation"
+# pattern from OSM data instead of WOF bare-name frequency.
+#
+# Launch:
+#   modal run scripts/modal/train_remote.py --config v0_5_2-classifier-rebalanced.yaml
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.5.0-a1
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 0.3
+    wof-postalcode: 1.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  label_smoothing: 0.1
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 100000
+  eval_every_steps: 5000
+  save_every_steps: 5000
+  log_every_steps: 100
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: cosine
+
+eval:
+  golden_dir: ""
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -32,6 +32,7 @@ from typing import Iterable, Iterator, Sequence
 
 import pyarrow.parquet as pq
 
+from .augment import augment_row
 from .config import Config, DataConfig
 from .labels import IGNORE_INDEX, active_components_present
 from .tokenizer import Tokenizer, encode_row, whitespace_spans
@@ -277,6 +278,8 @@ def iter_rows(
     source_weights: dict[str, float] | None = None,
     coarse_filter: bool,
     row_limit: int | None = None,
+    augment_directional_prob: float = 0.0,
+    augment_region_prob: float = 0.0,
     shuffle_buffer: int = 131072,
 ) -> Iterator[dict]:
     """Yield rows from parquet shards, filtered + shuffled.
@@ -325,22 +328,32 @@ def iter_rows(
             buf.append(next(upstream))
     except StopIteration:
         pass
+    do_augment = augment_directional_prob > 0 or augment_region_prob > 0
+
+    def _emit(row: dict) -> Iterator[dict]:
+        if do_augment:
+            yield from augment_row(row, rng, augment_directional_prob, augment_region_prob)
+        else:
+            yield row
+
     # Stream out: every time we yield, pull the next from upstream into the freed slot.
     for row in upstream:
         j = rng.randrange(len(buf))
         out = buf[j]
         buf[j] = row
-        yield out
-        yielded += 1
-        if row_limit is not None and yielded >= row_limit:
-            return
+        for emitted in _emit(out):
+            yield emitted
+            yielded += 1
+            if row_limit is not None and yielded >= row_limit:
+                return
     # Drain whatever remains in the buffer.
     rng.shuffle(buf)
     for out in buf:
-        yield out
-        yielded += 1
-        if row_limit is not None and yielded >= row_limit:
-            return
+        for emitted in _emit(out):
+            yield emitted
+            yielded += 1
+            if row_limit is not None and yielded >= row_limit:
+                return
 
 
 def iter_encoded(
@@ -365,6 +378,8 @@ def iter_encoded(
         source_weights=cfg_data.source_weights,
         coarse_filter=cfg_data.coarse_filter,
         row_limit=row_limit,
+        augment_directional_prob=cfg_data.augment_directional_prob,
+        augment_region_prob=cfg_data.augment_region_prob,
     ):
         enc = encode_row(
             tokenizer,

--- a/corpus-python/src/mailwoman_train/test_augment.py
+++ b/corpus-python/src/mailwoman_train/test_augment.py
@@ -1,0 +1,108 @@
+"""Tests for training-time augmentation."""
+
+import random
+
+from .augment import augment_row, _expand_token
+
+
+def test_expand_token_single_word():
+    tokens = ["350", "5th", "Ave", "NW"]
+    labels = ["B-house_number", "B-street", "I-street", "I-street"]
+    new_tokens, new_labels = _expand_token(tokens, labels, 3, "Northwest")
+    assert new_tokens == ["350", "5th", "Ave", "Northwest"]
+    assert new_labels == ["B-house_number", "B-street", "I-street", "I-street"]
+
+
+def test_expand_token_multi_word_b_label():
+    tokens = ["Washington", ",", "DC"]
+    labels = ["B-region", "O", "B-region"]
+    # Expand "DC" → "District of Columbia"
+    new_tokens, new_labels = _expand_token(tokens, labels, 2, "District of Columbia")
+    assert new_tokens == ["Washington", ",", "District", "of", "Columbia"]
+    assert new_labels == ["B-region", "O", "B-region", "I-region", "I-region"]
+
+
+def test_expand_token_multi_word_i_label():
+    tokens = ["New", "York", ",", "NY"]
+    labels = ["B-locality", "I-locality", "O", "B-region"]
+    # Expand "NY" → "New York" (B-region stays B-region, second word gets I-region)
+    new_tokens, new_labels = _expand_token(tokens, labels, 3, "New York")
+    assert new_tokens == ["New", "York", ",", "New", "York"]
+    assert new_labels == ["B-locality", "I-locality", "O", "B-region", "I-region"]
+
+
+def test_augment_row_original_always_yielded():
+    row = {
+        "raw": "350 5th Ave NW",
+        "tokens": ["350", "5th", "Ave", "NW"],
+        "labels": ["B-house_number", "B-street", "I-street", "I-street"],
+        "country": "US",
+        "source": "tiger",
+    }
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=0.0, region_prob=0.0))
+    assert len(results) == 1
+    assert results[0] is row
+
+
+def test_augment_row_directional_fires():
+    row = {
+        "raw": "350 5th Ave NW",
+        "tokens": ["350", "5th", "Ave", "NW"],
+        "labels": ["B-house_number", "B-street", "I-street", "I-street"],
+        "country": "US",
+        "source": "tiger",
+    }
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=1.0, region_prob=0.0))
+    assert len(results) == 2
+    assert results[0] is row
+    assert "Northwest" in results[1]["tokens"]
+
+
+def test_augment_row_region_fires():
+    row = {
+        "raw": "New York , NY",
+        "tokens": ["New", "York", ",", "NY"],
+        "labels": ["B-locality", "I-locality", "O", "B-region"],
+        "country": "US",
+        "source": "tiger",
+    }
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=0.0, region_prob=1.0))
+    assert len(results) == 2
+    augmented = results[1]
+    # "NY" should be expanded to "New" "York" with B-region I-region
+    assert "B-region" in augmented["labels"]
+    assert "I-region" in augmented["labels"]
+
+
+def test_augment_row_no_match_no_extra():
+    row = {
+        "raw": "123 Main St",
+        "tokens": ["123", "Main", "St"],
+        "labels": ["B-house_number", "B-street", "I-street"],
+        "country": "US",
+        "source": "tiger",
+    }
+    rng = random.Random(42)
+    # Even with prob=1.0, no directionals or region abbreviations → no augmented copy
+    results = list(augment_row(row, rng, directional_prob=1.0, region_prob=1.0))
+    assert len(results) == 1
+
+
+def test_augment_row_region_only_expands_region_labeled():
+    row = {
+        "raw": "PA Ave , DC",
+        "tokens": ["PA", "Ave", ",", "DC"],
+        "labels": ["B-street", "I-street", "O", "B-region"],
+        "country": "US",
+        "source": "tiger",
+    }
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=0.0, region_prob=1.0))
+    assert len(results) == 2
+    augmented = results[1]
+    # PA (labeled B-street) should NOT be expanded — only DC (B-region) should
+    assert augmented["tokens"][0] == "PA"
+    assert "District" in augmented["tokens"]


### PR DESCRIPTION
## Summary

- Source reweight: `wof-admin` 2.0 → 0.3 (counters bare-name frequency dominance)
- Training augmentation: directional expansion (NW → Northwest) + region-abbreviation expansion (NY → New York) at 30% probability per row
- `label_smoothing` 0.0 → 0.1 + cosine LR decay (addresses overconfidence + overfitting past step 65K)

## Context

Follows from the demo preset diagnosis (#164, `DEMO_PRESET_DIAGNOSIS.md`). The v0.5.1 model over-emits `B-region` on ambiguous place names because WOF bare-name entries outnumber OSM full-address entries. This recipe attacks the training-side root cause.

## Training status

Running on Modal A100 as of 2026-05-25 ~20:45 UTC. Config: `v0_5_2-classifier-rebalanced.yaml`. Expected wall: ~3h.

## Test plan

- [x] 8 unit tests for augmentation module (expand_token, augment_row, edge cases)
- [x] data_loader imports cleanly with augmentation wired
- [ ] Training completes without divergence
- [ ] val_macro_f1 ≥ v0.5.1 (0.638) — or locality/region ratio improves even if macro dips
- [ ] Demo presets #1 and #2 pass with new weights + locality soft prior

🤖 Generated with [Claude Code](https://claude.com/claude-code)