### PR TITLE
feat(codex): German address system (codex/de) — street types, PLZ, Bundesländer

### DIFF
--- a/codex/de/bundesland.test.ts
+++ b/codex/de/bundesland.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { DE_BUNDESLAENDER, isGermanStateCode, lookupGermanState } from "./bundesland.js"
+
+describe("DE_BUNDESLAENDER", () => {
+	it("covers all 16 Bundesländer", () => {
+		expect(Object.keys(DE_BUNDESLAENDER)).toHaveLength(16)
+		expect(DE_BUNDESLAENDER.BY).toEqual({ code: "BY", name: "Bayern", english: "Bavaria" })
+	})
+})
+
+describe("isGermanStateCode", () => {
+	it("accepts ISO 3166-2:DE codes, case-insensitively", () => {
+		expect(isGermanStateCode("BY")).toBe(true)
+		expect(isGermanStateCode("nw")).toBe(true)
+		expect(isGermanStateCode("CA")).toBe(false) // a US state, not German
+	})
+})
+
+describe("lookupGermanState", () => {
+	it("resolves code, German name, English exonym, and common alias to the ISO code", () => {
+		expect(lookupGermanState("BY")).toBe("BY")
+		expect(lookupGermanState("Bayern")).toBe("BY")
+		expect(lookupGermanState("Bavaria")).toBe("BY")
+		expect(lookupGermanState("Saxony")).toBe("SN")
+		expect(lookupGermanState("NRW")).toBe("NW")
+		expect(lookupGermanState("Nordrhein-Westfalen")).toBe("NW")
+	})
+
+	it("returns null for an unknown region", () => {
+		expect(lookupGermanState("California")).toBeNull()
+		expect(lookupGermanState(null)).toBeNull()
+	})
+})

