### PR TITLE
chore(train): v0.8.1 decisive-round fine-tune configs (100k, v0.7.2 recipe)

### DIFF
--- a/.agents/skills/deepseek-consult/ds-mlm-ft-turn4-results.txt
+++ b/.agents/skills/deepseek-consult/ds-mlm-ft-turn4-results.txt
@@ -1,0 +1,36 @@
+## Turn 3 Answers: Decisive Call on MLM Track
+
+### 1. Fix the fine‑tune recipe first, then scale pretrain if needed.
+
+**Yes.** The 40k/5e‑5 recipe is the bottleneck – it under‑trains both arms to ~50% resolver. Scaling pretrain to 100k will not help if the fine‑tune cannot reach the task ceiling. The pre‑registered “positive signal → scale pretrain” branch was made before we knew the fine‑tune was broken. Now we know: fix the fine‑tune recipe first, then judge pretraining at competitive performance.
+
+### 2. Concrete fine‑tune recipe for the next comparison.
+
+Run both arms (pretrained‑init from 20k MLM vs scratch‑init) with:
+
+- **LR**: constant `1.5e-4` (identical to v0.7.2)
+- **Steps**: `100,000`
+- **Warmup**: `1,000` steps
+- **Label smoothing**: `0.1` (keep it for fairness; both arms)
+- **CRF**: off (`crf_loss_weight=0.0`)
+- **bf16**: yes
+- **Batch size / seq length**: match v0.7.2
+
+This recipe is **known to reach ~96% resolver** from scratch (v0.7.2 without LS). Adding label smoothing 0.1 may cost <1pp but keeps calibration fair. If scratch cannot reach ≥94% under this recipe, then something else is wrong (e.g., data different) – but with the same corpus it should.
+
+**Run one seed of each arm first** (seed 42). If pretrained shows any improvement (resolver, harness, calibration) over scratch, then scale pretrain to 100k and repeat. If pretrained is worse or equal, decide per Q3.
+
+### 3. Is it worth more compute? Kill point.
+
+**Yes, it is worth one more round** (2 runs × 100k steps ≈ 2–3 A100 hours) because:
+
+- The secondary benefits (calibration +2pp, harness +4.8pp) are consistent and meaningful for a production system.
+- The product metric under‑training is an artefact of a bad recipe, not of pretraining.
+- The false‑negative risk – concluding “pretraining doesn’t help” when it might at ceiling – is high if we stop now.
+
+**Kill point after this round:**  
+- If pretrained **does not achieve equal or better resolver** than scratch (within ±0.5pp) **and** the harness and calibration gains disappear or reverse → drop pretraining.  
+- If pretrained **matches or slightly beats** scratch on resolver (even by 0.3pp) **and** retains the calibration/harness gains → ship with pretraining (the secondary benefits are valuable and cost free).  
+- If pretrained **beats** scratch on resolver by ≥1pp → scale pretrain to 100k immediately.
+
+Execute this single decisive round. No more exploratory recipes.

--- a/.agents/skills/deepseek-consult/session-notes-2026-05-31-mlm-finetune.md
+++ b/.agents/skills/deepseek-consult/session-notes-2026-05-31-mlm-finetune.md
@@ -36,3 +36,22 @@ and compare vs from-scratch, to judge whether pretraining helps. Full transcript
 - Drop pretraining ONLY if all metrics flat/worse AFTER the 100k pretrain attempt.
 - (Supersedes the earlier 'harness<22% AND Acc@1 gain<1.5pp → drop' — that was too quick to abandon
   an under-trained pretrain.)
