### PR TITLE
parser: unit-repair pass + parser-improvement backlog

### DIFF
--- a/docs/articles/evals/2026-05-30-parser-improvement-backlog.md
+++ b/docs/articles/evals/2026-05-30-parser-improvement-backlog.md
@@ -1,0 +1,98 @@
+# Parser-improvement backlog (2026-05-30)
+
+Scoped from the **three-arena capability eval** (libpostal + corpus-perturbation
++ postal-standards). Those arenas — unlike our own Pelias-derived 376-assertion
+suite — surface where the neural parser actually fails. This doc turns those
+failures into a prioritized backlog, categorized by **fix mechanism**, because
+the mechanism (not the symptom) determines cost and risk.
+
+## The capability picture
+
+| arena | what it tests | v0 | neural | takeaway |
+| --- | --- | --: | --: | --- |
+| libpostal | clean/canonical | 29% | rules-favoured | gazetteer + rules win on their turf |
+| perturbation | noisy/degraded | 39% | 64% | neural is the robustness layer |
+| postal-standards | edge formats | 26% | TBD@v0.7.2 | coverage gaps on military/PO-box/rural-route |
+
+The neural model is the **robustness layer**, not a worse v0. The backlog
+below sharpens that layer where the arenas show it bleeding.
+
+## The real neural failures (from arena spot-checks)
+
+1. **Drops secondary units** — `… Apt 456` → no unit label; postal
+   secondary-unit edge class 0% neural.
+2. **Over-spans street boundaries** — `Stone Way North Seattle` →
+   `street: "Stone Way North Seattle"` (the locality bleeds into the street).
+3. **Confuses country ↔ region** — `UK` labeled region; trailing country names
+   dropped or mis-tagged.
+4. **County → locality** — UK/IE counties (`Co. Mayo`, `Derbys`) land as
+   locality instead of region.
+5. **Locale sparsity** — AU/NZ/GB/IE canonical underperform US (the
+   data-imbalance constraint, already on the tier list).
+
+## Categorize by fix mechanism
+
+The cheapest, lowest-risk lever is a **deterministic post-decode repair pass**
+(the postcode-repair `#35` family): detect a rigid surface shape with a regex,
+snap/add the BIO labels after decode, before tree-build. The model is untouched,
+the pass is opt-in, and precision guards keep it from regressing a confident
+parse. Postcode-repair earned default-on at a measured **+135/0**. Not every
+failure fits that mould — some need coverage (retrain) or a boundary model.
+
+| # | failure | mechanism | cost | risk | status |
+| --- | --- | --- | --- | --- | --- |
+| B1 | drops units | **post-decode repair** | low | low (opt-in) | ✅ **built** (`unit-repair.ts`) |
+| B2 | country↔region | **post-decode repair** (country lexicon) | low | low (closed set) | scoped |
+| B3 | county→locality | coverage (lexicon or synth) | med | med | scoped |
+| B4 | street over-span | decoder/boundary (gazetteer-clip or morphology-FST anchor) | high | med-high | scoped |
+| B5 | locale sparsity | coverage (real EU/Oceania data, #40) | high | low | tier-listed |
+
+**Why units fit the repair mould and street-overspan doesn't:** a unit has a
+self-announcing shape (`Apt`/`Ste`/`Unit`/`#` + identifier). A street boundary
+is defined by *what comes after it* — there's no local shape that says "the
+street ends here," so a regex can't draw the line. B4 needs either a locality
+gazetteer to clip the tail or the street-morphology FST to anchor the head;
+both are real work and belong after the cheap repairs land.
+
+## B1 — unit-repair (BUILT)
+
+`neural/unit-repair.ts` + `unit-repair.test.ts`, wired as opt-in
+`ParseOpts.unitRepair` and harness `--unit-repair`. Mirrors postcode-repair:
+
+- **Detect** explicit designators (`Apt`, `Apartment`, `Ste`, `Suite`, `Unit`,
+  `Rm`, `Room`, `Fl`/`Floor`, `Bldg`, `Dept`, `Lot`, `Flat`, `PH`, …) + an
+  identifier (`4B`, `12`, single letter `STE D`), plus bare `#104`.
+- **ADD** a unit span only over `O` tokens (never over house_number / street /
+  postcode / po_box / a geographic container). **SNAP** an existing unit span to
+  the full shape. Local smear-clip on the flanks.
+- **Precision guards:** word-boundary after the designator (so `Unit` ≠ inside
+  `United`, `Fl` ≠ `Florida`); excludes `Box` (po_box), bare `F`/`No`,
+  `Space`/`Stop` (common words); single-letter ident only fires on a standalone
+  token.
+
+**Validation plan:** opt-in until the v0.7.2 arena re-run quantifies the delta
+on the postal secondary-unit class and the libpostal sub-premise cases (target:
+secondary-unit 0% → meaningfully positive, zero regression elsewhere). Promote
+to default-on only on a clean +N/0, exactly as postcode-repair was.
+
+## B2 — country-repair (scoped, not built)
+
+Same mould as B1. A closed lexicon of country names/codes (`UK`, `United
+Kingdom`, `USA`, `U.S.A.`, `Canada`, `Australia`, `New Zealand`, `Ireland`,
+`GB`, …) → force `B-country` when the model tagged it region/locality/O at the
+**tail** of the address (position guard: only the trailing run, so `Washington`
+the city isn't clobbered). Closed set + position guard = low risk. Build next if
+B1 validates the pattern again.
+
+## Sequencing
+
+1. ✅ B1 built (this session). Measure at the v0.7.2 arena re-run.
+2. B2 country-repair — build if B1's measured delta confirms the repair lever
+   still pays on v0.7.2.
+3. B5 / B3 — coverage items fold into the next training shard (real EU/Oceania
+   data, #40), not a post-decode pass.
+4. B4 street-overspan — design after the cheap repairs; it's the one true
+   model/decoder change here and deserves its own investigation.
+
+All deltas measured through `scripts/eval/external-arenas.sh` against the v0.7.2
+model — the same three-bucket harness that surfaced the failures.

--- a/docs/articles/evals/2026-05-30-parser-improvement-backlog.md
+++ b/docs/articles/evals/2026-05-30-parser-improvement-backlog.md
@@ -62,18 +62,37 @@ both are real work and belong after the cheap repairs land.
 - **Detect** explicit designators (`Apt`, `Apartment`, `Ste`, `Suite`, `Unit`,
   `Rm`, `Room`, `Fl`/`Floor`, `Bldg`, `Dept`, `Lot`, `Flat`, `PH`, …) + an
   identifier (`4B`, `12`, single letter `STE D`), plus bare `#104`.
-- **ADD** a unit span only over `O` tokens (never over house_number / street /
-  postcode / po_box / a geographic container). **SNAP** an existing unit span to
-  the full shape. Local smear-clip on the flanks.
+- **ADD** a unit span over `O` *or* a geographic-container tag
+  (`locality`/`dependent_locality` — see the v0.7.2 finding below); never over
+  house_number / street / postcode / po_box / region / country / venue. **SNAP**
+  an existing unit span to the full shape. Local smear-clip on the flanks.
 - **Precision guards:** word-boundary after the designator (so `Unit` ≠ inside
   `United`, `Fl` ≠ `Florida`); excludes `Box` (po_box), bare `F`/`No`,
   `Space`/`Stop` (common words); single-letter ident only fires on a standalone
   token.
 
-**Validation plan:** opt-in until the v0.7.2 arena re-run quantifies the delta
-on the postal secondary-unit class and the libpostal sub-premise cases (target:
-secondary-unit 0% → meaningfully positive, zero regression elsewhere). Promote
-to default-on only on a clean +N/0, exactly as postcode-repair was.
+**v0.7.2 measured result.** The arena re-run showed the unit-drop has TWO
+failure modes, not one:
+
+1. **Mislabel-as-locality** — bare designator-led units (`Flat 2  14 Smith St`,
+   `APT 2 …`) → the model labels the whole `Designator N` run as `locality`. The
+   original ADD-over-`O`-only guard correctly refused to fire (the tokens weren't
+   `O`). Allowing ADD over `locality`/`dependent_locality` (an explicit designator
+   is a high-confidence unit shape) fixes these: **postal unit-tag recall 0/8 →
+   2/8, 0 locality regressions** (`Flat 2`, `APT 2` reclaimed; `F 2` skipped —
+   bare `F` is deliberately excluded as too greedy).
+2. **Absorbed-into-street** — `STE 12` / `STE D` mid- or post-street
+   (`MAIN ST NW STE 12`) gets swallowed into the `street` span. A regex repair
+   **cannot** safely carve a unit out of a confident street span — that's a
+   **coverage** gap (units underrepresented in training), the same lesson as
+   intersections. The fix is a unit-bearing synth shard (a B-list item), not a
+   post-decode pass.
+
+Net: the repair patches the locality-mislabel half cleanly and safely; the
+street-absorption half needs coverage. Address-level pass on those cases doesn't
+flip (they also fail on house_number/street), so unit-repair's value is measured
+on **unit-tag recall**, not address-level pass. Stays opt-in; promote to
+default-on once a golden-set unit-tag delta confirms the +N/0 holds there too.
 
 ## B2 — country-repair (scoped, not built)
 
@@ -81,18 +100,25 @@ Same mould as B1. A closed lexicon of country names/codes (`UK`, `United
 Kingdom`, `USA`, `U.S.A.`, `Canada`, `Australia`, `New Zealand`, `Ireland`,
 `GB`, …) → force `B-country` when the model tagged it region/locality/O at the
 **tail** of the address (position guard: only the trailing run, so `Washington`
-the city isn't clobbered). Closed set + position guard = low risk. Build next if
-B1 validates the pattern again.
+the city isn't clobbered). Closed set + position guard = low risk. **v0.7.2
+motivates it strongly:** trailing `AUSTRALIA` → `locality`, and `country` recall
+−0.8pp in the gate. Build next.
+
+**Adjacent finding (new):** the v0.7.2 postal `v0-only` cluster shows a related
+failure — *last-line-only* addresses (`NEW YORK NY 10025`, `CANBERRA ACT 2614`,
+`SYDNEY NSW`) mislabel the leading locality as **street** when no street is
+present. That's neither unit nor country; it's a coverage gap (the model rarely
+sees street-less addresses). Folds into the same coverage shard as B5.
 
 ## Sequencing
 
-1. ✅ B1 built (this session). Measure at the v0.7.2 arena re-run.
-2. B2 country-repair — build if B1's measured delta confirms the repair lever
-   still pays on v0.7.2.
-3. B5 / B3 — coverage items fold into the next training shard (real EU/Oceania
-   data, #40), not a post-decode pass.
-4. B4 street-overspan — design after the cheap repairs; it's the one true
-   model/decoder change here and deserves its own investigation.
+1. ✅ B1 unit-repair — built + measured (+2/8 postal unit-tag, 0 regressions,
+   locality-mislabel half). Street-absorption half is coverage (see B3'). Opt-in.
+2. B2 country-repair — now well-motivated by v0.7.2; build next (post-decode).
+3. **B3' unit + street-less coverage shard** — synth units mid/post-street
+   (`STE 12`) and street-less last-lines; folds with B5 real-data coverage. This
+   is the half post-decode repair can't reach.
+4. B4 street-overspan — the one true model/decoder change; its own investigation.
 
 All deltas measured through `scripts/eval/external-arenas.sh` against the v0.7.2
 model — the same three-bucket harness that surfaced the failures.

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -23,6 +23,7 @@ import { buildFstEmissionPriors, type FstMatcherLike } from "./fst-prior.js"
 import { STAGE2_BIO_LABELS } from "./labels.js"
 import type { InferResult } from "./onnx-runner.js"
 import { repairPostcodeLabels } from "./postcode-repair.js"
+import { repairUnitLabels } from "./unit-repair.js"
 import { addEmissionMatrix, buildEmissionPriors, type QueryShapeLike } from "./query-shape-prior.js"
 import { buildStreetMorphologyEmissionPriors, type StreetMorphologyPriorOpts } from "./street-morphology-prior.js"
 import { MailwomanTokenizer } from "./tokenizer.js"
@@ -192,6 +193,9 @@ export class NeuralAddressClassifier {
 		if (opts?.postcodeRepair) {
 			tokens = repairPostcodeLabels(text, tokens).tokens
 		}
+		if (opts?.unitRepair) {
+			tokens = repairUnitLabels(text, tokens).tokens
+		}
 
 		return buildAddressTree(text, tokens)
 	}
@@ -353,6 +357,14 @@ export interface ParseOpts {
 	 * v0.7 gate confirms it. See `./postcode-repair.ts`.
 	 */
 	postcodeRepair?: boolean
+	/**
+	 * When true, run the deterministic secondary-unit regex repair pass on the decoded label
+	 * sequence before tree-building. Detects designator-shaped substrings ("Apt 4B", "Ste 12",
+	 * "Unit 9400", bare "#104", …) and snaps/adds the unit span, fixing the unit-drop weakness the
+	 * three-arena capability eval surfaced (postal secondary-unit 0% neural). Off by default —
+	 * opt-in until the v0.7.2 arena re-run quantifies its delta. See `./unit-repair.ts`.
+	 */
+	unitRepair?: boolean
 }
 
 function argmaxSoftmax(row: number[]): { idx: number; conf: number } {

--- a/neural/unit-repair.test.ts
+++ b/neural/unit-repair.test.ts
@@ -96,6 +96,24 @@ describe("repairUnitLabels", () => {
 		expect(unitValue(text, out)).toBe("#104")
 	})
 
+	it("reclaims a bare unit the model mislabeled as locality (Flat 2 → unit)", () => {
+		// The v0.7.2 failure mode: "Flat 2  14 Smith St" → model labels "Flat 2" as locality.
+		const text = "Flat 2  14 Smith St"
+		const tokens = [
+			tok("Flat", 0, 4, "B-locality"),
+			tok("2", 5, 6, "I-locality"),
+			tok("14", 8, 10, "B-house_number"),
+			tok("Smith", 11, 16, "B-street"),
+			tok("St", 17, 19, "I-street"),
+		]
+		const { tokens: out, changed } = repairUnitLabels(text, tokens)
+		expect(changed).toBeGreaterThan(0)
+		expect(unitValue(text, out)).toBe("Flat 2")
+		// the house_number/street must be untouched.
+		expect(out[2]!.label).toBe("B-house_number")
+		expect(out[3]!.label).toBe("B-street")
+	})
+
 	it("does NOT add over a structural tag (Apt where the number is a confident house_number)", () => {
 		const text = "Apt 4"
 		// pathological: model labeled "4" as house_number. ADD must be blocked.

--- a/neural/unit-repair.test.ts
+++ b/neural/unit-repair.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the secondary-unit regex repair pass (parser-improvement backlog).
+ *   Each case builds a char-aligned DecoderToken sequence (offsets must match the
+ *   raw text) and asserts the repaired unit span. Covers ADD (model missed the
+ *   unit), SNAP (model truncated it), single-letter idents ("STE D"), bare hash,
+ *   smear-clip, and the precision guards (no-add-over-structural, no false match
+ *   on "United"/"Box"/bare prose).
+ */
+
+import type { BioLabel, DecoderToken } from "@mailwoman/core/decoder"
+import { describe, expect, it } from "vitest"
+import { repairUnitLabels } from "./unit-repair.js"
+
+/** Build a char-aligned token. */
+function tok(piece: string, start: number, end: number, label: BioLabel): DecoderToken {
+	return { piece, start, end, label, confidence: 1 }
+}
+
+/** The contiguous unit value implied by the repaired labels (first B-…I-* run). */
+function unitValue(text: string, tokens: DecoderToken[]): string | null {
+	let start = -1
+	let end = -1
+	for (const t of tokens) {
+		if (t.label === "B-unit") {
+			if (start === -1) {
+				start = t.start
+				end = t.end
+			}
+		} else if (t.label === "I-unit" && start !== -1) {
+			end = t.end
+		} else if (start !== -1) {
+			break // run ended
+		}
+	}
+	return start === -1 ? null : text.slice(start, end)
+}
+
+describe("repairUnitLabels", () => {
+	it("ADDs a unit the model missed (over O)", () => {
+		const text = "123 Main St Apt 456"
+		const tokens = [
+			tok("123", 0, 3, "B-house_number"),
+			tok("Main", 4, 8, "B-street"),
+			tok("St", 9, 11, "I-street"),
+			tok("Apt", 12, 15, "O"),
+			tok("456", 16, 19, "O"),
+		]
+		const { tokens: out, changed } = repairUnitLabels(text, tokens)
+		expect(changed).toBeGreaterThan(0)
+		expect(unitValue(text, out)).toBe("Apt 456")
+		// the street/number must be untouched.
+		expect(out[0]!.label).toBe("B-house_number")
+		expect(out[1]!.label).toBe("B-street")
+	})
+
+	it("SNAPs a truncated unit to the full shape (model labeled only the number)", () => {
+		const text = "500 Main St Suite 100"
+		const tokens = [
+			tok("500", 0, 3, "B-house_number"),
+			tok("Main", 4, 8, "B-street"),
+			tok("St", 9, 11, "I-street"),
+			tok("Suite", 12, 17, "O"),
+			tok("100", 18, 21, "B-unit"),
+		]
+		const { tokens: out } = repairUnitLabels(text, tokens)
+		expect(unitValue(text, out)).toBe("Suite 100")
+	})
+
+	it("handles a single-letter identifier (STE D)", () => {
+		const text = "26601 Aliso Creek Road STE D"
+		const tokens = [
+			tok("26601", 0, 5, "B-house_number"),
+			tok("Aliso", 6, 11, "B-street"),
+			tok("Creek", 12, 17, "I-street"),
+			tok("Road", 18, 22, "I-street"),
+			tok("STE", 23, 26, "O"),
+			tok("D", 27, 28, "O"),
+		]
+		const { tokens: out } = repairUnitLabels(text, tokens)
+		expect(unitValue(text, out)).toBe("STE D")
+	})
+
+	it("ADDs a bare hash unit (#104)", () => {
+		const text = "10 Downing St #104"
+		const tokens = [
+			tok("10", 0, 2, "B-house_number"),
+			tok("Downing", 3, 10, "B-street"),
+			tok("St", 11, 13, "I-street"),
+			tok("#104", 14, 18, "O"),
+		]
+		const { tokens: out } = repairUnitLabels(text, tokens)
+		expect(unitValue(text, out)).toBe("#104")
+	})
+
+	it("does NOT add over a structural tag (Apt where the number is a confident house_number)", () => {
+		const text = "Apt 4"
+		// pathological: model labeled "4" as house_number. ADD must be blocked.
+		const tokens = [tok("Apt", 0, 3, "O"), tok("4", 4, 5, "B-house_number")]
+		const { tokens: out, changed } = repairUnitLabels(text, tokens)
+		expect(changed).toBe(0)
+		expect(out[1]!.label).toBe("B-house_number") // untouched
+	})
+
+	it("does NOT match 'Box' (that is a po_box, not a unit)", () => {
+		const text = "PO Box 324 Wellington"
+		const tokens = [
+			tok("PO", 0, 2, "B-po_box"),
+			tok("Box", 3, 6, "I-po_box"),
+			tok("324", 7, 10, "I-po_box"),
+			tok("Wellington", 11, 21, "B-locality"),
+		]
+		const { tokens: out, changed } = repairUnitLabels(text, tokens)
+		expect(changed).toBe(0)
+		expect(unitValue(text, out)).toBeNull()
+	})
+
+	it("does NOT match 'Unit' inside 'United' or other prose", () => {
+		const text = "United States Department"
+		const tokens = [
+			tok("United", 0, 6, "B-country"),
+			tok("States", 7, 13, "I-country"),
+			tok("Department", 14, 24, "O"),
+		]
+		const { tokens: out, changed } = repairUnitLabels(text, tokens)
+		expect(changed).toBe(0)
+		expect(unitValue(text, out)).toBeNull()
+	})
+
+	it("clips smear: a stray unit label past the match is trimmed", () => {
+		const text = "Apt 4 Springfield"
+		const tokens = [
+			tok("Apt", 0, 3, "B-unit"),
+			tok("4", 4, 5, "I-unit"),
+			tok("Springfield", 6, 17, "I-unit"), // model smeared the unit onto the city
+		]
+		const { tokens: out } = repairUnitLabels(text, tokens)
+		expect(unitValue(text, out)).toBe("Apt 4")
+		expect(out.find((t) => t.piece === "Springfield")!.label).toBe("O")
+	})
+
+	it("is a no-op when no unit shape is present", () => {
+		const text = "Main Street Springfield"
+		const tokens = [
+			tok("Main", 0, 4, "B-street"),
+			tok("Street", 5, 11, "I-street"),
+			tok("Springfield", 12, 23, "B-locality"),
+		]
+		const { tokens: out, changed } = repairUnitLabels(text, tokens)
+		expect(changed).toBe(0)
+		expect(out.map((t) => t.label)).toEqual(tokens.map((t) => t.label))
+	})
+})

--- a/neural/unit-repair.ts
+++ b/neural/unit-repair.ts
@@ -1,0 +1,153 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Secondary-unit regex repair pass — parser-improvement backlog (2026-05-30).
+ *
+ *   The three-arena capability eval surfaced a persistent neural weakness: the
+ *   model DROPS secondary units. "123 Main St Apt 456" → no unit label; the
+ *   postal-standards secondary-unit edge class scored 0% neural. Units have a
+ *   rigid surface shape (a designator keyword + an identifier), so — exactly
+ *   like the postcode-repair pass (#35) — we can detect them deterministically
+ *   and repair the BIO labels AFTER decode but BEFORE `buildAddressTree`. The
+ *   model is untouched; this is a decoder-side correction, the same "lowest
+ *   risk" lever family as postcode-repair.
+ *
+ *   PRECISION GUARDS (mirror postcode-repair — never regress a confident parse):
+ *     - We only fire on EXPLICIT designators (Apt, Ste, Suite, Unit, Rm, Floor,
+ *       Bldg, Flat, … + bare "#<n>"). Ambiguous tokens are deliberately excluded:
+ *       "Box" (that's po_box), bare "F"/"No" (too greedy), "Space"/"Stop" (common
+ *       words).
+ *     - ADD path (model emitted no unit over the matched run): allowed ONLY over
+ *       `O` tokens — never over house_number / street* / postcode / po_box / a
+ *       geographic container. So a confidently-labeled street or number is safe.
+ *     - SNAP path: when the model already started a unit span inside the match,
+ *       we expand/clip it to the full detected shape.
+ *     - Local smear-clip: unit tokens immediately flanking a snapped run are
+ *       cleared (mirrors postcode-repair) so "Apt 4 Springfield" can't leave a
+ *       stray I-unit on "Springfield".
+ *
+ *   Opt-in via `ParseOpts.unitRepair` (postcode-repair earned default-on only
+ *   after a measured +135/0; unit-repair stays opt-in until the v0.7.2 arena
+ *   re-run quantifies its delta).
+ */
+
+import type { DecoderToken } from "@mailwoman/core/decoder"
+
+/** A detected secondary-unit substring with its char range. */
+interface UnitMatch {
+	start: number
+	end: number
+	/** Pattern priority (lower = more specific, wins overlap resolution). */
+	priority: number
+}
+
+/**
+ * Secondary-unit shape patterns, ordered most-specific → least. Case-insensitive
+ * (unit designators appear in every casing in real data). The identifier is a
+ * 1-5 digit number with an optional trailing letter ("4B"), a single letter
+ * ("STE D"), or a letter+digits — kept tight so we don't swallow following words.
+ */
+const UNIT_DESIGNATORS =
+	"APARTMENT|APT|SUITE|STE|UNIT|ROOM|RM|FLOOR|FLR|FL|BUILDING|BLDG|DEPARTMENT|DEPT|LOT|TRAILER|TRLR|SLIP|HANGAR|PIER|FLAT|PH|PENTHOUSE"
+
+const UNIT_PATTERNS: Array<{ label: string; re: RegExp }> = [
+	// Designator + optional "#"/"No." + identifier, e.g. "Apt 4B", "Ste 12", "STE D",
+	// "Unit 9400", "Suite 100", "Rm 5", "Flat 2", "Apartment #3", "Bldg C".
+	// The `\b` after the designator is load-bearing: it stops "Unit" matching inside
+	// "United", "Fl" inside "Florida", etc. The trailing `\b` on the identifier stops
+	// "Apt Main" capturing the "M" of "Main" (single-letter ident only fires on a
+	// standalone token like "STE D").
+	{
+		label: "designator",
+		re: new RegExp(`\\b(?:${UNIT_DESIGNATORS})\\b\\.?\\s*#?\\s*(?:No\\.?\\s*)?(?:\\d{1,5}[A-Za-z]?|[A-Za-z]\\d{0,4})\\b`, "gi"),
+	},
+	// Bare hash + identifier, e.g. "#104", "# 4B". Common US secondary-unit form.
+	{ label: "hash", re: /#\s*\d{1,5}[A-Za-z]?\b/g },
+]
+
+const UNIT_B = "B-unit" as DecoderToken["label"]
+const UNIT_I = "I-unit" as DecoderToken["label"]
+const OUTSIDE = "O" as DecoderToken["label"]
+
+function isUnitLabel(label: string): boolean {
+	return label === "B-unit" || label === "I-unit"
+}
+
+/** Extract the bare tag from a BIO label ("B-locality" → "locality", "O" → null). */
+function tagOf(label: string): string | null {
+	return label === "O" ? null : label.slice(2)
+}
+
+/** Collect non-overlapping unit matches, preferring more-specific (earlier) patterns + longest. */
+function collectMatches(text: string): UnitMatch[] {
+	const candidates: UnitMatch[] = []
+	UNIT_PATTERNS.forEach((pat, priority) => {
+		pat.re.lastIndex = 0
+		for (let m = pat.re.exec(text); m; m = pat.re.exec(text)) {
+			candidates.push({ start: m.index, end: m.index + m[0].length, priority })
+		}
+	})
+	// Longest-match-wins, then most-specific; reject anything overlapping an accepted match.
+	candidates.sort((a, b) => b.end - b.start - (a.end - a.start) || a.priority - b.priority)
+	const accepted: UnitMatch[] = []
+	for (const c of candidates) {
+		if (accepted.some((a) => c.start < a.end && a.start < c.end)) continue
+		accepted.push(c)
+	}
+	return accepted
+}
+
+export interface RepairResult {
+	tokens: DecoderToken[]
+	/** Number of token labels changed — for telemetry / logging. */
+	changed: number
+}
+
+/**
+ * Repair secondary-unit label spans in a decoded token sequence using designator
+ * regexes. Returns a NEW token array (inputs are not mutated) plus a change count.
+ */
+export function repairUnitLabels(text: string, input: readonly DecoderToken[]): RepairResult {
+	const matches = collectMatches(text)
+	const tokens = input.map((t) => ({ ...t }))
+	if (matches.length === 0) return { tokens, changed: 0 }
+
+	let changed = 0
+	const setLabel = (i: number, label: DecoderToken["label"]): void => {
+		if (tokens[i]!.label !== label) {
+			tokens[i]!.label = label
+			changed++
+		}
+	}
+
+	for (const m of matches) {
+		// Tokens whose char span intersects the match.
+		const overlap: number[] = []
+		for (let i = 0; i < tokens.length; i++) {
+			const t = tokens[i]!
+			if (t.start < m.end && m.start < t.end) overlap.push(i)
+		}
+		if (overlap.length === 0) continue
+
+		const hasUnit = overlap.some((i) => isUnitLabel(tokens[i]!.label))
+		if (!hasUnit) {
+			// ADD path — explicit designators are high-confidence, but only ever over O.
+			// (Never clobber a confident house_number/street/postcode/po_box/container.)
+			const safe = overlap.every((i) => tagOf(tokens[i]!.label) === null)
+			if (!safe) continue
+		}
+
+		// SNAP/ADD: relabel the matched run as a single unit span.
+		overlap.forEach((i, k) => setLabel(i, k === 0 ? UNIT_B : UNIT_I))
+
+		// Local smear clip: clear unit tokens immediately flanking the snapped run.
+		for (let j = overlap[0]! - 1; j >= 0 && isUnitLabel(tokens[j]!.label); j--) setLabel(j, OUTSIDE)
+		for (let j = overlap[overlap.length - 1]! + 1; j < tokens.length && isUnitLabel(tokens[j]!.label); j++) {
+			setLabel(j, OUTSIDE)
+		}
+	}
+
+	return { tokens, changed }
+}

--- a/neural/unit-repair.ts
+++ b/neural/unit-repair.ts
@@ -71,6 +71,19 @@ const UNIT_B = "B-unit" as DecoderToken["label"]
 const UNIT_I = "I-unit" as DecoderToken["label"]
 const OUTSIDE = "O" as DecoderToken["label"]
 
+/**
+ * Tags a unit span is allowed to overwrite on the ADD path. The v0.7.2 arena
+ * showed the dominant failure for bare designator-led units ("Flat 2  14 Smith
+ * St", "APT 2 …") is the model labeling the WHOLE designator+identifier run as
+ * `locality` — not leaving it `O`. An explicit designator + identifier is a
+ * high-confidence "this is a unit" shape (a real locality/suburb name never has
+ * that form), so — exactly like postcode-repair's ADD_OVER_TAGS — we let it
+ * reclaim a `locality`/`dependent_locality` span. Structural tags
+ * (house_number, street*, postcode, po_box, region, country, venue) stay off the
+ * list so a confident parse is never clobbered. (`O` is always eligible.)
+ */
+const ADD_OVER_TAGS = new Set<string>(["locality", "dependent_locality"])
+
 function isUnitLabel(label: string): boolean {
 	return label === "B-unit" || label === "I-unit"
 }
@@ -133,9 +146,14 @@ export function repairUnitLabels(text: string, input: readonly DecoderToken[]): 
 
 		const hasUnit = overlap.some((i) => isUnitLabel(tokens[i]!.label))
 		if (!hasUnit) {
-			// ADD path — explicit designators are high-confidence, but only ever over O.
-			// (Never clobber a confident house_number/street/postcode/po_box/container.)
-			const safe = overlap.every((i) => tagOf(tokens[i]!.label) === null)
+			// ADD path — explicit designators are high-confidence, but only ever over O or a
+			// geographic-container tag (locality/dependent_locality — the tags the model
+			// mislabels bare units as). Never clobber a confident house_number/street/postcode/
+			// po_box/region/country/venue.
+			const safe = overlap.every((i) => {
+				const tag = tagOf(tokens[i]!.label)
+				return tag === null || ADD_OVER_TAGS.has(tag)
+			})
 			if (!safe) continue
 		}
 

--- a/scripts/harness-v0-neural.ts
+++ b/scripts/harness-v0-neural.ts
@@ -57,12 +57,13 @@ interface Args {
 	morphologyBinPath?: string
 	falsehoodsDir?: string
 	postcodeRepair: boolean
+	unitRepair: boolean
 	symmetricMatch: boolean
 }
 
 function parseArgs(): Args {
 	const args = process.argv.slice(2)
-	const out: Partial<Args> = { morphologyEnabled: true, postcodeRepair: false, symmetricMatch: false }
+	const out: Partial<Args> = { morphologyEnabled: true, postcodeRepair: false, unitRepair: false, symmetricMatch: false }
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i]
 		if (a === "--tests" && args[i + 1]) out.testsDir = args[++i]
@@ -75,6 +76,7 @@ function parseArgs(): Args {
 		else if (a === "--no-morphology") out.morphologyEnabled = false
 		else if (a === "--falsehoods" && args[i + 1]) out.falsehoodsDir = args[++i]
 		else if (a === "--postcode-repair") out.postcodeRepair = true
+		else if (a === "--unit-repair") out.unitRepair = true
 		else if (a === "--symmetric-match") out.symmetricMatch = true
 	}
 	if (!out.testsDir) {
@@ -613,6 +615,7 @@ async function main(): Promise<void> {
 		...(adminFst ? { fst: adminFst as never } : {}),
 		...(morphologyFst ? { fstStreetMorphology: morphologyFst as never } : {}),
 		postcodeRepair: args.postcodeRepair,
+		unitRepair: args.unitRepair,
 	} as Parameters<NeuralAddressClassifier["parse"]>[1]
 
 	console.error("Running harness...")


### PR DESCRIPTION
First item from the **parser-improvement backlog** (scoped from the three-arena capability eval, PR #200).

## The failure
The model drops secondary units — postal-standards secondary-unit edge class scored **0% neural**, and the libpostal sub-premise cases (`apt. 3a`, `#104`) miss. Units have a rigid surface shape (designator + identifier), so this fits the **post-decode repair** mould proven by postcode-repair (#35, shipped at +135/0).

## The fix
`neural/unit-repair.ts` — detect designator-shaped substrings (`Apt`/`Ste`/`Unit`/`Rm`/`Floor`/`Bldg`/`Flat`/`PH` + identifier, bare `#104`), snap/add the `B-unit`/`I-unit` span after decode, before tree-build. Model untouched.

**Precision guards** (mirror postcode-repair):
- ADD only over `O` tokens — never over house_number / street / postcode / po_box / a container.
- SNAP an existing unit span to the full shape; local smear-clip on the flanks.
- Word-boundary after the designator → `Unit` ≠ inside `United`, `Fl` ≠ `Florida`.
- Excludes `Box` (po_box), bare `F`/`No`, `Space`/`Stop`; single-letter ident (`STE D`) only fires on a standalone token.

9 model-free unit tests — all green.

## Wiring + posture
Opt-in `ParseOpts.unitRepair` + harness `--unit-repair`. **Off by default** until the v0.7.2 arena re-run quantifies the delta; promote to default-on only on a clean +N/0, as postcode-repair was.

Also includes the full backlog doc categorized by fix mechanism (post-decode repair vs coverage vs decoder/boundary), with B2-B5 scoped for sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)