### PR TITLE
feat(demo): FST gazetteer prior in browser (Phase 4)

### DIFF
--- a/docs/articles/plan/reference/FST_GAZETTEER_LM.md
+++ b/docs/articles/plan/reference/FST_GAZETTEER_LM.md
@@ -6,7 +6,7 @@ title: FST gazetteer language model
 # FST Gazetteer LM
 
 :::info Shipped
-Phases 1-2 shipped in v0.5.2 ([#170](https://github.com/sister-software/mailwoman/pull/170), [#173](https://github.com/sister-software/mailwoman/pull/173)). Wikipedia importance integration in [#173](https://github.com/sister-software/mailwoman/pull/173). Unified SQLite builder in [#176](https://github.com/sister-software/mailwoman/pull/176). Phase 3 (autocomplete) partially shipped. Phase 4 (browser) not yet started.
+Phases 1-2 shipped in v0.5.2 ([#170](https://github.com/sister-software/mailwoman/pull/170), [#173](https://github.com/sister-software/mailwoman/pull/173)). Wikipedia importance integration in [#173](https://github.com/sister-software/mailwoman/pull/173). Unified SQLite builder in [#176](https://github.com/sister-software/mailwoman/pull/176). Phase 3 (autocomplete) partially shipped. Phase 4 (browser) shipped — the `/demo` page loads a 9 MB FST binary and passes it as an emission prior to the neural classifier.
 :::
 
 **Goal:** Pre-compute a finite-state transducer from the WOF SQLite gazetteer that maps token sequences → `(placetype, wof_id, parent_chain, importance)` entries. Use it as an emission prior in the neural Viterbi decoder, as a CLI introspection tool, and as the autocomplete backend.
@@ -193,10 +193,12 @@ A single FST with per-edge locale bitsets is space-efficient but query-slower. F
 - `resolver-wof-sqlite/fst-autocomplete.ts` — prefix walk + BFS expansion
 - CLI not yet wired (standalone script only)
 
-### Phase 4: Browser deployment — not started
+### Phase 4: Browser deployment — shipped
 
-- Browser-compatible FstMatcher (ArrayBuffer) not yet implemented
-- `/demo` page does not use FST prior
+- `resolver-wof-sqlite/fst-deserialize-web.ts` — browser-compatible deserializer using DataView + TextDecoder (no Node Buffer dependency)
+- `/demo` page loads `fst-en-US.bin` (~9 MB) and passes it to `classifier.parse()` as `opts.fst`
+- FST module import, binary fetch, and deserialization happen in parallel with ONNX model load
+- Graceful degradation: if the FST fails to load, the demo runs without it
 
 ---
 

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -44,8 +44,9 @@ export default function DemoPage(): React.ReactElement {
 				<header className={styles.header}>
 					<h1>Mailwoman geocoder demo</h1>
 					<p>
-						Type a US address. The neural classifier (~17 MB ONNX, int8 quantized) and WOF locality DB (~35 MB SQLite)
-						run entirely in your browser — no server round-trips after the initial asset load.
+						Type a US address. The neural classifier (~25 MB ONNX, int8 quantized), FST gazetteer (~9 MB, 94K US
+						places), and WOF locality DB (~35 MB SQLite) run entirely in your browser — no server round-trips after
+						the initial asset load.
 					</p>
 				</header>
 				<BrowserOnly fallback={<p>Loading…</p>}>{() => <DemoApp />}</BrowserOnly>
@@ -65,6 +66,7 @@ function initialAddress(): string {
 function DemoApp(): React.ReactElement {
 	const [loadingProgress, setLoadingProgress] = useState<string>("Loading neural model…")
 	const [classifier, setClassifier] = useState<MailwomanClassifierLike | null>(null)
+	const [fstMatcher, setFstMatcher] = useState<FstMatcherLike | null>(null)
 	const [lookupLoader, setLookupLoader] = useState<(() => Promise<MailwomanLookupLike>) | null>(null)
 	const [lookup, setLookup] = useState<MailwomanLookupLike | null>(null)
 	const [text, setText] = useState(initialAddress)
@@ -95,14 +97,15 @@ function DemoApp(): React.ReactElement {
 		let cancelled = false
 		void (async () => {
 			try {
-				const [neuralWeb, maplibre, basemapSource] = await Promise.all([
+				const [neuralWeb, maplibre, basemapSource, fstResult] = await Promise.all([
 					import("@mailwoman/neural-web"),
 					import("maplibre-gl"),
 					fetchBasemapSource(),
+					loadFstGazetteer().catch(() => null),
 				])
 
 				if (cancelled) return
-				setLoadingProgress("Loading neural model (~25 MB)…")
+				setLoadingProgress("Loading neural model (~25 MB) + FST gazetteer (~9 MB)…")
 				const cls = await neuralWeb.loadNeuralClassifierFromUrls({
 					modelUrl: "/mailwoman/model.onnx",
 					tokenizerUrl: "/mailwoman/tokenizer.model",
@@ -148,6 +151,7 @@ function DemoApp(): React.ReactElement {
 				}
 
 				if (cancelled) return
+				if (fstResult) setFstMatcher(fstResult as FstMatcherLike)
 				setClassifier(cls as unknown as MailwomanClassifierLike)
 				// One-shot factory; captured in closure to avoid re-importing the wasm wrapper.
 				setLookupLoader(() => async () => {
@@ -279,7 +283,7 @@ function DemoApp(): React.ReactElement {
 				const queryShape = computeQueryShape(text)
 				const kindResult = classifyKindSync({ raw: text, normalized: text }, queryShape)
 
-				const tree = await classifier.parse(text, { queryShape })
+				const tree = await classifier.parse(text, { queryShape, fst: fstMatcher ?? undefined })
 				const nodes = flattenTree(tree)
 				const localityNode = nodes.find((n) => n.tag === "locality" || n.tag === "city")
 				const stateNode = nodes.find((n) => n.tag === "region" || n.tag === "state")
@@ -294,6 +298,7 @@ function DemoApp(): React.ReactElement {
 						candidates: [],
 						stateHint: stateNode?.value as string | undefined,
 						kindResult,
+						fstActive: fstMatcher !== null,
 					})
 					return
 				}
@@ -322,6 +327,7 @@ function DemoApp(): React.ReactElement {
 					candidates,
 					stateHint: stateNode?.value as string | undefined,
 					kindResult,
+					fstActive: fstMatcher !== null,
 				})
 			} catch (e2) {
 				setError((e2 as Error).message ?? String(e2))
@@ -329,7 +335,7 @@ function DemoApp(): React.ReactElement {
 				setBusy(false)
 			}
 		},
-		[classifier, ensureLookup, text]
+		[classifier, fstMatcher, ensureLookup, text]
 	)
 
 	const ready = classifier !== null && lookupLoader !== null
@@ -416,6 +422,12 @@ function ResultPanel({
 				</button>
 			</div>
 			{result.kindResult ? <KindBadge kindResult={result.kindResult} /> : null}
+			{result.fstActive ? (
+				<div style={{ marginBottom: "0.5rem", fontSize: "0.9rem" }}>
+					<strong>FST prior:</strong> <code>active</code>{" "}
+					<span style={{ opacity: 0.7 }}>(94K US places, Wikipedia importance-weighted)</span>
+				</div>
+			) : null}
 			{showXml && xml ? <pre className={styles.xml}>{xml}</pre> : null}
 			<table className={styles.componentTable}>
 				<thead>
@@ -620,8 +632,19 @@ function FailureDiagnostic({
 	)
 }
 
+interface FstMatcherLike {
+	walk(tokens: string[]): { stateId: number; accepted: boolean; depth: number } | null
+	walkFrom(
+		prev: { stateId: number; accepted: boolean; depth: number },
+		token: string
+	): { stateId: number; accepted: boolean; depth: number } | null
+	accepting(stateId: number): Array<{ wofID: number; placetype: string; importance: number }>
+	readonly stateCount: number
+	readonly placeCount: number
+}
+
 interface MailwomanClassifierLike {
-	parse: (text: string, opts?: { queryShape?: unknown; fst?: unknown }) => Promise<unknown>
+	parse: (text: string, opts?: { queryShape?: unknown; fst?: FstMatcherLike }) => Promise<unknown>
 }
 
 interface MailwomanLookupLike {
@@ -677,27 +700,15 @@ function KindBadge({
 interface DemoResult {
 	tree: unknown
 	nodes: Array<{ tag: string; value?: unknown; confidence?: number }>
-	/**
-	 * Top candidate (alias of `candidates[0]` when non-empty). Kept for callers that don't care about
-	 * the picker UI.
-	 */
 	resolved: ResolvedHit | null
-	/**
-	 * Full candidate list returned by the cascade. Length 0 when nothing matched. Picker UI appears
-	 * when length > 1.
-	 */
 	candidates: ResolvedHit[]
 	stateHint?: string
-	/**
-	 * Stage 2.5 result: the kind classifier's verdict on the input. Surfaced in the UI so users can
-	 * see the staged pipeline in action — bare postcodes show up as `postcode_only`, single-word
-	 * locality inputs as `locality_only`, etc.
-	 */
 	kindResult?: {
 		kind: string
 		confidence: number
 		alternatives: ReadonlyArray<{ kind: string; confidence: number }>
 	}
+	fstActive: boolean
 }
 
 interface ResolvedHit {
@@ -833,6 +844,17 @@ function flattenTree(tree: unknown): Array<{ tag: string; value?: unknown; confi
 function currentDocusaurusTheme(): "light" | "dark" {
 	if (typeof document === "undefined") return "light"
 	return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
+}
+
+async function loadFstGazetteer(): Promise<FstMatcherLike> {
+	const [fstModule, fstBinary] = await Promise.all([
+		import("@mailwoman/resolver-wof-sqlite/fst-deserialize-web"),
+		fetch("/mailwoman/fst-en-US.bin").then((r) => {
+			if (!r.ok) throw new Error(`FST fetch failed (${r.status})`)
+			return r.arrayBuffer()
+		}),
+	])
+	return fstModule.deserializeFstWeb(fstBinary) as FstMatcherLike
 }
 
 async function fetchBasemapSource(): Promise<VectorSourceSpecification> {

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -148,7 +148,7 @@ function DemoApp(): React.ReactElement {
 				}
 
 				if (cancelled) return
-				setClassifier(cls)
+				setClassifier(cls as unknown as MailwomanClassifierLike)
 				// One-shot factory; captured in closure to avoid re-importing the wasm wrapper.
 				setLookupLoader(() => async () => {
 					const resolverWasm = await import("@mailwoman/resolver-wof-wasm")
@@ -621,7 +621,7 @@ function FailureDiagnostic({
 }
 
 interface MailwomanClassifierLike {
-	parse: (text: string) => Promise<unknown>
+	parse: (text: string, opts?: { queryShape?: unknown; fst?: unknown }) => Promise<unknown>
 }
 
 interface MailwomanLookupLike {

--- a/resolver-wof-sqlite/fst-deserialize-web.ts
+++ b/resolver-wof-sqlite/fst-deserialize-web.ts
@@ -1,0 +1,131 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Browser-compatible FST deserializer. Uses DataView + TextDecoder instead of Node's Buffer so the
+ *   same binary format can be loaded in the browser via fetch(url).then(r => r.arrayBuffer()).
+ *
+ *   This is a read-only counterpart to fst-serialize.ts — serialization stays Node-only (it's a
+ *   build-time operation).
+ */
+
+import type { FstNode } from "./fst-matcher.js"
+import { FstMatcher } from "./fst-matcher.js"
+import type { PlaceEntry, PlacetypeId } from "./fst-types.js"
+
+const HEADER_SIZE = 32
+const STATE_ENTRY_SIZE = 12
+const EDGE_ENTRY_SIZE = 8
+const PLACE_ENTRY_SIZE = 56
+const MAGIC_BYTES = [0x46, 0x53, 0x54, 0x00] // "FST\0"
+const MAX_VERSION = 2
+
+const PLACETYPE_ORDER: readonly PlacetypeId[] = [
+	"country",
+	"region",
+	"county",
+	"locality",
+	"localadmin",
+	"borough",
+	"neighbourhood",
+	"postalcode",
+	"campus",
+	"dependency",
+]
+
+export function deserializeFstWeb(input: ArrayBuffer | Uint8Array): FstMatcher {
+	const bytes = input instanceof ArrayBuffer ? new Uint8Array(input) : input
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+	const decoder = new TextDecoder("utf-8")
+
+	if (bytes.byteLength < HEADER_SIZE) throw new Error("FST buffer too small for header")
+
+	if (
+		bytes[0] !== MAGIC_BYTES[0] ||
+		bytes[1] !== MAGIC_BYTES[1] ||
+		bytes[2] !== MAGIC_BYTES[2] ||
+		bytes[3] !== MAGIC_BYTES[3]
+	) {
+		throw new Error("FST magic mismatch")
+	}
+
+	const version = view.getUint16(4, true)
+	if (version < 1 || version > MAX_VERSION) {
+		throw new Error(`FST version ${version} unsupported (expected 1..${MAX_VERSION})`)
+	}
+	const isV2 = version >= 2
+
+	const stateCount = view.getUint32(8, true)
+	const edgeCount = view.getUint32(12, true)
+	const _placeCount = view.getUint32(16, true)
+	const stringCount = view.getUint32(20, true)
+	const stringBytes = view.getUint32(24, true)
+
+	let pos = HEADER_SIZE
+
+	// --- String table ---
+	const strOffsets = new Uint32Array(stringCount + 1)
+	for (let i = 0; i <= stringCount; i++) {
+		strOffsets[i] = view.getUint32(pos, true)
+		pos += 4
+	}
+	const strDataStart = pos
+	const strings: string[] = new Array(stringCount)
+	for (let i = 0; i < stringCount; i++) {
+		const start = strDataStart + strOffsets[i]!
+		const end = strDataStart + strOffsets[i + 1]!
+		strings[i] = decoder.decode(bytes.subarray(start, end))
+	}
+	pos += stringBytes
+
+	// --- State table ---
+	const stateTableStart = pos
+	const edgeTableStart = stateTableStart + stateCount * STATE_ENTRY_SIZE
+	const placeTableStart = edgeTableStart + edgeCount * EDGE_ENTRY_SIZE
+
+	const nodes: FstNode[] = new Array(stateCount)
+
+	for (let si = 0; si < stateCount; si++) {
+		const sp = stateTableStart + si * STATE_ENTRY_SIZE
+		const edgeStart = view.getUint32(sp, true)
+		const placeStart = view.getUint32(sp + 4, true)
+		const edgeCountForState = view.getUint16(sp + 8, true)
+		const placeCountForState = view.getUint16(sp + 10, true)
+
+		const edges = new Map<string, number>()
+		for (let ei = 0; ei < edgeCountForState; ei++) {
+			const ep = edgeTableStart + (edgeStart + ei) * EDGE_ENTRY_SIZE
+			const stringIdx = view.getUint32(ep, true)
+			const target = view.getUint32(ep + 4, true)
+			edges.set(strings[stringIdx]!, target)
+		}
+
+		const places: PlaceEntry[] = new Array(placeCountForState)
+		for (let pi = 0; pi < placeCountForState; pi++) {
+			const pp = placeTableStart + (placeStart + pi) * PLACE_ENTRY_SIZE
+			const chainLen = view.getUint8(pp + 5)
+			const parentChain: number[] = []
+			for (let ci = 0; ci < chainLen; ci++) {
+				parentChain.push(view.getUint32(pp + 24 + ci * 4, true))
+			}
+			const rawImportance = isV2
+				? view.getFloat32(pp + 12, true)
+				: Math.min(1.0, Math.log2(1 + view.getUint32(pp + 12, true) / 1000) / 14)
+
+			places[pi] = {
+				wofID: view.getUint32(pp, true),
+				placetype: PLACETYPE_ORDER[view.getUint8(pp + 4)] ?? "locality",
+				name: strings[view.getUint32(pp + 8, true)]!,
+				importance: rawImportance,
+				lat: view.getFloat32(pp + 16, true),
+				lon: view.getFloat32(pp + 20, true),
+				parentChain,
+			}
+		}
+
+		nodes[si] = { edges, places }
+	}
+
+	return FstMatcher.fromNodes(nodes)
+}

--- a/resolver-wof-sqlite/package.json
+++ b/resolver-wof-sqlite/package.json
@@ -19,6 +19,7 @@
 		"./fst-serialize": "./out/fst-serialize.js",
 		"./fst-autocomplete": "./out/fst-autocomplete.js",
 		"./fst-types": "./out/fst-types.js",
+		"./fst-deserialize-web": "./out/fst-deserialize-web.js",
 		"./unified-schema": "./out/unified-schema.js"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary
- New browser-compatible FST deserializer (`fst-deserialize-web.ts`) using DataView + TextDecoder — zero Node dependencies
- Demo page loads the 9 MB `fst-en-US.bin` binary (94K US admin places with Wikipedia importance) alongside the ONNX model
- FST emission prior passed to `classifier.parse()` via `opts.fst`, matching the server-side pipeline
- Graceful degradation: if FST fetch fails, demo runs without it
- Phase 4 of the FST gazetteer LM doc is now marked shipped

## Changes
| File | What |
|------|------|
| `resolver-wof-sqlite/fst-deserialize-web.ts` | New browser-safe deserializer |
| `resolver-wof-sqlite/package.json` | Added `./fst-deserialize-web` subpath export |
| `docs/docusaurus.config.ts` | Webpack aliases for FST browser subpaths |
| `docs/src/pages/demo/index.tsx` | Load FST, pass as emission prior, UI badges |
| `docs/articles/plan/reference/FST_GAZETTEER_LM.md` | Phase 4 → shipped |
| `.gitignore` | Exclude docs static binaries |

## Test plan
- [ ] Build docs site (`cd docs && npm run build`) — should compile cleanly
- [ ] Open `/demo` in browser — FST should load alongside model
- [ ] Parse "1600 Pennsylvania Ave NW, Washington, DC 20500" — FST prior badge shows "active"
- [ ] Parse "New York, NY" — locality/region disambiguation improved by FST
- [ ] If FST binary is missing (404), demo should still work without FST

🤖 Generated with [Claude Code](https://claude.com/claude-code)