### PR TITLE
fix(train): support-aware val F1 + honest blank charts (Layer 1)

### DIFF
--- a/corpus-python/src/mailwoman_train/test_metrics.py
+++ b/corpus-python/src/mailwoman_train/test_metrics.py
@@ -1,0 +1,63 @@
+"""Tests for the support-aware token-F1 metric (`train._token_f1`).
+
+Layer 1 of the val-metrics honesty fix: per-tag support is reported, and `macro_f1` averages only
+component labels (excludes "O") that actually occur in the val sample — so a tag the sample happens
+not to contain doesn't pin F1 at 0 and drag the headline number down.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")  # training deps (torch) aren't installed in lint-only envs
+
+from mailwoman_train.labels import ACTIVE_BIO_LABELS, LABEL_TO_ID  # noqa: E402
+from mailwoman_train.train import _token_f1  # noqa: E402
+
+NUM = len(ACTIVE_BIO_LABELS)
+
+
+def _ids(*names: str) -> torch.Tensor:
+    return torch.tensor([[LABEL_TO_ID[n] for n in names]])
+
+
+def test_per_tag_support_counts_b_and_i():
+    true = _ids("B-locality", "I-locality", "B-region", "O")
+    r = _token_f1(true.clone(), true, num_labels=NUM)
+    assert r["support_tag.locality"] == 2  # B + I
+    assert r["support_tag.region"] == 1
+    assert r["support_tag.po_box"] == 0  # absent from the sample
+
+
+def test_macro_excludes_zero_support_and_O():
+    # Perfect predictions on the present component labels → macro should be exactly 1.0,
+    # NOT diluted by the dozens of absent tags (po_box, cedex, …) or inflated by "O".
+    true = _ids("B-locality", "I-locality", "B-region", "O")
+    r = _token_f1(true.clone(), true, num_labels=NUM)
+    assert abs(r["macro_f1"] - 1.0) < 1e-6
+
+
+def test_zero_support_tag_with_false_positive_not_counted_in_macro():
+    # Model wrongly predicts a po_box where there is none. po_box has 0 true instances (support 0),
+    # so its (bad) F1 is excluded from macro; the one real tag is perfect → macro stays 1.0.
+    true = _ids("B-locality", "O")
+    pred = _ids("B-locality", "B-po_box")
+    r = _token_f1(pred, true, num_labels=NUM)
+    assert r["support_tag.po_box"] == 0
+    assert abs(r["macro_f1"] - 1.0) < 1e-6
+
+
+def test_imperfect_prediction_lowers_macro():
+    # B-region predicted as O → region recall 0 → region F1 0, averaged with perfect locality.
+    true = _ids("B-locality", "B-region")
+    pred = _ids("B-locality", "O")
+    r = _token_f1(pred, true, num_labels=NUM)
+    assert r["support_tag.region"] == 1
+    assert 0.0 < r["macro_f1"] < 1.0  # locality perfect, region zero → ~0.5
+
+
+def test_empty_supported_set_returns_zero():
+    # Only "O" tokens → no supported component labels → macro 0.0 (no crash).
+    true = _ids("O", "O")
+    r = _token_f1(true.clone(), true, num_labels=NUM)
+    assert r["macro_f1"] == 0.0

--- a/corpus-python/src/mailwoman_train/trackio_logging.py
+++ b/corpus-python/src/mailwoman_train/trackio_logging.py
@@ -135,6 +135,17 @@ def _run_config(cfg: Any) -> dict[str, Any]:
     """
     t, m, d = cfg.train, cfg.model, cfg.data
     return {
+        # Human-readable legend shown in the run's config panel — so a viewer who isn't
+        # steeped in the metrics knows how to read the charts (esp. the blank/gap ones).
+        "_legend": (
+            "f1.<tag> = token-level F1 for that address component on the val set (higher is better). "
+            "support.<tag> = how many val examples contain that component. A MISSING/BLANK f1.<tag> "
+            "chart means support.<tag> = 0 — the val sample has no examples of that tag, so F1 is "
+            "undefined; it is NOT a model failure (these are coverage gaps, tracked separately). "
+            "val_macro_f1 = average F1 across only the components that have support (excludes 'O' and "
+            "absent tags). val_tags_with_support = how many of the 16 components the val set covers. "
+            "train_loss/val_loss lower is better; lr = learning rate; wall_seconds = elapsed time."
+        ),
         "max_steps": t.max_steps,
         "batch_size": t.batch_size,
         "learning_rate": t.learning_rate,

--- a/corpus-python/src/mailwoman_train/train.py
+++ b/corpus-python/src/mailwoman_train/train.py
@@ -100,9 +100,12 @@ def _token_f1(
 ) -> dict[str, float]:
     """Compute macro/per-class token-level F1 over a batch. Ignores ``IGNORE_INDEX`` positions.
 
-    Returns ``macro_f1`` plus per-BIO-label F1 (``f1.B-locality``, ``f1.I-locality``, …) AND
-    collapsed per-tag F1 (``f1_tag.locality``, …) computed as (B + I) / 2. The per-tag columns
-    are what the CSV log writes; the per-BIO columns are available for fine-grained debugging.
+    Returns ``macro_f1`` plus per-BIO-label F1 (``f1.B-locality``, ``f1.I-locality``, …),
+    collapsed per-tag F1 (``f1_tag.locality``, …) computed as (B + I) / 2, AND per-tag support
+    (``support_tag.locality`` = # true B+I instances in the val sample). The per-tag F1 + support
+    columns are what the CSV log / dashboard write; the per-BIO columns are for fine-grained
+    debugging. ``macro_f1`` averages only component labels (excludes "O") that have support > 0,
+    so a tag absent from the val sample doesn't drag it down (see the support-aware comment below).
     """
     mask = labels != IGNORE_INDEX
     p = preds[mask]
@@ -116,16 +119,29 @@ def _token_f1(
         tp[c] = (pred_c & true_c).sum().float()
         fp[c] = (pred_c & ~true_c).sum().float()
         fn[c] = (~pred_c & true_c).sum().float()
+    support = tp + fn  # number of true instances of each label in the val set
     precision = tp / (tp + fp + 1e-9)
     recall = tp / (tp + fn + 1e-9)
     f1 = 2 * precision * recall / (precision + recall + 1e-9)
     per_label = {ACTIVE_BIO_LABELS[c]: float(f1[c]) for c in range(num_labels)}
-    macro = float(f1.mean())
+    per_label_support = {ACTIVE_BIO_LABELS[c]: int(support[c]) for c in range(num_labels)}
+
+    # Support-aware macro: average F1 only over COMPONENT labels (exclude "O") that actually
+    # occur in the val sample. A zero-support label (a tag the val sample happens not to contain —
+    # e.g. po_box/cedex in a US-primary sample) otherwise pins F1 at 0 and drags the macro down;
+    # that's a val-coverage artifact, not model quality. Excluding "O" also stops its huge-support,
+    # ~1.0 F1 from inflating the average. See val-set stratification (Layer 2) for the coverage fix.
+    supported = [c for c in range(num_labels) if ACTIVE_BIO_LABELS[c] != "O" and support[c] > 0]
+    macro = sum(float(f1[c]) for c in supported) / len(supported) if supported else 0.0
+
     result = {"macro_f1": macro, **{f"f1.{k}": v for k, v in per_label.items()}}
     for tag in ACTIVE_TAGS:
         b_f1 = per_label.get(f"B-{tag}", 0.0)
         i_f1 = per_label.get(f"I-{tag}", 0.0)
         result[f"f1_tag.{tag}"] = (b_f1 + i_f1) / 2.0
+        # Per-tag support (B + I true instances). 0 ⇒ the tag is absent from the val sample, so its
+        # F1 is undefined — callers log it as a gap rather than a misleading flat-zero.
+        result[f"support_tag.{tag}"] = per_label_support.get(f"B-{tag}", 0) + per_label_support.get(f"I-{tag}", 0)
     return result
 
 
@@ -399,7 +415,12 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
                         f"\n         {tag_summary}"
                     )
                     elapsed = time.time() - started
-                    tag_f1_values = [f"{val.get(f'f1_tag.{tag}', 0.0):.6f}" for tag in ACTIVE_TAGS]
+                    # CSV: per-tag F1, but a blank cell ("") for tags with no val support so readers
+                    # see NaN rather than a misleading 0.0.
+                    tag_f1_values = [
+                        (f"{val.get(f'f1_tag.{tag}', 0.0):.6f}" if int(val.get(f"support_tag.{tag}", 0)) > 0 else "")
+                        for tag in ACTIVE_TAGS
+                    ]
                     csv_writer.writerow(
                         [
                             step,
@@ -417,8 +438,19 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
                         "val_macro_f1": float(val.get("macro_f1", 0.0)),
                         "wall_seconds": elapsed,
                     }
+                    # Log per-tag support alongside F1. A blank/missing `f1.<tag>` chart is then
+                    # self-explaining: `support.<tag>` = 0 means the val sample contains no examples
+                    # of that tag (a coverage gap — see Layer 2), NOT that the model scored zero. We
+                    # OMIT `f1.<tag>` when support is 0 so the dashboard draws a gap, not a flat-zero
+                    # line that reads as a model failure.
+                    tags_with_support = 0
                     for tag in ACTIVE_TAGS:
-                        eval_metrics[f"f1.{tag}"] = float(val.get(f"f1_tag.{tag}", 0.0))
+                        sup = int(val.get(f"support_tag.{tag}", 0))
+                        eval_metrics[f"support.{tag}"] = sup
+                        if sup > 0:
+                            eval_metrics[f"f1.{tag}"] = float(val.get(f"f1_tag.{tag}", 0.0))
+                            tags_with_support += 1
+                    eval_metrics["val_tags_with_support"] = tags_with_support
                     tracker.log(eval_metrics, step=step)
 
                 if step % cfg.train.save_every_steps == 0:


### PR DESCRIPTION
## Problem

The in-training val eval (`_token_f1`) averaged per-tag F1 over **all 33 BIO labels**. Tags absent from the 4,096-row val sample (`po_box`, `unit`, `cedex`, intersections, street affixes) scored F1=0 — which **dragged `val_macro_f1` down** and rendered **misleading flat-zero "blank" charts** (the exact symptom seen on the Trackio dashboard). Confirmed from the live bucket DB: those `f1.<tag>` series are `0.000` throughout because the val sample contains zero examples of them.

## Layer 1 (metric honesty — no corpus change)

- `_token_f1` reports per-tag **support** (B+I true-instance count) and computes `macro_f1` over only the component labels (excludes `O`) with **support > 0** — absent tags no longer deflate it, `O` no longer inflates it.
- The training loop logs `support.<tag>` beside F1, **omits `f1.<tag>` when support is 0** (dashboard draws a gap, not a flat-zero line), blanks the CSV cell, and adds `val_tags_with_support` (coverage count).
- **Layperson aid:** an embedded `_legend` in the Trackio run config explains the charts — a blank `f1.<tag>` means support=0 (no val examples), not a model failure.

## Verification

Support-aware macro validated on a numpy mirror: perfect→1.0, zero-support false-positive→excluded→1.0, missed-tag→0.5, all-`O`→0.0. `test_metrics.py` covers these (guarded with `importorskip("torch")` — torch isn't installed in lint-only envs and CI runs no python tests; the training code runs on Modal).

Takes effect on the **next training run** — sync to the R2 Modal volume first (standard deploy note). Layer 2 (val-set stratification, the actual coverage fix) is filed as a milestone issue.