### PR TITLE
feat(kind-classifier): detect venue/landmark queries

### DIFF
--- a/docs/articles/plan/reference/FST_GAZETTEER_LM.md
+++ b/docs/articles/plan/reference/FST_GAZETTEER_LM.md
@@ -1,0 +1,218 @@
+---
+sidebar_position: 18
+title: FST gazetteer language model
+---
+
+# FST Gazetteer LM — Design Document
+
+**Goal:** Pre-compute a finite-state transducer from the WOF SQLite gazetteer that maps token sequences → `(placetype, wof_id, parent_chain)` entries. Use it as an emission prior in the neural Viterbi decoder, as a CLI introspection tool, and as the autocomplete backend.
+
+**Principle:** Pay down the combinatorial cross-product of "all valid place-name paths through the WOF hierarchy" at build time. At query time, walking the FST is O(depth), not O(gazetteer_size).
+
+---
+
+## Architecture overview
+
+### The FST data structure
+
+```ts
+FstState {
+  id: u32                              // dense index into states[]
+  edges: Vec<FstEdge>                  // 2-5 entries avg
+  places: Vec<PlaceEntry>              // accepting states only, 1-5 entries avg
+}
+
+FstEdge {
+  token: string                        // interned, lowercase, NFKC-normalized
+  target: u32                          // target state id
+}
+
+PlaceEntry {
+  wof_id: u32                          // WOF numeric ID
+  placetype: u8                        // PlacetypeId enum
+  parent_chain: Vec<u32>               // [country_id, region_id, county_id?], leaf-to-root
+  population: u32
+  lat: f32, lon: f32
+}
+```
+
+Tokenization is whitespace-split with punctuation stripping. The FST edge label is the normalized token. Accepting states carry ALL valid interpretations — "New York" ends at a state with entries for both NYC (locality) and NY state (region). The FST never picks; the neural model + reconciler do.
+
+### Build pipeline
+
+```
+WOF SQLite (spr + names tables)
+         │
+         ▼
+  fst-builder.ts  ← resolver-wof-sqlite/fst-builder.ts
+         │
+         ├─ Normalize names (NFKC, lowercase, strip punctuation)
+         ├─ Tokenize each name + alt_names into token sequences
+         ├─ Insert into incremental trie (shared prefixes)
+         ├─ At each terminal: attach PlaceEntry
+         ├─ Determinize + Minimize (Hopcroft)
+         │
+         ▼
+  fst.bin  ← compact binary (~8-12 MB for US)
+         │
+         ▼
+  FstMatcher class (fast prefix walk)
+```
+
+### Integration with the neural pipeline
+
+The FST provides per-token emission biases, composing additively with the existing QueryShape soft prior:
+
+```ts
+let emissions = logits
+if (opts?.queryShape) {
+  emissions = addEmissionMatrix(emissions, buildEmissionPriors(...))
+}
+if (opts?.fst) {
+  emissions = addEmissionMatrix(emissions, buildFstEmissionPriors(...))
+}
+// → Viterbi decode over biased emissions
+```
+
+The FST prior gets STRONGER as the prefix grows longer — a "wedge that tightens with information." A bare "S" spreads bias across many places; "San Fran" concentrates it on San Francisco.
+
+### The WFST analogy to speech recognition
+
+| Speech recognition | Address parsing |
+|---|---|
+| Acoustic model (DNN) | Neural classifier (transformer) |
+| Pronunciation lexicon (L) | FST (token sequences → place entries) |
+| Language model (G) | Address grammar (valid component sequences) |
+| Shallow fusion at decode time | Additive emission biases at Viterbi time |
+
+The neural model handles non-gazetteer components (streets, venues, house numbers, typos). The FST handles gazetteer components (countries, regions, localities). They compose via shallow fusion — same as modern ASR systems.
+
+---
+
+## CLI proof-of-concept
+
+### `mailwoman fst build`
+
+```bash
+mailwoman fst build --db /path/to/wof-admin-us.db --output fst-en-US.bin --countries US
+```
+
+### `mailwoman fst query`
+
+```bash
+mailwoman fst query 'New York' --fst fst-en-US.bin --show-continuations
+```
+
+Example output:
+
+```
+"new york" (complete match)
+├── Accepts: 2 interpretations
+│   ├── locality New York City    pop 8,804,000  wof:85977539
+│   │   chain: US ← New York (state) ← New York (city)
+│   └── region   New York State   pop 20,200,000 wof:85688543
+│       chain: US ← New York (state)
+└── Valid continuations:
+    ├── "ny"    → region (NY state, disambiguated)
+    ├── "10001" → postalcode
+    └── [end]   → valid terminal
+```
+
+**Negative evidence example** — `'Buffalo Health Clinic, Buffalo'`:
+
+```
+"buffalo" → 14 places (locality Buffalo, NY is top)
+"health"  → NOT IN FST (no gazetteer match)
+  → Strong signal: this span is NOT an admin component
+  → Fall back to neural model for typing (likely venue)
+```
+
+---
+
+## Locale strategy
+
+**Per-locale FSTs (recommended for v1).** One FST per locale: `fst-en-US.bin`, `fst-fr-FR.bin`. Filter by country during build. Names in all languages are included (a user typing "Munich" in an en-US context won't match — and that's correct, Munich isn't in the US).
+
+| Locale | Places | FST size |
+|---|---|---|
+| en-US | ~30K | ~8 MB |
+| fr-FR | ~36K (communes) | ~10 MB |
+| ja-JP | ~1,800 | ~5 MB |
+| en-GB | ~20K | ~6 MB |
+
+### Why not combined+filter
+
+A single FST with per-edge locale bitsets is space-efficient but query-slower. For v1, per-locale FSTs match the existing per-locale weights model. Revisit if multi-locale deployment becomes necessary.
+
+---
+
+## Size estimates
+
+**Admin only (Phase 1):** ~8-12 MB for US. Smaller than the current 35 MB WOF slim DB but encodes more structural information (parent chains, population, valid continuations).
+
+**With streets (Phase 2+):** ~200-500 MB for full US streets (3-5M unique street names). Too large for browser — shard per metro area (~5 MB each) for browser deployment. Server-side loads the full set.
+
+---
+
+## Implementation phases
+
+### Phase 1: FST builder + CLI (Week 1)
+
+New files:
+- `resolver-wof-sqlite/fst-builder.ts` — `buildFstFromWof(db, opts): FstBinary`
+- `resolver-wof-sqlite/fst-loader.ts` — `FstMatcher` class (walk, accepting, continuations)
+- `resolver-wof-sqlite/fst-builder.test.ts`
+- `mailwoman/commands/fst/build.tsx`
+- `mailwoman/commands/fst/query.tsx`
+
+### Phase 2: Neural emission prior (Week 2)
+
+Modified files:
+- `neural/query-shape-prior.ts` — add `buildFstEmissionPriors()`
+- `neural/classifier.ts` — add `fst?: FstMatcher` to config, compose in `parse()`
+
+New files:
+- `neural/fst-prior.test.ts`
+
+### Phase 3: Autocomplete prototype (Week 3)
+
+New files:
+- `resolver-wof-sqlite/fst-autocomplete.ts`
+- `mailwoman/commands/fst/autocomplete.tsx`
+
+### Phase 4: Browser deployment (Week 4)
+
+Modified files:
+- `resolver-wof-wasm/fst.ts` — browser-compatible FstMatcher (ArrayBuffer)
+- `docs/src/pages/demo/index.tsx` — load FST, typeahead UI
+
+---
+
+## Key design decisions
+
+1. **FST is an emission PRIOR, not a replacement.** The neural model remains the authority for non-gazetteer components. The FST handles what the model can't: knowing which place names exist and their hierarchies.
+
+2. **Population-weighted bias when ambiguous.** "New York" with two interpretations biases both proportionally to population. The neural model's context breaks the tie.
+
+3. **Full bias when deterministic.** When the FST narrows to one interpretation (e.g., "Portland" + "OR"), the bias is maximal.
+
+4. **Negative evidence is free.** When a token doesn't extend any FST path, that's a strong signal it's NOT an admin component — the neural model handles it alone. This is how "Buffalo Health Clinic" gets correctly NOT-biased toward locality.
+
+5. **The FST eliminates reconciler beam search for admin components.** Only concordant paths exist in the FST. Invalid admin combinations were pruned at build time.
+
+6. **Autocomplete is a prefix walk, not an index scan.** O(depth × branching) vs Elasticsearch's O(matches). The FST IS the autocomplete index.
+
+---
+
+## Relationship to existing architecture
+
+The FST is the "pay-it-forward" implementation of the mail-carrier philosophy: each carrier's knowledge is pre-compiled into a structure that narrows the search space with each token consumed. The deliberative assembly (phrase grouper + neural model + reconciler) still adjudicates — the FST just gives them much better priors to work with.
+
+Where the QueryShape soft prior says "this 5-digit token is probably a postcode" (structural pattern), the FST prior says "this token sequence matches 'New York' which is either locality WOF:85977539 or region WOF:85688543" (factual knowledge from the gazetteer). Both are additive biases; neither overrides the neural model.
+
+## See also
+
+- [`QUERY_SHAPE.md`](./QUERY_SHAPE.md) — the existing structural-prior system this extends
+- [`DEMO_PRESET_DIAGNOSIS.md`](./DEMO_PRESET_DIAGNOSIS.md) — the locality/region confusion this addresses
+- [`TRAINING_RECIPE_LEVERS.md`](./TRAINING_RECIPE_LEVERS.md) — training-side fixes (complementary)
+- `docs/articles/understanding/exotic-poi/` — venue detection that benefits from FST negative evidence

--- a/kind-classifier/classify.test.ts
+++ b/kind-classifier/classify.test.ts
@@ -273,6 +273,103 @@ describe("classifyKind — landmark", () => {
 	})
 })
 
