### PR TITLE
feat(train): optional Trackio experiment tracking → HF Space dashboard

### DIFF
--- a/corpus-python/pyproject.toml
+++ b/corpus-python/pyproject.toml
@@ -31,6 +31,9 @@ train = [
     "onnx>=1.16",
     "onnxruntime>=1.18",
     "tqdm>=4.66",
+    # Optional experiment tracking. Logging is best-effort and guarded at runtime
+    # (see mailwoman_train/trackio_logging.py) so its absence never breaks a train run.
+    "trackio",
 ]
 
 [build-system]

--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -120,6 +120,24 @@ class TrainConfig:
     # smoke window masks divergence by collapsing LR before the loss curve shows it; the
     # constant-LR mode keeps the signal visible. See the ref doc for when to pick which.
     lr_schedule: str = "cosine"
+    # Trackio experiment tracking (Hugging Face). Off by default so existing configs and
+    # plain/CI runs stay bit-identical and never depend on the optional 'trackio' package.
+    # When enabled, the metrics written to train_log.csv are also streamed to a Trackio
+    # project (see trackio_logging.py). All tracking is best-effort: a failure degrades to
+    # CSV-only and never aborts the run.
+    trackio_enabled: bool = False
+    trackio_project: str = "mailwoman"
+    # HF Space id for the hosted dashboard, e.g. "sister-software/mailwoman-trackio".
+    # The Space is auto-created on first run if it doesn't exist. Empty = local-only
+    # dashboard (~/.cache/huggingface/trackio), no HF upload.
+    trackio_space: str = ""
+    # Optional human-readable run name. Empty = derive a stable name from output_dir so
+    # a resumed run (resume="auto") continues the same dashboard run instead of forking.
+    trackio_run_name: str = ""
+    # Make the dashboard Space private (visible to org members only). Defaults True so
+    # in-progress training metrics aren't published publicly by accident. Ignored if the
+    # Space already exists.
+    trackio_private: bool = True
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/trackio_logging.py
+++ b/corpus-python/src/mailwoman_train/trackio_logging.py
@@ -1,0 +1,153 @@
+"""Optional Trackio experiment-tracking shim for the Phase 2 training loop.
+
+Trackio (https://huggingface.co/docs/trackio) is a lightweight, ``wandb``-compatible
+experiment tracker. We mirror the metrics already written to ``train_log.csv`` into a
+Trackio project so training curves and cross-version eval metrics show up on a
+self-hosted Hugging Face Space dashboard (free CPU-basic tier) instead of only living
+in a CSV. With ``space_id`` set, Trackio deploys/syncs the dashboard Space and persists
+every run to a backing HF Dataset; with no ``space_id`` it logs to a local dashboard
+(``~/.cache/huggingface/trackio``).
+
+Design rule — tracking must NEVER crash training. An A100 run costs real money and the
+night-shift workflow runs unattended; a metrics upload that 401s, a missing package, or
+an API drift must degrade to CSV-only, not take the run down with it. So:
+
+  * the whole thing no-ops when ``cfg.train.trackio_enabled`` is False (the default), or
+    when the ``trackio`` package isn't installed (plain tokenizer-only installs don't
+    pull it in — see corpus-python/pyproject.toml ``[train]`` extra);
+  * ``init`` failures fall back to a null tracker (CSV-only);
+  * every ``log``/``finish`` call swallows exceptions behind a one-line warning.
+
+Auth: Trackio uploads to the Space using the HF cached login or ``HF_TOKEN``. On Modal,
+``HF_TOKEN`` is injected via the ``hf_secret`` in scripts/modal/train_remote.py; locally
+it uses your ``hf auth login`` token. No token -> Space upload fails -> CSV-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class _NullTracker:
+    """No-op tracker. Returned when tracking is disabled or unavailable."""
+
+    enabled = False
+
+    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:  # noqa: D102
+        pass
+
+    def finish(self) -> None:  # noqa: D102
+        pass
+
+
+class _TrackioTracker:
+    """Thin best-effort wrapper around the ``trackio`` module. Never raises."""
+
+    enabled = True
+
+    def __init__(self, trackio_mod: Any) -> None:
+        self._trackio = trackio_mod
+
+    def log(self, metrics: dict[str, Any], step: int | None = None) -> None:
+        try:
+            if step is None:
+                self._trackio.log(metrics)
+            else:
+                # ``step`` is part of the wandb-compatible surface, but guard against an
+                # API that doesn't accept it by folding step into the payload instead.
+                try:
+                    self._trackio.log(metrics, step=step)
+                except TypeError:
+                    self._trackio.log({**metrics, "step": step})
+        except Exception as exc:  # logging must never kill training
+            print(f"  [trackio] log failed (ignored): {exc}")
+
+    def finish(self) -> None:
+        try:
+            self._trackio.finish()
+        except Exception as exc:
+            print(f"  [trackio] finish failed (ignored): {exc}")
+
+
+def init_tracker(cfg: Any) -> _NullTracker | _TrackioTracker:
+    """Initialize Trackio for this run, or return a no-op tracker.
+
+    Reads ``cfg.train.trackio_enabled`` / ``trackio_project`` / ``trackio_space`` /
+    ``trackio_run_name``. Returns a tracker whose ``.log()`` / ``.finish()`` are safe to
+    call unconditionally from the training loop.
+    """
+    tcfg = cfg.train
+    if not getattr(tcfg, "trackio_enabled", False):
+        return _NullTracker()
+
+    try:
+        import trackio
+    except ImportError:
+        print("  [trackio] trackio_enabled=True but the 'trackio' package isn't installed "
+              "— logging to CSV only. (pip install trackio)")
+        return _NullTracker()
+
+    init_kwargs: dict[str, Any] = {"project": getattr(tcfg, "trackio_project", "mailwoman")}
+    space_id = getattr(tcfg, "trackio_space", "")
+    if space_id:
+        init_kwargs["space_id"] = space_id
+        # Honor the private flag only on Space-backed runs (ignored if the Space exists).
+        init_kwargs["private"] = bool(getattr(tcfg, "trackio_private", True))
+    # Stable run name (explicit, else derived from output_dir) + resume="allow" so a
+    # restart-on-hang continues the same run rather than forking a new dashboard line.
+    init_kwargs["name"] = getattr(tcfg, "trackio_run_name", "") or _default_run_name(
+        getattr(tcfg, "output_dir", "")
+    )
+    init_kwargs["resume"] = "allow"
+    init_kwargs["config"] = _run_config(cfg)
+
+    try:
+        trackio.init(**init_kwargs)
+    except Exception as exc:
+        print(f"  [trackio] init failed (ignored, logging to CSV only): {exc}")
+        return _NullTracker()
+
+    print(f"  [trackio] tracking run -> project={init_kwargs['project']} "
+          f"space={space_id or '(local dashboard)'}")
+    return _TrackioTracker(trackio)
+
+
+def _default_run_name(output_dir: str) -> str:
+    """Derive a stable run name from the output dir so resumes continue the same run.
+
+    ``/data/output-v072/checkpoints`` -> ``output-v072`` (the bare ``checkpoints`` leaf
+    isn't distinctive, so fall back to its parent).
+    """
+    import os
+
+    base = os.path.basename(output_dir.rstrip("/"))
+    if base in ("", "checkpoints"):
+        base = os.path.basename(os.path.dirname(output_dir.rstrip("/")))
+    return base or "run"
+
+
+def _run_config(cfg: Any) -> dict[str, Any]:
+    """A flat, comparison-relevant snapshot of the run's hyperparameters.
+
+    Kept to flat scalars (rather than ``asdict`` of the whole nested Config) so it renders
+    cleanly as filterable columns in the Trackio dashboard — these are the knobs we
+    actually sweep between model versions.
+    """
+    t, m, d = cfg.train, cfg.model, cfg.data
+    return {
+        "max_steps": t.max_steps,
+        "batch_size": t.batch_size,
+        "learning_rate": t.learning_rate,
+        "lr_schedule": getattr(t, "lr_schedule", "cosine"),
+        "warmup_steps": t.warmup_steps,
+        "precision": t.precision,
+        "grad_clip_norm": getattr(t, "grad_clip_norm", 0.0),
+        "label_smoothing": m.label_smoothing,
+        "use_crf": m.use_crf,
+        "crf_loss_weight": m.crf_loss_weight,
+        "crf_normalization": getattr(m, "crf_normalization", "per_sequence"),
+        "hidden_size": m.hidden_size,
+        "num_hidden_layers": m.num_hidden_layers,
+        "corpus_dir": d.corpus_dir,
+        "tokenizer_dir": d.tokenizer_dir,
+    }

--- a/corpus-python/src/mailwoman_train/train.py
+++ b/corpus-python/src/mailwoman_train/train.py
@@ -298,6 +298,12 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
             ]
         )
 
+    # Optional Trackio mirror of the CSV metrics (no-op unless cfg.train.trackio_enabled).
+    # Defined before the try/ below so the finally block can always call tracker.finish().
+    from .trackio_logging import init_tracker
+
+    tracker = init_tracker(cfg)
+
     step = resume_step
     micro_step = 0
     started = time.time()
@@ -363,6 +369,7 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
                     )
                     csv_writer.writerow([step, f"{elapsed:.1f}", f"{avg:.6f}", f"{lr:.8f}", "", ""] + [""] * len(per_tag_cols))
                     csv_fh.flush()
+                    tracker.log({"train_loss": avg, "lr": lr, "wall_seconds": elapsed}, step=step)
 
                 if step % cfg.train.eval_every_steps == 0:
                     val = _eval_val(cfg, tokenizer, model, device, max_rows=cfg.data.val_rows)
@@ -389,6 +396,14 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
                         ]
                     )
                     csv_fh.flush()
+                    eval_metrics: dict[str, float] = {
+                        "val_loss": float(val.get("val_loss", float("nan"))),
+                        "val_macro_f1": float(val.get("macro_f1", 0.0)),
+                        "wall_seconds": elapsed,
+                    }
+                    for tag in ACTIVE_TAGS:
+                        eval_metrics[f"f1.{tag}"] = float(val.get(f"f1_tag.{tag}", 0.0))
+                    tracker.log(eval_metrics, step=step)
 
                 if step % cfg.train.save_every_steps == 0:
                     extras = {
@@ -417,3 +432,4 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
         save_checkpoint(model, output_dir, step, extras, optim=optim, scheduler=scheduler)
     finally:
         csv_fh.close()
+        tracker.finish()

--- a/scripts/modal/train_remote.py
+++ b/scripts/modal/train_remote.py
@@ -48,6 +48,9 @@ training_image = (
         "onnxruntime>=1.18",
         "onnxscript>=0.1",
         "tqdm>=4.66",
+        # Optional experiment tracking — streamed to a Hugging Face Space dashboard when
+        # the run config sets train.trackio_enabled (best-effort, see trackio_logging.py).
+        "trackio",
     )
 )
 
@@ -73,6 +76,31 @@ def _load_r2_env() -> dict[str, str]:
     return env
 
 r2_secret = modal.Secret.from_dict(_load_r2_env())
+
+
+# HF token for Trackio's Hugging Face Space upload. Reads HF_TOKEN (or the
+# HUGGING_FACE_HUB_TOKEN alias) from the local .env at deploy time, falling back to
+# os.environ. Empty when unset — Trackio logging then degrades to CSV-only (the upload
+# 401s and trackio_logging.py swallows it), so a token is only needed to push the
+# dashboard to a Space.
+def _load_hf_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    env_file = os.path.join(os.path.dirname(__file__), "..", "..", ".env")
+    if os.path.isfile(env_file):
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    key, _, val = line.partition("=")
+                    if key in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"):
+                        env[key] = val
+    for key in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"):
+        if key in os.environ:
+            env[key] = os.environ[key]
+    return env
+
+
+hf_secret = modal.Secret.from_dict(_load_hf_env())
 
 BUCKET = "mailwoman-assets"
 VOL_MOUNT = "/data"
@@ -128,6 +156,7 @@ def sync_corpus():
 @app.function(
     image=training_image,
     volumes={VOL_MOUNT: vol},
+    secrets=[hf_secret],  # HF_TOKEN for optional Trackio Space upload (empty/no-op when unset)
     gpu="A100",
     timeout=14400,  # 4h max (training should take ~1h)
     memory=32768,  # 32GB RAM
@@ -135,8 +164,15 @@ def sync_corpus():
 def train(
     config_name: str = "v0_5_0-classifier-ce-only-full.yaml",
     resume: str = "auto",
+    trackio: bool = False,
+    trackio_space: str = "",
 ):
-    """Run the CE-only classifier training on an A100."""
+    """Run the CE-only classifier training on an A100.
+
+    Pass ``--trackio`` (and optionally ``--trackio-space org/space``) to mirror metrics
+    to a Hugging Face Space dashboard. These override the YAML config's trackio fields;
+    omit them to honor whatever the config sets (default: tracking off).
+    """
     import sys
     import torch
 
@@ -179,6 +215,14 @@ def train(
     cfg = Config()
     _merge(cfg, yaml.safe_load(open(config_path)))
 
+    # CLI overrides for experiment tracking (take precedence over the YAML config).
+    if trackio:
+        cfg.train.trackio_enabled = True
+    if trackio_space:
+        cfg.train.trackio_space = trackio_space
+    if cfg.train.trackio_enabled:
+        print(f"Trackio: enabled (space={cfg.train.trackio_space or '(local)'})")
+
     # Use config's output_dir if it has one, otherwise default
     run_output = cfg.train.output_dir if cfg.train.output_dir.startswith("/data/") else f"{OUTPUT_DIR}/checkpoints"
     run_base = os.path.dirname(run_output)
@@ -212,13 +256,17 @@ def main(
     sync: bool = False,
     config: str = "v0_5_0-classifier-ce-only-full.yaml",
     resume: str = "auto",
+    trackio: bool = False,
+    trackio_space: str = "",
 ):
     """
     Run the mailwoman training pipeline on Modal.
 
-    --sync     Pull corpus from R2 first (only needed once)
-    --config   Training config YAML filename
-    --resume   Resume mode: 'auto' (find latest checkpoint) or 'none'
+    --sync           Pull corpus from R2 first (only needed once)
+    --config         Training config YAML filename
+    --resume         Resume mode: 'auto' (find latest checkpoint) or 'none'
+    --trackio        Mirror metrics to a Hugging Face Space dashboard (Trackio)
+    --trackio-space  HF Space id for the dashboard, e.g. sister-software/mailwoman-trackio
     """
     if sync:
         print("Syncing corpus from R2 into Modal volume...")
@@ -228,8 +276,8 @@ def main(
         print(f"  modal run scripts/modal/train_remote.py --config {config}")
         return
 
-    print(f"Training with config={config}, resume={resume}...")
-    train.remote(config_name=config, resume=resume)
+    print(f"Training with config={config}, resume={resume}, trackio={trackio}...")
+    train.remote(config_name=config, resume=resume, trackio=trackio, trackio_space=trackio_space)
     print("\nTraining complete!")
     print(f"\nDownload results with:\n  modal volume get mailwoman-training /output/ ./output/")
 


### PR DESCRIPTION
## Summary
Optional **Trackio** experiment tracking that mirrors `train_log.csv` metrics to a self-hosted Hugging Face Space dashboard (free CPU tier) — training curves + per-tag eval F1, with cross-run comparison across model versions. **Off by default**; the CSV path is unchanged.

## What changed
- **`trackio_logging.py`** (new): best-effort shim. Logging must never crash training — no-ops when disabled or when the `trackio` package is absent; `init`/`log`/`finish` swallow errors behind a one-line warning.
- **`config.py`**: `trackio_{enabled,project,space,run_name,private}` on `TrainConfig` (all off/safe by default).
- **`train.py`**: `init_tracker()` before the loop + a `tracker.log()` beside each existing CSV write (train-loss/lr and per-tag eval F1) + `tracker.finish()` in the `finally`.
- **`train_remote.py`**: `trackio` added to the Modal image; `HF_TOKEN` secret wired to `train()`; `--trackio` / `--trackio-space` CLI flags (override the YAML config).
- **`pyproject.toml`**: `trackio` in the `[train]` extra.

## Behavior
- Stable run name derived from `output_dir` + `resume="allow"` → a restart-on-hang continues the **same** dashboard run instead of forking a new line.
- Space defaults **private**.
- Verified: `py_compile` clean on all files; disabled + missing-package paths no-op gracefully; the Trackio API used (`init`/`log`/`finish`, `space_id`, `private`, `step`) was matched against the v0.26 reference.

## ⚠️ Deploy note
Modal pulls training code from the R2-synced volume (`sys.path` → `/data/corpus-python/src`), so `train.py` / `config.py` / `trackio_logging.py` must be synced to R2 + `sync_corpus` (or `modal volume put`) before a run picks them up. The image `pip_install` (trackio) is repo-driven and applies on the next `modal run`.

## Usage
```
modal run scripts/modal/train_remote.py --trackio --trackio-space sister-software/mailwoman-trackio --config <cfg>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