--- a/codex/de/bundesland.ts
+++ b/codex/de/bundesland.ts
@@ -1,0 +1,95 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The 16 German federal states (Bundesländer), keyed by their ISO 3166-2:DE subdivision code.
+ *
+ *   The US analog is `us/state.ts`. The informative difference: a US state's two-letter code (`CA`)
+ *   is the USPS abbreviation people actually write in an address, whereas a German address almost
+ *   never carries the Bundesland at all — it is `PLZ City`, and the state is inferred. So these
+ *   codes matter for resolver region-matching and display, not for parsing the surface string.
+ */
+
+/** Per-state record: ISO 3166-2:DE code, native German name, and the common English exonym. */
+export interface GermanStateInfo {
+	/** ISO 3166-2:DE subdivision code without the `DE-` prefix (e.g. `BY` for `DE-BY`). */
+	code: string
+	/** Native German name (e.g. `Bayern`). */
+	name: string
+	/** Common English name (e.g. `Bavaria`). */
+	english: string
+}
+
+/**
+ * ISO 3166-2:DE code → state info, for all 16 Bundesländer. Codes are the official subdivision
+ * codes minus the `DE-` prefix.
+ */
+export const DE_BUNDESLAENDER = {
+	BW: { code: "BW", name: "Baden-Württemberg", english: "Baden-Württemberg" },
+	BY: { code: "BY", name: "Bayern", english: "Bavaria" },
+	BE: { code: "BE", name: "Berlin", english: "Berlin" },
+	BB: { code: "BB", name: "Brandenburg", english: "Brandenburg" },
+	HB: { code: "HB", name: "Bremen", english: "Bremen" },
+	HH: { code: "HH", name: "Hamburg", english: "Hamburg" },
+	HE: { code: "HE", name: "Hessen", english: "Hesse" },
+	MV: { code: "MV", name: "Mecklenburg-Vorpommern", english: "Mecklenburg-Western Pomerania" },
+	NI: { code: "NI", name: "Niedersachsen", english: "Lower Saxony" },
+	NW: { code: "NW", name: "Nordrhein-Westfalen", english: "North Rhine-Westphalia" },
+	RP: { code: "RP", name: "Rheinland-Pfalz", english: "Rhineland-Palatinate" },
+	SL: { code: "SL", name: "Saarland", english: "Saarland" },
+	SN: { code: "SN", name: "Sachsen", english: "Saxony" },
+	ST: { code: "ST", name: "Sachsen-Anhalt", english: "Saxony-Anhalt" },
+	SH: { code: "SH", name: "Schleswig-Holstein", english: "Schleswig-Holstein" },
+	TH: { code: "TH", name: "Thüringen", english: "Thuringia" },
+} as const satisfies Record<string, GermanStateInfo>
+
+/** An ISO 3166-2:DE state code (`BW`, `BY`, `BE`, …). */
+export type GermanStateCode = keyof typeof DE_BUNDESLAENDER
+
+const STATE_CODE_SET: ReadonlySet<string> = new Set(Object.keys(DE_BUNDESLAENDER))
+
+/** Type-predicate for an ISO 3166-2:DE state code. Case-insensitive. */
+export function isGermanStateCode(input: unknown): input is GermanStateCode {
+	return typeof input === "string" && STATE_CODE_SET.has(input.toUpperCase())
+}
+
+/**
+ * Name (native German, English exonym, or common alias) → ISO 3166-2:DE code, lowercase-keyed.
+ * Includes the everyday aliases a parser actually meets: `NRW` for Nordrhein-Westfalen, `Bavaria`
+ * for Bayern, `Saxony` for Sachsen. The point is resolver region-matching: a German parse emits a
+ * region surface form, and the eval needs to map it to a code without a US-USPS-shaped matcher.
+ */
+export const DE_STATE_NAME_TO_CODE: ReadonlyMap<string, GermanStateCode> = (() => {
+	const out = new Map<string, GermanStateCode>()
+	for (const code of Object.keys(DE_BUNDESLAENDER) as GermanStateCode[]) {
+		const info = DE_BUNDESLAENDER[code]
+		out.set(info.name.toLowerCase(), code)
+		out.set(info.english.toLowerCase(), code)
+		out.set(code.toLowerCase(), code)
+	}
+	// Everyday aliases that are neither the ISO code nor the canonical name.
+	const aliases: Record<string, GermanStateCode> = {
+		nrw: "NW",
+		"nordrhein westfalen": "NW",
+		"baden wurttemberg": "BW",
+		"baden-wuerttemberg": "BW",
+		"baden wuerttemberg": "BW",
+		thueringen: "TH",
+		"freie hansestadt bremen": "HB",
+		"freie und hansestadt hamburg": "HH",
+	}
+	for (const [alias, code] of Object.entries(aliases)) out.set(alias, code)
+	return out
+})()
+
+/**
+ * Resolve a German state surface form (code, German name, English name, or common alias) to its ISO
+ * 3166-2:DE code. Returns null when unrecognized.
+ */
+export function lookupGermanState(input: string | null | undefined): GermanStateCode | null {
+	if (!input || typeof input !== "string") return null
+	const key = input.trim().toLowerCase()
+	if (STATE_CODE_SET.has(key.toUpperCase())) return key.toUpperCase() as GermanStateCode
+	return DE_STATE_NAME_TO_CODE.get(key) ?? null
+}

--- a/codex/de/index.ts
+++ b/codex/de/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The German address system (Deutsche Post / ISO 3166-2:DE): street types, postal codes
+ *   (Postleitzahl), and the federal states (Bundesländer).
+ */
+
+export * from "./bundesland.js"
+export * from "./postleitzahl.js"
+export * from "./street-type.js"

