### PR TITLE
feat(postcode-anchor): add NL (clean 100%-placed locale) + WOF data-quality survey (#240)

### DIFF
--- a/neural/postcode-anchor.test.ts
+++ b/neural/postcode-anchor.test.ts
@@ -45,6 +45,11 @@ describe("normalizePostcode", () => {
 		expect(normalizePostcode("D-68161")).toBe("68161")
 		expect(normalizePostcode("75008")).toBe("75008")
 	})
+
+	it("removes the space in a Dutch postcode so it matches the gazetteer key", () => {
+		expect(normalizePostcode("1012 LM")).toBe("1012LM")
+		expect(normalizePostcode("1012lm")).toBe("1012LM")
+	})
 })
 
 describe("extractPostcodeAnchors", () => {

--- a/neural/postcode-anchor.ts
+++ b/neural/postcode-anchor.ts
@@ -116,7 +116,8 @@ export function editDistance1Variants(s: string): string[] {
  */
 export function normalizePostcode(raw: string): string {
 	let s = raw.trim().toUpperCase().replace(/\s+/g, " ")
-	if (/^D-\d{5}$/.test(s)) s = s.slice(2)
+	if (/^D-\d{5}$/.test(s)) s = s.slice(2) // German courtesy prefix: D-68161 → 68161
+	if (/^\d{4} [A-Z]{2}$/.test(s)) s = s.replace(" ", "") // Dutch: gazetteer stores 1012LM, not 1012 LM
 	return s
 }
 

--- a/resolver-wof-sqlite/POSTCODE-ANCHOR.md
+++ b/resolver-wof-sqlite/POSTCODE-ANCHOR.md
@@ -104,16 +104,36 @@ Roughly a third of German postcode records are bare stubs with neither coordinat
 a non-WOF centroid source such as OpenAddresses point aggregation, which crosses the "extend the custom
 WOF build" line, so it is a deliberate policy call rather than a code fix.
 
+### WOF postcode data quality, by locale
+
+Whether a locale is placeable from WOF alone depends entirely on its postcode repo's data quality. A
+sample survey (orphan = no `wof:parent_id`; region = a usable `wof:hierarchy` ancestor):
+
+| locale | own coords | orphans | region ancestor | net placeable        |
+| ------ | ---------: | ------: | --------------: | -------------------- |
+| NL     |       100% |      0% |            100% | ~100% (own)          |
+| FR     |        39% |     39% |             61% | ~91%                 |
+| DE     |         0% |     27% |             73% | ~66%                 |
+| ES     |         0% |     64% |             36% | ~36%                 |
+| IT     |         0% |     73% |             27% | ~27% (+ wrong links) |
+
+US, NL, and FR carry enough of their own geometry (or clean ancestry) to place well. DE leans on the
+ancestor fallback. ES and IT are orphan-heavy and effectively WOF-unplaceable — IT also carries wrong
+links (Milan's `20121` points at a Liguria village), which is why it ships membership-only. Closing the
+ES/IT gap needs a non-WOF centroid source such as OpenAddresses point aggregation, a deliberate policy
+call rather than a code fix.
+
 ### Per-country status
 
-| Country | Shard                | Placement                                   |
-| ------- | -------------------- | ------------------------------------------- |
-| US      | `postalcode-us.db`   | own centroids (existing)                    |
-| FR      | `postalcode-intl.db` | 91% placed (own + parent-borrow + ancestor) |
-| DE      | `postalcode-intl.db` | 66% placed (parent-borrow + ancestor)       |
-| IT      | `postalcode-intl.db` | membership only — admin-it repo not built   |
-| ES      | not built            | orphan stubs (no parent) — needs admin-es   |
-| NL, GB  | not built            | deferred (NL admin-repo sprint; GB ~8 GB)   |
+| Country | Shard                | Placement                                            |
+| ------- | -------------------- | ---------------------------------------------------- |
+| US      | `postalcode-us.db`   | own centroids (existing)                             |
+| NL      | `postalcode-intl.db` | 100% placed (own centroids; PC6 stored as `1012LM`)  |
+| FR      | `postalcode-intl.db` | 91% placed (own + parent-borrow + ancestor)          |
+| DE      | `postalcode-intl.db` | 66% placed (parent-borrow + ancestor)                |
+| IT      | `postalcode-intl.db` | membership only — 73% orphans + wrong parents in WOF |
+| ES      | not built            | 64% orphans — WOF-unplaceable, needs OA aggregation  |
+| GB      | not built            | deferred — postcode-not-order locale, ~8 GB repo     |
 
-IT, ES, and NL reach placement once their `whosonfirst-data-admin-<cc>` repos are cloned and built into
-the admin gazetteer so the borrow can resolve. That is the next sprint for this lane.
+NL postcodes are stored space-less (`1012LM`), so the anchor normalizes `1012 LM` → `1012LM` before
+lookup. ES and IT need a non-WOF centroid source rather than another admin-repo build.


### PR DESCRIPTION
A WOF postcode data-quality survey across the order-locales found NL is the cleanest of all — better than DE — so it joins US/FR/DE as a placed locale.

## The survey (why NL, not IT/ES)

| locale | own coords | orphans | region ancestor | net placeable |
|---|--:|--:|--:|--:|
| **NL** | 100% | 0% | 100% | ~100% |
| FR | 39% | 39% | 61% | ~91% |
| DE | 0% | 27% | 73% | ~66% |
| ES | 0% | 64% | 36% | ~36% |
| IT | 0% | 73% | 27% | ~27% (+ wrong links) |

ES and IT are orphan-heavy and effectively WOF-unplaceable (IT also has wrong parent links — Milan's `20121` points at a Liguria village). NL is pristine.

## What ships

- **NL placement**: `postalcode-intl.db` rebuilt to include NL (371,628 codes, **100% placed** via own centroids — no backfill needed).
- **Normalize**: NL postcodes are stored space-less (PC6 `1012LM`), so `normalizePostcode` strips the space in the Dutch `#### AB` form. Verified on real shards: `1012 LM Amsterdam` → exact NL match at the correct Amsterdam centroid (52.37, 4.89).
- **Doc**: the per-locale data-quality survey + updated status table in `POSTCODE-ANCHOR.md`.

17 anchor tests green (39 across the postcode suite). The anchor now places **US + NL + FR + DE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)