### PR TITLE
feat(codex): Canada, UK, and Japan address systems (ca/gb/jp)

### DIFF
--- a/codex/ca/index.ts
+++ b/codex/ca/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The Canadian address system (Canada Post / ISO 3166-2:CA): bilingual street types, alphanumeric
+ *   postal codes, and the provinces and territories.
+ */
+
+export * from "./postal-code.js"
+export * from "./province.js"
+export * from "./street-type.js"

--- a/codex/ca/postal-code.test.ts
+++ b/codex/ca/postal-code.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { isCaPostalCode, isRuralPostalCode, normalizeCaPostalCode, provinceOfPostalCode } from "./postal-code.js"
+
+describe("normalizeCaPostalCode", () => {
+	it("uppercases and inserts a single space between FSA and LDU", () => {
+		expect(normalizeCaPostalCode("K1A0B1")).toBe("K1A 0B1")
+		expect(normalizeCaPostalCode("k1a 0b1")).toBe("K1A 0B1")
+		expect(normalizeCaPostalCode(" m5v2t6 ")).toBe("M5V 2T6")
+	})
+	it("returns null for non-codes", () => {
+		expect(normalizeCaPostalCode("K1A 0B")).toBeNull() // too short
+		expect(normalizeCaPostalCode("D1A 0B1")).toBeNull() // D never opens a postcode
+		expect(normalizeCaPostalCode("75008")).toBeNull() // a French code postal
+		expect(normalizeCaPostalCode(12345)).toBeNull()
+	})
+})
+
+describe("isCaPostalCode", () => {
+	it("accepts the spaced or unspaced surface form, rejects bad letters", () => {
+		expect(isCaPostalCode("K1A 0B1")).toBe(true)
+		expect(isCaPostalCode("K1A0B1")).toBe(true)
+		expect(isCaPostalCode("Z1A 0B1")).toBe(false) // Z never opens a postcode
+	})
+})
+
+describe("provinceOfPostalCode — the FSA-letter → province prior", () => {
+	it("maps the clean single-province letters", () => {
+		expect(provinceOfPostalCode("M5V 2T6")).toBe("ON") // Toronto
+		expect(provinceOfPostalCode("H2X 1Y4")).toBe("QC") // Montreal
+		expect(provinceOfPostalCode("V6B 1A1")).toBe("BC") // Vancouver
+		expect(provinceOfPostalCode("T2P 1J9")).toBe("AB") // Calgary
+	})
+
+	it("returns the shared NT/NU pair for the X letter", () => {
+		expect(provinceOfPostalCode("X0A 0H0")).toEqual(["NT", "NU"])
+	})
+
+	it("returns null for an invalid postal code", () => {
+		expect(provinceOfPostalCode("D1A 0B1")).toBeNull()
+		expect(provinceOfPostalCode("nope")).toBeNull()
+	})
+})
+
+describe("isRuralPostalCode — second character is 0", () => {
+	it("flags rural FSAs (first digit 0) and not urban ones", () => {
+		expect(isRuralPostalCode("X0A 0H0")).toBe(true) // rural northern
+		expect(isRuralPostalCode("A0A 1A0")).toBe(true) // rural Newfoundland
+		expect(isRuralPostalCode("M5V 2T6")).toBe(false) // urban Toronto
+		expect(isRuralPostalCode("H2X 1Y4")).toBe(false) // urban Montreal
+	})
+	it("returns false for a non-code", () => {
+		expect(isRuralPostalCode("nope")).toBe(false)
+	})
+})

--- a/codex/ca/postal-code.ts
+++ b/codex/ca/postal-code.ts
@@ -1,0 +1,116 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Canadian postal codes: the branded type, the shape, normalization, and the FSA-letter →
+ *   province/territory prior — the only ALPHANUMERIC postcode of the systems the codex models.
+ *
+ *   The informative contrast across `us/zipcode.ts`, `de/postleitzahl.ts`, `fr/code-postal.ts`, and
+ *   here:
+ *
+ *   - A US ZIP is numeric; its first digit maps to a loose BAND of states.
+ *   - A German PLZ is numeric; its first digit maps to a Leitzone that CROSSES Bundesland borders.
+ *   - A French code postal is numeric; its first TWO digits ARE the département.
+ *   - A Canadian postal code is `A1A 1A1` — Letter Digit Letter, then Digit Letter Digit — and its
+ *       first LETTER pins the province or territory directly (`M` → Ontario, `H` → Quebec, `V` →
+ *       British Columbia). So like the French prefix it is a clean admin prior, but it does the job
+ *       with a single ALPHA character rather than digits.
+ *
+ *   The clean rule has two wrinkles worth knowing. `X` is SHARED by the Northwest Territories and
+ *   Nunavut (no single letter splits them), so `provinceOfPostalCode` returns an array there. And
+ *   the large provinces span SEVERAL letters: Ontario alone owns `K L M N P`, Quebec owns `G H J`.
+ *   The first three characters form the FSA (Forward Sortation Area); the last three are the LDU
+ *   (Local Delivery Unit). A FSA whose SECOND character (the first digit) is `0` is a RURAL area —
+ *   the bridge to the wider, lower-density delivery zones.
+ */
+
+import type { Tagged } from "type-fest"
+import type { CanadianProvinceCode } from "./province.js"
+
+/**
+ * A Canadian postal code: `A1A 1A1`. Six alphanumeric characters in a strict
+ * Letter-Digit-Letter-Digit-Letter-Digit pattern, conventionally written with a single space after
+ * the third. Unlike the other systems' bare five digits, the shape alone already says "Canada".
+ *
+ * @category Postal
+ * @type string
+ * @title Postal Code
+ * @pattern ^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z] ?\d[ABCEGHJ-NPRSTV-Z]\d$
+ */
+export type PostalCode = Tagged<string, "CaPostalCode">
+
+/**
+ * The Canadian postal-code shape. The valid FIRST letters exclude `D F I O Q U W Z` (never used to
+ * open a postcode); the interior letters additionally exclude `D F I O Q U` (the visually ambiguous
+ * ones). The space between FSA and LDU is optional in the raw form.
+ */
+export const CA_POSTAL_CODE_PATTERN = /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z] ?\d[ABCEGHJ-NPRSTV-Z]\d$/i
+
+/**
+ * Normalize a postal-code surface form to canonical `A1A 1A1`: uppercase and ensure exactly one
+ * space between the FSA (first three chars) and the LDU (last three) — `K1A0B1` → `K1A 0B1`, `k1a
+ * 0b1` → `K1A 0B1`. Returns null if the input is not a valid Canadian postal code.
+ */
+export function normalizeCaPostalCode(raw: unknown): PostalCode | null {
+	if (typeof raw !== "string") return null
+	const compact = raw.trim().toUpperCase().replace(/\s+/g, "")
+	if (compact.length !== 6) return null
+	const spaced = `${compact.slice(0, 3)} ${compact.slice(3)}`
+	return CA_POSTAL_CODE_PATTERN.test(spaced) ? (spaced as PostalCode) : null
+}
+
+/** Type-predicate for a Canadian postal code (accepts the spaced or unspaced surface form). */
+export function isCaPostalCode(input: unknown): input is PostalCode {
+	return typeof input === "string" && CA_POSTAL_CODE_PATTERN.test(input)
+}
+
+/**
+ * FSA first letter → province/territory. Clean (one province per letter) except `X`, shared by the
+ * Northwest Territories and Nunavut, and the large provinces that span several letters: Ontario
+ * owns `K L M N P` and Quebec owns `G H J`. Letters `D F I O Q U W Z` never open a Canadian
+ * postcode and so do not appear here.
+ */
+export const FSA_LETTER_TO_PROVINCE: Record<string, CanadianProvinceCode | CanadianProvinceCode[]> = {
+	A: "NL",
+	B: "NS",
+	C: "PE",
+	E: "NB",
+	G: "QC",
+	H: "QC",
+	J: "QC",
+	K: "ON",
+	L: "ON",
+	M: "ON",
+	N: "ON",
+	P: "ON",
+	R: "MB",
+	S: "SK",
+	T: "AB",
+	V: "BC",
+	X: ["NT", "NU"],
+	Y: "YT",
+}
+
+/**
+ * The province/territory a postal code belongs to, via its FSA first letter. Returns the single
+ * code for the clean letters, the `["NT", "NU"]` pair for the shared `X`, and null if the input is
+ * not a valid Canadian postal code (or its first letter has no province, which the pattern already
+ * forbids).
+ */
+export function provinceOfPostalCode(postalCode: unknown): CanadianProvinceCode | CanadianProvinceCode[] | null {
+	const normalized = normalizeCaPostalCode(postalCode)
+	if (!normalized) return null
+	return FSA_LETTER_TO_PROVINCE[normalized[0]!] ?? null
+}
+
+/**
+ * True when a postal code is RURAL: its SECOND character (the FSA's first digit) is `0`. Canada
+ * Post uses a `0` in that position to mark the lower-density delivery zones (rural routes, small
+ * communities) — the contrast with the urban `1`–`9` FSAs. Returns false for a non-code.
+ */
+export function isRuralPostalCode(pc: unknown): boolean {
+	const normalized = normalizeCaPostalCode(pc)
+	if (!normalized) return false
+	return normalized[1] === "0"
+}

--- a/codex/ca/province.test.ts
+++ b/codex/ca/province.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { CA_PROVINCES, isCanadianProvinceCode, lookupCanadianProvince } from "./province.js"
+
+describe("CA_PROVINCES", () => {
+	it("covers all 13 provinces and territories", () => {
+		expect(Object.keys(CA_PROVINCES)).toHaveLength(13)
+		expect(CA_PROVINCES.QC).toEqual({ code: "QC", name: "Quebec", french: "Québec" })
+		expect(CA_PROVINCES.BC.french).toBe("Colombie-Britannique")
+	})
+})
+
+describe("isCanadianProvinceCode", () => {
+	it("accepts ISO 3166-2:CA codes, case-insensitively", () => {
+		expect(isCanadianProvinceCode("QC")).toBe(true)
+		expect(isCanadianProvinceCode("on")).toBe(true)
+		expect(isCanadianProvinceCode("CA")).toBe(false) // a US state, not a Canadian subdivision
+	})
+})
+
+describe("lookupCanadianProvince", () => {
+	it("resolves code, English name, and French name, accents optional", () => {
+		expect(lookupCanadianProvince("QC")).toBe("QC")
+		expect(lookupCanadianProvince("Quebec")).toBe("QC")
+		expect(lookupCanadianProvince("Québec")).toBe("QC") // co-official French form, accented
+		expect(lookupCanadianProvince("Colombie-Britannique")).toBe("BC")
+		expect(lookupCanadianProvince("British Columbia")).toBe("BC")
+		expect(lookupCanadianProvince("Nouvelle-Ecosse")).toBe("NS") // unaccented French surface form
+		expect(lookupCanadianProvince("Newfoundland and Labrador")).toBe("NL")
+	})
+
+	it("returns null for an unknown subdivision", () => {
+		expect(lookupCanadianProvince("Bavaria")).toBeNull()
+		expect(lookupCanadianProvince(null)).toBeNull()
+	})
+})

