### PR TITLE
feat(resolver): postcode→locality candidate table from source (#274)

### DIFF
--- a/scripts/build-postcode-locality.py
+++ b/scripts/build-postcode-locality.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Build the postcode -> containing-locality candidate table (#274), offline, FROM SOURCE.
+
+The PIP-containment probe (#274 groundwork) showed coordinate-first resolution lifts German locality
+accuracy where name-match misses (Sachsen +22pp). This productizes it: for every postcode, point-in-
+polygon its centroid against the WOF locality polygons and record the containing locality (+ a few
+nearby ones for the abutting-postcode / soft-scoring candidate set), with WOF alt-name aliases.
+
+The resolver consumes this at resolve time: postcode -> candidate localities -> soft-score by
+(postcode-proximity + name-match) -> pick. It supplies the COORDINATE candidate the FTS name-match
+can't generate when a small town isn't well-indexed.
+
+BUILD-FROM-SOURCE per the standing rule: locality polygons from the whosonfirst-data-admin-<cc>
+GeoJSON repos; postcode centroids from our own custom-built postalcode-intl.db (NOT a prebuilt dump).
+
+Usage:
+  python3 scripts/build-postcode-locality.py --country DE \
+    --admin-repo /mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data/whosonfirst-data-admin-de \
+    --postcode-db /mnt/playpen/mailwoman-data/wof/postalcode-intl.db \
+    --output /mnt/playpen/mailwoman-data/wof/postcode-locality-de.db \
+    --radius-km 10 --max-candidates 4
+"""
+import argparse, glob, json, math, os, sqlite3, collections
+
+def ray_in_ring(x, y, ring):
+    inside, n, j = False, len(ring), len(ring) - 1
+    for i in range(n):
+        xi, yi = ring[i][0], ring[i][1]; xj, yj = ring[j][0], ring[j][1]
+        if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
+            inside = not inside
+        j = i
+    return inside
+def in_poly(x, y, poly):
+    c = False
+    for ring in poly:
+        if ray_in_ring(x, y, ring): c = not c
+    return c
+def in_geom(x, y, geom):
+    t = geom["type"]
+    if t == "Polygon": return in_poly(x, y, geom["coordinates"])
+    if t == "MultiPolygon": return any(in_poly(x, y, p) for p in geom["coordinates"])
+    return False
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp, dl = math.radians(lat2 - lat1), math.radians(lon2 - lon1)
+    a = math.sin(dp/2)**2 + math.cos(p1)*math.cos(p2)*math.sin(dl/2)**2
+    return 2 * R * math.asin(math.sqrt(a))
+
+ALT_NAME_KEYS = ("wof:label",)  # plus name:* / label:* props, gathered below
+
+def aliases_for(props, canonical):
+    out = set()
+    for k, v in props.items():
+        if (k.startswith("name:") or k.startswith("label:") or k in ALT_NAME_KEYS) and isinstance(v, str):
+            out.add(v)
+        elif (k.startswith("name:") or k.startswith("label:")) and isinstance(v, list):
+            out.update(x for x in v if isinstance(x, str))
+    out.discard(canonical)
+    return sorted(out)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--country", required=True)
+    ap.add_argument("--admin-repo", required=True)
+    ap.add_argument("--postcode-db", required=True)
+    ap.add_argument("--output", required=True)
+    ap.add_argument("--radius-km", type=float, default=10.0)
+    ap.add_argument("--max-candidates", type=int, default=4)
+    args = ap.parse_args()
+
+    print(f"loading {args.country} locality polygons from source GeoJSON…")
+    locs = []  # dict: id, name, aliases, clat, clon, bbox, geom
+    for fp in glob.glob(args.admin_repo + "/data/**/*.geojson", recursive=True):
+        try:
+            g = json.load(open(fp)); p = g.get("properties", {})
+            if p.get("wof:placetype") != "locality" or p.get("mz:is_current", 1) == 0: continue
+            geom = g.get("geometry")
+            if not geom or geom["type"] not in ("Polygon", "MultiPolygon"): continue
+            xs, ys = [], []
+            def walk(c):
+                if isinstance(c[0], (int, float)): xs.append(c[0]); ys.append(c[1])
+                else:
+                    for cc in c: walk(cc)
+            walk(geom["coordinates"])
+            name = p.get("wof:name", "")
+            clat = p.get("lbl:latitude") if isinstance(p.get("lbl:latitude"), (int, float)) else (min(ys)+max(ys))/2
+            clon = p.get("lbl:longitude") if isinstance(p.get("lbl:longitude"), (int, float)) else (min(xs)+max(xs))/2
+            locs.append({"id": int(p["wof:id"]), "name": name, "aliases": aliases_for(p, name),
+                         "clat": clat, "clon": clon,
+                         "bbox": (min(xs), min(ys), max(xs), max(ys)), "geom": geom})
+        except Exception:
+            pass
+    print(f"  {len(locs)} localities")
+
+    # grid index (0.1° cells ≈ 11km) over locality centroids for the radius candidate set.
+    grid = collections.defaultdict(list)
+    for idx, l in enumerate(locs):
+        grid[(round(l["clon"]*10), round(l["clat"]*10))].append(idx)
+
+    con = sqlite3.connect(args.postcode_db)
+    postcodes = con.execute(
+        "SELECT name, latitude, longitude FROM spr WHERE country=? AND placetype='postalcode' AND is_current!=0",
+        (args.country,)).fetchall()
+    con.close()
+    print(f"  {len(postcodes)} {args.country} postcode centroids")
+
+    out = sqlite3.connect(args.output)
+    out.execute("DROP TABLE IF EXISTS postcode_locality")
+    out.execute("""CREATE TABLE postcode_locality (
+        postcode TEXT NOT NULL, country TEXT NOT NULL, locality_id INTEGER NOT NULL,
+        locality_name TEXT NOT NULL, aliases TEXT, distance_km REAL NOT NULL,
+        is_containing INTEGER NOT NULL)""")
+
+    rows, n_contained = 0, 0
+    for (pc, plat, plon) in postcodes:
+        if plat is None or plon is None: continue
+        # containing locality via bbox-prefiltered PIP
+        containing_idx = None
+        for idx, l in enumerate(locs):
+            minx, miny, maxx, maxy = l["bbox"]
+            if minx <= plon <= maxx and miny <= plat <= maxy and in_geom(plon, plat, l["geom"]):
+                containing_idx = idx; break
+        # nearby candidates within radius (grid-limited) for the soft-scoring candidate set + abutting case
+        cand = []
+        gx, gy = round(plon*10), round(plat*10)
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for idx in grid.get((gx+dx, gy+dy), ()):
+                    d = haversine(plat, plon, locs[idx]["clat"], locs[idx]["clon"])
+                    if d <= args.radius_km: cand.append((d, idx))
+        cand.sort()
+        chosen = []
+        if containing_idx is not None:
+            chosen.append((0.0, containing_idx, 1)); n_contained += 1
+        for d, idx in cand:
+            if idx == containing_idx: continue
+            if len([c for c in chosen if c[2] == 0]) >= args.max_candidates: break
+            chosen.append((d, idx, 0))
+        for d, idx, isc in chosen:
+            l = locs[idx]
+            out.execute("INSERT INTO postcode_locality VALUES (?,?,?,?,?,?,?)",
+                        (pc, args.country, l["id"], l["name"], "|".join(l["aliases"]), round(d, 3), isc))
+            rows += 1
+    out.execute("CREATE INDEX postcode_locality_by_pc ON postcode_locality(postcode, country)")
+    out.commit()
+    print(f"  wrote {rows} rows ({n_contained}/{len(postcodes)} postcodes have a containing locality) → {args.output}")
+    out.close()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval/coord-first-probe.py
+++ b/scripts/eval/coord-first-probe.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Coordinate-first ceiling probe (#274) — does PIP'ing the postcode centroid beat name-match resolution?
+
+The PIP-containment metric (#273) showed the German gap is real (Sachsen 54%), and that the postcode
+anchor already places addresses at ~1.3km. This probe tests the coordinate-first hypothesis directly:
+take each address's POSTCODE CENTROID, point-in-polygon it against the DE locality polygons, and ask —
+does the gold OA point fall inside the locality the centroid landed in? If that beats the current 54%
+Sachsen containment, the postcode->locality candidate table is the German fix.
+
+Build-from-SOURCE per the standing rule: locality polygons from the whosonfirst-data-admin-de GeoJSON
+repo; postcode centroids from our own custom-built postalcode-intl.db (NOT a prebuilt WOF dump).
+
+Usage: python3 scripts/eval/coord-first-probe.py
+"""
+import json, glob, sqlite3, collections
+
+ADMIN_DE = "/mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data/whosonfirst-data-admin-de/data"
+PC_DB = "/mnt/playpen/mailwoman-data/wof/postalcode-intl.db"
+SAMPLE = "data/eval/external/openaddresses-de-sample.jsonl"
+
+# ---- ray-cast PIP (even-odd, handles holes + MultiPolygon); x=lon, y=lat ----
+def in_ring(x, y, ring):
+    inside, n, j = False, len(ring), len(ring) - 1
+    for i in range(n):
+        xi, yi = ring[i][0], ring[i][1]; xj, yj = ring[j][0], ring[j][1]
+        if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
+            inside = not inside
+        j = i
+    return inside
+def in_poly(x, y, poly):
+    c = False
+    for ring in poly:
+        if in_ring(x, y, ring): c = not c
+    return c
+def in_geom(x, y, geom):
+    t = geom["type"]
+    if t == "Polygon": return in_poly(x, y, geom["coordinates"])
+    if t == "MultiPolygon": return any(in_poly(x, y, p) for p in geom["coordinates"])
+    return False
+
+# ---- load DE current locality polygons (from SOURCE GeoJSON) with bbox prefilter ----
+print("loading DE locality polygons from source GeoJSON...")
+locs = []  # (id, name, minx, miny, maxx, maxy, geom)
+for fp in glob.glob(ADMIN_DE + "/**/*.geojson", recursive=True):
+    try:
+        g = json.load(open(fp)); p = g.get("properties", {})
+        if p.get("wof:placetype") != "locality" or p.get("mz:is_current", 1) == 0: continue
+        geom = g.get("geometry")
+        if not geom or geom["type"] not in ("Polygon", "MultiPolygon"): continue
+        # bbox from coords
+        xs, ys = [], []
+        def walk(c):
+            if isinstance(c[0], (int, float)): xs.append(c[0]); ys.append(c[1])
+            else:
+                for cc in c: walk(cc)
+        walk(geom["coordinates"])
+        locs.append((int(p["wof:id"]), p.get("wof:name", ""), min(xs), min(ys), max(xs), max(ys), geom))
+    except Exception: pass
+print(f"  {len(locs)} DE localities loaded")
+
+def pip_locality(lon, lat):
+    """Return (id, name) of the DE locality whose polygon contains (lon,lat), or None."""
+    for (lid, name, minx, miny, maxx, maxy, geom) in locs:
+        if minx <= lon <= maxx and miny <= lat <= maxy and in_geom(lon, lat, geom):
+            return (lid, name)
+    return None
+
+# ---- postcode centroids from our custom postalcode-intl.db ----
+con = sqlite3.connect(PC_DB)
+pc_centroid = {}
+for name, lat, lon in con.execute("SELECT name, latitude, longitude FROM spr WHERE country='DE' AND placetype='postalcode'"):
+    pc_centroid[name] = (lat, lon)
+print(f"  {len(pc_centroid)} DE postcode centroids loaded")
+
+# ---- name-match signal (from the resolver dump, joined by input) ----
+# resolved-v072-de.json carries the neural-resolved locality WOF id per row; "name-correct" means that
+# resolved locality IS the true containing locality (== name-match PIP-containment from #273).
+try:
+    dump = {d["input"]: d.get("neuralLocId") for d in json.load(open("/tmp/resolved-v072-de.json"))}
+except Exception:
+    dump = {}
+
+# Load the resolver's resolved-locality polygon by WOF id (same as scripts/eval/pip-containment.py) so
+# "name-correct" = gold point inside the RESOLVER's chosen polygon (== #273's 77.1%), not an id-equality
+# against our independently-PIP'd truth (which mismatches on granularity, e.g. Berlin city vs borough).
+import os
+_admin_roots = sorted(glob.glob("/mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data/whosonfirst-data-admin-*/data")) + \
+               ["/mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data-admin-us/data"]
+_gcache = {}
+def geom_for_id(wid):
+    if wid in _gcache: return _gcache[wid]
+    s = str(int(wid)); chunks = [s[i:i+3] for i in range(0, len(s), 3)]
+    rel = "/".join(chunks) + f"/{s}.geojson"
+    g = None
+    for root in _admin_roots:
+        fp = os.path.join(root, rel)
+        if os.path.exists(fp):
+            try: g = json.load(open(fp)).get("geometry")
+            except Exception: g = None
+            break
+    _gcache[wid] = g; return g
+
+# ---- run the probe over the DE sample ----
+rows = [json.loads(l) for l in open(SAMPLE) if l.strip()]
+ov = collections.Counter(); by = collections.defaultdict(collections.Counter)
+for r in rows:
+    st = r.get("state") or "??"
+    ov["n"] += 1; by[st]["n"] += 1
+    glon, glat = r["lon"], r["lat"]
+    # ground truth: which DE locality actually contains the gold point
+    truth = pip_locality(glon, glat)
+    if truth: ov["truth"] += 1; by[st]["truth"] += 1
+    truth_id = truth[0] if truth else None
+    # name signal: is the gold point inside the RESOLVER's chosen locality polygon? (== #273)
+    nlid = dump.get(r["input"])
+    ngeom = geom_for_id(nlid) if nlid else None
+    name_ok = ngeom is not None and in_geom(glon, glat, ngeom)
+    if name_ok: ov["name"] += 1; by[st]["name"] += 1
+    pc = (r.get("expected") or {}).get("postcode")
+    cen = pc_centroid.get(pc) if pc else None
+    if not cen:
+        if name_ok: ov["hybrid"] += 1; by[st]["hybrid"] += 1
+        continue
+    ov["has_pc"] += 1; by[st]["has_pc"] += 1
+    cand = pip_locality(cen[1], cen[0])  # cen=(lat,lon) -> pip(lon,lat)
+    # coordinate-first containment: does the gold point fall inside the centroid-PIP'd locality?
+    cf_ok = cand is not None and truth_id is not None and cand[0] == truth_id
+    if cf_ok: ov["cf"] += 1; by[st]["cf"] += 1
+    # HYBRID ceiling: name signal OR coordinate signal lands the true locality
+    if name_ok or cf_ok: ov["hybrid"] += 1; by[st]["hybrid"] += 1
+
+def line(label, c):
+    n = c["n"]
+    if not n: return f"  {label}: n=0"
+    pc = lambda k: f"{100*c[k]/n:.1f}%"
+    return f"  {label:<10} n={n:<5} name={pc('name'):<7} coord-first={pc('cf'):<7} HYBRID(name OR coord)={pc('hybrid')}"
+
+print("\n=== Resolver containment by signal (gold point inside the chosen locality) ===")
+print(line("OVERALL", ov))
+for st in sorted(by): print(line(st, by[st]))
+print("\n  name = resolver's current name-match resolution; coord-first = postcode centroid -> PIP locality;")
+print("  HYBRID = either signal lands the true locality (the soft-scoring ceiling).")


### PR DESCRIPTION
Phase 1 of coordinate-first resolution. `scripts/build-postcode-locality.py` PIPs each postcode centroid (our custom postalcode-intl.db) against WOF locality polygons (whosonfirst-data-admin GeoJSON **source**, not a prebuilt dump) → flat SQLite `postcode_locality` table: containing locality + nearby candidates (abutting-postcode set) + WOF aliases.

DE: 92,689 rows, 82.3% of postcodes have a containing locality. Validated (08523→Plauen, 01069→Dresden); the abutting case 02699 (centroid in Neschwitz, candidate set includes Königswartha) shows the soft-scoring set works. Runtime = postcode lookup, zero geometry (WASM-friendly).

Supplies the coordinate candidate the FTS name-match can't generate for under-indexed small towns — the +22pp Sachsen signal toward the 93.9% hybrid ceiling. Next (#275): wire candidate injection + soft-scoring into `WofSqlitePlaceLookup.findPlace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)