+
+## RESULTS (turn 4, 2026-05-31) — INCONCLUSIVE-POSITIVE; fine-tune recipe was the bottleneck
+Both arms 40k/5e-5-cosine/ls0.1/CRF-off, seed 42, init-only variable. Held-out:
+                       A-pretrained  B-scratch  shipped-v0.7.2(100k/1.5e-4-const/ls0)
+  calib wrong@>=0.9       47.7%        49.7%      81%      (A better by 2.0pp; ls explains the big drop)
+  harness pass           14.2%         9.4%      19.8%     (A better by 4.8pp)
+  resolver locality      48.0%        50.6%      96.1%     (BOTH catastrophically under-trained)
+- Pretraining signal is REAL + consistent on calib + harness (A>B). But BOTH arms under-trained the
+  supervised task to ~50% resolver vs shipped 96.1% — the 40k/5e-5 recipe is the bottleneck, NOT init.
+- DeepSeek turn-4 call: FIX THE FINE-TUNE RECIPE first (not scale pretrain). Re-run both arms at the
+  v0.7.2-proven recipe: lr 1.5e-4 CONSTANT, 100k steps, 1k warmup, ls 0.1, CRF off, bf16. One seed each,
+  ONE decisive round. KILL POINT: if pretrained doesn't reach >= scratch resolver (within 0.5pp) AND
+  calib/harness gains vanish -> drop pretraining. If pretrained matches/slightly beats resolver AND keeps
+  the calib+harness gains -> ship WITH pretraining (secondary benefits ~free). If pretrained beats
+  resolver by >=1pp -> scale pretrain to 100k.
+- Artifacts: /tmp/{oaA,oaB}.json (resolver), /tmp/{hA,hB}.log (harness), /tmp/probe.txt (calibration).
+  ONNX exports: /tmp/ftA/model.onnx, /tmp/ftB/model.onnx. Checkpoints on volume:
+  output-v080-ft-{pretrained,scratch}-s42/checkpoints/step-040000.
+- NOTHING promoted: both arms far below shipped v0.7.2 on the product metric. v0.7.2 stays the default.