--- a/codex/de/postleitzahl.test.ts
+++ b/codex/de/postleitzahl.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { isPostleitzahl, leitzoneOf, normalizePLZ, PLZ_LEITZONEN } from "./postleitzahl.js"
+
+describe("normalizePLZ", () => {
+	it("strips the D- / DE- country prefix to the bare five digits", () => {
+		expect(normalizePLZ("D-68161")).toBe("68161")
+		expect(normalizePLZ("DE-12623")).toBe("12623")
+		expect(normalizePLZ(" 80331 ")).toBe("80331")
+	})
+
+	it("returns null for non-PLZ input", () => {
+		expect(normalizePLZ("8033")).toBeNull()
+		expect(normalizePLZ("SW1A 1AA")).toBeNull()
+		expect(normalizePLZ(68161)).toBeNull()
+	})
+})
+
+describe("isPostleitzahl", () => {
+	it("accepts five digits only", () => {
+		expect(isPostleitzahl("12623")).toBe(true)
+		expect(isPostleitzahl("1262")).toBe(false)
+		expect(isPostleitzahl("D-12623")).toBe(false) // normalize first
+	})
+})
+
+describe("leitzoneOf", () => {
+	it("maps the first digit to its Leitzone (postal region, not a Bundesland)", () => {
+		expect(leitzoneOf("12623")?.region).toContain("Berlin") // Leitzone 1
+		expect(leitzoneOf("80331")?.cities).toContain("München") // Leitzone 8
+		expect(leitzoneOf("D-60311")?.cities).toContain("Frankfurt am Main") // Leitzone 6, prefix stripped
+	})
+
+	it("Leitzone 6 deliberately spans three Bundesländer (Hessen / RP / Saarland)", () => {
+		// The informative contrast with US ZIP first-digit→state: a Leitzone crosses state borders.
+		const region = PLZ_LEITZONEN[6].region
+		expect(region).toMatch(/hessen/i)
+		expect(region).toContain("Rheinland-Pfalz")
+		expect(region).toContain("Saarland")
+	})
+
+	it("returns null for non-PLZ input", () => {
+		expect(leitzoneOf("nope")).toBeNull()
+	})
+})

