### PR TITLE
fix(eval): codex-aware region matcher — fold German states to ISO codes

### DIFF
--- a/docs/articles/evals/2026-06-03-postcode-anchor-resolver-fusion.md
+++ b/docs/articles/evals/2026-06-03-postcode-anchor-resolver-fusion.md
@@ -20,16 +20,24 @@ the address at a far-away same-shaped ZIP.
 
 ```
 | parser | locality-match | region-match | resolved | coord p50 km | coord p90 km | p99 km |
-| **neural** | 77.4% | 0.1% | 99.3% | 9.9 | 66.8 | 318.2 |
-| v0 (Pelias) | 79.3% | 50.0% | 99.3% | 7.0 | 16.9 | 106.8 |
-| **neural+anchor** | 77.4% | 0.1% | 99.3% | 1.3 | 5.7 | 13.5 |
+| **neural** | 77.4% | 43.8% | 99.3% | 9.9 | 66.8 | 318.2 |
+| v0 (Pelias) | 79.3% | 99.3% | 99.3% | 7.0 | 16.9 | 106.8 |
+| **neural+anchor** | 77.4% | 43.8% | 99.3% | 1.3 | 5.7 | 13.5 |
 ```
 
 The anchor drops coord p50 from 9.9 km to **1.3 km** (p90 66.8 → 5.7, p99 318 → 13.5), admin-match
-unchanged. The German parser is out of distribution (locality 77%, region near zero), so the resolver
-lands on a coarse admin centroid; the postcode anchor — a regex plus a gazetteer, no model in the loop —
-carries the coordinate to the postcode's own point. It also beats the Pelias parser (v0) on coordinate by
-a wide margin (1.3 vs 7.0 km).
+unchanged. The German parser is out of distribution (locality 77%), so the resolver lands on a coarse
+admin centroid; the postcode anchor — a regex plus a gazetteer, no model in the loop — carries the
+coordinate to the postcode's own point. It also beats the Pelias parser (v0) on coordinate by a wide
+margin (1.3 vs 7.0 km).
+
+(The region-match figures here come from the codex-aware matcher: the resolver returns WOF's English
+exonym `Saxony` while OA's expected is the German `Sachsen`, so the eval folds both through
+`@mailwoman/codex/de`'s `lookupGermanState` to one ISO 3166-2:DE code before comparing. Before that fix
+both parsers read ~0% on Saxony purely from the language mismatch. The remaining neural gap is real and
+concentrated in the Berlin city-state: per-state, neural emits a resolvable region for Saxony 87.5% of
+the time but for Berlin only 0.1% — `Berlin, Berlin` collapses region into locality and the OOD parser
+drops the duplicate. v0 reaches 99.3% because it emits the region in both.)
 
 ## US — the resolver already loads `postalcode-us.db`
 

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -43,6 +43,7 @@
  *   /mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postalcode-us.db
  */
 
+import { lookupGermanState } from "@mailwoman/codex/de"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { createWofResolver } from "@mailwoman/core/resolver"
 import { type ClassificationRecord, createAddressParser } from "mailwoman"
@@ -206,12 +207,29 @@ const STATE_NAME_TO_ABBR: Record<string, string> = {
 	"puerto rico": "PR",
 }
 
-/** True if the resolved region (full name OR already an abbrev) matches the expected USPS abbrev. */
-function regionMatches(resolvedName: string | undefined, expectedAbbr: string | undefined): boolean {
-	if (!resolvedName || !expectedAbbr) return false
-	const exp = norm(expectedAbbr)
+/**
+ * True if the resolved region matches the expected one, comparing like-for-like across the surface
+ * forms each side uses. Three paths, tried in order:
+ *
+ * 1. Verbatim — both already the same string (US `Berlin`==`Berlin`, or two identical abbrevs).
+ * 2. US — the resolver returns a state's CANONICAL full name (`California`) while OA's expected is the
+ *    USPS abbrev (`CA`); map full name → abbrev so they compare.
+ * 3. DE — the resolver returns WOF's ENGLISH exonym (`Saxony`) while OA's expected is the German name
+ *    (`Sachsen`); `lookupGermanState` folds code / German name / English name → one ISO 3166-2:DE
+ *    code on BOTH sides. Strict: distinct states (Bavaria vs Saxony) still miss, so this corrects
+ *    the cross-language mismatch without loosening a genuine wrong-region. The two code spaces
+ *    don't overlap on real inputs (a USPS abbrev is never a German state name, and vice versa), so
+ *    trying both is safe regardless of the row's country.
+ */
+function regionMatches(resolvedName: string | undefined, expected: string | undefined): boolean {
+	if (!resolvedName || !expected) return false
+	const exp = norm(expected)
 	const got = norm(resolvedName)
-	return got === exp || STATE_NAME_TO_ABBR[got]?.toLowerCase() === exp
+	if (got === exp) return true
+	if (STATE_NAME_TO_ABBR[got]?.toLowerCase() === exp) return true
+	const gotDe = lookupGermanState(resolvedName)
+	const expDe = lookupGermanState(expected)
+	return gotDe !== null && gotDe === expDe
 }
 
 function percentile(xs: number[], p: number): number | null {


### PR DESCRIPTION
Wires `@mailwoman/codex/de`'s `lookupGermanState` into the resolver eval's region matcher — the natural next consumer of the German codex slice.

## The bug

The matcher was US-only: map a resolved state's canonical full name (`California`) to its USPS abbrev (`CA`) and compare to OA's expected abbrev. On German data that path never fires, and the two sides speak different languages — the resolver returns WOF's **English exonym** `Saxony`, OA's expected is the **German** `Sachsen`. So a *correct* resolution scored as a region **miss** purely from the name mismatch.

## The fix

`regionMatches` now folds both sides through `lookupGermanState` to one ISO 3166-2:DE code before comparing (`Saxony`→`SN`, `Sachsen`→`SN` → match). It stays **strict** — distinct states (Bavaria vs Saxony) still miss — so it corrects the cross-language artifact without loosening a genuine wrong-region. The USPS abbrev and German name/code spaces don't overlap on real inputs, so trying both paths is safe regardless of the row's country (verified: US is untouched).

## Movement (1500-row DE sample, self-emitted)

| parser | region-match before | after |
|---|--:|--:|
| v0 (Pelias) | 50.0% | **99.3%** |
| neural | 0.1% | **43.8%** |
| US (both) | — | **unchanged** (99.9 / 99.4) |

The v0 jump is the whole Saxony half that was mis-scored. The neural jump *unmasks* a measurement artifact: per-state, neural already emits a resolvable region for **Saxony 87.5%** of the time — the real gap is the **Berlin city-state** (reg 0.1%), where `Berlin, Berlin` collapses region into locality and the OOD parser drops the duplicate. The broken matcher had both states reading ~0%, so you couldn't tell Saxony was basically working.

Updates the postcode-anchor fusion eval doc's DE table + the now-false "region near zero" prose to the corrected figures (machine-emitted via `--out-md`, never hand-typed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)