### PR TITLE
feat(train): MLM self-supervised pre-training mode

### DIFF
--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -120,6 +120,19 @@ class TrainConfig:
     # smoke window masks divergence by collapsing LR before the loss curve shows it; the
     # constant-LR mode keeps the signal visible. See the ref doc for when to pick which.
     lr_schedule: str = "cosine"
+    # Training objective. "supervised" = the BIO token-classification loss (CE + optional CRF, the
+    # default and only historical mode). "mlm" = self-supervised masked-language-model PRE-training
+    # on the corpus text (BIO labels ignored): masks `mlm_mask_prob` of attended tokens and predicts
+    # them via the tied token-embedding head, producing an encoder checkpoint a later supervised run
+    # fine-tunes from (`init_from`). See pretrain.py. Off the supervised path entirely.
+    objective: str = "supervised"
+    # Fraction of attended (non-pad) tokens masked for the MLM objective. 0.15 is BERT-classic; the
+    # small-encoder literature favors ~0.4 — tune per experiment. Ignored unless objective == "mlm".
+    mlm_mask_prob: float = 0.15
+    # Initialize MODEL weights from this checkpoint dir at the start of a SUPERVISED run, WITHOUT
+    # loading optimizer/scheduler/step (unlike resume). This is how a fine-tune run starts from an
+    # MLM-pretrained encoder. Empty = fresh init. Ignored when resuming (resume takes precedence).
+    init_from: str = ""
     # Trackio experiment tracking (Hugging Face). Off by default so existing configs and
     # plain/CI runs stay bit-identical and never depend on the optional 'trackio' package.
     # When enabled, the metrics written to train_log.csv are also streamed to a Trackio

--- a/corpus-python/src/mailwoman_train/masking.py
+++ b/corpus-python/src/mailwoman_train/masking.py
@@ -1,0 +1,61 @@
+"""Masked-language-model token masking for self-supervised pre-training (pretrain.py).
+
+BERT 80/10/10 masking over a batch of token ids:
+
+  * select ``mask_prob`` of the ATTENDED (non-pad) positions, ~uniformly at random;
+  * of the selected: 80% -> mask token, 10% -> random token, 10% -> unchanged;
+  * the MLM target is the original id at selected positions, ``-100`` (ignore) elsewhere, so
+    ``cross_entropy(ignore_index=-100)`` scores only the masked positions.
+
+Mask token: the SentencePiece tokenizer has no dedicated ``[MASK]`` symbol, so callers pass the
+``<unk>`` id. Padding uses id 0 and ``<unk>`` is id 1 — but pad positions carry
+``attention_mask == 0`` and are never selected, while masked positions keep ``attention_mask == 1``,
+so the encoder distinguishes them via attention. No embedding-table change -> the pretrain
+checkpoint's state_dict stays key-identical to a supervised model's.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def mask_tokens(
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    *,
+    mask_prob: float,
+    mask_token_id: int,
+    vocab_size: int,
+    generator: torch.Generator | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return ``(masked_input_ids, mlm_labels)`` for a ``(batch, seq)`` batch.
+
+    ``masked_input_ids`` is a corrupted copy; ``mlm_labels`` holds the original id at masked
+    positions and ``-100`` everywhere else. Deterministic given ``generator``. Operates on CPU
+    tensors (the caller moves results to device) so the RNG stream is device-independent.
+    """
+    labels = input_ids.clone()
+    attended = attention_mask.bool()
+
+    # 1. choose positions: bernoulli(mask_prob) restricted to attended (non-pad) tokens.
+    probs = torch.full(input_ids.shape, float(mask_prob)) * attended.float()
+    selected = torch.bernoulli(probs, generator=generator).bool()
+    labels[~selected] = -100
+
+    masked = input_ids.clone()
+
+    # 2. 80% of selected -> mask token.
+    to_mask = torch.bernoulli(torch.full(input_ids.shape, 0.8), generator=generator).bool() & selected
+    masked[to_mask] = mask_token_id
+
+    # 3. 10% of selected -> random token (half of the remaining 20%).
+    to_random = (
+        torch.bernoulli(torch.full(input_ids.shape, 0.5), generator=generator).bool()
+        & selected
+        & ~to_mask
+    )
+    random_ids = torch.randint(0, vocab_size, input_ids.shape, generator=generator)
+    masked[to_random] = random_ids[to_random]
+
+    # 4. remaining ~10% of selected -> left unchanged (already correct in `masked`).
+    return masked, labels

