### PR TITLE
feat(corpus): assemble the DE-inclusive corpus for the PR3 pilot

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0.9.0-pilot-selfcond.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0.9.0-pilot-selfcond.yaml
@@ -19,22 +19,31 @@
 # If the gate holds, a follow-up extends to a full 100k run; if it fails, stop and diagnose ONE
 # knob (NaN protocol).
 #
-# ⚠ DATA DEPENDENCY (pre-launch): the from-scratch corpus must INCLUDE German rows. The v0.4.0
-# base below is US/FR; the German OA adapter (DE-1) exists but its shards must be merged into the
-# corpus the trainer reads, and the German source given a weight, before this launches. Until then
-# DE: 1.0 below filters to zero rows. Finalize corpus_dir + the DE source weight at launch.
+# CORPUS: v0.4.1-de — the v0.4.0 (US/FR) base overlaid with a German synth-german shard (200K train
+# + 4K val rows, real OpenAddresses Berlin/Saxony tuples rendered German-order via build-german-shard.mjs,
+# 40x the v0.8.0 continue-train supplement so a FROM-SCRATCH model can actually learn German). Assembled
+# 2026-06-04. Reproduce + deploy to the Modal volume:
+#   node scripts/build-german-shard.mjs --output /tmp/german-train.jsonl --count 200000 --seed 42
+#   node scripts/build-german-shard.mjs --output /tmp/german-val.jsonl   --count 4000   --seed 99
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-train.jsonl --output /tmp/part-german-train.parquet
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-val.jsonl   --output /tmp/part-german-val.parquet
+#   # then the overlay MANIFEST (v0.4.0 shards + the 2 German shards) — see the build-log doc — and:
+#   modal volume put mailwoman-training /tmp/part-german-train.parquet corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/train/part-german-train.parquet
+#   modal volume put mailwoman-training /tmp/part-german-val.parquet   corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/val/part-german-val.parquet
+#   modal volume put mailwoman-training <MANIFEST.json>                corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/MANIFEST.json
 #
-# Launch (after the corpus is DE-inclusive):
+# Launch:
 #   modal run -d scripts/modal/train_remote.py \
 #     --config v0.9.0-pilot-selfcond.yaml --resume none \
 #     --trackio --trackio-space sister-software/mailwoman-trackio
 
 data:
-  # TODO(launch): point at a DE-inclusive corpus (v0.4.0 base + German shards merged).
-  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  corpus_dir: /data/corpus/versioned/v0.4.1-de/corpus-v0.4.1-de
   tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
   max_length: 128
-  # US/FR/DE balanced — the three-way pilot. DE requires the corpus dependency above.
+  # US/FR/DE — the three-way pilot. FR comes from the `ban` source (Base Adresse Nationale),
+  # DE from `synth-german`. country_weights is an acceptance filter, not a count balancer; the MIX
+  # is steered by source_weights below.
   country_weights:
     US: 1.0
     FR: 1.0
@@ -54,9 +63,12 @@ data:
     deepseek-kryptonite: 3.0
     synth-po-box: 1.5
     synth-intersection: 0.2
-    # TODO(launch): add the German OA adapter's source id + weight (e.g. oa-de: 3.0).
+    # German at ~18% of the mix (6.0 of a ~34 total) — enough for a from-scratch model to learn it,
+    # while staying within the synthesis-as-supplement guideline. THE key tunable: raise it if DE
+    # locality F1 lags the 70% gate, lower it if US/FR slip past the 1pp tripwire.
+    synth-german: 6.0
   train_rows_per_epoch: 1000000
-  val_rows: 4096 # bumped vs v0.8.1 so the per-locale cross_pollution tripwire has DE support
+  val_rows: 4096 # the per-locale cross_pollution tripwire now has DE val support (the 4K German val shard)
   coarse_filter: true
   augment_directional_prob: 0.3
   augment_region_prob: 0.3

