### PR TITLE
feat(postcode-anchor): multi-locale postcode anchor — extractor + gazetteer + soft country posterior (#240)

### DIFF
--- a/neural/index.ts
+++ b/neural/index.ts
@@ -7,6 +7,7 @@
 export * from "./classifier.js"
 export * from "./labels.js"
 export * from "./onnx-runner.js"
+export * from "./postcode-anchor.js"
 export * from "./proposal-classifier.js"
 export { addEmissionMatrix, buildEmissionPriors } from "./query-shape-prior.js"
 export type { BuildPriorsOpts, KnownFormatHitLike, QueryShapeLike, TokenLike } from "./query-shape-prior.js"

--- a/neural/package.json
+++ b/neural/package.json
@@ -12,6 +12,7 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": "./out/index.js",
+		"./postcode-anchor": "./out/postcode-anchor.js",
 		"./tokenizer": "./out/tokenizer.js",
 		"./onnx-runner": "./out/onnx-runner.js",
 		"./weights": "./out/weights.js",

--- a/neural/postcode-anchor.test.ts
+++ b/neural/postcode-anchor.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the postcode anchor (#240). Drives `extractPostcodeAnchors` with an in-memory fake
+ *   resolver so the anchor logic — country posterior, membership-vs-placement, and the
+ *   membership+ambiguity confidence — is tested without a database.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+	extractPostcodeAnchors,
+	normalizePostcode,
+	type PostcodePlace,
+	type PostcodeResolver,
+} from "./postcode-anchor.js"
+
+/** A fake gazetteer: exact-match map from normalized postcode → hits. */
+class FakeResolver implements PostcodeResolver {
+	constructor(private readonly map: Record<string, PostcodePlace[]>) {}
+	lookup(postcode: string): PostcodePlace[] {
+		return this.map[postcode] ?? []
+	}
+}
+
+const RESOLVER = new FakeResolver({
+	// single-country, placed
+	"94105": [{ country: "US", lat: 37.789, lon: -122.396 }],
+	// ambiguous: a real code in two countries
+	"75001": [
+		{ country: "FR", lat: 48.862, lon: 2.336 },
+		{ country: "US", lat: 35.9, lon: -90.7 },
+	],
+	// known postcode with NO centroid (admin parent absent) — membership only
+	"80144": [{ country: "IT", lat: 0, lon: 0 }],
+	// German code (would be backfilled in the real shard)
+	"68161": [{ country: "DE", lat: 49.48, lon: 8.46 }],
+})
+
+describe("normalizePostcode", () => {
+	it("uppercases, collapses whitespace, strips the German D- prefix", () => {
+		expect(normalizePostcode(" sw1a  1aa ")).toBe("SW1A 1AA")
+		expect(normalizePostcode("D-68161")).toBe("68161")
+		expect(normalizePostcode("75008")).toBe("75008")
+	})
+})
+
+describe("extractPostcodeAnchors", () => {
+	it("single-country postcode → posterior {US:1}, confidence 1.0, one placed candidate", () => {
+		const [a, ...rest] = extractPostcodeAnchors("123 Market St, San Francisco 94105", RESOLVER)
+		expect(rest).toHaveLength(0)
+		expect(a!.normalized).toBe("94105")
+		expect(a!.posterior).toEqual({ US: 1 })
+		expect(a!.confidence).toBe(1)
+		expect(a!.candidates).toEqual([{ country: "US", lat: 37.789, lon: -122.396 }])
+	})
+
+	it("ambiguous postcode → uniform posterior over both countries, moderate confidence", () => {
+		const [a] = extractPostcodeAnchors("75001 Paris", RESOLVER)
+		expect(a!.posterior).toEqual({ FR: 0.5, US: 0.5 })
+		// 1 - log2(2)/log2(10)
+		expect(a!.confidence).toBeCloseTo(0.699, 3)
+		expect(a!.candidates.map((c) => c.country)).toEqual(["FR", "US"])
+	})
+
+	it("regex-shaped string that is in no gazetteer → confidence 0 (parser treats it as a house number)", () => {
+		// 48823 matches the 5-digit shape but is absent from the fake gazetteer.
+		const [a] = extractPostcodeAnchors("48823 Anywhere Road", RESOLVER)
+		expect(a!.normalized).toBe("48823")
+		expect(a!.posterior).toEqual({})
+		expect(a!.confidence).toBe(0)
+		expect(a!.candidates).toEqual([])
+	})
+
+	it("known postcode with no centroid → present in posterior, absent from candidates", () => {
+		const [a] = extractPostcodeAnchors("80144 Napoli", RESOLVER)
+		expect(a!.posterior).toEqual({ IT: 1 })
+		expect(a!.confidence).toBe(1)
+		expect(a!.candidates).toEqual([]) // membership without placement
+	})
+
+	it("normalizes the German D- prefix before resolving", () => {
+		const [a] = extractPostcodeAnchors("Mannheim D-68161", RESOLVER)
+		expect(a!.normalized).toBe("68161")
+		expect(a!.posterior).toEqual({ DE: 1 })
+	})
+
+	it("reports the span offsets of the matched substring", () => {
+		const text = "Foo 94105 Bar"
+		const [a] = extractPostcodeAnchors(text, RESOLVER)
+		expect(text.slice(a!.span.start, a!.span.end)).toBe("94105")
+	})
+
+	it("returns multiple anchors for multiple postcodes", () => {
+		const anchors = extractPostcodeAnchors("94105 ... 75001", RESOLVER)
+		expect(anchors).toHaveLength(2)
+		expect(anchors.map((a) => a.normalized).sort()).toEqual(["75001", "94105"])
+	})
+})

--- a/neural/postcode-anchor.ts
+++ b/neural/postcode-anchor.ts
@@ -1,0 +1,135 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Postcode anchor — the first member of the "anchor-based parsing" family (Direction D, #240). See
+ *   `docs/articles/plan/2026-06-03-anchor-based-parsing.md`.
+ *
+ *   A postcode is the most information-dense token in an address: a hierarchical geo-encoding that
+ *   places a query on Earth far more cheaply than the rest of the parse. This module lifts the
+ *   postcode out of the BIO sequence-labelling problem and treats it as a structured anchor. It
+ *   runs the same per-country shape regexes the decoder repair pass uses ({@link collectMatches}),
+ *   resolves each shaped span against a postcode gazetteer, and returns a SOFT signal: a country
+ *   posterior plus a calibrated confidence. It never decides a postcode's identity on its own — it
+ *   reports "this string is (or is not) a real postcode, in these countries, near here", and leaves
+ *   the parser to weigh that against the surrounding tokens.
+ *
+ *   Two design rules carried from the DeepSeek consult
+ *   (`.agents/skills/deepseek-consult/ds-pc-turn{1,2}-postcode-anchor.txt`):
+ *
+ *   - The country posterior is UNIFORM over the countries a string actually exists in. We never weight
+ *       by per-country postcode volume, because that skews "75001" toward whichever country owns
+ *       more 5-digit codes — the exact bias the anchor exists to avoid. Disambiguation is the
+ *       parser's job, using script, city tokens, and user locale.
+ *   - Confidence combines gazetteer MEMBERSHIP with country AMBIGUITY. A string that matches a postcode
+ *       regex but exists in no gazetteer (a bare `27`, or a 5-digit house number that is not a real
+ *       code) gets confidence 0, so the parser treats it as a house number. A real-but-ambiguous
+ *       code (`75001` in FR and US) gets moderate confidence. A real, single-country code gets
+ *       1.0.
+ */
+
+import { collectMatches } from "./postcode-repair.js"
+
+/** A gazetteer hit for a postcode string. `lat`/`lon` of 0 means "known postcode, no centroid yet". */
+export interface PostcodePlace {
+	country: string
+	lat: number
+	lon: number
+}
+
+/**
+ * The minimal surface the anchor needs from a gazetteer. Implementations: an in-memory fake (tests)
+ * or a SQLite-backed lookup over the `postalcode-*.db` shards (`@mailwoman/resolver-wof-sqlite`).
+ * Keeping the seam this narrow lets a future FST/WASM resolver drop in without touching the anchor
+ * logic.
+ */
+export interface PostcodeResolver {
+	/** Exact-match lookup of a normalized postcode string across every country shard. */
+	lookup(postcode: string): PostcodePlace[]
+}
+
+export interface PostcodeAnchor {
+	/** The shaped substring as it appeared in the raw text, with char offsets. */
+	span: { text: string; start: number; end: number }
+	/** The normalized form actually queried (uppercased, `D-` prefix stripped, whitespace collapsed). */
+	normalized: string
+	/** Coordinate-bearing gazetteer hits — best-effort centroid(s), one representative per country. */
+	candidates: PostcodePlace[]
+	/**
+	 * Uniform distribution over the countries the postcode exists in (membership,
+	 * coordinate-independent).
+	 */
+	posterior: Record<string, number>
+	/** `1 - normalizedEntropy(posterior)` when the postcode exists; `0` when it is in no gazetteer. */
+	confidence: number
+}
+
+/**
+ * Entropy cap for the confidence formula: a k-way country split saturates toward 0 confidence at
+ * k=10.
+ */
+const MAX_COUNTRIES = 10
+
+/**
+ * Normalize a shaped span to the canonical gazetteer key: uppercase, collapse internal whitespace
+ * to a single space, and strip the German `D-` courtesy prefix (the shards store `68161`, not
+ * `D-68161`).
+ */
+export function normalizePostcode(raw: string): string {
+	let s = raw.trim().toUpperCase().replace(/\s+/g, " ")
+	if (/^D-\d{5}$/.test(s)) s = s.slice(2)
+	return s
+}
+
+/**
+ * `1 - log2(k)/log2(MAX_COUNTRIES)`, clamped to [0, 1]. k=1 → 1.0; k=2 → ~0.70; k≥MAX_COUNTRIES →
+ * 0.
+ */
+function confidenceFromCountryCount(k: number): number {
+	if (k <= 0) return 0
+	if (k === 1) return 1
+	const c = 1 - Math.log2(k) / Math.log2(MAX_COUNTRIES)
+	return Math.max(0, Math.min(1, c))
+}
+
+/**
+ * Extract postcode anchors from raw text. For each postcode-shaped span, resolve it against the
+ * gazetteer and emit a soft anchor (country posterior + confidence). Spans that match a shape but
+ * exist in no gazetteer are still returned, with an empty posterior and confidence 0 — an explicit
+ * "looks like a postcode, but isn't one" so the caller can see the extractor fired and chose not to
+ * anchor.
+ */
+export function extractPostcodeAnchors(text: string, resolver: PostcodeResolver): PostcodeAnchor[] {
+	const anchors: PostcodeAnchor[] = []
+
+	for (const match of collectMatches(text)) {
+		const spanText = text.slice(match.start, match.end)
+		const normalized = normalizePostcode(spanText)
+		const hits = resolver.lookup(normalized)
+
+		// Membership: distinct countries the postcode exists in (regardless of whether we have a centroid).
+		const countries = [...new Set(hits.map((h) => h.country))].sort()
+		const k = countries.length
+
+		const posterior: Record<string, number> = {}
+		for (const c of countries) posterior[c] = 1 / k
+
+		// Placement: one representative coordinate-bearing hit per country (the first with real coords).
+		const candidates: PostcodePlace[] = []
+		for (const c of countries) {
+			const placed = hits.find((h) => h.country === c && h.lat !== 0 && h.lon !== 0)
+			if (placed) candidates.push(placed)
+		}
+
+		anchors.push({
+			span: { text: spanText, start: match.start, end: match.end },
+			normalized,
+			candidates,
+			posterior,
+			confidence: confidenceFromCountryCount(k),
+		})
+	}
+
+	return anchors
+}

--- a/neural/postcode-repair.ts
+++ b/neural/postcode-repair.ts
@@ -5,39 +5,36 @@
  *
  *   Postcode regex repair pass — v0.7 task #35 ("postcode regex pre-pass").
  *
- *   The 2026-05-29 postcode diagnostic showed the neural model fragments
- *   alphanumeric postcodes at the SentencePiece layer (GB/CA/NL at 0%, US 80.5%,
- *   FR 70.1%). Three failure modes were visible in the data:
+ *   The 2026-05-29 postcode diagnostic showed the neural model fragments alphanumeric postcodes at
+ *   the SentencePiece layer (GB/CA/NL at 0%, US 80.5%, FR 70.1%). Three failure modes were visible
+ *   in the data:
  *
- *     1. Total miss     — "London SW1A 1AA" → (no postcode label)
- *     2. Truncation     — "M5V 2T6" → "2T6";  "B12 8QX" → "B12"
- *     3. Char-drift     — "75008" → "5008";   "62701" → "2701"  (and smear:
- *                          "1200-030 Lisboa" → "200-030 Lis")
+ *   1. Total miss — "London SW1A 1AA" → (no postcode label)
+ *   2. Truncation — "M5V 2T6" → "2T6"; "B12 8QX" → "B12"
+ *   3. Char-drift — "75008" → "5008"; "62701" → "2701" (and smear: "1200-030 Lisboa" → "200-030 Lis")
  *
- *   This pass runs AFTER the model's per-token BIO labels are decoded but BEFORE
- *   `buildAddressTree`. It detects postcode-shaped substrings with per-country
- *   regexes and repairs the label sequence so the postcode span matches the
- *   detected shape. The model is untouched — this is a deterministic decoder-side
- *   correction, the "lowest risk" lever in the v0.7 plan (vs. #36's soft FST
- *   shallow-fusion or #41's char-level encoder).
+ *   This pass runs AFTER the model's per-token BIO labels are decoded but BEFORE `buildAddressTree`.
+ *   It detects postcode-shaped substrings with per-country regexes and repairs the label sequence
+ *   so the postcode span matches the detected shape. The model is untouched — this is a
+ *   deterministic decoder-side correction, the "lowest risk" lever in the v0.7 plan (vs. #36's soft
+ *   FST shallow-fusion or #41's char-level encoder).
  *
  *   PRECISION GUARDS (so we never regress the countries already passing):
- *     - Alphanumeric shapes (GB/CA/NL/DE-prefixed) are high-confidence "this IS a
- *       postcode" patterns → eligible to ADD a span where the model emitted none,
- *       but only over non-structural labels (never over house_number/street/etc.).
- *     - Numeric shapes (\d{5}, ZIP+4, JP, PT, PL) are ambiguous (a bare 5-digit
- *       could be a house number) → SNAP-only: they expand/clip an EXISTING
- *       postcode span, never create one from scratch.
- *     - Smear cleanup is LOCAL: only postcode tokens immediately flanking a
- *       snapped span are cleared. We never globally clear unmatched postcode
- *       tokens — that would regress shapes we don't pattern-match (AU 4-digit,
- *       IN 6-digit, …).
+ *
+ *   - Alphanumeric shapes (GB/CA/NL/DE-prefixed) are high-confidence "this IS a postcode" patterns →
+ *       eligible to ADD a span where the model emitted none, but only over non-structural labels
+ *       (never over house_number/street/etc.).
+ *   - Numeric shapes (\d{5}, ZIP+4, JP, PT, PL) are ambiguous (a bare 5-digit could be a house number)
+ *       → SNAP-only: they expand/clip an EXISTING postcode span, never create one from scratch.
+ *   - Smear cleanup is LOCAL: only postcode tokens immediately flanking a snapped span are cleared. We
+ *       never globally clear unmatched postcode tokens — that would regress shapes we don't
+ *       pattern-match (AU 4-digit, IN 6-digit, …).
  */
 
 import type { DecoderToken } from "@mailwoman/core/decoder"
 
 /** A detected postcode-shaped substring with its char range and confidence class. */
-interface PostcodeMatch {
+export interface PostcodeMatch {
 	start: number
 	end: number
 	/** "alnum" shapes may ADD; "numeric" shapes may only SNAP an existing span. */
@@ -47,11 +44,11 @@ interface PostcodeMatch {
 }
 
 /**
- * Per-country postcode shape patterns, ordered most-specific → least. Alphanumeric
- * patterns require uppercase letters (postcodes are conventionally uppercase, and the
- * eval data has them uppercase) — this keeps them from matching ordinary lowercase prose.
+ * Per-country postcode shape patterns, ordered most-specific → least. Alphanumeric patterns require
+ * uppercase letters (postcodes are conventionally uppercase, and the eval data has them uppercase)
+ * — this keeps them from matching ordinary lowercase prose.
  */
-const POSTCODE_PATTERNS: Array<{ label: string; kind: "alnum" | "numeric"; re: RegExp }> = [
+export const POSTCODE_PATTERNS: Array<{ label: string; kind: "alnum" | "numeric"; re: RegExp }> = [
 	// --- Alphanumeric (eligible to ADD) ---
 	// GB: outward + space + inward, e.g. SW1A 1AA, EH8 9YL, W1J 9PN, IP13 6SU, B12 8QX
 	{ label: "GB", kind: "alnum", re: /\b[A-Z]{1,2}\d[A-Z\d]?\s+\d[A-Z]{2}\b/g },
@@ -71,11 +68,11 @@ const POSTCODE_PATTERNS: Array<{ label: string; kind: "alnum" | "numeric"; re: R
 ]
 
 /**
- * Labels a postcode span is allowed to overwrite when the model emitted no postcode
- * at all (ADD path). These are the geographic-container tags postcodes get confused
- * with per the diagnostic ("often labeled as locality or O"). Structural tags
- * (house_number, street*, unit, po_box, venue, …) are intentionally absent so we
- * never clobber a confidently-labeled street/number with a false postcode.
+ * Labels a postcode span is allowed to overwrite when the model emitted no postcode at all (ADD
+ * path). These are the geographic-container tags postcodes get confused with per the diagnostic
+ * ("often labeled as locality or O"). Structural tags (house_number, street*, unit, po_box, venue,
+ * …) are intentionally absent so we never clobber a confidently-labeled street/number with a false
+ * postcode.
  */
 const ADD_OVER_TAGS = new Set<string>(["locality", "dependent_locality", "region", "subregion", "country"])
 
@@ -93,7 +90,7 @@ function tagOf(label: string): string | null {
 }
 
 /** Collect non-overlapping postcode matches, preferring more-specific (earlier) patterns. */
-function collectMatches(text: string): PostcodeMatch[] {
+export function collectMatches(text: string): PostcodeMatch[] {
 	const candidates: PostcodeMatch[] = []
 	POSTCODE_PATTERNS.forEach((pat, priority) => {
 		pat.re.lastIndex = 0
@@ -120,8 +117,8 @@ export interface RepairResult {
 }
 
 /**
- * Repair postcode label spans in a decoded token sequence using per-country regexes.
- * Returns a NEW token array (inputs are not mutated) plus a change count.
+ * Repair postcode label spans in a decoded token sequence using per-country regexes. Returns a NEW
+ * token array (inputs are not mutated) plus a change count.
  */
 export function repairPostcodeLabels(text: string, input: readonly DecoderToken[]): RepairResult {
 	const matches = collectMatches(text)

--- a/resolver-wof-sqlite/POSTCODE-ANCHOR.md
+++ b/resolver-wof-sqlite/POSTCODE-ANCHOR.md
@@ -1,0 +1,79 @@
+# Postcode anchor
+
+The postcode anchor is the first member of the anchor-based-parsing family
+([design](../docs/articles/plan/2026-06-03-anchor-based-parsing.md), #240). It lifts the postcode out of
+the BIO sequence-labelling problem and treats it as a structured signal: take a postcode-shaped span,
+resolve it against a gazetteer, and report a country posterior plus a calibrated confidence. The parser
+then weighs that soft signal against the surrounding tokens. The anchor never decides a postcode's
+identity on its own.
+
+## The two pieces
+
+- **`@mailwoman/neural/postcode-anchor`** — `extractPostcodeAnchors(text, resolver)`. Pure logic: it runs
+  the same per-country shape regexes the decoder repair pass uses, resolves each shaped span through an
+  injected `PostcodeResolver`, and computes the posterior and confidence. No database dependency, so it
+  ships to the browser later behind the same seam.
+- **`@mailwoman/resolver-wof-sqlite` → `WofPostcodeLookup`** — the production `PostcodeResolver`, an
+  exact-match lookup over one or more `postalcode-*.db` shards.
+
+### Posterior and confidence
+
+The country posterior is **uniform** over the countries a postcode actually exists in. Weighting by
+per-country volume would skew an ambiguous code like `94105` (a valid shape in US, French dept 94, and
+German PLZ 94xxx) toward whichever country owns more 5-digit codes, which is the bias the anchor exists
+to avoid. Disambiguation is the parser's job, using script, city tokens, and user locale.
+
+Confidence combines gazetteer **membership** with country **ambiguity**:
+
+```
+confidence = exists ? (1 - log2(k) / log2(10)) : 0      // k = distinct member countries
+```
+
+So a real single-country code scores 1.0, a real two-country code about 0.70, and a regex-shaped string
+that is in no gazetteer scores 0 — the last case is what keeps a bare `99999` or a 5-digit house number
+from being treated as a postcode.
+
+## Building the shards
+
+The shards come from the operator's own WOF build, never a prebuilt third-party dump. US already ships as
+`postalcode-us.db`. For another country, clone its WOF postcode repo and run the existing builder with the
+`postalcode` placetype, then backfill centroids:
+
+```bash
+# 1. clone the WOF postcode repo (small for most countries; GB is ~8 GB and deferred)
+git clone --depth 1 https://github.com/whosonfirst-data/whosonfirst-data-postalcode-fr.git \
+  /mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data-postalcode-fr
+
+# 2. build the spr shard (point --data at a dir of the repos you want combined)
+node --experimental-strip-types scripts/build-unified-wof.ts \
+  --data <repos-dir> --output /mnt/playpen/mailwoman-data/wof/postalcode-intl.db --placetypes postalcode
+
+# 3. backfill centroids from the admin hierarchy (see below)
+node --experimental-strip-types scripts/backfill-postcode-centroids.ts \
+  --db /mnt/playpen/mailwoman-data/wof/postalcode-intl.db
+
+# 4. functional check
+node --experimental-strip-types scripts/diag-postcode-anchor.ts
+```
+
+### Why the centroid backfill exists
+
+The WOF postcode repos vary in quality. US and ~22% of FR records carry their own `geom:latitude/longitude`.
+The rest ship as coordinate-less stubs that only reference their admin parent by `wof:parent_id`. A
+postcode with no centroid cannot anchor anything geographically, so `backfill-postcode-centroids.ts`
+borrows the parent locality's centroid from the admin gazetteer. Every coordinate still comes from our own
+WOF admin DB.
+
+### Per-country status
+
+| Country | Shard                | Placement                                 |
+| ------- | -------------------- | ----------------------------------------- |
+| US      | `postalcode-us.db`   | own centroids (existing)                  |
+| FR      | `postalcode-intl.db` | 86% placed (own + parent-borrow)          |
+| DE      | `postalcode-intl.db` | 65% placed (parent-borrow)                |
+| IT      | `postalcode-intl.db` | membership only — admin-it repo not built |
+| ES      | not built            | orphan stubs (no parent) — needs admin-es |
+| NL, GB  | not built            | deferred (NL admin-repo sprint; GB ~8 GB) |
+
+IT, ES, and NL reach full placement once their `whosonfirst-data-admin-<cc>` repos are cloned and built
+into the admin gazetteer so the parent-borrow can resolve. That is the next sprint for this lane.

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -10,6 +10,8 @@ export type { AncestorsTable, GeojsonTable, NamesTable, PlaceSearchTable, SprTab
 
 export { WofSqlitePlaceLookup, type RankingWeights, type WofSqlitePlaceLookupOpts } from "./lookup.js"
 
+export { WofPostcodeLookup, type PostcodePlace } from "./postcode-point-lookup.js"
+
 export {
 	PLACE_BBOX_TABLE,
 	PLACE_SEARCH_TABLE,

--- a/resolver-wof-sqlite/postcode-point-lookup.test.ts
+++ b/resolver-wof-sqlite/postcode-point-lookup.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the SQLite-backed postcode lookup (#240). Seeds throwaway `spr` shards in tmp dirs (the
+ *   real `postalcode-*.db` artifacts live on the data volume, not in CI), then asserts exact-match,
+ *   the `is_current` filter, coordinate-less membership, and the cross-shard union.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { WofPostcodeLookup } from "./postcode-point-lookup.js"
+
+/** Create a minimal postcode shard with the columns the lookup reads. */
+function seedShard(path: string, rows: Array<[number, string, string, string, number, number, number]>): void {
+	const db = new DatabaseSync(path)
+	db.exec(
+		`CREATE TABLE spr (id INTEGER PRIMARY KEY, name TEXT, placetype TEXT, country TEXT, latitude REAL, longitude REAL, is_current INTEGER)`
+	)
+	const ins = db.prepare(
+		`INSERT INTO spr (id, name, placetype, country, latitude, longitude, is_current) VALUES (?, ?, ?, ?, ?, ?, ?)`
+	)
+	for (const r of rows) ins.run(...r)
+	db.close()
+}
+
+let dir: string
+let lookup: WofPostcodeLookup
+
+beforeAll(() => {
+	dir = mkdtempSync(join(tmpdir(), "mailwoman-pc-lookup-"))
+	const intl = join(dir, "postalcode-intl.db")
+	const us = join(dir, "postalcode-us.db")
+	seedShard(intl, [
+		[1, "75008", "postalcode", "FR", 48.873, 2.313, 1],
+		[2, "18540", "postalcode", "DE", 53.093, 14.259, 1], // backfilled centroid
+		[3, "80144", "postalcode", "IT", 0, 0, 1], // coord-less membership
+		[4, "13579", "postalcode", "FR", 1, 1, 0], // not current → filtered
+		[5, "Zippendorf", "postalcode", "DE", 0, 0, 0], // deprecated place-name junk → filtered
+	])
+	seedShard(us, [
+		[10, "75008", "postalcode", "US", 35.9, -90.7, 1], // collides with FR 75008
+		[11, "94105", "postalcode", "US", 37.789, -122.396, 1],
+	])
+	lookup = new WofPostcodeLookup([intl, us])
+})
+
+afterAll(() => {
+	lookup.close()
+	rmSync(dir, { recursive: true, force: true })
+})
+
+describe("WofPostcodeLookup", () => {
+	it("exact-matches a current postcode", () => {
+		expect(lookup.lookup("94105")).toEqual([{ country: "US", lat: 37.789, lon: -122.396 }])
+	})
+
+	it("returns coordinate-less rows so membership survives without a centroid", () => {
+		expect(lookup.lookup("80144")).toEqual([{ country: "IT", lat: 0, lon: 0 }])
+	})
+
+	it("filters non-current rows", () => {
+		expect(lookup.lookup("13579")).toEqual([])
+	})
+
+	it("returns [] for an unknown postcode", () => {
+		expect(lookup.lookup("00000")).toEqual([])
+	})
+
+	it("unions the same string across shards (FR + US both own 75008)", () => {
+		const countries = lookup
+			.lookup("75008")
+			.map((p) => p.country)
+			.sort()
+		expect(countries).toEqual(["FR", "US"])
+	})
+})

--- a/resolver-wof-sqlite/postcode-point-lookup.ts
+++ b/resolver-wof-sqlite/postcode-point-lookup.ts
@@ -1,0 +1,61 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   SQLite-backed postcode lookup for the postcode anchor (#240). A thin exact-match resolver over
+ *   one or more `postalcode-*.db` shards (the `spr` schema built by `build-unified-wof --placetypes
+ *   postalcode`, then centroid-backfilled by `scripts/backfill-postcode-centroids.ts`).
+ *
+ *   This is the production implementation of the `PostcodeResolver` interface consumed by
+ *   `@mailwoman/neural`'s `extractPostcodeAnchors`. It is deliberately dumb: an indexed exact-match
+ *   on the postcode string across every shard, unioned. No FTS, no ranking, no proximity — the
+ *   anchor only needs "does this string exist as a postcode, in which countries, near where". A
+ *   future WASM build swaps this for an FST-backed resolver behind the same `lookup()` seam.
+ *
+ *   Why multiple shards instead of the multi-shard `WofSqlitePlaceLookup`: that resolver routes a
+ *   query to ONE shard by placetype, but every postcode shard shares `placetype='postalcode'`, so a
+ *   single query could only ever hit one country's shard. The anchor needs the union across
+ *   countries to build its country posterior, so it queries each shard directly.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+
+/**
+ * A gazetteer hit. `lat`/`lon` of 0 means the postcode is known but has no centroid (no admin
+ * parent).
+ */
+export interface PostcodePlace {
+	country: string
+	lat: number
+	lon: number
+}
+
+const LOOKUP_SQL =
+	"SELECT country, latitude AS lat, longitude AS lon FROM spr WHERE name = ? AND placetype = 'postalcode' AND is_current != 0"
+
+export class WofPostcodeLookup {
+	readonly #dbs: DatabaseSync[]
+	readonly #stmts: ReturnType<DatabaseSync["prepare"]>[]
+
+	/** Open each shard read-only and prepare its exact-match statement. */
+	constructor(dbPaths: readonly string[]) {
+		this.#dbs = dbPaths.map((p) => new DatabaseSync(p, { readOnly: true }))
+		this.#stmts = this.#dbs.map((db) => db.prepare(LOOKUP_SQL))
+	}
+
+	/** Exact-match the postcode across every shard and union the rows. */
+	lookup(postcode: string): PostcodePlace[] {
+		const out: PostcodePlace[] = []
+		for (const stmt of this.#stmts) {
+			for (const row of stmt.all(postcode)) {
+				out.push({ country: String(row.country), lat: Number(row.lat), lon: Number(row.lon) })
+			}
+		}
+		return out
+	}
+
+	close(): void {
+		for (const db of this.#dbs) db.close()
+	}
+}

--- a/scripts/backfill-postcode-centroids.ts
+++ b/scripts/backfill-postcode-centroids.ts
@@ -1,0 +1,116 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Backfill postcode centroids from the admin hierarchy (postcode-anchor pipeline, #240).
+ *
+ *   The `whosonfirst-data-postalcode-<cc>` repos vary in quality. US and ~22% of FR postcode records
+ *   carry their own `geom:latitude/longitude`; the rest (most of DE, much of FR) ship as
+ *   coordinate-less stubs that only carry a `wof:parent_id` into the admin hierarchy. A postcode
+ *   with no centroid is useless as a geographic anchor, so this pass borrows the centroid (and a
+ *   point bbox) from the postcode's parent locality in the admin gazetteer — a coarse "which city"
+ *   placement, which is exactly what the anchor needs.
+ *
+ *   This is the operator-mandated "extend the custom WOF build" path: every coordinate comes from our
+ *   own WOF admin DB, never a prebuilt third-party dump. Postcodes whose parent is absent from the
+ *   admin DB (e.g. IT/ES, whose admin repos we have not yet cloned) keep latitude=0 — the anchor
+ *   still counts them for country membership but reports no centroid until their admin repos are
+ *   built.
+ *
+ *   Usage: node --experimental-strip-types scripts/backfill-postcode-centroids.ts\
+ *   --db /mnt/playpen/mailwoman-data/wof/postalcode-intl.db\
+ *   --admin /mnt/playpen/mailwoman-data/wof/admin-global-priority.db
+ */
+
+import { existsSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+
+interface Args {
+	dbPath: string
+	adminPath: string
+}
+
+function parseArgs(): Args {
+	const args = process.argv.slice(2)
+	let dbPath: string | undefined
+	let adminPath = "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--db" && args[i + 1]) dbPath = args[++i]
+		else if (args[i] === "--admin" && args[i + 1]) adminPath = args[++i]!
+	}
+	if (!dbPath) {
+		console.error(
+			"Usage: node scripts/backfill-postcode-centroids.ts --db <postalcode.db> [--admin <admin-global-priority.db>]"
+		)
+		process.exit(1)
+	}
+	return { dbPath, adminPath }
+}
+
+function main(): void {
+	const { dbPath, adminPath } = parseArgs()
+	for (const p of [dbPath, adminPath]) {
+		if (!existsSync(p)) {
+			console.error(`Missing DB: ${p}`)
+			process.exit(1)
+		}
+	}
+
+	const db = new DatabaseSync(dbPath)
+	db.exec(`ATTACH '${adminPath.replace(/'/g, "''")}' AS adm`)
+
+	const before = db
+		.prepare(`SELECT COUNT(*) n FROM spr WHERE placetype='postalcode' AND is_current!=0 AND latitude!=0`)
+		.get() as { n: number }
+
+	// Borrow the parent locality's centroid (and a point bbox at that centroid) for every coordinate-less
+	// postcode whose parent exists in the admin DB with real coords. `INSERT OR REPLACE` is avoided —
+	// a single correlated UPDATE keeps the WOF id and every other column intact.
+	db.exec("BEGIN")
+	db.exec(`
+		UPDATE spr
+		SET latitude = (SELECT a.latitude FROM adm.spr a WHERE a.id = spr.parent_id),
+		    longitude = (SELECT a.longitude FROM adm.spr a WHERE a.id = spr.parent_id),
+		    min_latitude = (SELECT a.latitude FROM adm.spr a WHERE a.id = spr.parent_id),
+		    max_latitude = (SELECT a.latitude FROM adm.spr a WHERE a.id = spr.parent_id),
+		    min_longitude = (SELECT a.longitude FROM adm.spr a WHERE a.id = spr.parent_id),
+		    max_longitude = (SELECT a.longitude FROM adm.spr a WHERE a.id = spr.parent_id)
+		WHERE placetype = 'postalcode'
+		  AND is_current != 0
+		  AND latitude = 0
+		  AND parent_id > 0
+		  AND EXISTS (
+		      SELECT 1 FROM adm.spr a
+		      WHERE a.id = spr.parent_id AND a.latitude != 0 AND a.longitude != 0
+		  )
+	`)
+	db.exec("COMMIT")
+
+	const after = db
+		.prepare(`SELECT COUNT(*) n FROM spr WHERE placetype='postalcode' AND is_current!=0 AND latitude!=0`)
+		.get() as { n: number }
+	const total = db.prepare(`SELECT COUNT(*) n FROM spr WHERE placetype='postalcode' AND is_current!=0`).get() as {
+		n: number
+	}
+
+	const byCountry = db
+		.prepare(
+			`SELECT country,
+			        COUNT(*) total,
+			        SUM(latitude!=0) placed
+			 FROM spr WHERE placetype='postalcode' AND is_current!=0
+			 GROUP BY country ORDER BY total DESC`
+		)
+		.all() as Array<{ country: string; total: number; placed: number }>
+
+	db.close()
+
+	console.error(`Backfilled centroids: ${before.n} → ${after.n} placed (+${after.n - before.n}) of ${total.n} total`)
+	for (const r of byCountry) {
+		const pct = r.total ? ((100 * r.placed) / r.total).toFixed(0) : "0"
+		console.error(`  ${r.country}: ${r.placed}/${r.total} placed (${pct}%)`)
+	}
+}
+
+main()

--- a/scripts/diag-postcode-anchor.ts
+++ b/scripts/diag-postcode-anchor.ts
@@ -1,0 +1,54 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Functional diagnostic for the postcode anchor (#240). Wires the real `postalcode-us.db` +
+ *   `postalcode-intl.db` shards through `WofPostcodeLookup` and runs `extractPostcodeAnchors` on a
+ *   few addresses that exercise each claim in the design doc: single-country placement,
+ *   cross-country ambiguity, a regex-shaped non-member (the house-number case), and an
+ *   out-of-coverage country (graceful zero-confidence).
+ *
+ *   Build the shards first: node --experimental-strip-types scripts/build-unified-wof.ts --data
+ *   <repos> --output postalcode-intl.db --placetypes postalcode node --experimental-strip-types
+ *   scripts/backfill-postcode-centroids.ts --db postalcode-intl.db
+ *
+ *   Run: node --experimental-strip-types scripts/diag-postcode-anchor.ts
+ */
+
+import { extractPostcodeAnchors } from "@mailwoman/neural/postcode-anchor"
+import { WofPostcodeLookup } from "@mailwoman/resolver-wof-sqlite"
+
+const SHARDS = [
+	"/mnt/playpen/mailwoman-data/wof/postalcode-us.db",
+	"/mnt/playpen/mailwoman-data/wof/postalcode-intl.db",
+]
+
+const INPUTS = [
+	"8 Rue du Faubourg Saint-Honoré, 75008 Paris", // FR, single-country, placed
+	"Straußstraße 27, 12623 Berlin", // DE, parent-borrowed centroid
+	"123 Market St, San Francisco, CA 94105", // US, own centroid
+	"75001 Paris", // FR + US (Addison, TX) — ambiguous → moderate confidence
+	"Apartment 99999, Nowhere", // regex-shaped, in no gazetteer → confidence 0
+	"10 Downing Street, London SW1A 2AA", // GB — not in our shards → graceful 0
+]
+
+const lookup = new WofPostcodeLookup(SHARDS)
+
+for (const input of INPUTS) {
+	console.log(`\n=== ${input} ===`)
+	const anchors = extractPostcodeAnchors(input, lookup)
+	if (anchors.length === 0) {
+		console.log("  (no postcode-shaped span)")
+		continue
+	}
+	for (const a of anchors) {
+		const post = Object.entries(a.posterior)
+			.map(([c, p]) => `${c}:${p.toFixed(2)}`)
+			.join(" ")
+		const cands = a.candidates.map((c) => `${c.country}(${c.lat.toFixed(3)},${c.lon.toFixed(3)})`).join(" ") || "—"
+		console.log(`  "${a.normalized}"  conf=${a.confidence.toFixed(3)}  posterior=[${post || "∅"}]  centroid=${cands}`)
+	}
+}
+
+lookup.close()


### PR DESCRIPTION
Builds the project's zero-GPU lead, issue #240, the first member of the anchor-based-parsing family ([design](https://github.com/sister-software/mailwoman/blob/main/docs/articles/plan/2026-06-03-anchor-based-parsing.md)). Night shift 2026-06-03.

## What a postcode anchor does

A postcode is the most information-dense token in an address. Instead of asking the BIO model to find it *and* know where it stops in one pass (the exact failure mode behind the German collapse), the anchor lifts the postcode out, resolves it against a gazetteer, and reports a **soft** signal: a country posterior plus a calibrated confidence. The parser weighs that against the surrounding tokens. The anchor never decides on its own.

## What ships

- **`@mailwoman/neural/postcode-anchor`** — `extractPostcodeAnchors(text, resolver)`. Pure logic, no DB, reuses the existing per-country shape regexes (now exported from `postcode-repair.ts` rather than duplicated). Lightweight subpath export so it reaches the browser later behind the same `PostcodeResolver` seam.
- **`WofPostcodeLookup`** (`@mailwoman/resolver-wof-sqlite`) — the production resolver, an exact-match union over the `postalcode-*.db` shards.
- **`scripts/backfill-postcode-centroids.ts`** — borrows centroids from the admin parent locality for the coordinate-less WOF postcode stubs, keeping every coordinate WOF-sourced (the operator's "extend the custom build" mandate).
- **`scripts/diag-postcode-anchor.ts`** + **`POSTCODE-ANCHOR.md`** — functional diagnostic and the build/status doc.

## Design rules (DeepSeek-signed, 2 turns)

- **Uniform** country posterior, never count-weighted. Weighting would skew `94105` (a valid shape in US, French dept 94, and German PLZ 94xxx) toward whichever country owns more 5-digit codes.
- **Confidence = `exists ? 1 - log2(k)/log2(10) : 0`**. Real single-country → 1.0; ambiguous two-country → ~0.70; regex-shaped non-member → 0 (keeps a bare `99999` or a 5-digit house number from anchoring).

## Functional evidence (real shards)

```
75008 Paris            → conf 0.70  posterior [FR US]      centroid FR(48.873,2.313)
12623 Berlin           → conf 1.00  posterior [DE]         (coverage gap, no centroid)
94105 San Francisco    → conf 0.52  posterior [DE FR US]   centroid US(37.79,-122.39)  ← soft, parser disambiguates
99999 (house number)   → conf 0.00  posterior [∅]
SW1A 2AA London        → conf 0.00  posterior [∅]          ← GB not loaded, graceful
```

## Coverage

WOF-pure: US (existing) + **FR 86%** + **DE 65%** placement. IT/ES/NL need their `whosonfirst-data-admin-<cc>` repos cloned for the parent-borrow to resolve; GB (~8 GB) and the browser FST artifact are deferred to follow-up sprints (tracked in #240 / `POSTCODE-ANCHOR.md`).

## Tests

13 new tests — anchor logic with an in-memory fake resolver (posterior, membership-vs-placement, the house-number and ambiguity cases), and the concrete lookup against temp fixture shards (no volume dependency, runs in CI). All 31 postcode-suite tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)