### PR TITLE
fix(docs): unblock docs-build CI — MDX <digit escapes + broken links + tags

### DIFF
--- a/docs/articles/evals/2026-05-29-v0.6.2-100k-eval.md
+++ b/docs/articles/evals/2026-05-29-v0.6.2-100k-eval.md
@@ -112,7 +112,7 @@ shouldn't be admin spans.
 1. **Direct:** synth-no-street's adversarial venues included `5th Avenue Theatre` and
    `7th Street Bistro`. These taught the model that `5th`/`7th` (which should be
    `house_number` in real addresses) belong to venues. (See
-   [`corpus-poisoning-vulnerability.md`](TBD) for the broader analysis.)
+   [`corpus-poisoning-vulnerability.md`](../concepts/corpus-poisoning-vulnerability.md) for the broader analysis.)
 2. **Distributional:** adding 122K rows where `house_number` is absent shifted the training
    distribution toward "house_number is rare," so the model under-emits the tag.
 

--- a/docs/articles/evals/2026-05-29-v0.6.3-100k-eval.md
+++ b/docs/articles/evals/2026-05-29-v0.6.3-100k-eval.md
@@ -104,9 +104,8 @@ v0.6.3 falls in row 4: **HOLD**. Two paths from here:
    evaluation methodology, schema design, or model capacity.
 
 **The operator chose path 2.** This doc captures what we learned. The
-[v0.6.x retrospective](2026-05-29-v06x-retrospective.md) — separate doc
-to be written — synthesizes what the cycle revealed and proposes a
-rethink agenda.
+[v0.6.x retrospective](../retrospectives/v0-6-x-cycle-retrospective.md)
+synthesizes what the cycle revealed and proposes a rethink agenda.
 
 ## Pre-staged v0.6.4 — held but not discarded
 

--- a/docs/articles/retrospectives/v0-6-x-cycle-retrospective.md
+++ b/docs/articles/retrospectives/v0-6-x-cycle-retrospective.md
@@ -223,7 +223,7 @@ the speculative-architecture work (per-locale routing) to v0.8.
 
 **P1 — Postcode fix** (depends on diagnostic + calibration result)
 
-The diagnostic confirms postcode <90% on most countries (US 80.5%, FR
+The diagnostic confirms postcode `<90%` on most countries (US 80.5%, FR
 70.1%, GB/CA/NL 0%). Three approaches in priority order:
 
 1. **Character-level feature extractor** — parallel char-CNN or
@@ -249,7 +249,7 @@ upward, the tokenizer fix becomes smaller-scope.
 If postcode accuracy is still < 90% after calibration + tokenizer fix,
 the locale-router approach becomes the next lever. Recommended
 architecture: lexical-feature classifier (regex + char n-grams → tiny
-MLP), <0.1ms latency, <100KB serialized. 99% accuracy on
+MLP), `<0.1ms` latency, `<100KB` serialized. 99% accuracy on
 postcode-bearing inputs is achievable via postcode-pattern features
 alone.
 

--- a/docs/blog/tags.yml
+++ b/docs/blog/tags.yml
@@ -72,6 +72,10 @@ staged-pipeline:
   label: Staged pipeline
   description: Articles about the six-stage runtime pipeline and the Knowledge Ladder decomposition.
 
+stage-3:
+  label: Stage 3 (extended schema)
+  description: Articles about Knowledge Ladder Stage 3 — the 33-label extended schema (PO box, unit, street affixes, intersections).
+
 resolver:
   label: Resolver / WOF
   description: Articles about the Who's On First gazetteer, concordance scoring, and resolver candidate ranking.
@@ -139,6 +143,14 @@ fr-fr:
 ja-jp:
   label: Japan (ja-JP)
   description: Articles discussing Japanese addressing — block-based numbering, no streets, chōme/banchi/gō, Phase 6 planning.
+
+japan:
+  label: Japan
+  description: Articles discussing Japanese addressing conventions — block numbering, chōme/banchi/gō, and the no-street grid.
+
+locale:
+  label: Locale-specific
+  description: Articles about locale-specific addressing conventions and the per-country rules that shape parsing.
 
 international:
   label: International


### PR DESCRIPTION
## Why

The `docs-build` workflow has been **failing on `main`** since 6f8ea75 (\"Format.\"). Root cause: MDX compile error in the v0.6.x retrospective — `<90%`, `<0.1ms`, `<100KB` were parsed as JSX tag opens (`Unexpected character 9 before name`).

## What

- **Fatal MDX fix:** wrapped the three `<digit` comparisons in inline code, matching the repo convention (e.g. `tokenizer-a1-results.md`). `< 90%` with a space is tolerated by MDX and left as-is.
- **Latent broken links** (the link-validation phase never ran in CI while compile aborted):
  - v0.6.2 eval doc linked `corpus-poisoning-vulnerability.md` → `TBD`; the doc now exists, pointed at `../concepts/`.
  - v0.6.3 eval doc linked a "to be written" retrospective that now exists, pointed at `../retrospectives/v0-6-x-cycle-retrospective.md`.
- **Tag warnings:** defined the three undefined blog tags (`japan`, `locale`, `stage-3`) additively in `blog/tags.yml` — no post frontmatter changes.

## Verification

Local `docusaurus build` is fully green: `[SUCCESS] Generated static files in "build"`. No MDX errors, no broken links, no tag warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)