### PR TITLE
fix(publish): correct FST filename casing in HF-bucket publish (BCP-47)

### DIFF
--- a/scripts/publish-release-to-hf.mjs
+++ b/scripts/publish-release-to-hf.mjs
@@ -94,8 +94,15 @@ async function main() {
 	if (!args.label) fail("--label required")
 	if (!args.description) fail("--description required")
 
-	// Adapt remote FST filename to the locale
-	const fstRemoteName = `fst-${args.locale.toUpperCase().replace(/-/g, "-")}.bin`.replace("-US", "-US")
+	// Adapt remote FST filename to the locale, in BCP-47 casing (lowercase language subtag,
+	// uppercase region subtag): "en-us" -> "en-US" -> "fst-en-US.bin". This MUST match the exact
+	// name the demo fetches (docs/src/shared/resources.tsx → "fst-en-US.bin"); a casing mismatch
+	// 404s the gazetteer at runtime. (Previously `locale.toUpperCase()` produced "fst-EN-US.bin".)
+	const bcp47 = args.locale
+		.split("-")
+		.map((part, i) => (i === 0 ? part.toLowerCase() : part.toUpperCase()))
+		.join("-")
+	const fstRemoteName = `fst-${bcp47}.bin`
 	REQUIRED_FILES[3].remoteName = fstRemoteName
 
 	console.error(`Publishing ${args.version} (${args.locale}) to HF Bucket...`)


### PR DESCRIPTION
## Bug

`scripts/publish-release-to-hf.mjs` built the remote FST name as `fst-${locale.toUpperCase()}.bin` → **`fst-EN-US.bin`** for `en-us`. The demo fetches **`fst-en-US.bin`** (`docs/src/shared/resources.tsx`), so the published gazetteer **404s at runtime** — the demo silently loses FST resolution.

Caught + worked around during today's v0.7.2 demo publish (the live bucket asset was corrected manually); this patches the script so the next publish doesn't repeat it.

## Fix

Build the filename in **BCP-47 casing** (lowercase language subtag, uppercase region subtag):

| locale | before (broken) | after |
|---|---|---|
| en-us | `fst-EN-US.bin` | **`fst-en-US.bin`** ✓ |
| fr-fr | `fst-FR-FR.bin` | `fst-fr-FR.bin` |
| ja-jp | `fst-JA-JP.bin` | `fst-ja-JP.bin` |

Verified locally for en-us/fr-fr/ja-jp/de-de/en-gb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)