### PR TITLE
Locale-generic synthesizer (synthesizeLocaleRow)

### DIFF
--- a/corpus/src/synthesize-german.test.ts
+++ b/corpus/src/synthesize-german.test.ts
@@ -11,10 +11,10 @@
 
 import { describe, expect, it } from "vitest"
 import { alignRow } from "./align.js"
-import { type GermanBaseTuple, synthesizeGermanRow } from "./synthesize-german.js"
+import { type LocaleBaseTuple, synthesizeGermanRow, synthesizeLocaleRow } from "./synthesize-german.js"
 import type { CanonicalRow } from "./types.js"
 
-const BERLIN: GermanBaseTuple = {
+const BERLIN: LocaleBaseTuple = {
 	house_number: "27",
 	street: "Straußstraße",
 	locality: "Berlin",
@@ -50,5 +50,24 @@ describe("synthesizeGermanRow", () => {
 		expect(firstOf("street")).toBeGreaterThanOrEqual(0)
 		expect(firstOf("house_number")).toBeGreaterThan(firstOf("street"))
 		expect(firstOf("locality")).toBeGreaterThan(firstOf("postcode"))
+	})
+})
+
+describe("synthesizeLocaleRow (generic)", () => {
+	it("ES renders Spanish order (house after street, postcode before city) and tags the locale", () => {
+		const madrid: LocaleBaseTuple = { house_number: "12", street: "Calle Mayor", locality: "Madrid", postcode: "28013" }
+		const row = synthesizeLocaleRow(madrid, "ES", { random: keepAll })!
+		expect(row).not.toBeNull()
+		expect(row.locale).toBe("es-ES")
+		// ES renders "Calle Mayor, 12, 28013 Madrid" — house AFTER street (a comma between them,
+		// unlike German), postcode BEFORE city. The order is what the recipe teaches.
+		expect(row.raw.indexOf("Calle Mayor")).toBeLessThan(row.raw.indexOf("12"))
+		expect(row.raw).toContain("28013 Madrid")
+	})
+
+	it("synthesizeGermanRow is the DE wrapper", () => {
+		const row = synthesizeGermanRow(BERLIN, { random: keepAll })!
+		expect(row.locale).toBe("de-DE")
+		expect(synthesizeLocaleRow(BERLIN, "DE", { random: keepAll })!.raw).toBe(row.raw)
 	})
 })

--- a/corpus/src/synthesize-german.ts
+++ b/corpus/src/synthesize-german.ts
@@ -25,23 +25,40 @@
 import { formatAddress } from "./format.js"
 import type { CanonicalRow } from "./types.js"
 
-/** A real German address tuple (e.g. one OpenAddresses Berlin/Saxony row). */
-export interface GermanBaseTuple {
+/** A real address tuple (e.g. one OpenAddresses row): street + locality required, rest optional. */
+export interface LocaleBaseTuple {
 	house_number?: string
 	street: string
 	locality: string
 	region?: string
 	postcode?: string
 }
+/** @deprecated Alias — use LocaleBaseTuple. */
+export type GermanBaseTuple = LocaleBaseTuple
 
-export interface SynthesizedGermanRow {
+export interface SynthesizedLocaleRow {
 	raw: string
 	components: CanonicalRow["components"]
 	locale: string
 }
+/** @deprecated Alias — use SynthesizedLocaleRow. */
+export type SynthesizedGermanRow = SynthesizedLocaleRow
 
-export interface GermanSynthesisOpts {
+export interface LocaleSynthesisOpts {
 	random?: () => number
+}
+/** @deprecated Alias — use LocaleSynthesisOpts. */
+export type GermanSynthesisOpts = LocaleSynthesisOpts
+
+/** ISO-3166 alpha-2 → BCP-47 tag for the emitted rows (primary language per country). */
+const LOCALE_TAG: Record<string, string> = {
+	DE: "de-DE",
+	ES: "es-ES",
+	IT: "it-IT",
+	NL: "nl-NL",
+	GB: "en-GB",
+	FR: "fr-FR",
+	US: "en-US",
 }
 
 /** True when `value` appears verbatim AND as a standalone token (so BIO alignment lands cleanly). */
@@ -57,28 +74,30 @@ function tokenPresent(raw: string, value: string): boolean {
 }
 
 /**
- * Render one real German tuple into an idiomatic German-order `{raw, components}` row, with light
- * variation (drop house number / postcode some of the time) so the model sees both full and partial
- * German addresses. Returns `null` when the tuple is too thin or a component wouldn't align
- * cleanly.
+ * Render one real tuple into an idiomatic, locale-ordered `{raw, components}` row via the OpenCage
+ * `country` template (DE → house-after-street + postcode-before-city; ES/IT the same; GB
+ * house-first; NL carries the `1012 LM` postcode), with light variation (drop house number /
+ * postcode some of the time). Returns `null` when the tuple is too thin or a component wouldn't
+ * align cleanly.
  *
- * Region is intentionally omitted: the German template absorbs the Bundesland into the
- * postcode/city line, so it rarely renders verbatim — including it would break alignment.
+ * Region is intentionally omitted: these templates absorb the admin region into the postcode/city
+ * line, so it rarely renders verbatim, and including it would break BIO alignment.
  */
-export function synthesizeGermanRow(
-	base: GermanBaseTuple,
-	opts: GermanSynthesisOpts = {}
-): SynthesizedGermanRow | null {
+export function synthesizeLocaleRow(
+	base: LocaleBaseTuple,
+	country: string,
+	opts: LocaleSynthesisOpts = {}
+): SynthesizedLocaleRow | null {
 	const random = opts.random ?? Math.random
 	if (!base.street || !base.locality) return null
 
 	const components: CanonicalRow["components"] = { street: base.street, locality: base.locality }
-	// ~80% keep the house number (the rest are street-only "Straße, Stadt" forms, also idiomatic).
+	// ~80% keep the house number (the rest are street-only forms, also idiomatic).
 	if (base.house_number && random() < 0.8) components.house_number = base.house_number
-	// ~85% keep the postcode (German postcodes lead the city line: "12623 Berlin").
+	// ~85% keep the postcode.
 	if (base.postcode && random() < 0.85) components.postcode = base.postcode
 
-	const raw = formatAddress(components, "DE", { separator: ", " })
+	const raw = formatAddress(components, country, { separator: ", " })
 	if (!raw) return null
 
 	// Every component must align — drop the row if the template didn't surface one verbatim, or a
@@ -87,5 +106,13 @@ export function synthesizeGermanRow(
 		if (!value || !tokenPresent(raw, value)) return null
 	}
 
-	return { raw, components, locale: "de-DE" }
+	return { raw, components, locale: LOCALE_TAG[country] ?? country.toLowerCase() }
+}
+
+/** German wrapper over {@link synthesizeLocaleRow}. Kept for the build-german-shard caller + tests. */
+export function synthesizeGermanRow(
+	base: LocaleBaseTuple,
+	opts: LocaleSynthesisOpts = {}
+): SynthesizedLocaleRow | null {
+	return synthesizeLocaleRow(base, "DE", opts)
 }


### PR DESCRIPTION
Generalizes the German synthesizer to any locale via the OpenCage country template. `synthesizeGermanRow` becomes a thin DE wrapper; the German shard rebuilds **byte-identical** (regression-checked), so the staged DE shard is untouched. Makes the next locale (ES/IT, per the roadmap) a one-call change. +2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)