### PR TITLE
chore(train): v0.8.0 MLM pre-training config

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0_8_0-mlm-pretrain.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_8_0-mlm-pretrain.yaml
@@ -1,0 +1,90 @@
+# v0.8.0 — MLM self-supervised PRE-training (phase 1 of pretrain -> fine-tune).
+#
+# The first run of the new objective="mlm" path (feat/mlm-pretraining). Pre-trains the
+# encoder on corpus TEXT (BIO labels ignored) via masked-language-modeling, producing a
+# checkpoint a later SUPERVISED run fine-tunes from (cfg.train.init_from). Goal: give the
+# encoder a self-supervised prior BEFORE it ever sees a label, to attack the two diagnosed
+# pathologies that two corpus-recipe cycles couldn't move — 81%-of-wrong-at->=0.9
+# overconfidence + format/delimiter over-reliance (the small-encoder literature attributes
+# both to training from scratch on labels only). See docs MLM spec.
+#
+# GEOMETRY IS IDENTICAL TO v0_7_2-intersection-bare.yaml on purpose: the pretrained encoder
+# must be state_dict-key-identical to the supervised model so `init_from` loads it cleanly.
+# use_phrase_priors / use_crf stay true so their params exist in the checkpoint (untrained
+# here; the fine-tune trains them). forward_mlm skips the phrase-projection + CRF heads.
+#
+# This is a VALIDATION run: 20k steps to confirm the loss descends sanely + the Trackio
+# dashboard works end to end, then a fine-tune from the resulting checkpoint decides whether
+# pretraining helps (pre-registered revert: fine-tune harness <22% AND resolver Acc@1 gain
+# <1.5pp vs the from-scratch baseline -> drop pretraining).
+#
+# Launch (Trackio debut):
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0_8_0-mlm-pretrain.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+  # v0.3.0 (674 train shards) NOT v0.4.0 (12 synth-overlay shards): MLM wants broad,
+  # representative text coverage, and v0.4.0 is a thin synth overlay meant to be used WITH
+  # source-weighting (which we drop here). v0.3.0 is also the version train_remote.py
+  # verifies on the volume.
+data:
+  corpus_dir: /data/corpus/versioned/v0.3.0/corpus-v0.3.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  # No source_weights: MLM wants BROAD text exposure (it's learning token/morphology
+  # structure, not a label distribution), so let every source through uniformly. The
+  # supervised fine-tune re-applies its own sampling recipe.
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  # No augmentation for pretraining — learn the raw token distribution as-is.
+  augment_directional_prob: 0.0
+  augment_region_prob: 0.0
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  # Heads exist in the checkpoint (key-match for init_from) but are untrained by the MLM
+  # objective — the supervised fine-tune trains them.
+  use_crf: true
+  label_smoothing: 0.0
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  objective: mlm
+  mlm_mask_prob: 0.15
+  output_dir: /data/output-v080-mlm-pretrain/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.0e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 20000
+  eval_every_steps: 1000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.8.0-mlm-pretrain
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""


### PR DESCRIPTION
The recipe for the first `objective=mlm` run (a 20k-step validation pretrain).

- **Geometry identical to `v0_7_2-intersection-bare`** so the pretrained encoder is state_dict-key-identical to the supervised model → `init_from` loads it cleanly into the later fine-tune.
- **Corpus v0.3.0** (674 shards, broad coverage) not v0.4.0 (12 synth-overlay shards) — MLM wants representative text, and no source-weighting.
- mask_prob 0.15, bf16, constant LR, eval every 1k.
- Launch: `modal run -d scripts/modal/train_remote.py --config v0_8_0-mlm-pretrain.yaml --resume none --trackio --trackio-space sister-software/mailwoman-trackio`

Config-only; depends on the MLM code (#216, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)