### PR TITLE
feat(train): PR3 self-conditioning architecture + Pilot A config (no GPU)

### DIFF
--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -91,6 +91,19 @@ class ModelConfig:
     # config field so corpus-side feature shape and model-side projection width stay
     # in lockstep through the model-card layer.
     phrase_feature_dim: int = 10  # = PHRASE_BIE_DIM (3) + PHRASE_KIND_DIM (7)
+    # PR3: self-conditioning. When True, the encoder pools its output into a locale posterior
+    # (an auxiliary head over the labels.LOCALE_COUNTRIES vocabulary, trained on the corpus
+    # ``country`` field) and FiLM-modulates the per-token representations by it before the BIO
+    # head — the model infers "which country" globally, then conditions its own labeling on it.
+    # The head is exported as the LocalePosterior the resolver consumes. Default False keeps
+    # v0.8.x numerics for back-compat. ``num_locales`` is NOT a yaml knob — build_model derives
+    # it from labels.NUM_LOCALES so the head width and the target vocabulary can never drift.
+    use_locale_conditioning: bool = False
+    # Weight on the auxiliary locale cross-entropy leg (loss = BIO_CE + crf + locale_loss_weight ×
+    # locale_CE). 0.0 disables the aux loss even when conditioning is on (the FiLM path still runs
+    # unsupervised, which is rarely what you want); a value like 0.3 keeps the locale signal a
+    # genuine but secondary objective behind the per-token BIO task.
+    locale_loss_weight: float = 0.0
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/configs/v0.9.0-pilot-selfcond.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0.9.0-pilot-selfcond.yaml
@@ -1,0 +1,145 @@
+# PR3 Pilot A — self-conditioning, from scratch, US/FR/DE. The de-risk run.
+#
+# Tests ONE hypothesis: a model that infers the country from the whole address (an auxiliary
+# locale head over the pooled sequence) and FiLM-conditions its own per-token labeling on it
+# parses better and stops the Saint-Albans cross-tag collapse — WITHOUT regressing US/FR. The
+# probe behind PR3 (docs/articles/plan/2026-06-04-pr3-self-conditioned-retrain.md) showed the
+# postcode alone pins the country only 28-44% of the time, so the city/street evidence the model
+# reads is genuinely load-bearing.
+#
+# SINGLE VARIABLE: this is the v0.7.2-PROVEN recipe (1.5e-4 constant / 1k warmup, ls 0.1, CRF off,
+# bf16) with self-conditioning the ONLY addition. Any delta is attributable to the conditioning,
+# not the recipe — the same A/B discipline as the v0.8.x MLM arms.
+#
+# STOP AT 20k (the early gate). Pre-registered, from the design doc:
+#   - cross_pollution < 1% per locale (the live tripwire — watch it on the dashboard)
+#   - DE locality F1 >= 70% and rising
+#   - US/FR within ~1pp of v0.7.2 (no-regression on the incumbents)
+#   - locale_acc climbing (the aux head is actually learning "which country")
+# If the gate holds, a follow-up extends to a full 100k run; if it fails, stop and diagnose ONE
+# knob (NaN protocol).
+#
+# ⚠ DATA DEPENDENCY (pre-launch): the from-scratch corpus must INCLUDE German rows. The v0.4.0
+# base below is US/FR; the German OA adapter (DE-1) exists but its shards must be merged into the
+# corpus the trainer reads, and the German source given a weight, before this launches. Until then
+# DE: 1.0 below filters to zero rows. Finalize corpus_dir + the DE source weight at launch.
+#
+# Launch (after the corpus is DE-inclusive):
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0.9.0-pilot-selfcond.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  # TODO(launch): point at a DE-inclusive corpus (v0.4.0 base + German shards merged).
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  # US/FR/DE balanced — the three-way pilot. DE requires the corpus dependency above.
+  country_weights:
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+    # TODO(launch): add the German OA adapter's source id + weight (e.g. oa-de: 3.0).
+  train_rows_per_epoch: 1000000
+  val_rows: 4096 # bumped vs v0.8.1 so the per-locale cross_pollution tripwire has DE support
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  # CRF off via zero weight — head exists (parity) but contributes no loss. Avoids the
+  # CRF-under-bf16 NaN; keeps self-conditioning the only new behaviour in the loss.
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  # PR3: the headline change. Self-conditioning on; the aux locale loss is a genuine but
+  # secondary objective behind the per-token BIO task. num_locales is derived from labels, not set
+  # here (it can't drift from the aux-target vocabulary).
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v090-pilot-selfcond-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  # Stop at the 20k early gate. Extend to 100k in a follow-up config only if the gate holds.
+  max_steps: 20000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.9.0-pilot-selfcond-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -37,7 +37,7 @@ import pyarrow.parquet as pq
 
 from .augment import augment_row
 from .config import Config, DataConfig
-from .labels import IGNORE_INDEX, active_components_present
+from .labels import IGNORE_INDEX, active_components_present, locale_id
 from .tokenizer import Tokenizer, encode_row, whitespace_spans
 
 _REQUIRED_COLUMNS: tuple[str, ...] = ("raw", "tokens", "labels", "country", "source")
