### PR TITLE
fix(ci): tolerate already-published versions in publish-workspace

### DIFF
--- a/scripts/publish-workspace.mjs
+++ b/scripts/publish-workspace.mjs
@@ -94,7 +94,17 @@ try {
 		process.exit(0)
 	}
 
-	const publishResult = spawnSync("npm", publishArgs, { stdio: "inherit" })
+	const publishResult = spawnSync("npm", publishArgs, { stdio: ["inherit", "inherit", "pipe"] })
+	const stderr = publishResult.stderr?.toString() ?? ""
+
+	if (publishResult.status !== 0 && /cannot publish over the previously published version/i.test(stderr)) {
+		console.error(
+			`publish-workspace: ${workspacePath} already published at this version — skipping (tolerate-republish)`
+		)
+		process.exit(0)
+	}
+
+	if (stderr) process.stderr.write(stderr)
 	process.exit(publishResult.status ?? 1)
 } finally {
 	rmSync(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- `publish-workspace.mjs` now captures npm publish stderr and exits 0 when the failure is specifically "cannot publish over previously published versions"
- Fixes partial-release recovery: when a CI run fails mid-publish, re-running the workflow no longer crashes on workspaces that already published successfully

## Context
The v3.0.0 publish run failed at `neural-weights-en-us` because that package was already published from a previous partial run. The script had no tolerance for re-publishes — it propagated npm's exit code 1 directly.

## Test plan
- [ ] Merge and re-trigger the publish workflow with `patch` version bump
- [ ] Verify all workspaces publish (or skip gracefully if already at that version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)