--- a/codex/de/postleitzahl.ts
+++ b/codex/de/postleitzahl.ts
@@ -1,0 +1,90 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   German postal codes (Postleitzahl, PLZ): the branded type, the shape, normalization, and the
+ *   first-digit → Leitzone geographic prior.
+ *
+ *   The US analog is `us/zipcode.ts`, and the contrast is the informative part. A US ZIP's first
+ *   digit maps cleanly to a band of states (`StateAbbreviationZipCodePrefixRecord`). A German PLZ's
+ *   first digit maps to a **Leitzone** — a postal routing region that deliberately **crosses
+ *   Bundesland borders** (Leitzone 6 covers Frankfurt in Hessen, Saarbrücken in Saarland, and Mainz
+ *   in Rheinland-Pfalz). So the PLZ prior narrows geography, but it does NOT narrow the state the
+ *   way a US ZIP does — a lesson for any code that tries to derive a German region from a postcode
+ *   alone.
+ */
+
+import type { Tagged } from "type-fest"
+
+/**
+ * A German postal code: five digits since the 1993 reform (`12623`). A bare 5-digit string, same
+ * shape as a US ZIP or a French code postal — disambiguation is the parser's job, not the shape's.
+ *
+ * @category Postal
+ * @type string
+ * @title Postleitzahl
+ * @pattern ^\d{5}$
+ */
+export type Postleitzahl = Tagged<string, "Postleitzahl">
+
+/** The PLZ shape: exactly five digits. */
+export const PLZ_PATTERN = /^\d{5}$/
+
+/**
+ * Normalize a PLZ surface form to the bare five digits: strip the `D-` / `DE-` country courtesy
+ * prefix and surrounding whitespace (`D-68161` → `68161`). Returns null if the result is not a
+ * PLZ.
+ */
+export function normalizePLZ(raw: unknown): Postleitzahl | null {
+	if (typeof raw !== "string") return null
+	const s = raw.trim().toUpperCase().replace(/^DE?-/, "")
+	return PLZ_PATTERN.test(s) ? (s as Postleitzahl) : null
+}
+
+/** Type-predicate for a (normalized) German postal code. */
+export function isPostleitzahl(input: unknown): input is Postleitzahl {
+	return typeof input === "string" && PLZ_PATTERN.test(input)
+}
+
+/** A PLZ Leitzone first digit. */
+export type LeitzoneDigit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
+
+/** Per-Leitzone descriptor: the routing region and a few anchor cities (coarse, postal not admin). */
+export interface LeitzoneInfo {
+	digit: LeitzoneDigit
+	/** Coarse routing-region label. */
+	region: string
+	/** Well-known anchor cities in the zone (illustrative, not exhaustive). */
+	cities: readonly string[]
+}
+
+/**
+ * PLZ first digit → Leitzone. A coarse, postal-routing prior: these zones cross Bundesland borders,
+ * so the label is "which corner of Germany", not "which state". Anchor cities are the safe,
+ * well-known way to pin a zone without over-claiming a boundary the routing geography does not
+ * actually follow.
+ */
+export const PLZ_LEITZONEN = {
+	0: { digit: 0, region: "Sachsen / Ostthüringen", cities: ["Leipzig", "Dresden", "Chemnitz"] },
+	1: { digit: 1, region: "Berlin / Brandenburg / Mecklenburg-Vorpommern", cities: ["Berlin", "Potsdam", "Rostock"] },
+	2: { digit: 2, region: "Hamburg / Schleswig-Holstein / Bremen", cities: ["Hamburg", "Kiel", "Bremen"] },
+	3: { digit: 3, region: "Niedersachsen / Nordhessen", cities: ["Hannover", "Braunschweig", "Kassel"] },
+	4: { digit: 4, region: "nördliches Nordrhein-Westfalen", cities: ["Düsseldorf", "Dortmund", "Münster"] },
+	5: { digit: 5, region: "südliches NRW / nördliches Rheinland-Pfalz", cities: ["Köln", "Bonn", "Aachen"] },
+	6: {
+		digit: 6,
+		region: "Südhessen / Rheinland-Pfalz / Saarland",
+		cities: ["Frankfurt am Main", "Mainz", "Saarbrücken"],
+	},
+	7: { digit: 7, region: "Baden-Württemberg", cities: ["Stuttgart", "Karlsruhe", "Freiburg"] },
+	8: { digit: 8, region: "südliches Bayern", cities: ["München", "Augsburg", "Ingolstadt"] },
+	9: { digit: 9, region: "nördliches Bayern / Oberpfalz", cities: ["Nürnberg", "Würzburg", "Regensburg"] },
+} as const satisfies Record<LeitzoneDigit, LeitzoneInfo>
+
+/** The Leitzone of a PLZ (its first digit's routing region), or null if the input is not a PLZ. */
+export function leitzoneOf(plz: unknown): LeitzoneInfo | null {
+	const normalized = normalizePLZ(plz)
+	if (!normalized) return null
+	return PLZ_LEITZONEN[Number(normalized[0]) as LeitzoneDigit]
+}

--- a/codex/de/street-type.test.ts
+++ b/codex/de/street-type.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { DE_STREET_SUFFIXES, isGermanStreetToken } from "./street-type.js"
+
+describe("isGermanStreetToken", () => {
+	it("matches fused compound streets via their suffix", () => {
+		expect(isGermanStreetToken("Straußstraße")).toBe(true)
+		expect(isGermanStreetToken("Karl-Liebknecht-Straße")).toBe(true) // hyphen stripped, ends straße
+		expect(isGermanStreetToken("Hauptstrasse")).toBe(true) // ss spelling
+		expect(isGermanStreetToken("Schlossallee")).toBe(true)
+		expect(isGermanStreetToken("Rosenweg")).toBe(true)
+	})
+
+	it("matches the standalone type word and the Str. abbreviation", () => {
+		expect(isGermanStreetToken("Platz")).toBe(true)
+		expect(isGermanStreetToken("Str.")).toBe(true) // punctuation stripped → "str"
+	})
+
+	it("does NOT flag city names that merely end in a place-name suffix", () => {
+		// The collision guard: -berg/-burg/-dorf/-feld are excluded so a city token in a `PLZ City`
+		// segment is not mistaken for a street.
+		expect(isGermanStreetToken("Nürnberg")).toBe(false)
+		expect(isGermanStreetToken("Hamburg")).toBe(false)
+		expect(isGermanStreetToken("Düsseldorf")).toBe(false)
+		expect(isGermanStreetToken("Bielefeld")).toBe(false)
+		expect(isGermanStreetToken("Berlin")).toBe(false)
+	})
+
+	it("rejects non-strings and too-short tokens", () => {
+		expect(isGermanStreetToken(123)).toBe(false)
+		expect(isGermanStreetToken("am")).toBe(false)
+	})
+})
+
+describe("DE_STREET_SUFFIXES", () => {
+	it("carries both ß and ss spellings of Straße and excludes place-name suffixes", () => {
+		expect(DE_STREET_SUFFIXES).toContain("straße")
+		expect(DE_STREET_SUFFIXES).toContain("strasse")
+		expect(DE_STREET_SUFFIXES).not.toContain("berg")
+		expect(DE_STREET_SUFFIXES).not.toContain("burg")
+	})
+})

