### PR TITLE
feat(training): v0.5.3 diagnostic training config

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0_5_3-classifier-diagnostic.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_5_3-classifier-diagnostic.yaml
@@ -1,0 +1,114 @@
+# v0.5.3 classifier — "diagnostic" iteration.
+#
+# Purpose: identify WHY v0.5.2 only emits region/O despite training on 673M structured
+# addresses. This run keeps v0.5.2's architecture but fixes observability:
+#
+# Changes from v0.5.2:
+#   - golden_dir wired to /data/eval/golden/v0.1.2 (per-tag F1 at every eval step)
+#   - eval_every_steps: 5000 → 2000 (more frequent checkpoints for loss-curve diagnosis)
+#   - save_every_steps: 5000 → 2000 (aligned with eval)
+#   - label_smoothing: 0.1 → 0.05 (suspected over-smoothing causing tag collapse)
+#   - dependent_locality class_weight: 0.3 → 1.0 (0.3 may cause model to avoid the tag)
+#   - subregion class_weight: 0.3 → 1.0 (same concern)
+#   - max_steps: 100000 → 50000 (shorter run, faster iteration — extend if curves healthy)
+#   - log_every_steps: 100 → 50 (denser loss curve)
+#
+# Unchanged from v0.5.2:
+#   - h384, batch=128 direct, CE-only, phrase priors ON
+#   - cosine LR, wof-admin: 0.3, ban: 3.0, tiger: 4.0
+#   - v0.5.0-a1 tokenizer (48K vocab)
+#
+# Launch:
+#   modal run scripts/modal/train_remote.py --config v0_5_3-classifier-diagnostic.yaml
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.5.0-a1
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 0.3
+    wof-postalcode: 1.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  label_smoothing: 0.05
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 1.0
+    I-dependent_locality: 1.0
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 1.0
+    I-subregion: 1.0
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v053/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 50000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: cosine
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -25,10 +25,13 @@ Per Phase 2 §2:
 
 from __future__ import annotations
 
+import logging
 import random
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Iterator, Sequence
+
+logger = logging.getLogger(__name__)
 
 import pyarrow.parquet as pq
 
