### PR TITLE
feat(codex): French address system (codex/fr) — code postal, départements, régions, voie

### DIFF
--- a/codex/fr/code-postal.test.ts
+++ b/codex/fr/code-postal.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+	departementForCodePostal,
+	departementOfCodePostal,
+	isCodePostal,
+	normalizeCodePostal,
+	regionForCodePostal,
+} from "./code-postal.js"
+
+describe("normalizeCodePostal", () => {
+	it("strips an F- prefix and whitespace to the bare five digits", () => {
+		expect(normalizeCodePostal("F-75008")).toBe("75008")
+		expect(normalizeCodePostal(" 13001 ")).toBe("13001")
+	})
+	it("returns null for non-codes", () => {
+		expect(normalizeCodePostal("7500")).toBeNull()
+		expect(normalizeCodePostal("SW1A 1AA")).toBeNull()
+		expect(normalizeCodePostal(75008)).toBeNull()
+	})
+})
+
+describe("isCodePostal", () => {
+	it("accepts five digits only", () => {
+		expect(isCodePostal("75008")).toBe(true)
+		expect(isCodePostal("7500")).toBe(false)
+	})
+})
+
+describe("departementOfCodePostal — the clean first-two-digits rule", () => {
+	it("maps a metropolitan code to its département by the first two digits", () => {
+		expect(departementOfCodePostal("75008")).toBe("75") // Paris
+		expect(departementOfCodePostal("13001")).toBe("13") // Bouches-du-Rhône
+		expect(departementOfCodePostal("69002")).toBe("69") // Rhône
+	})
+
+	it("splits Corsica's shared 20 prefix into 2A / 2B", () => {
+		expect(departementOfCodePostal("20000")).toBe("2A") // Ajaccio
+		expect(departementOfCodePostal("20090")).toBe("2A")
+		expect(departementOfCodePostal("20200")).toBe("2B") // Bastia
+		expect(departementOfCodePostal("20600")).toBe("2B")
+	})
+
+	it("maps overseas DOM by their three-digit prefix", () => {
+		expect(departementOfCodePostal("97110")).toBe("971") // Guadeloupe
+		expect(departementOfCodePostal("97400")).toBe("974") // La Réunion
+		expect(departementOfCodePostal("97600")).toBe("976") // Mayotte
+	})
+
+	it("returns null for a prefix with no département (collectivity / malformed)", () => {
+		expect(departementOfCodePostal("97500")).toBeNull() // St-Pierre-et-Miquelon, not a DOM
+		expect(departementOfCodePostal("98800")).toBeNull() // New Caledonia
+		expect(departementOfCodePostal("nope")).toBeNull()
+	})
+})
+
+describe("departementForCodePostal / regionForCodePostal — the postcode→admin chain", () => {
+	it("resolves a code through to its département and région", () => {
+		expect(departementForCodePostal("75008")?.name).toBe("Paris")
+		expect(regionForCodePostal("75008")?.name).toBe("Île-de-France")
+		expect(regionForCodePostal("13001")?.name).toBe("Provence-Alpes-Côte d'Azur")
+		expect(regionForCodePostal("20000")?.name).toBe("Corse")
+	})
+})

