### PR TITLE
feat(postcode-anchor): opt-in fuzzy (edit-distance-1) typo/OCR tolerance (#240)

### DIFF
--- a/neural/postcode-anchor.test.ts
+++ b/neural/postcode-anchor.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, it } from "vitest"
 import {
+	editDistance1Variants,
 	extractPostcodeAnchors,
 	normalizePostcode,
 	type PostcodePlace,
@@ -96,5 +97,56 @@ describe("extractPostcodeAnchors", () => {
 		const anchors = extractPostcodeAnchors("94105 ... 75001", RESOLVER)
 		expect(anchors).toHaveLength(2)
 		expect(anchors.map((a) => a.normalized).sort()).toEqual(["75001", "94105"])
+	})
+
+	it("tags an exact hit with matchType 'exact'", () => {
+		const [a] = extractPostcodeAnchors("94105", RESOLVER)
+		expect(a!.matchType).toBe("exact")
+	})
+})
+
+describe("editDistance1Variants", () => {
+	it("covers deletions, same-class substitutions, insertions, and transpositions", () => {
+		const v = new Set(editDistance1Variants("75"))
+		expect(v.has("7")).toBe(true) // deletion
+		expect(v.has("5")).toBe(true) // deletion
+		expect(v.has("57")).toBe(true) // transposition
+		expect(v.has("76")).toBe(true) // substitution (digit→digit)
+		expect(v.has("750")).toBe(true) // insertion
+		expect(v.has("75")).toBe(false) // never the original
+	})
+
+	it("keeps substitutions within the character class (digits stay digits)", () => {
+		for (const variant of editDistance1Variants("75")) {
+			// every variant is digits-only (no letters introduced for a numeric postcode)
+			expect(/^[0-9]*$/.test(variant)).toBe(true)
+		}
+	})
+})
+
+describe("extractPostcodeAnchors — fuzzy fallback", () => {
+	it("is off by default: a one-typo postcode is a non-member at confidence 0", () => {
+		const [a] = extractPostcodeAnchors("94155 Somewhere", RESOLVER) // 94155 is edit-1 of 94105
+		expect(a!.matchType).toBe("none")
+		expect(a!.confidence).toBe(0)
+	})
+
+	it("with fuzzy on, a one-typo postcode resolves to the real code with a confidence penalty", () => {
+		const [a] = extractPostcodeAnchors("94155 Somewhere", RESOLVER, { fuzzy: true })
+		expect(a!.matchType).toBe("fuzzy")
+		expect(a!.posterior).toEqual({ US: 1 }) // recovered 94105 → US
+		expect(a!.confidence).toBeCloseTo(0.6, 5) // 1.0 (single country) × fuzzy penalty
+	})
+
+	it("recovers a transposed postcode", () => {
+		const [a] = extractPostcodeAnchors("94015 Somewhere", RESOLVER, { fuzzy: true }) // 1↔0 swap of 94105
+		expect(a!.matchType).toBe("fuzzy")
+		expect(a!.posterior).toEqual({ US: 1 })
+	})
+
+	it("an exact match never triggers the fuzzy path", () => {
+		const [a] = extractPostcodeAnchors("94105", RESOLVER, { fuzzy: true })
+		expect(a!.matchType).toBe("exact")
+		expect(a!.confidence).toBe(1)
 	})
 })

--- a/neural/postcode-anchor.ts
+++ b/neural/postcode-anchor.ts
@@ -63,6 +63,19 @@ export interface PostcodeAnchor {
 	posterior: Record<string, number>
 	/** `1 - normalizedEntropy(posterior)` when the postcode exists; `0` when it is in no gazetteer. */
 	confidence: number
+	/**
+	 * `exact` — the string is a real postcode; `fuzzy` — only an edit-distance-1 variant exists (a
+	 * likely typo / OCR slip), so the confidence carries a penalty; `none` — in no gazetteer.
+	 */
+	matchType: "exact" | "fuzzy" | "none"
+}
+
+export interface ExtractPostcodeAnchorsOpts {
+	/**
+	 * When an exact lookup finds nothing, retry Damerau–Levenshtein ≤1 variants to absorb typos and
+	 * OCR slips (`75OO8` → `75008`). Off by default so existing callers keep exact-match behaviour.
+	 */
+	fuzzy?: boolean
 }
 
 /**
@@ -70,6 +83,31 @@ export interface PostcodeAnchor {
  * k=10.
  */
 const MAX_COUNTRIES = 10
+
+/** A fuzzy (typo-corrected) match is less certain than an exact one — scale its confidence down. */
+const FUZZY_PENALTY = 0.6
+
+/**
+ * Class-aware edit-distance-1 variants of a postcode string: deletions, same-class substitutions
+ * (digit↔digit, letter↔letter), same-class insertions, and adjacent transpositions. Restricting
+ * substitutions/insertions to the character's class mirrors how humans mistype or OCR a postcode (a
+ * digit becomes another digit, not a letter) and keeps the candidate set small.
+ */
+export function editDistance1Variants(s: string): string[] {
+	const classOf = (ch: string): string =>
+		/[0-9]/.test(ch) ? "0123456789" : /[A-Z]/.test(ch) ? "ABCDEFGHIJKLMNOPQRSTUVWXYZ" : ""
+	const variants = new Set<string>()
+	for (let i = 0; i < s.length; i++) variants.add(s.slice(0, i) + s.slice(i + 1)) // deletions
+	for (let i = 0; i < s.length; i++) {
+		for (const c of classOf(s[i]!)) if (c !== s[i]) variants.add(s.slice(0, i) + c + s.slice(i + 1)) // substitutions
+	}
+	for (let i = 0; i <= s.length; i++) {
+		for (const c of classOf(s[i] ?? s[i - 1] ?? "")) variants.add(s.slice(0, i) + c + s.slice(i)) // insertions
+	}
+	for (let i = 0; i + 1 < s.length; i++) variants.add(s.slice(0, i) + s[i + 1] + s[i] + s.slice(i + 2)) // transpositions
+	variants.delete(s)
+	return [...variants]
+}
 
 /**
  * Normalize a shaped span to the canonical gazetteer key: uppercase, collapse internal whitespace
@@ -100,13 +138,30 @@ function confidenceFromCountryCount(k: number): number {
  * "looks like a postcode, but isn't one" so the caller can see the extractor fired and chose not to
  * anchor.
  */