--- a/codex/de/street-type.ts
+++ b/codex/de/street-type.ts
@@ -1,0 +1,82 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   German street types (Straßentypen).
+ *
+ *   The US analog is `us/street-suffix.ts`, and the structural contrast is the whole lesson of this
+ *   file. A US street type is a separate trailing word with a USPS-standardized abbreviation (`Main
+ *   Street` → `ST`). A German street type is overwhelmingly an **agglutinative suffix** fused onto
+ *   the name (`Straußstraße`, `Karl-Liebknecht-Straße`), with only one abbreviation in real use
+ *   (`Str.`). So detection is by suffix, not by a trailing token, and there is no Pub-28-style
+ *   abbreviation table to salvage.
+ *
+ *   The second lesson is the collision, the German cousin of the US `KY` = Key / Kentucky problem.
+ *   Many German PLACE names end in what look like street suffixes — `-berg` (Nürnberg), `-burg`
+ *   (Hamburg), `-dorf` (Düsseldorf), `-feld`, `-hof`, `-stadt`. If those counted as street markers,
+ *   the city token in a `PLZ City` segment would masquerade as a street and wrongly flag the
+ *   postcode as a house number. {@link DE_STREET_SUFFIXES} is therefore a curated, place-name-SAFE
+ *   set — the suffixes that are distinctively streets and (almost) never the tail of a city name.
+ */
+
+/**
+ * Canonical German street type → recognized written variants (including the `Str.` abbreviation and
+ * the `ß`/`ss` spelling split). The full reference table, used for synthesis/expansion. For the "is
+ * this token part of a street" test, use {@link DE_STREET_SUFFIXES} / {@link isGermanStreetToken},
+ * which exclude the place-name-colliding suffixes.
+ */
+export const DE_STREET_TYPE_VARIANTS = {
+	Straße: ["Str.", "Str", "Strasse"],
+	Weg: [],
+	Platz: ["Pl.", "Pl"],
+	Gasse: [],
+	Allee: [],
+	Ring: [],
+	Damm: [],
+	Ufer: [],
+	Steig: [],
+	Stieg: [],
+	Pfad: [],
+	Chaussee: ["Chaussée"],
+	Twiete: [],
+} as const satisfies Record<string, readonly string[]>
+
+/** A canonical German street type (e.g. `Straße`, `Weg`, `Platz`). */
+export type GermanStreetType = keyof typeof DE_STREET_TYPE_VARIANTS
+
+/**
+ * Place-name-SAFE street suffixes for "is this token part of a street" detection, lowercase, with
+ * the `ß`/`ss` split spelled out and `str` for the `Str.` abbreviation. Deliberately EXCLUDES the
+ * suffixes that also end German city names — `-berg`, `-burg`, `-dorf`, `-feld`, `-hof`, `-stadt`,
+ * `-heim`, `-bach`, `-tal` — so a city token in a `PLZ City` segment is not mistaken for a street.
+ */
+export const DE_STREET_SUFFIXES = [
+	"straße",
+	"strasse",
+	"str",
+	"weg",
+	"platz",
+	"gasse",
+	"allee",
+	"ring",
+	"damm",
+	"ufer",
+	"steig",
+	"stieg",
+	"pfad",
+	"chaussee",
+	"twiete",
+] as const
+
+/**
+ * True when a token reads as (part of) a German street: it ends with one of the place-name-safe
+ * {@link DE_STREET_SUFFIXES}. Handles both the fused compound (`Straußstraße` → ends `straße`) and
+ * the standalone type word or `Str.` abbreviation (`Platz`, `Str` → end `platz` / `str`).
+ */
+export function isGermanStreetToken(token: unknown): boolean {
+	if (typeof token !== "string") return false
+	const t = token.toLowerCase().replace(/[^a-zà-ÿß]/g, "")
+	if (t.length < 3) return false
+	return DE_STREET_SUFFIXES.some((s) => t.endsWith(s))
+}

