### PR TITLE
feat(postcode-anchor): GeoNames centroid backfill — ES/IT/DE, +accuracy, fixes Milan (#240)

### DIFF
--- a/resolver-wof-sqlite/POSTCODE-ANCHOR.md
+++ b/resolver-wof-sqlite/POSTCODE-ANCHOR.md
@@ -47,23 +47,28 @@ exact-match behaviour.
 
 ## Building the shards
 
-The shards come from the operator's own WOF build, never a prebuilt third-party dump. US already ships as
-`postalcode-us.db`. For another country, clone its WOF postcode repo and run the existing builder with the
-`postalcode` placetype, then backfill centroids:
+The WOF postcode records (and their ids) come from the operator's own WOF build; coordinates come from
+the priority chain below (own → GeoNames → WOF admin). US already ships as `postalcode-us.db`. For another
+country, clone its WOF postcode repo, build the shard, then backfill:
 
 ```bash
-# 1. clone the WOF postcode repo (small for most countries; GB is ~8 GB and deferred)
+# 1. clone the WOF postcode repo (small for most; GB is ~8 GB and deferred)
 git clone --depth 1 https://github.com/whosonfirst-data/whosonfirst-data-postalcode-fr.git \
   /mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data-postalcode-fr
+
+# 1b. (for GeoNames-filled locales) fetch the GeoNames postal dump (CC-BY 4.0)
+curl -sL https://download.geonames.org/export/zip/ES.zip -o /tmp/ES.zip && unzip -o /tmp/ES.zip ES.txt \
+  -d /mnt/playpen/mailwoman-data/geonames
 
 # 2. build the spr shard (point --data at a dir of the repos you want combined)
 node --experimental-strip-types scripts/build-unified-wof.ts \
   --data <repos-dir> --output /mnt/playpen/mailwoman-data/wof/postalcode-intl.db --placetypes postalcode
 
-# 3. backfill centroids from the admin hierarchy. --repos turns on the coarse ancestor
-#    fallback (see below): broader coverage, looser centroids.
+# 3. backfill centroids: GeoNames first (the postcode's own centroid), then the WOF admin parent-borrow
+#    + --repos ancestor fallback for what GeoNames misses.
 node --experimental-strip-types scripts/backfill-postcode-centroids.ts \
   --db /mnt/playpen/mailwoman-data/wof/postalcode-intl.db \
+  --geonames /mnt/playpen/mailwoman-data/geonames \
   --repos /mnt/playpen/mailwoman-data/wof/repos
 
 # 4. functional check + accuracy
@@ -72,73 +77,56 @@ node --experimental-strip-types scripts/eval/postcode-anchor-accuracy.ts \
   --eval data/eval/external/openaddresses-de-sample.jsonl --country DE
 ```
 
-### Why the centroid backfill exists
+### The centroid backfill: three priority passes
 
-The WOF postcode repos vary in quality. US and ~22% of FR records carry their own `geom:latitude/longitude`.
-The rest ship as coordinate-less stubs that only reference their admin parent by `wof:parent_id`. A
-postcode with no centroid cannot anchor anything geographically, so `backfill-postcode-centroids.ts`
-borrows a centroid from the admin gazetteer in two passes:
+The WOF postcode repos vary in quality (see the survey below), so `backfill-postcode-centroids.ts` fills
+a coordinate for every coordinate-less postcode, in priority order:
 
-1. **Parent-borrow** (always): copy the parent locality's centroid. Tight, town-level placement.
-2. **Ancestor fallback** (`--repos`): for postcodes whose parent locality is missing from the admin DB
-   (common for city-states like Berlin, whose locality node we never imported), read the GeoJSON
-   hierarchy and borrow the finest available ancestor, preferring county over region. Broader coverage at
-   a looser centroid.
+1. **Own coordinate** — the record's own `geom:latitude/longitude` from the build (US/NL, ~22% of FR). Most authoritative.
+2. **GeoNames postal** (`--geonames <dir>`) — the postcode's OWN centroid, matched by string from the GeoNames `zip` dump (CC-BY 4.0, ~80+ countries). The cleanest fill for ES/IT and ~half of DE; it is _finer_ than the WOF parent-borrow (the postcode's point, not a borrowed locality's), and it corrects WOF's mis-linked Italian parents (`20121` → central Milan, not a Liguria village). WOF ids stay the spine; only the coordinate comes from GeoNames.
+3. **WOF parent-borrow / ancestor fallback** (`--admin`, `--repos`) — a coarse "which city/region" approximation from the admin hierarchy, last resort for postcodes GeoNames does not cover.
 
-Every coordinate still comes from our own WOF admin DB.
+Postcodes neither GeoNames nor WOF can place keep `latitude=0` (membership only — the country posterior still works). **Licensing:** a shard shipping GeoNames-sourced coordinates must attribute "GeoNames (CC-BY 4.0)".
 
 ### Coverage and accuracy
 
-Measured against 3,000 OpenAddresses German points (`postcode-anchor-accuracy.ts`). The `--repos`
-fallback trades precision for coverage, so it is a knob, not a default:
+Per-country placement after the full chain, plus DE accuracy against 3,000 OpenAddresses German points (`postcode-anchor-accuracy.ts`):
 
-| Backfill           | DE placed (Berlin/Saxony sample) | distance to true address |
-| ------------------ | -------------------------------- | ------------------------ |
-| parent-borrow only | 34%                              | p50 2.8 km, 93% ≤ 10 km  |
-| with `--repos`     | 84%                              | p50 7.5 km, 98% ≤ 25 km  |
+| locale | placed | source                                  |
+| ------ | -----: | --------------------------------------- |
+| NL     |   100% | own PC6 coords                          |
+| ES     |    95% | GeoNames                                |
+| FR     |    91% | own + WOF borrow                        |
+| IT     |    90% | GeoNames (and it fixes WOF's bad links) |
+| DE     |    82% | GeoNames + WOF borrow                   |
 
-Membership (the country posterior) is 100% either way — every German postcode in the sample is in the
-gazetteer; only the centroid varies. When the anchor places a postcode it lands in the right town; the
-fallback extends that to the right region for the city-state and large-Land postcodes the parent-borrow
-misses.
+DE accuracy jumped once GeoNames supplied the postcode's own centroid: **p50 1.2 km, 99.9% placed, 100% within 25 km** (max 15.8 km), versus the WOF parent-borrow's 2.8–7.5 km median with 489 km tail outliers. GeoNames is both broader and tighter, because it places the postcode itself rather than borrowing a parent.
 
-### The WOF-pure ceiling
+### WOF postcode data quality, by locale (why GeoNames was needed)
 
-Roughly a third of German postcode records are bare stubs with neither coordinates nor a usable hierarchy
-(no county or region ancestor). Nothing in the admin DB can place those. Closing that last gap would need
-a non-WOF centroid source such as OpenAddresses point aggregation, which crosses the "extend the custom
-WOF build" line, so it is a deliberate policy call rather than a code fix.
+WOF-alone placeability, from a sample survey (orphan = no `wof:parent_id`; region = a usable `wof:hierarchy` ancestor), and what GeoNames adds:
 
-### WOF postcode data quality, by locale
+| locale | own coords | orphans | region ancestor |            WOF alone | with GeoNames                      |
+| ------ | ---------: | ------: | --------------: | -------------------: | ---------------------------------- |
+| NL     |       100% |      0% |            100% |                ~100% | WOF wins (GeoNames is coarser PC4) |
+| FR     |        39% |     39% |             61% |                 ~91% | ~91%                               |
+| DE     |         0% |     27% |             73% |                 ~66% | **82%**                            |
+| ES     |         0% |     64% |             36% |                 ~36% | **95%**                            |
+| IT     |         0% |     73% |             27% | ~27% (+ wrong links) | **90%** (links fixed)              |
 
-Whether a locale is placeable from WOF alone depends entirely on its postcode repo's data quality. A
-sample survey (orphan = no `wof:parent_id`; region = a usable `wof:hierarchy` ancestor):
-
-| locale | own coords | orphans | region ancestor | net placeable        |
-| ------ | ---------: | ------: | --------------: | -------------------- |
-| NL     |       100% |      0% |            100% | ~100% (own)          |
-| FR     |        39% |     39% |             61% | ~91%                 |
-| DE     |         0% |     27% |             73% | ~66%                 |
-| ES     |         0% |     64% |             36% | ~36%                 |
-| IT     |         0% |     73% |             27% | ~27% (+ wrong links) |
-
-US, NL, and FR carry enough of their own geometry (or clean ancestry) to place well. DE leans on the
-ancestor fallback. ES and IT are orphan-heavy and effectively WOF-unplaceable — IT also carries wrong
-links (Milan's `20121` points at a Liguria village), which is why it ships membership-only. Closing the
-ES/IT gap needs a non-WOF centroid source such as OpenAddresses point aggregation, a deliberate policy
-call rather than a code fix.
+WOF is a strong _admin_ gazetteer but a weak _postcode_ one outside a few countries: ES/IT are orphan-heavy and IT carries wrong links. GeoNames postal closes those gaps cleanly and keeps the WOF id as the key, so eval integrity holds. NL stays on WOF (its PC6 is finer than GeoNames' PC4). The wider supplement landscape is catalogued in `docs/articles/plan/reference/address-data-sources.md` ("Gazetteer / resolver coordinate sources").
 
 ### Per-country status
 
-| Country | Shard                | Placement                                            |
-| ------- | -------------------- | ---------------------------------------------------- |
-| US      | `postalcode-us.db`   | own centroids (existing)                             |
-| NL      | `postalcode-intl.db` | 100% placed (own centroids; PC6 stored as `1012LM`)  |
-| FR      | `postalcode-intl.db` | 91% placed (own + parent-borrow + ancestor)          |
-| DE      | `postalcode-intl.db` | 66% placed (parent-borrow + ancestor)                |
-| IT      | `postalcode-intl.db` | membership only — 73% orphans + wrong parents in WOF |
-| ES      | not built            | 64% orphans — WOF-unplaceable, needs OA aggregation  |
-| GB      | not built            | deferred — postcode-not-order locale, ~8 GB repo     |
+| Country | Shard                | Placement                                        |
+| ------- | -------------------- | ------------------------------------------------ |
+| US      | `postalcode-us.db`   | own centroids                                    |
+| NL      | `postalcode-intl.db` | 100% (own PC6 `1012LM`)                          |
+| ES      | `postalcode-intl.db` | 95% (GeoNames)                                   |
+| FR      | `postalcode-intl.db` | 91% (own + WOF borrow)                           |
+| IT      | `postalcode-intl.db` | 90% (GeoNames; WOF's bad links corrected)        |
+| DE      | `postalcode-intl.db` | 82% (GeoNames + WOF borrow)                      |
+| GB      | not built            | deferred — postcode-not-order locale, ~8 GB repo |
 
 NL postcodes are stored space-less (`1012LM`), so the anchor normalizes `1012 LM` → `1012LM` before
-lookup. ES and IT need a non-WOF centroid source rather than another admin-repo build.
+lookup.

--- a/scripts/backfill-postcode-centroids.ts
+++ b/scripts/backfill-postcode-centroids.ts
@@ -3,24 +3,33 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Backfill postcode centroids from the admin hierarchy (postcode-anchor pipeline, #240).
+ *   Backfill postcode centroids for the postcode-anchor pipeline (#240).
  *
- *   The `whosonfirst-data-postalcode-<cc>` repos vary in quality. US and ~22% of FR postcode records
- *   carry their own `geom:latitude/longitude`; the rest (most of DE, much of FR) ship as
- *   coordinate-less stubs that only carry a `wof:parent_id` into the admin hierarchy. A postcode
- *   with no centroid is useless as a geographic anchor, so this pass borrows the centroid (and a
- *   point bbox) from the postcode's parent locality in the admin gazetteer — a coarse "which city"
- *   placement, which is exactly what the anchor needs.
+ *   The `whosonfirst-data-postalcode-<cc>` repos vary in quality. US and ~22% of FR records carry
+ *   their own `geom:latitude/longitude`; the rest ship as coordinate-less stubs (DE leans on its
+ *   admin parent; ES/IT are orphan-heavy with no usable parent at all). A postcode with no centroid
+ *   is useless as a geographic anchor, so this pass fills coordinates from, in priority order:
  *
- *   This is the operator-mandated "extend the custom WOF build" path: every coordinate comes from our
- *   own WOF admin DB, never a prebuilt third-party dump. Postcodes whose parent is absent from the
- *   admin DB (e.g. IT/ES, whose admin repos we have not yet cloned) keep latitude=0 — the anchor
- *   still counts them for country membership but reports no centroid until their admin repos are
- *   built.
+ *   1. The postcode record's own `geom:latitude/longitude` (from the build — US/NL/FR), most
+ *        authoritative;
+ *   2. **GeoNames postal** (`--geonames <dir>`): the postcode's OWN centroid, matched by string. This is
+ *        the cleanest fill for ES/IT and ~half of DE, and it corrects WOF's mis-linked Italian
+ *        parents;
+ *   3. The WOF admin parent-borrow (`--admin`, `--repos`): a coarse "which city/region" approximation,
+ *        last resort for postcodes GeoNames does not cover.
+ *
+ *   Source/integrity note: WOF ids stay the spine and the eval keys — GeoNames only supplies a
+ *   COORDINATE keyed by the postcode string, never an entity id, so the eval-WOF-id integrity
+ *   behind the custom-WOF rule is preserved (delegated-authority consult, 2026-06-03). GeoNames is
+ *   CC-BY 4.0: any DB that ships GeoNames-sourced coordinates must attribute "GeoNames (CC-BY
+ *   4.0)". Files: download.geonames.org/ export/zip/<CC>.zip → `<CC>.txt`. Postcodes neither
+ *   GeoNames nor WOF can place keep latitude=0 (membership only).
  *
  *   Usage: node --experimental-strip-types scripts/backfill-postcode-centroids.ts\
  *   --db /mnt/playpen/mailwoman-data/wof/postalcode-intl.db\
- *   --admin /mnt/playpen/mailwoman-data/wof/admin-global-priority.db
+ *   --geonames /mnt/playpen/mailwoman-data/geonames\
+ *   --admin /mnt/playpen/mailwoman-data/wof/admin-global-priority.db --repos
+ *   /mnt/playpen/mailwoman-data/wof/repos
  */
 
 import { existsSync, readFileSync } from "node:fs"
@@ -31,6 +40,7 @@ interface Args {
 	dbPath: string
 	adminPath: string
 	reposDir?: string
+	geonamesDir?: string
 }
 
 function parseArgs(): Args {
@@ -38,18 +48,77 @@ function parseArgs(): Args {
 	let dbPath: string | undefined
 	let adminPath = "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
 	let reposDir: string | undefined
+	let geonamesDir: string | undefined
 	for (let i = 0; i < args.length; i++) {
 		if (args[i] === "--db" && args[i + 1]) dbPath = args[++i]
 		else if (args[i] === "--admin" && args[i + 1]) adminPath = args[++i]!
 		else if (args[i] === "--repos" && args[i + 1]) reposDir = args[++i]!
+		else if (args[i] === "--geonames" && args[i + 1]) geonamesDir = args[++i]!
 	}
 	if (!dbPath) {
 		console.error(
-			"Usage: node scripts/backfill-postcode-centroids.ts --db <postalcode.db> [--admin <admin-global-priority.db>] [--repos <wof-repos-dir>]"
+			"Usage: node scripts/backfill-postcode-centroids.ts --db <postalcode.db> [--geonames <dir>] [--admin <admin-global-priority.db>] [--repos <wof-repos-dir>]"
 		)
 		process.exit(1)
 	}
-	return { dbPath, adminPath, reposDir }
+	return { dbPath, adminPath, reposDir, geonamesDir }
+}
+
+/**
+ * Priority-2 fill: for every coordinate-less postcode, take its OWN centroid from the GeoNames
+ * postal file for that country (`<geonamesDir>/<CC>.txt`, the GeoNames `zip` dump). A postcode that
+ * appears on several GeoNames rows (one per place sharing the code) is averaged into a single
+ * centroid. Matched by the postcode string only — the WOF id is untouched, so the eval keys stay
+ * WOF's.
+ */
+function geonamesFill(db: DatabaseSync, geonamesDir: string): number {
+	// The GeoNames UPDATE matches on (country, name); the build only indexes placetype/country/parent,
+	// so without this the per-postcode UPDATEs scan each country's rows (minutes on 400k+ rows).
+	db.exec(`CREATE INDEX IF NOT EXISTS spr_by_country_name ON spr (country, name)`)
+
+	const countries = (
+		db
+			.prepare(`SELECT DISTINCT country FROM spr WHERE placetype='postalcode' AND is_current!=0 AND latitude=0`)
+			.all() as Array<{ country: string }>
+	).map((r) => r.country)
+
+	const update = db.prepare(
+		`UPDATE spr SET latitude=?, longitude=?, min_latitude=?, max_latitude=?, min_longitude=?, max_longitude=?
+		 WHERE country=? AND placetype='postalcode' AND is_current!=0 AND latitude=0 AND name=?`
+	)
+
+	let fixed = 0
+	for (const cc of countries) {
+		const file = join(geonamesDir, `${cc}.txt`)
+		if (!existsSync(file)) continue
+
+		// Build postcode → mean(lat,lon) from the TSV (cols: country, postcode, place, ...adm..., lat, lon, acc).
+		const acc = new Map<string, { lat: number; lon: number; n: number }>()
+		for (const line of readFileSync(file, "utf8").split("\n")) {
+			if (!line) continue
+			const f = line.split("\t")
+			const pc = f[1]
+			const lat = Number(f[9])
+			const lon = Number(f[10])
+			if (!pc || !Number.isFinite(lat) || !Number.isFinite(lon) || (lat === 0 && lon === 0)) continue
+			const cur = acc.get(pc)
+			if (cur) {
+				cur.lat += lat
+				cur.lon += lon
+				cur.n++
+			} else acc.set(pc, { lat, lon, n: 1 })
+		}
+
+		db.exec("BEGIN")
+		for (const [pc, s] of acc) {
+			const lat = s.lat / s.n
+			const lon = s.lon / s.n
+			const res = update.run(lat, lon, lat, lat, lon, lon, cc, pc)
+			fixed += Number(res.changes)
+		}
+		db.exec("COMMIT")
+	}
+	return fixed
 }
 
 /** WOF id → repo-relative GeoJSON path: chunk the id into groups of 3, then `<id>.geojson`. */
@@ -108,7 +177,7 @@ function ancestorFallback(db: DatabaseSync, reposDir: string): number {
 }
 
 function main(): void {
-	const { dbPath, adminPath, reposDir } = parseArgs()
+	const { dbPath, adminPath, reposDir, geonamesDir } = parseArgs()
 	for (const p of [dbPath, adminPath]) {
 		if (!existsSync(p)) {
 			console.error(`Missing DB: ${p}`)
@@ -123,7 +192,15 @@ function main(): void {
 		.prepare(`SELECT COUNT(*) n FROM spr WHERE placetype='postalcode' AND is_current!=0 AND latitude!=0`)
 		.get() as { n: number }
 
-	// Borrow the parent locality's centroid (and a point bbox at that centroid) for every coordinate-less
+	// Priority 2: GeoNames postal (the postcode's own centroid). Runs FIRST so it wins over the coarser
+	// WOF parent-borrow below, and so it overrides any WOF mis-link (e.g. the Italian Milan→Liguria case).
+	let geonamesFixed = 0
+	if (geonamesDir) {
+		if (!existsSync(geonamesDir)) console.error(`Missing geonames dir, skipping: ${geonamesDir}`)
+		else geonamesFixed = geonamesFill(db, geonamesDir)
+	}
+
+	// Priority 3: borrow the parent locality's centroid for every coordinate-less postcode whose parent
 	// postcode whose parent exists in the admin DB with real coords. `INSERT OR REPLACE` is avoided —
 	// a single correlated UPDATE keeps the WOF id and every other column intact.
 	db.exec("BEGIN")
@@ -176,7 +253,8 @@ function main(): void {
 
 	console.error(
 		`Backfilled centroids: ${before.n} → ${after.n} placed (+${after.n - before.n}) of ${total.n} total` +
-			(reposDir ? ` (${ancestorFixed} via county/region ancestor fallback)` : "")
+			(geonamesDir ? ` [${geonamesFixed} via GeoNames]` : "") +
+			(reposDir ? ` [${ancestorFixed} via county/region ancestor fallback]` : "")
 	)
 	for (const r of byCountry) {
 		const pct = r.total ? ((100 * r.placed) / r.total).toFixed(0) : "0"

--- a/scripts/diag-postcode-anchor.ts
+++ b/scripts/diag-postcode-anchor.ts
@@ -26,8 +26,10 @@ const SHARDS = [
 
 const INPUTS = [
 	"8 Rue du Faubourg Saint-Honoré, 75008 Paris", // FR, single-country, placed
-	"Straußstraße 27, 12623 Berlin", // DE, parent-borrowed centroid
+	"Straußstraße 27, 12623 Berlin", // DE, GeoNames centroid
 	"123 Market St, San Francisco, CA 94105", // US, own centroid
+	"Calle de Alcalá 1, 28014 Madrid", // ES, GeoNames centroid
+	"Via Roma 1, 20121 Milano", // IT, GeoNames centroid (corrects WOF's bad Milan→Liguria link)
 	"75001 Paris", // FR + US (Addison, TX) — ambiguous → moderate confidence
 	"Apartment 99999, Nowhere", // regex-shaped, in no gazetteer → confidence 0
 	"10 Downing Street, London SW1A 2AA", // GB — not in our shards → graceful 0


### PR DESCRIPTION
Acts on the GeoNames probe (#255) with the operator's go-ahead. GeoNames postal (CC-BY) supplies the postcode's *own* centroid where WOF can't.

## What

`backfill-postcode-centroids.ts` gains a **`--geonames <dir>`** pass that runs **first** — priority order is now own-coord → **GeoNames** → WOF parent-borrow. It matches by postcode string and keeps the WOF id, so the eval-WOF-id integrity holds (the delegated-authority consult cleared exactly this). ES is now built into the shard.

## Result

| locale | before | after | source |
|---|--:|--:|---|
| **ES** | 0% (not built) | **95%** | GeoNames |
| **IT** | 0% | **90%** | GeoNames (+ fixes WOF's bad links) |
| **DE** | 66% | **82%** | GeoNames + WOF borrow |
| NL | 100% | 100% | own PC6 (GeoNames is coarser PC4) |
| FR | 91% | 91% | own + WOF |

And it's not just coverage — GeoNames gives the postcode's own point, so **DE accuracy jumped to p50 1.2 km / 99.9% placed / 100% within 25 km** (max 15.8 km), versus the WOF parent-borrow's 2.8–7.5 km with 489 km tail outliers. It also **corrects WOF's mis-linked Italian parents**: Milan `20121` → 45.46, 9.19 (central Milan), not the Liguria village WOF had.

## Notes

- Adds a `(country, name)` index inside the pass (the build only indexes placetype/country/parent, so the per-postcode UPDATEs would otherwise scan — minutes vs ~1s).
- GeoNames is CC-BY 4.0; a shard shipping its coordinates must attribute "GeoNames (CC-BY 4.0)" — documented.
- The shard + GeoNames files are volume artifacts (generated); the PR ships the script + doc. 46 postcode-suite tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)