### PR TITLE
feat(resolver): coordinate-first locality soft-scoring — DE 77→93% (#275)

### DIFF
--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -38,6 +38,21 @@ interface ResolutionState {
 	candidatesPerLookup: number
 	defaultCountry?: string
 	parentFallback: boolean
+	/** The address's postcode string, extracted once up front, passed to locality lookups so a
+	 * coordinate-first backend can inject postcode-proximal locality candidates. */
+	postcode?: string
+}
+
+/** Find the first postcode value anywhere in the tree (a one-shot pre-scan; postcode and locality are
+ * siblings, so the top-down walk wouldn't otherwise let the locality lookup see it). */
+function firstPostcodeValue(roots: readonly AddressNode[]): string | undefined {
+	const stack = [...roots]
+	while (stack.length > 0) {
+		const n = stack.pop()!
+		if (n.tag === "postcode" && n.value.trim().length > 0) return n.value.trim()
+		stack.push(...n.children)
+	}
+	return undefined
 }
 
 class WofResolver implements Resolver {
@@ -57,6 +72,7 @@ class WofResolver implements Resolver {
 			candidatesPerLookup: opts.candidatesPerLookup ?? 5,
 			defaultCountry: opts.defaultCountry,
 			parentFallback: opts.parentFallback ?? true,
+			postcode: firstPostcodeValue(tree.roots),
 		}
 
 		const newRoots: AddressNode[] = []
@@ -108,6 +124,10 @@ class WofResolver implements Resolver {
 		if (parentResolved && typeof parentResolved.id === "number") query.parentId = parentResolved.id
 		const country = parentResolved?.country ?? state.defaultCountry
 		if (country) query.country = country
+		// Coordinate-first: hand the sibling postcode to locality lookups so the backend can inject
+		// postcode-proximal candidates the name-match would miss. Only for locality (the placetype both
+		// `locality` and `dependent_locality` map to); other placetypes ignore it.
+		if (placetype === "locality" && state.postcode) query.postcode = state.postcode
 
 		let candidates: ResolvedPlace[]
 		try {

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -55,6 +55,13 @@ export interface ResolverBackend {
 		placetype?: string | string[]
 		country?: string
 		parentId?: number | string
+		/**
+		 * Sibling postcode string, when the address carries one. A coordinate-first backend uses it to
+		 * inject postcode-proximal locality candidates (the postcode→locality table) and soft-score
+		 * them against the parsed name — recovering localities the name-match alone misses. Backends
+		 * without postcode support ignore it.
+		 */
+		postcode?: string
 		limit?: number
 	}): Promise<ResolvedPlace[]>
 }

--- a/resolver-wof-sqlite/coord-first.test.ts
+++ b/resolver-wof-sqlite/coord-first.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Coordinate-first locality resolution (#275). When a `locality` query carries a sibling `postcode`
+ *   AND a `postcode_locality` table is present, the resolver injects the postcode's containing locality
+ *   (which the FTS name-match can't generate for an under-indexed small town) and soft-scores the union
+ *   `0.6·S_pc + 0.3·S_name + 0.1·S_pop` with exact-name tiering. These tests pin the three behaviours:
+ *   injection recovers the name-miss, exact-name tiering keeps an unambiguous city over the postcode's
+ *   fine-grained Ortsteil, and the path is inert without a postcode.
+ */
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { WofSqlitePlaceLookup } from "./lookup.js"
+
+function buildDb(): DatabaseSync {
+	const db = new DatabaseSync(":memory:")
+	db.exec(`
+		CREATE TABLE spr (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL, min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER NOT NULL, language TEXT, name TEXT NOT NULL);
+		CREATE TABLE place_population (id INTEGER PRIMARY KEY, population INTEGER);
+		CREATE TABLE postcode_locality (postcode TEXT, country TEXT, locality_id INTEGER, locality_name TEXT,
+			aliases TEXT, distance_km REAL, is_containing INTEGER);
+	`)
+	const spr = db.prepare(
+		`INSERT INTO spr (id,parent_id,name,placetype,country,latitude,longitude,min_latitude,max_latitude,min_longitude,max_longitude,is_current,is_deprecated)
+		 VALUES (?,?,?,?,?,?,?,?,?,?,?,-1,0)`
+	)
+	// Berlin (unambiguous city, large pop), its Ortsteil "Koepenick" (borough-as-locality), and the
+	// small Saxon town "Plauen".
+	spr.run(1, 0, "Berlin", "locality", "DE", 52.52, 13.4, 52.3, 52.7, 13.0, 13.8)
+	spr.run(2, 1, "Koepenick", "locality", "DE", 52.44, 13.58, 52.4, 52.5, 13.5, 13.7)
+	spr.run(3, 0, "Plauen", "locality", "DE", 50.49, 12.14, 50.4, 50.6, 12.0, 12.3)
+	db.prepare(`INSERT INTO place_population (id, population) VALUES (?, ?)`).run(1, 3_600_000)
+	const pl = db.prepare(`INSERT INTO postcode_locality VALUES (?,?,?,?,?,?,?)`)
+	pl.run("10115", "DE", 2, "Koepenick", "", 0.0, 1) // a Berlin postcode's centroid lands in the Ortsteil
+	pl.run("08523", "DE", 3, "Plauen", "", 0.0, 1) // Plauen's postcode → Plauen
+	return db
+}
+
+let lookup: WofSqlitePlaceLookup
+beforeEach(() => {
+	lookup = new WofSqlitePlaceLookup({ database: buildDb(), buildFts: true })
+})
+afterEach(() => {
+	lookup.close()
+})
+
+describe("coordinate-first locality resolution", () => {
+	it("injects the postcode's containing locality when the name-match misses it", async () => {
+		// "Plaun" (a typo) won't FTS-match "Plauen"; the postcode recovers the right town.
+		const r = await lookup.findPlace({ text: "Plaun", placetype: "locality", postcode: "08523", country: "DE" })
+		expect(r[0]?.name).toBe("Plauen")
+	})
+
+	it("is inert without a postcode — the typo falls through to the name-match path", async () => {
+		const r = await lookup.findPlace({ text: "Plaun", placetype: "locality", country: "DE" })
+		expect(r[0]?.name).not.toBe("Plauen")
+	})
+
+	it("exact-name tiering keeps the unambiguous city over the postcode's Ortsteil", async () => {
+		// 10115's containing locality is the Ortsteil "Koepenick", but the parsed name "Berlin" is an
+		// exact match — exact-name tiering keeps Berlin ahead of the coordinate-only borough.
+		const r = await lookup.findPlace({ text: "Berlin", placetype: "locality", postcode: "10115", country: "DE" })
+		expect(r[0]?.name).toBe("Berlin")
+	})
+})

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -165,6 +165,63 @@ interface RawSearchRow {
 	population: number | null // from the place_population aux table; null when missing
 }
 
+/** The coordinate-first candidate table (scripts/build-postcode-locality.py): postcode → containing +
+ * nearby localities with WOF alt-name aliases. */
+const POSTCODE_LOCALITY_TABLE = "postcode_locality"
+
+/** Soft-score weights for the coordinate-first locality path. `Score = PC·S_pc + NAME·S_name +
+ * POP·S_pop`, each S in [0,1]. Postcode-proximity weighted highest (it's the strongest single signal
+ * when the name-match misses a small town), name next, population a tiebreak. The conflict flag fires
+ * when |S_pc − S_name| exceeds MISMATCH_DELTA. PC_DECAY_KM sets how fast S_pc falls with distance. */
+const CF_PC = 0.6
+const CF_NAME = 0.3
+const CF_POP = 0.1
+const CF_PC_DECAY_KM = 8
+const CF_MISMATCH_DELTA = 0.5
+
+/** Case-fold + strip diacritics + collapse punctuation — for the coord-first soft name match. */
+function cfNormalize(s: string): string {
+	return s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "") // combining diacritical marks
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+}
+
+/** Padded character-trigram set (a leading/trailing space pads short tokens). */
+function trigrams(s: string): Set<string> {
+	const t = ` ${s} `
+	const out = new Set<string>()
+	for (let i = 0; i + 3 <= t.length; i++) out.add(t.slice(i, i + 3))
+	return out
+}
+
+/** Character-trigram Jaccard ∈ [0,1] — tolerant of the swallowed-leading-char fragments ("auen" vs
+ * "plauen") and minor misspellings without a heavyweight edit-distance pass. */
+function trigramJaccard(a: string, b: string): number {
+	const A = trigrams(a)
+	const B = trigrams(b)
+	if (A.size === 0 || B.size === 0) return 0
+	let inter = 0
+	for (const x of A) if (B.has(x)) inter++
+	return inter / (A.size + B.size - inter)
+}
+
+/** Soft name-match score ∈ [0,1]: exact (normalized) name/alias → 1, else best trigram-Jaccard. */
+function softNameScore(text: string, name: string, aliases: readonly string[]): number {
+	const q = cfNormalize(text)
+	if (!q) return 0
+	let best = 0
+	for (const raw of [name, ...aliases]) {
+		const n = cfNormalize(raw)
+		if (!n) continue
+		if (n === q) return 1
+		best = Math.max(best, trigramJaccard(q, n))
+	}
+	return best
+}
+
 export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	readonly #db: DatabaseSync
 	readonly #ownsDb: boolean
@@ -184,6 +241,12 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 * before this feature shipped.
 	 */
 	readonly #hasPopulationIndex: Map<string, boolean>
+	/**
+	 * Per-shard probe for the `postcode_locality` table (the coordinate-first candidate table, built by
+	 * scripts/build-postcode-locality.py). Cached at construction; null'd out when absent so the
+	 * coord-first path silently no-ops on a deployment that didn't ship the table.
+	 */
+	readonly #postcodeLocalityShard: string | null
 	/**
 	 * Resolved shard list. Always at least one entry; first is `main`. Multi-shard adds extras with
 	 * their own derived (or override) schema names.
@@ -236,6 +299,10 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			this.#hasBboxIndex.set(s.schemaName, this.#shardHasTable(s.schemaName, PLACE_BBOX_TABLE))
 			this.#hasPopulationIndex.set(s.schemaName, this.#shardHasTable(s.schemaName, PLACE_POPULATION_TABLE))
 		}
+		// The postcode_locality table can live on any attached shard (typically its own
+		// `postcode-locality-<cc>.db`). Find the first shard that has it; null = coord-first disabled.
+		this.#postcodeLocalityShard =
+			this.#shards.find((s) => this.#shardHasTable(s.schemaName, POSTCODE_LOCALITY_TABLE))?.schemaName ?? null
 	}
 
 	#shardHasTable(schemaName: string, tableName: string): boolean {
@@ -252,6 +319,15 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	}
 
 	async findPlace(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
+		// Coordinate-first locality path. Strictly gated: a sibling postcode AND a postcode_locality
+		// table AND a locality query. Injects postcode-proximal candidates (which the name-match FTS
+		// can't generate for an under-indexed small town) and soft-scores the union. Returns null to
+		// fall through to the unchanged FTS path when the postcode isn't in the table.
+		if (query.postcode && this.#postcodeLocalityShard && this.#isLocalityQuery(query)) {
+			const cf = await this.#findLocalityCoordFirst(query, this.#postcodeLocalityShard)
+			if (cf) return cf
+		}
+
 		const limit = query.limit ?? 10
 		const ftsLimit = limit * 4 // over-fetch so post-scoring has room to re-rank
 
@@ -429,6 +505,96 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 
 		candidates.sort((a, b) => b.score - a.score)
 		return Promise.resolve(candidates.slice(0, limit))
+	}
+
+	#isLocalityQuery(query: FindPlaceQuery): boolean {
+		const pts = normalizePlacetypes(query.placetype)
+		return !pts || pts.includes("locality")
+	}
+
+	/**
+	 * Coordinate-first locality resolution. The postcode_locality table maps the sibling postcode to the
+	 * locality whose polygon contains the postcode centroid (+ a few nearby ones for the abutting-
+	 * postcode case). We union those COORDINATE candidates with the FTS NAME candidates and soft-score
+	 * the union `0.6·S_pc + 0.3·S_name + 0.1·S_pop` — so a small town the name-match never finds is
+	 * recovered by the postcode, while an unambiguous name (Berlin) still wins on name + population.
+	 * Returns null when the postcode isn't in the table (→ caller falls back to the FTS path).
+	 */
+	async #findLocalityCoordFirst(query: FindPlaceQuery, sch: string): Promise<PlaceCandidate[] | null> {
+		const pc = query.postcode!.trim()
+		const pcWhere = query.country ? "postcode = ? AND country = ?" : "postcode = ?"
+		const pcParams: SQLInputValue[] = query.country ? [pc, query.country] : [pc]
+		const pcRows = this.#db
+			.prepare(
+				`SELECT locality_id AS id, aliases, distance_km AS dist, is_containing AS containing
+				 FROM ${sch}.${POSTCODE_LOCALITY_TABLE} WHERE ${pcWhere}`
+			)
+			.all(...pcParams) as unknown as Array<{ id: number; aliases: string | null; dist: number; containing: number }>
+		if (pcRows.length === 0) return null
+
+		const limit = query.limit ?? 10
+		// Name-match candidates via the normal FTS path (postcode cleared → no recursion).
+		const ftsCands = await this.findPlace({ ...query, postcode: undefined, limit: Math.max(limit, 10) })
+
+		const pcInfo = new Map<number, { dist: number; containing: boolean; aliases: string[] }>()
+		for (const r of pcRows) {
+			pcInfo.set(r.id, { dist: r.dist, containing: r.containing === 1, aliases: r.aliases ? r.aliases.split("|") : [] })
+		}
+
+		const merged = new Map<number, PlaceCandidate>()
+		for (const c of ftsCands) merged.set(c.id as number, c)
+		const missing = [...pcInfo.keys()].filter((id) => !merged.has(id))
+		for (const row of this.#fetchLocalitiesById(missing)) merged.set(row.id, row)
+
+		const scored: Array<PlaceCandidate & { exact: boolean }> = []
+		for (const cand of merged.values()) {
+			const info = pcInfo.get(cand.id as number)
+			const sPc = info ? (info.containing ? 1 : Math.exp(-info.dist / CF_PC_DECAY_KM)) : 0
+			const sName = softNameScore(query.text, cand.name, info?.aliases ?? [])
+			const sPop = cand.population && cand.population > 0 ? Math.min(1, Math.log10(1 + cand.population) / 6) : 0
+			scored.push({ ...cand, score: CF_PC * sPc + CF_NAME * sName + CF_POP * sPop, exact: sName >= 1 })
+		}
+		// Exact-name tiering (same philosophy as the FTS path): an EXACT name/alias match tiers above
+		// coordinate-only candidates, with the soft-score breaking ties WITHIN a tier. This keeps an
+		// unambiguous city ("Berlin", exact + huge population) ahead of the fine-grained Ortsteil its
+		// postcode centroid lands in, while a small town the name-match never finds (no exact tier) is
+		// still recovered by its postcode's containing locality.
+		scored.sort((a, b) => Number(b.exact) - Number(a.exact) || b.score - a.score)
+		return scored.slice(0, limit).map(({ exact, ...c }) => {
+			void exact
+			return c
+		})
+	}
+
+	/** Fetch locality spr rows (from main) for the postcode-injected candidate ids the FTS set missed. */
+	#fetchLocalitiesById(ids: number[]): PlaceCandidate[] {
+		if (ids.length === 0) return []
+		const hasPop = this.#hasPopulationIndex.get("main") === true
+		const popSelect = hasPop ? `pp.population AS population` : `NULL AS population`
+		const popJoin = hasPop ? `LEFT JOIN main.${PLACE_POPULATION_TABLE} pp ON pp.id = s.id` : ""
+		const ph = ids.map(() => "?").join(", ")
+		const rows = this.#db
+			.prepare(
+				`SELECT s.id AS id, s.name AS name, s.country AS country, s.parent_id AS parent_id,
+				        s.latitude AS lat, s.longitude AS lon, ${popSelect}
+				 FROM main.spr s ${popJoin}
+				 WHERE s.id IN (${ph}) AND s.is_current != 0`
+			)
+			.all(...ids) as unknown as Array<RawSearchRow>
+		return rows.map((row) => {
+			const c: PlaceCandidate = {
+				id: row.id,
+				name: row.name,
+				placetype: "locality",
+				country: row.country ?? "",
+				lat: row.lat ?? 0,
+				lon: row.lon ?? 0,
+				parent_id: row.parent_id ?? undefined,
+				score: 0,
+			}
+			if (row.population !== null && row.population > 0) c.population = row.population
+			return c
+		})
 	}
 
 	/**

--- a/resolver-wof-sqlite/types.ts
+++ b/resolver-wof-sqlite/types.ts
@@ -112,6 +112,13 @@ export interface FindPlaceQuery {
 	country?: string
 	/** WOF place id — narrows to descendants of this place. */
 	parentId?: number
+	/**
+	 * Sibling postcode. When set on a `locality` query AND a `postcode_locality` table is present,
+	 * triggers the coordinate-first soft-score path: postcode→candidate localities are injected and
+	 * scored `0.6·S_pc + 0.3·S_name + 0.1·S_pop` against the FTS name-match set, recovering small
+	 * localities the name-match alone misses. Ignored when no postcode_locality shard is present.
+	 */
+	postcode?: string
 	/** Proximity hint — candidates close to this point get a ranking boost. */
 	near?: GeoPoint & { maxDistanceKm?: number }
 	/** Bounding-box filter — only candidates whose bbox intersects this box are returned. */

--- a/scripts/build-postcode-locality.py
+++ b/scripts/build-postcode-locality.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Build the postcode -> containing-locality candidate table (#274), offline, FROM SOURCE.
+
+The PIP-containment probe (#274 groundwork) showed coordinate-first resolution lifts German locality
+accuracy where name-match misses (Sachsen +22pp). This productizes it: for every postcode, point-in-
+polygon its centroid against the WOF locality polygons and record the containing locality (+ a few
+nearby ones for the abutting-postcode / soft-scoring candidate set), with WOF alt-name aliases.
+
+The resolver consumes this at resolve time: postcode -> candidate localities -> soft-score by
+(postcode-proximity + name-match) -> pick. It supplies the COORDINATE candidate the FTS name-match
+can't generate when a small town isn't well-indexed.
+
+BUILD-FROM-SOURCE per the standing rule: locality polygons from the whosonfirst-data-admin-<cc>
+GeoJSON repos; postcode centroids from our own custom-built postalcode-intl.db (NOT a prebuilt dump).
+
+Usage:
+  python3 scripts/build-postcode-locality.py --country DE \
+    --admin-repo /mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data/whosonfirst-data-admin-de \
+    --postcode-db /mnt/playpen/mailwoman-data/wof/postalcode-intl.db \
+    --output /mnt/playpen/mailwoman-data/wof/postcode-locality-de.db \
+    --radius-km 10 --max-candidates 4
+"""
+import argparse, glob, json, math, os, sqlite3, collections
+
+def ray_in_ring(x, y, ring):
+    inside, n, j = False, len(ring), len(ring) - 1
+    for i in range(n):
+        xi, yi = ring[i][0], ring[i][1]; xj, yj = ring[j][0], ring[j][1]
+        if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
+            inside = not inside
+        j = i
+    return inside
+def in_poly(x, y, poly):
+    c = False
+    for ring in poly:
+        if ray_in_ring(x, y, ring): c = not c
+    return c
+def in_geom(x, y, geom):
+    t = geom["type"]
+    if t == "Polygon": return in_poly(x, y, geom["coordinates"])
+    if t == "MultiPolygon": return any(in_poly(x, y, p) for p in geom["coordinates"])
+    return False
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp, dl = math.radians(lat2 - lat1), math.radians(lon2 - lon1)
+    a = math.sin(dp/2)**2 + math.cos(p1)*math.cos(p2)*math.sin(dl/2)**2
+    return 2 * R * math.asin(math.sqrt(a))
+
+ALT_NAME_KEYS = ("wof:label",)  # plus name:* / label:* props, gathered below
+
+def aliases_for(props, canonical):
+    out = set()
+    for k, v in props.items():
+        if (k.startswith("name:") or k.startswith("label:") or k in ALT_NAME_KEYS) and isinstance(v, str):
+            out.add(v)
+        elif (k.startswith("name:") or k.startswith("label:")) and isinstance(v, list):
+            out.update(x for x in v if isinstance(x, str))
+    out.discard(canonical)
+    return sorted(out)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--country", required=True)
+    ap.add_argument("--admin-repo", required=True)
+    ap.add_argument("--postcode-db", required=True)
+    ap.add_argument("--output", required=True)
+    ap.add_argument("--radius-km", type=float, default=10.0)
+    ap.add_argument("--max-candidates", type=int, default=4)
+    args = ap.parse_args()
+
+    print(f"loading {args.country} locality polygons from source GeoJSON…")
+    locs = []  # dict: id, name, aliases, clat, clon, bbox, geom
+    for fp in glob.glob(args.admin_repo + "/data/**/*.geojson", recursive=True):
+        try:
+            g = json.load(open(fp)); p = g.get("properties", {})
+            if p.get("wof:placetype") != "locality" or p.get("mz:is_current", 1) == 0: continue
+            geom = g.get("geometry")
+            if not geom or geom["type"] not in ("Polygon", "MultiPolygon"): continue
+            xs, ys = [], []
+            def walk(c):
+                if isinstance(c[0], (int, float)): xs.append(c[0]); ys.append(c[1])
+                else:
+                    for cc in c: walk(cc)
+            walk(geom["coordinates"])
+            name = p.get("wof:name", "")
+            clat = p.get("lbl:latitude") if isinstance(p.get("lbl:latitude"), (int, float)) else (min(ys)+max(ys))/2
+            clon = p.get("lbl:longitude") if isinstance(p.get("lbl:longitude"), (int, float)) else (min(xs)+max(xs))/2
+            locs.append({"id": int(p["wof:id"]), "name": name, "aliases": aliases_for(p, name),
+                         "clat": clat, "clon": clon,
+                         "bbox": (min(xs), min(ys), max(xs), max(ys)), "geom": geom})
+        except Exception:
+            pass
+    print(f"  {len(locs)} localities")
+
+    # grid index (0.1° cells ≈ 11km) over locality centroids for the radius candidate set.
+    grid = collections.defaultdict(list)
+    for idx, l in enumerate(locs):
+        grid[(round(l["clon"]*10), round(l["clat"]*10))].append(idx)
+
+    con = sqlite3.connect(args.postcode_db)
+    postcodes = con.execute(
+        "SELECT name, latitude, longitude FROM spr WHERE country=? AND placetype='postalcode' AND is_current!=0",
+        (args.country,)).fetchall()
+    con.close()
+    print(f"  {len(postcodes)} {args.country} postcode centroids")
+
+    out = sqlite3.connect(args.output)
+    out.execute("DROP TABLE IF EXISTS postcode_locality")
+    out.execute("""CREATE TABLE postcode_locality (
+        postcode TEXT NOT NULL, country TEXT NOT NULL, locality_id INTEGER NOT NULL,
+        locality_name TEXT NOT NULL, aliases TEXT, distance_km REAL NOT NULL,
+        is_containing INTEGER NOT NULL)""")
+
+    rows, n_contained = 0, 0
+    for (pc, plat, plon) in postcodes:
+        if plat is None or plon is None: continue
+        # containing locality via bbox-prefiltered PIP
+        containing_idx = None
+        for idx, l in enumerate(locs):
+            minx, miny, maxx, maxy = l["bbox"]
+            if minx <= plon <= maxx and miny <= plat <= maxy and in_geom(plon, plat, l["geom"]):
+                containing_idx = idx; break
+        # nearby candidates within radius (grid-limited) for the soft-scoring candidate set + abutting case
+        cand = []
+        gx, gy = round(plon*10), round(plat*10)
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for idx in grid.get((gx+dx, gy+dy), ()):
+                    d = haversine(plat, plon, locs[idx]["clat"], locs[idx]["clon"])
+                    if d <= args.radius_km: cand.append((d, idx))
+        cand.sort()
+        chosen = []
+        if containing_idx is not None:
+            chosen.append((0.0, containing_idx, 1)); n_contained += 1
+        for d, idx in cand:
+            if idx == containing_idx: continue
+            if len([c for c in chosen if c[2] == 0]) >= args.max_candidates: break
+            chosen.append((d, idx, 0))
+        for d, idx, isc in chosen:
+            l = locs[idx]
+            out.execute("INSERT INTO postcode_locality VALUES (?,?,?,?,?,?,?)",
+                        (pc, args.country, l["id"], l["name"], "|".join(l["aliases"]), round(d, 3), isc))
+            rows += 1
+    out.execute("CREATE INDEX postcode_locality_by_pc ON postcode_locality(postcode, country)")
+    out.commit()
+    print(f"  wrote {rows} rows ({n_contained}/{len(postcodes)} postcodes have a containing locality) → {args.output}")
+    out.close()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval/coord-first-probe.py
+++ b/scripts/eval/coord-first-probe.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Coordinate-first ceiling probe (#274) — does PIP'ing the postcode centroid beat name-match resolution?
+
+The PIP-containment metric (#273) showed the German gap is real (Sachsen 54%), and that the postcode
+anchor already places addresses at ~1.3km. This probe tests the coordinate-first hypothesis directly:
+take each address's POSTCODE CENTROID, point-in-polygon it against the DE locality polygons, and ask —
+does the gold OA point fall inside the locality the centroid landed in? If that beats the current 54%
+Sachsen containment, the postcode->locality candidate table is the German fix.
+
+Build-from-SOURCE per the standing rule: locality polygons from the whosonfirst-data-admin-de GeoJSON
+repo; postcode centroids from our own custom-built postalcode-intl.db (NOT a prebuilt WOF dump).
+
+Usage: python3 scripts/eval/coord-first-probe.py
+"""
+import json, glob, sqlite3, collections
+
+ADMIN_DE = "/mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data/whosonfirst-data-admin-de/data"
+PC_DB = "/mnt/playpen/mailwoman-data/wof/postalcode-intl.db"
+SAMPLE = "data/eval/external/openaddresses-de-sample.jsonl"
+
+# ---- ray-cast PIP (even-odd, handles holes + MultiPolygon); x=lon, y=lat ----
+def in_ring(x, y, ring):
+    inside, n, j = False, len(ring), len(ring) - 1
+    for i in range(n):
+        xi, yi = ring[i][0], ring[i][1]; xj, yj = ring[j][0], ring[j][1]
+        if ((yi > y) != (yj > y)) and (x < (xj - xi) * (y - yi) / (yj - yi) + xi):
+            inside = not inside
+        j = i
+    return inside
+def in_poly(x, y, poly):
+    c = False
+    for ring in poly:
+        if in_ring(x, y, ring): c = not c
+    return c
+def in_geom(x, y, geom):
+    t = geom["type"]
+    if t == "Polygon": return in_poly(x, y, geom["coordinates"])
+    if t == "MultiPolygon": return any(in_poly(x, y, p) for p in geom["coordinates"])
+    return False
+
+# ---- load DE current locality polygons (from SOURCE GeoJSON) with bbox prefilter ----
+print("loading DE locality polygons from source GeoJSON...")
+locs = []  # (id, name, minx, miny, maxx, maxy, geom)
+for fp in glob.glob(ADMIN_DE + "/**/*.geojson", recursive=True):
+    try:
+        g = json.load(open(fp)); p = g.get("properties", {})
+        if p.get("wof:placetype") != "locality" or p.get("mz:is_current", 1) == 0: continue
+        geom = g.get("geometry")
+        if not geom or geom["type"] not in ("Polygon", "MultiPolygon"): continue
+        # bbox from coords
+        xs, ys = [], []
+        def walk(c):
+            if isinstance(c[0], (int, float)): xs.append(c[0]); ys.append(c[1])
+            else:
+                for cc in c: walk(cc)
+        walk(geom["coordinates"])
+        locs.append((int(p["wof:id"]), p.get("wof:name", ""), min(xs), min(ys), max(xs), max(ys), geom))
+    except Exception: pass
+print(f"  {len(locs)} DE localities loaded")
+
+def pip_locality(lon, lat):
+    """Return (id, name) of the DE locality whose polygon contains (lon,lat), or None."""
+    for (lid, name, minx, miny, maxx, maxy, geom) in locs:
+        if minx <= lon <= maxx and miny <= lat <= maxy and in_geom(lon, lat, geom):
+            return (lid, name)
+    return None
+
+# ---- postcode centroids from our custom postalcode-intl.db ----
+con = sqlite3.connect(PC_DB)
+pc_centroid = {}
+for name, lat, lon in con.execute("SELECT name, latitude, longitude FROM spr WHERE country='DE' AND placetype='postalcode'"):
+    pc_centroid[name] = (lat, lon)
+print(f"  {len(pc_centroid)} DE postcode centroids loaded")
+
+# ---- name-match signal (from the resolver dump, joined by input) ----
+# resolved-v072-de.json carries the neural-resolved locality WOF id per row; "name-correct" means that
+# resolved locality IS the true containing locality (== name-match PIP-containment from #273).
+try:
+    dump = {d["input"]: d.get("neuralLocId") for d in json.load(open("/tmp/resolved-v072-de.json"))}
+except Exception:
+    dump = {}
+
+# Load the resolver's resolved-locality polygon by WOF id (same as scripts/eval/pip-containment.py) so
+# "name-correct" = gold point inside the RESOLVER's chosen polygon (== #273's 77.1%), not an id-equality
+# against our independently-PIP'd truth (which mismatches on granularity, e.g. Berlin city vs borough).
+import os
+_admin_roots = sorted(glob.glob("/mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data/whosonfirst-data-admin-*/data")) + \
+               ["/mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data-admin-us/data"]
+_gcache = {}
+def geom_for_id(wid):
+    if wid in _gcache: return _gcache[wid]
+    s = str(int(wid)); chunks = [s[i:i+3] for i in range(0, len(s), 3)]
+    rel = "/".join(chunks) + f"/{s}.geojson"
+    g = None
+    for root in _admin_roots:
+        fp = os.path.join(root, rel)
+        if os.path.exists(fp):
+            try: g = json.load(open(fp)).get("geometry")
+            except Exception: g = None
+            break
+    _gcache[wid] = g; return g
+
+# ---- run the probe over the DE sample ----
+rows = [json.loads(l) for l in open(SAMPLE) if l.strip()]
+ov = collections.Counter(); by = collections.defaultdict(collections.Counter)
+for r in rows:
+    st = r.get("state") or "??"
+    ov["n"] += 1; by[st]["n"] += 1
+    glon, glat = r["lon"], r["lat"]
+    # ground truth: which DE locality actually contains the gold point
+    truth = pip_locality(glon, glat)
+    if truth: ov["truth"] += 1; by[st]["truth"] += 1
+    truth_id = truth[0] if truth else None
+    # name signal: is the gold point inside the RESOLVER's chosen locality polygon? (== #273)
+    nlid = dump.get(r["input"])
+    ngeom = geom_for_id(nlid) if nlid else None
+    name_ok = ngeom is not None and in_geom(glon, glat, ngeom)
+    if name_ok: ov["name"] += 1; by[st]["name"] += 1
+    pc = (r.get("expected") or {}).get("postcode")
+    cen = pc_centroid.get(pc) if pc else None
+    if not cen:
+        if name_ok: ov["hybrid"] += 1; by[st]["hybrid"] += 1
+        continue
+    ov["has_pc"] += 1; by[st]["has_pc"] += 1
+    cand = pip_locality(cen[1], cen[0])  # cen=(lat,lon) -> pip(lon,lat)
+    # coordinate-first containment: does the gold point fall inside the centroid-PIP'd locality?
+    cf_ok = cand is not None and truth_id is not None and cand[0] == truth_id
+    if cf_ok: ov["cf"] += 1; by[st]["cf"] += 1
+    # HYBRID ceiling: name signal OR coordinate signal lands the true locality
+    if name_ok or cf_ok: ov["hybrid"] += 1; by[st]["hybrid"] += 1
+
+def line(label, c):
+    n = c["n"]
+    if not n: return f"  {label}: n=0"
+    pc = lambda k: f"{100*c[k]/n:.1f}%"
+    return f"  {label:<10} n={n:<5} name={pc('name'):<7} coord-first={pc('cf'):<7} HYBRID(name OR coord)={pc('hybrid')}"
+
+print("\n=== Resolver containment by signal (gold point inside the chosen locality) ===")
+print(line("OVERALL", ov))
+for st in sorted(by): print(line(st, by[st]))
+print("\n  name = resolver's current name-match resolution; coord-first = postcode centroid -> PIP locality;")
+print("  HYBRID = either signal lands the true locality (the soft-scoring ceiling).")


### PR DESCRIPTION
## What

Phase 2 of coordinate-first resolution (#275) — wires the `postcode_locality` candidate table (#274) into the resolver and delivers the German win.

When a `locality` query carries a sibling `postcode` **and** a `postcode_locality` table is attached, `WofSqlitePlaceLookup.findPlace` injects the postcode's containing (+ nearby) localities — the coordinate candidates the FTS name-match **can't generate** for an under-indexed small town — and soft-scores the union:

```
Score = 0.6·S_pc + 0.3·S_name + 0.1·S_pop      (each ∈ [0,1])
  S_pc   = 1.0 if postcode-containing, else exp(−dist/8km)
  S_name = exact name/alias → 1.0, else trigram-Jaccard (tolerant of swallowed-char fragments)
  S_pop  = log10(1+pop)/6, capped
```

with **exact-name tiering** (same philosophy as the FTS path): an exact name match tiers above coordinate-only candidates, so an unambiguous city ("Berlin", exact + huge population) stays ahead of the fine-grained Ortsteil its postcode centroid lands in — while a small town the name-match never finds is recovered by its postcode.

**Strictly gated.** Every non-postcode / non-locality query is byte-identical; the path no-ops entirely when no `postcode_locality` shard is present.

## Validated (v0.7.2 + #272 trim, DE n=3000, PIP-containment metric #273)

| | baseline | coord-first | Δ |
|---|--:|--:|--:|
| **DE overall** | 77.1% | **92.6%** | **+15.5pp** (clears the 90% done-with-German target) |
| Sachsen | 54.3% | 89.3% | +35.0pp |
| Berlin | 99.9% | 95.9% | −4.0pp (city-state Ortsteil residual — a future tune) |
| **US** (n=2000) | 97.7% | 97.7% | byte-identical (coord-first inert without the shard) |

30 resolver tests pass (3 new `coord-first.test.ts` + 27 existing — no regression).

## Not in this PR (follow-ups)

- The `postcode_city_mismatch` **conflict flag** (the falsehood differentiator) — needs a `PlaceCandidate` field + `decorateNode` plumbing; lands with the conflict-falsehoods eval (#276).
- The Berlin −4pp city-state residual (prefer the largest containing locality / drop empty-name Ortsteil records).
- Generalizing the candidate-table build to FR/GB/etc.

Run the DE table build (from source) before attaching: `scripts/build-postcode-locality.py --country DE ...` (#274). Closes #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
