### PR TITLE
feat(postcode-anchor): ancestor-fallback backfill + centroid-accuracy eval (#240)

### DIFF
--- a/resolver-wof-sqlite/POSTCODE-ANCHOR.md
+++ b/resolver-wof-sqlite/POSTCODE-ANCHOR.md
@@ -48,12 +48,16 @@ git clone --depth 1 https://github.com/whosonfirst-data/whosonfirst-data-postalc
 node --experimental-strip-types scripts/build-unified-wof.ts \
   --data <repos-dir> --output /mnt/playpen/mailwoman-data/wof/postalcode-intl.db --placetypes postalcode
 
-# 3. backfill centroids from the admin hierarchy (see below)
+# 3. backfill centroids from the admin hierarchy. --repos turns on the coarse ancestor
+#    fallback (see below): broader coverage, looser centroids.
 node --experimental-strip-types scripts/backfill-postcode-centroids.ts \
-  --db /mnt/playpen/mailwoman-data/wof/postalcode-intl.db
+  --db /mnt/playpen/mailwoman-data/wof/postalcode-intl.db \
+  --repos /mnt/playpen/mailwoman-data/wof/repos
 
-# 4. functional check
+# 4. functional check + accuracy
 node --experimental-strip-types scripts/diag-postcode-anchor.ts
+node --experimental-strip-types scripts/eval/postcode-anchor-accuracy.ts \
+  --eval data/eval/external/openaddresses-de-sample.jsonl --country DE
 ```
 
 ### Why the centroid backfill exists
@@ -61,19 +65,48 @@ node --experimental-strip-types scripts/diag-postcode-anchor.ts
 The WOF postcode repos vary in quality. US and ~22% of FR records carry their own `geom:latitude/longitude`.
 The rest ship as coordinate-less stubs that only reference their admin parent by `wof:parent_id`. A
 postcode with no centroid cannot anchor anything geographically, so `backfill-postcode-centroids.ts`
-borrows the parent locality's centroid from the admin gazetteer. Every coordinate still comes from our own
-WOF admin DB.
+borrows a centroid from the admin gazetteer in two passes:
+
+1. **Parent-borrow** (always): copy the parent locality's centroid. Tight, town-level placement.
+2. **Ancestor fallback** (`--repos`): for postcodes whose parent locality is missing from the admin DB
+   (common for city-states like Berlin, whose locality node we never imported), read the GeoJSON
+   hierarchy and borrow the finest available ancestor, preferring county over region. Broader coverage at
+   a looser centroid.
+
+Every coordinate still comes from our own WOF admin DB.
+
+### Coverage and accuracy
+
+Measured against 3,000 OpenAddresses German points (`postcode-anchor-accuracy.ts`). The `--repos`
+fallback trades precision for coverage, so it is a knob, not a default:
+
+| Backfill           | DE placed (Berlin/Saxony sample) | distance to true address |
+| ------------------ | -------------------------------- | ------------------------ |
+| parent-borrow only | 34%                              | p50 2.8 km, 93% ≤ 10 km  |
+| with `--repos`     | 84%                              | p50 7.5 km, 98% ≤ 25 km  |
+
+Membership (the country posterior) is 100% either way — every German postcode in the sample is in the
+gazetteer; only the centroid varies. When the anchor places a postcode it lands in the right town; the
+fallback extends that to the right region for the city-state and large-Land postcodes the parent-borrow
+misses.
+
+### The WOF-pure ceiling
+
+Roughly a third of German postcode records are bare stubs with neither coordinates nor a usable hierarchy
+(no county or region ancestor). Nothing in the admin DB can place those. Closing that last gap would need
+a non-WOF centroid source such as OpenAddresses point aggregation, which crosses the "extend the custom
+WOF build" line, so it is a deliberate policy call rather than a code fix.
 
 ### Per-country status
 
-| Country | Shard                | Placement                                 |
-| ------- | -------------------- | ----------------------------------------- |
-| US      | `postalcode-us.db`   | own centroids (existing)                  |
-| FR      | `postalcode-intl.db` | 86% placed (own + parent-borrow)          |
-| DE      | `postalcode-intl.db` | 65% placed (parent-borrow)                |
-| IT      | `postalcode-intl.db` | membership only — admin-it repo not built |
-| ES      | not built            | orphan stubs (no parent) — needs admin-es |
-| NL, GB  | not built            | deferred (NL admin-repo sprint; GB ~8 GB) |
+| Country | Shard                | Placement                                   |
+| ------- | -------------------- | ------------------------------------------- |
+| US      | `postalcode-us.db`   | own centroids (existing)                    |
+| FR      | `postalcode-intl.db` | 91% placed (own + parent-borrow + ancestor) |
+| DE      | `postalcode-intl.db` | 66% placed (parent-borrow + ancestor)       |
+| IT      | `postalcode-intl.db` | membership only — admin-it repo not built   |
+| ES      | not built            | orphan stubs (no parent) — needs admin-es   |
+| NL, GB  | not built            | deferred (NL admin-repo sprint; GB ~8 GB)   |
 
-IT, ES, and NL reach full placement once their `whosonfirst-data-admin-<cc>` repos are cloned and built
-into the admin gazetteer so the parent-borrow can resolve. That is the next sprint for this lane.
+IT, ES, and NL reach placement once their `whosonfirst-data-admin-<cc>` repos are cloned and built into
+the admin gazetteer so the borrow can resolve. That is the next sprint for this lane.

--- a/scripts/backfill-postcode-centroids.ts
+++ b/scripts/backfill-postcode-centroids.ts
@@ -23,33 +23,92 @@
  *   --admin /mnt/playpen/mailwoman-data/wof/admin-global-priority.db
  */
 
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
 import { DatabaseSync } from "node:sqlite"
 
 interface Args {
 	dbPath: string
 	adminPath: string
+	reposDir?: string
 }
 
 function parseArgs(): Args {
 	const args = process.argv.slice(2)
 	let dbPath: string | undefined
 	let adminPath = "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+	let reposDir: string | undefined
 	for (let i = 0; i < args.length; i++) {
 		if (args[i] === "--db" && args[i + 1]) dbPath = args[++i]
 		else if (args[i] === "--admin" && args[i + 1]) adminPath = args[++i]!
+		else if (args[i] === "--repos" && args[i + 1]) reposDir = args[++i]!
 	}
 	if (!dbPath) {
 		console.error(
-			"Usage: node scripts/backfill-postcode-centroids.ts --db <postalcode.db> [--admin <admin-global-priority.db>]"
+			"Usage: node scripts/backfill-postcode-centroids.ts --db <postalcode.db> [--admin <admin-global-priority.db>] [--repos <wof-repos-dir>]"
 		)
 		process.exit(1)
 	}
-	return { dbPath, adminPath }
+	return { dbPath, adminPath, reposDir }
+}
+
+/** WOF id → repo-relative GeoJSON path: chunk the id into groups of 3, then `<id>.geojson`. */
+function wofIdPath(id: number): string {
+	const s = String(id)
+	const parts: string[] = []
+	for (let i = 0; i < s.length; i += 3) parts.push(s.slice(i, i + 3))
+	return join(...parts, `${s}.geojson`)
+}
+
+/**
+ * Second-pass fallback: for postcodes still coordinate-less after the parent-borrow (their
+ * immediate parent locality is absent from the admin DB — common for city-states like Berlin, whose
+ * locality node we never imported), borrow the finest available ANCESTOR centroid from the GeoJSON
+ * hierarchy. County is preferred over region for tighter placement. Every coordinate still comes
+ * from our own admin DB.
+ */
+function ancestorFallback(db: DatabaseSync, reposDir: string): number {
+	const unplaced = db
+		.prepare(`SELECT id, country FROM spr WHERE placetype='postalcode' AND is_current!=0 AND latitude=0 AND id>0`)
+		.all() as Array<{ id: number; country: string }>
+
+	const adminCentroid = db.prepare(
+		`SELECT latitude AS lat, longitude AS lon FROM adm.spr WHERE id=? AND latitude!=0 AND longitude!=0 LIMIT 1`
+	)
+	const update = db.prepare(
+		`UPDATE spr SET latitude=?, longitude=?, min_latitude=?, max_latitude=?, min_longitude=?, max_longitude=? WHERE id=?`
+	)
+
+	let fixed = 0
+	db.exec("BEGIN")
+	for (const row of unplaced) {
+		const file = join(reposDir, `whosonfirst-data-postalcode-${row.country.toLowerCase()}`, "data", wofIdPath(row.id))
+		let hierarchy: Record<string, number> | undefined
+		try {
+			hierarchy = JSON.parse(readFileSync(file, "utf8")).properties?.["wof:hierarchy"]?.[0]
+		} catch {
+			continue // file missing or unreadable — leave unplaced
+		}
+		if (!hierarchy) continue
+
+		// Finest-available ancestor: county, then region.
+		for (const key of ["county_id", "region_id"] as const) {
+			const ancestorId = hierarchy[key]
+			if (!ancestorId) continue
+			const c = adminCentroid.get(ancestorId) as { lat: number; lon: number } | undefined
+			if (c) {
+				update.run(c.lat, c.lon, c.lat, c.lat, c.lon, c.lon, row.id)
+				fixed++
+				break
+			}
+		}
+	}
+	db.exec("COMMIT")
+	return fixed
 }
 
 function main(): void {
-	const { dbPath, adminPath } = parseArgs()
+	const { dbPath, adminPath, reposDir } = parseArgs()
 	for (const p of [dbPath, adminPath]) {
 		if (!existsSync(p)) {
 			console.error(`Missing DB: ${p}`)
@@ -87,6 +146,15 @@ function main(): void {
 	`)
 	db.exec("COMMIT")
 
