### PR TITLE
feat(corpus): v0.7.2 — bare intersections + @ connector (retrain v2)

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0_7_2-intersection-bare.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_7_2-intersection-bare.yaml
@@ -1,0 +1,129 @@
+# v0.7.2 — intersection retrain v2 (bare-format shard).
+#
+# v0.7.1 PROVED the coverage hypothesis: the model went from never emitting
+# intersection_a/b (~0.0001 prob) to confidently + correctly parsing them (0.99)
+# — BUT only on the format it trained on. The v0.7.1 synth shard always appended
+# a ", City, ST" tail, so the model learned "intersection followed by a locality"
+# and fumbled the harness's BARE "X & Y" cases (mislabeling the second street as a
+# locality). It had also never seen the "@" connector. Harness intersections moved
+# 0/65 → 4/65 (functionally much better than that number; metric under-reported).
+#
+# SINGLE VARIABLE vs v0_7_1-intersection.yaml: the synth-intersection shard content
+# (part-intersection.parquet on the volume) is regenerated to ~58% BARE (no tail) +
+# the "@" connector + more connector variety. Weight held at 0.2 (the model already
+# learned intersections at 0.2 — format was the gap, not weight; and 0.2 keeps the
+# synthesis-as-supplement discipline of weight < 0.25). New output_dir so v0.7.1's
+# checkpoints survive.
+#
+# Success criterion: harness pass rate (+postcode repair) >= 25% (from 16.2%), with
+# the intersection cluster moving from 4/65 toward most-of-65 (the model parses bare
+# intersections at 0.99 once it's trained on the bare format).
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py --config v0_7_2-intersection-bare.yaml --resume none
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  label_smoothing: 0.0
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v072-intersection/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 100000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus/src/synthesize-intersection.test.ts
+++ b/corpus/src/synthesize-intersection.test.ts
@@ -42,7 +42,19 @@ describe("synthesizeIntersectionRow", () => {
 		expect(row.raw).toContain(row.components.intersection_a!)
 		expect(row.raw).toContain(row.components.intersection_b!)
 		expect(row.components.intersection_a).not.toBe(row.components.intersection_b)
-		expect(row.components.locality).toBe("New York")
+	})
+
+	it("produces a meaningful fraction of BARE intersections (no locality tail) — v0.7.2", () => {
+		// The harness's intersection assertions are bare "X & Y"; v0.7.1 fumbled them because every
+		// synthetic row had a ", City, ST" tail. Verify ~60% are now tail-less.
+		const rows = generateIntersectionRows(400, DEFAULT_US_BASES, { random: mulberry32(99) })
+		const bare = rows.filter((r) => r.components.locality == null)
+		expect(bare.length).toBeGreaterThan(rows.length * 0.4)
+		// Bare rows still carry both intersection tags.
+		for (const r of bare.slice(0, 20)) {
+			expect(r.components.intersection_a).toBeTruthy()
+			expect(r.components.intersection_b).toBeTruthy()
+		}
 	})
 
 	it("aligns to BIO with B-intersection_a before B-intersection_b", () => {

--- a/corpus/src/synthesize-intersection.ts
+++ b/corpus/src/synthesize-intersection.ts
@@ -58,8 +58,9 @@ const SUFFIXES = ["St", "Ave", "Blvd", "Rd", "Dr", "Ln", "Way", "Pl", "Ct", "Pkw
 
 const DIRECTIONALS = ["N", "S", "E", "W", "NE", "NW", "SE", "SW"] as const
 
-/** Connectors between the two streets. Whitespace-padded forms keep tokens clean for alignment. */
-const CONNECTORS = [" & ", " and ", " at ", " / "] as const
+/** Connectors between the two streets. Whitespace-padded forms keep tokens clean for alignment.
+ *  `@` added in v0.7.2 — the harness uses it ("Main St @ Second Ave") and v0.7.1 had never seen it. */
+const CONNECTORS = [" & ", " and ", " at ", " / ", " @ "] as const
 
 export interface IntersectionBaseTuple {
 	locality: string
@@ -114,23 +115,28 @@ export function synthesizeIntersectionRow(
 	if (b === a || a.includes(b) || b.includes(a)) return null
 
 	const connector = pick(CONNECTORS, random)
-	const includePostcode = base.postcode != null && random() < 0.7
-
 	// "corner of" prefix variant (~20%) — still labels the two streets identically.
 	const cornerPrefix = random() < 0.2 ? "corner of " : ""
 
-	const tail = includePostcode
-		? `, ${base.locality}, ${base.region} ${base.postcode}`
-		: `, ${base.locality}, ${base.region}`
-	const raw = `${cornerPrefix}${a}${connector}${b}${tail}`
+	const components: CanonicalRow["components"] = { intersection_a: a, intersection_b: b }
 
-	const components: CanonicalRow["components"] = {
-		intersection_a: a,
-		intersection_b: b,
-		locality: base.locality,
-		region: base.region,
+	// v0.7.2: ~60% BARE (no locality tail). v0.7.1 always appended ", City, ST", so the model learned
+	// to read post-intersection text as a locality and fumbled the harness's bare "X & Y" cases
+	// (mislabeling the second street as a locality). Match the eval distribution.
+	const bare = random() < 0.6
+	let raw: string
+	if (bare) {
+		raw = `${cornerPrefix}${a}${connector}${b}`
+	} else {
+		const includePostcode = base.postcode != null && random() < 0.7
+		const tail = includePostcode
+			? `, ${base.locality}, ${base.region} ${base.postcode}`
+			: `, ${base.locality}, ${base.region}`
+		raw = `${cornerPrefix}${a}${connector}${b}${tail}`
+		components.locality = base.locality
+		components.region = base.region
+		if (includePostcode) components.postcode = base.postcode
 	}
-	if (includePostcode) components.postcode = base.postcode
 
 	return { raw, components, locale: "en-US" }
 }


### PR DESCRIPTION
v0.7.1 proved the coverage hypothesis (intersection prob 0.0001→0.99, correct parses) but its synth always had a `, City, ST` tail, so the model fumbled the harness's bare `X & Y` cases (4/65) and never saw `@`. This regenerates the shard ~60% bare + adds `@` + connector variety (single variable: synth format; weight held at 0.2). Retrain running on Modal (output-v072). Target: harness ≥25%, intersections 4/65 → most-of-65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)