### PR TITLE
Multi-locale roadmap + multi-script tokenizer scoping (night-shift 2026-06-02)

### DIFF
--- a/docs/articles/evals/2026-06-02-multi-locale-roadmap.md
+++ b/docs/articles/evals/2026-06-02-multi-locale-roadmap.md
@@ -1,0 +1,49 @@
+# Which locales need the German treatment, and which don't (2026-06-02)
+
+The German coverage shard taught the model one thing: addresses where the house number comes after
+the street and the postcode comes before the city. Before generalizing that recipe to more locales,
+it's worth knowing which locales actually have that problem, because "the parser is bad at European
+addresses" is not one bug. A spot-check of the v0.7.2 parser against a handful of native-order
+addresses per locale sorts them into three groups.
+
+## The map
+
+| locale | convention                                         | what the parser does                                                                       | the fix                          |
+| ------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------- |
+| DE     | house after street, postcode before city           | `Hauptstraße 5` → street=`Hauptstraße 5` (house swallowed)                                 | order shard (done)               |
+| ES     | house after street, postcode before city           | `Calle Mayor 12` → street=`Calle Mayor 12`                                                 | **same order shard**             |
+| IT     | house after street, postcode before city           | `Via Roma 12` → street=`Via Roma 12`                                                       | **same order shard**             |
+| NL     | house after street, `1012 LM` postcode before city | `Damrak 70, 1012 LM Amsterdam` → street tagged venue, `locality: "LM Amsterdam"`           | order shard + Dutch postcode     |
+| GB     | house **first**, alphanumeric postcode last        | `10 Downing Street, London SW1A 2AA` → house+street correct, `locality: "London SW1A 2AA"` | postcode coverage, **not** order |
+
+## What this means for the recipe
+
+ES and IT are German all over again. They share the exact convention the model never learned, and
+they fail the exact same way: the house number gets absorbed into the street span because the model
+expects the number first. The `synthesize-german.ts` approach (real OpenAddresses tuples rendered in
+locale order through the OpenCage template) drops straight onto them. When the German train
+validates the recipe, ES and IT are the obvious next two, and the only new inputs are their OA source
+keys and a bounding box.
+
+NL is mostly the same story with a twist: the Dutch postcode carries two letters (`1012 LM`), and the
+model glues that letter-part onto the city. Rendering real Dutch tuples teaches both the order and
+the postcode shape at once, so the same tooling covers it, but the postcode format is worth watching
+in the eval.
+
+GB is the one that does not fit. British addresses already run house-number-first, which is what the
+model was trained on, so it tags house and street correctly. What it cannot do is recognize
+`SW1A 2AA` as a postcode, so the postcode lands inside the locality. An order shard would do nothing
+for GB. It needs postcode coverage, which is closer to the existing postcode-repair work than to the
+German order shard.
+
+## Sequencing
+
+Hold all of this behind the German result. If the German train lifts street and house_number without
+costing US or French accuracy, the recipe is proven and ES, IT, and NL follow on the same rails. If
+German shows interference instead, that same interference would hit the others, and pre-building them
+would just be three more shards to pull back out. So this is a map, not a backlog. Measure the first
+one before you commit to the rest.
+
+The spot-check is directional (a few hand-written addresses per locale, not a labeled set); treat the
+groupings as a planning aid, and confirm each locale with a held-out set the way German was confirmed
+before training on it.

--- a/docs/articles/evals/2026-06-02-multi-locale-roadmap.md
+++ b/docs/articles/evals/2026-06-02-multi-locale-roadmap.md
@@ -36,6 +36,24 @@ model was trained on, so it tags house and street correctly. What it cannot do i
 for GB. It needs postcode coverage, which is closer to the existing postcode-repair work than to the
 German order shard.
 
+## The tokenizer is not the wall, for any script
+
+A reasonable worry is that the harder locales fail because the tokenizer can't represent their
+scripts, which would mean a tokenizer change (a bigger, more expensive lever) instead of coverage.
+Checked directly across ten scripts with `diag-tokenizer-multiscript.ts`, that worry doesn't hold.
+
+The v0.6.0-a0 SentencePiece tokenizer round-trips every script losslessly, which is expected given
+byte_fallback. The telling number is fragmentation, and there is almost none: zero byte-fallback
+pieces across Cyrillic, Greek, Japanese, Chinese, Korean, Arabic, Thai, and Devanagari, all sitting
+at roughly 0.5 to 1.1 pieces per character, the same range as Latin. The 48K vocab carries real
+subword pieces (and for CJK, per-character pieces) for all of them, not raw byte soup.
+
+So the non-Latin collapse measured earlier is not the tokenizer shredding the script. The pieces
+exist; their embeddings are just under-trained, because the corpus is almost entirely Latin. That is
+the same diagnosis as German: coverage, not tokenizer. The synth-from-real-OA recipe therefore reaches
+past the Latin scripts, and the expensive option of swapping in a multilingual encoder is less
+necessary than it looked, since the vocabulary is already multilingual enough to learn from.
+
 ## Sequencing
 
 Hold all of this behind the German result. If the German train lifts street and house_number without