--- a/codex/index.ts
+++ b/codex/index.ts
@@ -17,4 +17,5 @@
  *   other systems land here as the multi-locale push needs them.
  */
 
+export * as de from "./de/index.js"
 export * as us from "./us/index.js"

--- a/codex/package.json
+++ b/codex/package.json
@@ -12,7 +12,8 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": "./out/index.js",
-		"./us": "./out/us/index.js"
+		"./us": "./out/us/index.js",
+		"./de": "./out/de/index.js"
 	},
 	"dependencies": {
 		"type-fest": "^5.6.0"

--- a/neural/postcode-anchor.ts
+++ b/neural/postcode-anchor.ts
@@ -29,6 +29,7 @@
  *       1.0.
  */
 
+import { isGermanStreetToken } from "@mailwoman/codex/de"
 import { isStreetSuffixToken, isUsStateAbbreviation } from "@mailwoman/codex/us"
 import { collectMatches } from "./postcode-repair.js"
 
@@ -153,10 +154,9 @@ function confidenceFromCountryCount(k: number): number {
 const HOUSE_NUMBER_PENALTY = 0.2
 
 /**
- * Non-US street-type words the USPS codex does not cover: locales that write the type as its own
- * word (FR/ES/IT). German/Dutch agglutinative compounds (`Straußstraße`, `Stationsstraat`) are
- * matched by the suffix list below. US suffixes come from `@mailwoman/codex/us` (the full USPS
- * Pub-28 table) so this set never needs a US entry.
+ * Standalone street-type words for locales that write the type as its own word (FR/ES/IT). US comes
+ * from `@mailwoman/codex/us` and German from `@mailwoman/codex/de`; the Dutch compound suffixes are
+ * still inline below until a `codex/nl` slice exists.
  */
 const NON_US_STREET_WORDS = new Set([
 	// French
@@ -189,41 +189,31 @@ const NON_US_STREET_WORDS = new Set([
 	"contrada",
 ])
 
-/** Compound street suffixes for agglutinative locales — matched against a token's tail. */
-const NON_US_STREET_SUFFIXES = [
-	"straße",
-	"strasse",
-	"weg",
-	"platz",
-	"gasse",
-	"allee",
-	"damm",
-	"chaussee",
-	"steig", // German
-	"straat",
-	"laan",
-	"plein",
-	"gracht",
-	"kade",
-	"dijk",
-	"steeg",
-	"dreef", // Dutch
-]
+/** Dutch compound street suffixes — matched against a token's tail (pending a `codex/nl` slice). */
+const NL_STREET_SUFFIXES = ["straat", "laan", "plein", "gracht", "kade", "dijk", "steeg", "dreef"]
 
 /**
- * True when a token denotes a street. US suffixes are taken from the USPS Pub-28 table in
+ * True when a token denotes a street. US suffixes come from the USPS Pub-28 table in
  * `@mailwoman/codex/us` (complete, so `Trl`/`Holw`/`Xing` all match), EXCEPT the abbreviations that
- * collide with a state code — `KY` (Key vs Kentucky), `PR` (Prairie vs Puerto Rico) — because those
- * appear in the postcode's own `City, ST ZIP` segment, where treating them as a street word would
- * wrongly flag a real ZIP as a house number. Non-US locales fall back to the inline word/suffix
- * lists.
+ * collide with a state code — `KY` (Key vs Kentucky), `PR` (Prairie vs Puerto Rico) — which sit in
+ * the postcode's own `City, ST ZIP` segment. German compounds come from `@mailwoman/codex/de`
+ * ({@link isGermanStreetToken}), whose suffix set already excludes the place-name endings (`-berg`,
+ * `-burg`, `-dorf`) that would otherwise flag a city token. FR/ES/IT and Dutch fall back to the
+ * inline lists.
+ *
+ * Suffix vocabularies collide across locales (German `-ring` matches English `spring`). That stays
+ * harmless because the caller only tests tokens inside the postcode's OWN comma-segment, which
+ * holds the city/state, not a street — and a misfire only scales confidence, which the consumer's
+ * floor absorbs. A locale-conditioned check is the cleaner long-term fix once the anchor carries a
+ * locale.
  */
 function looksLikeStreetWord(token: string): boolean {
 	const t = token.toLowerCase().replace(/[^\p{L}]/gu, "")
 	if (t.length < 2) return false
 	if (isStreetSuffixToken(t) && !isUsStateAbbreviation(t)) return true
+	if (isGermanStreetToken(t)) return true
 	if (NON_US_STREET_WORDS.has(t)) return true
-	return NON_US_STREET_SUFFIXES.some((s) => t.length > s.length && t.endsWith(s))
+	return NL_STREET_SUFFIXES.some((s) => t.length > s.length && t.endsWith(s))
 }
 
 /**


### PR DESCRIPTION
The second per-address-system slice for `@mailwoman/codex`, and — as you predicted — an informative one. Encoding the German postal system surfaces the exact contrasts the multi-locale push has to handle. Three modules under `@mailwoman/codex/de`:

## What's in it (and what each one teaches)

**`street-type`** — German *Straßentypen*. The contrast with USPS Pub-28 is the whole lesson: a US street type is a separate trailing word with a standard abbreviation (`Main Street`→`ST`); a German one is an **agglutinative suffix** fused onto the name (`Straußstraße`, `Karl-Liebknecht-Straße`). So detection is by suffix, and there's no Pub-28-style table to salvage. `DE_STREET_SUFFIXES` is curated **place-name-safe** — it excludes `-berg`/`-burg`/`-dorf`/`-feld` (Nürnberg, Hamburg, Düsseldorf), which is the German cousin of the US `KY`=Key/Kentucky collision: those would otherwise flag a city token in a `PLZ City` segment as a street.

**`postleitzahl`** — PLZ branded type, shape, `D-`/`DE-` normalization, and the first-digit → **Leitzone** prior. The contrast with `us/zipcode`: a US ZIP's first digit maps to a band of states, but a German Leitzone deliberately **crosses Bundesland borders** (zone 6 = Hessen + Rheinland-Pfalz + Saarland). A PLZ narrows geography but *not* the state — a caution for anything deriving a German region from a postcode alone.

**`bundesland`** — the 16 Bundesländer (ISO 3166-2:DE) with German + English names and a `name→code` lookup (handles `NRW`, `Bavaria`, `Saxony`). This is the missing piece for de-US-centric resolver region matching — German addresses almost never carry the state on the surface, so it's inferred, not parsed.

## Anchor wiring

The postcode anchor now consumes `isGermanStreetToken` from `codex/de`, dropping its inline German suffix list (NL stays inline until a `codex/nl` slice). Cross-locale suffix collisions (German `-ring` vs English `spring`) are real but **contained** by the existing comma-segment scope + confidence floor — a postcode's segment holds the city/state, not a street. Verified, no regression:

| locale | neural+anchor p50 / p99 | vs before |
|---|--:|--:|
| DE | 1.3 / 13.5 km | unchanged |
| US | 2.8 / 25.7 km | unchanged |

57 tests green (codex 36 + anchor 21). Adds a `./de` subpath export; no release-pipeline change (the `codex` workspace was already wired in #258).

🤖 Generated with [Claude Code](https://claude.com/claude-code)