@@ -216,17 +219,41 @@ def _raw_row_stream(
     shard_paths = _shard_paths(corpus_dir, split)
     max_weight = max(country_weights.values())
 
+    logger.info("Indexing %d shards by source...", len(shard_paths))
     by_source: dict[str, list[Path]] = {}
+    skipped_shards: list[tuple[Path, str]] = []
     for s in shard_paths:
-        src = _shard_first_source(s)
+        if not s.exists():
+            skipped_shards.append((s, "file not found"))
+            continue
+        try:
+            src = _shard_first_source(s)
+        except Exception as exc:
+            skipped_shards.append((s, str(exc)))
+            continue
         by_source.setdefault(src, []).append(s)
 
+    if skipped_shards:
+        logger.warning(
+            "Skipped %d shards (missing or unreadable):\n  %s",
+            len(skipped_shards),
+            "\n  ".join(f"{p}: {reason}" for p, reason in skipped_shards[:10]),
+        )
+
+    logger.info(
+        "Shard index: %s",
+        ", ".join(f"{src}={len(shards)}" for src, shards in sorted(by_source.items())),
+    )
+
     if source_weights is not None:
+        dropped = {src for src in by_source if source_weights.get(src, 0) <= 0}
         by_source = {
             src: shards
             for src, shards in by_source.items()
             if source_weights.get(src, 0) > 0
         }
+        if dropped:
+            logger.info("Dropped %d zero-weighted sources: %s", len(dropped), dropped)
         if not by_source:
             raise ValueError(
                 "no shards remain after applying source_weights — every shard's source "

--- a/scripts/diagnose-corpus.py
+++ b/scripts/diagnose-corpus.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Diagnose corpus shard loading — run locally or on Modal to confirm which
+shards the data loader actually sees.
+
+Usage:
+  uv run python scripts/diagnose-corpus.py --corpus-dir /mnt/playpen/mailwoman-data/corpus/versioned/v0.4.0/corpus-v0.4.0
+
+On Modal:
+  modal run scripts/modal/train_remote.py::diagnose_corpus
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus-dir", required=True)
+    args = parser.parse_args()
+
+    corpus_dir = Path(args.corpus_dir)
+    manifest = corpus_dir / "MANIFEST.json"
+
+    print(f"Corpus dir: {corpus_dir}")
+    print(f"Manifest exists: {manifest.exists()}")
+
+    if manifest.exists():
+        data = json.loads(manifest.read_text())
+        shards = data.get("shards", [])
+        train_shards = [s for s in shards if s.get("split") == "train"]
+        print(f"MANIFEST: {len(shards)} total shards, {len(train_shards)} train")
+        print(f"MANIFEST train rows: {sum(s['rows'] for s in train_shards):,}")
+
+        # Check which paths exist
+        existing = 0
+        missing = 0
+        for s in train_shards:
+            p = Path(s["path"])
+            if p.exists():
+                existing += 1
+            else:
+                missing += 1
+                if missing <= 5:
+                    print(f"  MISSING: {p}")
+
+        print(f"\nTrain shard files: {existing} exist, {missing} missing")
+        if missing > 5:
+            print(f"  ... and {missing - 5} more missing")
+
+    # Now test the actual data loader indexing
+    print("\n--- Data loader shard indexing ---")
+    sys.path.insert(0, str(Path(__file__).parent.parent / "corpus-python" / "src"))
+    from mailwoman_train.data_loader import _shard_paths, _shard_first_source
+
+    paths = _shard_paths(corpus_dir, "train")
+    print(f"_shard_paths returned {len(paths)} train shards")
+
+    from collections import Counter
+    by_source = Counter()
+    errors = 0
+    for p in paths:
+        if not p.exists():
+            errors += 1
+            continue
+        try:
+            src = _shard_first_source(p)
+            by_source[src] += 1
+        except Exception as exc:
+            errors += 1
+            print(f"  ERROR reading {p}: {exc}")
+
+    print(f"\nSource index ({errors} errors):")
+    for src, count in by_source.most_common():
+        print(f"  {src:35s} {count:4d} shards")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/modal/train_remote.py
+++ b/scripts/modal/train_remote.py
@@ -174,11 +174,13 @@ def train(
     cfg = Config()
     _merge(cfg, yaml.safe_load(open(config_path)))
 
-    # Override output dir to write to the volume
-    cfg.train.output_dir = f"{OUTPUT_DIR}/checkpoints"
-    cfg.train.csv_log_path = f"{OUTPUT_DIR}/train_log.csv"
+    # Use config's output_dir if it has one, otherwise default
+    run_output = cfg.train.output_dir if cfg.train.output_dir.startswith("/data/") else f"{OUTPUT_DIR}/checkpoints"
+    run_base = os.path.dirname(run_output)
+    cfg.train.output_dir = run_output
+    cfg.train.csv_log_path = cfg.train.csv_log_path.replace("{output_dir}", run_output) if "{output_dir}" in cfg.train.csv_log_path else f"{run_base}/train_log.csv"
 
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    os.makedirs(run_base, exist_ok=True)
 
     if resume == "auto":
         run_train(cfg, resume_from="auto")
@@ -260,3 +262,61 @@ def export_onnx():
 
     vol.commit()
     print("Committed to volume.")
+
+
+@app.function(
+    volumes={VOL_MOUNT: vol},
+    image=training_image,
+    timeout=300,
+)
+def diagnose_corpus():
+    """Check which corpus shards the data loader actually sees on the Modal volume."""
+    import json
+    import sys
+    from collections import Counter
+    from pathlib import Path
+
+    sys.path.insert(0, "/data/corpus-python/src")
+
+    corpus_dir = Path("/data/corpus/versioned/v0.4.0/corpus-v0.4.0")
+    manifest = corpus_dir / "MANIFEST.json"
+
+    print(f"Corpus dir: {corpus_dir}")
+    print(f"Manifest exists: {manifest.exists()}")
+
+    if manifest.exists():
+        data = json.loads(manifest.read_text())
+        train_shards = [s for s in data.get("shards", []) if s.get("split") == "train"]
+        print(f"MANIFEST: {len(train_shards)} train shards, {sum(s['rows'] for s in train_shards):,} rows")
+
+        existing = sum(1 for s in train_shards if Path(s["path"]).exists())
+        missing = len(train_shards) - existing
+        print(f"Train shard files: {existing} exist, {missing} missing")
+        if missing > 0:
+            for s in train_shards:
+                if not Path(s["path"]).exists():
+                    print(f"  MISSING: {s['path']}")
+                    break
+
+    from mailwoman_train.data_loader import _shard_paths, _shard_first_source
+
+    paths = _shard_paths(corpus_dir, "train")
+    print(f"\n_shard_paths returned {len(paths)} train shards")
+
+    by_source: Counter[str] = Counter()
+    errors = 0
+    for p in paths:
+        if not p.exists():
+            errors += 1
+            continue
+        try:
+            src = _shard_first_source(p)
+            by_source[src] += 1
+        except Exception as exc:
+            errors += 1
+            if errors <= 3:
+                print(f"  ERROR reading {p}: {exc}")
+
+    print(f"\nSource index ({errors} errors, {sum(by_source.values())} readable):")
+    for src, count in by_source.most_common():
+        print(f"  {src:35s} {count:4d} shards")


### PR DESCRIPTION
## Summary

Diagnostic training run to identify why v0.5.2 only emits region/O tags despite being trained on 673M structured addresses.

### Investigation findings
- **Corpus is intact**: Modal volume has all 680 shards (674 from v0.3.0 base + 6 from v0.4.0 augmentation), 673M total rows
- **Data loader correctly resolves MANIFEST paths**: Confirmed with `diagnose_corpus` Modal function — all shards readable
- **No validation metrics were recorded for v0.5.2**: `golden_dir` and `val_jsonl` were empty strings, `eval_every_steps` was 5000 but log only captured 4000 steps

### v0.5.3 config changes from v0.5.2
- `golden_dir: /data/eval/golden/v0.1.2` — per-tag F1 at every eval step
- `eval_every_steps: 5000 → 2000` — more frequent checkpoints
- `label_smoothing: 0.1 → 0.05` — suspected over-smoothing causing tag collapse
- `dependent_locality/subregion class_weights: 0.3 → 1.0` — 0.3 may cause avoidance
- Explicit transliteration source weights (0.5) to prevent domination
- `max_steps: 100K → 50K` — faster iteration cycle
- Separate output dir `/data/output-v053/` to preserve v0.5.2 checkpoints

### Data loader improvements
- Logs shard count per source at startup
- Skips + warns on missing/unreadable shards instead of crashing
- Reports dropped zero-weighted sources

Training running on Modal A100 now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)