### PR TITLE
chore: fix all eslint errors — unblock pre-commit on main

### DIFF
--- a/mailwoman/commands/corpus/download.tsx
+++ b/mailwoman/commands/corpus/download.tsx
@@ -57,8 +57,9 @@ const CorpusDownload: CommandComponent<typeof OptionsSchema> = ({ options }) => 
 			try {
 				await $`rclone sync ${rcloneBase}/corpus/v0.3.0/ ${out}/corpus/versioned/v0.3.0/corpus-v0.3.0/ --progress --transfers 8 --checkers 16 ${dryFlag}`.quiet()
 				updateStep(0, { status: "done" })
-			} catch (e: any) {
-				updateStep(0, { status: "error", detail: String(e.stderr ?? e.message).slice(0, 100) })
+			} catch (_e: unknown) {
+				const e = _e as Record<string, unknown>
+				updateStep(0, { status: "error", detail: String(e.stderr ?? e.message ?? _e).slice(0, 100) })
 				return
 			}
 
@@ -67,8 +68,9 @@ const CorpusDownload: CommandComponent<typeof OptionsSchema> = ({ options }) => 
 			try {
 				await $`rclone sync ${rcloneBase}/corpus/v0.4.0/ ${out}/corpus/versioned/v0.4.0/corpus-v0.4.0/ --progress --transfers 4 ${dryFlag}`.quiet()
 				updateStep(1, { status: "done" })
-			} catch (e: any) {
-				updateStep(1, { status: "error", detail: String(e.stderr ?? e.message).slice(0, 100) })
+			} catch (_e: unknown) {
+				const e = _e as Record<string, unknown>
+				updateStep(1, { status: "error", detail: String(e.stderr ?? e.message ?? _e).slice(0, 100) })
 				return
 			}
 
@@ -77,8 +79,9 @@ const CorpusDownload: CommandComponent<typeof OptionsSchema> = ({ options }) => 
 			try {
 				await $`rclone sync ${rcloneBase}/models/tokenizer/ ${out}/models/tokenizer/ --progress ${dryFlag}`.quiet()
 				updateStep(2, { status: "done" })
-			} catch (e: any) {
-				updateStep(2, { status: "error", detail: String(e.stderr ?? e.message).slice(0, 100) })
+			} catch (_e: unknown) {
+				const e = _e as Record<string, unknown>
+				updateStep(2, { status: "error", detail: String(e.stderr ?? e.message ?? _e).slice(0, 100) })
 				return
 			}
 
@@ -87,8 +90,9 @@ const CorpusDownload: CommandComponent<typeof OptionsSchema> = ({ options }) => 
 			try {
 				await $`rclone sync ${rcloneBase}/corpus-python/ ./corpus-python/ --progress ${dryFlag}`.quiet()
 				updateStep(3, { status: "done" })
-			} catch (e: any) {
-				updateStep(3, { status: "error", detail: String(e.stderr ?? e.message).slice(0, 100) })
+			} catch (_e: unknown) {
+				const e = _e as Record<string, unknown>
+				updateStep(3, { status: "error", detail: String(e.stderr ?? e.message ?? _e).slice(0, 100) })
 				return
 			}
 		}