@@ -48,6 +48,10 @@ class EncodedExample:
     input_ids: list[int]
     attention_mask: list[int]
     labels: list[int]
+    # PR3 self-conditioning: the row's locale class id (from its ``country``), or IGNORE_INDEX
+    # when unmapped. The aux locale head's per-row target. Defaults to IGNORE_INDEX so encoders
+    # built without locale conditioning are unaffected.
+    locale_id: int = IGNORE_INDEX
 
 
 def _shard_paths(corpus_dir: Path, split: str) -> list[Path]:
@@ -456,6 +460,7 @@ def iter_encoded(
             input_ids=enc["input_ids"],
             attention_mask=enc["attention_mask"],
             labels=enc["labels"],
+            locale_id=locale_id(row.get("country")),
         )
 
 
@@ -465,6 +470,7 @@ def collate(batch: list[EncodedExample]) -> dict:
         "input_ids": [ex.input_ids for ex in batch],
         "attention_mask": [ex.attention_mask for ex in batch],
         "labels": [ex.labels for ex in batch],
+        "locale_ids": [ex.locale_id for ex in batch],
     }
 
 

--- a/corpus-python/src/mailwoman_train/labels.py
+++ b/corpus-python/src/mailwoman_train/labels.py
@@ -94,6 +94,33 @@ ID_TO_LABEL: Final[dict[int, str]] = {i: label for label, i in LABEL_TO_ID.items
 # Labels that mean "ignore" in cross-entropy. The HF Trainer treats ``-100`` as the sentinel.
 IGNORE_INDEX: Final[int] = -100
 
+# --- Locale conditioning (PR3 / self-conditioning) -----------------------------------
+# Country (ISO 3166-1 alpha-2) → locale class id for the auxiliary self-conditioning head.
+# The head predicts which country an address belongs to from the POOLED sequence; that
+# posterior conditions the per-token labeling (model.py FiLM) and is the LocalePosterior the
+# resolver consumes. The probe behind PR3 showed the postcode alone pins the country only
+# 28–44% of the time, so the model must infer it from the whole string — this map is the
+# aux head's target vocabulary.
+#
+# Stable order: NEVER reorder, only APPEND, so a checkpoint's locale-head ids stay
+# reproducible (same discipline as the BIO STAGE-N constants above). A row whose ``country``
+# is absent from this map maps to IGNORE_INDEX and contributes nothing to the aux loss —
+# graceful for locales the head wasn't trained on. The head still carries a slot for every
+# entry here, so the pilot (US/FR/DE) can grow to the others without a geometry change.
+LOCALE_COUNTRIES: Final[tuple[str, ...]] = (
+    "US", "FR", "DE", "CA", "GB", "JP", "ES", "IT", "NL",
+)
+LOCALE_TO_ID: Final[dict[str, int]] = {c: i for i, c in enumerate(LOCALE_COUNTRIES)}
+ID_TO_LOCALE: Final[dict[int, str]] = {i: c for c, i in LOCALE_TO_ID.items()}
+NUM_LOCALES: Final[int] = len(LOCALE_COUNTRIES)
+
+
+def locale_id(country: str | None) -> int:
+    """Country (ISO-2, case-insensitive) → locale class id, or IGNORE_INDEX if unmapped."""
+    if not country:
+        return IGNORE_INDEX
+    return LOCALE_TO_ID.get(country.strip().upper(), IGNORE_INDEX)
+
 
 def collapse_label(bio_label: str) -> str:
     """Rewrite a BIO label to its active-set equivalent, or ``O``.

--- a/corpus-python/src/mailwoman_train/model.py
+++ b/corpus-python/src/mailwoman_train/model.py
@@ -37,7 +37,7 @@ from torch import nn
 
 from .config import Config
 from .crf import LinearChainCRF, TopKPath
-from .labels import ID_TO_LABEL, LABEL_TO_ID, ACTIVE_BIO_LABELS
+from .labels import ID_TO_LABEL, LABEL_TO_ID, ACTIVE_BIO_LABELS, IGNORE_INDEX, NUM_LOCALES
 from .phrase_priors import PHRASE_FEATURE_DIM
 
 
@@ -64,11 +64,19 @@ class _CoarseEncoderOutput:
     to the bert-style call signature the trainer and exporter expect.
     """
 
-    __slots__ = ("loss", "logits")
+    __slots__ = ("loss", "logits", "locale_logits")
 
-    def __init__(self, logits: torch.Tensor, loss: torch.Tensor | None) -> None:
+    def __init__(
+        self,
+        logits: torch.Tensor,
+        loss: torch.Tensor | None,
+        locale_logits: torch.Tensor | None = None,
+    ) -> None:
         self.logits = logits
         self.loss = loss
+        # PR3 self-conditioning: ``(batch, num_locales)`` locale posterior logits from the aux
+        # head, or None when the encoder was built without ``use_locale_conditioning``.
+        self.locale_logits = locale_logits
 
 
 class EncoderBlock(nn.Module):
@@ -150,11 +158,20 @@ class MailwomanCoarseEncoder(nn.Module):
         class_weights: torch.Tensor | None = None,
         use_phrase_priors: bool = False,
         phrase_feature_dim: int = PHRASE_FEATURE_DIM,
+        use_locale_conditioning: bool = False,
+        num_locales: int = NUM_LOCALES,
+        locale_loss_weight: float = 0.0,
     ) -> None:
         super().__init__()
         self.pad_token_id = pad_token_id
         self.max_position_embeddings = max_position_embeddings
         self.num_labels = num_labels