-export function extractPostcodeAnchors(text: string, resolver: PostcodeResolver): PostcodeAnchor[] {
+export function extractPostcodeAnchors(
+	text: string,
+	resolver: PostcodeResolver,
+	opts: ExtractPostcodeAnchorsOpts = {}
+): PostcodeAnchor[] {
 	const anchors: PostcodeAnchor[] = []
 
 	for (const match of collectMatches(text)) {
 		const spanText = text.slice(match.start, match.end)
 		const normalized = normalizePostcode(spanText)
-		const hits = resolver.lookup(normalized)
+
+		// Exact first; fall back to edit-distance-1 variants only when exact finds nothing.
+		let hits = resolver.lookup(normalized)
+		let matchType: PostcodeAnchor["matchType"] = hits.length > 0 ? "exact" : "none"
+		if (matchType === "none" && opts.fuzzy) {
+			const fuzzyHits: PostcodePlace[] = []
+			for (const variant of editDistance1Variants(normalized)) {
+				for (const h of resolver.lookup(variant)) fuzzyHits.push(h)
+			}
+			if (fuzzyHits.length > 0) {
+				hits = fuzzyHits
+				matchType = "fuzzy"
+			}
+		}
 
 		// Membership: distinct countries the postcode exists in (regardless of whether we have a centroid).
 		const countries = [...new Set(hits.map((h) => h.country))].sort()
@@ -122,12 +177,15 @@ export function extractPostcodeAnchors(text: string, resolver: PostcodeResolver)
 			if (placed) candidates.push(placed)
 		}
 
+		const confidence = confidenceFromCountryCount(k) * (matchType === "fuzzy" ? FUZZY_PENALTY : 1)
+
 		anchors.push({
 			span: { text: spanText, start: match.start, end: match.end },
 			normalized,
 			candidates,
 			posterior,
-			confidence: confidenceFromCountryCount(k),
+			confidence,
+			matchType,
 		})
 	}
 

--- a/resolver-wof-sqlite/POSTCODE-ANCHOR.md
+++ b/resolver-wof-sqlite/POSTCODE-ANCHOR.md
@@ -33,6 +33,13 @@ So a real single-country code scores 1.0, a real two-country code about 0.70, an
 that is in no gazetteer scores 0 — the last case is what keeps a bare `99999` or a 5-digit house number
 from being treated as a postcode.
 
+Pass `{ fuzzy: true }` to absorb typos and OCR slips. When an exact lookup finds nothing, the anchor
+retries class-aware edit-distance-1 variants (digit↔digit, letter↔letter substitutions, plus deletions,
+insertions, and adjacent transpositions), tags the result `matchType: "fuzzy"`, and multiplies the
+confidence by a 0.6 penalty. A mistyped `12624` recovers its real neighbour `12623` at low confidence,
+leaving the parser's city tokens to confirm it. Fuzzy is off by default so existing callers keep
+exact-match behaviour.
+
 ## Building the shards
 
 The shards come from the operator's own WOF build, never a prebuilt third-party dump. US already ships as


### PR DESCRIPTION
Adds the typo tolerance the design promised (Damerau-Levenshtein ≤1) but the first cut deferred. Directly serves human-entered/OCR'd postcodes, where a single digit is often wrong.

## What

`extractPostcodeAnchors(text, resolver, { fuzzy: true })`. When an exact lookup finds nothing, the anchor retries **class-aware** edit-distance-1 variants — digit↔digit and letter↔letter substitutions, deletions, insertions, and adjacent transpositions, mirroring how people actually mistype a postcode (a digit slips to another digit, not a letter). It tags every anchor `matchType: "exact" | "fuzzy" | "none"` and multiplies fuzzy confidence by a 0.6 penalty.

## Functional evidence (real shards)

```
12623 Berlin          → "12623" exact  conf 1.000  [DE]
12624 Berlin (typo)   → "12624" fuzzy  conf 0.239  [DE FR IT US]
```

`12624` isn't a real postcode; fuzzy recovers its neighbour `12623` (DE) at low confidence — low because the recovery is multi-country ambiguous, which is the right soft signal: the parser's "Berlin" token confirms DE. (`75088`, by contrast, turned out to be a real code, a good reminder that most 5-digit strings are valid.)

## Safety

Fuzzy is **off by default**, so the merged exact-match callers and tests are unchanged. The fast path (exact hit) never runs the variant generation, so the cost is bounded to genuine misses.

7 new tests (variant generation + the fuzzy path, exact-still-wins, off-by-default); all 15 anchor tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)