### PR TITLE
ci: derive R2 weights path from model-card.json

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,8 +100,12 @@ jobs:
         run: | # shell
           # Install rclone
           curl -sSL https://rclone.org/install.sh | sudo bash
-          # Pull model + tokenizer from the latest release path on R2
-          RELEASE_PATH="${MAILWOMAN_R2_RELEASE_PATH:-releases/v0.5.3}"
+          # Derive the R2 release path from the model card (source of truth).
+          # Falls back to env override for manual intervention.
+          MODEL_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('neural-weights-en-us/model-card.json','utf8')).version)")
+          RELEASE_PATH="${MAILWOMAN_R2_RELEASE_PATH:-releases/v${MODEL_VERSION}}"
+          echo "Model card version: ${MODEL_VERSION}"
+          echo "R2 release path: ${RELEASE_PATH}"
           rclone copy ":s3:mailwoman-assets/${RELEASE_PATH}/model.onnx" neural-weights-en-us/
           rclone copy ":s3:mailwoman-assets/${RELEASE_PATH}/tokenizer.model" neural-weights-en-us/
           # fr-fr uses the same model for now (same training, locale-specific weights are future work)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,7 @@ jobs:
           # Install rclone
           curl -sSL https://rclone.org/install.sh | sudo bash
           # Pull model + tokenizer from the latest release path on R2
-          RELEASE_PATH="${MAILWOMAN_R2_RELEASE_PATH:-releases/v0.5.1}"
+          RELEASE_PATH="${MAILWOMAN_R2_RELEASE_PATH:-releases/v0.5.3}"
           rclone copy ":s3:mailwoman-assets/${RELEASE_PATH}/model.onnx" neural-weights-en-us/
           rclone copy ":s3:mailwoman-assets/${RELEASE_PATH}/tokenizer.model" neural-weights-en-us/
           # fr-fr uses the same model for now (same training, locale-specific weights are future work)


### PR DESCRIPTION
The publish workflow was hardcoding `releases/v0.5.1` (then manually updated to `v0.5.3`) as the R2 path for pulling weights. This required remembering to edit the YAML every time weights changed.

Now reads the version from `neural-weights-en-us/model-card.json` and constructs `releases/v{version}` automatically. The model card is already the source of truth for weights metadata — now the CI uses it too.

Still supports `MAILWOMAN_R2_RELEASE_PATH` env override for manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)