--- a/codex/ca/province.ts
+++ b/codex/ca/province.ts
@@ -1,0 +1,95 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The 13 Canadian provinces and territories (10 provinces + 3 territories), keyed by their ISO
+ *   3166-2:CA code.
+ *
+ *   The informative contrast with `de/bundesland.ts` and `us/state.ts`: a Canadian subdivision is
+ *   officially BILINGUAL, so each unit carries two equally-canonical names — an English one and a
+ *   French one — and the gap between them is wide (`Nova Scotia` / `Nouvelle-Écosse`, `British
+ *   Columbia` / `Colombie-Britannique`). That mirrors the German English-exonym pattern (`Bavaria`
+ *   / `Bayern`), except here the French name is not a foreign exonym but a co-official form a real
+ *   address can be written in. And like a US two-letter state code, the ISO code (`ON`, `QC`, `BC`)
+ *   is the abbreviation people actually write on the address line — so unlike German or French
+ *   regions, the Canadian code IS a surface form, not just a resolver key.
+ */
+
+/** Per-province record: ISO 3166-2:CA code, English name, and the co-official French name. */
+export interface CanadianProvinceInfo {
+	/** ISO 3166-2:CA subdivision code without the `CA-` prefix (e.g. `ON` for `CA-ON`). */
+	code: string
+	/** English name (e.g. `Quebec`). */
+	name: string
+	/** Co-official French name (e.g. `Québec`). */
+	french: string
+}
+
+/**
+ * ISO 3166-2:CA code → province/territory info, for all 13 subdivisions (10 provinces + 3
+ * territories). Codes are the official subdivision codes minus the `CA-` prefix.
+ */
+export const CA_PROVINCES = {
+	AB: { code: "AB", name: "Alberta", french: "Alberta" },
+	BC: { code: "BC", name: "British Columbia", french: "Colombie-Britannique" },
+	MB: { code: "MB", name: "Manitoba", french: "Manitoba" },
+	NB: { code: "NB", name: "New Brunswick", french: "Nouveau-Brunswick" },
+	NL: { code: "NL", name: "Newfoundland and Labrador", french: "Terre-Neuve-et-Labrador" },
+	NS: { code: "NS", name: "Nova Scotia", french: "Nouvelle-Écosse" },
+	NT: { code: "NT", name: "Northwest Territories", french: "Territoires du Nord-Ouest" },
+	NU: { code: "NU", name: "Nunavut", french: "Nunavut" },
+	ON: { code: "ON", name: "Ontario", french: "Ontario" },
+	PE: { code: "PE", name: "Prince Edward Island", french: "Île-du-Prince-Édouard" },
+	QC: { code: "QC", name: "Quebec", french: "Québec" },
+	SK: { code: "SK", name: "Saskatchewan", french: "Saskatchewan" },
+	YT: { code: "YT", name: "Yukon", french: "Yukon" },
+} as const satisfies Record<string, CanadianProvinceInfo>
+
+/** An ISO 3166-2:CA province/territory code (`AB`, `ON`, `QC`, …). */
+export type CanadianProvinceCode = keyof typeof CA_PROVINCES
+
+const PROVINCE_CODE_SET: ReadonlySet<string> = new Set(Object.keys(CA_PROVINCES))
+
+/** Type-predicate for an ISO 3166-2:CA province/territory code. Case-insensitive. */
+export function isCanadianProvinceCode(input: unknown): input is CanadianProvinceCode {
+	return typeof input === "string" && PROVINCE_CODE_SET.has(input.toUpperCase())
+}
+
+/** Strip diacritics + lowercase so `Québec`, `Quebec`, and `quebec` all key alike. */
+function foldName(s: string): string {
+	return s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+}
+
+/**
+ * Folded province name (English or French) / code → ISO 3166-2:CA code. Built diacritic-insensitive
+ * so both co-official names map regardless of accents: `Québec`, `Quebec`, and an unaccented
+ * `Nouvelle-Ecosse` all resolve. The two-name design is the Canadian wrinkle — unlike the German
+ * lookup's English exonym, the French form here is a name a real address may legitimately use.
+ */
+export const CA_PROVINCE_NAME_TO_CODE: ReadonlyMap<string, CanadianProvinceCode> = (() => {
+	const out = new Map<string, CanadianProvinceCode>()
+	for (const code of Object.keys(CA_PROVINCES) as CanadianProvinceCode[]) {
+		const info = CA_PROVINCES[code]
+		out.set(foldName(info.name), code)
+		out.set(foldName(info.french), code)
+		out.set(code.toLowerCase(), code)
+	}
+	return out
+})()
+
+/**
+ * Resolve a Canadian province/territory surface form (ISO code, English name, or French name,
+ * accents optional) to its ISO code; null if unknown.
+ */
+export function lookupCanadianProvince(input: string | null | undefined): CanadianProvinceCode | null {
+	if (!input || typeof input !== "string") return null
+	const upper = input.trim().toUpperCase()
+	if (PROVINCE_CODE_SET.has(upper)) return upper as CanadianProvinceCode
+	return CA_PROVINCE_NAME_TO_CODE.get(foldName(input)) ?? null
+}

--- a/codex/ca/street-type.test.ts
+++ b/codex/ca/street-type.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { isCanadianDirectional, isCanadianStreetWord } from "./street-type.js"
+
+describe("isCanadianStreetWord", () => {
+	it("matches English street types, case-insensitive", () => {
+		expect(isCanadianStreetWord("Street")).toBe(true)
+		expect(isCanadianStreetWord("avenue")).toBe(true)
+		expect(isCanadianStreetWord("Crescent")).toBe(true)
+		expect(isCanadianStreetWord("Boulevard")).toBe(true)
+	})
+
+	it("matches French street types, case- and accent-insensitive", () => {
+		expect(isCanadianStreetWord("Rue")).toBe(true)
+		expect(isCanadianStreetWord("Chemin")).toBe(true)
+		expect(isCanadianStreetWord("Côte")).toBe(true)
+		expect(isCanadianStreetWord("cote")).toBe(true) // unaccented surface form
+		expect(isCanadianStreetWord("Allée")).toBe(true)
+	})
+
+	it("rejects non-street words and non-strings", () => {
+		expect(isCanadianStreetWord("Toronto")).toBe(false)
+		expect(isCanadianStreetWord("Maple")).toBe(false)
+		expect(isCanadianStreetWord(42)).toBe(false)
+		expect(isCanadianStreetWord(null)).toBe(false)
+	})
+})
+
+describe("isCanadianDirectional", () => {
+	it("matches bare letters and full English words", () => {
+		expect(isCanadianDirectional("N")).toBe(true)
+		expect(isCanadianDirectional("North")).toBe(true)
+		expect(isCanadianDirectional("NW")).toBe(true) // compound quadrant
+		expect(isCanadianDirectional("se")).toBe(true)
+	})
+
+	it("matches the French words and the O = Ouest bilingual twist", () => {
+		expect(isCanadianDirectional("Nord")).toBe(true)
+		expect(isCanadianDirectional("Ouest")).toBe(true)
+		expect(isCanadianDirectional("O")).toBe(true) // French Ouest abbreviates to O, not W
+		expect(isCanadianDirectional("Est")).toBe(true)
+	})
+
+	it("rejects non-directional tokens and non-strings", () => {
+		expect(isCanadianDirectional("Rue")).toBe(false)
+		expect(isCanadianDirectional("XY")).toBe(false)
+		expect(isCanadianDirectional(null)).toBe(false)
+	})
+})

--- a/codex/ca/street-type.ts
+++ b/codex/ca/street-type.ts
@@ -1,0 +1,156 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Canadian street types and directionals — BILINGUAL, because Canada Post recognizes both English
+ *   and French forms on the same national network.
+ *
+ *   The informative contrast with `us/street-suffix.ts`, `de/street-type.ts`, and `fr/voie.ts`:
+ *
+ *   - US — a trailing word with a USPS-standardized abbreviation (`Main Street` → `ST`).
+ *   - German — a fused TRAILING suffix (`Hauptstraße`).
+ *   - French — a LEADING standalone word (`Rue de la Paix`).
+ *   - Canadian — BOTH at once. An English street puts the type LAST (`Maple Avenue`, `Sunset
+ *       Crescent`); a French street puts it FIRST (`Rue Sainte-Catherine`, `Boulevard
+ *       René-Lévesque`). So {@link isCanadianStreetWord} matches a whole token against EITHER
+ *       vocabulary and stays position-agnostic — it cannot assume a side the way the
+ *       single-language files do.
+ *
+ *   The directionals carry the same bilingual twist, and one trap inside it: French `Ouest`
+ *   abbreviates to `O`, not `W`. A naive English-only matcher reading `Rue Sherbrooke O` would miss
+ *   the quadrant entirely. {@link CA_DIRECTIONALS} spells out the French abbreviations so `O` =
+ *   Ouest = West is recognized.
+ */
+
+/**
+ * English Canadian street-type words (Canada Post's recognized set, lowercase). Appear as the
+ * TRAILING token of an English street name (`Maple Avenue`, `Sunset Crescent`).
+ */
+export const CA_STREET_TYPES_EN: ReadonlySet<string> = new Set([
+	"street",
+	"avenue",
+	"boulevard",
+	"drive",
+	"road",
+	"crescent",
+	"court",
+	"place",
+	"lane",
+	"way",
+	"trail",
+	"terrace",
+	"close",
+	"circle",
+	"square",
+	"heights",
+	"grove",
+	"gardens",
+	"hill",
+	"park",
+	"row",
+	"walk",
+	"green",
+	"bay",
+	"cove",
+	"gate",
+	"point",
+	"ridge",
+	"view",
+])
+
+/**
+ * French Canadian street-type words (Canada Post's recognized set, lowercase, accent-bearing).
+ * Appear as the LEADING token of a French street name (`Rue Sainte-Catherine`, `Chemin du Roy`).
+ * Folded for matching in {@link isCanadianStreetWord}, so `Côte`/`cote` and `Allée`/`allee` key
+ * alike.
+ */
+export const CA_STREET_TYPES_FR: ReadonlySet<string> = new Set([
+	"rue",
+	"avenue",
+	"boulevard",
+	"chemin",
+	"côte",
+	"place",
+	"impasse",
+	"allée",
+	"croissant",
+	"montée",
+	"rang",
+	"ruelle",
+	"voie",
+	"passage",
+	"carré",
+	"terrasse",
+	"promenade",
+	"sentier",
+])
+
+/** Strip diacritics + lowercase so `Côte`/`cote`, `Allée`/`allee`, `Crescent`/`crescent` key alike. */
+function foldToken(s: string): string {
+	return s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z]/g, "")
+}
+
+/** The English + French street-type vocabularies, both folded, for one position-agnostic lookup. */
+const STREET_WORD_SET: ReadonlySet<string> = (() => {
+	const out = new Set<string>()
+	for (const w of CA_STREET_TYPES_EN) out.add(foldToken(w))
+	for (const w of CA_STREET_TYPES_FR) out.add(foldToken(w))
+	return out
+})()
+
+/**
+ * True when a token is a Canadian street-type word in EITHER language (case- and
+ * accent-insensitive) — `Street`, `Crescent`, `Rue`, `Chemin`, `Côte`. Position-agnostic, because
+ * an English type trails the name and a French type leads it; the matcher cannot lean on a side.
+ */
+export function isCanadianStreetWord(token: unknown): boolean {
+	if (typeof token !== "string") return false
+	const t = foldToken(token)
+	return t.length > 0 && STREET_WORD_SET.has(t)
+}
+
+/**
+ * Bilingual directional words → canonical compass letter. Covers the bare letters (`N S E W`), the
+ * full English words (`North`/`South`/`East`/`West`), and the full French words
+ * (`Nord`/`Sud`/`Est`/`Ouest`). The bilingual twist is `O`: French `Ouest` abbreviates to `O`, NOT
+ * `W`, so an English-only matcher silently drops the quadrant on a French address line. Keys are
+ * folded (lowercase, accent-free); values are the English compass letter.
+ */
+export const CA_DIRECTIONALS: Record<string, "N" | "S" | "E" | "W"> = {
+	n: "N",
+	north: "N",
+	nord: "N",
+	s: "S",
+	south: "S",
+	sud: "S",
+	e: "E",
+	east: "E",
+	est: "E",
+	w: "W",
+	west: "W",
+	ouest: "W",
+	o: "W", // French Ouest abbreviates to O, not W — the bilingual trap.
+}
+
+/**
+ * True when a token is a Canadian directional in either language (case- and accent-insensitive) —
+ * `N`, `NW`, `Nord`, `Ouest`, `O`. Compound English quadrants (`NW`, `SE`) are accepted by
+ * decomposing into their single-letter halves; the lone French `O` resolves to West.
+ */
+export function isCanadianDirectional(token: unknown): boolean {
+	if (typeof token !== "string") return false
+	const t = foldToken(token)
+	if (t.length === 0) return false
+	if (t in CA_DIRECTIONALS) return true
+	// Compound English quadrants like NW / SE / NE / SW: each half must be a single-letter directional.
+	if (t.length === 2) {
+		const isLetter = (h: string): boolean => h === "n" || h === "s" || h === "e" || h === "w"
+		return isLetter(t[0]!) && isLetter(t[1]!)
+	}
+	return false
+}