+	let ancestorFixed = 0
+	if (reposDir) {
+		if (!existsSync(reposDir)) {
+			console.error(`Missing repos dir, skipping ancestor fallback: ${reposDir}`)
+		} else {
+			ancestorFixed = ancestorFallback(db, reposDir)
+		}
+	}
+
 	const after = db
 		.prepare(`SELECT COUNT(*) n FROM spr WHERE placetype='postalcode' AND is_current!=0 AND latitude!=0`)
 		.get() as { n: number }
@@ -106,7 +174,10 @@ function main(): void {
 
 	db.close()
 
-	console.error(`Backfilled centroids: ${before.n} → ${after.n} placed (+${after.n - before.n}) of ${total.n} total`)
+	console.error(
+		`Backfilled centroids: ${before.n} → ${after.n} placed (+${after.n - before.n}) of ${total.n} total` +
+			(reposDir ? ` (${ancestorFixed} via county/region ancestor fallback)` : "")
+	)
 	for (const r of byCountry) {
 		const pct = r.total ? ((100 * r.placed) / r.total).toFixed(0) : "0"
 		console.error(`  ${r.country}: ${r.placed}/${r.total} placed (${pct}%)`)

--- a/scripts/eval/postcode-anchor-accuracy.ts
+++ b/scripts/eval/postcode-anchor-accuracy.ts
@@ -1,0 +1,109 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Gazetteer-quality eval for the postcode anchor (#240): how close does the anchor's centroid land
+ *   to the true address? For each OpenAddresses point with a postcode and real coordinates, look
+ *   the postcode up in the shards, take the centroid for that country, and measure the haversine
+ *   distance to the true point.
+ *
+ *   This measures the parent-borrow backfill, not rooftop accuracy. A backfilled centroid is the
+ *   parent LOCALITY's centre, so the expected distance is "how far is this address from the middle
+ *   of its town" — a few km in a city, more in a large rural postcode. That is exactly the
+ *   resolution a "which city/region" anchor needs; the eval just confirms the borrow lands in the
+ *   right town.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/postcode-anchor-accuracy.ts\
+ *   --eval data/eval/external/openaddresses-de-sample.jsonl --country DE
+ */
+
+import { haversineKm, WofPostcodeLookup } from "@mailwoman/resolver-wof-sqlite"
+import { readFileSync } from "node:fs"
+
+interface Args {
+	evalPath: string
+	country: string
+	shards: string[]
+}
+
+function parseArgs(): Args {
+	const args = process.argv.slice(2)
+	let evalPath = "data/eval/external/openaddresses-de-sample.jsonl"
+	let country = "DE"
+	const shards = [
+		"/mnt/playpen/mailwoman-data/wof/postalcode-us.db",
+		"/mnt/playpen/mailwoman-data/wof/postalcode-intl.db",
+	]
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--eval" && args[i + 1]) evalPath = args[++i]!
+		else if (args[i] === "--country" && args[i + 1]) country = args[++i]!
+		else if (args[i] === "--shard" && args[i + 1]) shards.push(args[++i]!)
+	}
+	return { evalPath, country, shards }
+}
+
+function pct(sorted: number[], p: number): number {
+	if (sorted.length === 0) return NaN
+	const i = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))
+	return sorted[i]!
+}
+
+function main(): void {
+	const { evalPath, country, shards } = parseArgs()
+	const lookup = new WofPostcodeLookup(shards)
+
+	const lines = readFileSync(evalPath, "utf8").split("\n").filter(Boolean)
+	let withPostcode = 0
+	let placed = 0
+	let inGazetteerNoCentroid = 0
+	let notInGazetteer = 0
+	const distances: number[] = []
+
+	for (const line of lines) {
+		const row = JSON.parse(line)
+		const postcode: string | undefined = row.expected?.postcode ?? row.postcode ?? row.components?.postcode
+		const lat: number | undefined = row.lat
+		const lon: number | undefined = row.lon
+		if (!postcode || typeof lat !== "number" || typeof lon !== "number") continue
+		withPostcode++
+
+		const hits = lookup.lookup(String(postcode)).filter((h) => h.country === country)
+		if (hits.length === 0) {
+			notInGazetteer++
+			continue
+		}
+		const placedHit = hits.find((h) => h.lat !== 0 && h.lon !== 0)
+		if (!placedHit) {
+			inGazetteerNoCentroid++
+			continue
+		}
+		placed++
+		distances.push(haversineKm(lat, lon, placedHit.lat, placedHit.lon))
+	}
+
+	lookup.close()
+	distances.sort((a, b) => a - b)
+
+	console.log(`# Postcode-anchor centroid accuracy — ${country}`)
+	console.log(`eval: ${evalPath}`)
+	console.log(`rows with postcode + coords: ${withPostcode}`)
+	console.log(`  placed (centroid found):     ${placed} (${((100 * placed) / withPostcode).toFixed(1)}%)`)
+	console.log(
+		`  in gazetteer, no centroid:   ${inGazetteerNoCentroid} (${((100 * inGazetteerNoCentroid) / withPostcode).toFixed(1)}%)`
+	)
+	console.log(
+		`  not in gazetteer at all:     ${notInGazetteer} (${((100 * notInGazetteer) / withPostcode).toFixed(1)}%)`
+	)
+	console.log(`distance to true address (placed only), km:`)
+	console.log(
+		`  p50 ${pct(distances, 50).toFixed(1)}  p90 ${pct(distances, 90).toFixed(1)}  p99 ${pct(distances, 99).toFixed(1)}  max ${(distances[distances.length - 1] ?? NaN).toFixed(1)}`
+	)
+	const within10 = distances.filter((d) => d <= 10).length
+	const within25 = distances.filter((d) => d <= 25).length
+	console.log(
+		`  within 10km: ${((100 * within10) / placed).toFixed(1)}%   within 25km: ${((100 * within25) / placed).toFixed(1)}%`
+	)
+}
+
+main()


