### PR TITLE
fix(docs): escape bare brace in plan doc — fixes red Docs build on main

### DIFF
--- a/docs/articles/plan/2026-05-30-resolver-routing-plan.md
+++ b/docs/articles/plan/2026-05-30-resolver-routing-plan.md
@@ -85,7 +85,7 @@ for every v0-involving baseline.
    retrain on decay.
 
 **Follow-on (parallel, droppable):** OpenAddresses eval track (~10k real US
-{address, lat/lon} points) → independent great-circle coordinate-error number
+`{address, lat/lon}` points) → independent great-circle coordinate-error number
 for external credibility. Not on the gate's critical path.
 
 ## First PR scope (Phase 1, steps 1–2)


### PR DESCRIPTION
Line 88 of the Direction-C plan doc (merged via #203) has a bare `{address, lat/lon}` — MDX parses `{...}` as a JSX expression, breaking the Docusaurus SSG build for that page. main's Docs CI has been red since #203. Wrapping the brace in inline code fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)