--- a/codex/gb/country.test.ts
+++ b/codex/gb/country.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { GB_COUNTRIES, isUkCountryCode, lookupUkCountry } from "./country.js"
+
+describe("GB_COUNTRIES", () => {
+	it("covers the four constituent countries of the UK", () => {
+		expect(Object.keys(GB_COUNTRIES)).toHaveLength(4)
+		expect(GB_COUNTRIES.ENG).toEqual({ code: "ENG", name: "England" })
+		expect(GB_COUNTRIES.NIR.name).toBe("Northern Ireland")
+	})
+})
+
+describe("isUkCountryCode", () => {
+	it("accepts ISO 3166-2:GB codes, case-insensitively", () => {
+		expect(isUkCountryCode("ENG")).toBe(true)
+		expect(isUkCountryCode("sct")).toBe(true)
+		expect(isUkCountryCode("BY")).toBe(false) // a German state, not a UK country
+	})
+})
+
+describe("lookupUkCountry", () => {
+	it("resolves ISO code and English name to the ISO code", () => {
+		expect(lookupUkCountry("ENG")).toBe("ENG")
+		expect(lookupUkCountry("England")).toBe("ENG")
+		expect(lookupUkCountry("Scotland")).toBe("SCT")
+		expect(lookupUkCountry("wales")).toBe("WLS")
+		expect(lookupUkCountry("Northern Ireland")).toBe("NIR")
+		expect(lookupUkCountry("northern-ireland")).toBe("NIR")
+	})
+
+	it("returns null for an unknown country", () => {
+		expect(lookupUkCountry("Ireland")).toBeNull() // the Republic, not a UK country
+		expect(lookupUkCountry("Bavaria")).toBeNull()
+		expect(lookupUkCountry(null)).toBeNull()
+	})
+})

--- a/codex/gb/country.ts
+++ b/codex/gb/country.ts
@@ -1,0 +1,70 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The four constituent countries of the United Kingdom, keyed by their ISO 3166-2:GB code: England
+ *   (`ENG`), Scotland (`SCT`), Wales (`WLS`), Northern Ireland (`NIR`).
+ *
+ *   The UK's top-level admin tier is itself the first oddity of this system. France has régions,
+ *   Germany has Bundesländer, the US has states — a single flat layer. The UK has _countries_
+ *   inside a country, and an address almost never names which one: a line reads `street, town,
+ *   postcode`, and the constituent country is inferred — usually, but not always cleanly, from the
+ *   postcode area (see `postcode-area.ts`). So this file is the coarse admin label, and the
+ *   postcode is the thing that actually carries the geography.
+ */
+
+/** Per-country record: ISO 3166-2:GB code (sans `GB-` prefix) + English name. */
+export interface UkCountryInfo {
+	/** ISO 3166-2:GB country code without the `GB-` prefix (e.g. `ENG` for `GB-ENG`). */
+	code: string
+	/** English name (e.g. `Scotland`). */
+	name: string
+}
+
+/** ISO 3166-2:GB country code → info, for all four constituent countries. */
+export const GB_COUNTRIES = {
+	ENG: { code: "ENG", name: "England" },
+	SCT: { code: "SCT", name: "Scotland" },
+	WLS: { code: "WLS", name: "Wales" },
+	NIR: { code: "NIR", name: "Northern Ireland" },
+} as const satisfies Record<string, UkCountryInfo>
+
+/** An ISO 3166-2:GB constituent-country code (`ENG`, `SCT`, `WLS`, `NIR`). */
+export type UkCountryCode = keyof typeof GB_COUNTRIES
+
+const COUNTRY_CODE_SET: ReadonlySet<string> = new Set(Object.keys(GB_COUNTRIES))
+
+/** Type-predicate for an ISO 3166-2:GB country code. Case-insensitive. */
+export function isUkCountryCode(input: unknown): input is UkCountryCode {
+	return typeof input === "string" && COUNTRY_CODE_SET.has(input.toUpperCase())
+}
+
+/** Lowercase + collapse non-alphanumerics so `Northern Ireland`, `northern-ireland` key alike. */
+function foldName(s: string): string {
+	return s
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+}
+
+/** Folded country name / code → ISO 3166-2:GB code, so a surface form maps regardless of casing. */
+const COUNTRY_NAME_TO_CODE: ReadonlyMap<string, UkCountryCode> = (() => {
+	const out = new Map<string, UkCountryCode>()
+	for (const code of Object.keys(GB_COUNTRIES) as UkCountryCode[]) {
+		out.set(foldName(GB_COUNTRIES[code].name), code)
+		out.set(code.toLowerCase(), code)
+	}
+	return out
+})()
+
+/**
+ * Resolve a UK constituent-country surface form (ISO code or English name) to its ISO code; null if
+ * unknown. Accepts `ENG`, `England`, `Northern Ireland`, `scotland`, etc.
+ */
+export function lookupUkCountry(input: string | null | undefined): UkCountryCode | null {
+	if (!input || typeof input !== "string") return null
+	const upper = input.trim().toUpperCase()
+	if (COUNTRY_CODE_SET.has(upper)) return upper as UkCountryCode
+	return COUNTRY_NAME_TO_CODE.get(foldName(input)) ?? null
+}

--- a/codex/gb/index.ts
+++ b/codex/gb/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The United Kingdom address system (Royal Mail / ISO 3166-2:GB): the variable-length alphanumeric
+ *   postcode and its Royal-Mail postcode areas, the four constituent countries, and British street
+ *   vocabulary.
+ */
+
+export * from "./country.js"
+export * from "./postcode-area.js"
+export * from "./postcode.js"
+export * from "./street-type.js"

--- a/codex/gb/postcode-area.test.ts
+++ b/codex/gb/postcode-area.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { countryOfPostcode, countryOfPostcodeArea, GB_POSTCODE_AREA_COUNTRY } from "./postcode-area.js"
+
+describe("GB_POSTCODE_AREA_COUNTRY", () => {
+	it("maps the explicit non-England areas to their country", () => {
+		expect(GB_POSTCODE_AREA_COUNTRY.BT).toBe("NIR") // Belfast → Northern Ireland
+		expect(GB_POSTCODE_AREA_COUNTRY.EH).toBe("SCT") // Edinburgh → Scotland
+		expect(GB_POSTCODE_AREA_COUNTRY.G).toBe("SCT") // Glasgow → Scotland
+		expect(GB_POSTCODE_AREA_COUNTRY.CF).toBe("WLS") // Cardiff → Wales
+	})
+
+	it("assigns the border-straddling areas to their majority country", () => {
+		expect(GB_POSTCODE_AREA_COUNTRY.TD).toBe("SCT") // Galashiels — majority Scotland
+		expect(GB_POSTCODE_AREA_COUNTRY.SY).toBe("WLS") // Shrewsbury — majority Wales
+	})
+
+	it("does not list England — it is the transparent default", () => {
+		expect(GB_POSTCODE_AREA_COUNTRY.SW).toBeUndefined()
+		expect(GB_POSTCODE_AREA_COUNTRY.M).toBeUndefined()
+	})
+})
+
+describe("countryOfPostcodeArea", () => {
+	it("returns the explicit country for a known non-England area", () => {
+		expect(countryOfPostcodeArea("BT")).toBe("NIR")
+		expect(countryOfPostcodeArea("EH")).toBe("SCT")
+		expect(countryOfPostcodeArea("CF")).toBe("WLS")
+	})
+
+	it("defaults a validly-shaped unknown area to England", () => {
+		expect(countryOfPostcodeArea("SW")).toBe("ENG")
+		expect(countryOfPostcodeArea("M")).toBe("ENG")
+		expect(countryOfPostcodeArea("ox")).toBe("ENG") // case-insensitive
+	})
+
+	it("returns null for clearly-invalid input (not one-or-two letters)", () => {
+		expect(countryOfPostcodeArea("123")).toBeNull()
+		expect(countryOfPostcodeArea("LONG")).toBeNull()
+		expect(countryOfPostcodeArea("")).toBeNull()
+		expect(countryOfPostcodeArea(null)).toBeNull()
+	})
+})
+
+describe("countryOfPostcode", () => {
+	it("resolves a whole postcode through its area to a constituent country", () => {
+		expect(countryOfPostcode("BT1 1AA")).toBe("NIR")
+		expect(countryOfPostcode("EH1 1BB")).toBe("SCT")
+		expect(countryOfPostcode("CF10 1AA")).toBe("WLS")
+		expect(countryOfPostcode("SW1A 1AA")).toBe("ENG")
+		expect(countryOfPostcode("M1 1AE")).toBe("ENG")
+	})
+
+	it("returns null when no postcode area can be extracted", () => {
+		expect(countryOfPostcode("12345")).toBeNull()
+		expect(countryOfPostcode(null)).toBeNull()
+	})
+
+	it("area→country is a real mapping, but a postcode is not a county", () => {
+		// London (`SW`) and Manchester (`M`) are different cities in different English counties, yet
+		// both resolve to ENG — the area→country map is genuine. But that is as far as it goes: the
+		// postcode carries the COUNTRY, never the county, while a Scottish area like Glasgow's `G`
+		// flips the country outright. Royal Mail routing, not administrative geography.
+		expect(countryOfPostcode("SW1A 1AA")).toBe("ENG") // London
+		expect(countryOfPostcode("M1 1AE")).toBe("ENG") // Manchester
+		expect(countryOfPostcode("G1 1XW")).toBe("SCT") // Glasgow
+	})
+})

