### PR TITLE
feat(anchor): system-gate the postcode anchor's street check (system-conditioning PR1)

### DIFF
--- a/codex/index.ts
+++ b/codex/index.ts
@@ -13,8 +13,9 @@
  *   for the same tables instead of each carrying their own copy.
  *
  *   Systems are exposed as namespaces (`import { us } from "@mailwoman/codex"`) and as subpaths
- *   (`import { lookupStreetSuffix } from "@mailwoman/codex/us"`). Today only `us` is populated;
- *   other systems land here as the multi-locale push needs them.
+ *   (`import { lookupStreetSuffix } from "@mailwoman/codex/us"`). The cross-system
+ *   `candidateSystemsForPostcode` (the inverse of the per-slice postcode patterns) is a top-level
+ *   export.
  */
 
 export * as ca from "./ca/index.js"
@@ -22,4 +23,5 @@ export * as de from "./de/index.js"
 export * as fr from "./fr/index.js"
 export * as gb from "./gb/index.js"
 export * as jp from "./jp/index.js"
+export { candidateSystemsForPostcode, type SystemCode } from "./postcode-systems.js"
 export * as us from "./us/index.js"

--- a/codex/postcode-systems.test.ts
+++ b/codex/postcode-systems.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { candidateSystemsForPostcode } from "./postcode-systems.js"
+
+describe("candidateSystemsForPostcode", () => {
+	it("a bare 5-digit code is eligible for every numeric-postcode system (shape can't split them)", () => {
+		expect(candidateSystemsForPostcode("68161").sort()).toEqual(["de", "fr", "us"])
+		expect(candidateSystemsForPostcode("75001").sort()).toEqual(["de", "fr", "us"])
+	})
+
+	it("the German D- prefix narrows to Germany alone", () => {
+		expect(candidateSystemsForPostcode("D-68161")).toEqual(["de"])
+	})
+
+	it("US ZIP+4 is US-only (the -NNNN tail no other system accepts)", () => {
+		expect(candidateSystemsForPostcode("94105-1234")).toEqual(["us"])
+	})
+
+	it("an alphanumeric Canadian code resolves to Canada alone", () => {
+		expect(candidateSystemsForPostcode("K1A 0B1")).toEqual(["ca"])
+		expect(candidateSystemsForPostcode("M5V2T6")).toEqual(["ca"])
+	})
+
+	it("a UK postcode resolves to the UK alone", () => {
+		expect(candidateSystemsForPostcode("SW1A 1AA")).toEqual(["gb"])
+		expect(candidateSystemsForPostcode("M1 1AE")).toEqual(["gb"])
+	})
+
+	it("a Japanese NNN-NNNN code resolves to Japan alone", () => {
+		expect(candidateSystemsForPostcode("100-0001")).toEqual(["jp"])
+	})
+
+	it("returns empty for a shape no system recognizes", () => {
+		expect(candidateSystemsForPostcode("27")).toEqual([])
+		expect(candidateSystemsForPostcode("123456789")).toEqual([])
+		expect(candidateSystemsForPostcode("")).toEqual([])
+	})
+})