+        # PR3 self-conditioning: an auxiliary locale head over the pooled sequence + a FiLM
+        # modulation of the per-token reps by the inferred locale. See forward() for the data
+        # flow and the design doc (2026-06-04-pr3-self-conditioned-retrain.md) for the why.
+        self.use_locale_conditioning = use_locale_conditioning
+        self.num_locales = int(num_locales)
+        self.locale_loss_weight = float(locale_loss_weight)
         # v0.5.0 thread C: phrase-prior input-layer features (from Stage 2.7 phrase grouper,
         # Thread E). When ``use_phrase_priors`` is on, the encoder takes an additional
         # ``(B, S, phrase_feature_dim)`` tensor at forward time, concatenates it onto the
@@ -242,6 +259,23 @@ class MailwomanCoarseEncoder(nn.Module):
         # pre-v0.3.0 checkpoints.
         self.crf: LinearChainCRF | None = LinearChainCRF(num_labels, ID_TO_LABEL) if use_crf else None
 
+        # PR3 self-conditioning modules. ``locale_head`` maps the pooled (mean over real tokens)
+        # representation to the locale posterior — the aux supervised signal AND the exported
+        # LocalePosterior. ``locale_film`` produces a (scale, shift) pair from the same pooled
+        # vector that FiLM-modulates the per-token reps feeding the BIO head. ``locale_film`` is
+        # zero-initialized in _init_weights so the model starts as the EXACT identity of an
+        # unconditioned encoder (gamma=0, beta=0 → h unchanged) and only learns to modulate as the
+        # aux gradient flows — this is the de-risking move against the CRF-style from-scratch
+        # divergence (one new behaviour, introduced gently, not a cold-start architecture shock).
+        self.locale_head: nn.Linear | None
+        self.locale_film: nn.Linear | None
+        if self.use_locale_conditioning:
+            self.locale_head = nn.Linear(hidden_size, self.num_locales)
+            self.locale_film = nn.Linear(hidden_size, 2 * hidden_size)
+        else:
+            self.locale_head = None
+            self.locale_film = None
+
         self._init_weights()
 
     def _init_weights(self) -> None:
@@ -270,6 +304,12 @@ class MailwomanCoarseEncoder(nn.Module):
         if self.token_embeddings.padding_idx is not None:
             with torch.no_grad():
                 self.token_embeddings.weight[self.token_embeddings.padding_idx].zero_()
+        # PR3: zero-init the FiLM projection so conditioning starts as a no-op (gamma=0, beta=0).
+        # The blanket xavier loop above gave it real weights; reset them so the from-scratch model
+        # begins identical to an unconditioned encoder and learns to modulate gradually.
+        if self.locale_film is not None:
+            nn.init.zeros_(self.locale_film.weight)
+            nn.init.zeros_(self.locale_film.bias)
 
     def forward(
         self,
@@ -277,6 +317,7 @@ class MailwomanCoarseEncoder(nn.Module):
         attention_mask: torch.Tensor | None = None,
         labels: torch.Tensor | None = None,
         phrase_features: torch.Tensor | None = None,
+        locale_ids: torch.Tensor | None = None,
     ) -> "_CoarseEncoderOutput":
         bsz, seq = input_ids.shape
         if seq > self.max_position_embeddings:
@@ -325,6 +366,29 @@ class MailwomanCoarseEncoder(nn.Module):
             h = block(h, key_padding_mask=kpm)
 
         h = self.final_ln(h)
+
+        # PR3 self-conditioning: infer a locale posterior from the WHOLE sequence, then let it
+        # reshape the per-token reps before the BIO head. This is the "globally, before per-token
+        # labels" step the design calls for — and the reason it earns its keep is the probe: the
+        # postcode alone settles the country <50% of the time, so the model has to read the city
+        # and street to know where it is, then condition on that. Runs at inference too (predict()
+        # routes through here), so the conditioning shapes real emissions, not just the loss.
+        locale_logits: torch.Tensor | None = None
+        if self.use_locale_conditioning and self.locale_head is not None and self.locale_film is not None:
+            # Mean-pool over real (non-pad) tokens. fp32 reduction on principle — the v0.6.0 CRF
+            # NaN was a bf16-reduction failure, and we keep every new reduction in fp32.
+            if attention_mask is not None:
+                m = attention_mask.to(torch.float32).unsqueeze(-1)  # (B, S, 1)
+                pooled = (h.float() * m).sum(dim=1) / m.sum(dim=1).clamp(min=1.0)  # (B, hidden)
+            else:
+                pooled = h.float().mean(dim=1)
+            pooled = pooled.to(h.dtype)
+            locale_logits = self.locale_head(pooled)  # (B, num_locales)
+            # FiLM modulation: scale by (1 + gamma) and shift by beta, both predicted from the
+            # pooled locale rep. gamma/beta start at 0 (zero-init film) so this begins as identity.
+            gamma, beta = self.locale_film(pooled).chunk(2, dim=-1)  # each (B, hidden)
+            h = (1.0 + gamma).unsqueeze(1) * h + beta.unsqueeze(1)
+
         logits = self.classifier(h)
 
         loss: torch.Tensor | None = None
