### PR TITLE
feat(neural): region-aware locality bias guard

### DIFF
--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -237,8 +237,9 @@ export async function runPipeline(
 
 	let tree: AddressTree = { raw: normalized.normalized, roots: [] }
 
-	// Joint-reconcile path: when the flag is set AND we have phrase proposals AND the classifier
-	// exposes parseWithLogits, use per-span logit aggregation + reconcileSpans instead of argmax.
+	// Joint-reconcile path: opt-in until phrase-grouper proposal quality supports it as default.
+	// The reconciler produces single-token spans when phrase proposals don't cover multi-word
+	// streets/localities — needs grouper improvements before becoming the default path.
 	const useJointReconcile =
 		opts?.forceJointReconcile &&
 		phraseProposals.length > 0 &&

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -29,15 +29,9 @@ export interface PipelineOpts {
 	/** Disable fast-path shortcuts; always run the full pipeline. */
 	forceFullPipeline?: boolean
 	/**
-	 * Enable the joint-reconcile path (Stage 5 beam search over candidates). When set, the pipeline:
-	 *
-	 * 1. Aggregates per-token logits over phrase-grouper spans (per-span top-K tag candidates).
-	 * 2. Feeds candidates into `reconcileSpans` for joint-coherence scoring.
-	 * 3. Returns the reconciled tree instead of the argmax tree.
-	 *
-	 * Requires both a phrase grouper AND a classifier that exposes raw logits (the standard
-	 * `NeuralAddressClassifier` does via its `parseWithLogits` method). Falls back to argmax if
-	 * either is missing.
+	 * Enable the joint-reconcile path (Stage 5 beam search). Opt-in until phrase-grouper proposal
+	 * quality supports multi-word streets/localities — currently produces single-token spans.
+	 * Requires phrase grouper + classifier with `parseWithLogits`.
 	 */
 	forceJointReconcile?: boolean
 	/** Hard cap on lookups the resolver may issue; passed through. */

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -133,6 +133,7 @@ export class NeuralAddressClassifier {
 					logits,
 					buildEmissionPriors(opts.queryShape, pieces, this.labels, {
 						biasScale: opts.queryShapeBiasScale ?? 1.0,
+						inputText: text,
 					})
 				)
 			: logits
@@ -187,6 +188,7 @@ export class NeuralAddressClassifier {
 					logits,
 					buildEmissionPriors(opts.queryShape, pieces, this.labels, {
 						biasScale: opts.queryShapeBiasScale ?? 1.0,
+						inputText: text,
 					})
 				)
 			: logits

--- a/neural/query-shape-prior.test.ts
+++ b/neural/query-shape-prior.test.ts
@@ -192,6 +192,44 @@ describe("buildEmissionPriors — locality bias", () => {
 		expect(m[0]?.[bLocCol]).toBe(3.0)
 	})
 
+	it("does not bias when preceding text matches the region name (Washington, WA)", () => {
+		// "Washington, WA" — "Washington" IS the region name for WA, should NOT get locality bias
+		const shape: QueryShapeLike = {
+			knownFormats: [],
+			regionAbbreviations: [{ start: 12, span: "WA" }],
+		}
+		const toks = tokens([0, 10], [12, 14])
+		const m = buildEmissionPriors(shape, toks, FULL_LABELS, { inputText: "Washington, WA" })
+		const bLocCol = FULL_LABELS.indexOf("B-locality")
+		expect(m[0]?.[bLocCol]).toBe(0)
+	})
+
+	it("still biases when text does NOT match region name (Washington, DC)", () => {
+		// "Washington, DC" — DC's region name is "District of Columbia", NOT "Washington"
+		const shape: QueryShapeLike = {
+			knownFormats: [],
+			regionAbbreviations: [{ start: 12, span: "DC" }],
+		}
+		const toks = tokens([0, 10], [12, 14])
+		const m = buildEmissionPriors(shape, toks, FULL_LABELS, { inputText: "Washington, DC" })
+		const bLocCol = FULL_LABELS.indexOf("B-locality")
+		expect(m[0]?.[bLocCol]).toBe(2.0)
+	})
+
+	it("does not bias New York before NY (region name match)", () => {
+		// "New York, NY" — "New York" IS the region name for NY
+		const shape: QueryShapeLike = {
+			knownFormats: [],
+			regionAbbreviations: [{ start: 10, span: "NY" }],
+		}
+		const toks = tokens([0, 3], [4, 8], [10, 12])
+		const m = buildEmissionPriors(shape, toks, FULL_LABELS, { inputText: "New York, NY" })
+		const bLocCol = FULL_LABELS.indexOf("B-locality")
+		const iLocCol = FULL_LABELS.indexOf("I-locality")
+		expect(m[0]?.[bLocCol]).toBe(0)
+		expect(m[1]?.[iLocCol]).toBe(0)
+	})
+
 	it("skips tokens overlapping a known postcode format", () => {
 		// "10118, NY" — "10118" overlaps a postcode hit, should NOT get locality bias
 		const shape: QueryShapeLike = {

--- a/neural/query-shape-prior.ts
+++ b/neural/query-shape-prior.ts
@@ -73,6 +73,8 @@ export interface BuildPriorsOpts {
 	 * odds to B-locality / I-locality for tokens preceding a detected region abbreviation.
 	 */
 	localityBiasScale?: number
+	/** Raw input text for region-name matching in the locality bias guard. */
+	inputText?: string
 }
 
 /**
@@ -123,7 +125,7 @@ export function buildEmissionPriors(
 	// preceding alphabetic tokens toward B-locality / I-locality. This counters the WOF
 	// bare-name frequency dominance that makes the model over-emit B-region on ambiguous
 	// place names like "Washington" or "New York".
-	applyLocalityBias(matrix, shape, tokens, labelToCol, opts.localityBiasScale ?? 2.0)
+	applyLocalityBias(matrix, shape, tokens, labelToCol, opts.localityBiasScale ?? 2.0, opts.inputText)
 
 	return matrix
 }
@@ -134,6 +136,10 @@ export function buildEmissionPriors(
  * For "Washington, DC" — "DC" is the region abbreviation; "Washington" gets biased toward
  * B-locality. For "New York, NY" — "New" gets B-locality and "York" gets I-locality.
  *
+ * Guard: if the preceding text matches the full name of the region that the abbreviation
+ * represents (e.g., "Washington" before "WA"), the locality bias is NOT applied — the text
+ * IS the region, not a locality within it.
+ *
  * Constraint: only bias tokens that appear BEFORE the abbreviation's character offset and are
  * alphabetic (start with uppercase). Tokens that are part of a known postcode format or are
  * themselves region abbreviations are skipped.
@@ -141,9 +147,10 @@ export function buildEmissionPriors(
 function applyLocalityBias(
 	matrix: number[][],
 	shape: QueryShapeLike,
-	tokens: ReadonlyArray<TokenLike>,
+	tokens: ReadonlyArray<TokenLike & { piece?: string }>,
 	labelToCol: Map<string, number>,
-	localityBias: number
+	localityBias: number,
+	inputText?: string
 ): void {
 	const abbrevs = shape.regionAbbreviations
 	if (!abbrevs || abbrevs.length === 0) return
@@ -153,9 +160,6 @@ function applyLocalityBias(
 	if (bLocCol === undefined) return
 
 	for (const abbrev of abbrevs) {
-		// Walk backward from the abbreviation collecting preceding tokens. The first token must be
-		// within 4 chars of the abbreviation (accounts for ", " separator). Subsequent tokens must
-		// be within 2 chars of each other (normal word spacing).
 		const candidates: number[] = []
 		let prevStart = abbrev.start
 
@@ -181,9 +185,15 @@ function applyLocalityBias(
 		}
 
 		if (candidates.length === 0) continue
-
-		// candidates is in reverse order (closest to abbreviation first). Reverse to get text order.
 		candidates.reverse()
+
+		if (inputText) {
+			const firstTok = tokens[candidates[0]!]!
+			const lastTok = tokens[candidates[candidates.length - 1]!]!
+			const candidateText = inputText.slice(firstTok.start, lastTok.end).toLowerCase()
+			const regionNames = ABBREV_TO_REGION.get(abbrev.span)
+			if (regionNames?.some((name) => candidateText === name)) continue
+		}
 
 		for (let i = 0; i < candidates.length; i++) {
 			const t = candidates[i]!
@@ -193,6 +203,65 @@ function applyLocalityBias(
 		}
 	}
 }
+
+const ABBREV_TO_REGION: ReadonlyMap<string, string[]> = new Map([
+	["AL", ["alabama"]],
+	["AK", ["alaska"]],
+	["AZ", ["arizona"]],
+	["AR", ["arkansas"]],
+	["CA", ["california"]],
+	["CO", ["colorado"]],
+	["CT", ["connecticut"]],
+	["DE", ["delaware"]],
+	["DC", ["district of columbia"]],
+	["FL", ["florida"]],
+	["GA", ["georgia"]],
+	["HI", ["hawaii"]],
+	["ID", ["idaho"]],
+	["IL", ["illinois"]],
+	["IN", ["indiana"]],
+	["IA", ["iowa"]],
+	["KS", ["kansas"]],
+	["KY", ["kentucky"]],
+	["LA", ["louisiana"]],
+	["ME", ["maine"]],
+	["MD", ["maryland"]],
+	["MA", ["massachusetts"]],
+	["MI", ["michigan"]],
+	["MN", ["minnesota"]],
+	["MS", ["mississippi"]],
+	["MO", ["missouri"]],
+	["MT", ["montana"]],
+	["NE", ["nebraska"]],
+	["NV", ["nevada"]],
+	["NH", ["new hampshire"]],
+	["NJ", ["new jersey"]],
+	["NM", ["new mexico"]],
+	["NY", ["new york"]],
+	["NC", ["north carolina"]],
+	["ND", ["north dakota"]],
+	["OH", ["ohio"]],
+	["OK", ["oklahoma"]],
+	["OR", ["oregon"]],
+	["PA", ["pennsylvania"]],
+	["RI", ["rhode island"]],
+	["SC", ["south carolina"]],
+	["SD", ["south dakota"]],
+	["TN", ["tennessee"]],
+	["TX", ["texas"]],
+	["UT", ["utah"]],
+	["VT", ["vermont"]],
+	["VA", ["virginia"]],
+	["WA", ["washington"]],
+	["WV", ["west virginia"]],
+	["WI", ["wisconsin"]],
+	["WY", ["wyoming"]],
+	["AS", ["american samoa"]],
+	["GU", ["guam"]],
+	["MP", ["northern mariana islands"]],
+	["PR", ["puerto rico"]],
+	["VI", ["virgin islands"]],
+])
 
 function overlaps(a: { start: number; end: number }, b: { start: number; end: number }): boolean {
 	return a.start < b.end && b.start < a.end


### PR DESCRIPTION
## Summary

The locality soft prior previously biased ALL tokens preceding a region abbreviation toward B-locality. This caused "Washington, WA" to incorrectly get locality bias on "Washington" when it IS the region name.

Now `applyLocalityBias` checks whether the candidate token text matches the full name of the region the abbreviation represents (via a static `ABBREV_TO_REGION` map — 55 US states/territories). If the text matches, the locality bias is skipped.

| Input | Before | After |
|-------|--------|-------|
| Washington, DC | B-locality +2.0 on "Washington" | Same (DC = District of Columbia, not Washington) |
| Washington, WA | B-locality +2.0 on "Washington" | **No bias** (Washington IS the WA region name) |
| New York, NY | B-locality +2.0 on "New York" | **No bias** (New York IS the NY region name) |
| Springfield, IL | B-locality +2.0 on "Springfield" | Same (Springfield is not Illinois) |

## Test plan

- [x] `yarn compile` — clean
- [x] `docs build` — clean
- [x] 21 query-shape-prior tests pass (3 new: WA guard, DC still works, NY guard)
- [x] 1740/1741 total tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)