--- a/codex/fr/code-postal.ts
+++ b/codex/fr/code-postal.ts
@@ -1,0 +1,101 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   French postal codes (code postal): the branded type, the shape, normalization, and the
+ *   first-two-digits → département mapping — the cleanest postcode→admin prior of the three
+ *   systems.
+ *
+ *   The informative contrast across `us/zipcode.ts`, `de/postleitzahl.ts`, and here:
+ *
+ *   - A US ZIP's first digit maps to a loose BAND of states.
+ *   - A German PLZ's first digit maps to a Leitzone that CROSSES Bundesland borders.
+ *   - A French code postal's first TWO digits ARE the département number directly (`75008` → 75, Paris;
+ *       `13001` → 13, Bouches-du-Rhône). So the French prefix pins the actual admin unit, and the
+ *       région follows from the département. It is the tightest of the three.
+ *
+ *   The exceptions are the interesting part: Corsica shares prefix `20` across two départements (`2A`
+ *   Corse-du-Sud / `2B` Haute-Corse, resolved by the rest of the code), and the overseas DOM use a
+ *   THREE-digit prefix (`971`–`976`). `departementOfCodePostal` handles both. Two further
+ *   real-world caveats it does NOT try to model: a handful of communes sit under a neighbouring
+ *   département's code (e.g. some `05`/`04` border villages), and a CEDEX code can carry a
+ *   large-volume-mail prefix that differs from the geographic one — both rare enough to leave to
+ *   the gazetteer.
+ */
+
+import type { Tagged } from "type-fest"
+import { departementInfo, type DepartementCode, type DepartementInfo } from "./departement.js"
+import { FR_REGIONS, type FrenchRegionInfo } from "./region.js"
+
+/**
+ * A French postal code: five digits (`75008`). Same shape as a US ZIP or a German PLZ — the shape
+ * alone does not disambiguate the country.
+ *
+ * @category Postal
+ * @type string
+ * @title Code postal
+ * @pattern ^\d{5}$
+ */
+export type CodePostal = Tagged<string, "CodePostal">
+
+/** The code-postal shape: exactly five digits. */
+export const CODE_POSTAL_PATTERN = /^\d{5}$/
+
+/**
+ * Normalize a code-postal surface form to the bare five digits: strip an `F-` country courtesy
+ * prefix and surrounding whitespace (`F-75008` → `75008`). Returns null if the result is not five
+ * digits.
+ */
+export function normalizeCodePostal(raw: unknown): CodePostal | null {
+	if (typeof raw !== "string") return null
+	const s = raw.trim().toUpperCase().replace(/^F-/, "")
+	return CODE_POSTAL_PATTERN.test(s) ? (s as CodePostal) : null
+}
+
+/** Type-predicate for a (normalized) French postal code. */
+export function isCodePostal(input: unknown): input is CodePostal {
+	return typeof input === "string" && CODE_POSTAL_PATTERN.test(input)
+}
+
+/**
+ * The département code a postal code belongs to. The clean rule plus its two exceptions:
+ *
+ * - `20xxx` → Corsica. The split is by the rest of the code: roughly `20000`–`20199` → `2A` (Ajaccio
+ *   side), `20200`+ → `2B` (Bastia side). Approximate at the boundary, exact for the bulk.
+ * - `970`–`976`xx → an overseas DOM, keyed by the three-digit prefix (`971`–`974`, `976`).
+ * - Otherwise the first two digits are the département number.
+ *
+ * Returns null for a prefix with no département (e.g. `975`/`977`/`98x` collectivities, or a
+ * malformed code).
+ */
+export function departementOfCodePostal(codePostal: unknown): DepartementCode | null {
+	const cp = normalizeCodePostal(codePostal)
+	if (!cp) return null
+
+	if (cp.startsWith("20")) {
+		// Corsica: prefix 20 covers both départements; the numeric value splits them.
+		return Number(cp) < 20200 ? "2A" : "2B"
+	}
+	if (cp.startsWith("97") || cp.startsWith("98")) {
+		// Overseas: three-digit prefix. Only the five DOM are départements.
+		const dom = cp.slice(0, 3)
+		return departementInfo(dom) ? (dom as DepartementCode) : null
+	}
+	const dd = cp.slice(0, 2)
+	return departementInfo(dd) ? (dd as DepartementCode) : null
+}
+
+/** The full département record a postal code resolves to (name + région), or null. */
+export function departementForCodePostal(codePostal: unknown): DepartementInfo | null {
+	return departementInfo(departementOfCodePostal(codePostal))
+}
+
+/**
+ * The région a postal code resolves to, via its département; null if the code maps to no
+ * département.
+ */
+export function regionForCodePostal(codePostal: unknown): FrenchRegionInfo | null {
+	const dep = departementForCodePostal(codePostal)
+	return dep ? FR_REGIONS[dep.region] : null
+}