@@ -383,7 +447,28 @@ class MailwomanCoarseEncoder(nn.Module):
                 loss = ce_loss + self.crf_loss_weight * crf_loss.to(ce_loss.dtype)
             else:
                 loss = ce_loss
-        return _CoarseEncoderOutput(logits=logits, loss=loss)
+
+        # PR3: auxiliary locale cross-entropy. Supervises the locale head against the row's
+        # country so the pooled representation (and therefore the FiLM conditioning) actually
+        # encodes "which country". fp32 CE over the small locale vocabulary. Rows whose country
+        # is unmapped carry IGNORE_INDEX and are skipped; a batch with no mapped row contributes
+        # nothing (guards the all-ignored 0/0 → NaN edge).
+        if (
+            self.use_locale_conditioning
+            and locale_logits is not None
+            and locale_ids is not None
+            and self.locale_loss_weight > 0
+            and bool((locale_ids != IGNORE_INDEX).any())
+        ):
+            locale_ce = nn.functional.cross_entropy(
+                locale_logits.float(),
+                locale_ids,
+                ignore_index=IGNORE_INDEX,
+            )
+            locale_term = self.locale_loss_weight * locale_ce
+            loss = locale_term if loss is None else loss + locale_term.to(loss.dtype)
+
+        return _CoarseEncoderOutput(logits=logits, loss=loss, locale_logits=locale_logits)
 
     @torch.no_grad()
     def predict(
@@ -509,6 +594,11 @@ class MailwomanCoarseEncoder(nn.Module):
             # ``phrase_input_projection`` layer.
             "use_phrase_priors": bool(self.use_phrase_priors),
             "phrase_feature_dim": int(self.phrase_feature_dim),
+            # PR3 self-conditioning. False/0 on pre-PR3 weights; loaders branch on the flag to
+            # materialize locale_head / locale_film at the persisted num_locales width.
+            "use_locale_conditioning": bool(self.use_locale_conditioning),
+            "num_locales": int(self.num_locales),
+            "locale_loss_weight": float(self.locale_loss_weight),
             "id2label": dict(ID_TO_LABEL),
             "label2id": dict(LABEL_TO_ID),
         }
@@ -552,6 +642,10 @@ class MailwomanCoarseEncoder(nn.Module):
             # v0.5.0+ fields. Default to v0.4.0 behavior (no phrase priors).
             use_phrase_priors=cfg.get("use_phrase_priors", False),
             phrase_feature_dim=cfg.get("phrase_feature_dim", PHRASE_FEATURE_DIM),
+            # PR3 fields. Default off for back-compat with pre-PR3 checkpoints.
+            use_locale_conditioning=cfg.get("use_locale_conditioning", False),
+            num_locales=cfg.get("num_locales", NUM_LOCALES),
+            locale_loss_weight=cfg.get("locale_loss_weight", 0.0),
         )
         # Use weights_only=True if available (torch 2.4+) to avoid pickle-arbitrary-code warning.
         try:
@@ -595,6 +689,11 @@ def build_model(cfg: Config, vocab_size: int, pad_token_id: int) -> MailwomanCoa
         # v0.5.0 thread C additions.
         use_phrase_priors=getattr(cfg.model, "use_phrase_priors", False),
         phrase_feature_dim=getattr(cfg.model, "phrase_feature_dim", PHRASE_FEATURE_DIM),
+        # PR3 self-conditioning. num_locales is derived from labels.NUM_LOCALES (single source of
+        # truth), never from the yaml, so the head width and the aux-target vocabulary can't drift.
+        use_locale_conditioning=getattr(cfg.model, "use_locale_conditioning", False),
+        num_locales=NUM_LOCALES,
+        locale_loss_weight=getattr(cfg.model, "locale_loss_weight", 0.0),
     )
 
 

--- a/corpus-python/src/mailwoman_train/train.py
+++ b/corpus-python/src/mailwoman_train/train.py
@@ -31,7 +31,7 @@ from torch.optim.lr_scheduler import LambdaLR
 
 from .config import Config, csv_log_path
 from .data_loader import IGNORE_INDEX, iter_batches, verify_tokenizer_alignment
-from .labels import ACTIVE_BIO_LABELS, ACTIVE_TAGS
+from .labels import ACTIVE_BIO_LABELS, ACTIVE_TAGS, ID_TO_LOCALE, LABEL_TO_ID
 from .model import build_model, force_math_sdpa, model_param_count
 from .tokenizer import Tokenizer
 
@@ -44,11 +44,17 @@ def _set_seed(seed: int) -> None:
 
 
 def _to_tensor_batch(batch: dict, device: torch.device) -> dict:
