### PR TITLE
feat(decoder): AddressTree.system + per-system containment indirection

### DIFF
--- a/core/decoder/build-tree.ts
+++ b/core/decoder/build-tree.ts
@@ -22,8 +22,8 @@
  */
 
 import type { BioLabel, ComponentTag } from "../types/component.js"
-import { PARENT_OF } from "./containment.js"
-import type { AddressNode, AddressTree, DecoderToken } from "./types.js"
+import { containmentFor } from "./containment.js"
+import type { AddressNode, AddressSystem, AddressTree, DecoderToken } from "./types.js"
 
 /**
  * Optional caller-supplied attribution stamped on every emitted node. The BIO stream comes from a
@@ -34,6 +34,13 @@ import type { AddressNode, AddressTree, DecoderToken } from "./types.js"
 export interface BuildTreeOpts {
 	source?: string
 	sourceId?: string
+	/**
+	 * Addressing system to decode under — selects the containment hierarchy via `containmentFor`.
+	 * Stamped onto the returned `AddressTree.system`. Omit for the default Western hierarchy. Today
+	 * all systems share one map, so this only records intent + threads the discriminator; it becomes
+	 * behavioral when a system-specific map lands (Phase 6 JP). See `containment.ts`.
+	 */
+	system?: AddressSystem
 }
 
 interface OpenSpan {
@@ -111,8 +118,12 @@ function distance(a: AddressNode, b: AddressNode): number {
 	return 0
 }
 
-function findParent(span: AddressNode, all: AddressNode[]): AddressNode | null {
-	const candidates = PARENT_OF[span.tag] ?? []
+function findParent(
+	span: AddressNode,
+	all: AddressNode[],
+	parentOf: Partial<Record<ComponentTag, ComponentTag[]>>
+): AddressNode | null {
+	const candidates = parentOf[span.tag] ?? []
 	for (const parentTag of candidates) {
 		const matches = all.filter((s) => s !== span && s.tag === parentTag)
 		if (matches.length === 0) continue
@@ -138,13 +149,16 @@ function sortByStart(nodes: AddressNode[]): void {
 export function buildAddressTree(raw: string, tokens: DecoderToken[], opts: BuildTreeOpts = {}): AddressTree {
 	const spans = emitSpans(raw, tokens, opts)
 	const roots: AddressNode[] = []
+	const parentOf = containmentFor(opts.system)
 
 	for (const span of spans) {
-		const parent = findParent(span, spans)
+		const parent = findParent(span, spans, parentOf)
 		if (parent) parent.children.push(span)
 		else roots.push(span)
 	}
 
 	sortByStart(roots)
-	return { raw, roots }
+	const tree: AddressTree = { raw, roots }
+	if (opts.system !== undefined) tree.system = opts.system
+	return tree
 }

--- a/core/decoder/containment.ts
+++ b/core/decoder/containment.ts
@@ -11,13 +11,28 @@
  *   distance wins. Spans whose tag is absent from this map (or has no labeled parent) become
  *   roots.
  *
- *   Tags absent from this map are treated as root-only (no parent ever accepted).
+ *   Tags absent from a map are treated as root-only (no parent ever accepted).
+ *
+ *   ## Per-system containment (anti-lock-in)
+ *
+ *   Addressing _systems_ disagree on hierarchy: a US street address nests `house_number → street →
+ *   locality`, while a Japanese block address nests `building_number → sub_block → block →
+ *   district` — there is no `street` parent at all. Today a single global map suffices only because
+ *   the tag sets don't collide, but the moment the resolver or tree builder hardcodes the Western
+ *   shape, retrofitting a second system gets expensive (DeepSeek resolver consult, 2026-05-30).
+ *
+ *   The cheap insurance is this indirection: callers ask `containmentFor(system)` rather than
+ *   importing one global constant. Today every system resolves to `WESTERN_PARENT_OF` (the
+ *   historical map, behavior-identical), and `PARENT_OF` is kept as an alias so existing imports
+ *   don't break. When a genuinely distinct system map lands (Phase 6 JP), it slots in here with
+ *   zero call-site churn. See `AddressSystem` in `./types.ts`.
  */
 
 import type { ComponentTag } from "../types/component.js"
+import type { AddressSystem } from "./types.js"
 
 /** Preferred-parent ordering for each tag. Empty / missing = always root. */
-export const PARENT_OF: Partial<Record<ComponentTag, ComponentTag[]>> = {
+export const WESTERN_PARENT_OF: Partial<Record<ComponentTag, ComponentTag[]>> = {
 	// Universal coarse — containment follows geographic granularity.
 	region: ["country"],
 	subregion: ["region", "country"],
@@ -41,7 +56,8 @@ export const PARENT_OF: Partial<Record<ComponentTag, ComponentTag[]>> = {
 	attention: ["venue"],
 	po_box: ["locality", "subregion", "region"],
 
-	// JP — declared for forward-compat; mapping is provisional and will be revisited in Phase 6.
+	// JP — declared for forward-compat; mapping is provisional and will be revisited in Phase 6, when
+	// a dedicated `japanese` system map likely supersedes these entries with a no-street hierarchy.
 	prefecture: ["country"],
 	municipality: ["prefecture"],
 	district: ["municipality"],
@@ -50,3 +66,23 @@ export const PARENT_OF: Partial<Record<ComponentTag, ComponentTag[]>> = {
 	building_number: ["sub_block", "block"],
 	building_name: ["building_number", "sub_block", "block"],
 }
+
+/**
+ * The containment map for a given addressing system.
+ *
+ * Currently every system maps to {@link WESTERN_PARENT_OF} — the indirection exists so a future
+ * system-specific map (e.g. Japanese block addressing) can be introduced without touching the tree
+ * builder or validator. `undefined` (the common case — system not yet detected) uses the default.
+ */
+export function containmentFor(_system?: AddressSystem): Partial<Record<ComponentTag, ComponentTag[]>> {
+	// Single system today. The parameter is intentionally consumed lazily — adding `case "japanese":`
+	// here is the entire surface area for a new system's hierarchy.
+	return WESTERN_PARENT_OF
+}
+
+/**
+ * Backwards-compatible alias for the default (Western) containment map. Prefer `containmentFor()`
+ * in new code so the system parameter threads through; this export remains for existing call
+ * sites.
+ */
+export const PARENT_OF = WESTERN_PARENT_OF

--- a/core/decoder/system-field.test.ts
+++ b/core/decoder/system-field.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Contract tests for `AddressTree.system` + the `containmentFor` indirection — the forward-compat
+ *   anti-lock-in seam (DeepSeek resolver consult, 2026-05-30). These lock in two guarantees:
+ *
+ *   1. The discriminator round-trips: `buildAddressTree(..., { system })` stamps `tree.system`, and
+ *        omitting it leaves `system` absent (the default Western path).
+ *   2. It is currently BEHAVIOR-NEUTRAL: every system resolves to the same containment map, so the same
+ *        tokens produce a structurally identical tree regardless of `system`. (When a distinct
+ *        system map lands in Phase 6, that last guarantee is the one that intentionally changes —
+ *        and this test is where the change must be made deliberately, not by accident.)
+ */
+
+import { describe, expect, test } from "vitest"
+
+import type { BioLabel } from "../types/component.js"
+import { buildAddressTree } from "./build-tree.js"
+import { containmentFor, PARENT_OF, WESTERN_PARENT_OF } from "./containment.js"
+import type { DecoderToken } from "./types.js"
+import { validateTree } from "./validate-tree.js"
+
+function tok(piece: string, start: number, end: number, label: BioLabel): DecoderToken {
+	return { piece, start, end, label, confidence: 1 }
+}
+
+const RAW = "1600 Pennsylvania Avenue NW, Washington, DC 20500"
+function tokens(): DecoderToken[] {
+	return [
+		tok("1600", 0, 4, "B-house_number"),
+		tok("Pennsylvania", 5, 17, "B-street"),
+		tok("Avenue", 18, 24, "I-street"),
+		tok("NW", 25, 27, "I-street"),
+		tok("Washington", 29, 39, "B-locality"),
+		tok("DC", 41, 43, "B-region"),
+		tok("20500", 44, 49, "B-postcode"),
+	]
+}
+
+/** Stable structural fingerprint: each node as `tag(value)` with nested children. */
+function shape(nodes: { tag: string; value: string; children: unknown[] }[]): string {
+	return nodes.map((n) => `${n.tag}[${shape(n.children as never)}]`).join(",")
+}
+
+describe("AddressTree.system + containmentFor", () => {
+	test("system is absent by default", () => {
+		const tree = buildAddressTree(RAW, tokens())
+		expect(tree.system).toBeUndefined()
+	})
+
+	test("buildAddressTree stamps the requested system onto the tree", () => {
+		expect(buildAddressTree(RAW, tokens(), { system: "western" }).system).toBe("western")
+		expect(buildAddressTree(RAW, tokens(), { system: "japanese" }).system).toBe("japanese")
+	})
+
+	test("system is behavior-neutral today — identical structure regardless of system", () => {
+		const base = shape(buildAddressTree(RAW, tokens()).roots as never)
+		const western = shape(buildAddressTree(RAW, tokens(), { system: "western" }).roots as never)
+		const japanese = shape(buildAddressTree(RAW, tokens(), { system: "japanese" }).roots as never)
+		expect(western).toBe(base)
+		expect(japanese).toBe(base)
+	})
+
+	test("containmentFor returns the Western map for every system today", () => {
+		expect(containmentFor(undefined)).toBe(WESTERN_PARENT_OF)
+		expect(containmentFor("western")).toBe(WESTERN_PARENT_OF)
+		expect(containmentFor("japanese")).toBe(WESTERN_PARENT_OF)
+	})
+
+	test("PARENT_OF alias still points at the Western map (back-compat for existing imports)", () => {
+		expect(PARENT_OF).toBe(WESTERN_PARENT_OF)
+	})
+
+	test("validateTree honors the tree's system (a valid Western tree stays valid when tagged)", () => {
+		const tree = buildAddressTree(RAW, tokens(), { system: "western" })
+		expect(validateTree(tree).valid).toBe(true)
+	})
+})

--- a/core/decoder/types.ts
+++ b/core/decoder/types.ts
@@ -117,4 +117,26 @@ export interface AddressTree {
 	/** The original raw input text — preserved for round-trip and XML root @raw attribute. */
 	raw: string
 	roots: AddressNode[]
+	/**
+	 * The addressing SYSTEM this tree was decoded under, which selects the containment hierarchy
+	 * (`containmentFor(system)` in `./containment.ts`). Absent means the default Western hierarchy
+	 * (`house_number → street → locality → …`).
+	 *
+	 * This is forward-compat insurance, not yet a behavioral switch: every system currently resolves
+	 * to the same map, so an absent or present `system` produces identical trees today. It exists so
+	 * that when a genuinely distinct system lands (e.g. Japanese block addressing, where
+	 * `building_number` nests under `sub_block`/`block` with no `street` parent), consumers and the
+	 * tree builder already carry the discriminator — no `AddressTree` shape change later. A locale
+	 * pre-classifier (Phase 6+) is the intended source of this value.
+	 */
+	system?: AddressSystem
 }
+
+/**
+ * The addressing system a tree was decoded under — selects the containment hierarchy. Western
+ * covers US/EU/most-Latin-script street addressing (`house_number → street → locality`). `japanese`
+ * is declared for forward-compat (block addressing: `building_number → sub_block → block →
+ * district`, no street); it currently shares the Western map until Phase 6 gives it a distinct one.
+ * Open string union so a new system can be added without a breaking enum change.
+ */
+export type AddressSystem = "western" | "japanese" | (string & {})

--- a/core/decoder/validate-tree.ts
+++ b/core/decoder/validate-tree.ts
@@ -5,35 +5,32 @@
  *
  *   Structural-validity checker for the decoded `AddressTree` — v0.7 task #37.
  *
- *   The postcode-only harness scores an address as "pass" on exact component
- *   match, but a parse can match a component and still be STRUCTURALLY
- *   incoherent — e.g. a `house_number` or `street_suffix` floating with no
- *   `street` anywhere, an `attention` with no `venue`. These orphan fragments
- *   are the signature of the overconfident hallucinations the v0.6.x cycle
- *   fought. This checker lifts the harness from "address-level pass" to
- *   "address-level pass AND structurally valid."
+ *   The postcode-only harness scores an address as "pass" on exact component match, but a parse can
+ *   match a component and still be STRUCTURALLY incoherent — e.g. a `house_number` or
+ *   `street_suffix` floating with no `street` anywhere, an `attention` with no `venue`. These
+ *   orphan fragments are the signature of the overconfident hallucinations the v0.6.x cycle fought.
+ *   This checker lifts the harness from "address-level pass" to "address-level pass AND
+ *   structurally valid."
  *
  *   Two checks:
  *
- *   1. **illegal-edge** — invariant: a non-root node's parent tag must appear in
- *      its `PARENT_OF` list. (The tree builder enforces this by construction;
- *      the check guards against regressions in build-tree.ts.)
- *
- *   2. **stranded-dependent** — a STRICT dependent tag (one that is meaningless
- *      without a structural anchor) whose anchor type is entirely ABSENT from
- *      the tree. Geographic containers (postcode / locality / region / street /
- *      venue / po_box) are deliberately NOT checked: a postcode-only or
- *      city-only input is a degenerate-but-valid parse, not a violation.
+ *   1. **illegal-edge** — invariant: a non-root node's parent tag must appear in its `PARENT_OF` list.
+ *        (The tree builder enforces this by construction; the check guards against regressions in
+ *        build-tree.ts.)
+ *   2. **stranded-dependent** — a STRICT dependent tag (one that is meaningless without a structural
+ *        anchor) whose anchor type is entirely ABSENT from the tree. Geographic containers
+ *        (postcode / locality / region / street / venue / po_box) are deliberately NOT checked: a
+ *        postcode-only or city-only input is a degenerate-but-valid parse, not a violation.
  */
 
 import type { ComponentTag } from "../types/component.js"
-import { PARENT_OF } from "./containment.js"
+import { containmentFor } from "./containment.js"
 import type { AddressNode, AddressTree } from "./types.js"
 
 /**
- * Tags that cannot stand alone: each is a sub-component of a specific structural
- * anchor (street / locality / venue / postcode). If none of a tag's allowed
- * parents appear anywhere in the tree, the node is an orphan fragment.
+ * Tags that cannot stand alone: each is a sub-component of a specific structural anchor (street /
+ * locality / venue / postcode). If none of a tag's allowed parents appear anywhere in the tree, the
+ * node is an orphan fragment.
  */
 const STRICT_DEPENDENTS: ReadonlySet<ComponentTag> = new Set<ComponentTag>([
 	"street_prefix",
@@ -63,6 +60,8 @@ export interface TreeValidity {
 /** Validate an `AddressTree`'s structural coherence. See module docstring. */
 export function validateTree(tree: AddressTree): TreeValidity {
 	const violations: TreeViolation[] = []
+	// Validate against the tree's own addressing system's hierarchy (defaults to Western).
+	const parentOf = containmentFor(tree.system)
 
 	const present = new Set<ComponentTag>()
 	const collect = (n: AddressNode): void => {
@@ -72,7 +71,7 @@ export function validateTree(tree: AddressTree): TreeValidity {
 	tree.roots.forEach(collect)
 
 	const walk = (node: AddressNode, parent: AddressNode | null): void => {
-		const allowed = PARENT_OF[node.tag]
+		const allowed = parentOf[node.tag]
 
 		// 1. Edge invariant.
 		if (parent && (!allowed || !allowed.includes(parent.tag))) {


### PR DESCRIPTION
## What

Direction-C resolver-depth, the **anti-lock-in** item from the DeepSeek consult: add the addressing-**system** discriminator *before* resolver/tree-builder code hardens around the US/Western tree shape.

**Behavior-neutral today.** Every system resolves to the same containment map, so trees are byte-identical whether or not `system` is set — this only records intent and threads the seam. It becomes behavioral when a system-specific map lands (Phase 6 JP block addressing, where `building_number` nests under `sub_block`/`block` with no `street` parent). Carrying the discriminator now is cheap; retrofitting the `AddressTree` shape + all call sites later is the expensive part DeepSeek flagged.

## Changes
- `types.ts` — `AddressTree.system?: AddressSystem` (optional; absent = Western default) + the open `AddressSystem` union.
- `containment.ts` — `containmentFor(system)` indirection (all systems → `WESTERN_PARENT_OF` today). `PARENT_OF` kept as a back-compat alias.
- `build-tree.ts` — `BuildTreeOpts.system` selects the map and is stamped onto the tree.
- `validate-tree.ts` — validates against the tree's own system's hierarchy.
- `system-field.test.ts` (6 tests) — round-trip, default-absent, the **behavior-neutrality guarantee** (the test that must change deliberately when a real JP map lands), containmentFor mapping, alias, validate-honors-system.

## Verification
Full decoder suite **94 passed** (88 prior unchanged + 6 new). Pure additive change — no behavioral diff for existing Western trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)