--- a/codex/gb/postcode-area.ts
+++ b/codex/gb/postcode-area.ts
@@ -1,0 +1,106 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Postcode AREA → constituent country, the Royal Mail mapping — and the concrete proof of the
+ *   lesson in `postcode.ts` that UK postcodes do NOT track administrative geography.
+ *
+ *   A postcode area is the leading one or two letters of a postcode (`SW`, `M`, `EH`, `BT`), named
+ *   after the sorting town Royal Mail routes it through, NOT after a county or a constituent
+ *   country. There is no clean postcode→admin hierarchy to inherit the way France gives you a
+ *   département from the first two digits. The only honest thing we _can_ derive is which of the
+ *   four UK countries an area predominantly falls in — and even that has border exceptions:
+ *
+ *   - **TD** (Galashiels) and **SY** (Shrewsbury) straddle the Scotland/England and Wales/England
+ *       borders respectively; each is assigned to its MAJORITY country here (TD → Scotland, SY →
+ *       Wales). A handful of individual postcodes on the wrong side of the line are a gazetteer
+ *       concern, not a thing this coarse table tries to model.
+ *
+ *   So this is the ROYAL MAIL area→country mapping, and the fact that it needs a hand-built
+ *   non-England set with documented border fudges — rather than a tidy prefix rule — is exactly why
+ *   a UK postcode is not a county.
+ */
+
+import type { UkCountryCode } from "./country.js"
+
+/** Northern Ireland is a single postcode area: BT (Belfast). */
+const NORTHERN_IRELAND_AREAS = ["BT"] as const
+
+/**
+ * Scotland's postcode areas. TD (Galashiels) straddles the border with England and is assigned to
+ * Scotland as its majority country.
+ */
+const SCOTLAND_AREAS = [
+	"AB", // Aberdeen
+	"DD", // Dundee
+	"DG", // Dumfries
+	"EH", // Edinburgh
+	"FK", // Falkirk
+	"G", //  Glasgow
+	"HS", // Outer Hebrides (Na h-Eileanan Siar)
+	"IV", // Inverness
+	"KA", // Kilmarnock
+	"KW", // Kirkwall (Orkney + Caithness)
+	"KY", // Kirkcaldy (Fife)
+	"ML", // Motherwell
+	"PA", // Paisley
+	"PH", // Perth
+	"TD", // Galashiels (Scottish Borders) — straddles the England border, majority Scotland
+	"ZE", // Lerwick (Shetland)
+] as const
+
+/**
+ * Wales's postcode areas. SY (Shrewsbury) straddles the border with England and is assigned to
+ * Wales as its majority country.
+ */
+const WALES_AREAS = [
+	"CF", // Cardiff
+	"LD", // Llandrindod Wells
+	"LL", // Llandudno
+	"NP", // Newport
+	"SA", // Swansea
+	"SY", // Shrewsbury — straddles the Wales/England border, majority Wales
+] as const
+
+/**
+ * The explicit non-England postcode areas, area → constituent country. England is intentionally
+ * absent: it is the DEFAULT (the great majority of UK areas are English), so listing it would be
+ * both enormous and a maintenance trap. Keeping only the non-England set makes the default
+ * transparent — anything not named here is England.
+ */
+export const GB_POSTCODE_AREA_COUNTRY: Record<string, UkCountryCode> = {
+	...Object.fromEntries(NORTHERN_IRELAND_AREAS.map((a) => [a, "NIR" as const])),
+	...Object.fromEntries(SCOTLAND_AREAS.map((a) => [a, "SCT" as const])),
+	...Object.fromEntries(WALES_AREAS.map((a) => [a, "WLS" as const])),
+}
+
+/** True when `area` looks like a valid postcode-area string: one or two ASCII letters. */
+function isAreaShape(area: unknown): area is string {
+	return typeof area === "string" && /^[A-Z]{1,2}$/i.test(area)
+}
+
+/**
+ * The constituent country a postcode AREA belongs to. Returns the explicit country for a known
+ * non-England area (e.g. `BT` → `NIR`, `G` → `SCT`, `CF` → `WLS`), and `ENG` as the default for any
+ * other validly-shaped area — England is by far the largest, so the default is transparent and the
+ * non-England exceptions live in {@link GB_POSTCODE_AREA_COUNTRY}. Returns null for clearly-invalid
+ * input (not one-or-two letters), so a malformed token is not silently called England.
+ */
+export function countryOfPostcodeArea(area: unknown): UkCountryCode | null {
+	if (!isAreaShape(area)) return null
+	return GB_POSTCODE_AREA_COUNTRY[area.toUpperCase()] ?? "ENG"
+}
+
+/**
+ * The constituent country a whole postcode resolves to, by extracting its area. `BT1 1AA` → `NIR`,
+ * `EH1 1BB` → `SCT`, `CF10 1AA` → `WLS`, `SW1A 1AA` → `ENG`. Null if the input has no extractable
+ * postcode area.
+ */
+export function countryOfPostcode(postcode: unknown): UkCountryCode | null {
+	if (typeof postcode !== "string") return null
+	// Extract the leading 1-2 letters directly, tolerating the inward code / spacing.
+	const match = /^\s*([A-Z]{1,2})/i.exec(postcode)
+	if (!match) return null
+	return countryOfPostcodeArea(match[1])
+}

--- a/codex/gb/postcode.test.ts
+++ b/codex/gb/postcode.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { inwardCode, isUkPostcode, normalizeUkPostcode, outwardCode, postcodeArea } from "./postcode.js"
+
+describe("normalizeUkPostcode", () => {
+	it("uppercases and inserts the single canonical space before the inward 3 chars", () => {
+		expect(normalizeUkPostcode("sw1a1aa")).toBe("SW1A 1AA")
+		expect(normalizeUkPostcode("M11AE")).toBe("M1 1AE")
+		expect(normalizeUkPostcode("b33 8th")).toBe("B33 8TH")
+		expect(normalizeUkPostcode(" CR2  6XH ")).toBe("CR2 6XH")
+		expect(normalizeUkPostcode("dn551pt")).toBe("DN55 1PT")
+	})
+
+	it("returns null for non-postcodes", () => {
+		expect(normalizeUkPostcode("75008")).toBeNull() // a French code postal
+		expect(normalizeUkPostcode("ABC")).toBeNull()
+		expect(normalizeUkPostcode("")).toBeNull()
+		expect(normalizeUkPostcode(12345)).toBeNull()
+	})
+})
+
+describe("isUkPostcode", () => {
+	it("accepts valid postcodes (spaced or not)", () => {
+		expect(isUkPostcode("SW1A 1AA")).toBe(true)
+		expect(isUkPostcode("M1 1AE")).toBe(true)
+		expect(isUkPostcode("B338TH")).toBe(true) // space optional
+		expect(isUkPostcode("nonsense")).toBe(false)
+	})
+})
+
+describe("outwardCode / inwardCode — the outward + inward split", () => {
+	it("cleaves the outward (area + district) from the inward (sector + unit)", () => {
+		expect(outwardCode("SW1A 1AA")).toBe("SW1A")
+		expect(inwardCode("SW1A 1AA")).toBe("1AA")
+		expect(outwardCode("M1 1AE")).toBe("M1")
+		expect(inwardCode("M1 1AE")).toBe("1AE")
+		expect(outwardCode("DN55 1PT")).toBe("DN55")
+		expect(inwardCode("DN55 1PT")).toBe("1PT")
+	})
+
+	it("normalizes an un-spaced input before cleaving", () => {
+		expect(outwardCode("sw1a1aa")).toBe("SW1A")
+		expect(inwardCode("sw1a1aa")).toBe("1AA")
+	})
+
+	it("returns null for an invalid postcode", () => {
+		expect(outwardCode("nope")).toBeNull()
+		expect(inwardCode("nope")).toBeNull()
+	})
+})
+
+describe("postcodeArea — the leading 1-2 letters", () => {
+	it("extracts the Royal Mail area, stripping the district digits", () => {
+		expect(postcodeArea("SW1A 1AA")).toBe("SW")
+		expect(postcodeArea("B33 8TH")).toBe("B")
+		expect(postcodeArea("EH1 1BB")).toBe("EH")
+		expect(postcodeArea("M1 1AE")).toBe("M")
+		expect(postcodeArea("DN55 1PT")).toBe("DN")
+	})
+
+	it("returns null for an invalid postcode", () => {
+		expect(postcodeArea("12345")).toBeNull()
+	})
+})

