### PR TITLE
fix(decoder): repair fragmented multi-word locality spans (Saint Paul → one span)

### DIFF
--- a/core/decoder/build-tree.test.ts
+++ b/core/decoder/build-tree.test.ts
@@ -165,6 +165,102 @@ describe("buildAddressTree — boundary trim", () => {
 	})
 })
 
+// Spurious-boundary repair. The neural model fragments some multi-word locality values into two
+// B-locality spans ("Saint Paul" → B-locality "Saint" + B-locality "Paul") — a real, decode-
+// agnostic emission bug (argmax == viterbi; see scripts/diag-saintalbans.ts). A `B-X` token that is
+// whitespace-adjacent to an open `X` span is folded in; a comma/separator keeps spans distinct.
+describe("buildAddressTree — adjacent same-tag merge (fragmentation repair)", () => {
+	function localitySpans(nodes: AddressNode[]): AddressNode[] {
+		const out: AddressNode[] = []
+		const walk = (n: AddressNode): void => {
+			if (n.tag === "locality") out.push(n)
+			for (const c of n.children) walk(c)
+		}
+		for (const n of nodes) walk(n)
+		return out
+	}
+
+	test("folds whitespace-adjacent B-locality B-locality into one span", () => {
+		// "Saint Paul, MN" — model emits B-locality on BOTH "Saint" and "Paul".
+		const raw = "Saint Paul, MN"
+		const tokens: DecoderToken[] = [
+			tok("Saint", 0, 5, "B-locality"),
+			tok("Paul", 6, 10, "B-locality"),
+			tok(",", 10, 11, "O"),
+			tok("MN", 12, 14, "B-region"),
+		]
+		const locs = localitySpans(buildAddressTree(raw, tokens).roots)
+		expect(locs.length).toBe(1)
+		expect(locs[0]!.value).toBe("Saint Paul")
+		expect(locs[0]!.start).toBe(0)
+		expect(locs[0]!.end).toBe(10)
+	})
+
+	test("folds across a zero-width whitespace-only O artifact (real SentencePiece stream)", () => {
+		// Exact stream observed from the model (scripts/diag-saintalbans.ts): SentencePiece emits a
+		// standalone zero-width "▁" marker between the words, labeled O. It must not break the span.
+		const raw = "Saint Paul, MN"
+		const tokens: DecoderToken[] = [
+			tok("▁Saint", 0, 5, "B-locality"),
+			tok("▁", 6, 6, "O"),
+			tok("Paul", 6, 10, "B-locality"),
+			tok(",", 10, 11, "O"),
+			tok("▁", 12, 12, "O"),
+			tok("MN", 12, 14, "B-region"),
+		]
+		const locs = localitySpans(buildAddressTree(raw, tokens).roots)
+		expect(locs.length).toBe(1)
+		expect(locs[0]!.value).toBe("Saint Paul")
+	})
+
+	test("merges within a full address too (St + Albans → one locality)", () => {
+		// "22 Brigham Rd, Saint Albans, VT 05478"
+		const raw = "22 Brigham Rd, Saint Albans, VT 05478"
+		const tokens: DecoderToken[] = [
+			tok("22", 0, 2, "B-house_number"),
+			tok("Brigham", 3, 10, "B-street"),
+			tok("Rd", 11, 13, "I-street"),
+			tok(",", 13, 14, "O"),
+			tok("Saint", 15, 20, "B-locality"),
+			tok("Albans", 21, 27, "B-locality"),
+			tok(",", 27, 28, "O"),
+			tok("VT", 29, 31, "B-region"),
+			tok("05478", 32, 37, "B-postcode"),
+		]
+		const locs = localitySpans(buildAddressTree(raw, tokens).roots)
+		expect(locs.length).toBe(1)
+		expect(locs[0]!.value).toBe("Saint Albans")
+	})
+
+	test("GUARD: comma between same-tag spans keeps them distinct (no merge)", () => {
+		// Two genuinely separate localities, comma in the gap (no intervening O token).
+		const raw = "Dallas, Austin"
+		const tokens: DecoderToken[] = [tok("Dallas", 0, 6, "B-locality"), tok("Austin", 8, 14, "B-locality")]
+		const locs = localitySpans(buildAddressTree(raw, tokens).roots)
+		expect(locs.length).toBe(2)
+		expect(locs.map((l) => l.value).sort()).toEqual(["Austin", "Dallas"])
+	})
+
+	test("GUARD: intervening O token keeps same-tag spans distinct", () => {
+		const raw = "Dallas , Austin"
+		const tokens: DecoderToken[] = [
+			tok("Dallas", 0, 6, "B-locality"),
+			tok(",", 7, 8, "O"),
+			tok("Austin", 9, 15, "B-locality"),
+		]
+		const locs = localitySpans(buildAddressTree(raw, tokens).roots)
+		expect(locs.length).toBe(2)
+	})
+
+	test("merged span confidence is the mean across all folded tokens", () => {
+		const raw = "Saint Paul"
+		const tokens: DecoderToken[] = [tok("Saint", 0, 5, "B-locality", 0.9), tok("Paul", 6, 10, "B-locality", 0.5)]
+		const locs = localitySpans(buildAddressTree(raw, tokens).roots)
+		expect(locs.length).toBe(1)
+		expect(locs[0]!.confidence).toBeCloseTo(0.7, 5)
+	})
+})
+
 function findByTag(nodes: AddressNode[], tag: string): AddressNode | null {
 	for (const n of nodes) {
 		if (n.tag === tag) return n

--- a/core/decoder/build-tree.ts
+++ b/core/decoder/build-tree.ts
@@ -8,9 +8,11 @@
  *   Two passes:
  *
  *   1. Span emission — walk the token stream, group `B-X` followed by `I-X*` into one span. Lenient on
- *        hanging `I-X` (treat as new span). Span `value` is sliced from `raw` by [start, end), NOT
- *        concatenated from `piece` — this avoids SentencePiece's synthetic leading-space markers in
- *        the output.
+ *        hanging `I-X` (treat as new span). A `B-X` that is whitespace-adjacent to an already-open
+ *        `X` span is also folded in (spurious-boundary repair for multi-word values the model
+ *        fragments, e.g. "Saint Paul" → B-locality B-locality); a comma/separator between them keeps
+ *        them distinct. Span `value` is sliced from `raw` by [start, end), NOT concatenated from
+ *        `piece` — this avoids SentencePiece's synthetic leading-space markers in the output.
  *   2. Parent attachment — for each span, find the nearest labeled span whose tag is the
  *        highest-priority entry in this span's `PARENT_OF` list. Distance is the tiebreaker only.
  *        Spans with no found parent become roots.
@@ -93,11 +95,32 @@ function emitSpans(raw: string, tokens: DecoderToken[], attribution: BuildTreeOp
 		const { prefix, tag } = bioParts(tok.label)
 
 		if (prefix === "O") {
+			// A zero-width or whitespace-only `O` piece is a tokenizer artifact — SentencePiece emits a
+			// standalone `▁` word-boundary marker between words and the model labels it `O` (e.g.
+			// "Saint Paul" → "▁Saint"[B-loc], "▁"[O, zero-width], "Paul"[B-loc]). It is NOT a real
+			// component boundary, so it must not flush the open span; keeping the span alive lets the
+			// following same-tag `B-` token merge in (see the spurious-boundary repair below). A
+			// non-whitespace `O` (comma, slash, …) is a genuine separator and still flushes.
+			if (open !== null && /^\s*$/.test(raw.slice(tok.start, tok.end))) continue
 			open = flush(open, raw, out, attribution)
 			continue
 		}
 
 		if (prefix === "B" || open === null || open.tag !== tag) {
+			// Spurious-boundary repair: a `B-X` token that is whitespace-adjacent to an already-open
+			// `X` span is the model fragmenting a multi-word value — e.g. "Saint Paul" emitted as
+			// B-locality B-locality instead of B-locality I-locality (a real, decode-agnostic
+			// emission bug; see scripts/diag-saintalbans.ts). Fold it into the open span.
+			//
+			// Guard: only merge when the text in `raw` between the two spans is whitespace-only. A
+			// comma or any other separator keeps them distinct, and an intervening O/different-tag
+			// token already nulls/replaces `open` above — so two genuinely separate same-tag spans
+			// (e.g. "Springfield, Chicago") are never merged.
+			if (prefix === "B" && open !== null && open.tag === tag && /^\s*$/.test(raw.slice(open.end, tok.start))) {
+				open.end = tok.end
+				open.confidences.push(tok.confidence)
+				continue
+			}
 			open = flush(open, raw, out, attribution)
 			open = { tag: tag!, start: tok.start, end: tok.end, confidences: [tok.confidence] }
 			continue


### PR DESCRIPTION
## Bug

The neural model fragments some multi-word localities into **two** B-locality spans — `Saint Paul` → `"Saint"` + `"Paul"` (also Belle Fourche, Fort Pierre, Saint Albans). The orphan `"Saint"` then mis-resolves (→ St. Johnsbury), the `Saint Albans → St. Johnsbury` miss from the resolver failure analysis.

This is **not** a corpus gap and **not** a retrain fix: `Saint Paul` has **344,799** correct contiguous-locality training rows yet still fragments, in full addresses, identically under argmax and viterbi (so it's the raw emissions, not the decoder/CRF).

## Root mechanism

`scripts/diag-saintalbans.ts` shows SentencePiece emits a standalone **zero-width `▁`** word-boundary marker between the words, labeled `O`:

```
["▁Saint",0,5,B-locality]  ["▁",6,6,O]  ["Paul",6,10,B-locality]
```

That `O` piece flushed the open span, so `Paul` started a fresh locality.

## Fix (`core/decoder/build-tree.ts`, span emission)

Two whitespace-guarded repairs:
1. A **zero-width / whitespace-only `O`** piece is a tokenizer artifact, not a boundary — it no longer flushes the open span.
2. A `B-X` token **whitespace-adjacent** to an open `X` span folds in (spurious-boundary repair).

A non-whitespace separator (comma, `/`, …) between spans still keeps them **distinct** — so `"Dallas, Austin"` stays two localities.

## Verification

- **20** `build-tree` unit tests pass — incl. the exact real `▁`-artifact stream, full-address merge, and guard cases (comma gap, intervening O token).
- End-to-end: `Saint Paul` / `Belle Fourche` / `Fort Pierre` / `Saint Albans` all now emit **one** locality span.
- **Resolver locality Acc@1 97.1% → 98.1%** on 3k OA rows (no regression; lead over Pelias widens to +2pp).
- Pure decoder fix — **no model retrain or republish** needed; benefits the eval and the live demo on next deploy.

Fixes the `Saint Albans` class. The complementary resolver population-tiebreak mitigation is filed separately as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)