### PR TITLE
fix(decoder): hand postcode over-extension back to the city (DE prerequisite)

### DIFF
--- a/neural/postcode-repair.test.ts
+++ b/neural/postcode-repair.test.ts
@@ -38,6 +38,25 @@ function postcodeValue(text: string, tokens: DecoderToken[]): string | null {
 	return start === -1 ? null : text.slice(start, end)
 }
 
+/** The contiguous locality value implied by the repaired labels (first B-…I-locality run). */
+function localityValue(text: string, tokens: DecoderToken[]): string | null {
+	let start = -1
+	let end = -1
+	for (const t of tokens) {
+		if (t.label === "B-locality") {
+			if (start === -1) {
+				start = t.start
+				end = t.end
+			} else break
+		} else if (t.label === "I-locality" && start !== -1) {
+			end = t.end
+		} else if (start !== -1) {
+			break
+		}
+	}
+	return start === -1 ? null : text.slice(start, end)
+}
+
 describe("repairPostcodeLabels", () => {
 	it("ADDs an alphanumeric postcode the model missed (GB), over O/locality", () => {
 		const text = "London SW1A 1AA"
@@ -85,6 +104,20 @@ describe("repairPostcodeLabels", () => {
 		const { tokens: out } = repairPostcodeLabels(text, tokens)
 		expect(postcodeValue(text, out)).toBe("75008")
 		expect(out.find((t) => t.piece === "France")!.label).toBe("O")
+	})
+
+	it("hands a trailing over-extension BACK to the city (DE postcode→city absorption)", () => {
+		// The model swallowed the city's leading "Pl" into the postcode span ("08523 Pl|auen").
+		const text = "08523 Plauen"
+		const tokens = [
+			tok("08523", 0, 5, "B-postcode"),
+			tok("Pl", 6, 8, "I-postcode"), // over-extension: the city's first chars
+			tok("auen", 8, 12, "B-locality"), // the city remainder
+		]
+		const { tokens: out } = repairPostcodeLabels(text, tokens)
+		expect(postcodeValue(text, out)).toBe("08523")
+		// "Pl" is reassigned to locality and merged with "auen" into one span → "Plauen".
+		expect(localityValue(text, out)).toBe("Plauen")
 	})
 
 	it("does NOT add a numeric postcode from scratch (a bare 5-digit could be a house number)", () => {

--- a/neural/postcode-repair.ts
+++ b/neural/postcode-repair.ts
@@ -78,6 +78,8 @@ const ADD_OVER_TAGS = new Set<string>(["locality", "dependent_locality", "region
 
 const POSTCODE_B = "B-postcode" as DecoderToken["label"]
 const POSTCODE_I = "I-postcode" as DecoderToken["label"]
+const LOCALITY_B = "B-locality" as DecoderToken["label"]
+const LOCALITY_I = "I-locality" as DecoderToken["label"]
 const OUTSIDE = "O" as DecoderToken["label"]
 
 function isPostcodeLabel(label: string): boolean {
@@ -156,10 +158,33 @@ export function repairPostcodeLabels(text: string, input: readonly DecoderToken[
 		// SNAP/ADD: relabel the matched run as a single postcode span.
 		overlap.forEach((i, k) => setLabel(i, k === 0 ? POSTCODE_B : POSTCODE_I))
 
-		// Local smear clip: clear postcode tokens immediately flanking the snapped run.
+		// Leading smear clip: postcode tokens immediately BEFORE the snapped run are noise (e.g. a
+		// house-number digit the model over-labeled) — clear to O as before.
 		for (let j = overlap[0]! - 1; j >= 0 && isPostcodeLabel(tokens[j]!.label); j--) setLabel(j, OUTSIDE)
+
+		// Trailing smear: the model over-extended the postcode to the RIGHT. In postcode-before-city
+		// locales (DE/FR/ES/IT, "08523 Plauen") this swallows the leading characters of the city, which
+		// the historical clip-to-O then DISCARDED ("08523 Pl|auen Vogtl" → postcode "08523" + O +
+		// locality "auen Vogtl", dropping the "Pl"). When the smear connects to a following locality run,
+		// hand those characters BACK to the city — reassign them to locality and demote the city's
+		// leading B so the prefix + city form ONE span ("Pl"+"auen"+"Vogtl" → "Plauen Vogtl"). A
+		// standalone neighbour with no following locality (a country, "Paris 75008 France") keeps the
+		// historical clip-to-O. This is the decoder-side repair for the cross-tag postcode→city
+		// absorption diagnosed in the PR3 Pilot A postmortem (+36pp DE exact-locality, no-op on US,
+		// where the postcode sits at the end with nothing to trim).
+		const trailing: number[] = []
 		for (let j = overlap[overlap.length - 1]! + 1; j < tokens.length && isPostcodeLabel(tokens[j]!.label); j++) {
-			setLabel(j, OUTSIDE)
+			trailing.push(j)
+		}
+		if (trailing.length > 0) {
+			const after = trailing[trailing.length - 1]! + 1
+			const connectsToCity = after < tokens.length && tagOf(tokens[after]!.label) === "locality"
+			if (connectsToCity) {
+				trailing.forEach((j, k) => setLabel(j, k === 0 ? LOCALITY_B : LOCALITY_I))
+				if (tokens[after]!.label === "B-locality") setLabel(after, LOCALITY_I)
+			} else {
+				for (const j of trailing) setLabel(j, OUTSIDE)
+			}
 		}
 	}
 


### PR DESCRIPTION
## What

A decoder-side correctness fix surfaced by the PR3 Pilot A postmortem.

The German parser fails by over-extending the postcode span into the **leading characters of the trailing city** (cross-tag absorption): `08523 Plauen Vogtl` → postcode `"08523 Pl"` + locality `"auen Vogtl"`. The existing `repairPostcodeLabels` smear-clip already trimmed the over-extension — but it discarded those swallowed city-start chars to `O`, so the city stayed broken.

This changes the **trailing** smear-clip: when the over-extension connects to a following locality run, hand those characters back to the city (reassign to locality + demote the city's leading `B` so they form one span) instead of dropping them. A standalone neighbour with no following locality (a country — `Paris 75008 France`) keeps the historical clip-to-`O`.

## Evidence

Confirmed in the production viterbi+repair path:

```
"08523 Plauen Vogtl"  before: locality="auen Vogtl"   after: "Plauen Vogtl"
"04654 Frohburg"      before: "hburg"                 after: "Frohburg"
"08066 Zwickau"       before: "wickau"                after: "Zwickau"
```

- **+36pp DE exact-locality** (28% → 65% on the postcode-before-city subset).
- **No-op on US** (the postcode sits at the end of a US address — nothing to trim).
- 8/8 `postcode-repair` unit tests pass (incl. the `France` clip-to-`O` preservation case + a new DE hand-back case).

## Honest scope: this is a prerequisite, not the German resolver win

The trim fixes the parse string but does **not** move the resolver locality-match on its own (byte-identical DE/US). Root cause traced: OA's gold locality carries a region suffix (`Plauen Vogtl`) that WOF's name lacks (`Plauen`), so the resolver can't match the suffixed string regardless of parse quality — the German wall is the resolver's locality name-matching, not the parser. This fix is the **prerequisite** that gives the resolver a clean string to suffix-strip/fuzzy-match in the paired follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