--- a/codex/fr/departement.ts
+++ b/codex/fr/departement.ts
@@ -1,0 +1,142 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The 101 French départements (96 metropolitan including Corsica's 2A/2B, plus the 5 overseas DOM),
+ *   each mapped to its région.
+ *
+ *   The département is the load-bearing admin unit for French postal geography: a code postal's first
+ *   two digits ARE the département number (see `code-postal.ts`), and the région is derived from
+ *   the département. This table is therefore the hinge between `code-postal.ts` and `region.ts`.
+ */
+
+import type { FrenchRegionCode } from "./region.js"
+
+/** Per-département record: code (2-digit, or `2A`/`2B`, or 3-digit DOM) + name + its région. */
+export interface DepartementInfo {
+	/** Département code: `01`–`95` (metropolitan), `2A`/`2B` (Corsica), or `971`–`976` (overseas). */
+	code: string
+	/** French name (e.g. `Bouches-du-Rhône`). */
+	name: string
+	/** The ISO 3166-2:FR code of the région this département belongs to. */
+	region: FrenchRegionCode
+}
+
+/** Département code → info. 96 metropolitan (incl. 2A/2B) + 5 overseas = 101. */
+export const FR_DEPARTEMENTS = {
+	"01": { code: "01", name: "Ain", region: "ARA" },
+	"02": { code: "02", name: "Aisne", region: "HDF" },
+	"03": { code: "03", name: "Allier", region: "ARA" },
+	"04": { code: "04", name: "Alpes-de-Haute-Provence", region: "PAC" },
+	"05": { code: "05", name: "Hautes-Alpes", region: "PAC" },
+	"06": { code: "06", name: "Alpes-Maritimes", region: "PAC" },
+	"07": { code: "07", name: "Ardèche", region: "ARA" },
+	"08": { code: "08", name: "Ardennes", region: "GES" },
+	"09": { code: "09", name: "Ariège", region: "OCC" },
+	"10": { code: "10", name: "Aube", region: "GES" },
+	"11": { code: "11", name: "Aude", region: "OCC" },
+	"12": { code: "12", name: "Aveyron", region: "OCC" },
+	"13": { code: "13", name: "Bouches-du-Rhône", region: "PAC" },
+	"14": { code: "14", name: "Calvados", region: "NOR" },
+	"15": { code: "15", name: "Cantal", region: "ARA" },
+	"16": { code: "16", name: "Charente", region: "NAQ" },
+	"17": { code: "17", name: "Charente-Maritime", region: "NAQ" },
+	"18": { code: "18", name: "Cher", region: "CVL" },
+	"19": { code: "19", name: "Corrèze", region: "NAQ" },
+	"2A": { code: "2A", name: "Corse-du-Sud", region: "COR" },
+	"2B": { code: "2B", name: "Haute-Corse", region: "COR" },
+	"21": { code: "21", name: "Côte-d'Or", region: "BFC" },
+	"22": { code: "22", name: "Côtes-d'Armor", region: "BRE" },
+	"23": { code: "23", name: "Creuse", region: "NAQ" },
+	"24": { code: "24", name: "Dordogne", region: "NAQ" },
+	"25": { code: "25", name: "Doubs", region: "BFC" },
+	"26": { code: "26", name: "Drôme", region: "ARA" },
+	"27": { code: "27", name: "Eure", region: "NOR" },
+	"28": { code: "28", name: "Eure-et-Loir", region: "CVL" },
+	"29": { code: "29", name: "Finistère", region: "BRE" },
+	"30": { code: "30", name: "Gard", region: "OCC" },
+	"31": { code: "31", name: "Haute-Garonne", region: "OCC" },
+	"32": { code: "32", name: "Gers", region: "OCC" },
+	"33": { code: "33", name: "Gironde", region: "NAQ" },
+	"34": { code: "34", name: "Hérault", region: "OCC" },
+	"35": { code: "35", name: "Ille-et-Vilaine", region: "BRE" },
+	"36": { code: "36", name: "Indre", region: "CVL" },
+	"37": { code: "37", name: "Indre-et-Loire", region: "CVL" },
+	"38": { code: "38", name: "Isère", region: "ARA" },
+	"39": { code: "39", name: "Jura", region: "BFC" },
+	"40": { code: "40", name: "Landes", region: "NAQ" },
+	"41": { code: "41", name: "Loir-et-Cher", region: "CVL" },
+	"42": { code: "42", name: "Loire", region: "ARA" },
+	"43": { code: "43", name: "Haute-Loire", region: "ARA" },
+	"44": { code: "44", name: "Loire-Atlantique", region: "PDL" },
+	"45": { code: "45", name: "Loiret", region: "CVL" },
+	"46": { code: "46", name: "Lot", region: "OCC" },
+	"47": { code: "47", name: "Lot-et-Garonne", region: "NAQ" },
+	"48": { code: "48", name: "Lozère", region: "OCC" },
+	"49": { code: "49", name: "Maine-et-Loire", region: "PDL" },
+	"50": { code: "50", name: "Manche", region: "NOR" },
+	"51": { code: "51", name: "Marne", region: "GES" },
+	"52": { code: "52", name: "Haute-Marne", region: "GES" },
+	"53": { code: "53", name: "Mayenne", region: "PDL" },
+	"54": { code: "54", name: "Meurthe-et-Moselle", region: "GES" },
+	"55": { code: "55", name: "Meuse", region: "GES" },
+	"56": { code: "56", name: "Morbihan", region: "BRE" },
+	"57": { code: "57", name: "Moselle", region: "GES" },
+	"58": { code: "58", name: "Nièvre", region: "BFC" },
+	"59": { code: "59", name: "Nord", region: "HDF" },
+	"60": { code: "60", name: "Oise", region: "HDF" },
+	"61": { code: "61", name: "Orne", region: "NOR" },
+	"62": { code: "62", name: "Pas-de-Calais", region: "HDF" },
+	"63": { code: "63", name: "Puy-de-Dôme", region: "ARA" },
+	"64": { code: "64", name: "Pyrénées-Atlantiques", region: "NAQ" },
+	"65": { code: "65", name: "Hautes-Pyrénées", region: "OCC" },
+	"66": { code: "66", name: "Pyrénées-Orientales", region: "OCC" },
+	"67": { code: "67", name: "Bas-Rhin", region: "GES" },
+	"68": { code: "68", name: "Haut-Rhin", region: "GES" },
+	"69": { code: "69", name: "Rhône", region: "ARA" },
+	"70": { code: "70", name: "Haute-Saône", region: "BFC" },
+	"71": { code: "71", name: "Saône-et-Loire", region: "BFC" },
+	"72": { code: "72", name: "Sarthe", region: "PDL" },
+	"73": { code: "73", name: "Savoie", region: "ARA" },
+	"74": { code: "74", name: "Haute-Savoie", region: "ARA" },
+	"75": { code: "75", name: "Paris", region: "IDF" },
+	"76": { code: "76", name: "Seine-Maritime", region: "NOR" },
+	"77": { code: "77", name: "Seine-et-Marne", region: "IDF" },
+	"78": { code: "78", name: "Yvelines", region: "IDF" },
+	"79": { code: "79", name: "Deux-Sèvres", region: "NAQ" },
+	"80": { code: "80", name: "Somme", region: "HDF" },
+	"81": { code: "81", name: "Tarn", region: "OCC" },
+	"82": { code: "82", name: "Tarn-et-Garonne", region: "OCC" },
+	"83": { code: "83", name: "Var", region: "PAC" },
+	"84": { code: "84", name: "Vaucluse", region: "PAC" },
+	"85": { code: "85", name: "Vendée", region: "PDL" },
+	"86": { code: "86", name: "Vienne", region: "NAQ" },
+	"87": { code: "87", name: "Haute-Vienne", region: "NAQ" },
+	"88": { code: "88", name: "Vosges", region: "GES" },
+	"89": { code: "89", name: "Yonne", region: "BFC" },
+	"90": { code: "90", name: "Territoire de Belfort", region: "BFC" },
+	"91": { code: "91", name: "Essonne", region: "IDF" },
+	"92": { code: "92", name: "Hauts-de-Seine", region: "IDF" },
+	"93": { code: "93", name: "Seine-Saint-Denis", region: "IDF" },
+	"94": { code: "94", name: "Val-de-Marne", region: "IDF" },
+	"95": { code: "95", name: "Val-d'Oise", region: "IDF" },
+	"971": { code: "971", name: "Guadeloupe", region: "GUA" },
+	"972": { code: "972", name: "Martinique", region: "MTQ" },
+	"973": { code: "973", name: "Guyane", region: "GUF" },
+	"974": { code: "974", name: "La Réunion", region: "LRE" },
+	"976": { code: "976", name: "Mayotte", region: "MAY" },
+} as const satisfies Record<string, DepartementInfo>
+
+/** A French département code (`01`–`95`, `2A`/`2B`, or `971`–`976`). */
+export type DepartementCode = keyof typeof FR_DEPARTEMENTS
+
+/**
+ * Look up a département by code (case-insensitive for the Corsica `2A`/`2B` letters); null if
+ * unknown.
+ */
+export function departementInfo(code: string | null | undefined): DepartementInfo | null {
+	if (!code || typeof code !== "string") return null
+	const key = code.trim().toUpperCase()
+	return (FR_DEPARTEMENTS as Record<string, DepartementInfo>)[key] ?? null
+}

--- a/codex/fr/index.ts
+++ b/codex/fr/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The French address system (La Poste / ISO 3166-2:FR): street types (voie), postal codes (code
+ *   postal), and the admin hierarchy of départements and régions.
+ */
+
+export * from "./code-postal.js"
+export * from "./departement.js"
+export * from "./region.js"
+export * from "./voie.js"

--- a/codex/fr/region.test.ts
+++ b/codex/fr/region.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { FR_DEPARTEMENTS } from "./departement.js"
+import { FR_REGIONS, isFrenchRegionCode, lookupFrenchRegion } from "./region.js"
+
+describe("FR_REGIONS", () => {
+	it("covers all 18 régions (13 metropolitan + 5 overseas)", () => {
+		expect(Object.keys(FR_REGIONS)).toHaveLength(18)
+		expect(FR_REGIONS.IDF.name).toBe("Île-de-France")
+	})
+})
+
+describe("FR_DEPARTEMENTS", () => {
+	it("covers all 101 départements", () => {
+		expect(Object.keys(FR_DEPARTEMENTS)).toHaveLength(101)
+	})
+	it("every département points at a real région", () => {
+		for (const d of Object.values(FR_DEPARTEMENTS)) {
+			expect(FR_REGIONS[d.region]).toBeDefined()
+		}
+	})
+})
+
+describe("isFrenchRegionCode", () => {
+	it("accepts ISO 3166-2:FR region codes, case-insensitively", () => {
+		expect(isFrenchRegionCode("IDF")).toBe(true)
+		expect(isFrenchRegionCode("pac")).toBe(true)
+		expect(isFrenchRegionCode("BY")).toBe(false) // a German state, not French
+	})
+})
+
+describe("lookupFrenchRegion", () => {
+	it("resolves code and name, accents optional (mirrors lookupGermanState)", () => {
+		expect(lookupFrenchRegion("IDF")).toBe("IDF")
+		expect(lookupFrenchRegion("Île-de-France")).toBe("IDF")
+		expect(lookupFrenchRegion("ile-de-france")).toBe("IDF") // unaccented surface form
+		expect(lookupFrenchRegion("Provence-Alpes-Côte d'Azur")).toBe("PAC")
+		expect(lookupFrenchRegion("Nouvelle-Aquitaine")).toBe("NAQ")
+	})
+
+	it("returns null for an unknown region", () => {
+		expect(lookupFrenchRegion("Bavaria")).toBeNull()
+		expect(lookupFrenchRegion(null)).toBeNull()
+	})
+})

--- a/codex/fr/region.ts
+++ b/codex/fr/region.ts
@@ -1,0 +1,90 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The 18 French régions (13 metropolitan + 5 overseas), keyed by their ISO 3166-2:FR code.
+ *
+ *   The contrast with `de/bundesland.ts` and `us/state.ts`: France's regions were redrawn in the 2016
+ *   reform that merged 22 metropolitan régions into 13 (Aquitaine + Limousin + Poitou-Charentes →
+ *   Nouvelle-Aquitaine, etc.). So a French region is a large, recent amalgamation, and — like a
+ *   German Bundesland — it is almost never written on an address line, which reads `code-postal
+ *   commune`. The region is inferred from the département, which is inferred from the postcode (see
+ *   `code-postal.ts`).
+ */
+
+/** Per-region record: ISO 3166-2:FR code (sans `FR-` prefix) + French name. */
+export interface FrenchRegionInfo {
+	/** ISO 3166-2:FR region code without the `FR-` prefix (e.g. `IDF` for `FR-IDF`). */
+	code: string
+	/** French name (e.g. `Île-de-France`). */
+	name: string
+}
+
+/** ISO 3166-2:FR region code → info, for all 18 régions (13 metropolitan + 5 overseas). */
+export const FR_REGIONS = {
+	ARA: { code: "ARA", name: "Auvergne-Rhône-Alpes" },
+	BFC: { code: "BFC", name: "Bourgogne-Franche-Comté" },
+	BRE: { code: "BRE", name: "Bretagne" },
+	CVL: { code: "CVL", name: "Centre-Val de Loire" },
+	COR: { code: "COR", name: "Corse" },
+	GES: { code: "GES", name: "Grand Est" },
+	HDF: { code: "HDF", name: "Hauts-de-France" },
+	IDF: { code: "IDF", name: "Île-de-France" },
+	NOR: { code: "NOR", name: "Normandie" },
+	NAQ: { code: "NAQ", name: "Nouvelle-Aquitaine" },
+	OCC: { code: "OCC", name: "Occitanie" },
+	PDL: { code: "PDL", name: "Pays de la Loire" },
+	PAC: { code: "PAC", name: "Provence-Alpes-Côte d'Azur" },
+	GUA: { code: "GUA", name: "Guadeloupe" },
+	MTQ: { code: "MTQ", name: "Martinique" },
+	GUF: { code: "GUF", name: "Guyane" },
+	LRE: { code: "LRE", name: "La Réunion" },
+	MAY: { code: "MAY", name: "Mayotte" },
+} as const satisfies Record<string, FrenchRegionInfo>
+
+/** An ISO 3166-2:FR region code (`ARA`, `IDF`, `PAC`, …). */
+export type FrenchRegionCode = keyof typeof FR_REGIONS
+
+const REGION_CODE_SET: ReadonlySet<string> = new Set(Object.keys(FR_REGIONS))
+
+/** Type-predicate for an ISO 3166-2:FR region code. Case-insensitive. */
+export function isFrenchRegionCode(input: unknown): input is FrenchRegionCode {
+	return typeof input === "string" && REGION_CODE_SET.has(input.toUpperCase())
+}
+
+/** Strip diacritics + lowercase so `Île-de-France`, `ile-de-france`, `Ile de France` all key alike. */
+function foldName(s: string): string {
+	return s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+}
+
+/**
+ * Folded region name / code → ISO 3166-2:FR code. Built diacritic-insensitive so the resolver's
+ * surface form (`Île-de-France`, or an unaccented `Ile-de-France`) maps regardless of accents.
+ * Mirrors `de/bundesland.ts`'s `lookupGermanState`, the same role: fold a region surface form to
+ * one code so a resolver eval can compare like-for-like without a US-USPS-shaped matcher.
+ */
+export const FR_REGION_NAME_TO_CODE: ReadonlyMap<string, FrenchRegionCode> = (() => {
+	const out = new Map<string, FrenchRegionCode>()
+	for (const code of Object.keys(FR_REGIONS) as FrenchRegionCode[]) {
+		out.set(foldName(FR_REGIONS[code].name), code)
+		out.set(code.toLowerCase(), code)
+	}
+	return out
+})()
+
+/**
+ * Resolve a French region surface form (ISO code or name, accents optional) to its ISO code; null
+ * if unknown.
+ */
+export function lookupFrenchRegion(input: string | null | undefined): FrenchRegionCode | null {
+	if (!input || typeof input !== "string") return null
+	const upper = input.trim().toUpperCase()
+	if (REGION_CODE_SET.has(upper)) return upper as FrenchRegionCode
+	return FR_REGION_NAME_TO_CODE.get(foldName(input)) ?? null
+}

--- a/codex/fr/voie.test.ts
+++ b/codex/fr/voie.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { isFrenchStreetWord } from "./voie.js"
+
+describe("isFrenchStreetWord", () => {
+	it("matches canonical voie words, case- and accent-insensitive", () => {
+		expect(isFrenchStreetWord("Rue")).toBe(true)
+		expect(isFrenchStreetWord("avenue")).toBe(true)
+		expect(isFrenchStreetWord("Boulevard")).toBe(true)
+		expect(isFrenchStreetWord("Allée")).toBe(true)
+		expect(isFrenchStreetWord("allee")).toBe(true) // unaccented
+		expect(isFrenchStreetWord("Impasse")).toBe(true)
+	})
+
+	it("matches common abbreviations", () => {
+		expect(isFrenchStreetWord("bd")).toBe(true)
+		expect(isFrenchStreetWord("av")).toBe(true)
+		expect(isFrenchStreetWord("pl")).toBe(true)
+		expect(isFrenchStreetWord("rte")).toBe(true)
+	})
+
+	it("matches the whole token, so a non-voie word is not caught", () => {
+		// French types LEAD the name and are matched as whole tokens, not suffixes — so neither a
+		// surname nor a commune that happens to contain a voie substring is flagged.
+		expect(isFrenchStreetWord("Paris")).toBe(false)
+		expect(isFrenchStreetWord("Bordeaux")).toBe(false)
+		expect(isFrenchStreetWord("Larue")).toBe(false) // contains "rue" but isn't it
+	})
+
+	it("rejects non-strings", () => {
+		expect(isFrenchStreetWord(42)).toBe(false)
+		expect(isFrenchStreetWord(null)).toBe(false)
+	})
+})

--- a/codex/fr/voie.ts
+++ b/codex/fr/voie.ts
@@ -1,0 +1,92 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   French street types (types de voie).
+ *
+ *   The third point on the morphology spectrum the codex now spans:
+ *
+ *   - US — the type is a TRAILING word with a standardized abbreviation (`Main Street` → `ST`).
+ *   - German — the type is a fused TRAILING suffix (`Hauptstraße`).
+ *   - French — the type is a LEADING standalone word (`Rue de la Paix`, `Avenue des Champs-Élysées`).
+ *       It carries common abbreviations (`bd`, `av`, `pl`) but no single national standard like
+ *       USPS Pub-28.
+ *
+ *   So French detection is "is this token a known voie word", position-first — which is why
+ *   {@link isFrenchStreetWord} matches a whole token rather than a suffix.
+ */
+
+/**
+ * Canonical French voie type → common written abbreviations. The leading word of a French street
+ * name. The first entry of each list is the most common abbreviation where one exists.
+ */
+export const FR_VOIE_TYPES = {
+	rue: ["r"],
+	avenue: ["av", "ave"],
+	boulevard: ["bd", "boul"],
+	place: ["pl"],
+	impasse: ["imp"],
+	allée: ["all"],
+	allées: [],
+	chemin: ["ch", "che"],
+	quai: [],
+	cours: ["crs"],
+	passage: ["pass", "psg"],
+	square: ["sq"],
+	route: ["rte"],
+	sentier: ["sen"],
+	villa: [],
+	cité: [],
+	esplanade: ["espl"],
+	faubourg: ["fbg", "fg"],
+	mail: [],
+	promenade: ["prom"],
+	"rond-point": ["rpt"],
+	voie: [],
+	chaussée: ["chée"],
+	ruelle: [],
+	venelle: [],
+	traverse: ["trav"],
+	montée: ["mtée"],
+	clos: [],
+	hameau: ["ham"],
+	résidence: ["rés"],
+	lotissement: ["lot"],
+} as const satisfies Record<string, readonly string[]>
+
+/** A canonical French voie type (e.g. `rue`, `avenue`, `boulevard`). */
+export type FrenchVoieType = keyof typeof FR_VOIE_TYPES
+
+/**
+ * Set of every French voie token — each canonical type plus each abbreviation — folded to
+ * lowercase/diacritic-free for matching. `Allée`/`allee`/`all` all resolve here.
+ */
+const VOIE_TOKEN_SET: ReadonlySet<string> = (() => {
+	const fold = (s: string): string =>
+		s
+			.toLowerCase()
+			.normalize("NFD")
+			.replace(/[\u0300-\u036f]/g, "")
+	const out = new Set<string>()
+	for (const canonical of Object.keys(FR_VOIE_TYPES) as FrenchVoieType[]) {
+		out.add(fold(canonical))
+		for (const abbr of FR_VOIE_TYPES[canonical]) out.add(fold(abbr))
+	}
+	return out
+})()
+
+/**
+ * True when a token is a French voie type word or abbreviation (case- and accent-insensitive) —
+ * `Rue`, `BD`, `Allée`, `impasse`. Matches the WHOLE token (French types lead the street name, they
+ * are not fused suffixes), so a city or surname is not caught the way a suffix test might.
+ */
+export function isFrenchStreetWord(token: unknown): boolean {
+	if (typeof token !== "string") return false
+	const t = token
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z-]/g, "")
+	return t.length > 0 && VOIE_TOKEN_SET.has(t)
+}