--- a/corpus-python/src/mailwoman_train/model.py
+++ b/corpus-python/src/mailwoman_train/model.py
@@ -441,6 +441,43 @@ class MailwomanCoarseEncoder(nn.Module):
 
     # ---- HuggingFace-compatible save/load helpers ----
 
+    def forward_mlm(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        mlm_labels: torch.Tensor | None = None,
+    ) -> "_CoarseEncoderOutput":
+        """Masked-language-model forward for self-supervised PRE-training (see pretrain.py).
+
+        Mirrors ``forward``'s encoder body, then projects hidden states through the TIED token-
+        embedding matrix (no new parameters -> the pretrain checkpoint's ``state_dict`` is identical
+        to a supervised model's, so it loads via ``from_pretrained`` for fine-tuning). The classifier
+        / CRF heads are untouched here — they stay at init through pretraining and are trained in the
+        later supervised fine-tune. Phrase priors are intentionally not threaded (pretraining runs on
+        raw text only).
+        """
+        bsz, seq = input_ids.shape
+        pos = torch.arange(seq, device=input_ids.device).unsqueeze(0).expand(bsz, seq)
+        h = self.token_embeddings(input_ids) + self.position_embeddings(pos)
+        h = self.input_dropout(self.input_ln(h))
+        kpm: torch.Tensor | None = None
+        if attention_mask is not None:
+            kpm = attention_mask == 0
+        for block in self.blocks:
+            h = block(h, key_padding_mask=kpm)
+        h = self.final_ln(h)
+        # Tied head: (B, S, hidden) @ (hidden, vocab) -> (B, S, vocab).
+        vocab_size = self.token_embeddings.num_embeddings
+        lm_logits = h @ self.token_embeddings.weight.t()
+        loss: torch.Tensor | None = None
+        if mlm_labels is not None:
+            loss = nn.functional.cross_entropy(
+                lm_logits.view(-1, vocab_size),
+                mlm_labels.view(-1),
+                ignore_index=-100,
+            )
+        return _CoarseEncoderOutput(lm_logits, loss)
+
     def save_pretrained(self, output_dir: Path | str) -> None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/corpus-python/src/mailwoman_train/pretrain.py
