### PR TITLE
eval(resolver): gazetteer-alias locality matching + per-row failure dump

### DIFF
--- a/docs/articles/evals/2026-05-31-resolver-failure-analysis.md
+++ b/docs/articles/evals/2026-05-31-resolver-failure-analysis.md
@@ -1,0 +1,81 @@
+---
+title: "Resolver failure analysis — OpenAddresses real-point eval (v0.7.2 neural vs v0/Pelias)"
+date: 2026-05-31
+status: analysis (read-only) — scopes the next resolver-depth PRs
+---
+
+# Resolver failure analysis (v0.7.2, 1500 OA real points)
+
+Read-only triage of where the **resolver** misses, run while the v0.8.1 MLM arms trained.
+Method: `scripts/eval/oa-resolver-eval.ts --limit 1500 --errors-json` (new flag, this branch)
+scores the real v0.7.2 neural parser AND v0/Pelias through the same WOF resolver on real
+OpenAddresses points, and dumps every row where either parser missed locality, carrying each
+parser's **resolved admin name** so a miss can be bucketed as resolve-wrong vs unresolved.
+
+## Headline
+
+| parser       | locality-match | region-match | resolved |
+|--------------|---------------:|-------------:|---------:|
+| **neural**   | **94.9%**      | 99.9%        | 100.0%   |
+| v0 (Pelias)  | 93.7%          | 99.4%        | 99.7%    |
+
+**Neural beats v0/Pelias on real points** (+1.2pp locality) — the north-star claim, on an
+honest non-circular signal. 101 rows had a miss from one or both parsers.
+
+## Where neural's 76 locality-misses actually go
+
+| bucket | count | what it is |
+|--------|------:|------------|
+| **(A) name-form variant** | **40** | resolver found the RIGHT place; the eval's name-matcher rejects the form |
+| (B) genuinely wrong place | 13 | resolved to a real but incorrect admin — the resolver-disambiguation target |
+| (C) no locality resolved  | 23 | parser mis-segment, `<Null>` tokens, or WOF coverage gap |
+
+> **If bucket (A) were credited, neural locality on these 1500 rows is ≈97.6%, not 94.9%.**
+> And several of (B) are *also* name-form (`Mt Pleasant`→`Mount Pleasant`, `Mc Laughlin`→
+> `McLaughlin`, `Enosburgh`→`Enosburg Center`), so true locality accuracy is ~97–98%.
+
+The eval has been *underselling* the resolver. Examples from (A): `Butte`→`Butte-Silver Bow`
+(consolidated city-county — WOF's canonical name), `Saint Johnsbury`→`St. Johnsbury`,
+`Derby`→`Derby Center`, `Monroe Twp`→`Monroe`, `Barre City`→`Barre`.
+
+## Recommended next PRs, ranked by ROI
+
+1. **Eval name-match fidelity (HIGH ROI, low risk) — but do it via the gazetteer, not ad-hoc
+   string loosening.** Match OA's expected name against WOF's **alias/altname** set for the
+   resolved place (Saint/St, Mt/Mount, Mc/Mac spacing, consolidated city-county names,
+   township/city/village/center suffixes) instead of a single canonical string. This is
+   *correctness*, not gaming: these resolutions are right. Risk if done naively (blanket
+   substring/loosening) is masking real errors — so anchor on WOF altnames + a tight
+   suffix/abbreviation list, and keep bucket (B)'s genuine errors failing. Expected effect:
+   measured neural locality 94.9% → ~97.6%, and a *truer* delta vs v0.
+
+2. **Resolver disambiguation — the `Saint Albans Town/City → St. Johnsbury` cluster (4 rows).**
+   A genuine ranking bug: for "Saint Albans, VT" the resolver picks the wrong VT town. Check
+   whether this is name-collision handling or the population/importance tiebreak (must stay
+   ALIGNED with the population/importance ranking used elsewhere — or document why it differs
+   here). This is real resolver-depth work, small but clear.
+
+3. **Neural parser robustness (feeds the retrain/MLM track, not the resolver).** Two concrete
+   patterns from (C):
+   - **`<Null>` literal tokens** in OA input (`21695 <Null> 210TH STREET, Holland, IA`) →
+     neural fails to parse; v0 survives. Input sanitization and/or a corpus augmentation.
+   - **DC directional quadrant** (`6th Street Ne, Washington` → neural tags `Ne Smith` as
+     locality) and **multi-word locality truncation** (`Belle Fourche`→`Belle`, `Fort Pierre`
+     →`Fort`, SD). Corpus-augmentation candidates for the next train.
+
+4. **WOF coverage (lowest priority, after (1)).** A handful of tiny localities resolve to
+   nothing (`Pennco`, `Dakota Dunes`, `Essex Junction Village SD/VT`). Extend the custom
+   `admin-global-priority.db` build rather than chasing these individually.
+
+## Geography of failures
+
+VT 39, IA 26, SD 14, MT 11, IL 7, DC 3, CA 1 — concentrated in rural/township-heavy states
+with many small villages and Saint-/Mount-/township name variants. This is consistent with
+(A) dominating: the failures cluster exactly where canonical-name forms diverge most, not
+where the resolver is structurally weak.
+
+## Where neural already wins (bucket: v0-only failures, 25 rows)
+
+v0/Pelias returns *no locality* for many that neural gets right: `Des Moines`, `Des Plaines`
+(v0 mishandles the `Des` token), `Chicago`, `Georgia, VT` (v0 confuses the locality with the
+state), `Moretown`. These are the cases the neural parser exists to win — and does.

--- a/docs/articles/evals/2026-05-31-resolver-failure-analysis.md
+++ b/docs/articles/evals/2026-05-31-resolver-failure-analysis.md
@@ -40,14 +40,25 @@ The eval has been *underselling* the resolver. Examples from (A): `Butte`→`But
 
 ## Recommended next PRs, ranked by ROI
 
-1. **Eval name-match fidelity (HIGH ROI, low risk) — but do it via the gazetteer, not ad-hoc
-   string loosening.** Match OA's expected name against WOF's **alias/altname** set for the
-   resolved place (Saint/St, Mt/Mount, Mc/Mac spacing, consolidated city-county names,
-   township/city/village/center suffixes) instead of a single canonical string. This is
-   *correctness*, not gaming: these resolutions are right. Risk if done naively (blanket
-   substring/loosening) is masking real errors — so anchor on WOF altnames + a tight
-   suffix/abbreviation list, and keep bucket (B)'s genuine errors failing. Expected effect:
-   measured neural locality 94.9% → ~97.6%, and a *truer* delta vs v0.
+1. **Eval name-match fidelity (HIGH ROI) — ✅ SHIPPED IN THIS PR.** Match OA's expected name
+   against the resolved place's full WOF **`names` altname set** (normalized), not a single
+   canonical string, plus a tight abbreviation layer (St→Saint, Mt→Mount, Ft→Fort, Mc-despace,
+   diacritics/punct). Deliberately **no civic-suffix stripping** — `Barre City` and `Barre Town`
+   are distinct VT municipalities. This is *correctness*, not gaming: WOF records these as the
+   same place.
+
+   **Result (1500 OA rows, real v0.7.2):**
+
+   | parser | locality BEFORE | locality AFTER | Δ |
+   |--------|----------------:|---------------:|---:|
+   | **neural**  | 94.9% | **97.1%** | +2.2 |
+   | v0 (Pelias) | 93.7% | 95.3% | +1.6 |
+
+   Both parsers rise (the matcher is parser-agnostic), and neural's lead over Pelias **widens
+   to +1.8pp**. 32 neural misses credited — all legitimate (`Saint↔St. Johnsbury`,
+   `Mt↔Mount Pleasant`, `Butte↔Butte-Silver Bow`, `Rutland City↔Rutland`). **Guard verified:**
+   all 4 `Saint Albans → St. Johnsbury` genuine errors still fail (0 wrongly credited) — the
+   matcher trusts disjoint WOF ids, so real ranking bugs stay visible for PR #2.
 
 2. **Resolver disambiguation — the `Saint Albans Town/City → St. Johnsbury` cluster (4 rows).**
    A genuine ranking bug: for "Saint Albans, VT" the resolver picks the wrong VT town. Check

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -240,17 +240,29 @@ async function main(): Promise<void> {
 	const scoreTree = (
 		row: OaRow,
 		resolved: Resolved[]
-	): { locMatch: boolean; regMatch: boolean; resolved: boolean; err: number | null } => {
+	): {
+		locMatch: boolean
+		regMatch: boolean
+		resolved: boolean
+		err: number | null
+		resolvedLoc?: string
+		resolvedReg?: string
+	} => {
 		const best = mostSpecific(resolved)
 		// Admin-match is by NAME (OA carries no WOF id): a row matches if a resolved locality's
 		// canonical gazetteer name equals OA's expected locality; region is name-or-abbrev tolerant.
-		const locName = norm(resolved.find((r) => r.placetype === "locality")?.name)
+		const locRaw = resolved.find((r) => r.placetype === "locality")?.name
+		const locName = norm(locRaw)
 		const regResolved = resolved.find((r) => r.placetype === "region")
 		return {
 			locMatch: !!row.expected.locality && locName === norm(row.expected.locality),
 			regMatch: regionMatches(regResolved?.name, row.expected.region),
 			resolved: !!best,
 			err: best ? haversineKm(best.lat, best.lon, row.lat, row.lon) : null,
+			// Raw resolved names for the --errors-json per-row dump: a present-but-wrong resolvedLoc
+			// => resolver ranking/disambiguation miss; an absent one => coverage/parse miss.
+			resolvedLoc: locRaw,
+			resolvedReg: regResolved?.name,
 		}
 	}
 
@@ -271,6 +283,12 @@ async function main(): Promise<void> {
 		bump(agg[who].overall, s.locMatch, s.regMatch, s.resolved, s.err)
 	}
 
+	// Per-row failure dump (--errors-json): one record per row where neural OR v0 missed locality,
+	// carrying each parser's resolved admin names so failures can be bucketed offline (resolve-wrong
+	// vs unresolved vs neural-only vs v0-only). Aggregates are unaffected.
+	const collectErrors = !!arg("errors-json")
+	const errorRows: Record<string, unknown>[] = []
+
 	let i = 0
 	for (const row of rows) {
 		i++
@@ -283,7 +301,8 @@ async function main(): Promise<void> {
 		} catch {
 			/* unresolved */
 		}
-		record("neural", row, scoreTree(row, nResolved))
+		const ns = scoreTree(row, nResolved)
+		record("neural", row, ns)
 
 		// v0 (Pelias parser) via the flat→tree adapter
 		let vResolved: Resolved[] = []
@@ -295,7 +314,22 @@ async function main(): Promise<void> {
 		} catch {
 			/* unresolved */
 		}
-		record("v0", row, scoreTree(row, vResolved))
+		const vs = scoreTree(row, vResolved)
+		record("v0", row, vs)
+
+		if (collectErrors && (!ns.locMatch || !vs.locMatch)) {
+			errorRows.push({
+				input: row.input,
+				state: row.state ?? "??",
+				expected: row.expected,
+				neural: { locMatch: ns.locMatch, resolved: ns.resolved, resolvedLoc: ns.resolvedLoc, resolvedReg: ns.resolvedReg, errKm: ns.err },
+				v0: { locMatch: vs.locMatch, resolved: vs.resolved, resolvedLoc: vs.resolvedLoc, resolvedReg: vs.resolvedReg, errKm: vs.err },
+			})
+		}
+	}
+	if (collectErrors) {
+		writeFileSync(arg("errors-json"), JSON.stringify(errorRows, null, 2))
+		console.error(`wrote ${errorRows.length} failure rows → ${arg("errors-json")}`)
 	}
 
 	// ---- report (self-emitted; eval figures are NEVER hand-typed into docs) ----

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -41,6 +41,7 @@ import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { createWofResolver } from "@mailwoman/core/resolver"
 import { type ClassificationRecord, createAddressParser } from "mailwoman"
 import { readFileSync, writeFileSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
 import { v0RecordToTree } from "./v0-tree-adapter.ts"
 
 function arg(name: string, fallback = ""): string {
@@ -111,6 +112,30 @@ function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): nu
 }
 
 const norm = (s: string | undefined): string => (s ?? "").toLowerCase().trim()
+
+/**
+ * Aggressive name normalization for gazetteer-alias locality matching. Lowercases, strips
+ * diacritics + punctuation, expands the universal US place abbreviations (St→Saint, Mt→Mount,
+ * Ft→Fort, Ste→Sainte), and de-spaces "Mc X" → "McX". Deliberately does NOT strip civic
+ * suffixes (City/Town/Township/Village): in New England "Barre City" and "Barre Town" are
+ * DISTINCT municipalities, so collapsing them would over-credit genuine wrong-place misses.
+ * Pair with the WOF altname set (a place's own recorded variants) rather than loosening here.
+ */
+const ABBR: Record<string, string> = { st: "saint", ste: "sainte", mt: "mount", ft: "fort" }
+const normName = (s: string | undefined): string => {
+	if (!s) return ""
+	const x = s
+		.toLowerCase()
+		.normalize("NFD")
+			.replace(/[\u0300-\u036f]/g, "") // drop diacritics
+		.replace(/[^a-z0-9]+/g, " ") // punctuation/hyphens → space (Butte-Silver Bow → butte silver bow)
+		.trim()
+	const toks = x
+		.split(" ")
+		.filter(Boolean)
+		.map((t) => ABBR[t] ?? t)
+	return toks.join(" ").replace(/\bmc (\w)/g, "mc$1").replace(/\s+/g, " ").trim()
+}
 
 // Resolved region names are the gazetteer's CANONICAL full names ("California", "District of
 // Columbia"); OA's expected.region is the USPS abbreviation ("CA", "DC"). Map full name → abbrev so
@@ -216,6 +241,35 @@ async function main(): Promise<void> {
 	const backend = new WofSqlitePlaceLookup({ databasePath: wofPaths.length === 1 ? wofPaths[0]! : wofPaths })
 	const resolver = createWofResolver(backend as never)
 
+	// Gazetteer-alias locality matching. A resolved place counts as a locality match if OA's
+	// expected name equals ANY of that place's WOF `names` rows (normalized) — not just its
+	// single canonical name. This credits forms WOF records as the SAME place (Butte ↔
+	// Butte-Silver Bow, Saint ↔ St. Johnsbury, Mt ↔ Mount Pleasant) WITHOUT loosening genuine
+	// wrong-place misses: different WOF ids carry disjoint name sets, so Saint Albans never
+	// matches St. Johnsbury. The admin db (shard 0) is opened read-only; `names` is indexed on
+	// id, and lookups are cached + only fire on a near-miss, so the cost is negligible.
+	const adminDb = new DatabaseSync(wofPaths[0]!, { readOnly: true })
+	const namesStmt = adminDb.prepare("SELECT name FROM names WHERE id = ?")
+	const altCache = new Map<number, Set<string>>()
+	const altNamesFor = (id: number): Set<string> => {
+		let set = altCache.get(id)
+		if (!set) {
+			set = new Set<string>()
+			for (const r of namesStmt.all(id) as { name: string }[]) {
+				const n = normName(r.name)
+				if (n) set.add(n)
+			}
+			altCache.set(id, set)
+		}
+		return set
+	}
+	const localityMatches = (expected: string | undefined, locNode: Resolved | undefined): boolean => {
+		if (!expected || !locNode) return false
+		const e = normName(expected)
+		if (!e) return false
+		return normName(locNode.name) === e || altNamesFor(locNode.id).has(e)
+	}
+
 	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
 	const resolveOpts = { defaultCountry: "US" }
 
@@ -249,13 +303,14 @@ async function main(): Promise<void> {
 		resolvedReg?: string
 	} => {
 		const best = mostSpecific(resolved)
-		// Admin-match is by NAME (OA carries no WOF id): a row matches if a resolved locality's
-		// canonical gazetteer name equals OA's expected locality; region is name-or-abbrev tolerant.
-		const locRaw = resolved.find((r) => r.placetype === "locality")?.name
-		const locName = norm(locRaw)
+		// Admin-match is by NAME (OA carries no WOF id): a row matches if OA's expected locality
+		// equals the resolved place's canonical name OR any of its WOF altnames (see
+		// localityMatches); region is name-or-abbrev tolerant.
+		const locNode = resolved.find((r) => r.placetype === "locality")
+		const locRaw = locNode?.name
 		const regResolved = resolved.find((r) => r.placetype === "region")
 		return {
-			locMatch: !!row.expected.locality && locName === norm(row.expected.locality),
+			locMatch: localityMatches(row.expected.locality, locNode),
 			regMatch: regionMatches(regResolved?.name, row.expected.region),
 			resolved: !!best,
 			err: best ? haversineKm(best.lat, best.lon, row.lat, row.lon) : null,


### PR DESCRIPTION
## What

Two changes to the OpenAddresses real-point resolver eval (`scripts/eval/oa-resolver-eval.ts`):

1. **`--errors-json`** — per-row dump of every row where neural OR v0 missed locality, carrying each parser's *resolved* admin name, so a miss can be bucketed offline (resolve-wrong vs unresolved). Aggregates unchanged.
2. **Gazetteer-alias locality matching** — match OA's expected locality against the resolved place's full WOF `names` altname set (normalized), not just its single canonical name, plus a tight abbreviation layer (St→Saint, Mt→Mount, Ft→Fort, Mc-despace, diacritics/punct). **No civic-suffix stripping** (`Barre City` ≠ `Barre Town` in VT).

## Why it's correctness, not gaming

WOF records these forms as the **same place**: `Butte` is an `eng` altname of `Butte-Silver Bow`; `St. Johnsbury` carries `Saint Johnsbury`; `Mount Pleasant` carries `Mt Pleasant`. The matcher anchors on per-place WOF **ids**, so genuinely different places carry disjoint name sets and stay misses.

## Result (1500 OA real points, real v0.7.2 neural)

| parser | locality BEFORE | locality AFTER | Δ |
|--------|----------------:|---------------:|---:|
| **neural**  | 94.9% | **97.1%** | +2.2 |
| v0 (Pelias) | 93.7% | 95.3% | +1.6 |

Both parsers rise (matcher is parser-agnostic); **neural's lead over Pelias widens to +1.8pp** — the north-star claim on a non-circular signal. 32 misses credited (all legitimate name-forms). **Guard verified:** all 4 `Saint Albans → St. Johnsbury` genuine errors still fail (0 wrongly credited), keeping real ranking bugs visible.

Full triage + the forward resolver-PR backlog: `docs/articles/evals/2026-05-31-resolver-failure-analysis.md`.

## Notes
- Uses `node:sqlite` (built into Node 24, no new dep); `names` indexed on id, lookups cached + fire only on near-miss → negligible cost.
- `scripts/` isn't in the tsc build graph and no test imports this CLI, so CI is unaffected by the eval-script change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)