-    return {
+    tb = {
         "input_ids": torch.tensor(batch["input_ids"], dtype=torch.long, device=device),
         "attention_mask": torch.tensor(batch["attention_mask"], dtype=torch.long, device=device),
         "labels": torch.tensor(batch["labels"], dtype=torch.long, device=device),
     }
+    # PR3: per-row locale target for the self-conditioning aux head. Present whenever the data
+    # loader emitted it (always, post-PR3); guarded so a pre-PR3 batch dict still works. The model
+    # ignores it unless built with use_locale_conditioning.
+    if "locale_ids" in batch:
+        tb["locale_ids"] = torch.tensor(batch["locale_ids"], dtype=torch.long, device=device)
+    return tb
 
 
 def _cosine_with_warmup(optimizer: AdamW, warmup_steps: int, max_steps: int) -> LambdaLR:
@@ -145,6 +151,45 @@ def _token_f1(
     return result
 
 
+def _cross_pollution(
+    preds: torch.Tensor,
+    labels: torch.Tensor,
+    row_locale_ids: torch.Tensor | None,
+) -> dict[str, float]:
+    """The Saint-Albans collapse tripwire: rate at which gold city/region-START tokens
+    (``B-locality`` / ``B-region``) are predicted as a POSTCODE label (``B-`` / ``I-postcode``).
+
+    Overall, plus per-locale when ``row_locale_ids`` (one id per sequence) is supplied. The
+    pre-registered PR3 gate wants this under 1% per locale by 20k steps — it is the direct readout
+    of a city's lead token bleeding into the postcode span, the failure self-conditioning exists to
+    stop. Returns an empty dict when the val sample contains no city/region-start tokens.
+    """
+    start = torch.zeros_like(labels, dtype=torch.bool)
+    for name in ("B-locality", "B-region"):
+        start |= labels == LABEL_TO_ID[name]
+    pc = torch.zeros_like(preds, dtype=torch.bool)
+    for name in ("B-postcode", "I-postcode"):
+        pc |= preds == LABEL_TO_ID[name]
+    polluted = start & pc
+
+    def _rate(mask_start: torch.Tensor, mask_poll: torch.Tensor) -> float:
+        denom = int(mask_start.sum())
+        return float(int(mask_poll.sum()) / denom) if denom > 0 else 0.0
+
+    if int(start.sum()) == 0:
+        return {}
+    out: dict[str, float] = {"cross_pollution": _rate(start, polluted)}
+    if row_locale_ids is not None:
+        tok_locale = row_locale_ids.unsqueeze(1).expand_as(labels)
+        for lid in torch.unique(row_locale_ids).tolist():
+            if lid not in ID_TO_LOCALE:  # IGNORE_INDEX / unmapped country
+                continue
+            sel = tok_locale == lid
+            if int((start & sel).sum()) > 0:
+                out[f"cross_pollution.{ID_TO_LOCALE[lid]}"] = _rate(start & sel, polluted & sel)
+    return out
+
+
 @torch.no_grad()
 def _eval_val(
     cfg: Config,
@@ -153,12 +198,15 @@ def _eval_val(
     device: torch.device,
     max_rows: int | None,
 ) -> dict[str, float]:
-    """Streaming val-set eval. Returns mean val loss + token-level macro F1."""
+    """Streaming val-set eval. Returns mean val loss + token-level macro F1 + (PR3) the
+    cross-pollution tripwire and the aux locale-head accuracy when self-conditioning is on."""
     model.eval()
     loss_total = 0.0
     seen_batches = 0
     all_preds: list[torch.Tensor] = []
     all_labels: list[torch.Tensor] = []
+    all_locale_ids: list[torch.Tensor] = []
+    all_locale_preds: list[torch.Tensor] = []
     rows_seen = 0
     for batch in iter_batches(
         cfg,
@@ -175,6 +223,10 @@ def _eval_val(
         rows_seen += tb["input_ids"].shape[0]
         all_preds.append(out.logits.argmax(dim=-1).detach().cpu())
         all_labels.append(tb["labels"].detach().cpu())
+        if "locale_ids" in tb:
+            all_locale_ids.append(tb["locale_ids"].detach().cpu())
+        if getattr(out, "locale_logits", None) is not None:
+            all_locale_preds.append(out.locale_logits.argmax(dim=-1).detach().cpu())
     if seen_batches == 0:
         return {"val_loss": float("nan"), "val_rows": 0, "macro_f1": 0.0}
     preds = torch.cat(all_preds, dim=0)
@@ -182,6 +234,14 @@ def _eval_val(
     metrics = _token_f1(preds, labels, num_labels=len(ACTIVE_BIO_LABELS))
     metrics["val_loss"] = loss_total / seen_batches
     metrics["val_rows"] = rows_seen
+    # PR3 tripwire + aux-head accuracy.
+    row_locale = torch.cat(all_locale_ids, dim=0) if all_locale_ids else None
+    metrics.update(_cross_pollution(preds, labels, row_locale))
+    if all_locale_preds and row_locale is not None:
+        locale_pred = torch.cat(all_locale_preds, dim=0)
+        valid = row_locale != IGNORE_INDEX
+        if int(valid.sum()) > 0:
+            metrics["locale_acc"] = float((locale_pred[valid] == row_locale[valid]).float().mean())
     return metrics
 
 
@@ -414,6 +474,18 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
                         f"  val_rows={val.get('val_rows', 0)}"
                         f"\n         {tag_summary}"
                     )
+                    # PR3 tripwire: city/region-start → postcode rate (gate < 1% per locale), plus
+                    # the aux locale-head accuracy. Only prints when self-conditioning is active.
+                    if "cross_pollution" in val:
+                        xpoll = "  ".join(
+                            f"{k.split('.', 1)[1]}={val[k] * 100:.2f}%"
+                            for k in sorted(val)
+                            if k.startswith("cross_pollution.")
+                        )
+                        print(
+                            f"         [pr3] cross_pollution={val['cross_pollution'] * 100:.2f}%"
+                            f"  ({xpoll})  locale_acc={val.get('locale_acc', float('nan')):.3f}"
+                        )
                     elapsed = time.time() - started
                     # CSV: per-tag F1, but a blank cell ("") for tags with no val support so readers
                     # see NaN rather than a misleading 0.0.
@@ -451,6 +523,11 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
                             eval_metrics[f"f1.{tag}"] = float(val.get(f"f1_tag.{tag}", 0.0))
                             tags_with_support += 1
                     eval_metrics["val_tags_with_support"] = tags_with_support
+                    # PR3: stream the cross-pollution tripwire (overall + per-locale) and the aux
+                    # locale-head accuracy to the dashboard, so the 20k gate is watchable live.
+                    for k, v in val.items():
+                        if k.startswith("cross_pollution") or k == "locale_acc":
+                            eval_metrics[k] = float(v)
                     tracker.log(eval_metrics, step=step)
 
                 if step % cfg.train.save_every_steps == 0:

--- a/corpus-python/tests/mailwoman_train/test_pr3_self_conditioning.py
+++ b/corpus-python/tests/mailwoman_train/test_pr3_self_conditioning.py
@@ -1,0 +1,234 @@
+"""PR3 self-conditioning wiring smoke (CPU, seconds).
+
+The "is the new architecture wired correctly?" check that PR3 ships BEFORE any GPU run. Builds a
+tiny encoder with ``use_locale_conditioning=True``, runs forward, and asserts the locale head +
+FiLM modulation + auxiliary loss are wired and finite. Also covers the cross-pollution tripwire
+metric, save/load round-trip, back-compat with the conditioning OFF, and that the pilot config
+loads with the expected scope.
+
+NO loss.backward, NO optimizer step, NO GPU. Geometry + numerical-sanity only — the falsify-before-
+you-spend gate for the self-conditioned retrain.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from mailwoman_train.labels import (  # noqa: E402
+    ACTIVE_BIO_LABELS,
+    IGNORE_INDEX,
+    LABEL_TO_ID,
+    LOCALE_TO_ID,
+    NUM_LOCALES,
+    locale_id,
+)
+from mailwoman_train.model import MailwomanCoarseEncoder  # noqa: E402
+from mailwoman_train.train import _cross_pollution  # noqa: E402
+
+NUM_LABELS = len(ACTIVE_BIO_LABELS)
+VOCAB_SIZE = 64
+PAD_ID = 0
+HIDDEN_SIZE = 64
+
+
+def _build_encoder(
+    use_locale_conditioning: bool,
+    locale_loss_weight: float = 0.3,
+    use_crf: bool = True,
+) -> MailwomanCoarseEncoder:
+    return MailwomanCoarseEncoder(
+        vocab_size=VOCAB_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=128,
+        max_position_embeddings=32,
+        hidden_dropout_prob=0.0,  # deterministic forward
+        num_labels=NUM_LABELS,
+        pad_token_id=PAD_ID,
+        use_crf=use_crf,
+        label_smoothing=0.0,
+        crf_loss_weight=0.0,  # CRF off like the pilot
+        use_locale_conditioning=use_locale_conditioning,
+        locale_loss_weight=locale_loss_weight,
+    ).eval()
+
+
+def _stub_batch(bsz: int = 2, seq_len: int = 8) -> dict[str, torch.Tensor]:
+    torch.manual_seed(0)
+    input_ids = torch.randint(1, VOCAB_SIZE, (bsz, seq_len))
+    input_ids[:, 0] = 1
+    attention_mask = torch.ones(bsz, seq_len, dtype=torch.long)
+    if bsz >= 2 and seq_len > 5:
+        attention_mask[0, 5:] = 0
+        input_ids[0, 5:] = PAD_ID
+    return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+# --- labels: locale id map ------------------------------------------------------------
+
+
+def test_locale_id_map():
+    assert locale_id("US") == LOCALE_TO_ID["US"]
+    assert locale_id("de") == LOCALE_TO_ID["DE"]  # case-insensitive
+    assert locale_id("ZZ") == IGNORE_INDEX  # unmapped country
+    assert locale_id(None) == IGNORE_INDEX
+    assert NUM_LOCALES == len(LOCALE_TO_ID)
+    # Append-only contract: US/FR/DE are the pilot's first three ids.
+    assert LOCALE_TO_ID["US"] == 0 and LOCALE_TO_ID["FR"] == 1 and LOCALE_TO_ID["DE"] == 2
+
+
+# --- forward: shapes + finiteness -----------------------------------------------------
+
+
+def test_forward_emits_locale_logits_and_bio_logits():
+    enc = _build_encoder(use_locale_conditioning=True)
+    b = _stub_batch(2, 8)
+    out = enc(input_ids=b["input_ids"], attention_mask=b["attention_mask"])
+    assert out.logits.shape == (2, 8, NUM_LABELS)
+    assert out.locale_logits is not None
+    assert out.locale_logits.shape == (2, NUM_LOCALES)
+    assert torch.isfinite(out.logits).all()
+    assert torch.isfinite(out.locale_logits).all()
+    assert out.loss is None  # no labels
+
+
+def test_film_is_identity_at_init():
+    """The FiLM projection is zero-initialized, so conditioning starts as an exact no-op — the
+    model begins identical to an unconditioned encoder and learns to modulate gradually. This is
+    the de-risking move against a cold-start architecture shock."""
+    enc = _build_encoder(use_locale_conditioning=True)
+    assert enc.locale_film is not None
+    assert int(torch.count_nonzero(enc.locale_film.weight)) == 0
+    assert int(torch.count_nonzero(enc.locale_film.bias)) == 0
+
+
+def test_aux_locale_loss_is_finite():
+    enc = _build_encoder(use_locale_conditioning=True, locale_loss_weight=0.3)
+    b = _stub_batch(2, 8)
+    labels = torch.zeros(2, 8, dtype=torch.long)
+    labels[0, 5:] = IGNORE_INDEX
+    locale_ids = torch.tensor([LOCALE_TO_ID["US"], LOCALE_TO_ID["DE"]], dtype=torch.long)
+    out = enc(
+        input_ids=b["input_ids"],
+        attention_mask=b["attention_mask"],
+        labels=labels,
+        locale_ids=locale_ids,
+    )
+    assert out.loss is not None
+    assert torch.isfinite(out.loss)
+
+
+def test_all_ignored_locale_batch_does_not_nan():
+    """A batch whose every row has an unmapped country (all IGNORE_INDEX) must not poison the loss
+    with a 0/0 → NaN from the aux CE — the aux term is skipped, the BIO loss stands alone."""
+    enc = _build_encoder(use_locale_conditioning=True, locale_loss_weight=0.3)
+    b = _stub_batch(2, 8)
+    labels = torch.zeros(2, 8, dtype=torch.long)
+    labels[0, 5:] = IGNORE_INDEX
+    locale_ids = torch.full((2,), IGNORE_INDEX, dtype=torch.long)
+    out = enc(
+        input_ids=b["input_ids"],
+        attention_mask=b["attention_mask"],
+        labels=labels,
+        locale_ids=locale_ids,
+    )
+    assert out.loss is not None and torch.isfinite(out.loss)
+
+
+# --- back-compat: conditioning OFF ----------------------------------------------------
+
+
+def test_conditioning_off_emits_no_locale_logits_and_ignores_locale_ids():
+    enc = _build_encoder(use_locale_conditioning=False)
+    assert enc.locale_head is None and enc.locale_film is None
+    b = _stub_batch(2, 8)
+    # Passing locale_ids to an unconditioned encoder is harmless (ignored, not an error) — the
+    # data loader always emits them now, so the off path must tolerate them.
+    out = enc(
+        input_ids=b["input_ids"],
+        attention_mask=b["attention_mask"],
+        locale_ids=torch.tensor([0, 1], dtype=torch.long),
+    )
+    assert out.locale_logits is None
+    assert out.logits.shape == (2, 8, NUM_LABELS)
+
+
+# --- save / load round-trip -----------------------------------------------------------
+
+
+def test_save_load_roundtrip_preserves_locale_config(tmp_path):
+    m = _build_encoder(use_locale_conditioning=True, locale_loss_weight=0.3)
+    m.save_pretrained(tmp_path)
+    loaded = type(m).from_pretrained(tmp_path)
+    assert loaded.use_locale_conditioning is True
+    assert loaded.num_locales == NUM_LOCALES
+    assert loaded.locale_loss_weight == pytest.approx(0.3)
+    assert loaded.locale_head is not None and loaded.locale_film is not None
+    sd_before, sd_after = m.state_dict(), loaded.state_dict()
+    assert set(sd_before) == set(sd_after)
+    for k in sd_before:
+        assert torch.allclose(sd_before[k], sd_after[k]), f"mismatch on {k}"
+
+
+def test_load_pre_pr3_card_back_compat(tmp_path):
+    """A model card written before PR3 (no locale keys) loads with conditioning OFF."""
+    m = _build_encoder(use_locale_conditioning=False)
+    m.save_pretrained(tmp_path)
+    card = tmp_path / "config.json"
+    cfg = json.loads(card.read_text())
+    cfg.pop("use_locale_conditioning", None)
+    cfg.pop("num_locales", None)
+    cfg.pop("locale_loss_weight", None)
+    card.write_text(json.dumps(cfg))
+    loaded = type(m).from_pretrained(tmp_path)
+    assert loaded.use_locale_conditioning is False
+    assert loaded.locale_head is None
+
+
+# --- the cross-pollution tripwire metric ----------------------------------------------
+
+
+def test_cross_pollution_counts_city_start_as_postcode():
+    b_loc = LABEL_TO_ID["B-locality"]
+    b_reg = LABEL_TO_ID["B-region"]
+    b_pc = LABEL_TO_ID["B-postcode"]
+    o = LABEL_TO_ID["O"]
+    # 4 gold city/region-start tokens; 1 predicted as postcode → 25%.
+    labels = torch.tensor([[b_loc, o, b_reg, o], [b_loc, o, b_reg, o]])
+    preds = torch.tensor([[b_pc, o, b_reg, o], [b_loc, o, b_reg, o]])
+    row_locale = torch.tensor([LOCALE_TO_ID["US"], LOCALE_TO_ID["DE"]])
+    out = _cross_pollution(preds, labels, row_locale)
+    assert out["cross_pollution"] == pytest.approx(0.25)
+    # Per-locale: the US row had the one pollution (2 starts, 1 polluted = 50%); DE clean.
+    assert out["cross_pollution.US"] == pytest.approx(0.5)
+    assert out["cross_pollution.DE"] == pytest.approx(0.0)
+
+
+def test_cross_pollution_empty_when_no_city_tokens():
+    o = LABEL_TO_ID["O"]
+    labels = torch.tensor([[o, o], [o, o]])
+    preds = torch.tensor([[o, o], [o, o]])
+    assert _cross_pollution(preds, labels, None) == {}
+
+
+# --- pilot config loads with the expected scope ---------------------------------------
+
+
+def test_pilot_config_loads_and_matches_scope():
+    from mailwoman_train.config import load_config
+
+    here = Path(__file__).resolve().parent.parent.parent
+    cfg = load_config(here / "src/mailwoman_train/configs/v0.9.0-pilot-selfcond.yaml")
+    assert cfg.model.use_locale_conditioning is True
+    assert cfg.model.locale_loss_weight > 0
+    assert cfg.model.crf_loss_weight == 0.0  # CRF off — single variable
+    assert cfg.model.label_smoothing == 0.1  # v0.7.2 recipe held
+    assert set(cfg.data.country_weights) == {"US", "FR", "DE"}  # the three-way pilot
+    assert cfg.train.max_steps == 20000  # stop at the early gate
+    assert cfg.train.lr_schedule == "constant"


### PR DESCRIPTION
The reviewable, no-GPU code for the self-conditioned retrain ([plan](../blob/main/docs/articles/plan/2026-06-04-pr3-self-conditioned-retrain.md)). **No training run** — this is the architecture, the Pilot A config, and the falsification gate, ready to review *before* any spend.

## What the model does now

It infers a locale posterior from the **whole sequence** and FiLM-conditions its own per-token labeling on it — the step the probe said is genuinely required (the postcode alone pins the country only 28–44% of the time, so the city/street evidence is load-bearing).

- **`labels.py`** — `LOCALE_COUNTRIES` (append-only) + `locale_id(country)` → id or IGNORE. The aux head's target vocabulary and the single source of truth for `num_locales`.
- **`model.py`** — an **aux locale head** (pooled → locale logits, the exported `LocalePosterior` the resolver wanted) + a **FiLM modulation** of the token reps by the pooled locale rep. `locale_film` is **zero-initialized**, so conditioning starts as an exact identity: the model begins *identical* to an unconditioned encoder and learns to modulate gradually (de-risks the cold-start divergence the CRF hit). The masked mean-pool runs in **fp32** (the CRF NaN was a bf16-reduction failure; every new reduction stays fp32). Aux CE on the `country` label, guarded against the all-ignored 0/0→NaN edge. Runs at inference too, so it shapes real emissions. Persisted through save/load; **off by default** (back-compat).
- **`config.py`** — `use_locale_conditioning` + `locale_loss_weight` knobs. `num_locales` is derived from `labels`, never the yaml, so the head width can't drift from the target vocab.
- **`data_loader.py` + `train.py`** — thread the per-row locale target through the batch; add the **`cross_pollution`** tripwire (gold city/region-start predicted as postcode, overall + per-locale) and the aux **`locale_acc`**, both streamed to the dashboard so the **20k gate is watchable live**.
- **`configs/v0.9.0-pilot-selfcond.yaml`** — Pilot A: US/FR/DE, self-conditioning on, CRF off, the v0.7.2-proven recipe otherwise, **stop at the 20k gate**. The DE corpus dependency is flagged honestly (the German shards must be merged before launch).

## The seam reused, not built

The conditioning rides the existing `phrase_priors`-style pattern and the corpus's existing `country` column, so the footprint is small: an aux head, a zero-init FiLM, one threaded target, one metric.

## Validation (CPU, no GPU)

**11 new tests pass**: forward emits both BIO + locale logits, FiLM-is-identity-at-init, aux loss finite, all-ignored-batch no NaN, conditioning-off back-compat, save/load round-trip, pre-PR3 card back-compat, the `cross_pollution` metric (city-start→postcode counted correctly, per-locale), and the pilot config loads with the expected scope. The 3–4 pre-existing `test_labels`/`test_v0_5_0` failures are stale STAGE2/256-dim assertions, untouched by this change.

## Still gated on operator sign-off

The run itself waits — and the launch still needs the DE-inclusive corpus assembled (flagged in the config). The architecture is the falsify-before-you-spend deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