+++ b/corpus-python/src/mailwoman_train/pretrain.py
@@ -1,0 +1,195 @@
+"""Self-supervised masked-language-model PRE-training loop.
+
+The supervised trainer (train.py) learns BIO token classification from scratch — which the
+small-encoder literature identifies as the root of mailwoman's two diagnosed pathologies
+(overconfidence + format/delimiter over-reliance). This module adds the missing first phase: MLM
+pre-training on the corpus TEXT (BIO labels ignored), producing an encoder checkpoint that a later
+supervised run fine-tunes from via ``cfg.train.init_from``.
+
+Reuse-heavy by design: it borrows train.py's helpers (``_build_scheduler``, ``_precision_to_dtype``,
+``_to_tensor_batch``, ``save_checkpoint``, ``find_latest_checkpoint``, ``force_math_sdpa``,
+``model_param_count``), data_loader's ``iter_batches``, masking.py's BERT 80/10/10 masking, and
+trackio_logging's tracker. The only new model surface is ``MailwomanCoarseEncoder.forward_mlm`` (a
+tied-embedding head, no new params -> the saved state_dict is key-identical to a supervised model's
+and loads via ``from_pretrained``).
+
+Mirrors the supervised loop's conventions: bf16 via explicit model cast (no autocast — the gfx1103
+fast-path hang documented in train.py), AdamW, grad-clip, crash-and-resume via optimizer.pt /
+scheduler.pt / training_state.json, Trackio mirror of metrics. Activated by
+``cfg.train.objective == "mlm"`` (train.train() routes here); the CLI ``train`` subcommand is reused.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from pathlib import Path
+
+import torch
+from torch.optim import AdamW
+
+from .config import Config
+from .data_loader import iter_batches
+from .masking import mask_tokens
+from .model import build_model, force_math_sdpa, model_param_count
+from .tokenizer import Tokenizer
+from .train import (
+    _build_scheduler,
+    _precision_to_dtype,
+    _to_tensor_batch,
+    find_latest_checkpoint,
+    save_checkpoint,
+)
+from .trackio_logging import init_tracker
+
+
+@torch.no_grad()
+def _mlm_eval(cfg: Config, model, tokenizer: Tokenizer, device, *, mask_token_id: int) -> dict:
+    """MLM cross-entropy + perplexity over a bounded slice of the val split."""
+    was_training = model.training
+    model.eval()
+    gen = torch.Generator().manual_seed(cfg.train.seed)
+    total, n = 0.0, 0
+    max_batches = max(1, cfg.train.eval_every_steps // 50)  # cheap, bounded
+    for batch in iter_batches(
+        cfg, tokenizer, split="val", batch_size=cfg.train.batch_size, seed=cfg.train.seed
+    ):
+        tb = _to_tensor_batch(batch, device)
+        masked, labels = mask_tokens(
+            tb["input_ids"].cpu(), tb["attention_mask"].cpu(),
+            mask_prob=cfg.train.mlm_mask_prob, mask_token_id=mask_token_id,
+            vocab_size=tokenizer.vocab_size, generator=gen,
+        )
+        out = model.forward_mlm(
+            input_ids=masked.to(device), attention_mask=tb["attention_mask"], mlm_labels=labels.to(device)
+        )
+        if out.loss is not None:
+            total += float(out.loss.item())
+            n += 1
+        if n >= max_batches:
+            break
+    if was_training:
+        model.train()
+    avg = total / max(1, n)
+    return {"mlm_val_loss": avg, "mlm_val_perplexity": math.exp(min(20.0, avg))}
+
+
+def pretrain(cfg: Config, *, resume_from: str | Path | None = None) -> None:
+    """Run MLM pre-training; write encoder checkpoints to ``cfg.train.output_dir``."""
+    assert cfg.train.objective == "mlm", f"pretrain() needs objective='mlm', got {cfg.train.objective!r}"
+    force_math_sdpa()
+    output_dir = Path(cfg.train.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if resume_from == "auto":
+        resume_from = find_latest_checkpoint(output_dir)
+
+    tokenizer = Tokenizer(Path(cfg.data.tokenizer_dir) / "tokenizer.model")
+    mask_token_id = tokenizer.unk_id  # SentencePiece has no [MASK]; reuse <unk> (see masking.py)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    if resume_from is not None:
+        from .model import MailwomanCoarseEncoder
+
+        print(f"[pretrain] resuming from {resume_from}")
+        model = MailwomanCoarseEncoder.from_pretrained(resume_from)
+    else:
+        model = build_model(cfg, vocab_size=tokenizer.vocab_size, pad_token_id=tokenizer.pad_id)
+    model.to(device)
+
+    amp_dtype = _precision_to_dtype(cfg.train.precision, device)
+    if amp_dtype is not None and device.type == "cuda":
+        model.to(dtype=amp_dtype)  # explicit cast, not autocast (gfx1103 hang — see train.py)
+
+    print(f"[pretrain] device={device} params={model_param_count(model):,} "
+          f"objective=mlm mask_prob={cfg.train.mlm_mask_prob} mask_token_id={mask_token_id}")
+
+    optim = AdamW(model.parameters(), lr=cfg.train.learning_rate, weight_decay=cfg.train.weight_decay)
+    scheduler = _build_scheduler(optim, cfg.train)
+
+    resume_step = 0
+    if resume_from is not None:
+        rp = Path(resume_from)
+        if (rp / "optimizer.pt").is_file():
+            optim.load_state_dict(torch.load(rp / "optimizer.pt", weights_only=False))
+        if (rp / "training_state.json").is_file():
+            resume_step = int(json.loads((rp / "training_state.json").read_text()).get("step", 0))
+        if (rp / "scheduler.pt").is_file():
+            scheduler.load_state_dict(torch.load(rp / "scheduler.pt", weights_only=False))
+        else:
+            for _ in range(resume_step):
+                scheduler.step()
+        print(f"[pretrain] resumed at step={resume_step}")
+
+    tracker = init_tracker(cfg)
+    gen = torch.Generator().manual_seed(cfg.train.seed)
+    step = resume_step
+    started = time.time()
+    loss_running = 0.0
+    log_every = max(1, cfg.train.log_every_steps)
+    grad_clip = float(getattr(cfg.train, "grad_clip_norm", 1.0))
+
+    def extras() -> dict:
+        from dataclasses import asdict
+
+        return {
+            "step": step,
+            "config": {"data": asdict(cfg.data), "model": asdict(cfg.model), "train": asdict(cfg.train)},
+            "vocab_size": tokenizer.vocab_size,
+        }
+
+    try:
+        epoch = 0
+        while step < cfg.train.max_steps:
+            epoch += 1
+            for batch in iter_batches(
+                cfg, tokenizer, split="train", batch_size=cfg.train.batch_size,
+                seed=cfg.train.seed + epoch, row_limit=cfg.data.train_rows_per_epoch,
+            ):
+                if step >= cfg.train.max_steps:
+                    break
+                model.train()
+                tb = _to_tensor_batch(batch, device)
+                # Mask on CPU (cheap, keeps the RNG device-independent), then move to device.
+                masked, labels = mask_tokens(
+                    tb["input_ids"].cpu(), tb["attention_mask"].cpu(),
+                    mask_prob=cfg.train.mlm_mask_prob, mask_token_id=mask_token_id,
+                    vocab_size=tokenizer.vocab_size, generator=gen,
+                )
+                optim.zero_grad(set_to_none=True)
+                out = model.forward_mlm(
+                    input_ids=masked.to(device), attention_mask=tb["attention_mask"], mlm_labels=labels.to(device)
+                )
+                loss = out.loss
+                loss.backward()
+                if grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=grad_clip)
+                optim.step()
+                scheduler.step()
+                step += 1
+                loss_running += float(loss.detach().cpu())
+
+                if step % log_every == 0:
+                    avg = loss_running / log_every
+                    loss_running = 0.0
+                    lr = float(scheduler.get_last_lr()[0])
+                    ppl = math.exp(min(20.0, avg))
+                    elapsed = time.time() - started
+                    print(f"[pretrain] step {step}/{cfg.train.max_steps} mlm_loss={avg:.4f} "
+                          f"ppl={ppl:.1f} lr={lr:.6f} rate={step/elapsed:.2f}/s")
+                    tracker.log({"mlm_train_loss": avg, "mlm_train_perplexity": ppl, "lr": lr,
+                                 "wall_seconds": elapsed}, step=step)
+
+                if step % cfg.train.eval_every_steps == 0:
+                    metrics = _mlm_eval(cfg, model, tokenizer, device, mask_token_id=mask_token_id)
+                    print(f"[pretrain]   [eval] {metrics}")
+                    tracker.log(metrics, step=step)
+
+                if step % cfg.train.save_every_steps == 0:
+                    save_checkpoint(model, output_dir, step, extras(), optim=optim, scheduler=scheduler)
+                    print(f"[pretrain]   [save] checkpoint @ step {step}")
+        save_checkpoint(model, output_dir, step, extras(), optim=optim, scheduler=scheduler)
+        print(f"[pretrain] done @ step {step} -> {output_dir}")
+    finally:
+        tracker.finish()

--- a/corpus-python/src/mailwoman_train/train.py
+++ b/corpus-python/src/mailwoman_train/train.py
@@ -212,6 +212,13 @@ def find_latest_checkpoint(output_dir: Path) -> Path | None:
 
 def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
     _set_seed(cfg.train.seed)
+    # MLM pre-training is a different objective + loop; route there (lazy import avoids a
+    # train<->pretrain module cycle). pretrain() writes from_pretrained-loadable checkpoints.
+    if getattr(cfg.train, "objective", "supervised") == "mlm":
+        from .pretrain import pretrain
+
+        pretrain(cfg, resume_from=resume_from)
+        return
     # Mandatory on gfx1103 — flash/mem-efficient SDPA paths crash bf16 on this GPU.
     force_math_sdpa()
     output_dir = Path(cfg.train.output_dir)
@@ -234,6 +241,15 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
         model = MailwomanCoarseEncoder.from_pretrained(resume_from)
     else:
         model = build_model(cfg, vocab_size=tokenizer.vocab_size, pad_token_id=tokenizer.pad_id)
+        # Fine-tune from a pre-trained encoder: load MODEL weights only (no optimizer/scheduler/
+        # step, unlike resume), so the supervised run starts fresh on the MLM-pretrained encoder.
+        # The pretrain checkpoint's state_dict is key-identical (tied MLM head adds no params), so
+        # this loads cleanly; strict=False surfaces any head mismatch instead of raising.
+        init_from = getattr(cfg.train, "init_from", "")
+        if init_from:
+            sd = torch.load(Path(init_from) / "pytorch_model.bin", map_location="cpu", weights_only=True)
+            missing, unexpected = model.load_state_dict(sd, strict=False)
+            print(f"[init_from] loaded encoder from {init_from} (missing={len(missing)} unexpected={len(unexpected)})")
     model.to(device)
 
     print(f"device={device} param_count={model_param_count(model):,}")

--- a/corpus-python/tests/mailwoman_train/test_mlm_pretrain.py
+++ b/corpus-python/tests/mailwoman_train/test_mlm_pretrain.py
@@ -1,0 +1,115 @@
+"""MLM pre-training wiring smoke: masking + forward_mlm correctness.
+
+The supervised trainer learns BIO classification from scratch; this checks the new
+self-supervised PRE-training surface (masking.py + MailwomanCoarseEncoder.forward_mlm),
+which produces an encoder checkpoint a later supervised run fine-tunes from. Runs in
+seconds on CPU; NO real corpus, NO backward, NO optimizer — those are exercised by the
+manual end-to-end smoke. Geometry + invariants only.
+
+Covered:
+- mask_tokens: ~mask_prob of ATTENDED tokens selected; pad positions NEVER masked; targets
+  are the ORIGINAL ids at masked positions and -100 elsewhere; unselected inputs unchanged.
+- forward_mlm: returns (B, S, vocab) logits + a finite scalar loss; uses the TIED token-
+  embedding head so it adds NO parameters (state_dict key-identical to a supervised model);
+  the supervised forward path still works unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mailwoman_train.labels import ACTIVE_BIO_LABELS  # noqa: E402
+from mailwoman_train.masking import mask_tokens  # noqa: E402
+from mailwoman_train.model import MailwomanCoarseEncoder  # noqa: E402
+
+NUM_LABELS = len(ACTIVE_BIO_LABELS)
+VOCAB_SIZE = 64
+PAD_ID = 0
+UNK_ID = 1  # the mask substitute (SentencePiece has no [MASK])
+HIDDEN_SIZE = 32
+
+
+def _build_encoder() -> MailwomanCoarseEncoder:
+    return MailwomanCoarseEncoder(
+        vocab_size=VOCAB_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        intermediate_size=64,
+        max_position_embeddings=32,
+        hidden_dropout_prob=0.1,
+        num_labels=NUM_LABELS,
+        pad_token_id=PAD_ID,
+        use_crf=False,
+    )
+
+
+def test_mask_tokens_respects_padding_and_targets() -> None:
+    gen = torch.Generator().manual_seed(0)
+    b, s = 32, 24
+    ids = torch.randint(2, VOCAB_SIZE, (b, s))  # 2.. avoids pad(0)/unk(1)
+    am = torch.ones(b, s, dtype=torch.long)
+    am[:, 18:] = 0  # last 6 positions are padding
+
+    masked, labels = mask_tokens(
+        ids, am, mask_prob=0.15, mask_token_id=UNK_ID, vocab_size=VOCAB_SIZE, generator=gen
+    )
+
+    assert masked.shape == ids.shape
+    assert labels.shape == ids.shape
+    # pad positions are never selected for masking
+    assert bool((labels[am == 0] == -100).all())
+    selected = labels != -100
+    # selection rate is roughly mask_prob over attended tokens
+    rate = float(selected.sum()) / float(am.sum())
+    assert 0.08 < rate < 0.22, rate
+    # unselected inputs are unchanged; targets at selected positions equal the original id
+    assert bool((masked[~selected] == ids[~selected]).all())
+    assert bool((labels[selected] == ids[selected]).all())
+
+
+def test_mask_tokens_deterministic_under_generator() -> None:
+    ids = torch.randint(2, VOCAB_SIZE, (8, 16))
+    am = torch.ones(8, 16, dtype=torch.long)
+    a = mask_tokens(ids, am, mask_prob=0.15, mask_token_id=UNK_ID, vocab_size=VOCAB_SIZE,
+                    generator=torch.Generator().manual_seed(7))
+    b = mask_tokens(ids, am, mask_prob=0.15, mask_token_id=UNK_ID, vocab_size=VOCAB_SIZE,
+                    generator=torch.Generator().manual_seed(7))
+    assert bool((a[0] == b[0]).all()) and bool((a[1] == b[1]).all())
+
+
+def test_forward_mlm_shapes_and_finite_loss() -> None:
+    model = _build_encoder()
+    ids = torch.randint(2, VOCAB_SIZE, (4, 12))
+    am = torch.ones(4, 12, dtype=torch.long)
+    am[:, 9:] = 0
+    labels = ids.clone()
+    labels[am == 0] = -100
+
+    out = model.forward_mlm(input_ids=ids, attention_mask=am, mlm_labels=labels)
+    assert out.logits.shape == (4, 12, VOCAB_SIZE)
+    assert out.loss is not None
+    assert out.loss.dim() == 0
+    assert torch.isfinite(out.loss)
+    # loss without labels is None (pure inference)
+    assert model.forward_mlm(input_ids=ids, attention_mask=am).loss is None
+
+
+def test_forward_mlm_adds_no_parameters_vs_supervised() -> None:
+    """The tied-embedding MLM head reuses token_embeddings.weight — no new params, so the
+    pretrain checkpoint's state_dict is key-identical to a supervised model's (loads via
+    from_pretrained for fine-tuning)."""
+    model = _build_encoder()
+    keys_before = set(model.state_dict().keys())
+    # touch forward_mlm; it must not have lazily created any module/parameter
+    _ = model.forward_mlm(input_ids=torch.randint(2, VOCAB_SIZE, (2, 8)),
+                          attention_mask=torch.ones(2, 8, dtype=torch.long))
+    assert set(model.state_dict().keys()) == keys_before
+    # supervised forward still works unchanged
+    sup = model(input_ids=torch.randint(2, VOCAB_SIZE, (2, 8)),
+                attention_mask=torch.ones(2, 8, dtype=torch.long),
+                labels=torch.randint(0, NUM_LABELS, (2, 8)))
+    assert sup.logits.shape == (2, 8, NUM_LABELS)
+    assert torch.isfinite(sup.loss)


