### PR TITLE
feat(grouper): penalize LOCALITY_PHRASE for US state names

### DIFF
--- a/phrase-grouper/group.test.ts
+++ b/phrase-grouper/group.test.ts
@@ -211,6 +211,21 @@ describe("scoreLocalityPhrase", () => {
 		const out = scoreLocalityPhrase(tokenizeSegment("NY foo", 0), "NY foo", true)
 		expect(out.find((p) => p.span.body === "NY")).toBeUndefined()
 	})
+
+	it("penalizes single-word US state names in non-tail position", () => {
+		const tokens = tokenizeSegment("Washington DC", 0)
+		const out = scoreLocalityPhrase(tokens, "Washington DC", false)
+		const washConf = out.find((p) => p.span.body === "Washington")?.confidence ?? 0
+		const springTokens = tokenizeSegment("Springfield IL", 0)
+		const springOut = scoreLocalityPhrase(springTokens, "Springfield IL", false)
+		const springConf = springOut.find((p) => p.span.body === "Springfield")!.confidence
+		expect(washConf).toBeLessThan(springConf)
+	})
+
+	it("still emits multi-word runs containing a state name (New York)", () => {
+		const out = scoreLocalityPhrase(tokenizeSegment("New York", 0), "New York", true)
+		expect(out.find((p) => p.span.body === "New York")).toBeDefined()
+	})
 })
 
 describe("scoreVenuePhrase", () => {

--- a/phrase-grouper/rules.ts
+++ b/phrase-grouper/rules.ts
@@ -31,6 +31,15 @@ export interface SegmentToken {
 
 const WHITESPACE = /\s+/
 
+const US_REGION_NAMES: ReadonlySet<string> = new Set([
+	"alabama", "alaska", "arizona", "arkansas", "california", "colorado", "connecticut",
+	"delaware", "florida", "georgia", "hawaii", "idaho", "illinois", "indiana", "iowa",
+	"kansas", "kentucky", "louisiana", "maine", "maryland", "massachusetts", "michigan",
+	"minnesota", "mississippi", "missouri", "montana", "nebraska", "nevada", "ohio",
+	"oklahoma", "oregon", "pennsylvania", "tennessee", "texas", "utah", "vermont",
+	"virginia", "washington", "wisconsin", "wyoming",
+])
+
 /**
  * Split a segment body into whitespace-separated tokens. Offsets are absolute into the original
  * input (caller supplies the segment's `start` offset).
@@ -402,8 +411,11 @@ export function scoreLocalityPhrase(
 		for (let len = 1; len <= maxLen; len++) {
 			const startTok = tokens[i]!
 			const endTok = tokens[i + len - 1]!
+			const spanText = text.slice(startTok.start, endTok.end)
+			const isRegionName = len === 1 && US_REGION_NAMES.has(spanText.toLowerCase())
 			const atTail = i + len - 1 === tokens.length - 1
 			let confidence = 0.55 + (len === 2 ? 0.15 : 0) + (len === 3 ? 0.1 : 0)
+			if (isRegionName && !atTail) confidence -= 0.20
 			if (atTail && segmentIsLast) confidence += 0.1
 			if (atTail) confidence += 0.05
 			out.push({


### PR DESCRIPTION
## Summary
Single-word US state names ("Pennsylvania", "Washington", "Illinois") were being proposed as `LOCALITY_PHRASE` at the same confidence as actual city names. When the neural model left gaps, the grouper-audit injected wrong provisional nodes like `locality=Pennsylvania` on "1600 Pennsylvania Ave NW".

Now applies a -0.20 confidence penalty to single-word `LOCALITY_PHRASE` proposals matching a US state name, but ONLY in non-tail positions. Tail position (like "Texas" in "Paris, Texas") keeps full confidence.

## Design choice: penalty, not suppression
DeepSeek recommended suppressing state names entirely, but "Paris, Texas" proves state names CAN be legitimate locality-context text. Penalizing in non-tail position is the right middle ground — the reconciler still sees the proposal but at lower confidence, so it loses to the classifier's region tag when present.

## Test plan
- [x] `npx vitest run phrase-grouper/group.test.ts` — 32/32 pass
- [x] `npx vitest run phrase-grouper/kryptonite.test.ts` — 20/20 pass (Paris, Texas preserved)
- [x] New test: "Washington" penalized vs "Springfield" in non-tail position

🤖 Generated with [Claude Code](https://claude.com/claude-code)