--- a/codex/gb/postcode.ts
+++ b/codex/gb/postcode.ts
@@ -1,0 +1,102 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   UK postcodes: the branded type, the validation shape, normalization, and the outward/inward
+ *   split.
+ *
+ *   This is the MOST COMPLEX postcode of any system in the codex, and the contrast is the whole point
+ *   of the file. A US ZIP, a German PLZ, and a French code postal are all a fixed five digits — the
+ *   shape is trivial and the only interesting question is what admin unit the prefix maps to. The
+ *   UK postcode is none of that:
+ *
+ *   - It is **variable-length alphanumeric**, from six characters (`M1 1AE`) to eight (`SW1A 1AA`),
+ *       across forms like `B33 8TH`, `CR2 6XH`, `DN55 1PT`.
+ *   - It splits into an **OUTWARD code** (area + district, the part before the space — `SW1A`) and an
+ *       **INWARD code** (sector + unit, the three chars after — `1AA`). Royal Mail sorts on the
+ *       outward to a delivery office, then on the inward to a walk.
+ *   - And — the lesson that propagates to `postcode-area.ts` — it does **NOT align with administrative
+ *       geography**. A postcode area is a Royal Mail routing construct named after a sorting town
+ *       (`SW` = south-west London, `EH` = Edinburgh), NOT a county or a constituent country. You
+ *       cannot read a county off a UK postcode the way you read a département off a French one; the
+ *       postcode→country mapping in `postcode-area.ts` exists precisely _because_ there is no clean
+ *       hierarchy to inherit.
+ *
+ *   So unlike the other systems, the hard work here is the shape itself — validating, normalizing the
+ *   internal space, and cleaving outward from inward — not a prefix→admin lookup.
+ */
+
+import type { Tagged } from "type-fest"
+
+/**
+ * A UK postcode: variable-length alphanumeric, outward + inward (`SW1A 1AA`, `M1 1AE`). The
+ * canonical form carries exactly one space before the final three characters. Unlike a US/DE/FR
+ * postcode, the shape is not a fixed-width numeric string — see {@link UK_POSTCODE_PATTERN}.
+ *
+ * @category Postal
+ * @type string
+ * @title UK postcode
+ * @pattern ^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$
+ */
+export type Postcode = Tagged<string, "UkPostcode">
+
+/**
+ * UK postcode shape. A robust, slightly permissive form of the Royal Mail / UK-gov regex: one or
+ * two leading letters (the area), a district digit, an optional district letter-or-digit, then the
+ * inward sector digit and two unit letters, with the inward space optional so an un-spaced
+ * `SW1A1AA` still validates. The full UK-gov pattern additionally whitelists the British Overseas
+ * Territory codes (`ASCN`, `STHL`, `BBND`, …); those are rare enough to leave to the gazetteer.
+ */
+export const UK_POSTCODE_PATTERN = /^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$/i
+
+/**
+ * Normalize a UK postcode surface form: uppercase, strip surrounding whitespace, and ensure exactly
+ * one space before the final three characters (the inward code). `sw1a1aa` → `SW1A 1AA`, `M11AE` →
+ * `M1 1AE`, `b33 8th` → `B33 8TH`. Returns null if the result is not a valid postcode.
+ */
+export function normalizeUkPostcode(raw: unknown): Postcode | null {
+	if (typeof raw !== "string") return null
+	// Drop all whitespace, uppercase, then re-insert the single canonical space before the inward 3.
+	const compact = raw.replace(/\s+/g, "").toUpperCase()
+	if (compact.length < 5) return null
+	const spaced = `${compact.slice(0, -3)} ${compact.slice(-3)}`
+	return UK_POSTCODE_PATTERN.test(spaced) ? (spaced as Postcode) : null
+}
+
+/** Type-predicate for a UK postcode surface form (space optional). */
+export function isUkPostcode(input: unknown): input is Postcode {
+	return typeof input === "string" && UK_POSTCODE_PATTERN.test(input.trim())
+}
+
+/**
+ * The OUTWARD code — the part before the space (area + district), e.g. `SW1A 1AA` → `SW1A`, `M1
+ * 1AE` → `M1`. Normalizes first so an un-spaced input still cleaves correctly; null if invalid.
+ */
+export function outwardCode(pc: unknown): string | null {
+	const normalized = normalizeUkPostcode(pc)
+	if (!normalized) return null
+	return normalized.slice(0, normalized.indexOf(" "))
+}
+
+/**
+ * The INWARD code — the three characters after the space (sector + unit), e.g. `SW1A 1AA` → `1AA`,
+ * `M1 1AE` → `1AE`. Null if invalid.
+ */
+export function inwardCode(pc: unknown): string | null {
+	const normalized = normalizeUkPostcode(pc)
+	if (!normalized) return null
+	return normalized.slice(normalized.indexOf(" ") + 1)
+}
+
+/**
+ * The POSTCODE AREA — the leading one or two LETTERS of the outward code, the Royal Mail routing
+ * region named after a sorting town: `SW1A 1AA` → `SW`, `M1 1AE` → `M`, `B33 8TH` → `B`. This is
+ * the key into `postcode-area.ts`'s area→country map. Null if the input is not a valid postcode.
+ */
+export function postcodeArea(pc: unknown): string | null {
+	const outward = outwardCode(pc)
+	if (!outward) return null
+	const match = /^[A-Z]{1,2}/.exec(outward)
+	return match ? match[0] : null
+}

--- a/codex/gb/street-type.test.ts
+++ b/codex/gb/street-type.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { GB_STREET_TYPES, isBritishStreetWord } from "./street-type.js"
+
+describe("GB_STREET_TYPES", () => {
+	it("spans the common core and the distinctively British vocabulary", () => {
+		expect(GB_STREET_TYPES).toContain("street")
+		expect(GB_STREET_TYPES).toContain("crescent")
+		expect(GB_STREET_TYPES).toContain("mews")
+		expect(GB_STREET_TYPES).toContain("wynd") // Scots
+		expect(GB_STREET_TYPES).toContain("brae") // Scots
+	})
+})
+
+describe("isBritishStreetWord", () => {
+	it("matches thoroughfare words, case-insensitively, as whole tokens", () => {
+		expect(isBritishStreetWord("Crescent")).toBe(true)
+		expect(isBritishStreetWord("Mews")).toBe(true)
+		expect(isBritishStreetWord("Close")).toBe(true)
+		expect(isBritishStreetWord("road")).toBe(true)
+		expect(isBritishStreetWord("TERRACE")).toBe(true)
+	})
+
+	it("does not flag an unrelated place name", () => {
+		expect(isBritishStreetWord("Tokyo")).toBe(false)
+		expect(isBritishStreetWord("Bordeaux")).toBe(false)
+		expect(isBritishStreetWord("London")).toBe(false)
+	})
+
+	it("rejects non-strings", () => {
+		expect(isBritishStreetWord(42)).toBe(false)
+		expect(isBritishStreetWord(null)).toBe(false)
+	})
+})

--- a/codex/gb/street-type.ts
+++ b/codex/gb/street-type.ts
@@ -1,0 +1,90 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   British street vocabulary (thoroughfare types).
+ *
+ *   The contrast across the codex's street files is structural. A US street type is a trailing word
+ *   with a USPS-standardized abbreviation (`Main Street` → `ST`). A German street type is a fused
+ *   agglutinative suffix (`Hauptstraße`). A French type is a leading standalone word (`Rue de la
+ *   Paix`). British practice is the US shape — a separate TRAILING word — but with a notably RICHER
+ *   and more local vocabulary: alongside the everyday `Road`/`Street`/`Avenue` sit `Crescent`,
+ *   `Mews`, `Close`, `Wynd`, `Brae`, `Gait`, `Croft`, `Dene` and a long tail of landscape words
+ *   (`Brook`, `Copse`, `Dell`, `Hollow`, `Spinney`) that read as thoroughfare types in the UK and
+ *   essentially nowhere else.
+ *
+ *   So detection is, like French, a whole-token match — {@link isBritishStreetWord} asks "is this
+ *   token a known British thoroughfare word" rather than testing a suffix — because these are
+ *   distinct trailing words, not fused endings.
+ */
+
+/**
+ * The British thoroughfare vocabulary. Lowercase canonical forms, matched as whole tokens. Spans
+ * the common core (`street`, `road`, `lane`, `avenue`) through the distinctively British
+ * (`crescent`, `mews`, `close`, `terrace`) and the regional/landscape tail (`wynd`, `brae`, `gait`,
+ * `croft`, `dene`, `spinney`, `dell`, `hollow`).
+ */
+export const GB_STREET_TYPES = [
+	"street",
+	"road",
+	"lane",
+	"avenue",
+	"close",
+	"crescent",
+	"court",
+	"drive",
+	"place",
+	"way",
+	"gardens",
+	"grove",
+	"terrace",
+	"mews",
+	"walk",
+	"hill",
+	"green",
+	"park",
+	"rise",
+	"view",
+	"row",
+	"square",
+	"parade",
+	"vale",
+	"wharf",
+	"yard",
+	"gate",
+	"croft",
+	"dene",
+	"end",
+	"fields",
+	"meadow",
+	"brook",
+	"chase",
+	"copse",
+	"dale",
+	"dell",
+	"glen",
+	"hollow",
+	"paddock",
+	"ridge",
+	"spinney",
+	"wynd",
+	"brae",
+	"gait",
+] as const
+
+/** A canonical British thoroughfare word (e.g. `street`, `crescent`, `mews`). */
+export type BritishStreetType = (typeof GB_STREET_TYPES)[number]
+
+const STREET_TYPE_SET: ReadonlySet<string> = new Set(GB_STREET_TYPES)
+
+/**
+ * True when a token is a British thoroughfare type word (case-insensitive, whole-token match) —
+ * `Crescent`, `Mews`, `Close`, `Road`. Matches the WHOLE token, not a suffix, so an unrelated place
+ * name (`Tokyo`, `Bordeaux`) is not flagged the way an `-endsWith` test might.
+ */
+export function isBritishStreetWord(token: unknown): boolean {
+	if (typeof token !== "string") return false
+	const t = token.toLowerCase().replace(/[^a-z]/g, "")
+	return t.length > 0 && STREET_TYPE_SET.has(t)
+}

--- a/codex/index.ts
+++ b/codex/index.ts
@@ -17,6 +17,9 @@
  *   other systems land here as the multi-locale push needs them.
  */
 
+export * as ca from "./ca/index.js"
 export * as de from "./de/index.js"
 export * as fr from "./fr/index.js"
+export * as gb from "./gb/index.js"
+export * as jp from "./jp/index.js"
 export * as us from "./us/index.js"

--- a/codex/jp/address-unit.test.ts
+++ b/codex/jp/address-unit.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { isJapaneseAdminSuffix, JP_ADMIN_SUFFIXES, JP_BLOCK_MARKERS, stripAdminSuffix } from "./address-unit.js"
+
+describe("JP_ADMIN_SUFFIXES / JP_BLOCK_MARKERS", () => {
+	it("carries the prefecture-level and city-level admin markers", () => {
+		expect(JP_ADMIN_SUFFIXES).toContain("都") // metropolis (Tokyo)
+		expect(JP_ADMIN_SUFFIXES).toContain("県") // prefecture
+		expect(JP_ADMIN_SUFFIXES).toContain("市") // city
+		expect(JP_ADMIN_SUFFIXES).toContain("区") // ward
+	})
+
+	it("carries the numbered-tail block markers (the no-street house-number stand-in)", () => {
+		expect(JP_BLOCK_MARKERS).toContain("丁目") // chōme
+		expect(JP_BLOCK_MARKERS).toContain("番地") // banchi
+		expect(JP_BLOCK_MARKERS).toContain("号") // gō
+	})
+})
+
+describe("isJapaneseAdminSuffix", () => {
+	it("accepts a single admin-suffix kanji", () => {
+		expect(isJapaneseAdminSuffix("都")).toBe(true)
+		expect(isJapaneseAdminSuffix("市")).toBe(true)
+		expect(isJapaneseAdminSuffix("区")).toBe(true)
+	})
+
+	it("rejects non-suffixes and multi-character input", () => {
+		expect(isJapaneseAdminSuffix("X")).toBe(false)
+		expect(isJapaneseAdminSuffix("東京都")).toBe(false) // a name, not a lone suffix
+		expect(isJapaneseAdminSuffix(123)).toBe(false)
+	})
+})
+
+describe("stripAdminSuffix", () => {
+	it("removes a trailing admin-suffix kanji from a place name", () => {
+		expect(stripAdminSuffix("東京都")).toBe("東京")
+		expect(stripAdminSuffix("大阪市")).toBe("大阪")
+		expect(stripAdminSuffix("千代田区")).toBe("千代田")
+	})
+
+	it("leaves Hokkaido whole — its 道 is indivisible", () => {
+		expect(stripAdminSuffix("北海道")).toBe("北海道")
+	})
+
+	it("leaves a name with no admin suffix untouched", () => {
+		expect(stripAdminSuffix("渋谷")).toBe("渋谷")
+		expect(stripAdminSuffix("")).toBe("")
+	})
+})

