### PR TITLE
chore(train): v0.8.0 fine-tune A/B configs (pretrained-init vs scratch)

### DIFF
--- a/.agents/skills/deepseek-consult/ds-mlm-ft-turn1.txt
+++ b/.agents/skills/deepseek-consult/ds-mlm-ft-turn1.txt
@@ -1,0 +1,77 @@
+# Fine-Tune Recipe & Experiment Design — Turn 1
+
+## 1. LR + Schedule
+
+**Primary: `5e-5` constant, 500-step warmup, 100k steps.** (~1/3 of the from-scratch 1.5e-4.) Rationale:
+
+- The encoder is no longer random — it's in a meaningful basin. Standard fine-tuning rule: 1/5 to 1/10 of the from-scratch LR. I'm going slightly higher (1/3) because this is only 20k pretrain steps on a 29M model — the pretrained features are real but shallow, not deeply baked. You can afford a moderately higher LR without washing them out.
+- 500-step warmup is plenty. The encoder isn't starting from noise; only the classifier + CRF heads are random-init. Warmup is just a safety rail against early gradient spikes on the random heads.
+- 100k steps for comparability with the baseline. The heads need the steps even if the encoder converges faster — check validation loss every ~5k steps and be prepared to use the best checkpoint, not necessarily the final one.
+- Constant schedule keeps it comparable to v0.7.2. But honestly, **cosine decay to near-zero (e.g., `1e-7`) would be better for calibration** — it prevents the late-training collapse into overconfidence that Hendrycks et al. describe. That's the calibration-preserving move.
+
+**Fallback: `5e-5` with cosine decay to `1e-7` over 100k steps, 500 warmup.** Better for calibration, slightly different from the baseline recipe, but defensible as the "correct" fine-tune recipe independent of the comparison question.
+
+> **Metadata note:** I'd also consider *discriminative LR* — `5e-5` for the encoder, `1.5e-4` for the heads — but that adds a tuning dimension. Save it for the scaling run.
+
+---
+
+## 2. Auxiliary MLM Loss During Fine-Tuning
+
+**Primary: CE-only for this run. Ship the clean experiment.** The question is "does pretraining help at all?" — not "does pretraining + aux-MLM + label-smoothing + every calibration trick help?" One variable at a time. If calibration *doesn't* improve from pretraining alone, then:
+
+1. Re-run with aux-MLM (weight 0.05–0.1) as a rescue experiment — Desai-Durrett is strong enough that this is the first knob to turn.
+2. Only if aux-MLM also fails do you conclude pretraining didn't pay.
+
+**Fallback: Run label smoothing (`0.1`) on the CE-only fine-tune.** Label smoothing is *trivial to add* (one flag), directly attacks overconfidence (it prevents the model from driving `p → 1.0` on the gold label), and is orthogonal to pretraining — it doesn't confound the init comparison since both the pretrained and from-scratch runs would use it. If you're going to add one thing beyond the clean experiment, make it label smoothing, not aux-MLM. It's simpler and hits the primary target (calibration) more directly.
+
+---
+
+## 3. Fairness — How to Keep the Comparison Honest
+
+This is the hardest question. Two clean answers, and the right one depends on what hypothesis you're testing:
+
+**Hypothesis A (narrow):** "Given the same training recipe, does pretrained init outperform random init?" → **Re-run from-scratch at 5e-5 constant, 100k steps, same seed, same everything.** This isolates `init_from` as the ONLY variable.
+
+**Hypothesis B (product):** "Does the best pretrained recipe beat the best known from-scratch recipe?" → **Compare pretrained fine-tune at 5e-5 against v0.7.2 at 1.5e-4.** Two variables (init + LR) but answers the product question directly.
+
+**Primary recommendation: Run BOTH.** It's one extra training run and you get both answers:
+
+| Run | Init | LR | Compare against | Answers |
+|-----|------|----|-----------------|---------|
+| Pretrained | pretrain ckpt | 5e-5 | — | — |
+| Control | random | 5e-5 | Pretrained | Hypothesis A |
+| v0.7.2 | random | 1.5e-4 | Both above | Hypothesis B |
+
+Three runs total. The control run at 5e-5 from-scratch will likely underperform v0.7.2 — that's fine, it's not competing, it's isolating the variable. If the pretrained run beats *both* the 5e-5 control AND v0.7.2, you've got an unassailable result. If it beats the control but loses to v0.7.2, then pretraining helps but the recipe gap (1.5e-4 vs 5e-5) swallows the gain — and you tune LR up on the pretrained run in round 2.
+
+**Fallback: Skip the 5e-5 from-scratch control and compare only against v0.7.2.** Least experimental hygiene, but cheapest. I don't recommend it — the control run costs one Modal job and prevents a week of arguing about fairness.
+
+---
+
+## 4. Is 20k Pretrain Steps Enough?
+
+**No, it's not converged — but that's OK for THIS experiment.** MLM loss (`4.58` and still descending) on a 48k vocab means the model has learned substantial token-level structure but is far from done. (For reference: random init `≈ ln(48000) = 10.78`; a well-pretrained BERT drops to `~1.5` on its vocab.)
+
+**Primary recommendation: Set the revert criterion to "inconclusive — scale pretrain" rather than "drop pretraining."** Specifically:
+
+| Fine-tune outcome | Conclusion |
+|---|---|
+| Calibration *improves* (any amount) | Pretraining helps. Next step: scale to 100k pretrain steps, re-evaluate. |
+| No change (`±2pp` on fraction-wrong-at-≥0.9) | Inconclusive. 20k pretrain may simply be too short. Scale to 100k pretrain, re-evaluate. |
+| Calibration *worsens* | Recipe problem (LR washing out features, heads not converged) OR pretraining genuinely doesn't transfer. Debug recipe first; then drop if re-run confirms. |
+
+The key insight: a *null* result at 20k pretrain steps does NOT falsify the pretraining hypothesis. It only falsifies "20k steps is enough." Don't let a null result kill the approach — it should trigger a scale-up, not a kill decision.
+
+---
+
+## Summary — What to Nail in Turn 2
+
+I need to pin down the concrete run card:
+
+1. **Batch size** — must match baseline (what was v0.7.2's batch size?) or change and justify.
+2. **CRF loss weight** — v0.7.2 used `0.0` because of bf16 NaN. Do we try CRF again with a NaN mitigation (gradient clipping, loss scaling, or fp32 CRF fallback)? The CRF is structurally helpful for the BIO constraint and the 33-label tag space.
+3. **Data** — same v0.3.0 corpus as v0.7.2? No augmentation? The corpus-recipe cycles (v0.6.x, v0.7.x) failed; is the training data itself part of the problem? The research says over-reliance on comma/format cues comes from the data distribution — should fine-tune data be augmented (drop punctuation, lowercasing, whitespace noise)?
+4. **Seeds & eval protocol** — 1 seed = noise. At minimum 3 seeds (42, 123, 456) for both pretrained and control. Report mean ± std on the primary metric (fraction-wrong-at-≥0.9).
+5. **Checkpoint selection** — best validation CE, not final step. Calibration can degrade late in training even as loss improves.
+
+State which of these you want me to opine on, or give me all of them and I'll design the complete run card in turn 2.

--- a/.agents/skills/deepseek-consult/ds-mlm-ft-turn2.txt
+++ b/.agents/skills/deepseek-consult/ds-mlm-ft-turn2.txt
@@ -1,0 +1,75 @@
+## Answer to Turn 2: Implementation Reality, Calibration Protocol, and Seed Variance
+
+### (A) Aux-MLM-During-Fine-Tune: Skip for This First Decisive Run
+
+**Primary recommendation:**  
+Yes – skip aux MLM. Run both the pretrained-init and scratch-init fine‑tunes as pure CE (with label smoothing 0.1, same recipe). This is the cleanest attribution: only the encoder initialization differs. Adding aux MLM would require a second forward and introduce a confound (the scratch run cannot fairly include it without a pretrained LM head, or would need its own randomly initialized LM head, which changes the recipe).  
+
+The risk of a false negative from skipping aux MLM is **low** given:  
+- You are using label smoothing (0.1) on both runs, which already mitigates overconfidence.  
+- The primary hypothesis is that a pretrained encoder **by itself** improves calibration and accuracy. If a 20k-step pretrained encoder cannot show any benefit in a plain CE fine‑tune, then the pretraining is too weak to matter even with aux MLM.  
+- The pre‑registered revert criterion (any positive signal → scale pretrain) will catch even small gains; aux MLM would only amplify them, not create them from zero.
+
+**Fallback:**  
+If the pretrained run shows *no improvement* (or worse) on both calibration and resolver Acc@1, then in a second round run an augmented comparison with aux MLM (weight 0.1) on both pretrained and scratch (scratch gets a randomly initialized LM head from the architecture). This isolates whether aux MLM is necessary to realize pretraining benefit.
+
+### (B) Calibration Measurement: Keep Label Smoothing, Report ECE + Fraction‑Wrong‑at‑0.9
+
+**Primary recommendation:**  
+Keep label smoothing 0.1 on both runs. Measure calibration with **both**:
+- **Expected Calibration Error (ECE)** with 10 bins (primary)
+- **Fraction‑wrong‑at‑≥0.9 confidence** (secondary, to align with the original metric)
+
+The delta between pretrained and scratch on *both* metrics is the honest signal. Label smoothing will lower the absolute fraction‑wrong for both, but the relative improvement attributable to pretraining remains interpretable. Do **not** drop label smoothing, because without it the scratch run would be more overconfident, inflating the apparent benefit of pretraining – which is unfair to the scratch baseline.
+
+**Fallback:**  
+If ECE implementation is non‑trivial in your codebase, rely on fraction‑wrong‑at‑≥0.9 alone, but compute it from the **raw logits** before applying label smoothing (the model’s actual confidence). Label smoothing only affects the loss, not the forward pass probabilities. So the metric is clean regardless.
+
+**Concrete protocol:**  
+- For both runs, after training, freeze model and compute softmax scores on the validation set (415‑assertion harness or a separate calibration set).  
+- Report: ECE, fraction‑wrong‑at‑≥0.9, and the full reliability diagram if possible.  
+- The comparison is *pretrained_vs_scratch under identical smoothing* – that delta is the answer.
+
+### (C) Seed Variance: Run 2 Seeds for Each Condition (4 Runs Total) – Worth the Cost
+
+**Primary recommendation:**  
+Use **2 independent seeds** for both pretrained-init and scratch-init fine‑tunes (4 runs total).  
+- Total A100 time: ~4 hours (40k steps × ~15 sec/step? Actually 40k steps at 1h per run = 4h). Acceptable.  
+- For the harness pass rate (fixed assertion set) a single seed is sufficient because the metric is deterministic given the weights; but we need 2 training seeds to confirm generalization.  
+- For resolver Acc@1 (real OpenAddresses 10k test set), the metric is deterministic given the model, but the model itself varies with seed. Two seeds let you estimate mean and range.
+
+**Decision rule with 2 seeds:**  
+- If the **mean** resolver Acc@1 gain (pretrained minus scratch) is ≥0.5 percentage points **and** both seeds show gains in the same direction, that is clear signal.  
+- If mean gain is between 0.3 and 0.5pp, consider it positive but weak – proceed to 100k pretrain.  
+- If mean gain is ≤0.3pp or both seeds disagree, then no signal – do not scale pretrain.
+
+**Fallback (cost‑constrained):**  
+If only 1 seed per condition is feasible, require a **minimum Acc@1 gain of 1.0pp** to avoid false positives from noise. This is conservative but still achievable if pretraining is valuable.
+
+### What’s Left for Turn 3 (Execution Punch List + Go/No‑Go)
+
+After you have the 2‑seed results for both init conditions, **Turn 3** will consist of:
+
+1. **Compute aggregated metrics:**  
+   - Mean + range for resolver Acc@1, harness pass rate, ECE, fraction‑wrong‑at‑0.9.  
+   - Compare against the new scratch baseline (not v0.7.2).  
+
+2. **Apply the updated revert rule:**  
+   - If **any** of: (a) mean Acc@1 gain > 0, (b) mean harness rate > scratch baseline, (c) mean ECE lower → **scale pretrain to 100k steps**.  
+   - If **all** metrics are flat or worse → drop pretraining.  
+
+3. **If scaling:**  
+   - Continue pretraining from the existing 20k checkpoint for another 80k steps (same hyperparameters: mask prob 0.15, lr 1e-4 constant, warmup 1000, bf16).  
+   - Then repeat the fine‑tune (same recipe) from the 100k checkpoint vs a fresh scratch baseline (again 2 seeds each).  
+
+4. **Deliver final verdict:** is pretraining worth it?  
+
+**Concrete punch list for Turn 2 (you):**  
+- Implement recipe: 5e-5 cosine decay, 2k linear warmup, 40k steps, label smoothing 0.1, no aux MLM.  
+- Set up two random seeds (e.g., 42 and 1234).  
+- Run pretrained-init fine‑tune (seed0, seed1).  
+- Run scratch-init fine‑tune (seed0, seed1).  
+- Collect metrics on the 415‑assertion harness and 10k OpenAddresses test set.  
+- Report results as per the protocol above.  
+
+There is no further design decision after this; Turn 3 is purely execution.

--- a/.agents/skills/deepseek-consult/ds-mlm-ft-turn3.txt
+++ b/.agents/skills/deepseek-consult/ds-mlm-ft-turn3.txt
@@ -1,0 +1,5 @@
+1. **Yes** – CRF off (crf_loss_weight=0.0) for both arms avoids NaN risk and keeps the only variable being the encoder init.
+
+2. **Yes** – 40k cosine decay is correct; fine-tuning from pretrained weights should use a shorter schedule with decay, not a constant long run.
+
+3. **Yes** – run 1 seed first; if the resolver Acc@1 delta (pretrained minus scratch) is >1.0pp or clearly negative, stop. If between 0.3–1.0pp, run the second seed for a defensible mean.

--- a/.agents/skills/deepseek-consult/session-notes-2026-05-31-mlm-finetune.md
+++ b/.agents/skills/deepseek-consult/session-notes-2026-05-31-mlm-finetune.md
@@ -1,0 +1,38 @@
+# DeepSeek consult — MLM fine-tune recipe + comparison (2026-05-31, deepseek-reasoner, 3 turns)
+
+Decides how to fine-tune from the MLM-pretrained encoder (output-v080-mlm-pretrain/step-020000)
+and compare vs from-scratch, to judge whether pretraining helps. Full transcript: /tmp/ds_ft_msgs.json.
+
+## RECIPE (both arms identical; ONLY encoder init differs)
+- lr 5e-5, cosine decay to 0 over 40k steps, 2k linear warmup (NOT v0.7.2's constant 1.5e-4/100k —
+  too-high constant LR washes out pretrained features).
+- label_smoothing 0.1 on BOTH arms (shared calibration lever; dropping it would unfairly inflate the
+  pretrained arm's apparent calibration win).
+- CRF OFF (crf_loss_weight=0.0) both arms — matches what trained stably; avoids reintroducing the
+  CRF-under-bf16 NaN. bf16.
+- Aux-MLM-during-finetune: SKIP for the first decisive run. It needs a 2nd forward/step (~1.8x) +
+  new supervised-hot-path code AND confounds the clean init-only comparison. Add only as a 2nd-round
+  lever IF the clean comparison shows no signal. label_smoothing already covers calibration.
+- v0.7.2 corpus recipe (v0.4.0 + source_weights + augmentation) otherwise. Shipped v0.7.2 (100k, old
+  recipe, ls=0, crf=0) stays a LOOSE external reference only — the honest A/B is the fresh scratch arm.
+
+## RUN MATRIX (staged for cost)
+1. pretrained-init (init_from=step-020000), seed 42, 40k.
+2. from-scratch, same recipe, seed 42, 40k.
+3. Decision on the seed-42 resolver-Acc@1 delta (pretrained − scratch):
+   - >1.0pp OR clearly negative → STOP, verdict now.
+   - 0.3–1.0pp ambiguous → add seed 1234 to BOTH arms for a defensible mean.
+   2-seed signal rule: mean gain ≥0.5pp AND both seeds same direction = clear.
+
+## METRICS (compute for both arms, vs the fresh scratch baseline NOT v0.7.2)
+- Calibration: ECE (10-bin) PRIMARY + fraction-wrong-at-≥0.9 — from RAW LOGITS (label_smoothing only
+  affects loss, not forward probs, so the metric is clean).
+- Harness pass-rate (Pelias-lineage regression gate, neural structurally ~19.8%).
+- Resolver end-to-end Acc@1 (the product metric; neural 96.1% locality on 10k OpenAddresses).
+
+## REVERT — REFRAMED (20k pretrain is under-trained, MLM loss still descending at 4.58)
+- ANY positive signal (mean Acc@1 gain >0, OR harness > scratch, OR ECE lower) → scale pretrain
+  20k→100k (continue from step-020000, same hyperparams) then re-run the fine-tune comparison.
+- Drop pretraining ONLY if all metrics flat/worse AFTER the 100k pretrain attempt.
+- (Supersedes the earlier 'harness<22% AND Acc@1 gain<1.5pp → drop' — that was too quick to abandon
+  an under-trained pretrain.)

--- a/corpus-python/src/mailwoman_train/configs/v0_8_0-finetune-pretrained.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_8_0-finetune-pretrained.yaml
@@ -1,0 +1,134 @@
+# v0.8.0 — supervised fine-tune FROM the MLM-pretrained encoder (arm A of the decisive A/B).
+#
+# Phase 2 of pretrain -> fine-tune. Loads the MLM-pretrained encoder
+# (output-v080-mlm-pretrain/checkpoints/step-020000) via init_from (ENCODER WEIGHTS ONLY — no
+# optimizer/scheduler/step), then trains the supervised BIO task on top. The ONLY difference vs the
+# scratch arm (v0_8_0-finetune-scratch.yaml) is this `init_from`. DeepSeek-signed recipe
+# (2026-05-31, session-notes-2026-05-31-mlm-finetune.md).
+#
+# RECIPE NOTES (differs from shipped v0.7.2 on purpose — both arms here are internally consistent):
+#   - lr 5e-5 cosine->0 over 40k, 2k warmup: 3x lower than v0.7.2's constant 1.5e-4 to avoid washing
+#     out the pretrained features (catastrophic forgetting); shorter (40k vs 100k) because a
+#     pretrained encoder adapts fast.
+#   - label_smoothing 0.1: shared calibration lever on BOTH arms.
+#   - CRF OFF (crf_loss_weight 0.0): matches what trained stably; avoids the CRF-under-bf16 NaN.
+#   - corpus v0.4.0 + source_weights + augmentation: the v0.7.2 supervised recipe (the labeled task),
+#     so the comparison reflects the parser the product actually uses.
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0_8_0-finetune-pretrained.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  # CRF OFF via zero weight — the head exists (geometry parity with the pretrained ckpt) but does not
+  # contribute to the loss. Avoids the CRF-under-bf16 NaN that disabled it in v0.7.2.
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  # Shared calibration lever (both arms). v0.7.2 used 0.0.
+  label_smoothing: 0.1
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  # THE one variable: initialize the encoder from the MLM pretrain checkpoint (weights only).
+  init_from: /data/output-v080-mlm-pretrain/checkpoints/step-020000
+  output_dir: /data/output-v080-ft-pretrained-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 5.0e-5
+  weight_decay: 0.01
+  warmup_steps: 2000
+  grad_clip_norm: 1.0
+  max_steps: 40000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: cosine
+  trackio_project: mailwoman
+  trackio_run_name: v0.8.0-ft-pretrained-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/configs/v0_8_0-finetune-scratch.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_8_0-finetune-scratch.yaml
@@ -1,0 +1,132 @@
+# v0.8.0 — supervised fine-tune FROM SCRATCH (arm B of the decisive A/B; the honest baseline).
+#
+# Random encoder init (no init_from), IDENTICAL recipe to v0_8_0-finetune-pretrained.yaml. This is
+# the fair baseline: the ONLY difference between the two arms is the encoder initialization, so any
+# delta is attributable to MLM pretraining (not the recipe). DeepSeek-signed recipe
+# (2026-05-31, session-notes-2026-05-31-mlm-finetune.md).
+#
+# RECIPE NOTES (differs from shipped v0.7.2 on purpose — both arms here are internally consistent):
+#   - lr 5e-5 cosine->0 over 40k, 2k warmup: 3x lower than v0.7.2's constant 1.5e-4 to avoid washing
+#     out the pretrained features (catastrophic forgetting); shorter (40k vs 100k) because a
+#     pretrained encoder adapts fast.
+#   - label_smoothing 0.1: shared calibration lever on BOTH arms.
+#   - CRF OFF (crf_loss_weight 0.0): matches what trained stably; avoids the CRF-under-bf16 NaN.
+#   - corpus v0.4.0 + source_weights + augmentation: the v0.7.2 supervised recipe (the labeled task),
+#     so the comparison reflects the parser the product actually uses.
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0_8_0-finetune-scratch.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  # CRF OFF via zero weight — the head exists (geometry parity with the pretrained ckpt) but does not
+  # contribute to the loss. Avoids the CRF-under-bf16 NaN that disabled it in v0.7.2.
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  # Shared calibration lever (both arms). v0.7.2 used 0.0.
+  label_smoothing: 0.1
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  # No init_from — random encoder init (the scratch baseline arm).
+  output_dir: /data/output-v080-ft-scratch-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 5.0e-5
+  weight_decay: 0.01
+  warmup_steps: 2000
+  grad_clip_norm: 1.0
+  max_steps: 40000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: cosine
+  trackio_project: mailwoman
+  trackio_run_name: v0.8.0-ft-scratch-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""


### PR DESCRIPTION
The decisive experiment for **does MLM pretraining help?** — two supervised fine-tune configs, **identical recipe, differing only in encoder init**:
- `v0_8_0-finetune-pretrained.yaml` — `init_from` the MLM-pretrained `step-020000` encoder
- `v0_8_0-finetune-scratch.yaml` — random init (the honest baseline)

DeepSeek-signed recipe (3-turn consult; notes + transcripts in `.agents/skills/deepseek-consult/`):
- **lr 5e-5 cosine→0 / 40k / 2k warmup** — 3× lower + shorter than v0.7.2's constant-1.5e-4/100k, to avoid washing out the pretrained features
- **label_smoothing 0.1** (shared calibration lever both arms), **CRF off** (avoids the CRF-bf16 NaN), bf16, v0.7.2 corpus recipe otherwise

A `diff` of the two configs is **only** `init_from` + `output_dir` + `run_name`. Shipped v0.7.2 stays a loose external reference; the fair baseline is the fresh scratch arm.

**Verified:** both load + route to supervised `train()`; the `init_from` load path is smoke-tested end-to-end (`missing=0 unexpected=0` — the tied MLM head keeps state_dicts key-identical, encoder weights transfer, supervised forward works after).

**Staged plan:** seed-42 both arms first → if resolver Acc@1 delta >1.0pp or clearly negative, verdict; if 0.3–1.0pp ambiguous, add seed 1234. Revert reframed: *any* positive signal → scale pretrain 20k→100k (it's under-trained), drop only if flat after 100k.

Config + notes only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)