--- a/codex/postcode-systems.ts
+++ b/codex/postcode-systems.ts
@@ -1,0 +1,61 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The inverse of the per-slice postcode patterns: given a postcode string, which address SYSTEMS
+ *   could it belong to? Each codex slice owns its own postcode shape (`us` accepts
+ *   `\d{5}(-\d{4})?`, `ca` accepts `A1A 1A1`, `jp` accepts `NNN-NNNN`, …); this is the single place
+ *   that asks all of them at once and collects the matches.
+ *
+ *   It is the shared source of truth for "which systems can this shape be" — consumed by the postcode
+ *   anchor (to narrow which systems' street vocabularies it checks) and, in time, by the runtime
+ *   pipeline's locale gate (so its format→locale scoring derives from the same patterns rather than
+ *   a second, divergent copy). The point is to unify the DATA, not to couple the modules: callers
+ *   depend on this pure function, never on each other.
+ *
+ *   Note this is a SHAPE test, not a gazetteer-membership test. A bare `68161` matches the US,
+ *   German, AND French 5-digit shapes, so it returns `["us", "de", "fr"]` — the shape alone cannot
+ *   split the numeric-postcode systems. The anchor uses real gazetteer membership for the finer
+ *   call; this function answers the coarser, model-free "which systems is this shape even eligible
+ *   for".
+ */
+
+import { normalizeCaPostalCode } from "./ca/index.js"
+import { normalizePLZ } from "./de/index.js"
+import { normalizeCodePostal } from "./fr/index.js"
+import { normalizeUkPostcode } from "./gb/index.js"
+import { normalizeJpPostalCode } from "./jp/index.js"
+import { isZipCode } from "./us/index.js"
+
+/** A codex address-system code — the subpath under `@mailwoman/codex/<system>`. */
+export type SystemCode = "us" | "de" | "fr" | "ca" | "gb" | "jp"
+
+/**
+ * Per-system membership test: each entry returns true when the string is accepted by that system's
+ * own postcode shape (after that system's normalization — so `D-68161` reaches `de`, `1012 LM`
+ * reaches nothing here since NL has no slice yet, etc.). Ordered for a stable, alphabetical-ish
+ * result.
+ */
+const SYSTEM_ACCEPTS: ReadonlyArray<readonly [SystemCode, (s: string) => boolean]> = [
+	["us", (s) => isZipCode(s)],
+	["de", (s) => normalizePLZ(s) !== null],
+	["fr", (s) => normalizeCodePostal(s) !== null],
+	["ca", (s) => normalizeCaPostalCode(s) !== null],
+	["gb", (s) => normalizeUkPostcode(s) !== null],
+	["jp", (s) => normalizeJpPostalCode(s) !== null],
+]
+
+/**
+ * Every address system whose own postcode shape accepts `postcode`. Empty when no system recognizes
+ * the shape (e.g. a bare `27`, or a 7-digit run). O(number of systems) — a handful of cheap regex
+ * tests, run only on the few postcode-shaped spans an address contains.
+ */
+export function candidateSystemsForPostcode(postcode: string): SystemCode[] {
+	if (typeof postcode !== "string" || postcode.length === 0) return []
+	const out: SystemCode[] = []
+	for (const [system, accepts] of SYSTEM_ACCEPTS) {
+		if (accepts(postcode)) out.push(system)
+	}
+	return out
+}