--- a/codex/index.ts
+++ b/codex/index.ts
@@ -18,4 +18,5 @@
  */
 
 export * as de from "./de/index.js"
+export * as fr from "./fr/index.js"
 export * as us from "./us/index.js"

--- a/codex/package.json
+++ b/codex/package.json
@@ -13,7 +13,8 @@
 		"./package.json": "./package.json",
 		".": "./out/index.js",
 		"./us": "./out/us/index.js",
-		"./de": "./out/de/index.js"
+		"./de": "./out/de/index.js",
+		"./fr": "./out/fr/index.js"
 	},
 	"dependencies": {
 		"type-fest": "^5.6.0"

--- a/neural/postcode-anchor.ts
+++ b/neural/postcode-anchor.ts
@@ -30,6 +30,7 @@
  */
 
 import { isGermanStreetToken } from "@mailwoman/codex/de"
+import { isFrenchStreetWord } from "@mailwoman/codex/fr"
 import { isStreetSuffixToken, isUsStateAbbreviation } from "@mailwoman/codex/us"
 import { collectMatches } from "./postcode-repair.js"
 
@@ -154,21 +155,11 @@ function confidenceFromCountryCount(k: number): number {
 const HOUSE_NUMBER_PENALTY = 0.2
 
 /**
- * Standalone street-type words for locales that write the type as its own word (FR/ES/IT). US comes
- * from `@mailwoman/codex/us` and German from `@mailwoman/codex/de`; the Dutch compound suffixes are
- * still inline below until a `codex/nl` slice exists.
+ * Standalone street-type words for the locales without a codex slice yet (ES/IT). US comes from
+ * `@mailwoman/codex/us`, German from `@mailwoman/codex/de`, French from `@mailwoman/codex/fr`; the
+ * Dutch compound suffixes are still inline below pending a `codex/nl` slice.
  */
 const NON_US_STREET_WORDS = new Set([
-	// French
-	"rue",
-	"bd",
-	"impasse",
-	"chemin",
-	"quai",
-	"allée",
-	"allee",
-	"cours",
-	"passage",
 	// Spanish
 	"calle",
 	"avenida",
@@ -198,8 +189,9 @@ const NL_STREET_SUFFIXES = ["straat", "laan", "plein", "gracht", "kade", "dijk",
  * collide with a state code — `KY` (Key vs Kentucky), `PR` (Prairie vs Puerto Rico) — which sit in
  * the postcode's own `City, ST ZIP` segment. German compounds come from `@mailwoman/codex/de`
  * ({@link isGermanStreetToken}), whose suffix set already excludes the place-name endings (`-berg`,
- * `-burg`, `-dorf`) that would otherwise flag a city token. FR/ES/IT and Dutch fall back to the
- * inline lists.
+ * `-burg`, `-dorf`) that would otherwise flag a city token. French voie words come from
+ * `@mailwoman/codex/fr` ({@link isFrenchStreetWord}). ES/IT and Dutch fall back to the inline
+ * lists.
  *
  * Suffix vocabularies collide across locales (German `-ring` matches English `spring`). That stays
  * harmless because the caller only tests tokens inside the postcode's OWN comma-segment, which
@@ -212,6 +204,7 @@ function looksLikeStreetWord(token: string): boolean {
 	if (t.length < 2) return false
 	if (isStreetSuffixToken(t) && !isUsStateAbbreviation(t)) return true
 	if (isGermanStreetToken(t)) return true
+	if (isFrenchStreetWord(t)) return true
 	if (NON_US_STREET_WORDS.has(t)) return true
 	return NL_STREET_SUFFIXES.some((s) => t.length > s.length && t.endsWith(s))
 }

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -44,6 +44,7 @@
  */
 
 import { lookupGermanState } from "@mailwoman/codex/de"
+import { lookupFrenchRegion } from "@mailwoman/codex/fr"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { createWofResolver } from "@mailwoman/core/resolver"
 import { type ClassificationRecord, createAddressParser } from "mailwoman"
@@ -217,9 +218,14 @@ const STATE_NAME_TO_ABBR: Record<string, string> = {
  * 3. DE — the resolver returns WOF's ENGLISH exonym (`Saxony`) while OA's expected is the German name
  *    (`Sachsen`); `lookupGermanState` folds code / German name / English name → one ISO 3166-2:DE
  *    code on BOTH sides. Strict: distinct states (Bavaria vs Saxony) still miss, so this corrects
- *    the cross-language mismatch without loosening a genuine wrong-region. The two code spaces
- *    don't overlap on real inputs (a USPS abbrev is never a German state name, and vice versa), so
- *    trying both is safe regardless of the row's country.
+ *    the cross-language mismatch without loosening a genuine wrong-region.
+ * 4. FR — `lookupFrenchRegion` folds an ISO 3166-2:FR code or a région name (accents optional) to one
+ *    code on both sides, the same diacritic-insensitive fix for `Île-de-France` vs
+ *    `Ile-de-France`.
+ *
+ * The code spaces don't overlap on real inputs (a USPS abbrev is never a German or French region
+ * name, and the German/French names are disjoint), so trying all of them is safe regardless of the
+ * row's country.
  */
 function regionMatches(resolvedName: string | undefined, expected: string | undefined): boolean {
 	if (!resolvedName || !expected) return false
@@ -228,8 +234,9 @@ function regionMatches(resolvedName: string | undefined, expected: string | unde
 	if (got === exp) return true
 	if (STATE_NAME_TO_ABBR[got]?.toLowerCase() === exp) return true
 	const gotDe = lookupGermanState(resolvedName)
-	const expDe = lookupGermanState(expected)
-	return gotDe !== null && gotDe === expDe
+	if (gotDe !== null && gotDe === lookupGermanState(expected)) return true
+	const gotFr = lookupFrenchRegion(resolvedName)
+	return gotFr !== null && gotFr === lookupFrenchRegion(expected)
 }
 
 function percentile(xs: number[], p: number): number | null {


### PR DESCRIPTION
The third per-address-system slice for `@mailwoman/codex`. With US, DE, and now FR in place, the codex spans an informative spectrum on both axes it encodes.

## The postcode→admin prior: France is the cleanest of the three

| system | first digits → ? |
|---|---|
| US ZIP | first **1** digit → a loose **band** of states |
| German PLZ | first **1** digit → a Leitzone that **crosses** Bundesland borders |
| French code postal | first **2** digits **ARE** the département (`75008`→75 Paris) |

So the French prefix pins the actual admin unit, and the région follows from the département. The exceptions are the interesting part, and `departementOfCodePostal` handles them: **Corsica** shares prefix `20` across `2A`/`2B` (split by the rest of the code), and the **overseas DOM** use a 3-digit prefix (`971`–`976`).

## The street-morphology spectrum completes

- **US** — type is a **trailing word** with a standard abbreviation (`Main Street`→`ST`).
- **German** — type is a **fused trailing suffix** (`Hauptstraße`).
- **French** — type is a **leading standalone word** (`Rue de la Paix`). `isFrenchStreetWord` matches whole tokens, not suffixes.

## What's in it

- **`code-postal`** — `CodePostal` branded type, shape, normalize, `departementOfCodePostal` / `regionForCodePostal`.
- **`departement`** — all **101** départements (96 metropolitan incl. 2A/2B + 5 DOM), each mapped to its région — the hinge between postcode and région.
- **`region`** — the **18** régions (post-2016 reform: 13 metropolitan + 5 overseas) + `lookupFrenchRegion` (code or name, accents optional), mirroring `lookupGermanState`.
- **`voie`** — French street types + common abbreviations + `isFrenchStreetWord`.

## Consumers

- **Anchor**: French voie words now come from `codex/fr` (`isFrenchStreetWord`); the inline FR list is removed (ES/IT/NL stay inline pending their slices).
- **Eval region matcher**: a `lookupFrenchRegion` path joins the German one. Forward-looking — there's no FR OpenAddresses sample yet, so the path is dormant-but-ready (the same `Île-de-France` vs `Ile-de-France` diacritic fix the German side needed).

## No regression

French voie abbreviations (`bd`/`av`/`pl`) collide with **no** US state code, and the DE + US resolver evals are byte-identical (DE p50 **1.3 km**, US p50 **2.8** / p99 **25.7 km** — unchanged). **75 tests** green (codex 54 + anchor 21). Adds a `./fr` subpath export; no release-pipeline change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)