--- a/corpus-python/tests/mailwoman_train/test_pr3_self_conditioning.py
+++ b/corpus-python/tests/mailwoman_train/test_pr3_self_conditioning.py
@@ -230,5 +230,8 @@ def test_pilot_config_loads_and_matches_scope():
     assert cfg.model.crf_loss_weight == 0.0  # CRF off — single variable
     assert cfg.model.label_smoothing == 0.1  # v0.7.2 recipe held
     assert set(cfg.data.country_weights) == {"US", "FR", "DE"}  # the three-way pilot
+    # The DE corpus is wired: the overlay dir + the German source weight (no longer a launch TODO).
+    assert "v0.4.1-de" in cfg.data.corpus_dir
+    assert (cfg.data.source_weights or {}).get("synth-german", 0) > 0
     assert cfg.train.max_steps == 20000  # stop at the early gate
     assert cfg.train.lr_schedule == "constant"

--- a/docs/articles/evals/2026-06-04-de-corpus-assembly.md
+++ b/docs/articles/evals/2026-06-04-de-corpus-assembly.md
@@ -1,0 +1,40 @@
+# DE-inclusive corpus assembly (2026-06-04)
+
+The data step that gates the PR3 self-conditioning pilot ([plan](../plan/2026-06-04-pr3-self-conditioned-retrain.md)). The Pilot A config wanted a US/FR/**DE** corpus from scratch; v0.4.0 is US/FR only. This records how the German rows were added and how to deploy them.
+
+## What was built
+
+A new overlay corpus, **v0.4.1-de**: v0.4.0's 684 base shards (US/FR, referenced verbatim by their Modal `/data` paths) plus two new German shards.
+
+| shard                       | split |    rows | source       |
+| --------------------------- | ----- | ------: | ------------ |
+| `part-german-train.parquet` | train | 200,000 | synth-german |
+| `part-german-val.parquet`   | val   |   4,000 | synth-german |
+
+The German rows are real OpenAddresses Berlin + Saxony tuples (~1.2M unique, cached on disk) rendered in **German order** (house-number after street, postcode before city) by `synthesize-german.ts`, then aligned to BIO. The build reuses the v0.8.0 `scripts/build-german-shard.mjs` precedent — but at **200K rows, 40× the v0.8.0 supplement**, because that run was a _continue-train_ supplement (0.2 weight on an already-trained model) while this is a _from-scratch_ pilot that has to learn German from zero. Align pass rate was ~99.9% (186 skipped of 200K).
+
+## Why this is the right data for the pilot, not a repeat of v0.8.0
+
+The v0.8.0 German order-shard [failed](2026-06-02-night-4-postmortem.md) — German street/house-number F1 jumped (+22/+16pp), but locality and postcode F1 _collapsed_ (−37/−58pp) via end-of-string span fragmentation, and US/FR slipped past the 1pp tripwire. That collapse is exactly the failure self-conditioning is designed to prevent: a model that has resolved "this is a German address" globally, before per-token labels, shouldn't bleed a city's lead token into the postcode span. So this corpus + the PR3 architecture is the test of that hypothesis, and the `cross_pollution` tripwire (now with the 4K German val shard for support) is the live readout of whether it holds.
+
+## The mix knob
+
+In `v0.9.0-pilot-selfcond.yaml`, `synth-german` is weighted 6.0 of a ~34 source-weight total — German at ~18% of the mix. Enough for a from-scratch model to learn it, inside the synthesis-as-supplement guideline. It is **the key tunable**: raise it if DE locality F1 lags the 70% gate, lower it if US/FR slip past the 1pp tripwire.
+
+## Reproduce + deploy
+
+Built locally at `/mnt/playpen/mailwoman-data/corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/`. Validated: the data loader reads `country=DE` / `locale_id=2` rows from both splits. To deploy to the Modal volume the trainer reads:
+
+```bash
+node scripts/build-german-shard.mjs --output /tmp/german-train.jsonl --count 200000 --seed 42
+node scripts/build-german-shard.mjs --output /tmp/german-val.jsonl   --count 4000   --seed 99
+python3 scripts/jsonl-to-parquet.py --input /tmp/german-train.jsonl --output <NEW>/train/part-german-train.parquet
+python3 scripts/jsonl-to-parquet.py --input /tmp/german-val.jsonl   --output <NEW>/val/part-german-val.parquet
+python3 scripts/assemble-de-overlay-manifest.py --base <v0.4.0 MANIFEST> --new-dir <NEW> \
+  --modal-root /data/corpus/versioned/v0.4.1-de/corpus-v0.4.1-de
+modal volume put mailwoman-training <NEW>/train/part-german-train.parquet corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/train/part-german-train.parquet
+modal volume put mailwoman-training <NEW>/val/part-german-val.parquet     corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/val/part-german-val.parquet
+modal volume put mailwoman-training <NEW>/MANIFEST.json                    corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/MANIFEST.json
+```
+
+After the upload, Pilot A is a one-command launch (`modal run -d scripts/modal/train_remote.py --config v0.9.0-pilot-selfcond.yaml --resume none --trackio`), against a tripwire already wired to report at 20k whether self-conditioning earns the full run.

--- a/scripts/assemble-de-overlay-manifest.py
+++ b/scripts/assemble-de-overlay-manifest.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Assemble the v0.4.1-de overlay MANIFEST for the PR3 self-conditioning pilot.
+
+The trainer reads a corpus_dir of parquet shards + a MANIFEST.json. v0.4.0 is US/FR; this writes a
+new overlay manifest that references v0.4.0's base shards VERBATIM (their Modal `/data` paths, which
+resolve on the volume) plus two new German shards (synth-german, Berlin/Saxony OA tuples rendered
+German-order). The data loader does not verify shard sha256 at load time (only existence), and it
+re-roots stale `/data` paths under corpus_dir — so the overlay is a pure shard-list concatenation,
+no rebuild of the 677M base rows.
+
+Pipeline (the German shards are built first, see build-german-shard.mjs + jsonl-to-parquet.py):
+  node scripts/build-german-shard.mjs --output /tmp/german-train.jsonl --count 200000 --seed 42
+  node scripts/build-german-shard.mjs --output /tmp/german-val.jsonl   --count 4000   --seed 99
+  python3 scripts/jsonl-to-parquet.py --input /tmp/german-train.jsonl --output <NEW>/train/part-german-train.parquet
+  python3 scripts/jsonl-to-parquet.py --input /tmp/german-val.jsonl   --output <NEW>/val/part-german-val.parquet
+  python3 scripts/assemble-de-overlay-manifest.py \
+      --base /mnt/playpen/mailwoman-data/corpus/versioned/v0.4.0/corpus-v0.4.0/MANIFEST.json \
+      --new-dir /mnt/playpen/mailwoman-data/corpus/versioned/v0.4.1-de/corpus-v0.4.1-de \
+      --modal-root /data/corpus/versioned/v0.4.1-de/corpus-v0.4.1-de
+  # then `modal volume put` the two parquets + the manifest onto the mailwoman-training volume.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+
+def _descriptor(local_path: Path, modal_path: str, split: str, source: str) -> dict:
+    sids = pq.read_table(local_path, columns=["source_id"])["source_id"].to_pylist()
+    return {
+        "split": split,
+        "path": modal_path,
+        "format": "parquet",
+        "compression": "SNAPPY",
+        "rows": len(sids),
+        "bytes": os.path.getsize(local_path),
+        "sha256": hashlib.sha256(local_path.read_bytes()).hexdigest(),
+        "first_source_id": sids[0],
+        "last_source_id": sids[-1],
+        "source": source,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", type=Path, required=True, help="v0.4.0 MANIFEST.json to overlay")
+    ap.add_argument("--new-dir", type=Path, required=True, help="local overlay corpus dir (holds the German parquets + the written manifest)")
+    ap.add_argument("--modal-root", required=True, help="the overlay corpus root as the trainer sees it on the Modal volume")
+    ap.add_argument("--version", default="v0.4.1-de")
+    args = ap.parse_args()
+
+    base = json.loads(args.base.read_text())
+    de_train = _descriptor(
+        args.new_dir / "train" / "part-german-train.parquet",
+        f"{args.modal_root}/train/part-german-train.parquet",
+        "train",
+        "synth-german",
+    )
+    de_val = _descriptor(
+        args.new_dir / "val" / "part-german-val.parquet",
+        f"{args.modal_root}/val/part-german-val.parquet",
+        "val",
+        "synth-german",
+    )
+
+    manifest = {
+        "corpus_version": args.version,
+        "overlay_base": base.get("corpus_version"),
+        "note": (
+            f"{base.get('corpus_version')} (US/FR) base shards referenced verbatim + a synth-german "
+            "overlay (Berlin/Saxony OA tuples, German-order) for the PR3 self-conditioning pilot."
+        ),
+        "schema": base["schema"],
+        "rows_per_shard": base["rows_per_shard"],
+        "row_group_size": base["row_group_size"],
+        "shards": base["shards"] + [de_train, de_val],
+        "counts": {
+            "train": base["counts"]["train"] + de_train["rows"],
+            "val": base["counts"]["val"] + de_val["rows"],
+            "test": base["counts"]["test"],
+        },
+        "total_rows": base["total_rows"] + de_train["rows"] + de_val["rows"],
+    }
+    out = args.new_dir / "MANIFEST.json"
+    out.write_text(json.dumps(manifest, indent=1) + "\n")
+    print(f"wrote {out}")
+    print(f"  shards: {len(manifest['shards'])} ({len(base['shards'])} base + 2 German)")
+    print(f"  counts: {manifest['counts']}  total: {manifest['total_rows']}")
+    print(f"  DE train: {de_train['rows']} rows ({de_train['bytes']} bytes)  DE val: {de_val['rows']} rows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The data step that gates Pilot A. The pilot config wanted US/FR/**DE** from scratch; v0.4.0 is US/FR. This adds the German training data and overlays it as **corpus v0.4.1-de**.

## What was built
- **200K-row German train shard + 4K val shard** — real OpenAddresses Berlin/Saxony tuples (~1.2M unique, cached) rendered **German-order** (house# after street, postcode before city) by `synthesize-german.ts`, aligned to BIO at ~99.9% pass.
- **40x the v0.8.0 German shard** — because that was a continue-train *supplement* (0.2 weight on a trained model), while Pilot A is *from scratch* and must learn German from zero. The 4K val shard gives the live `cross_pollution.DE` tripwire its DE support.
- **`scripts/assemble-de-overlay-manifest.py`** — reproducible overlay: v0.4.0's 684 base shards referenced verbatim (Modal `/data` paths) + the 2 German shards. The loader checks existence not sha256 and re-roots stale paths, so it's a shard-list concat — no rebuild of the 677M base rows.
- **Config** — `corpus_dir` → v0.4.1-de, `synth-german` weighted 6.0 (~18% of the mix, the key tunable), launch TODOs dropped.

## Why it's the test of self-conditioning, not a repeat of v0.8.0
The v0.8.0 German order-shard collapsed via end-of-string span fragmentation (locality −37pp, postcode −58pp). That collapse is *exactly* what self-conditioning is designed to prevent — resolve the country globally before per-token labels, and a city's lead token can't bleed into the postcode span. This corpus + the PR3 architecture is the hypothesis test; `cross_pollution` is the live readout.

## Status
Built + validated locally (the data loader reads `country=DE`/`locale_id=2` from both splits). The parquets + manifest are on disk; the **Modal upload + launch** are the remaining mechanical steps (recipe in the config header + the build-log doc). 11 PR3 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)