--- a/neural/postcode-anchor.test.ts
+++ b/neural/postcode-anchor.test.ts
@@ -117,6 +117,8 @@ describe("extractPostcodeAnchors — position-aware confidence (house-number dis
 		"12345": [{ country: "US", lat: 42.1, lon: -72.6 }],
 		"90210": [{ country: "US", lat: 34.1, lon: -118.4 }],
 		"SW1A 1AA": [{ country: "GB", lat: 51.5, lon: -0.12 }],
+		// A German-member code, for the membership-gated German-vocab cases below.
+		"12623": [{ country: "DE", lat: 52.48, lon: 13.6 }],
 	})
 
 	it("down-weights a real-code-shaped span sharing a street segment (likely a house number)", () => {
@@ -146,9 +148,18 @@ describe("extractPostcodeAnchors — position-aware confidence (house-number dis
 		expect(a!.confidence).toBe(1)
 	})
 
-	it("matches an agglutinative compound street (German Straße) by suffix", () => {
+	it("matches an agglutinative compound street (German Straße) by suffix — for a German-member code", () => {
+		// 12623 is a German member, so the German vocabulary is in the gate and Straußstraße fires.
+		const [a] = extractPostcodeAnchors("Straußstraße 12623, Berlin", R)
+		expect(a!.positionFactor).toBeLessThan(1)
+	})
+
+	it("GATES OUT a non-member system's vocabulary: a US-only code is not penalized by a German street word", () => {
+		// 12345 resolves US-only, so the German vocab is never consulted — Straußstraße does not fire.
+		// (This is the cross-locale-collision fix: an unrelated system's words can't down-weight a code
+		// that doesn't belong to that system.)
 		const [a] = extractPostcodeAnchors("Straußstraße 12345, Berlin", R)
-		expect(a!.positionFactor).toBeLessThan(1) // 12345 shares its segment with Straußstraße
+		expect(a!.positionFactor).toBe(1)
 	})
 })
 

--- a/neural/postcode-anchor.ts
+++ b/neural/postcode-anchor.ts
@@ -29,6 +29,7 @@
  *       1.0.
  */
 
+import { candidateSystemsForPostcode } from "@mailwoman/codex"
 import { isGermanStreetToken } from "@mailwoman/codex/de"
 import { isFrenchStreetWord } from "@mailwoman/codex/fr"
 import { isStreetSuffixToken, isUsStateAbbreviation } from "@mailwoman/codex/us"
@@ -193,20 +194,22 @@ const NL_STREET_SUFFIXES = ["straat", "laan", "plein", "gracht", "kade", "dijk",
  * `@mailwoman/codex/fr` ({@link isFrenchStreetWord}). ES/IT and Dutch fall back to the inline
  * lists.
  *
- * Suffix vocabularies collide across locales (German `-ring` matches English `spring`). That stays
- * harmless because the caller only tests tokens inside the postcode's OWN comma-segment, which
- * holds the city/state, not a street — and a misfire only scales confidence, which the consumer's
- * floor absorbs. A locale-conditioned check is the cleaner long-term fix once the anchor carries a
- * locale.
+ * `systems` GATES which vocabularies are consulted — only the systems the postcode plausibly
+ * belongs to (its gazetteer membership, e.g. a US-only ZIP gates to `{us}` and never checks the
+ * German or French vocab). This is what lets the check scale to 15-20 systems without a
+ * cross-locale collision (German `-ring` vs English `spring`): an unrelated system's vocabulary is
+ * simply never asked. The gate carries lowercase system/locale tags (`us`, `de`, `fr`, `es`, `it`,
+ * `nl`).
  */
-function looksLikeStreetWord(token: string): boolean {
+function looksLikeStreetWord(token: string, systems: ReadonlySet<string>): boolean {
 	const t = token.toLowerCase().replace(/[^\p{L}]/gu, "")
 	if (t.length < 2) return false
-	if (isStreetSuffixToken(t) && !isUsStateAbbreviation(t)) return true
-	if (isGermanStreetToken(t)) return true
-	if (isFrenchStreetWord(t)) return true
-	if (NON_US_STREET_WORDS.has(t)) return true
-	return NL_STREET_SUFFIXES.some((s) => t.length > s.length && t.endsWith(s))
+	if (systems.has("us") && isStreetSuffixToken(t) && !isUsStateAbbreviation(t)) return true
+	if (systems.has("de") && isGermanStreetToken(t)) return true
+	if (systems.has("fr") && isFrenchStreetWord(t)) return true
+	if ((systems.has("es") || systems.has("it")) && NON_US_STREET_WORDS.has(t)) return true
+	if (systems.has("nl")) return NL_STREET_SUFFIXES.some((s) => t.length > s.length && t.endsWith(s))
+	return false
 }
 
 /**
@@ -216,14 +219,17 @@ function looksLikeStreetWord(token: string): boolean {
  * tell a leading `12345 Main St` house number from a trailing `San Francisco 94105` postcode with
  * no model in the loop — and lets a consumer pick the right span by confidence instead of by raw
  * position.
+ *
+ * `systems` narrows the street vocabularies to the ones this code plausibly belongs to (its
+ * gazetteer membership, or — for a code in no gazetteer — the format-shape candidates from codex).
  */
-function positionFactor(text: string, start: number, normalized: string): number {
+function positionFactor(text: string, start: number, normalized: string, systems: ReadonlySet<string>): number {
 	if (!/^\d+$/.test(normalized)) return 1 // only digit-only codes collide with house numbers
 	const segStart = text.lastIndexOf(",", start - 1) + 1
 	let segEnd = text.indexOf(",", start)
 	if (segEnd < 0) segEnd = text.length
 	for (const token of text.slice(segStart, segEnd).split(/\s+/)) {
-		if (looksLikeStreetWord(token)) return HOUSE_NUMBER_PENALTY
+		if (looksLikeStreetWord(token, systems)) return HOUSE_NUMBER_PENALTY
 	}
 	return 1
 }
@@ -274,7 +280,14 @@ export function extractPostcodeAnchors(
 			if (placed) candidates.push(placed)
 		}
 
-		const position = positionFactor(text, match.start, normalized)
+		// Gate the street-word check to the systems this code plausibly belongs to: its gazetteer
+		// membership when known (precise — a US-only ZIP never checks the German vocab), else the
+		// format-shape candidates from codex (for a code in no gazetteer; its confidence is 0 anyway).
+		const systems =
+			countries.length > 0
+				? new Set(countries.map((c) => c.toLowerCase()))
+				: new Set<string>(candidateSystemsForPostcode(normalized))
+		const position = positionFactor(text, match.start, normalized, systems)
 		const confidence = confidenceFromCountryCount(k) * (matchType === "fuzzy" ? FUZZY_PENALTY : 1) * position
 
 		anchors.push({

--- a/scripts/diag-localeprior-probe.ts
+++ b/scripts/diag-localeprior-probe.ts
@@ -1,0 +1,65 @@
+/**
+ * Risk-probe for the LocalePrior architecture (DeepSeek consult 2026-06-03). Measures whether the
+ * postcode anchor alone can supply a confident country signal — the assumption PR2 (locale-prior
+ * replacing --default-country) rides on. For each OA address: highest-confidence anchor's posterior
+ * → max-prob, argmax, k. Reports: anchor-presence, high-confidence-rate (max-prob>0.9),
+ * argmax-correctness, k-histogram.
+ */
+import { extractPostcodeAnchors } from "@mailwoman/neural/postcode-anchor"
+import { WofPostcodeLookup } from "@mailwoman/resolver-wof-sqlite"
+import { readFileSync } from "node:fs"
+
+const SHARDS = [
+	"/mnt/playpen/mailwoman-data/wof/postalcode-us.db",
+	"/mnt/playpen/mailwoman-data/wof/postalcode-intl.db",
+]
+const lookup = new WofPostcodeLookup(SHARDS)
+
+function probe(path: string, trueCountry: string, limit = 1500) {
+	const rows = readFileSync(path, "utf8")
+		.split("\n")
+		.filter((l) => l.trim())
+		.slice(0, limit)
+		.map((l) => JSON.parse(l))
+	let noAnchor = 0,
+		withAnchor = 0,
+		highConf = 0,
+		highConfCorrect = 0,
+		argmaxCorrect = 0
+	const kHist: Record<number, number> = {}
+	for (const r of rows) {
+		const input = r.input ?? r.text ?? ""
+		const anchors = extractPostcodeAnchors(input, lookup)
+		// highest-confidence anchor with a non-empty posterior
+		const placed = anchors.filter((a) => Object.keys(a.posterior).length > 0)
+		if (placed.length === 0) {
+			noAnchor++
+			continue
+		}
+		withAnchor++
+		const best = placed.reduce((m, a) => (a.confidence > m.confidence ? a : m))
+		const entries = Object.entries(best.posterior).sort((x, y) => y[1] - x[1])
+		const [argCountry, maxProb] = entries[0]!
+		const k = entries.length
+		kHist[k] = (kHist[k] ?? 0) + 1
+		if (argCountry.toUpperCase() === trueCountry) argmaxCorrect++
+		if (maxProb > 0.9) {
+			highConf++
+			if (argCountry.toUpperCase() === trueCountry) highConfCorrect++
+		}
+	}
+	const n = rows.length
+	const pct = (x: number) => `${((100 * x) / n).toFixed(1)}%`
+	console.log(`\n=== ${trueCountry} sample (${n} rows) ===`)
+	console.log(`  anchor present:        ${pct(withAnchor)}  (no anchor: ${pct(noAnchor)})`)
+	console.log(`  HIGH-CONF (maxprob>0.9): ${pct(highConf)}   <-- the gate metric (bar ~60%)`)
+	console.log(
+		`    ...of which argmax == ${trueCountry}: ${highConf ? ((100 * highConfCorrect) / highConf).toFixed(1) : "0"}%`
+	)
+	console.log(`  argmax == ${trueCountry} (any conf): ${pct(argmaxCorrect)}`)
+	console.log(`  k (countries in posterior) histogram: ${JSON.stringify(kHist)}`)
+}
+
+probe("data/eval/external/openaddresses-us-sample.jsonl", "US")
+probe("data/eval/external/openaddresses-de-sample.jsonl", "DE")
+lookup.close()


### PR DESCRIPTION
The first concrete step out of the system-conditioning consult ([session notes](../blob/main/.agents/skills/deepseek-consult/session-notes-2026-06-03-system-conditioning.md)). DeepSeek reframed the locale-blind `looksLikeStreetWord` as a *symptom*: the real gap is "no single early locale prior the pre-neural passes can condition on." PR1 lays the foundation — give the anchor a way to **narrow** which systems it consults.

## What's in it

**codex** — a new top-level `candidateSystemsForPostcode(postcode) → SystemCode[]`: the **inverse** of the per-slice postcode patterns (asks every slice's shape at once). The single shared source of truth for "which systems can this shape be" — which `locale-gate`'s `scoreByPostcode` can later derive from too, instead of a second divergent copy. **Unify the data, not the modules.** It's a *shape* test: `68161` → `[us,de,fr]` (the shape can't split the numeric-postcode systems; that's the anchor's job via membership).

**anchor** — `looksLikeStreetWord(token, systems)` now **gates** each system's street vocabulary by the postcode's gazetteer **membership**. A US-only ZIP gates to `{us}` and never checks the German or French vocab; a code in no gazetteer falls back to the codex format-candidates. This is what lets the check scale to 15–20 systems without a cross-locale collision — an unrelated system's words can no longer down-weight a code that doesn't belong to it. Membership is computed before `positionFactor`, so it's non-circular.

## Tripwire 1 (no regression) — passes

US and DE `oa-resolver-eval` byte-identical (US 2.8/11.2/25.7 km, DE 1.3/5.7/13.5 km). The gating is a precision/scaling change, invisible on the clean samples — exactly as intended. A new test proves the gate **excludes** a non-member system's vocabulary. **149 codex+anchor tests green.**

## Why PR2/PR3 are deferred (the risk-probe earned its keep)

Before building anything, I ran the risk-probe (`scripts/diag-localeprior-probe.ts`, committed) the consult prescribed: can an anchor-only `LocalePrior` replace the resolver's `--default-country` flag?

| | US | DE |
|---|--:|--:|
| anchor present | 100% | 100% |
| **single-country postcode (confident)** | **27.9%** | **44.1%** |

It can't — a postcode is unambiguous only ~28%/44% of the time (the rest are 5-digit codes shared across US/DE/FR/ES/IT). This **empirically confirms the design's central thesis**: detecting the country before parsing needs the full parse, so the authoritative locale posterior belongs in the *model* (self-conditioning, the planned retrain), not a cheap pre-pass. PR2 as specified (drop the flag for an anchor-only prior) would have failed its own tripwire — the probe saved us from building it. **PR1 stands alone and is independently valuable.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)