### PR DESCRIPTION
## What

Adds the missing first phase the trainer never had: **masked-language-model PRE-training** on corpus text (BIO labels ignored), producing an encoder checkpoint a later supervised run fine-tunes from. Targets the two diagnosed pathologies — **81%-of-wrong-at-≥0.9 overconfidence** + **format/delimiter over-reliance** — that two corpus-recipe cycles (v0.6.x, v0.7.x) couldn't move; the small-encoder literature attributes both to training from scratch with no self-supervised prior (#210 spec).

**Purely additive** — `objective` defaults to `"supervised"`, so every existing config + run is bit-identical. No GPU spent yet; this is the *capability*, validated locally.

## Changes
- **`model.py`** — `forward_mlm()`: mirrors `forward()`'s encoder body, projects through the **tied** token-embedding matrix → **no new parameters**, so the pretrain checkpoint's `state_dict` is key-identical to a supervised model's and loads via `from_pretrained` for fine-tuning.
- **`masking.py`** — BERT 80/10/10 masking over attended tokens; `<unk>` as the mask id (SentencePiece has no `[MASK]`); pad positions never masked; deterministic under a generator.
- **`pretrain.py`** — the MLM loop: mask → `forward_mlm` → backward → eval (loss/perplexity) → checkpoint. bf16 via explicit cast (the gfx1103 autocast-hang convention from `train.py`), grad-clip, crash-and-resume, Trackio mirror — all matching the supervised loop. Reuses train.py's helpers + `iter_batches` unchanged.
- **`config.py`** — `train.objective` / `mlm_mask_prob` / `init_from` (load encoder-only weights for fine-tuning, distinct from `--resume`).
- **`train.py`** — routes `objective=="mlm"` to `pretrain()`; `init_from` for supervised runs.
- **`test_mlm_pretrain.py`** (4 tests).

## Verification
- 4 unit tests pass (masking pad-safety/targets/determinism + `forward_mlm` shapes/finite-loss/**no-new-params**/supervised-path-intact).
- **End-to-end CPU smoke**: ran `pretrain()` on real v0.3.0 shards for 6 steps — loss starts at log(48000)≈10.78 (correct for uniform init over the 48K vocab), eval path runs, checkpoint reloads via `from_pretrained`.

Next (separate, GPU): run a real pretrain on Modal with `--trackio` (the Trackio debut), then a fine-tune via `init_from` + the calibration/OOD comparison with the pre-registered revert criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)