+describe("classifyKind — landmark (venue/named-place)", () => {
+	it("classifies 'Pier 39' as landmark", () => {
+		const result = classifyKindSync(
+			input("Pier 39"),
+			shape({
+				knownFormats: [],
+				characterClass: "alphanumeric",
+				totalLength: 7,
+				segments: [{ body: "Pier 39", index: 0 }],
+			})
+		)
+		expect(result.kind).toBe("landmark")
+	})
+
+	it("classifies 'Empire State Building' as landmark", () => {
+		const result = classifyKindSync(
+			input("Empire State Building"),
+			shape({
+				knownFormats: [],
+				characterClass: "alpha",
+				totalLength: 21,
+				segments: [{ body: "Empire State Building", index: 0 }],
+			})
+		)
+		expect(result.kind).toBe("landmark")
+	})
+
+	it("classifies 'Wrigley Field' as landmark", () => {
+		const result = classifyKindSync(
+			input("Wrigley Field"),
+			shape({
+				knownFormats: [],
+				characterClass: "alpha",
+				totalLength: 13,
+				segments: [{ body: "Wrigley Field", index: 0 }],
+			})
+		)
+		expect(result.kind).toBe("landmark")
+	})
+
+	it("classifies 'Grand Central Terminal' as landmark", () => {
+		const result = classifyKindSync(
+			input("Grand Central Terminal"),
+			shape({
+				knownFormats: [],
+				characterClass: "alpha",
+				totalLength: 22,
+				segments: [{ body: "Grand Central Terminal", index: 0 }],
+			})
+		)
+		expect(result.kind).toBe("landmark")
+	})
+
+	it("does NOT classify '350 5th Ave' as landmark (starts with number)", () => {
+		const result = classifyKindSync(
+			input("350 5th Ave"),
+			shape({
+				knownFormats: [],
+				characterClass: "alphanumeric",
+				totalLength: 11,
+				segments: [{ body: "350 5th Ave", index: 0 }],
+			})
+		)
+		expect(result.kind).not.toBe("landmark")
+	})
+
+	it("does NOT classify '123 Main St' as landmark (has street suffix)", () => {
+		const result = classifyKindSync(
+			input("123 Main St"),
+			shape({
+				knownFormats: [],
+				characterClass: "alphanumeric",
+				totalLength: 11,
+				segments: [{ body: "123 Main St", index: 0 }],
+			})
+		)
+		expect(result.kind).not.toBe("landmark")
+	})
+
+	it("does NOT classify a multi-segment address as landmark", () => {
+		const result = classifyKindSync(
+			input("Pier 39, San Francisco, CA 94133"),
+			shape({
+				knownFormats: [{ format: "us_zip", span: { start: 27, end: 32 }, confidence: 0.6 }],
+				characterClass: "alphanumeric",
+				totalLength: 32,
+				segments: [
+					{ body: "Pier 39", index: 0 },
+					{ body: "San Francisco", index: 1 },
+					{ body: "CA 94133", index: 2 },
+				],
+			})
+		)
+		expect(result.kind).not.toBe("landmark")
+	})
+})
+
 describe("classifyKind — alternatives + confidence ordering", () => {
 	it("returns alternatives sorted descending by confidence", () => {
 		const result = classifyKindSync(

--- a/kind-classifier/classify.ts
+++ b/kind-classifier/classify.ts
@@ -21,6 +21,7 @@ import {
 	scorePostcodeOnly,
 	scoreStructuredAddress,
 	scoreVague,
+	scoreVenueLandmark,
 } from "./rules.js"
 import type { LocaleHint, NormalizedInputLite, QueryKind, QueryKindResult, QueryShapeLike } from "./types.js"
 
@@ -31,7 +32,7 @@ interface KindScorer {
 
 const SCORERS: ReadonlyArray<KindScorer> = [
 	{ kind: "po_box", score: scorePoBox },
-	{ kind: "landmark", score: scoreLandmark },
+	{ kind: "landmark", score: (i, s) => Math.max(scoreLandmark(i, s), scoreVenueLandmark(i, s)) },
 	{ kind: "intersection", score: scoreIntersection },
 	{ kind: "postcode_only", score: scorePostcodeOnly },
 	{ kind: "locality_only", score: scoreLocalityOnly },

--- a/kind-classifier/rules.ts
+++ b/kind-classifier/rules.ts
@@ -69,6 +69,87 @@ export function scoreLandmark(input: NormalizedInputLite, _shape: QueryShapeLike
 	return 0
 }
 
+/** Street-suffix tokens that indicate an address, not a venue name. */
+const STREET_SUFFIXES = new Set([
+	"st",
+	"street",
+	"ave",
+	"avenue",
+	"blvd",
+	"boulevard",
+	"rd",
+	"road",
+	"dr",
+	"drive",
+	"ln",
+	"lane",
+	"ct",
+	"court",
+	"pl",
+	"place",
+	"way",
+	"pkwy",
+	"parkway",
+	"hwy",
+	"highway",
+	"cir",
+	"circle",
+])
+
+/**
+ * `landmark` rule (venue/named-place variant): short capitalized input with no street suffixes, no
+ * postcode hits, and no region abbreviations. Captures "Pier 39", "Empire State Building", "Wrigley
+ * Field", "Grand Central Terminal".
+ *
+ * Fires at moderate confidence (0.65) — below structured_address (0.9) so addresses always win, but
+ * above vague (0.3) so the pipeline can route landmark queries to the venue resolver.
+ */
+export function scoreVenueLandmark(input: NormalizedInputLite, shape: QueryShapeLike): number {
+	const text = input.normalized.trim()
+	const len = text.length
+	if (len === 0 || len > 50) return 0
+
+	// Must have at least one capitalized word.
+	if (!/[A-Z]/.test(text)) return 0
+
+	// Reject if any known postcode format hit exists.
+	if (shape.knownFormats.length > 0) return 0
+
+	// Reject if it looks like a multi-segment structured address (City, ST ZIP).
+	const segCount = shape.segments?.length ?? 1
+	if (segCount > 2) return 0
+
+	// Reject if any word is a street suffix.
+	const words = text.split(/[\s,]+/)
+	for (const w of words) {
+		if (STREET_SUFFIXES.has(w.toLowerCase())) return 0
+	}
+
+	// Reject if the first token is a pure number (house-number-leading pattern).
+	if (/^\d+\s/.test(text)) return 0
+
+	// Boost if the input has a number NOT at the start (venue-style: "Pier 39", "Terminal 5").
+	const hasInternalNumber = /\s\d+/.test(text) && !/^\d/.test(text)
+
+	// Check if every word starts with uppercase (proper-noun pattern).
+	const allProperCase = words.length > 1 && words.every((w) => /^[A-Z]/.test(w))
+
+	// Boost for short single-segment capitalized phrases (2-4 words).
+	const wordCount = words.length
+	if (wordCount >= 2 && wordCount <= 4 && segCount === 1) {
+		if (hasInternalNumber) return 0.88
+		if (allProperCase) return 0.88
+		return 0.65
+	}
+
+	// Longer single-segment capitalized phrases get moderate confidence.
+	if (wordCount <= 6 && segCount === 1 && allProperCase) {
+		return 0.75
+	}
+
+	return 0
+}
+
 /** Known QueryShape format strings that indicate "this token is a postcode". */
 const POSTCODE_FORMATS: ReadonlySet<string> = new Set([
 	"us_zip",


### PR DESCRIPTION
## Summary

Adds `scoreVenueLandmark` to the kind classifier (Stage 2.5). Detects named venue/landmark queries like "Pier 39", "Empire State Building", "Wrigley Field" that should route to the WOF venue resolver rather than the neural BIO address parser.

## Detection heuristics

- Short (≤50 chars), multi-word (2-6 words), single-segment
- At least one capitalized word, no street suffixes
- No postcode format hits, no leading house number
- Proper-case phrases (every word capitalized) score 0.88
- Internal numbers boost confidence ("Pier 39", "Terminal 5")
- Addresses still win: `structured_address` scores 0.9 for multi-segment alphanumeric

## Why this matters for the demo

The demo's preset #3 ("Pier 39, San Francisco, CA 94133") is a full address and will still route to the neural parser. But a bare "Pier 39" query now classifies as `kind=landmark` rather than being force-parsed as address components. This is the foundation for #165's proposed venue-resolver routing.

## Test plan

- [x] 7 new tests: Pier 39, Empire State Building, Wrigley Field, Grand Central Terminal + 3 negative cases
- [x] 23 existing tests unchanged
- [x] tsc -b clean
- [x] prettier formatted

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)