### PR TITLE
docs(eval): reframe OA eval intro as neural-vs-Pelias head-to-head + drop throwaway diag scripts

### DIFF
--- a/docs/articles/evals/2026-05-30-openaddresses-real-point-eval.md
+++ b/docs/articles/evals/2026-05-30-openaddresses-real-point-eval.md
@@ -1,8 +1,10 @@
 # OpenAddresses real-point resolver eval — the non-circular accuracy track (2026-05-30)
 
-Direction-C resolver-depth, plan item 3. The first **non-circular** end-to-end
-accuracy number for the resolver: real US addresses with real government
-coordinates, resolved against a gazetteer they don't come from.
+Direction-C resolver-depth. The first **non-circular** end-to-end accuracy number
+for the resolver — real US addresses with real government coordinates, resolved
+against a gazetteer they don't come from — and, because `v0` is a TypeScript port
+of the Pelias parser, the **neural-vs-Pelias-parser head-to-head** at the same
+time (the parser axis of "beat Pelias", with no Docker Pelias stack needed).
 
 ## Why this is the honest scoreboard
 


### PR DESCRIPTION
Loose-end cleanup after the OA head-to-head landed (#214):

- **OA doc intro** still said "plan item 3" (the old eval-track framing) after #214 turned it into the neural-vs-Pelias-parser head-to-head. Intro now matches the body. Docs-only, **no number changes**.
- **Removed 4 untracked throwaway diag scripts** from the working tree (`scripts/diag-{findplace,resolve-trace,il,v0}.ts`) — ad-hoc one-off probes superseded by the committed `exact-match-tiering.test.ts` + OA runner. (The two *tracked* diag scripts, `diag-postcode`/`diag-resolver`, are kept.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)