--- a/scripts/diag-tokenizer-multiscript.ts
+++ b/scripts/diag-tokenizer-multiscript.ts
@@ -1,0 +1,65 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Multi-script tokenizer scoping (night-shift 2026-06-02) — the non-Latin generalization of the
+ *   DE-0 gate (`diag-tokenizer-de.ts`). DE-0 showed the v0.6.0-a0 SentencePiece tokenizer
+ *   round-trips German (Latin) orthography losslessly, so German is a coverage problem, not a
+ *   tokenizer one. This asks the same question of the scripts the multi-locale push will eventually
+ *   hit — Cyrillic, Greek, CJK, Korean, Arabic, Thai, Devanagari.
+ *
+ *   The interesting number here is NOT round-trip (SentencePiece `byte_fallback=true` guarantees
+ *   losslessness for anything — worst case it emits raw UTF-8 byte pieces). It's FRAGMENTATION: how
+ *   many pieces per character. A Latin morpheme like `straße` is one learned piece carrying
+ *   meaning; a CJK character with no vocab entry becomes 3 byte pieces carrying none. A high
+ *   pieces-per-char ratio means the model would have to learn address structure over structureless
+ *   byte soup — which is why "just add training data" may not be enough for those scripts, and why
+ *   a tokenizer change (factorized embedding / char-fusion / a multilingual vocab) is the real
+ *   lever for them.
+ */
+
+import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+
+const tokPath =
+	process.argv.includes("--tokenizer") && process.argv[process.argv.indexOf("--tokenizer") + 1]
+		? process.argv[process.argv.indexOf("--tokenizer") + 1]!
+		: "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+
+// One representative native-order address per script.
+const SAMPLES: Array<{ script: string; text: string }> = [
+	{ script: "Latin (DE)", text: "Straußstraße 27, 12623 Berlin" },
+	{ script: "Latin (FR)", text: "12 rue de la Paix, 75002 Paris" },
+	{ script: "Cyrillic (RU)", text: "ул. Тверская 12, 125009 Москва" },
+	{ script: "Greek (EL)", text: "Λεωφόρος Συγγρού 100, 11741 Αθήνα" },
+	{ script: "Japanese (JP)", text: "東京都中央区銀座1-1-1" },
+	{ script: "Chinese (ZH)", text: "上海市黄浦区南京东路100号" },
+	{ script: "Korean (KR)", text: "서울특별시 중구 세종대로 110" },
+	{ script: "Arabic (AR)", text: "شارع التحرير 12، القاهرة" },
+	{ script: "Thai (TH)", text: "ถนนสุขุมวิท 100 กรุงเทพ" },
+	{ script: "Devanagari (HI)", text: "मुख्य मार्ग 12, नई दिल्ली" },
+]
+
+const tok = await MailwomanTokenizer.loadFromFile(tokPath)
+
+// A byte-fallback piece looks like "<0xE6>" — count those to see raw-byte coverage.
+const isBytepiece = (p: string) => /^<0x[0-9A-Fa-f]{2}>$/.test(p)
+
+console.log("script              | chars | pieces | pcs/char | byte-pcs | round-trip")
+console.log("--------------------|-------|--------|----------|----------|-----------")
+for (const { script, text } of SAMPLES) {
+	const enc = tok.encode(text)
+	const decoded = tok.decode(enc.ids)
+	const chars = [...text.replace(/\s/g, "")].length
+	const pieces = enc.pieces.length
+	const bytePcs = enc.pieces.filter((p) => isBytepiece(p.piece)).length
+	const ratio = (pieces / chars).toFixed(2)
+	const rt = decoded === text ? "ok" : "LOSSY"
+	console.log(
+		`${script.padEnd(19)} | ${String(chars).padStart(5)} | ${String(pieces).padStart(6)} | ${ratio.padStart(8)} | ${String(bytePcs).padStart(8)} | ${rt}`
+	)
+}
+console.log("\nReading: round-trip 'ok' everywhere is expected (byte_fallback). The signal is pcs/char + byte-pcs:")
+console.log("Latin ≈ 0.3–0.5 (morpheme pieces). A script in the 1.5–3+ range with many byte-pcs is")
+console.log("represented as raw UTF-8 bytes — lossless but structureless. Those locales need a")
+console.log("tokenizer change (factorized/multilingual vocab), not just more training data.")


### PR DESCRIPTION
Two analysis deliverables that scope the multi-locale push beyond German (a map, not a backlog — held behind the German training result).

- **Order-sensitivity roadmap** (`2026-06-02-multi-locale-roadmap.md`): a v0.7.2 spot-check sorts locales by failure mode. ES + IT share German's house-after-street problem (same order shard); NL adds the Dutch `1012 LM` postcode shape; GB is house-first (order fine) but absorbs the alphanumeric postcode into locality — a postcode-coverage problem, not order.
- **Multi-script tokenizer scoping** (`diag-tokenizer-multiscript.ts`): **the tokenizer is not the wall, for any script.** Zero byte-fallback pieces and 0.5–1.1 pieces/char across Cyrillic/Greek/CJK/Korean/Arabic/Thai/Devanagari — same range as Latin. The non-Latin collapse is under-trained embeddings (coverage), not a tokenizer ceiling. The synth-from-real-OA recipe reaches past Latin; a multilingual-encoder swap is less necessary than feared.

Docs + one diagnostic script. No model or shared-state changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)