--- a/codex/jp/address-unit.ts
+++ b/codex/jp/address-unit.ts
@@ -1,0 +1,86 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Japan's analog of a "street-type" module — except the lesson here is the absence. Where
+ *   `us/street-suffix.ts` and `de/street-type.ts` exist to recognize the named-street part of an
+ *   address, Japan has **no street names** to recognize. A Japanese address is built from nested
+ *   administrative units and numbered blocks/lots, written largest-to-smallest:
+ *
+ *   ```
+ *   東京都 千代田区 千代田 1丁目 1番 1号
+ *   Tokyo-to · Chiyoda-ku · Chiyoda · 1-chōme · 1-ban · 1-gō
+ * ```
+ *
+ *   So instead of a street-suffix table this file ships two marker sets:
+ *
+ *   - {@link JP_ADMIN_SUFFIXES} — the kanji that close an administrative-area name (都/道/府/県 at the
+ *       prefecture level, then 市/区/郡/町/村 for city / ward / district / town / village). These are
+ *       the Japanese equivalent of a US street suffix in the parsing sense: the token-final marker
+ *       that tells you what KIND of unit the preceding name is.
+ *   - {@link JP_BLOCK_MARKERS} — the markers that close the numbered tail (丁目 / 番地 / 番 / 号), the part
+ *       that actually does the "house number" job in the absence of streets.
+ *
+ *   Note the reverse field order: the admin suffixes appear FIRST in the string (prefecture leads),
+ *   and the block markers LAST — the mirror image of a US line, where the house number leads and
+ *   the ZIP trails. See `postal-code.ts` for why, with no street name, the postcode is the primary
+ *   anchor.
+ */
+
+/**
+ * The kanji suffixes that close an administrative-area name, largest unit to smallest:
+ *
+ * - 都 (to) — metropolis; only Tokyo.
+ * - 道 (dō) — circuit; only Hokkaido.
+ * - 府 (fu) — urban prefecture; Osaka and Kyoto.
+ * - 県 (ken) — prefecture; the other 43.
+ * - 市 (shi) — city.
+ * - 区 (ku) — ward (a subdivision of a designated city, e.g. Tokyo's 23 special wards).
+ * - 郡 (gun) — district / county (rural grouping of towns and villages).
+ * - 町 (chō / machi) — town.
+ * - 村 (son / mura) — village.
+ */
+export const JP_ADMIN_SUFFIXES = ["都", "道", "府", "県", "市", "区", "郡", "町", "村"] as const
+
+/** A single administrative-area suffix kanji (`都`, `市`, `区`, …). */
+export type JapaneseAdminSuffix = (typeof JP_ADMIN_SUFFIXES)[number]
+
+/**
+ * The markers that close the numbered tail of an address — Japan's stand-in for a house number,
+ * since there is no named street to hang one on:
+ *
+ * - 丁目 (chōme) — a district block within a neighbourhood.
+ * - 番地 (banchi) — a lot number.
+ * - 番 (ban) — block number (the `番` in the modern `chōme-ban-gō` triple).
+ * - 号 (gō) — building number (the final element of the triple).
+ */
+export const JP_BLOCK_MARKERS = ["丁目", "番地", "番", "号"] as const
+
+/** A numbered-tail marker (`丁目`, `番地`, `番`, `号`). */
+export type JapaneseBlockMarker = (typeof JP_BLOCK_MARKERS)[number]
+
+const ADMIN_SUFFIX_SET: ReadonlySet<string> = new Set(JP_ADMIN_SUFFIXES)
+
+/**
+ * True when a single kanji is one of the {@link JP_ADMIN_SUFFIXES} admin-area markers (`都`, `市`,
+ * `区`, …). Strictly single-character: a multi-character input (even one ending in a suffix) is not
+ * a suffix on its own.
+ */
+export function isJapaneseAdminSuffix(ch: unknown): ch is JapaneseAdminSuffix {
+	return typeof ch === "string" && ADMIN_SUFFIX_SET.has(ch)
+}
+
+/**
+ * Strip a trailing admin-area suffix kanji from a place name, exposing the bare name (`東京都` → `東京`,
+ * `大阪市` → `大阪`, `千代田区` → `千代田`). Leaves a name untouched if it does not end in an admin suffix.
+ *
+ * Hokkaido (`北海道`) is the deliberate exception: its name ends in 道 but is indivisible, so it is
+ * returned whole rather than clipped to `北海` — mirroring the same carve-out in `prefecture.ts`.
+ */
+export function stripAdminSuffix(name: string): string {
+	if (typeof name !== "string" || name.length === 0) return name
+	if (name === "北海道") return name
+	const last = name[name.length - 1]!
+	return ADMIN_SUFFIX_SET.has(last) ? name.slice(0, -1) : name
+}

--- a/codex/jp/index.ts
+++ b/codex/jp/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The Japanese address system (Japan Post / ISO 3166-2:JP): the 47 prefectures, the postal code
+ *   that is the country's most reliable geographic anchor, and the address-unit markers that stand
+ *   in for the street names Japan does not use.
+ */
+
+export * from "./address-unit.js"
+export * from "./postal-code.js"
+export * from "./prefecture.js"

--- a/codex/jp/postal-code.test.ts
+++ b/codex/jp/postal-code.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { firstDigitRegion, isJpPostalCode, normalizeJpPostalCode } from "./postal-code.js"
+
+describe("normalizeJpPostalCode", () => {
+	it("strips the 〒 mark and whitespace, keeping the canonical NNN-NNNN", () => {
+		expect(normalizeJpPostalCode("〒100-0001")).toBe("100-0001")
+		expect(normalizeJpPostalCode(" 100-0001 ")).toBe("100-0001")
+		expect(normalizeJpPostalCode("100-0001")).toBe("100-0001")
+	})
+
+	it("inserts the hyphen for a bare seven-digit input", () => {
+		expect(normalizeJpPostalCode("1000001")).toBe("100-0001")
+		expect(normalizeJpPostalCode("〒1000001")).toBe("100-0001")
+	})
+
+	it("returns null when the result is not seven digits", () => {
+		expect(normalizeJpPostalCode("100-000")).toBeNull() // six digits
+		expect(normalizeJpPostalCode("10000012")).toBeNull() // eight digits
+		expect(normalizeJpPostalCode("SW1A 1AA")).toBeNull()
+		expect(normalizeJpPostalCode(1000001)).toBeNull()
+	})
+})
+
+describe("isJpPostalCode", () => {
+	it("accepts NNN-NNNN with the hyphen optional", () => {
+		expect(isJpPostalCode("100-0001")).toBe(true)
+		expect(isJpPostalCode("1000001")).toBe(true)
+		expect(isJpPostalCode("100-001")).toBe(false) // wrong digit count
+		expect(isJpPostalCode("〒100-0001")).toBe(false) // normalize first
+	})
+})
+
+describe("firstDigitRegion", () => {
+	it("maps the leading digit to a coarse routing region", () => {
+		expect(firstDigitRegion("100-0001")).toMatch(/Tokyo|Kanto/) // 1xx → Tokyo & Kanto
+		expect(firstDigitRegion("〒1000001")).toMatch(/Tokyo|Kanto/) // normalizes first
+		expect(firstDigitRegion("0600000")).toMatch(/Hokkaido/) // 0xx → Hokkaido & north
+	})
+
+	it("returns null for non-postal-code input", () => {
+		expect(firstDigitRegion("nope")).toBeNull()
+		expect(firstDigitRegion(null)).toBeNull()
+	})
+})

--- a/codex/jp/postal-code.ts
+++ b/codex/jp/postal-code.ts
@@ -1,0 +1,92 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Japanese postal codes (郵便番号, yūbin-bangō): the branded type, the shape, normalization, and the
+ *   first-digit → coarse-region prior.
+ *
+ *   This file is the far end of a spectrum whose other end is `us/zipcode.ts`. A US address leans on
+ *   the street line — a named street plus a house number — and the ZIP is a routing convenience. A
+ *   Japanese address is the inverse on two counts:
+ *
+ *   - It is written **largest-to-smallest**: prefecture → city/ward → district → block → lot (`東京都 千代田区
+ *       千代田 1-1`), the reverse of the US smallest-to-largest line order.
+ *   - There are **essentially no street names**. Outside a few Kyoto-style exceptions, you do not
+ *       navigate by named streets; you navigate by nested administrative areas and numbered
+ *       blocks/lots (丁目 / 番地 / 号 — see `address-unit.ts`).
+ *
+ *   With no street name to anchor on and a reverse field order, the **postal code is the single most
+ *   reliable geographic anchor** for a Japanese address — it pins the chōme-level area directly,
+ *   far tighter than a US ZIP pins a US address. So where the US parser treats the postcode as a
+ *   tie-breaker behind the street, the Japan parser should treat it as the primary key.
+ */
+
+import type { Tagged } from "type-fest"
+
+/**
+ * A Japanese postal code: three digits, a hyphen, then four digits (`100-0001`), conventionally
+ * written after the 〒 mark (`〒100-0001`). Branded so a normalized code is distinct from an
+ * arbitrary string — the 7-digit shape alone does not prove a code is real, only well-formed.
+ *
+ * @category Postal
+ * @type string
+ * @title 郵便番号
+ * @pattern ^\d{3}-?\d{4}$
+ */
+export type PostalCode = Tagged<string, "JpPostalCode">
+
+/** The postal-code shape: `NNN-NNNN`, the hyphen optional on input (`1000001` or `100-0001`). */
+export const JP_POSTAL_CODE_PATTERN = /^\d{3}-?\d{4}$/
+
+/**
+ * Normalize a postal-code surface form to the canonical hyphenated `NNN-NNNN`: strip a leading 〒
+ * mark and any whitespace, then re-insert the hyphen if the input gave the bare seven digits
+ * (`〒100-0001` → `100-0001`, `1000001` → `100-0001`). Returns null if the result is not seven
+ * digits.
+ */
+export function normalizeJpPostalCode(raw: unknown): PostalCode | null {
+	if (typeof raw !== "string") return null
+	// Drop the 〒 mark and all whitespace, then keep only the digits.
+	const digits = raw.replace(/〒/g, "").replace(/\s+/g, "").replace(/-/g, "")
+	if (!/^\d{7}$/.test(digits)) return null
+	return `${digits.slice(0, 3)}-${digits.slice(3)}` as PostalCode
+}
+
+/** Type-predicate for a Japanese postal code (hyphen optional, `100-0001` or `1000001`). */
+export function isJpPostalCode(input: unknown): input is PostalCode {
+	return typeof input === "string" && JP_POSTAL_CODE_PATTERN.test(input)
+}
+
+/**
+ * First digit of the postal code → a coarse region label. Japan Post's numbering grows roughly
+ * outward from Tokyo (`1xx`) and is **approximate** at this granularity — a single leading digit
+ * spans large, irregular areas and the boundaries are postal-routing, not administrative. Use it as
+ * a weak prior, never as a hard region assignment; the full code is what actually anchors the
+ * address.
+ *
+ * Approximate — the labels below are illustrative routing regions, not precise prefecture sets.
+ */
+export const JP_FIRST_DIGIT_REGION: Record<string, string> = {
+	"0": "Hokkaido & northern Tōhoku",
+	"1": "Tokyo & Kanto",
+	"2": "Kanagawa / Shizuoka & central",
+	"3": "northern Kanto / Tōhoku",
+	"4": "Tōkai / Chūbu",
+	"5": "Kinki / Kansai",
+	"6": "Kinki / Chūgoku west",
+	"7": "Chūgoku / Shikoku",
+	"8": "Kyūshū",
+	"9": "Tōhoku north / other",
+}
+
+/**
+ * The coarse region label for a postal code's first digit, or null if the input is not a Japanese
+ * postal code. A weak, approximate prior (see {@link JP_FIRST_DIGIT_REGION}); the full code anchors
+ * the address.
+ */
+export function firstDigitRegion(postalCode: unknown): string | null {
+	const normalized = normalizeJpPostalCode(postalCode)
+	if (!normalized) return null
+	return JP_FIRST_DIGIT_REGION[normalized[0]!] ?? null
+}