### PR DESCRIPTION
Two follow-ups to the postcode anchor (#247), from measuring the gazetteer quality during the night shift.

## Ancestor-fallback backfill (a coverage knob)

The parent-borrow misses postcodes whose parent locality is absent from the admin DB — most visibly **city-states like Berlin**, whose locality node we never imported. `backfill-postcode-centroids.ts` gains an optional `--repos` second pass that reads the GeoJSON hierarchy and borrows the finest available ancestor (county, then region).

It trades precision for coverage, so it stays a flag rather than a default:

| Backfill | DE placed (Berlin/Saxony sample) | distance to true address |
|---|---|---|
| parent-borrow only | 34% | p50 2.8 km, 93% ≤ 10 km |
| with `--repos` | 84% | p50 7.5 km, 98% ≤ 25 km |

DE overall 65→66%, FR 86→91%. Country membership (the posterior) is 100% either way; only the centroid varies.

## Centroid-accuracy eval

`scripts/eval/postcode-anchor-accuracy.ts` measures how close the anchor's centroid lands to the true address, against OpenAddresses points. This is what produced the table above and confirmed the parent-borrow lands in the right town (2.8 km median).

## The WOF-pure ceiling (documented)

Roughly a third of DE postcode records are bare stubs with no coordinates *and* no usable hierarchy — unplaceable from any admin ancestor. Closing that last gap needs a non-WOF centroid source (OpenAddresses aggregation), which crosses the "extend the custom WOF build" line, so it's a deliberate policy call for the operator, not a code fix.

Scripts + doc only; no workspace code changed. The shipped `postalcode-intl.db` is a volume artifact rebuilt by this pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)