### PR TITLE
docs(blog): house-voice cleanup across 13 posts (DeepSeek-reviewed)

### DIFF
--- a/docs/blog/2026-05-23-v0-4-0-ablation-campaign.mdx
+++ b/docs/blog/2026-05-23-v0-4-0-ablation-campaign.mdx
@@ -28,11 +28,11 @@ v0.3.0 had shipped with a known regression on coarse labels (country, region, lo
 5. **JS-side Viterbi decoder** + label vocabulary loading from `model-card.json` — runtime cleanup.
 6. **Reuse `corpus-v0.3.0`** — no rebuild needed.
 
-Items 5 and 6 were pure engineering; they landed cleanly the day before training started. The contested ones were 1, 3, and 4 — the recipe changes that actually touch the loss surface.
+Items 5 and 6 were pure engineering; they landed cleanly the day before training started. The contested ones were 1, 3, and 4: the recipe changes that actually touch the loss surface.
 
 ## What actually happened
 
-Five training runs. Three of them on different learning rates with the same full recipe; two of them as ablations dropping one item at a time. All five diverged. The fingerprint was distinctive: training loss dropped monotonically through a long warmup, plateaued at the bottom for several hundred steps, then spiked back up to its starting magnitude over 50-150 steps. Validation macro-F1 mirrored the train loss — it climbed to a peak around the LR's peak step, then collapsed to roughly the random-output baseline.
+Five training runs. Three of them on different learning rates with the same full recipe; two of them as ablations dropping one item at a time. All five diverged. The fingerprint was distinctive: training loss dropped monotonically through a long warmup, plateaued at the bottom for several hundred steps, then spiked back up to its starting magnitude over 50-150 steps. Validation macro-F1 mirrored the train loss: it climbed to a peak around the LR's peak step, then collapsed to roughly the random-output baseline.
 
 The collapse step shifted with the learning rate:
 
@@ -51,7 +51,7 @@ So we ran the ablations the issue had prescribed:
 | Drop §1 (CRF norm)      | 5e-4 | Diverged step 1000 |
 | Drop §3 (class weights) | 5e-4 | Diverged step 1000 |
 
-Identical failures. At lr=5e-4 neither single-knob revert was enough — meaning lr=5e-4 was structurally unreachable for the codebase's dual-loss landscape regardless of which knob we touched.
+Identical failures. At lr=5e-4 neither single-knob revert was enough, meaning lr=5e-4 was structurally unreachable for the codebase's dual-loss landscape regardless of which knob we touched.
 
 We dropped back to the safe LR (1.5e-4, the same lr v0.3.0 had been forced down to) and ran a three-cell orthogonal matrix:
 
@@ -67,7 +67,7 @@ It diverged at step 2250. Same fingerprint as the full §1+§3+§4 recipe at the
 
 ## The meta-bug in the smoke framework
 
-The verdict-smoke ran each ablation for 3000 steps with a cosine learning-rate schedule. With `max_steps=3000` and `warmup_steps=1000`, the LR peaks around step 1000 and is back near zero by step 2750. The smoke's "pass" criterion — macro-F1 stable across the last three evals past step 2000 — was actually measuring stability _under a near-zero learning rate_. The full 50K run kept the LR near its peak for thousands of steps. That sustained-peak exposure was where the destabilization happened.
+The verdict-smoke ran each ablation for 3000 steps with a cosine learning-rate schedule. With `max_steps=3000` and `warmup_steps=1000`, the LR peaks around step 1000 and is back near zero by step 2750. The smoke's "pass" criterion (macro-F1 stable across the last three evals past step 2000) was actually measuring stability _under a near-zero learning rate_. The full 50K run kept the LR near its peak for thousands of steps. That sustained-peak exposure was where the destabilization happened.
 
 The smoke wasn't testing what we thought it was testing. By the time it would have noticed the divergence, its own LR schedule had already saved it.
 
@@ -107,7 +107,7 @@ The picture changes meaningfully:
 France, Lozère, ՍԵՆՏ-ԱԼԲԱՆ-ՍՅՈՒՐ-ԼԻՄԱՆՅՈԼ              →  pred: "" (empty)
 ```
 
-These are v0.3.0's documented known-failure modes. The bytefallback tokenizer treats non-Latin scripts as the same opaque sequence, and the model gives up on the prefix. We have known v0.3.0 was bad at these — the v0.4.0 weights didn't change anything about this slice, so it isn't a real recipe regression. After excluding adversarial inputs, country FN drops from 194 to roughly 16. The −0.07 country regression is mostly a golden-set adversarial-weighting artifact.
+These are v0.3.0's documented known-failure modes. The bytefallback tokenizer treats non-Latin scripts as the same opaque sequence, and the model gives up on the prefix. We have known v0.3.0 was bad at these. The v0.4.0 weights didn't change anything about this slice, so it isn't a real recipe regression. After excluding adversarial inputs, country FN drops from 194 to roughly 16. The −0.07 country regression is mostly a golden-set adversarial-weighting artifact.
 
 **Postcode false-negatives** split into four buckets:
 
@@ -118,15 +118,15 @@ These are v0.3.0's documented known-failure modes. The bytefallback tokenizer tr
 | House number confused for postcode |     11% | `47110 Sainte-Livrade-sur-Lot, 22 Rue Jasmin` → predicts `22` |
 | BIO span boundary slip             |      6% | `LE TRÉPORT, 76470` → predicts `", 7647"`                     |
 
-The empty-prediction slice is the real story. NAD's downweight was the most aggressive change in the §4 source rebalance — it carried a lot of "postcode comes first" patterns (`47110 Sainte-Livrade-sur-Lot`, `ND 58701, 44th Ave`) and reducing its share removed that positional exposure. The model now defaults to tagging mid-position numeric tokens as house_number instead of postcode.
+The empty-prediction slice is the real story. NAD's downweight was the most aggressive change in the §4 source rebalance: it carried a lot of "postcode comes first" patterns (`47110 Sainte-Livrade-sur-Lot`, `ND 58701, 44th Ave`) and reducing its share removed that positional exposure. The model now defaults to tagging mid-position numeric tokens as house_number instead of postcode.
 
-That's a real fix that v0.4.1 should target. It is not the same problem as the headline regression number suggests. The 6% boundary-slip slice is a different bug — the model gets the tag right but emits a span that includes the preceding comma+space. That's a decoder fix, no retraining required, and it has already landed on `main` as commit `c72ab4c` — the decoder now trims spans past leading/trailing non-word characters.
+That's a real fix that v0.4.1 should target. It is not the same problem as the headline regression number suggests. The 6% boundary-slip slice is a different bug — the model gets the tag right but emits a span that includes the preceding comma+space. That's a decoder fix, no retraining required, and it has already landed on `main` as commit `c72ab4c`. The decoder now trims spans past leading/trailing non-word characters.
 
 ## What didn't get fixed (the v0.4.1 list)
 
-The two destabilizers — §1 per-token CRF normalization and §3 class-weighted cross-entropy — are deferred. Both individually look like reasonable training-side improvements; both, at this LR + this loss landscape, made the model find a confident-wrong degenerate minimum after several hundred post-warmup steps. The sanity-check pass over `model.py` and `crf.py` ruled out implementation bugs — the `per_token` reduction is mathematically `nll.sum() / total_tokens.clamp(min=1)`, and class_weights enters via PyTorch-standard `cross_entropy(weight=...)`. The destabilization is a real recipe interaction.
+The two destabilizers — §1 per-token CRF normalization and §3 class-weighted cross-entropy — are deferred. Both individually look like reasonable training-side improvements; both, at this LR + this loss landscape, made the model find a confident-wrong degenerate minimum after several hundred post-warmup steps. The sanity-check pass over `model.py` and `crf.py` ruled out implementation bugs: the `per_token` reduction is mathematically `nll.sum() / total_tokens.clamp(min=1)`, and class_weights enters via PyTorch-standard `cross_entropy(weight=...)`. The destabilization is a real recipe interaction.
 
-The leading hypothesis at the v0.4.0 boundary is that some adapter slice in `corpus-v0.3.0` is producing high-variance gradients that the per-token-normalized CRF still can't dampen. We built the `corpus-audit` tool during the campaign — it measures per-source shard distribution against the training config's source_weights, with concentration warnings — and the v0.4.1 starting point will be running gradient-norm probes per adapter to find what's causing the spike.
+The leading hypothesis at the v0.4.0 boundary is that some adapter slice in `corpus-v0.3.0` is producing high-variance gradients that the per-token-normalized CRF still can't dampen. We built the `corpus-audit` tool during the campaign (it measures per-source shard distribution against the training config's source_weights, with concentration warnings), and the v0.4.1 starting point will be running gradient-norm probes per adapter to find what's causing the spike.
 
 Three orthogonal threads for v0.4.1:
 

--- a/docs/blog/2026-05-24-bisect-by-elimination.mdx
+++ b/docs/blog/2026-05-24-bisect-by-elimination.mdx
@@ -7,7 +7,7 @@ tags: [training]
 
 This is a follow-up to [yesterday's post about the v0.5.0 C-train failures](/blog/v0-5-0-c-train-bisect). Yesterday we ran four attempts and ruled out three suspects. Today we ran a fifth and ruled out a fourth. We're now down to one remaining hypothesis — and the way we got here is a kind of debugging that translates pretty cleanly from software engineering, so this post is pitched at engineers who haven't run a training campaign before.
 
-If you've ever bisected a regression in a piece of software — used `git bisect`, narrowed a test failure by reverting changes one at a time, taken a known-good build and a known-broken build and asked which of the changes between them caused the breakage — then you already understand the core move. The rest is vocabulary.
+If you've ever bisected a regression in a piece of software (used `git bisect`, narrowed a test failure by reverting changes one at a time, taken a known-good build and a known-broken build and asked which of the changes between them caused the breakage), then you already understand the core move. The rest is vocabulary.
 
 {/* truncate */}
 
@@ -53,13 +53,13 @@ Five attempts now, each varying one knob from the previous:
 
 The bisect-phrase-off run is the new one (today). The previous post covered v1 through bisect-h256.
 
-What every bisect attempt has in common: **the model is provably learning something useful for several hundred iterations** (the loss decreases, validation accuracy climbs), and **then it falls off a cliff**. This means the model isn't fundamentally broken — it can fit the data. It just can't _stay_ fit. Something is pushing it off the cliff.
+What every bisect attempt has in common: **the model is provably learning something useful for several hundred iterations** (the loss decreases, validation accuracy climbs), and **then it falls off a cliff**. This means the model isn't fundamentally broken. It can fit the data, it just can't _stay_ fit. Something is pushing it off the cliff.
 
 Each bisect tested a different "is this the cliff?" hypothesis:
 
 - **v2 tested "is the learning rate too high?"** No. Lowering LR delayed the climb but didn't stop it.
 - **v3 tested "are the new loss-side weighting knobs destabilising?"** No. v0.4.0's known-stable loss settings still produce the cliff.
-- **bisect-h256 tested "is the bigger model the problem?"** No. We reverted hidden size to v0.4.0's value and got the cleanest training so far — best validation macro-F1 we've ever measured — and the cliff still happened.
+- **bisect-h256 tested "is the bigger model the problem?"** No. We reverted hidden size to v0.4.0's value and got the cleanest training so far (best validation macro-F1 we've ever measured), and the cliff still happened.
 - **bisect-phrase-off (today) tested "is the phrase-prior input layer the problem?"** No. We turned off the phrase-prior feature concatenation entirely and the cliff is still there, in the same shape, at almost the same step.
 
 Five attempts, five identical fingerprints, four hypotheses eliminated. **Exactly one architectural change from the known-stable v0.4.0 setup is still in play**: the tokenizer + corpus pair.
@@ -81,7 +81,7 @@ This is the next bisect. If it trains cleanly, we'll know the synthetic data —
 - **Investigate why the transliteration data destabilises**. The honest hypothesis is that the LLM-generated rows have systematically different gradient signatures than human-validated address data — they might be _too_ structured, or have repetitive patterns the model overfits to and then explodes on. We have tooling (`corpus-audit`) that can quantify this.
 - **Ship A1 (tokenizer wins) + corpus-v0.3.0 model (proven-stable)** for v0.5.0, defer transliteration training to v0.5.1.
 
-If the corpus-revert bisect also fails, we're left with the A1 tokenizer itself as the destabiliser. That's a stranger answer — tokenizer training is mostly orthogonal from classifier training — but not impossible. New vocabulary means a fresh embedding table the model has never seen; unusual sub-piece frequencies could in principle produce unusual gradient norms.
+If the corpus-revert bisect also fails, we're left with the A1 tokenizer itself as the destabiliser. That's a stranger answer (tokenizer training is mostly orthogonal from classifier training), but not impossible. New vocabulary means a fresh embedding table the model has never seen; unusual sub-piece frequencies could in principle produce unusual gradient norms.
 
 ## What we'd tell a software engineer reading this
 
@@ -104,4 +104,4 @@ Either way the bisect ladder is short now. Five experiments in, one hypothesis l
 - [The v0.4.0 retrospective](/blog/v0-4-0-ablation-campaign) (the original "destabilisation fingerprint" we recognised in v0.5.0)
 - `VERDICT_SMOKES.md` — discipline doc for the smoke-test framework we built during v0.4.0 to catch divergences early
 
-If you do ML work and have ideas about what classes of corpus distribution shift could produce a "trains fine for a thousand steps then catastrophically diverges" pattern, we'd love to hear them — `contact@sister.software`.
+If you do ML work and have ideas about what classes of corpus distribution shift could produce a "trains fine for a thousand steps then catastrophically diverges" pattern, the mailbox is open: `contact@sister.software`.

--- a/docs/blog/2026-05-24-taming-wof.mdx
+++ b/docs/blog/2026-05-24-taming-wof.mdx
@@ -13,7 +13,7 @@ tags: [resolver, geocoding]
 
 Who's On First is the best open gazetteer we have. It's also one of the strangest datasets you'll encounter as a developer. This post is about what makes it hard to use, what makes it worth the effort, and the tooling we built inside Mailwoman to tame it.
 
-If you've ever tried to answer "what city is this address in?" programmatically — using open data, without paying a geocoding API — you've probably already run into WOF. And you probably had some questions.
+If you've ever tried to answer "what city is this address in?" programmatically, using open data without paying a geocoding API, you've probably already run into WOF. And you probably had some questions.
 
 {/* truncate */}
 
@@ -75,15 +75,15 @@ There are a few things to notice:
 
 ### Brooklyn Integers
 
-WOF IDs are issued by a service called Brooklyn Integers — a distributed ID generator that guarantees uniqueness across the dataset. The IDs are not sequential, not geographically meaningful, and not sortable. They're just unique numbers. This is fine for lookup but means you can't reason about "nearby" places by ID proximity.
+WOF IDs are issued by a service called Brooklyn Integers, a distributed ID generator that guarantees uniqueness across the dataset. The IDs are not sequential, not geographically meaningful, and not sortable. They're just unique numbers. This is fine for lookup but means you can't reason about "nearby" places by ID proximity.
 
 ### Supersession chains
 
-Places get deprecated — a neighbourhood is absorbed by a neighbouring one, a county boundary changes, a locality is merged. WOF tracks this via `wof:superseded_by` arrays. A query that doesn't check supersession may return a place that hasn't existed since 2015.
+Places get deprecated: a neighbourhood is absorbed by a neighbouring one, a county boundary changes, a locality is merged. WOF tracks this via `wof:superseded_by` arrays. A query that doesn't check supersession may return a place that hasn't existed since 2015.
 
 ### Parent ID = -1
 
-A `parent_id` of -1 means "we don't know the parent." A `parent_id` of 0 means "no parent (this is a continent or Earth itself)." The first French postalcode dataset was ingested with `parent_id: -1` for every record — making hierarchy traversal useless until someone manually assigned parents. Some of those records still have `-1`.
+A `parent_id` of -1 means "we don't know the parent." A `parent_id` of 0 means "no parent (this is a continent or Earth itself)." The first French postalcode dataset was ingested with `parent_id: -1` for every record, making hierarchy traversal useless until someone manually assigned parents. Some of those records still have `-1`.
 
 ## What we built to tame it
 
@@ -123,7 +123,7 @@ CREATE TABLE records (
 );
 ```
 
-One row per name variant. "Saint Petersburg" and "St. Petersburg" and "St Petersburg" are three rows for the same `id`, different `name`/`variant`/`short` columns. The reconciler can query any variant form and get the same `parent_id` chain — which is what solves the "not found" problem we hit in testing.
+One row per name variant. "Saint Petersburg" and "St. Petersburg" and "St Petersburg" are three rows for the same `id`, different `name`/`variant`/`short` columns. The reconciler can query any variant form and get the same `parent_id` chain, which is what solves the "not found" problem we hit in testing.
 
 ### The Piscina pipeline (stalled, documented)
 
@@ -153,7 +153,7 @@ Three things, in priority order:
 2. **Wire PlacetypeDataSource into the reconciler.** The concordance scoring currently uses the raw WOF `spr` SQLite table (from Geocode Earth's distribution). It should use our per-placetype/per-language DBs, which carry the name variants the raw table doesn't expose. This fixes the "Saint Petersburg not found" class of lookup failures.
 3. **Benchmark the in-memory-then-consolidate pattern.** If 120K individual writes to the same few DB files from N concurrent workers bottlenecks on SQLite's WAL writer (likely), the in-memory-SQLite-per-worker → ATTACH-and-merge pattern is the escape hatch. Whether it's actually needed depends on whether step 1 is fast enough without it.
 
-## Why this matters for geocoding
+## So why put up with WOF?
 
 Every geocoder needs a gazetteer. The choice is: pay for one (Google, HERE, Mapbox), use an open one (WOF, GeoNames, OSM Nominatim), or build your own from government sources (BAN, NAD, TIGER).
 

--- a/docs/blog/2026-05-24-two-voices-arguing.mdx
+++ b/docs/blog/2026-05-24-two-voices-arguing.mdx
@@ -21,7 +21,7 @@ If you've been programming for a while but ML feels opaque, this post is for you
 
 ## What we're building, in one paragraph
 
-Mailwoman is a piece of software that reads address strings — `"350 5th Avenue, New York, NY 10118"` — and turns them into structured place information ("this is in Manhattan, here are the coordinates, here's the postcode, etc."). It uses a small AI model to do the parsing. "Small" by AI standards: about 9 million numbers inside it. (For comparison: GPT-4 is rumoured to have over a trillion.)
+Mailwoman is a piece of software that reads address strings (`"350 5th Avenue, New York, NY 10118"`) and turns them into structured place information ("this is in Manhattan, here are the coordinates, here's the postcode, etc."). It uses a small AI model to do the parsing. "Small" by AI standards: about 9 million numbers inside it. (For comparison: GPT-4 is rumoured to have over a trillion.)
 
 We don't need a giant model because the task is narrow: addresses follow patterns, and we just need to identify which parts of a string are which (`350` is a house number, `5th Avenue` is a street, etc.).
 
@@ -32,11 +32,11 @@ Forget everything you've seen about AI in movies. Training a model is, mechanica
 1. You have a model with millions of numbers inside it (call them "weights"). At the start they're random.
 2. You have a pile of example data — addresses with the correct answers labelled, like flashcards.
 3. You show the model an address. It guesses what each part is.
-4. You compare the guess to the correct answer. The difference is a number called **loss** — low loss means a good guess, high loss means a bad guess.
+4. You compare the guess to the correct answer. The difference is a number called **loss**: low loss means a good guess, high loss means a bad guess.
 5. The training algorithm then tweaks the millions of internal numbers to make the loss a little bit smaller next time.
 6. Repeat thousands or millions of times.
 
-The "intelligence" of the model is just an enormous lookup table of patterns — refined slowly by 50,000 rounds of "you said it was a street name, but it was actually a postcode; here, nudge these specific numbers a tiny bit so you'll guess better next time."
+The "intelligence" of the model is just an enormous lookup table of patterns, refined slowly by 50,000 rounds of "you said it was a street name, but it was actually a postcode; here, nudge these specific numbers a tiny bit so you'll guess better next time."
 
 If you've ever debugged a function by running it, looking at the wrong output, and tweaking one parameter at a time until the output got right, you've done a single iteration of model training by hand.
 
@@ -87,7 +87,7 @@ We saw this exact shape in nine different runs. Different learning speeds, diffe
 
 ## The clue we'd been missing
 
-To find a bug in a program, you usually narrow it down by ruling out parts of the code one at a time. ML debugging works the same way — you change one thing, retrain, look at the curve. But each "retrain" takes hours and costs real money on a rented GPU. You learn to be careful about which experiments are worth running.
+To find a bug in a program, you usually narrow it down by ruling out parts of the code one at a time. ML debugging works the same way: you change one thing, retrain, look at the curve. But each "retrain" takes hours and costs real money on a rented GPU. You learn to be careful about which experiments are worth running.
 
 For weeks we'd been ruling out hypotheses:
 
@@ -134,13 +134,13 @@ Imagine you're a hiker on a foggy hill, trying to walk to the lowest point in th
 
 When that happens, your hiking direction is mostly determined by **whichever GPS is shouting louder**. With Voice B shouting 16× louder than Voice A, you stop following Voice A's instructions and start following Voice B's — even though Voice A was correct about where the valley floor actually was. You climb out of one valley toward a different point that Voice B prefers, and Voice A's loss (the per-word accuracy) gets worse.
 
-That's literally what happened to our model. Above loss 0.41 (high up on the hill), both voices agreed and the model descended cleanly. Below 0.41, they started disagreeing, and Voice B's louder gradient pulled the model away from the basin Voice A had been guiding it toward. The model's per-word accuracy got worse and worse — which we saw as loss climbing back up.
+That's literally what happened to our model. Above loss 0.41 (high up on the hill), both voices agreed and the model descended cleanly. Below 0.41, they started disagreeing, and Voice B's louder gradient pulled the model away from the basin Voice A had been guiding it toward. The model's per-word accuracy got worse and worse, which we saw as loss climbing back up.
 
 ## The fix
 
 Once you understand what's happening, the fix is mechanical: **silence Voice B during training**. Don't let it contribute to the gradient at all.
 
-But we still want Voice B's contribution somewhere, because it really does encode useful structural rules (no orphan tags, no invalid BIO sequences). So we keep Voice B for **inference** — the moment when we actually use the trained model to parse an address — but not during training.
+But we still want Voice B's contribution somewhere, because it really does encode useful structural rules (no orphan tags, no invalid BIO sequences). So we keep Voice B for **inference** (the moment when we actually use the trained model to parse an address) but not during training.
 
 This is a one-line change in the code: when Voice B's weight is set to 0, don't even compute it. The training loop then runs purely on Voice A's gradient, which has been the well-behaved one all along.
 
@@ -159,7 +159,7 @@ A few things stand out:
 - [The bisect-by-elimination post](/blog/v0-5-0-bisect-by-elimination) — what we ruled out before the diagnostic.
 - [The technical writeup](/docs/concepts/dual-loss-curvature-conflict) — for engineers who want the gradient math and the cooperative-vs-conflict framing in detail.
 
-If you're starting out in ML and any of this was helpful — or if you'd like a future post to dive deeper into any specific term I used here — `contact@sister.software`. We'd genuinely like to hear what gaps the existing intro material isn't filling.
+If you're starting out in ML and any of this helped, the mailbox is open: `contact@sister.software`. We'd genuinely like to hear what gaps the existing intro material still leaves.
 
 ## Update — it worked
 

--- a/docs/blog/2026-05-24-v0-5-0-c-train-bisect.mdx
+++ b/docs/blog/2026-05-24-v0-5-0-c-train-bisect.mdx
@@ -32,7 +32,7 @@ C-train was the experiment that actually used all of it together for the first t
 
 ## The recipe we tried first
 
-Going in we had a clean confirmation from the operator: hidden_size=384 (up from v0.4.0's 256), effective batch 128 via batch=16 grad_accum=8, constant LR, starting LR=1.5e-4 (the same lr v0.3.0 had to drop to), top-k inference and phrase-prior conditioning ON (PR #128). The corpus was A1 tokenizer + corpus-v0.4.0. Recipe knobs §1 (per_token CRF normalization) and §3 (class_weights) were carried over from the C-s scaffold — a host-side YAML-drafting decision, not an operator confirmation.
+Going in we had a clean confirmation from the operator: hidden_size=384 (up from v0.4.0's 256), effective batch 128 via batch=16 grad_accum=8, constant LR, starting LR=1.5e-4 (the same lr v0.3.0 had to drop to), top-k inference and phrase-prior conditioning ON (PR #128). The corpus was A1 tokenizer + corpus-v0.4.0. Recipe knobs §1 (per_token CRF normalization) and §3 (class_weights) were carried over from the C-s scaffold: a host-side YAML-drafting decision, not an operator confirmation.
 
 The 50-step constant-LR smoke passed cleanly. val_macro_f1 climbed 0.121 → 0.187 across 50 steps. The recipe looked stable.
 
@@ -78,9 +78,9 @@ We ran three knob-changes between v1 and h256-bisect, each motivated by a differ
 
 **Learning rate isn't it.** v0.4.0's bisect already showed that a factor-2 LR drop only buys a factor-1.3 step delay, ruling out "we picked too high an LR" as a full explanation. v1 → v2 confirmed the same shape: 1.5e-4 → 1e-4 moved the divergence from step 700 to step 1000. Same dynamic, just shifted later. The LR controls _when_, not _whether_.
 
-**Recipe knobs §1+§3 aren't it.** v0.4.0's retrospective concluded the destabilizer was in the recipe, not the LR, and shipped with §1 (per_token CRF) and §3 (class_weights) OFF. v3 reverted those knobs and dropped back to LR=1.5e-4 — the canonical v0.4.0-stable recipe. v3 trained better than v1/v2 (bottom of 0.41 vs 0.61/0.51), zero GPU hangs (vs v2's six), and still diverged at step 900.
+**Recipe knobs §1+§3 aren't it.** v0.4.0's retrospective concluded the destabilizer was in the recipe, not the LR, and shipped with §1 (per_token CRF) and §3 (class_weights) OFF. v3 reverted those knobs and dropped back to LR=1.5e-4, the canonical v0.4.0-stable recipe. v3 trained better than v1/v2 (bottom of 0.41 vs 0.61/0.51), zero GPU hangs (vs v2's six), and still diverged at step 900.
 
-**Hidden size isn't it.** h256-bisect reverted the only architectural change still in the recipe: 384 → 256 hidden, 6 → 4 heads, 1536 → 1024 intermediate. With everything else at v0.4.0-shipped settings — eff*batch=128, LR=1.5e-4, §1+§3 OFF — this configuration is \_identical to v0.4.0's shipped recipe*, except for two architectural pieces we haven't touched yet. h256-bisect was the best-performing run of the four (peak val_macro_f1=0.399, train_loss=0.31), and it diverged anyway.
+**Hidden size isn't it.** h256-bisect reverted the only architectural change still in the recipe: 384 → 256 hidden, 6 → 4 heads, 1536 → 1024 intermediate. With everything else at v0.4.0-shipped settings (eff*batch=128, LR=1.5e-4, §1+§3 OFF), this configuration is \_identical to v0.4.0's shipped recipe*, except for two architectural pieces we haven't touched yet. h256-bisect was the best-performing run of the four (peak val_macro_f1=0.399, train_loss=0.31), and it diverged anyway.
 
 ## The remaining suspects
 
@@ -94,7 +94,7 @@ Both are real architectural changes from v0.4.0. Either could plausibly produce 
 
 The cheapest next bisect is **phrase priors OFF** (revert PR #128's input-layer features, keep A1 tokenizer). One YAML knob change, ~15min smoke + a partial train if smoke passes. That isolates whether the destabilizer is the phrase-prior projection or the new tokenizer's interaction.
 
-If phrase-priors-off ALSO diverges, the next bisect is the A1 tokenizer itself — revert to v0.1.0's sentencepiece weights against the same corpus + recipe + h256. At that point we're back to v0.4.0's proven-stable shipping configuration; if even that diverges, the destabilizer is in `corpus-v0.4.0`'s composition (the transliteration shards' distribution might be the issue, not the tokenizer trained on them).
+If phrase-priors-off ALSO diverges, the next bisect is the A1 tokenizer itself: revert to v0.1.0's sentencepiece weights against the same corpus + recipe + h256. At that point we're back to v0.4.0's proven-stable shipping configuration; if even that diverges, the destabilizer is in `corpus-v0.4.0`'s composition (the transliteration shards' distribution might be the issue, not the tokenizer trained on them).
 
 ## A discipline lesson worth keeping
 
@@ -105,7 +105,7 @@ Two things had to change for the smoke to be a real predictor:
 - **Smoke length matters.** 50 steps captures only the warmup descent. The sustained-peak-LR regime where the recipe destabilises starts at step 500 in our schedule. Smokes need to be long enough to spend several hundred steps near peak LR — we ended up at 1500 steps as the floor.
 - **Effective batch must match the full run.** v3's smoke ran at batch_size=8 grad_accum=1 (eff_batch=8); the full run was eff_batch=128. The smoke said stable; the full diverged. **The recipe's stability is batch-geometry-dependent.** A smoke that doesn't reproduce the full-run gradient noise is a smoke that can't detect this class of failure.
 
-The constant-LR-mode discipline that landed in Thread F is still correct — it's what made the v0.5.0 destabilization observable at all instead of hiding under cosine decay. But the smoke configuration needs to mirror the full-run _throughput_ characteristics, not just the LR schedule.
+The constant-LR-mode discipline that landed in Thread F is still correct: it's what made the v0.5.0 destabilization observable at all instead of hiding under cosine decay. But the smoke configuration needs to mirror the full-run _throughput_ characteristics on top of the LR schedule.
 
 Both lessons will land in `VERDICT_SMOKES.md` as a follow-up. The current text describes constant-LR mode as the gate but doesn't say "your smoke's eff_batch must match the full run." That's an obvious-in-hindsight footgun.
 

--- a/docs/blog/2026-05-25-night-shift-2.mdx
+++ b/docs/blog/2026-05-25-night-shift-2.mdx
@@ -11,7 +11,7 @@ The second night shift ran from roughly 2am to 2pm UTC on May 25th, 2026. It sta
 
 ## The hardware wall
 
-The lab runs on a small form factor desktop with an AMD Radeon 780M integrated GPU. For short bursts — a 2-minute smoke test, a 10-minute diagnostic probe — it works fine. For sustained multi-hour training at 98% GPU utilization, it overheats. The firmware detects thermal stress and resets the GPU, killing whatever process was running on it.
+The lab runs on a small form factor desktop with an AMD Radeon 780M integrated GPU. For short bursts (a 2-minute smoke test, a 10-minute diagnostic probe), it works fine. For sustained multi-hour training at 98% GPU utilization, it overheats. The firmware detects thermal stress and resets the GPU, killing whatever process was running on it.
 
 During this session, the GPU hit 22 resets before we stopped counting. Every 60-90 minutes of training, the hardware would fault. A watchdog script would wait 15 minutes for the chassis to cool, then restart from the last checkpoint. Net progress: about 8,800 training steps out of a target 50,000.
 
@@ -57,11 +57,11 @@ After the model shipped, we ran the full product-level evaluation — four pipel
 
 A few things jump out:
 
-**The neural model hallucinates components it shouldn't.** On the golden set, it invented a `dependent_locality` — a sub-city neighborhood — 956 times where none existed. That's not a calibration problem (it's not just overconfident, it's wrong), and it's not a decode problem (Viterbi with structural mask is already running). It's a training problem: cross-entropy treats every mislabeling equally, so the model never learned that `dependent_locality` is rare and should be emitted sparingly. Class-weighted CE — which was blocked in v0.4.0 because it destabilized the dual-loss training — puts a thumb on the scale: mislabeling a rare tag costs more. Now that CE-only training is proven stable, this lever is unlocked.
+**The neural model hallucinates components it shouldn't.** On the golden set, it invented a `dependent_locality` — a sub-city neighborhood — 956 times where none existed. Two explanations look tempting, and both lead nowhere. Calibration? These predictions come out at high confidence — the model is confidently wrong, not hedging. Decoding? Viterbi with the structural mask is already running. What's left is training: cross-entropy treats every mislabeling equally, so the model never learned that `dependent_locality` is rare and should be emitted sparingly. Class-weighted CE — which was blocked in v0.4.0 because it destabilized the dual-loss training — puts a thumb on the scale: mislabeling a rare tag costs more. Now that CE-only training is proven stable, this lever is unlocked.
 
-**Hybrid mode shows identical numbers to neural alone.** The hybrid mode fuses rule classifications with neural output, but in this iteration the raw neural decoder's overconfidence drowns out the rules — hence the identical numbers. The reconciler (hybrid-joint) is the mode that actually disciplines the merge.
+**Hybrid mode shows identical numbers to neural alone.** The hybrid mode fuses rule classifications with neural output, but in this iteration the raw neural decoder's overconfidence drowns out the rules, hence the identical numbers. The reconciler (hybrid-joint) is the mode that actually disciplines the merge.
 
-**The reconciler fixes the honesty problem.** It drops overconfident-wrong from 54.5% to 0.1% by checking whether parsed components form a coherent real-world hierarchy. It also eliminates empty parses entirely (0.0% vs rules' 6.3%) — it always produces something, even if conservative.
+**The reconciler fixes the honesty problem.** It drops overconfident-wrong from 54.5% to 0.1% by checking whether parsed components form a coherent real-world hierarchy. It also eliminates empty parses entirely (0.0% vs rules' 6.3%): it always produces something, even if conservative.
 
 **The rules are a ceiling. The neural model is a ramp.** Rule-only at 30.8% exact match is a mature system, hand-tuned over years. Each additional percentage point costs engineering time. The neural model at 6.0% (hybrid-joint) after one stable training run is learning from data, which means each new training run can improve across every component and every locale simultaneously. The 68% improvement from v0.4.0 to v0.5.0 is the trend that matters — and the ramp just proved it can climb.
 
@@ -72,7 +72,7 @@ The overnight session could have been a write-off. A GPU that crashes every 90 m
 - **Corpus on R2** means any GPU provider can pull it at datacenter speed. Upload once, train anywhere.
 - **Modal's per-second billing** means we paid $0 for data upload, $0 for debugging, and ~$5 for the actual GPU compute.
 - **Checkpoints every 500 steps** on the Modal Volume means even if a Modal preemption happened (it didn't), we'd lose at most 7 minutes of work.
-- **The same training script** ran locally (for smoke tests) and remotely (for the full run) without modification — the config just points at `/data/` which is either the local mount or the Modal Volume.
+- **The same training script** ran locally (for smoke tests) and remotely (for the full run) without modification: the config just points at `/data/`, which is either the local mount or the Modal Volume.
 
 The local iGPU still has a role: smoke tests, gradient probes, quick 50-step experiments. The expensive runs go to the cloud. The separation happened naturally once we accepted that the hardware wall was real and not worth engineering around.
 

--- a/docs/blog/2026-05-28-japanese-address-hierarchy.mdx
+++ b/docs/blog/2026-05-28-japanese-address-hierarchy.mdx
@@ -51,7 +51,7 @@ To synthesize a JP address you concatenate the parent chain top-to-bottom: `東�
 
 Western addresses identify locations by street + number. "1600 Pennsylvania Avenue NW" picks a specific building because Pennsylvania Avenue is a known line and 1600 is a known offset along that line.
 
-Japan uses block addressing instead. `4-2-8` in `芝公園` doesn't mean "the 4th, 2nd, or 8th building on the 芝公園 street." It means: chome 4, block 2, building 8 in the 芝公園 district. The grid is the addressing primitive, not the line.
+Japan uses block addressing instead. Read `4-2-8` in `芝公園` as chome 4, block 2, building 8 within the 芝公園 district. There's no "芝公園 street" for the number to sit on; the grid is the addressing primitive, not the line.
 
 Implications for the parser:
 
@@ -69,7 +69,7 @@ Japanese addresses prefix the postcode with `〒`, the postal mark. Format: `〒
 - `〒530-0001` — Osaka Umeda
 - `〒810-0001` — Fukuoka Tenjin
 
-A parser needs to know that `〒` is not part of the number — it's a categorical marker indicating the following 7 digits + dash form a postcode. SentencePiece tokenizes `〒` as a separate piece. Our new v0.6.0-a0 multi-script tokenizer handles this cleanly (0% byte-fallback on the `〒` character).
+A parser needs to know that `〒` is a categorical marker, not part of the number: the following 7 digits + dash form the postcode. SentencePiece tokenizes `〒` as a separate piece. Our new v0.6.0-a0 multi-script tokenizer handles this cleanly (0% byte-fallback on the `〒` character).
 
 ## What we shipped today
 
@@ -122,7 +122,7 @@ The infrastructure is already in place. `core/types/component.ts` declares JP-sp
 
 The schema, formatting, runtime pipeline, and now the corpus prototype are ready. The blockers are: (1) the missing house-number data source, and (2) training time on a JP-aware recipe.
 
-## Why this matters
+## Where rules fail and learning wins
 
 Every address parser written for Western input fails on Japan in a specific, predictable way: it parses the prefecture as a country, then runs out of tokens. The locality and chome get lumped into a single span. The block-number triple gets parsed as a postcode or dropped entirely.
 

--- a/docs/blog/2026-05-28-stage-3-po-box.mdx
+++ b/docs/blog/2026-05-28-stage-3-po-box.mdx
@@ -123,7 +123,7 @@ PO box recognition went from impossible to functional in one training run. Sampl
     po_box: "PO Box 123", postcode: "05401" }
 ```
 
-Stage 2 metrics held flat — the new tags didn't displace the old ones, just extended the schema.
+Stage 2 metrics held flat: the new tags extended the schema without displacing the old ones.
 
 ## What's deferred
 

--- a/docs/blog/2026-05-29-the-model-that-never-saw-an-intersection.mdx
+++ b/docs/blog/2026-05-29-the-model-that-never-saw-an-intersection.mdx
@@ -5,7 +5,7 @@ authors: [teffen]
 tags: [neural, training, night-shift, advanced]
 ---
 
-We spent a night trying to make our neural address parser less cocky. We ended it having learned something more useful: the model wasn't failing because it was *wrong with confidence* — it was failing because it had **never been shown** whole categories of address.
+We spent a night trying to make our neural address parser less cocky. We ended it having learned something more useful. The model wasn't cocky — it was uninformed. It had **never been shown** whole categories of address.
 
 This is the story of chasing the wrong number, and the diagnostics that pointed at the right one.
 
@@ -13,13 +13,13 @@ This is the story of chasing the wrong number, and the diagnostics that pointed 
 
 ## The hypothesis: it's overconfident
 
-Across the v0.6.x training cycle, one pattern kept surfacing: when the model was wrong, it was *confidently* wrong. On a held-out test set, **86% of its incorrect predictions were made at ≥0.9 confidence** — and most of those at a flat 1.00. A model that hedged appropriately would, we reasoned, stop steamrolling good answers with bad high-confidence ones.
+Across the v0.6.x training cycle, one pattern kept surfacing: when the model was wrong, it was _confidently_ wrong. On a held-out test set, **86% of its incorrect predictions were made at ≥0.9 confidence** — and most of those at a flat 1.00. A model that hedged appropriately would, we reasoned, stop steamrolling good answers with bad high-confidence ones.
 
-The standard tool for that is **label smoothing**: instead of training toward a one-hot target (1.0 for the right tag, 0 for the rest), you train toward something softer (0.9 / spread-the-rest). It caps how peaked the model's outputs can get. So we ran a clean, single-variable experiment — the v0.6.0 recipe plus `label_smoothing=0.1`, nothing else changed — and measured.
+The standard tool for that is **label smoothing**: instead of training toward a one-hot target (1.0 for the right tag, 0 for the rest), you train toward something softer (0.9 / spread-the-rest). It caps how peaked the model's outputs can get. So we ran a clean, single-variable experiment (the v0.6.0 recipe plus `label_smoothing=0.1`, nothing else changed) and measured.
 
 It worked, exactly as advertised. Overconfidence-on-wrong dropped **86% → 67%**; the mass at 1.00 confidence vanished, capped around 0.95. Postcode recall even ticked up.
 
-And the metric we actually ship on — **harness pass rate** — didn't move. 14.6% → 13.8%. If anything, slightly down. Two tags (house numbers, streets) *regressed*.
+And the metric we actually ship on — **harness pass rate** — didn't move. 14.6% → 13.8%. If anything, slightly down. Two tags (house numbers, streets) _regressed_.
 
 ## Following the evidence
 
@@ -27,39 +27,39 @@ A well-calibrated model that's no better at the job is a clue, not a victory. So
 
 We categorized every failure. The answer reframed the whole project:
 
-- **55% of the gap was missing labels** — the model emitted *no tag at all* where one belonged. Not a wrong value, not a fuzzy boundary. Silence.
+- **55% of the gap was missing labels** — the model emitted _no tag at all_ where one belonged. Not a wrong value, not a fuzzy boundary. Silence.
 - The most-missed tags were `street` (×197) and `house_number` (×100).
 - One cluster stood out: **intersections** — addresses like `Broadway & W 42nd St`. They're 17% of our harness, and the model scored **0%** on them.
 
-Calibration softens the confidence of labels the model *does* emit. It is structurally incapable of conjuring a label the model never produces. That's why it left the harness flat: we'd been sharpening the model's aim at targets it wasn't even shooting at.
+Calibration softens the confidence of labels the model _does_ emit. It is structurally incapable of conjuring a label the model never produces. That's why it left the harness flat: we'd been sharpening the model's aim at targets it wasn't even shooting at.
 
-## The smoking gun
+## The probe
 
 We ran a single probe on a canonical intersection. For every token in `Broadway & W 42nd St`, we read off the probability the model assigned to the `intersection_a` / `intersection_b` tags.
 
 The maximum, across every token, was **~0.0001**.
 
-That's not a model that's unsure about intersections. That's a model that has *no representation of them whatsoever*. The labels existed in its output vocabulary; it had simply never learned to use them.
+Uncertainty doesn't look like that. A model that's merely unsure still puts _some_ probability on the right tag; ~0.0001 means the model has _no representation of intersections whatsoever_. The labels existed in its output vocabulary; it had simply never learned to use them.
 
 Why? We checked the corpus pipeline. There are synthesizers for streets, no-street venues, PO boxes, house+venue combinations… and **nothing that generates intersections**. The real-world adapters don't emit them in that form either. The training signal for intersections was, to a very good approximation, zero. The model never saw one — so it never learned one. No loss function, no calibration trick, no bigger model recovers a category that isn't in the data.
 
 ## A different coverage gap, a different fix
 
-Calibration's one genuine win — a small postcode bump — pointed at a *second* coverage story, this one about tokenization.
+Calibration's one genuine win (a small postcode bump) pointed at a _second_ coverage story, this one about tokenization.
 
 Alphanumeric postcodes (`SW1A 1AA`, `M5V 2T6`) get shredded by the subword tokenizer into fragments like `["S","##W","##1","##A", "1","##AA"]`. The seven-character shape a regex would trivially recognize is invisible to a model reasoning over disconnected pieces. The result: GB/CA/NL postcodes at 0%.
 
-Here the fix wasn't more training at all — it was a **deterministic regex repair** that runs *after* the model decodes: detect a postcode-shaped substring, and snap the label span to it. On the postcode harness that single pass fixed **135 cases and regressed zero**, taking GB/CA/DE/PT to 100%. Sometimes the right tool is a retrain. Sometimes it's eight lines of pattern-matching and a careful "longest-match-wins" rule so a US ZIP+4 doesn't get mistaken for a Dutch postcode.
+Here the fix wasn't training at all. A **deterministic regex repair** runs _after_ the model decodes: detect a postcode-shaped substring, and snap the label span to it. On the postcode harness that single pass fixed **135 cases and regressed zero**, taking GB/CA/DE/PT to 100%. Sometimes the right tool is a retrain. Sometimes it's eight lines of pattern-matching and a careful "longest-match-wins" rule so a US ZIP+4 doesn't get mistaken for a Dutch postcode.
 
 ## What we actually learned
 
 A few lessons we're keeping:
 
-- **Pick a metric that can't be gamed by the thing you're optimizing.** Per-tag F1 looked fine while the product was stuck; harness pass rate (does the *whole* address come out right?) told the truth.
+- **Pick a metric that can't be gamed by the thing you're optimizing.** Per-tag F1 looked fine while the product was stuck; harness pass rate (does the _whole_ address come out right?) told the truth.
 - **A confident-wrong model and an ignorant model need opposite fixes.** We assumed the former; the data showed the latter. Calibration for one, coverage for the other.
 - **Structural validity is its own signal.** A checker that flags incoherent parses — a house number with no street, an orphaned unit — caught a mid-training regression that the headline accuracy number completely hid.
 - **You can't learn what you never see.** The most expensive-sounding problem of the night had the cheapest root cause: a missing synthesizer.
 
-So the fix for intersections isn't a cleverer model. It's a couple thousand synthetic `X & Y St` examples, labeled, dropped into the corpus as a small targeted supplement — and a retrain that finally gives the model something to learn from. That run is training as we publish this.
+So the real fix for intersections is mundane: a couple thousand synthetic `X & Y St` examples, labeled and dropped into the corpus as a small targeted supplement, plus a retrain that finally gives the model something to learn from. That run is training as we publish this.
 
 We'll report what the model does once it has, for the first time, actually seen an intersection.

--- a/docs/blog/2026-05-31-two-scoreboards.mdx
+++ b/docs/blog/2026-05-31-two-scoreboards.mdx
@@ -31,32 +31,32 @@ in a landslide: 93.7% to 20.7%.
 Look one level down, at the per-file results, and something jumps out: **`v0` passes 100% of
 every functional file.** Not 99%. Every single one.
 
-That's not skill — it's lineage. Those 415 assertions were ported from the test suites of
-Pelias and `addressit`. And `v0` *is* our port of Pelias. So the suite is grading a parser
-against its own author's answer key. It cannot, even in principle, catch `v0` being wrong,
+That's not skill — it's lineage. Every one of those 415 assertions was ported from the
+Pelias and `addressit` test suites, and `v0` _is_ our port of Pelias, so the suite is grading a
+parser against its own author's answer key. It cannot, even in principle, catch `v0` being wrong,
 because `v0`'s output **is** the definition of correct.
 
-So "neural scores 20.7%" doesn't mean "neural is wrong 80% of the time." It means **neural
-disagrees with Pelias's exact conventions 80% of the time** — where to split a multi-word
-street, where a venue ends and a locality begins, the dozens of micro-decisions addressit
-happened to encode. Useful as a *regression gate* (did a retrain break something we used to
-match?). Useless as a verdict on which parser is better.
+So "neural scores 20.7%" measures one thing: **how often neural disagrees with Pelias's exact
+conventions** — where to split a multi-word street, where a venue ends and a locality begins, the
+dozens of micro-decisions addressit happened to encode. It says nothing about how often neural is
+_wrong_. Useful as a regression gate (did a retrain break something we used to match?); useless
+as a verdict on which parser is better.
 
 ## Decomposing the 20%
 
-To judge quality fairly we need benches drawn from *outside* the Pelias lineage. We score both
+To judge quality fairly we need benches drawn from _outside_ the Pelias lineage. We score both
 parsers on three:
 
-| arena | what it is | n | v0 | neural |
-|-------|-----------|--:|---:|-------:|
-| **libpostal** | clean, canonical strings | 69 | **29%** | 16% |
-| **perturb** | noisy, abbreviated, reordered | 398 | 39% | **61%** |
-| **postal** | edge formats (PO box, military…) | 38 | **26%** | 8% |
+| arena         | what it is                       |   n |      v0 |  neural |
+| ------------- | -------------------------------- | --: | ------: | ------: |
+| **libpostal** | clean, canonical strings         |  69 | **29%** |     16% |
+| **perturb**   | noisy, abbreviated, reordered    | 398 |     39% | **61%** |
+| **postal**    | edge formats (PO box, military…) |  38 | **26%** |      8% |
 
 Three different stories:
 
 - **Clean input → rules win.** Canonical strings are exactly what hand-tuned regexes are for.
-  This is also the *entire* harness — all canonical, all Pelias-convention — which is why
+  This is also the _entire_ harness — all canonical, all Pelias-convention — which is why
   neural looks worst there.
 - **Messy input → neural wins, decisively** (61% vs 39%) — and this is the biggest bench by
   far (398 cases), built by perturbing real addresses: dropped commas, abbreviations,
@@ -67,15 +67,15 @@ Three different stories:
 
 ## The scoreboard that matters
 
-A geocoder's job isn't to match a tagging convention — it's to put a real address on the map.
+A geocoder's job is to put a real address on the map, not to match a tagging convention.
 So the honest test is end-to-end: take 10,000 real US addresses with real government
-coordinates, run each parser through the *same* resolver, and ask which one lands on the right
+coordinates, run each parser through the _same_ resolver, and ask which one lands on the right
 city.
 
-| parser | locality match (10k real addresses) |
-|--------|------------------------------------:|
-| **neural** | **97.3%** |
-| v0 (Pelias) | 95.8% |
+| parser      | locality match (10k real addresses) |
+| ----------- | ----------------------------------: |
+| **neural**  |                           **97.3%** |
+| v0 (Pelias) |                               95.8% |
 
 On the metric that matches the product — real addresses, end to end — **the neural parser
 beats the rules parser.** The 20.7% and the 97.3% are measuring two completely different
@@ -84,16 +84,17 @@ things: agreement with Pelias's answer key, versus getting real addresses right.
 ## The lesson
 
 If you port your test suite from the system you're trying to beat, that system scores 100% by
-construction, and your challenger will always look broken. The suite isn't lying — it's
-faithfully measuring *agreement with the incumbent*. Just don't mistake that for quality.
+construction, and your challenger will always look broken. The suite is doing its job:
+faithfully measuring _agreement with the incumbent_. Just don't mistake that for a measure of
+quality.
 
 Measure on the distribution you actually serve. For us that's messy, abbreviated, real-world
 addresses — and there, the learned model is ahead.
 
 ---
 
-The full breakdown — every arena, the genuine neural deficits (it does truncate
-`Belle Fourche` to `Belle`), a masked-LM pre-training experiment that turned into a clean
-negative result, and what's next (street-level geometry, to go from "right city" to "right
-spot") — is in the
-[v0.7–v0.8 retrospective](/docs/retrospectives/v0-7-v0-8-neural-vs-rules-retrospective).
+The full breakdown is in the
+[v0.7–v0.8 retrospective](/docs/retrospectives/v0-7-v0-8-neural-vs-rules-retrospective): every
+arena, the genuine neural deficits (it does truncate `Belle Fourche` to `Belle`), the masked-LM
+pre-training experiment that turned into a clean negative result, and what's next (street-level
+geometry, to go from "right city" to "right spot").


### PR DESCRIPTION
Voice/copy cleanup of all 13 blog posts, moving them toward the project's house voice and away from the LLM accent.

## What changed
- **Banned families removed:** antithesis/contrastive-negation templates ("it's not X, it's Y", "X doesn't mean A, it means B"), the `## The smoking gun` and `## Why this matters` signpost headers, and engagement-bait closings.
- **Earned contrasts kept:** contrasts that land after the evidence with concrete specifics (e.g. "That's not skill — it's lineage.") stay — they match the author's own voice.
- **Em-dash density thinned** on the long-form posts (irregular, clustered at argument pivots), keeping pivot dashes and definition-list separators. Heavy posts dropped from 21–35 → 15–26.

## Review
Two adversarial DeepSeek review rounds. Round 1 flagged six over-corrections (flattened contrasts, a deleted warm closing, period-ized parentheticals); all were restored. Hard bans verified clean (smoking-gun / signpost / bait = 0).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)