--- a/corpus-python/src/mailwoman_train/configs/v0_8_1-finetune-pretrained.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_8_1-finetune-pretrained.yaml
@@ -1,0 +1,138 @@
+# DECISIVE ROUND (v0.8.1): the v0.8.0 40k/5e-5 fine-tune UNDER-TRAINED both arms (resolver ~50%
+# vs shipped v0.7.2's 96%). Per DeepSeek turn-4: re-run at the v0.7.2-PROVEN recipe (1.5e-4
+# constant / 100k / 1k warmup) — known to reach ~96% resolver — so pretraining is judged at the
+# task CEILING, not the basement. ls 0.1 + CRF off retained. Only encoder init differs across arms.
+# v0.8.1 — supervised fine-tune FROM the MLM-pretrained encoder (arm A of the decisive A/B).
+#
+# Phase 2 of pretrain -> fine-tune. Loads the MLM-pretrained encoder
+# (output-v080-mlm-pretrain/checkpoints/step-020000) via init_from (ENCODER WEIGHTS ONLY — no
+# optimizer/scheduler/step), then trains the supervised BIO task on top. The ONLY difference vs the
+# scratch arm (v0_8_0-finetune-scratch.yaml) is this `init_from`. DeepSeek-signed recipe
+# (2026-05-31, session-notes-2026-05-31-mlm-finetune.md).
+#
+# RECIPE NOTES (differs from shipped v0.7.2 on purpose — both arms here are internally consistent):
+#   - lr 5e-5 cosine->0 over 40k, 2k warmup: 3x lower than v0.7.2's constant 1.5e-4 to avoid washing
+#     out the pretrained features (catastrophic forgetting); shorter (40k vs 100k) because a
+#     pretrained encoder adapts fast.
+#   - label_smoothing 0.1: shared calibration lever on BOTH arms.
+#   - CRF OFF (crf_loss_weight 0.0): matches what trained stably; avoids the CRF-under-bf16 NaN.
+#   - corpus v0.4.0 + source_weights + augmentation: the v0.7.2 supervised recipe (the labeled task),
+#     so the comparison reflects the parser the product actually uses.
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0_8_0-finetune-pretrained.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  # CRF OFF via zero weight — the head exists (geometry parity with the pretrained ckpt) but does not
+  # contribute to the loss. Avoids the CRF-under-bf16 NaN that disabled it in v0.7.2.
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  # Shared calibration lever (both arms). v0.7.2 used 0.0.
+  label_smoothing: 0.1
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  # THE one variable: initialize the encoder from the MLM pretrain checkpoint (weights only).
+  init_from: /data/output-v080-mlm-pretrain/checkpoints/step-020000
+  output_dir: /data/output-v081-ft-pretrained-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 100000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.8.1-ft-pretrained-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/configs/v0_8_1-finetune-scratch.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_8_1-finetune-scratch.yaml
@@ -1,0 +1,136 @@
+# DECISIVE ROUND (v0.8.1): the v0.8.0 40k/5e-5 fine-tune UNDER-TRAINED both arms (resolver ~50%
+# vs shipped v0.7.2's 96%). Per DeepSeek turn-4: re-run at the v0.7.2-PROVEN recipe (1.5e-4
+# constant / 100k / 1k warmup) — known to reach ~96% resolver — so pretraining is judged at the
+# task CEILING, not the basement. ls 0.1 + CRF off retained. Only encoder init differs across arms.
+# v0.8.1 — supervised fine-tune FROM SCRATCH (arm B of the decisive A/B; the honest baseline).
+#
+# Random encoder init (no init_from), IDENTICAL recipe to v0_8_0-finetune-pretrained.yaml. This is
+# the fair baseline: the ONLY difference between the two arms is the encoder initialization, so any
+# delta is attributable to MLM pretraining (not the recipe). DeepSeek-signed recipe
+# (2026-05-31, session-notes-2026-05-31-mlm-finetune.md).
+#
+# RECIPE NOTES (differs from shipped v0.7.2 on purpose — both arms here are internally consistent):
+#   - lr 5e-5 cosine->0 over 40k, 2k warmup: 3x lower than v0.7.2's constant 1.5e-4 to avoid washing
+#     out the pretrained features (catastrophic forgetting); shorter (40k vs 100k) because a
+#     pretrained encoder adapts fast.
+#   - label_smoothing 0.1: shared calibration lever on BOTH arms.
+#   - CRF OFF (crf_loss_weight 0.0): matches what trained stably; avoids the CRF-under-bf16 NaN.
+#   - corpus v0.4.0 + source_weights + augmentation: the v0.7.2 supervised recipe (the labeled task),
+#     so the comparison reflects the parser the product actually uses.
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0_8_0-finetune-scratch.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  # CRF OFF via zero weight — the head exists (geometry parity with the pretrained ckpt) but does not
+  # contribute to the loss. Avoids the CRF-under-bf16 NaN that disabled it in v0.7.2.
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  # Shared calibration lever (both arms). v0.7.2 used 0.0.
+  label_smoothing: 0.1
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  # No init_from — random encoder init (the scratch baseline arm).
+  output_dir: /data/output-v081-ft-scratch-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 100000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.8.1-ft-scratch-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""


### PR DESCRIPTION
The v0.8.0 40k/5e-5 fine-tune **under-trained both arms** (resolver locality ~48-50% vs shipped v0.7.2's 96.1%) — the recipe, not the init, was the bottleneck. Per DeepSeek turn-4: re-run both arms at the **v0.7.2-proven recipe** (lr 1.5e-4 constant / 100k / 1k warmup — known to reach ~96% resolver) so MLM pretraining is judged at the task **ceiling**, not the basement.

- `v0_8_1-finetune-pretrained.yaml` — `init_from` the 20k-MLM encoder
- `v0_8_1-finetune-scratch.yaml` — random init
- Recipe **verified identical to v0.7.2** on lr/schedule/warmup/steps/batch; only `label_smoothing` differs (0.1 vs 0.0, the shared calibration lever) and the encoder init (the one variable).

**v0.8.0 held-out result** (recorded in session notes): pretraining showed a real **+2pp calibration / +4.8pp harness** signal even under-trained, but nothing promotable (both far below shipped on the product metric). **Kill point this round:** if pretrained doesn't reach ≥ scratch resolver (within 0.5pp) AND the calib/harness gains vanish → drop pretraining; else ship-with / scale-pretrain per the deltas.

Config + notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)