@@ -99,7 +103,7 @@ const CorpusDownload: CommandComponent<typeof OptionsSchema> = ({ options }) => 
 	return (
 		<Box flexDirection="column">
 			<Text bold>Corpus Download ← R2 ({options.bucket})</Text>
-			{options.dryRun && <Text color="yellow">DRY RUN — no files will be transferred</Text>}
+			{Boolean(options.dryRun) && <Text color="yellow">DRY RUN — no files will be transferred</Text>}
 			<Text> </Text>
 			{steps.map((step, i) => (
 				<Box key={i}>

--- a/mailwoman/commands/corpus/upload.tsx
+++ b/mailwoman/commands/corpus/upload.tsx
@@ -55,7 +55,7 @@ const CorpusUpload: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 			try {
 				await $`rclone mkdir ${rcloneBase} ${dryFlag}`.quiet()
 				updateStep(0, { status: "done" })
-			} catch (e: any) {
+			} catch {
 				updateStep(0, { status: "done", detail: "bucket may already exist" })
 			}
 
@@ -65,8 +65,9 @@ const CorpusUpload: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 				const result =
 					await $`rclone sync ${options.corpusDir}/v0.3.0/corpus-v0.3.0/ ${rcloneBase}/corpus/v0.3.0/ --progress --transfers 8 --checkers 16 ${dryFlag}`.quiet()
 				updateStep(1, { status: "done", detail: "v0.3.0 synced" })
-			} catch (e: any) {
-				updateStep(1, { status: "error", detail: String(e.stderr ?? e.message).slice(0, 100) })
+			} catch (_e: unknown) {
+				const e = _e as Record<string, unknown>
+				updateStep(1, { status: "error", detail: String(e.stderr ?? e.message ?? _e).slice(0, 100) })
 				return
 			}
 
@@ -75,8 +76,9 @@ const CorpusUpload: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 			try {
 				await $`rclone sync ${options.corpusDir}/v0.4.0/corpus-v0.4.0/ ${rcloneBase}/corpus/v0.4.0/ --progress --transfers 4 ${dryFlag}`.quiet()
 				updateStep(2, { status: "done", detail: "v0.4.0 synced" })
-			} catch (e: any) {
-				updateStep(2, { status: "error", detail: String(e.stderr ?? e.message).slice(0, 100) })
+			} catch (_e: unknown) {
+				const e = _e as Record<string, unknown>
+				updateStep(2, { status: "error", detail: String(e.stderr ?? e.message ?? _e).slice(0, 100) })
 				return
 			}
 
@@ -85,8 +87,9 @@ const CorpusUpload: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 			try {
 				await $`rclone sync ${options.tokenizerDir}/ ${rcloneBase}/models/tokenizer/ --progress ${dryFlag}`.quiet()
 				updateStep(3, { status: "done", detail: "tokenizer synced" })
-			} catch (e: any) {
-				updateStep(3, { status: "error", detail: String(e.stderr ?? e.message).slice(0, 100) })
+			} catch (_e: unknown) {
+				const e = _e as Record<string, unknown>
+				updateStep(3, { status: "error", detail: String(e.stderr ?? e.message ?? _e).slice(0, 100) })
 				return
 			}
 
@@ -95,8 +98,9 @@ const CorpusUpload: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 			try {
 				await $`rclone sync ./corpus-python/ ${rcloneBase}/corpus-python/ --exclude '.venv/**' --exclude '__pycache__/**' --exclude '*.egg-info/**' --progress ${dryFlag}`.quiet()
 				updateStep(4, { status: "done", detail: "training code synced" })
-			} catch (e: any) {
-				updateStep(4, { status: "error", detail: String(e.stderr ?? e.message).slice(0, 100) })
+			} catch (_e: unknown) {
+				const e = _e as Record<string, unknown>
+				updateStep(4, { status: "error", detail: String(e.stderr ?? e.message ?? _e).slice(0, 100) })
 				return
 			}
 		}
@@ -107,7 +111,7 @@ const CorpusUpload: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 	return (
 		<Box flexDirection="column">
 			<Text bold>Corpus Upload → R2 ({options.bucket})</Text>
-			{options.dryRun && <Text color="yellow">DRY RUN — no files will be transferred</Text>}
+			{Boolean(options.dryRun) && <Text color="yellow">DRY RUN — no files will be transferred</Text>}
 			<Text> </Text>
 			{steps.map((step, i) => (
 				<Box key={i}>

--- a/mailwoman/test/locale-flag.test.ts
+++ b/mailwoman/test/locale-flag.test.ts
@@ -83,7 +83,6 @@ describe("npx mailwoman parse --isolated --locale <bcp47> '<input>' (legacy rule
 			exec(process.execPath, [cliBin, "parse", "--isolated", sample]),
 		])
 		// Strip ANSI escapes and ink spinner frames; compare the JSON payload only.
-		// eslint-disable-next-line no-control-regex
 		const ansi = /\[[0-9;]*[a-zA-Z]/gu
 		const json = (stdout: string) => {
 			const clean = stdout.replace(ansi, "")

--- a/mailwoman/test/pipeline-debug-cli.test.ts
+++ b/mailwoman/test/pipeline-debug-cli.test.ts
@@ -24,7 +24,6 @@ const cliBin = resolve(repoRoot, "out", "cli.js")
 
 /** Strip ANSI escapes + ink spinner frames; isolate the JSON payload. */
 function extractJson(stdout: string): unknown {
-	// eslint-disable-next-line no-control-regex
 	const ansi = /\[[0-9;]*[a-zA-Z]/gu
 	const cleaned = stdout.replace(ansi, "").trim()
 	// Find the outermost JSON object (debug mode emits an object — non-debug emits an array).

--- a/mailwoman/test/resolve-flag.test.ts
+++ b/mailwoman/test/resolve-flag.test.ts
@@ -144,7 +144,6 @@ describeIfWof(`npx mailwoman parse --neural --resolve against ${wofPath}`, () =>
 
 /** Strip ANSI escape sequences + ink spinner frames so JSON.parse can consume CLI stdout. */
 function stripAnsiSpinner(stdout: string): string {
-	// eslint-disable-next-line no-control-regex
 	const ansi = /\[[0-9;]*[a-zA-Z]/gu
 	const cleaned = stdout.replace(ansi, "").trim()
 	// Find the start of the JSON payload (`{` or `[`).

--- a/scripts/eval/eval-matrix.ts
+++ b/scripts/eval/eval-matrix.ts
@@ -117,7 +117,7 @@ function extractFailureClasses(row: GoldenRow): string[] {
 	const classes: string[] = []
 
 	if (/kryptonite/i.test(notes)) {
-		const match = notes.match(/kryptonite\/([a-z\-]+)/i)
+		const match = notes.match(/kryptonite\/([a-z-]+)/i)
 		if (match) classes.push(`kryptonite/${match[1]}`)
 		else classes.push("kryptonite/general")
 	}


### PR DESCRIPTION
## Summary

Fixes all 12 eslint errors that were blocking the pre-commit hook on main.

- `catch (e: any)` → `catch (_e: unknown)` with typed cast (corpus download/upload)
- `Boolean()` wrap for `jsx-no-leaked-render` (corpus download/upload)
- Remove useless escape `\-` in regex character class (eval-matrix)
- Remove stale `no-control-regex` disable directives (3 test files)

Zero errors remaining. 4 jsdoc warnings in `spatial/sdk/` are non-blocking.

## Test plan

- [x] `npx eslint .` reports 0 errors
- [x] `tsc -b` clean
- [x] prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)