--- a/codex/jp/prefecture.test.ts
+++ b/codex/jp/prefecture.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { isJapanesePrefectureCode, JP_PREFECTURES, lookupJapanesePrefecture } from "./prefecture.js"
+
+describe("JP_PREFECTURES", () => {
+	it("covers all 47 prefectures", () => {
+		expect(Object.keys(JP_PREFECTURES)).toHaveLength(47)
+		expect(JP_PREFECTURES["13"].kanji).toBe("東京都")
+		expect(JP_PREFECTURES["13"].romaji).toBe("Tokyo")
+	})
+
+	it("has the legal to/dō/fu/ken split (1 to, 1 do, 2 fu, 43 ken)", () => {
+		const counts = { to: 0, do: 0, fu: 0, ken: 0 }
+		for (const info of Object.values(JP_PREFECTURES)) counts[info.type]++
+		expect(counts).toEqual({ to: 1, do: 1, fu: 2, ken: 43 })
+	})
+
+	it("pins the four special-type prefectures by name", () => {
+		expect(JP_PREFECTURES["13"].type).toBe("to") // Tokyo
+		expect(JP_PREFECTURES["01"].type).toBe("do") // Hokkaido
+		expect(JP_PREFECTURES["26"].type).toBe("fu") // Kyoto
+		expect(JP_PREFECTURES["27"].type).toBe("fu") // Osaka
+	})
+})
+
+describe("isJapanesePrefectureCode", () => {
+	it("accepts the two-digit ISO 3166-2:JP codes", () => {
+		expect(isJapanesePrefectureCode("13")).toBe(true)
+		expect(isJapanesePrefectureCode("01")).toBe(true)
+		expect(isJapanesePrefectureCode("47")).toBe(true)
+		expect(isJapanesePrefectureCode("48")).toBe(false) // out of range
+		expect(isJapanesePrefectureCode("1")).toBe(false) // not zero-padded
+	})
+})
+
+describe("lookupJapanesePrefecture", () => {
+	it("resolves a code directly", () => {
+		expect(lookupJapanesePrefecture("13")).toBe("13")
+		expect(lookupJapanesePrefecture("27")).toBe("27")
+	})
+
+	it("resolves romaji, case-insensitive and macron-optional", () => {
+		expect(lookupJapanesePrefecture("Tokyo")).toBe("13")
+		expect(lookupJapanesePrefecture("tokyo")).toBe("13")
+		expect(lookupJapanesePrefecture("Tōkyō")).toBe("13") // macrons folded
+		expect(lookupJapanesePrefecture("Osaka")).toBe("27")
+	})
+
+	it("resolves romaji with the appended -to / -fu / -ken type-suffix", () => {
+		expect(lookupJapanesePrefecture("Tokyo-to")).toBe("13")
+		expect(lookupJapanesePrefecture("Osaka-fu")).toBe("27")
+		expect(lookupJapanesePrefecture("Aomori-ken")).toBe("02")
+	})
+
+	it("does NOT clip a bare romaji name that merely ends in a suffix syllable", () => {
+		// The guard: only a separated suffix is stripped, so Kyoto/Gifu/Hokkaido/Kumamoto survive.
+		expect(lookupJapanesePrefecture("Kyoto")).toBe("26")
+		expect(lookupJapanesePrefecture("Gifu")).toBe("21")
+		expect(lookupJapanesePrefecture("Hokkaido")).toBe("01")
+		expect(lookupJapanesePrefecture("Kumamoto")).toBe("43")
+	})
+
+	it("resolves kanji, with or without the 都/道/府/県 suffix", () => {
+		expect(lookupJapanesePrefecture("東京都")).toBe("13")
+		expect(lookupJapanesePrefecture("東京")).toBe("13")
+		expect(lookupJapanesePrefecture("大阪府")).toBe("27")
+		expect(lookupJapanesePrefecture("大阪")).toBe("27")
+		expect(lookupJapanesePrefecture("北海道")).toBe("01") // indivisible, indexed whole
+	})
+
+	it("returns null for an unknown surface form", () => {
+		expect(lookupJapanesePrefecture("Bavaria")).toBeNull()
+		expect(lookupJapanesePrefecture("48")).toBeNull()
+		expect(lookupJapanesePrefecture("北海")).toBeNull() // Hokkaido is never clipped to 北海
+		expect(lookupJapanesePrefecture("")).toBeNull()
+		expect(lookupJapanesePrefecture(null)).toBeNull()
+	})
+})

