### PR TITLE
fix(train): _shard_paths prefer valid manifest paths, re-root only stale (overlay corpora)

### DIFF
--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -54,34 +54,44 @@ def _shard_paths(corpus_dir: Path, split: str) -> list[Path]:
     """Resolve train/val/test shard paths via MANIFEST.json (adapter-addition corpora)
     or legacy glob fallback (monolithic corpora).
 
-    The MANIFEST stores ABSOLUTE paths from the machine that built the corpus (e.g.
-    ``/mnt/playpen/.../v0.3.0/corpus-v0.3.0/train/part-0000.parquet``). Those don't exist when
-    the same corpus is mounted elsewhere — notably the Modal volume at ``/data/...``. So we
-    RE-ROOT each manifest entry under the actual ``corpus_dir``: take the ``<split>/<basename>``
-    tail and join it to ``corpus_dir``. This keeps the manifest's split assignment + shard list
-    authoritative while making the paths portable. If a manifest path doesn't contain the split
-    segment (unexpected layout), fall back to its basename under ``corpus_dir/split``."""
+    The MANIFEST lists per-shard absolute ``path`` + ``split``. Two realities complicate this:
+
+    1. **Overlay corpora.** An overlay (e.g. v0.4.0 = synth shards layered on v0.3.0's base) keeps
+       a manifest whose base-shard paths deliberately point into the OTHER corpus dir
+       (``/data/.../v0.3.0/...``). Those are correct and must be used VERBATIM — re-rooting them to
+       ``corpus_dir`` would point at files that don't exist (v0.4.0 only has the overlay shards).
+    2. **Portability.** A non-overlay manifest stores absolute paths from the BUILD machine
+       (``/mnt/playpen/...``) that don't exist when the corpus is mounted elsewhere (Modal volume
+       at ``/data/...``).
+
+    So per shard: use the manifest path AS-IS when it exists; otherwise RE-ROOT it under
+    ``corpus_dir`` (take the ``<split>/<basename>`` tail). This serves both cases — overlay
+    cross-dir refs are preserved when valid, build-machine paths are re-rooted when stale — and is
+    why v0.7.2 (v0.4.0 overlay → v0.3.0 base) trained fine: its manifest paths resolve as-is on the
+    volume. Falls back to a glob over ``corpus_dir/split`` only when the manifest yields nothing
+    usable."""
     import json
     manifest = corpus_dir / "MANIFEST.json"
     if manifest.exists():
         data = json.loads(manifest.read_text())
-        rerooted: list[Path] = []
+        resolved: list[Path] = []
         for s in data.get("shards", []):
             if s.get("split") != split:
                 continue
             raw = Path(s["path"])
+            if raw.exists():
+                # Path is valid as-is (overlay cross-dir ref, or corpus on its build machine).
+                resolved.append(raw)
+                continue
+            # Stale absolute path (corpus moved): re-root the <split>/<file> tail under corpus_dir.
             parts = raw.parts
-            # Re-root at corpus_dir from the split segment onward (…/<split>/<file> -> corpus_dir/<split>/<file>).
-            if split in parts:
-                tail = Path(*parts[parts.index(split):])
-                rerooted.append(corpus_dir / tail)
-            else:
-                rerooted.append(corpus_dir / split / raw.name)
-        if rerooted:
-            # If the re-rooted paths exist, use them; else (corpus laid out differently) fall through to glob.
-            if any(p.exists() for p in rerooted):
-                return sorted(rerooted)
-    # legacy fallback (monolithic corpora, or manifest paths that don't resolve here)
+            tail = Path(*parts[parts.index(split):]) if split in parts else Path(split) / raw.name
+            cand = corpus_dir / tail
+            if cand.exists():
+                resolved.append(cand)
+        if resolved:
+            return sorted(resolved)
+    # legacy fallback (monolithic corpora, or manifest yielded no resolvable shards)
     paths = sorted((corpus_dir / split).glob("*.parquet"))
     if not paths:
         raise FileNotFoundError(f"no shards via MANIFEST or {corpus_dir / split}")


### PR DESCRIPTION
**My prior re-root fix (#218) broke overlay corpora.** v0.4.0 is a synth overlay whose MANIFEST deliberately references the **v0.3.0 base** shards by absolute path (`/data/.../v0.3.0/...`). #218 blindly re-rooted those to `corpus_dir` (`v0.4.0/...`), which only has the 12 overlay shards + an empty `val/` — so a v0.4.0 fine-tune **crashed at the first eval**: `no shards via MANIFEST or .../v0.4.0/.../val`. (v0.7.2 trained fine precisely because it used the manifest's v0.3.0 paths *as-is*.)

**Correct rule (per shard):** use the manifest path **as-is when it exists** (overlay cross-dir ref, or corpus on its build machine); **re-root** under `corpus_dir` only when the original is **stale** (corpus moved — e.g. `/mnt/playpen` build paths on the Modal volume). Serves both overlay and portability.

**Verified 3 cases:** real v0.3.0 local (674+2+2 resolve), simulated overlay (cross-dir val path preserved as-is), simulated portability (stale path re-rooted). On the volume, v0.4.0's manifest val paths point into `v0.3.0/val` (synced) → v0.8.0 fine-tunes now eval correctly.

Surfaced by the Arm-A fine-tune crashing at step 2000 (training was healthy — `train_loss=0.86` — only the eval shard-resolution failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)