### PR TITLE
chore(v0.7): postcode repair default-on + manifest refresh (operator-signed)

### DIFF
--- a/core/pipeline/runtime-pipeline.test.ts
+++ b/core/pipeline/runtime-pipeline.test.ts
@@ -108,7 +108,7 @@ describe("runPipeline — stage composition", () => {
 			computeQueryShape: () => shape,
 			classifier,
 		})
-		expect(classifier.parse).toHaveBeenCalledWith("10118", { queryShape: shape })
+		expect(classifier.parse).toHaveBeenCalledWith("10118", { queryShape: shape, postcodeRepair: true })
 	})
 
 	it("skips resolver when not wired", async () => {

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -342,7 +342,8 @@ async function safeClassify(
 	fst?: FstMatcherLike
 ): Promise<AddressTree> {
 	try {
-		return await classifier.parse(text, { queryShape, fst })
+		// Postcode regex repair on by default (v0.7 #35, operator-signed).
+		return await classifier.parse(text, { queryShape, fst, postcodeRepair: true })
 	} catch {
 		return { raw: text, roots: [] }
 	}

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -152,6 +152,8 @@ export interface ClassifierOpts {
 	queryShape?: QueryShapeLite
 	fst?: FstMatcherLike
 	fstBiasScale?: number
+	/** Run the deterministic postcode regex repair pass (v0.7 #35) on the decoded labels. */
+	postcodeRepair?: boolean
 }
 
 export interface AddressClassifier {

--- a/data/eval/golden/v0.1.2/MANIFEST.json
+++ b/data/eval/golden/v0.1.2/MANIFEST.json
@@ -8,12 +8,14 @@
 			"sha256": "90b4b61355bdc7283917940edc9fd75b53f0660e04251a20c5f8430525070742"
 		},
 		"fr.jsonl": {
-			"entries": 1545,
-			"sha256": "9c6609e0d7c56cbc4b337523f2e8dd211d9b4384ab7df8e6e14a90701a39a113"
+			"entries": 1551,
+			"sha256": "29d72dcd34ea2a576459b78be57ba3c0febd353d4b88bf801772ccdb415f46f6"
 		},
 		"us.jsonl": {
-			"entries": 2936,
-			"sha256": "fe9e4bb5cbd492b04ae5936fbbbef6d50b453f00bd0714208ce3d33b7d9ddef3"
+			"entries": 2956,
+			"sha256": "8cad55caed20e4998543e1bf09faf8da5d6dec8bcc9e4384805da760f950e50f"
 		}
-	}
+	},
+	"manifest_refreshed_at": "2026-05-29",
+	"manifest_refreshed_note": "Counts/shas re-synced to the current files (us/fr were expanded after the original 2026-05-18 promotion); promoted_at/from preserve the original provenance."
 }

--- a/neural/proposal-classifier.ts
+++ b/neural/proposal-classifier.ts
@@ -54,7 +54,9 @@ export function createNeuralProposalClassifier(cfg: NeuralProposalClassifierConf
 	const penalty = cfg.penalty ?? 0
 
 	async function classify(section: Section, _ctx: ClassifierContext): Promise<ClassificationProposal[]> {
-		const tree = await cfg.classifier.parse(section.body)
+		// Postcode regex repair on by default (v0.7 #35, operator-signed): +135/0 on the postcode
+		// harness, model-independent. Fixes the SentencePiece-fragmentation misses (GB/CA/NL/…).
+		const tree = await cfg.classifier.parse(section.body, { postcodeRepair: true })
 		const proposals: ClassificationProposal[] = []
 		const sectionOffset = section.start
 


### PR DESCRIPTION
Two operator-signed-off cleanups:
- **Postcode repair default-on** (#35): enabled in the proposal-classifier (default AddressParser) + runtime-pipeline safeClassify paths; `postcodeRepair` added to core `ClassifierOpts`. Smoke-validated (US postcodes extract, no regression). GB/CA/NL benefit lands when the default weights update to v0.6.0+ (the +135/0 was measured there; shipped default is older).
- **Manifest refresh**: golden v0.1.2 MANIFEST counts/shas re-synced to current files; provenance preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)