--- a/codex/jp/prefecture.ts
+++ b/codex/jp/prefecture.ts
@@ -1,0 +1,168 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The 47 Japanese prefectures (都道府県, todōfuken), keyed by their ISO 3166-2:JP code — the two-digit
+ *   numeric string `"01"`..`"47"` standing in for `JP-01`..`JP-47`.
+ *
+ *   The contrast with `fr/region.ts`, `de/bundesland.ts`, and `us/state.ts` is in the name itself.
+ *   "都道府県" is four kanji because the top-level admin unit comes in four legally distinct flavours,
+ *   even though all 47 are peers in practice:
+ *
+ *   - 都 (to, "metropolis") — exactly **1**: Tokyo (東京都). The capital's special form.
+ *   - 道 (dō, "circuit") — exactly **1**: Hokkaido (北海道). A historical term; the name already ends in 道,
+ *       so Hokkaido is written and indexed whole, never stripped to "北海".
+ *   - 府 (fu, "urban prefecture") — exactly **2**: Osaka (大阪府) and Kyoto (京都府). The old imperial capital
+ *       region.
+ *   - 県 (ken, "prefecture") — the remaining **43**. The ordinary case.
+ *
+ *   Unlike a French région or a German Bundesland, the prefecture DOES appear on a normal address
+ *   line: a Japanese address is written largest-to-smallest (prefecture → city → ward → block), so
+ *   the prefecture is the first thing written, not an inferred-from-postcode afterthought. See
+ *   `postal-code.ts` for why the postcode is nonetheless the single most reliable anchor.
+ */
+
+/** A to/dō/fu/ken classification of the top-level admin unit. */
+export type JapanesePrefectureType = "to" | "do" | "fu" | "ken"
+
+/** Per-prefecture record: ISO 3166-2:JP numeric code + kanji + romaji + to/dō/fu/ken type. */
+export interface JapanesePrefectureInfo {
+	/** ISO 3166-2:JP code without the `JP-` prefix: a two-digit numeric string (`"13"` for `JP-13`). */
+	code: string
+	/** Kanji name, including its 都/道/府/県 suffix (e.g. `東京都`). */
+	kanji: string
+	/** Macron-free romaji name, suffix-less (e.g. `Tokyo`). */
+	romaji: string
+	/** Which of the four flavours of top-level unit this is. */
+	type: JapanesePrefectureType
+}
+
+/**
+ * ISO 3166-2:JP numeric code → info, for all 47 prefectures. Ordered by code, which is also the
+ * conventional north-to-south-ish ordering (Hokkaido `01` at the top, Okinawa `47` at the bottom).
+ */
+export const JP_PREFECTURES = {
+	"01": { code: "01", kanji: "北海道", romaji: "Hokkaido", type: "do" },
+	"02": { code: "02", kanji: "青森県", romaji: "Aomori", type: "ken" },
+	"03": { code: "03", kanji: "岩手県", romaji: "Iwate", type: "ken" },
+	"04": { code: "04", kanji: "宮城県", romaji: "Miyagi", type: "ken" },
+	"05": { code: "05", kanji: "秋田県", romaji: "Akita", type: "ken" },
+	"06": { code: "06", kanji: "山形県", romaji: "Yamagata", type: "ken" },
+	"07": { code: "07", kanji: "福島県", romaji: "Fukushima", type: "ken" },
+	"08": { code: "08", kanji: "茨城県", romaji: "Ibaraki", type: "ken" },
+	"09": { code: "09", kanji: "栃木県", romaji: "Tochigi", type: "ken" },
+	"10": { code: "10", kanji: "群馬県", romaji: "Gunma", type: "ken" },
+	"11": { code: "11", kanji: "埼玉県", romaji: "Saitama", type: "ken" },
+	"12": { code: "12", kanji: "千葉県", romaji: "Chiba", type: "ken" },
+	"13": { code: "13", kanji: "東京都", romaji: "Tokyo", type: "to" },
+	"14": { code: "14", kanji: "神奈川県", romaji: "Kanagawa", type: "ken" },
+	"15": { code: "15", kanji: "新潟県", romaji: "Niigata", type: "ken" },
+	"16": { code: "16", kanji: "富山県", romaji: "Toyama", type: "ken" },
+	"17": { code: "17", kanji: "石川県", romaji: "Ishikawa", type: "ken" },
+	"18": { code: "18", kanji: "福井県", romaji: "Fukui", type: "ken" },
+	"19": { code: "19", kanji: "山梨県", romaji: "Yamanashi", type: "ken" },
+	"20": { code: "20", kanji: "長野県", romaji: "Nagano", type: "ken" },
+	"21": { code: "21", kanji: "岐阜県", romaji: "Gifu", type: "ken" },
+	"22": { code: "22", kanji: "静岡県", romaji: "Shizuoka", type: "ken" },
+	"23": { code: "23", kanji: "愛知県", romaji: "Aichi", type: "ken" },
+	"24": { code: "24", kanji: "三重県", romaji: "Mie", type: "ken" },
+	"25": { code: "25", kanji: "滋賀県", romaji: "Shiga", type: "ken" },
+	"26": { code: "26", kanji: "京都府", romaji: "Kyoto", type: "fu" },
+	"27": { code: "27", kanji: "大阪府", romaji: "Osaka", type: "fu" },
+	"28": { code: "28", kanji: "兵庫県", romaji: "Hyogo", type: "ken" },
+	"29": { code: "29", kanji: "奈良県", romaji: "Nara", type: "ken" },
+	"30": { code: "30", kanji: "和歌山県", romaji: "Wakayama", type: "ken" },
+	"31": { code: "31", kanji: "鳥取県", romaji: "Tottori", type: "ken" },
+	"32": { code: "32", kanji: "島根県", romaji: "Shimane", type: "ken" },
+	"33": { code: "33", kanji: "岡山県", romaji: "Okayama", type: "ken" },
+	"34": { code: "34", kanji: "広島県", romaji: "Hiroshima", type: "ken" },
+	"35": { code: "35", kanji: "山口県", romaji: "Yamaguchi", type: "ken" },
+	"36": { code: "36", kanji: "徳島県", romaji: "Tokushima", type: "ken" },
+	"37": { code: "37", kanji: "香川県", romaji: "Kagawa", type: "ken" },
+	"38": { code: "38", kanji: "愛媛県", romaji: "Ehime", type: "ken" },
+	"39": { code: "39", kanji: "高知県", romaji: "Kochi", type: "ken" },
+	"40": { code: "40", kanji: "福岡県", romaji: "Fukuoka", type: "ken" },
+	"41": { code: "41", kanji: "佐賀県", romaji: "Saga", type: "ken" },
+	"42": { code: "42", kanji: "長崎県", romaji: "Nagasaki", type: "ken" },
+	"43": { code: "43", kanji: "熊本県", romaji: "Kumamoto", type: "ken" },
+	"44": { code: "44", kanji: "大分県", romaji: "Oita", type: "ken" },
+	"45": { code: "45", kanji: "宮崎県", romaji: "Miyazaki", type: "ken" },
+	"46": { code: "46", kanji: "鹿児島県", romaji: "Kagoshima", type: "ken" },
+	"47": { code: "47", kanji: "沖縄県", romaji: "Okinawa", type: "ken" },
+} as const satisfies Record<string, JapanesePrefectureInfo>
+
+/** An ISO 3166-2:JP prefecture code (`"01"`..`"47"`). */
+export type JapanesePrefectureCode = keyof typeof JP_PREFECTURES
+
+const PREFECTURE_CODE_SET: ReadonlySet<string> = new Set(Object.keys(JP_PREFECTURES))
+
+/** Type-predicate for an ISO 3166-2:JP prefecture code (`"01"`..`"47"`). */
+export function isJapanesePrefectureCode(input: unknown): input is JapanesePrefectureCode {
+	return typeof input === "string" && PREFECTURE_CODE_SET.has(input)
+}
+
+/**
+ * Fold a romaji surface form so `Tōkyō`, `Tokyo`, and `Tokyo-to` all key alike: strip macrons (NFD
+ *
+ * - Drop the combining marks), lowercase, peel off an appended `-to`/`-do`/`-fu`/`-ken` type-suffix,
+ *   then drop everything but `a-z`. `Tōkyō-to` and `tokyo` both → `tokyo`.
+ *
+ * The suffix is only stripped when it is a genuine appendage — separated by a
+ * hyphen/space/middle-dot (`Tokyo-to`, `Osaka fu`) or trailing the macron-bearing long-vowel form.
+ * That guard is load-bearing: four bare romaji names already END in a suffix syllable (Kyo**to**,
+ * Gi**fu**, Hokkai**do**, Kumamo**to**), and a blind trailing-strip would maim them. We never strip
+ * from an unseparated bare name, so `kyoto` stays `kyoto`.
+ */
+function foldRomaji(s: string): string {
+	const lowered = s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+	// Strip an appended type-suffix only when a separator (hyphen / space / middle dot) precedes it.
+	const desuffixed = lowered.replace(/[-\s·][\s]*(to|do|fu|ken)$/, "")
+	return desuffixed.replace(/[^a-z]/g, "")
+}
+
+/**
+ * Strip the trailing 都/道/府/県 admin kanji from a prefecture name (`東京都` → `東京`). Hokkaido is the
+ * exception: `北海道` ends in 道 but is a single indivisible name, so it is left whole.
+ */
+function stripKanjiSuffix(kanji: string): string {
+	if (kanji === "北海道") return kanji
+	return kanji.replace(/[都道府県]$/, "")
+}
+
+/**
+ * Folded romaji / kanji surface form → ISO 3166-2:JP code. Every prefecture contributes several
+ * keys: the macron-folded romaji (and the suffixed `name-ken` form folds to the same key), the full
+ * kanji (`東京都`), and the suffix-less kanji (`東京`). Hokkaido keeps its 道 in both kanji keys.
+ */
+export const JP_PREFECTURE_NAME_TO_CODE: ReadonlyMap<string, JapanesePrefectureCode> = (() => {
+	const out = new Map<string, JapanesePrefectureCode>()
+	for (const code of Object.keys(JP_PREFECTURES) as JapanesePrefectureCode[]) {
+		const info = JP_PREFECTURES[code]
+		out.set(foldRomaji(info.romaji), code)
+		out.set(info.kanji, code)
+		out.set(stripKanjiSuffix(info.kanji), code)
+	}
+	return out
+})()
+
+/**
+ * Resolve a Japanese prefecture surface form to its ISO 3166-2:JP code, accepting:
+ *
+ * - A code directly (`"13"` → `"13"`),
+ * - A romaji name, case-insensitive, macrons optional, with OR without the romaji type-suffix
+ *   (`Tōkyō` / `Tokyo` / `tokyo` / `Tokyo-to` → `"13"`),
+ * - A kanji name, with or without its 都/道/府/県 suffix (`東京都` / `東京` → `"13"`).
+ *
+ * Returns null for anything it cannot place.
+ */
+export function lookupJapanesePrefecture(input: string | null | undefined): JapanesePrefectureCode | null {
+	if (!input || typeof input !== "string") return null
+	const trimmed = input.trim()
+	if (PREFECTURE_CODE_SET.has(trimmed)) return trimmed as JapanesePrefectureCode
+	// Try kanji first (exact, then suffix-less), then fall back to the macron-folded romaji.
+	return JP_PREFECTURE_NAME_TO_CODE.get(trimmed) ?? JP_PREFECTURE_NAME_TO_CODE.get(foldRomaji(trimmed)) ?? null
+}

--- a/codex/package.json
+++ b/codex/package.json
@@ -14,7 +14,10 @@
 		".": "./out/index.js",
 		"./us": "./out/us/index.js",
 		"./de": "./out/de/index.js",
-		"./fr": "./out/fr/index.js"
+		"./fr": "./out/fr/index.js",
+		"./ca": "./out/ca/index.js",
+		"./gb": "./out/gb/index.js",
+		"./jp": "./out/jp/index.js"
 	},
 	"dependencies": {
 		"type-fest": "^5.6.0"


### PR DESCRIPTION
Three more `@mailwoman/codex` slices to stretch the sails before the system-conditioning work. Each was picked because it **breaks an assumption** the US/DE/FR slices share — together they span the real diversity of address systems.

## codex/ca — Canada

- **Alphanumeric postcode** (`A1A 1A1`) — the first *letter* pins the province (`M`→Ontario, `H`→Quebec, `V`→BC). Clean except `X` (shared NT/NU → returns an array) and the big provinces that span several letters (ON owns `K L M N P`).
- **Bilingual street types** — English trails the name (`Maple Avenue`), French leads it (`Rue Sainte-Catherine`), so `isCanadianStreetWord` is position-agnostic. The directionals carry the trap that French `Ouest` abbreviates to **`O`, not `W`**.
- 13 provinces/territories with EN+FR names.

## codex/gb — United Kingdom

- **The most complex postcode** — variable-length alphanumeric (`SW1A 1AA`, `M1 1AE`, `B33 8TH`), split into outward + inward codes, with area/district extraction.
- **The informative twist**: the postcode deliberately does **not** nest into admin geography — postcode areas are a Royal Mail construct, not counties. The area→country map is explicit for the Scottish/Welsh/NI sets (`BT`→NIR, `EH`→SCT, `CF`→WLS…), England by default. A test asserts London `SW` and Manchester `M` both → ENG while Glasgow `G` → SCT.
- 4 constituent countries + British street vocabulary (Crescent, Mews, Wynd, Brae).

## codex/jp — Japan

- **The far end of the spectrum from a US street address**: written largest-to-smallest (prefecture→city→ward→block), with essentially **no street names** — you navigate by numbered blocks/lots, so the **postal code is the primary geographic anchor**.
- `address-unit.ts` ships what stands in for street types: admin suffixes `都/道/府/県/市/区/町/村` and block markers `丁目/番地/番/号`, plus `stripAdminSuffix` (`東京都`→`東京`, with the Hokkaido `北海道` carve-out).
- 47 prefectures (kanji + romaji, the `1 to / 1 do / 2 fu / 43 ken` split), with a romaji fold that correctly leaves **Kyoto/Gifu/Hokkaido/Kumamoto** intact (a blind `-to`/`-fu` strip would have maimed them).

## Scope: reference data only, no consumer wiring

Deliberate — these postcodes are alphanumeric/hyphenated, so they never hit the anchor's digit-only house-number `positionFactor` path, and there's no CA/GB/JP OpenAddresses sample yet for the eval region matcher. The lookups (`lookupCanadianProvince`, `lookupJapanesePrefecture`, `lookupUkCountry`) are exported and ready for when one lands.

## Verification

Drafted in parallel, then integrated and **independently verified**: real-address spot-checks (`M5V 2T6`→ON, `EH1 1BB`→SCT, `〒100-0001`→`100-0001`, `東京都`→13), type counts (13 provinces / 4 countries / 47 prefectures with the correct to/do/fu/ken split). **120 codex tests** green (54 prior + 66 new), 0 eslint errors. Adds `./ca` `./gb` `./jp` subpath exports + root namespaces; no release-pipeline change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)