### PR TITLE
docs: update for v0.5.2 — FST shipped, training resolved, demo copy

### DIFF
--- a/docs/articles/concepts/fst-gazetteer-prior.md
+++ b/docs/articles/concepts/fst-gazetteer-prior.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 21
+title: FST gazetteer prior
+tags:
+  - concepts
+  - neural
+  - fst
+  - architecture
+---
+
+# FST gazetteer prior
+
+The FST (finite-state transducer) gazetteer prior is a pre-computed lookup structure that tells the neural classifier which token sequences are known place names. Where the [QueryShape soft prior](./neural-classification.md) says "this 5-digit token is probably a postcode" (structural pattern), the FST prior says "this token sequence matches 'New York' which is either locality WOF:85977539 or region WOF:85688543" (factual knowledge from the gazetteer).
+
+Both are additive emission biases in the Viterbi CRF decoder. Neither overrides the neural model — they nudge uncertain predictions toward the structurally or factually implied label.
+
+## How it works
+
+At build time, the FST builder reads every admin place from a WOF SQLite database and inserts its normalized name tokens into a trie. Accepting states carry all valid interpretations for that token sequence — placetype, WOF ID, parent chain, and a Wikipedia-derived importance score.
+
+At inference time, the FST prior:
+
+1. Groups SentencePiece subword tokens into whitespace words
+2. Walks all contiguous subpaths through the FST
+3. For each matching path, adds an importance-weighted logit bias to the corresponding BIO labels (B-locality, I-locality, B-region, etc.)
+4. Suppresses non-place labels (B-street, B-house\_number) by -1.5 logits when a place match is found
+
+## Wikipedia importance
+
+Raw population is a poor proxy for place importance — Washington state (7.6M) outranks Washington DC (678K) despite DC being the overwhelmingly more common referent. The FST uses Wikipedia importance scores from [Nominatim's methodology](https://nominatim.org/release-docs/latest/customize/Importance/): `log(total_links) / log(max_links)`, normalized to \[0, 1\].
+
+| Place | Population | Wikipedia importance |
+|-------|-----------|---------------------|
+| Washington DC (locality) | 678K | 0.815 |
+| Washington (state) | 7.6M | 0.764 |
+| New York City (locality) | 8.8M | 0.950 |
+
+The bias formula is linear: `importance × biasScale × maxBias`, capped at 3.0 logits. This nudges the Viterbi decoder without overriding confident model predictions.
+
+## Composition with QueryShape
+
+The FST prior composes additively with the existing QueryShape soft prior:
+
+```
+finalEmissions[t][label] = rawLogits[t][label]
+                         + queryShapeBias[t][label]
+                         + fstBias[t][label]
+```
+
+For "Washington, DC": the QueryShape prior detects "DC" as a region abbreviation and adds +2.0 to B-locality on preceding tokens. The FST prior adds +2.45 to B-locality (DC importance 0.815 × 3.0). Together: +4.45 logit advantage for the correct interpretation.
+
+The QueryShape prior includes a region-aware guard: it skips the locality bias when the preceding text matches the region's full name (e.g., "Washington" before "WA" gets no locality bias, because Washington IS the state).
+
+## See also
+
+- [FST Gazetteer LM (reference)](../plan/reference/FST_GAZETTEER_LM.md) — full design document with metrics and implementation phases
+- [Neural classification](./neural-classification.md) — the transformer + CRF Viterbi decoder
+- [WOF data pipeline](./wof-data-pipeline.md) — how the unified SQLite is built from GeoJSON repos

--- a/docs/articles/concepts/staged-pipeline-contract.md
+++ b/docs/articles/concepts/staged-pipeline-contract.md
@@ -29,8 +29,10 @@ interface RuntimePipelineStages {
 	computeQueryShape?: (input: NormalizedInputLite | string, opts?: { locale?: string }) => QueryShapeLite
 	detectLocale?: (input: NormalizedInputLite, shape: QueryShapeLite, opts?: { hint?: LocaleTag }) => Promise<LocaleHint>
 	classifyKind?: (input: NormalizedInputLite, shape: QueryShapeLite, locale: LocaleHint) => Promise<QueryKindResult>
-	classifier?: { parse(text: string, opts?: { queryShape?: QueryShapeLite }): Promise<AddressTree> }
-	resolver?: { resolveTree(tree: AddressTree, opts?: ResolveOpts): Promise<AddressTree> }
+	groupPhrases?: (input: NormalizedInputLite, shape: QueryShapeLite, locale: LocaleHint) => Promise&lt;PhraseProposal[]&gt;
+	classifier?: { parse(text: string, opts?: ClassifierOpts): Promise&lt;AddressTree&gt; }
+	fst?: FstMatcherLike  // FST gazetteer matcher — produces emission biases during classification
+	resolver?: { resolveTree(tree: AddressTree, opts?: ResolveOpts): Promise&lt;AddressTree&gt; }
 }
 ```
 

--- a/docs/articles/concepts/wof-data-pipeline.md
+++ b/docs/articles/concepts/wof-data-pipeline.md
@@ -30,11 +30,12 @@ WOF GitHub repos                     Per-placetype SQLite DBs
                         └──────────────────┘
 ```
 
-**Status:**
+**Status (updated 2026-05-26):**
 
 - **sync** works end-to-end. Clones WOF repos, filters via `--repos`, calls `Placetype.prepare()` to load the hierarchy.
-- **prepare** has the globbing + Piscina parallelism + GeoJSON parsing working, but writes to the **wrong target** (Redis) instead of `PlacetypeDataSource` (SQLite). The pipeline stalls at the storage boundary.
-- **PlacetypeDataSource** schema is correct and has working `upsert` + `find` methods, but nobody calls `upsert` in the production data path.
+- **prepare** writes to per-placetype SQLite mini-DBs via `PlacetypeDataSource`. The Redis target was removed.
+- **build-unified-wof** ([#176](https://github.com/sister-software/mailwoman/pull/176)) — standalone script that reads 293K GeoJSON files from cloned repos and produces a unified SQLite (spr, names, concordances, place\_population tables) in 43 seconds. Uses `spliterator`'s `asyncParallelIterator` for bounded-concurrency file reads. This unified SQLite replaces the geocode.earth pre-built download as the FST builder and resolver input.
+- **build-importance** — post-processing step that downloads Nominatim's `wikimedia-importance.csv.gz`, joins through WOF concordances, and writes a `place_importance` table into the unified SQLite.
 
 ## Layer by layer
 
@@ -70,7 +71,7 @@ interface ParsedWOFPlacetype {
 
 The `localizedPropMap` is the multilingual name-variant surface — for each language code (ISO 639-3b), it carries `preferred`, `variant`, `colloquial`, `abbr`, and `short` forms. This is exactly what `PlacetypeDataSource.records` expects in its columns.
 
-**Where it stalls:** the worker currently targets Redis (`ioredis` sadd per placetype/language/name-kind) — an earlier iteration where the pipeline was backed by a Redis instance. The rest of the codebase has since moved to SQLite via `PlacetypeDataSource`. The worker needs to write to SQLite instead.
+The worker writes to `PlacetypeDataSource` (per-placetype SQLite mini-DBs). An earlier iteration targeted Redis; that was replaced in v0.5.0.
 
 ### The incomplete "send batches of filenames" design
 

--- a/docs/articles/plan/reference/DEMO_PRESET_DIAGNOSIS.md
+++ b/docs/articles/plan/reference/DEMO_PRESET_DIAGNOSIS.md
@@ -5,6 +5,13 @@ title: Demo preset diagnosis
 
 # Demo Preset Diagnosis — v0.5.1 Locality/Region Confusion
 
+:::info Fixes shipped
+- **"New York, NY"**: Fixed by the region-aware locality bias guard ([#174](https://github.com/sister-software/mailwoman/pull/174)). The QueryShape prior now skips locality bias when the preceding text matches the region's full name.
+- **FST importance weighting**: Washington DC locality (0.815) correctly outranks Washington state (0.764) via Wikipedia importance ([#173](https://github.com/sister-software/mailwoman/pull/173)).
+- **"Washington, DC"**: Partially improved — FST biases toward locality, but the model's high B-street confidence after street phrases resists the prior. Remaining fix is in training data quality.
+- **"San Francisco"**: Fixed in v0.5.2 model — correctly labeled as locality.
+:::
+
 Documents the root-cause analysis of v0.5.1's demo preset failures and the fix plan. Derived from an 8-turn DeepSeek consultation (2026-05-25).
 
 ## The failures

--- a/docs/articles/plan/reference/FST_GAZETTEER_LM.md
+++ b/docs/articles/plan/reference/FST_GAZETTEER_LM.md
@@ -3,11 +3,28 @@ sidebar_position: 18
 title: FST gazetteer language model
 ---
 
-# FST Gazetteer LM — Design Document
+# FST Gazetteer LM
 
-**Goal:** Pre-compute a finite-state transducer from the WOF SQLite gazetteer that maps token sequences → `(placetype, wof_id, parent_chain)` entries. Use it as an emission prior in the neural Viterbi decoder, as a CLI introspection tool, and as the autocomplete backend.
+:::info Shipped
+Phases 1-2 shipped in v0.5.2 ([#170](https://github.com/sister-software/mailwoman/pull/170), [#173](https://github.com/sister-software/mailwoman/pull/173)). Wikipedia importance integration in [#173](https://github.com/sister-software/mailwoman/pull/173). Unified SQLite builder in [#176](https://github.com/sister-software/mailwoman/pull/176). Phase 3 (autocomplete) partially shipped. Phase 4 (browser) not yet started.
+:::
 
-**Principle:** Pay down the combinatorial cross-product of "all valid place-name paths through the WOF hierarchy" at build time. At query time, walking the FST is O(depth), not O(gazetteer_size).
+**Goal:** Pre-compute a finite-state transducer from the WOF SQLite gazetteer that maps token sequences → `(placetype, wof_id, parent_chain, importance)` entries. Use it as an emission prior in the neural Viterbi decoder, as a CLI introspection tool, and as the autocomplete backend.
+
+**Principle:** Pay down the combinatorial cross-product of "all valid place-name paths through the WOF hierarchy" at build time. At query time, walking the FST is O(depth), not O(gazetteer\_size).
+
+### Shipped metrics (US admin)
+
+| Metric | Value |
+|--------|-------|
+| FST states | 114,214 |
+| Name insertions | 163,271 |
+| Binary size | 5.57 MB |
+| Load time | ~10 ms |
+| Build time (from unified SQLite) | 2.7 s |
+| Build time (unified SQLite from 293K GeoJSON) | 43 s |
+| Wikipedia importance matches | 47,348 places |
+| Population fallback | 108,111 places |
 
 ---
 
@@ -156,35 +173,30 @@ A single FST with per-edge locale bitsets is space-efficient but query-slower. F
 
 ## Implementation phases
 
-### Phase 1: FST builder + CLI (Week 1)
+### Phase 1: FST builder + CLI — shipped (#170)
 
-New files:
-- `resolver-wof-sqlite/fst-builder.ts` — `buildFstFromWof(db, opts): FstBinary`
-- `resolver-wof-sqlite/fst-loader.ts` — `FstMatcher` class (walk, accepting, continuations)
-- `resolver-wof-sqlite/fst-builder.test.ts`
-- `mailwoman/commands/fst/build.tsx`
-- `mailwoman/commands/fst/query.tsx`
+- `resolver-wof-sqlite/fst-builder.ts`, `fst-matcher.ts`, `fst-types.ts`
+- `resolver-wof-sqlite/fst-serialize.ts` (binary format, VERSION 2)
+- `scripts/fst-query.ts` (interactive CLI)
+- 24 integration tests against WOF US admin data
 
-### Phase 2: Neural emission prior (Week 2)
+### Phase 2: Neural emission prior — shipped (#170, #173)
 
-Modified files:
-- `neural/query-shape-prior.ts` — add `buildFstEmissionPriors()`
-- `neural/classifier.ts` — add `fst?: FstMatcher` to config, compose in `parse()`
+- `neural/fst-prior.ts` — `buildFstEmissionPriors()` with Wikipedia importance weighting
+- `neural/classifier.ts` — FST threaded through `ParseOpts.fst`
+- `core/pipeline/runtime-pipeline.ts` — FST threaded through `RuntimePipelineStages`
+- Wikipedia importance ETL: `scripts/build-importance.ts`
+- Region-aware locality bias guard: `neural/query-shape-prior.ts` (#174)
 
-New files:
-- `neural/fst-prior.test.ts`
+### Phase 3: Autocomplete prototype — partially shipped (#170)
 
-### Phase 3: Autocomplete prototype (Week 3)
+- `resolver-wof-sqlite/fst-autocomplete.ts` — prefix walk + BFS expansion
+- CLI not yet wired (standalone script only)
 
-New files:
-- `resolver-wof-sqlite/fst-autocomplete.ts`
-- `mailwoman/commands/fst/autocomplete.tsx`
+### Phase 4: Browser deployment — not started
 
-### Phase 4: Browser deployment (Week 4)
-
-Modified files:
-- `resolver-wof-wasm/fst.ts` — browser-compatible FstMatcher (ArrayBuffer)
-- `docs/src/pages/demo/index.tsx` — load FST, typeahead UI
+- Browser-compatible FstMatcher (ArrayBuffer) not yet implemented
+- `/demo` page does not use FST prior
 
 ---
 
@@ -192,9 +204,9 @@ Modified files:
 
 1. **FST is an emission PRIOR, not a replacement.** The neural model remains the authority for non-gazetteer components. The FST handles what the model can't: knowing which place names exist and their hierarchies.
 
-2. **Population-weighted bias when ambiguous.** "New York" with two interpretations biases both proportionally to population. The neural model's context breaks the tie.
+2. **Wikipedia importance-weighted bias when ambiguous.** Each place carries a [0,1] importance score derived from Wikipedia link count ([Nominatim methodology](https://nominatim.org/release-docs/latest/customize/Importance/)). "New York" biases both locality (0.95) and region (0.85) proportionally. Washington DC locality (0.815) correctly outranks Washington state (0.764) despite lower population. Formula: `importance × biasScale × maxBias` (linear, capped at 3.0 logits).
 
-3. **Full bias when deterministic.** When the FST narrows to one interpretation (e.g., "Portland" + "OR"), the bias is maximal.
+3. **Negative suppression on non-place labels.** When the FST matches a place name, B-street, I-street, B-house\_number, I-house\_number, and B-venue receive -1.5 logit suppression. This narrows the gap between place-tag and non-place-tag logits without overriding the model.
 
 4. **Negative evidence is free.** When a token doesn't extend any FST path, that's a strong signal it's NOT an admin component — the neural model handles it alone. This is how "Buffalo Health Clinic" gets correctly NOT-biased toward locality.
 

--- a/docs/articles/plan/reference/WIKIPEDIA_IMPORTANCE.md
+++ b/docs/articles/plan/reference/WIKIPEDIA_IMPORTANCE.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 19
+title: Wikipedia importance scores
+---
+
+# Wikipedia Importance Scores
+
+Place importance scores derived from Wikipedia link count, replacing raw population as the FST emission prior weight. Shipped in [#173](https://github.com/sister-software/mailwoman/pull/173).
+
+## Source
+
+[Nominatim's wikimedia-importance.csv.gz](https://nominatim.org/release-docs/latest/customize/Importance/) — 19M rows mapping Wikidata IDs to importance scores. The score is `log(total_links) / log(max_links)` where `total_links` = internal links + cross-language links to the Wikipedia article. Normalized to \[0, 1\] where the United States article (5.2M links) = 1.0.
+
+## ETL pipeline
+
+```
+wikimedia-importance.csv.gz (19M rows, ~250 MB compressed)
+         │
+         ▼
+  scripts/build-importance.ts
+         │
+         ├─ Load WOF concordances (other_source='wd:id') → Set of needed Wikidata IDs
+         ├─ Stream-decompress TSV, filter to matching IDs only
+         ├─ Collapse duplicates by MAX(importance) per Wikidata ID
+         ├─ JOIN: wof_id → concordance wikidata_id → importance score
+         ├─ Write place_importance(id, importance) table
+         └─ Population fallback: min(1.0, log2(1+pop/1000)/14) for places without Wikidata
+```
+
+## Coverage (US admin)
+
+| Source | Places |
+|--------|--------|
+| Wikipedia importance (via Wikidata concordance) | 47,348 |
+| Population fallback | 108,111 |
+| **Total in place\_importance** | **155,459** |
+
+## How scores flow into the FST
+
+1. `build-importance.ts` writes `place_importance` table into the WOF SQLite
+2. `fst-builder.ts` reads `place_importance` (falls back to `place_population` → pseudo-importance)
+3. `PlaceEntry.importance` carries the score through serialization (Float32 in the binary FST)
+4. `fst-prior.ts` computes bias: `importance × biasScale × maxBias` (linear, capped at 3.0 logits)
+
+## Why not population
+
+| Signal | Washington DC | Washington state | Winner |
+|--------|--------------|-----------------|--------|
+| Population | 678K | 7.6M | State (wrong for bare "Washington") |
+| Wikipedia importance | 0.815 | 0.764 | DC (correct — more culturally prominent) |
+
+Population is an administrative headcount. Wikipedia importance captures actual cultural prominence — how often the place is referenced, linked to, and discussed across languages.
+
+## Regeneration
+
+Run after any WOF data refresh:
+
+```bash
+node scripts/build-importance.js --db /path/to/wof-unified.db [--tsv /path/to/wikimedia-importance.csv.gz]
+```
+
+The TSV is cached at `/tmp/wikimedia-importance.csv.gz` after first download. Pass `--tsv` to skip the download.
+
+## See also
+
+- [FST Gazetteer LM](./FST_GAZETTEER_LM.md) — the FST architecture this feeds into
+- [Nominatim importance docs](https://nominatim.org/release-docs/latest/customize/Importance/) — upstream methodology

--- a/docs/articles/understanding/our-approach/how-it-works-now.md
+++ b/docs/articles/understanding/our-approach/how-it-works-now.md
@@ -125,9 +125,10 @@ The live demo at [mailwoman.sister.software/demo](https://mailwoman.sister.softw
 
 ## What is honest to admit about today (May 2026)
 
-- **Coarse F1 is still regressed.** The v0.4.0-shipped model has `region` F1 of 0.19 and `country` F1 of 0.21. Rule classifiers are doing the heavy lifting on coarse components. The v0.5.0 fresh-slate work (new tokenizer, phrase grouper, joint decode) targets this structurally — but the C-train that would produce improved weights is not yet stable.
-- **Training divergence is the current blocker.** Both v0.4.0 and v0.5.0 training runs diverge under sustained peak learning rate. The leading hypothesis (as of May 2026) is that the CRF-NLL + CE dual loss has opposing curvature below a threshold loss value. CE-only training is the current experiment.
-- **Joint decode is opt-in.** The reconciler code ships in `runtime-pipeline.ts` with `parseWithLogits` + `aggregateSpanLogits` + `reconcileSpans`, but requires the `forceJointReconcile` flag. The argmax fallback is the default path. End-to-end validation against the kryptonite catalogue with real model output is tracked in [#153](https://github.com/sister-software/mailwoman/issues/153).
-- **The model is small.** Nine million parameters is enough for the address-parsing task but not enough for free-text understanding. We are not building a chatbot.
+- **CE-only training resolved the divergence problem.** The v0.5.2 model ships from a stable 100K-step CE-only training run on an A100. The dual-loss CRF-NLL + CE divergence that blocked v0.4.0 and v0.5.0 was resolved by setting `crf_loss_weight: 0.0` — CRF is used at inference only, not training. v0.5.3 diagnostic training is in progress with per-tag F1 visibility.
+- **The FST gazetteer prior is shipped but not yet in the browser.** The FST builder, Wikipedia importance scoring, and emission prior compose with the QueryShape soft prior in the Node.js pipeline. The browser `/demo` page runs the neural classifier directly without the FST — it would need a browser-compatible FST loader (Phase 4).
+- **Joint decode is still opt-in.** The reconciler produces single-token spans when phrase-grouper proposals don't cover multi-word streets/localities. It stays behind `forceJointReconcile` until the grouper proposes multi-word phrases.
+- **Locality/region confusion persists on some inputs.** "New York, NY" is fixed (region-aware guard). "Washington, DC" is partially fixed (FST correctly biases locality) but the model's high B-street confidence for "Washington" after a street phrase resists the prior. Fix is in training data, not more priors.
+- **The model is small.** 29M parameters (h384, 6 layers, 6 heads). Runs in ~10ms per address on CPU via ONNX Runtime. The int8 quantized model is 17 MB.
 
 Continue with [How it will work](./how-it-will-work.md) for the near-future roadmap.

--- a/docs/articles/understanding/our-approach/the-knowledge-ladder.md
+++ b/docs/articles/understanding/our-approach/the-knowledge-ladder.md
@@ -24,11 +24,13 @@ Each layer adds one kind of knowledge the layers below it cannot easily derive:
 | **1. Normalize**         | input preprocessing rules                                     | Yes                                                               |
 | **2. Locale gate**       | language / script family                                      | Yes (rule-based)                                                  |
 | **2.5. Kind classifier** | overall query category (postcode_only, structured_address, …) | Yes (rule-based)                                                  |
-| **2.7. Phrase grouper**  | **coherent input units (boundary discovery)**                 | **Yes (rule-based, v0.5.0; learned variant scoped for v0.5.1)**   |
-| **3. Token classify**    | per-token semantic type                                       | Yes (neural)                                                      |
+| **2.7. Phrase grouper**  | **coherent input units (boundary discovery)**                 | **Yes (rule-based, v0.5.0; 57 venue markers, unit gate, positional prior)** |
+| **3. Token classify**    | per-token semantic type                                       | Yes (neural, v0.5.2)                                              |
+| **3.5. FST prior**       | **gazetteer-derived emission biases**                         | **Yes (Wikipedia importance-weighted, v0.5.2; [#173](https://github.com/sister-software/mailwoman/pull/173))** |
 | **4. Sequence correct**  | per-token BIO sequence validity                               | Yes (CRF with structural mask)                                    |
-| **5. Reconcile**         | **joint-coherent interpretation across candidates**           | **Yes (joint-decoding path shipped in v0.5.0; mocks Thread C-s)** |
-| **6. Resolve**           | world hierarchy (gazetteer)                                   | Yes (WOF SQLite)                                                  |
+| **4.5. Grouper audit**   | **provisional nodes for all-O spans**                         | **Yes (injects venue/locality from grouper proposals; [#170](https://github.com/sister-software/mailwoman/pull/170))** |
+| **5. Reconcile**         | **joint-coherent interpretation across candidates**           | Yes (joint-decoding path shipped in v0.5.0; opt-in via `forceJointReconcile`) |
+| **6. Resolve**           | world hierarchy (gazetteer)                                   | Yes (WOF SQLite, unified builder in [#176](https://github.com/sister-software/mailwoman/pull/176)) |
 
 The two emphasized rows are the layers that v0.4.0's mixed result exposed as missing. They're complementary: the phrase grouper feeds cleaner spans IN to the classifier; the expanded reconciler picks coherent assignments OUT of the classifier's candidates.
 

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -44,8 +44,8 @@ export default function DemoPage(): React.ReactElement {
 				<header className={styles.header}>
 					<h1>Mailwoman geocoder demo</h1>
 					<p>
-						Type a US address. The neural classifier (~25 MB ONNX) and WOF locality DB (~35 MB SQLite) run entirely in
-						your browser — no server round-trips after the initial asset load.
+						Type a US address. The neural classifier (~17 MB ONNX, int8 quantized) and WOF locality DB (~35 MB SQLite)
+						run entirely in your browser — no server round-trips after the initial asset load.
 					</p>
 				</header>
 				<BrowserOnly fallback={<p>Loading…</p>}>{() => <DemoApp />}</BrowserOnly>


### PR DESCRIPTION
## Summary

Updates docs to reflect the 6 PRs merged today (#170-#176).

### Changes
- **FST_GAZETTEER_LM.md**: Converted from design doc to shipped reference. Added metrics table (114K states, 5.57 MB, 43s build). Updated design decisions: population → Wikipedia importance. Phase status: 1-2 shipped, 3 partial, 4 not started.
- **DEMO_PRESET_DIAGNOSIS.md**: Added shipped-fixes banner with PR links. "New York, NY" fixed, "Washington, DC" partially improved, "San Francisco" fixed.
- **how-it-works-now.md**: Removed "divergence is the blocker" (resolved by CE-only training). Updated model size to 29M params / 17 MB int8. Added FST prior and joint-reconcile status.
- **/demo page**: Model size 25→17 MB (int8 quantized).

## Test plan
- [x] `yarn compile` — clean
- [x] `docs build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)