### PR TITLE
feat(resolver): postcode/city conflict flag + falsehoods eval (#276)

### DIFF
--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -179,6 +179,10 @@ function decorateNode(node: AddressNode, resolved: ResolvedPlace, alternatives: 
 	// lets consumers display the canonical name and lets the end-to-end eval check the resolver chose
 	// the right PLACE (gazetteer-name vs ground-truth) rather than merely echoing the parser's text.
 	node.metadata = { ...(node.metadata ?? {}), resolver_score: resolved.score, resolver_name: resolved.name }
+	// The postcode/locality conflict flag (the falsehood differentiator): the postcode pointed to a
+	// geographically different place than the parsed city name. Surface it so callers can warn rather
+	// than silently trust the resolved point.
+	if (resolved.mismatch) node.metadata["postcode_city_mismatch"] = true
 	if (alternatives.length > 0) {
 		node.alternatives = alternatives
 	}

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -40,6 +40,13 @@ export interface ResolvedPlace {
 	 * defined; callers should treat as ordinal.
 	 */
 	score: number
+	/**
+	 * Set when the resolver detected that the address's postcode and its parsed locality name point to
+	 * geographically different places (a transposed / wrong-for-the-city postcode). Surfaced onto the
+	 * resolved node's metadata as `postcode_city_mismatch` so callers can lower confidence or flag the
+	 * conflict instead of silently mislocating.
+	 */
+	mismatch?: boolean
 }
 
 /**

--- a/data/eval/falsehoods/postcode-city-conflicts.jsonl
+++ b/data/eval/falsehoods/postcode-city-conflicts.jsonl
@@ -1,0 +1,9 @@
+{"input": "80331 Berlin", "locale": "de-DE", "components": {"locality": "Berlin", "postcode": "80331"}, "falsehood": "München postcode on a Berlin address — wrong city for postcode", "conflict": true, "expect_flag": true}
+{"input": "10115 München", "locale": "de-DE", "components": {"locality": "München", "postcode": "10115"}, "falsehood": "Berlin postcode on a München address", "conflict": true, "expect_flag": true}
+{"input": "50667 Hamburg", "locale": "de-DE", "components": {"locality": "Hamburg", "postcode": "50667"}, "falsehood": "Köln postcode on a Hamburg address", "conflict": true, "expect_flag": true}
+{"input": "20095 Dresden", "locale": "de-DE", "components": {"locality": "Dresden", "postcode": "20095"}, "falsehood": "Hamburg postcode on a Dresden address", "conflict": true, "expect_flag": true}
+{"input": "01067 Köln", "locale": "de-DE", "components": {"locality": "Köln", "postcode": "01067"}, "falsehood": "Dresden postcode on a Köln address", "conflict": true, "expect_flag": true}
+{"input": "10117 Berlin", "locale": "de-DE", "components": {"locality": "Berlin", "postcode": "10117"}, "falsehood": "control — correct Berlin postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
+{"input": "01069 Dresden", "locale": "de-DE", "components": {"locality": "Dresden", "postcode": "01069"}, "falsehood": "control — correct Dresden postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
+{"input": "80333 München", "locale": "de-DE", "components": {"locality": "München", "postcode": "80333"}, "falsehood": "control — correct München postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
+{"input": "02699 Königswartha", "locale": "de-DE", "components": {"locality": "Königswartha", "postcode": "02699"}, "falsehood": "control — abutting postcode (centroid in neighbouring Neschwitz); the named town wins, NOT a conflict", "conflict": false, "expect_flag": false}

--- a/resolver-wof-sqlite/coord-first.test.ts
+++ b/resolver-wof-sqlite/coord-first.test.ts
@@ -35,7 +35,9 @@ function buildDb(): DatabaseSync {
 	spr.run(1, 0, "Berlin", "locality", "DE", 52.52, 13.4, 52.3, 52.7, 13.0, 13.8)
 	spr.run(2, 1, "Koepenick", "locality", "DE", 52.44, 13.58, 52.4, 52.5, 13.5, 13.7)
 	spr.run(3, 0, "Plauen", "locality", "DE", 50.49, 12.14, 50.4, 50.6, 12.0, 12.3)
+	spr.run(4, 0, "Muenchen", "locality", "DE", 48.14, 11.58, 48.0, 48.3, 11.4, 11.8) // ~500 km from Berlin
 	db.prepare(`INSERT INTO place_population (id, population) VALUES (?, ?)`).run(1, 3_600_000)
+	db.prepare(`INSERT INTO place_population (id, population) VALUES (?, ?)`).run(4, 1_500_000)
 	const pl = db.prepare(`INSERT INTO postcode_locality VALUES (?,?,?,?,?,?,?)`)
 	pl.run("10115", "DE", 2, "Koepenick", "", 0.0, 1) // a Berlin postcode's centroid lands in the Ortsteil
 	pl.run("08523", "DE", 3, "Plauen", "", 0.0, 1) // Plauen's postcode → Plauen
@@ -67,5 +69,19 @@ describe("coordinate-first locality resolution", () => {
 		// exact match — exact-name tiering keeps Berlin ahead of the coordinate-only borough.
 		const r = await lookup.findPlace({ text: "Berlin", placetype: "locality", postcode: "10115", country: "DE" })
 		expect(r[0]?.name).toBe("Berlin")
+	})
+
+	it("flags a postcode/city conflict (wrong-for-the-city postcode) but still returns the named city", async () => {
+		// "10115" is a Berlin postcode, but the parsed city is München (~500 km away) — a transposed or
+		// wrong postcode. The name wins (München), but the mismatch flag fires.
+		const r = await lookup.findPlace({ text: "Muenchen", placetype: "locality", postcode: "10115", country: "DE" })
+		expect(r[0]?.name).toBe("Muenchen")
+		expect(r[0]?.mismatch).toBe(true)
+	})
+
+	it("does NOT flag a city-state Ortsteil as a conflict (the city is near its own borough)", async () => {
+		// Berlin chosen over its borough Koepenick (~15 km) — close, so no false conflict.
+		const r = await lookup.findPlace({ text: "Berlin", placetype: "locality", postcode: "10115", country: "DE" })
+		expect(r[0]?.mismatch).toBeFalsy()
 	})
 })

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -177,6 +177,12 @@ const CF_PC = 0.6
 const CF_NAME = 0.3
 const CF_POP = 0.1
 const CF_PC_DECAY_KM = 8
+/** The chosen locality must be within this distance of the postcode's containing locality, else the
+ * postcode and the parsed city name are judged to disagree (a transposed / wrong-for-the-city
+ * postcode) and the `mismatch` flag fires. Generous enough that a city-state Ortsteil (~15km from the
+ * city centroid) and an abutting town (~few km) are NOT flagged, tight enough to catch a wrong city
+ * (hundreds of km). */
+const CF_MISMATCH_KM = 50
 const CF_MISMATCH_DELTA = 0.5
 
 /** Case-fold + strip diacritics + collapse punctuation — for the coord-first soft name match. */
@@ -560,6 +566,25 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		// postcode centroid lands in, while a small town the name-match never finds (no exact tier) is
 		// still recovered by its postcode's containing locality.
 		scored.sort((a, b) => Number(b.exact) - Number(a.exact) || b.score - a.score)
+
+		// Conflict flag: if the chosen locality is NOT the postcode's containing locality and sits far
+		// from it, the postcode and the city name disagree (a transposed / wrong-for-the-city postcode).
+		// We keep the name-chosen locality but flag it — the falsehood signal a BM25 geocoder can't give.
+		const top = scored[0]
+		if (top) {
+			// The postcode's geographic anchor: among the postcode's candidate localities that actually
+			// resolved (some — e.g. unnamed Ortsteile — are in the postcode table but not the admin DB),
+			// prefer the containing one, else the nearest. Postcodes whose centroid falls just outside
+			// every locality polygon still anchor to the closest town.
+			const anchorRow = pcRows
+				.filter((r) => merged.has(r.id))
+				.sort((a, b) => b.containing - a.containing || a.dist - b.dist)[0]
+			const anchor = anchorRow ? merged.get(anchorRow.id) : undefined
+			if (anchor && (top.id as number) !== anchorRow!.id) {
+				if (haversineKm(top.lat, top.lon, anchor.lat, anchor.lon) > CF_MISMATCH_KM) top.mismatch = true
+			}
+		}
+
 		return scored.slice(0, limit).map(({ exact, ...c }) => {
 			void exact
 			return c

--- a/resolver-wof-sqlite/types.ts
+++ b/resolver-wof-sqlite/types.ts
@@ -70,6 +70,14 @@ export interface PlaceCandidate {
 	 * the underlying schema lacks the columns.
 	 */
 	bbox?: GeoBbox
+	/**
+	 * Set by the coordinate-first path when the chosen locality and the sibling postcode's containing
+	 * locality are geographically far apart — the postcode and the parsed city name disagree (a
+	 * transposed / wrong-for-the-city postcode). The candidate is still returned (the name wins for the
+	 * locality), but the flag lets callers lower confidence / surface the conflict rather than silently
+	 * mislocate. A retrieval/BM25 geocoder can't raise this — it's the falsehood-detection differentiator.
+	 */
+	mismatch?: boolean
 }
 
 /**

--- a/scripts/eval/postcode-conflict-eval.ts
+++ b/scripts/eval/postcode-conflict-eval.ts
@@ -1,0 +1,94 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Postcode/city CONFLICT falsehoods eval (#276). The differentiator a retrieval/BM25 geocoder can't
+ *   offer: when the address's postcode and its parsed city name point to geographically different
+ *   places (a transposed / wrong-for-the-city postcode), the coordinate-first resolver returns the
+ *   named city but raises `postcode_city_mismatch`. This eval feeds the resolver a set of CONFLICT
+ *   rows (must flag) and CONTROL rows (correct or abutting — must NOT flag) and scores the flag.
+ *
+ *   We build the AddressTree directly from each row's components (locality + postcode siblings) so the
+ *   eval isolates the RESOLVER's conflict detection, independent of the parser.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/postcode-conflict-eval.ts \
+ *     --eval data/eval/falsehoods/postcode-city-conflicts.jsonl \
+ *     --wof /mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postcode-locality-de.db \
+ *     [--out-md <path>]
+ */
+import { createWofResolver } from "@mailwoman/core/resolver"
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { readFileSync, writeFileSync } from "node:fs"
+
+function arg(name: string, fallback = ""): string {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+}
+
+interface Row {
+	input: string
+	components: { locality?: string; postcode?: string }
+	falsehood: string
+	conflict: boolean
+	expect_flag: boolean
+}
+
+function node(tag: string, value: string): AddressNode {
+	return { tag, value, children: [] } as unknown as AddressNode
+}
+
+/** Did the resolved locality node carry the conflict flag? */
+function flagged(tree: AddressTree): boolean {
+	let hit = false
+	const walk = (n: AddressNode): void => {
+		const meta = n.metadata as Record<string, unknown> | undefined
+		if (meta?.["postcode_city_mismatch"] === true) hit = true
+		for (const c of n.children) walk(c)
+	}
+	for (const r of tree.roots) walk(r)
+	return hit
+}
+
+const rows: Row[] = readFileSync(arg("eval", "data/eval/falsehoods/postcode-city-conflicts.jsonl"), "utf8")
+	.split("\n")
+	.filter(Boolean)
+	.map((l) => JSON.parse(l))
+
+const wofPaths = arg("wof", "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db").split(",")
+const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
+const backend = new WofSqlitePlaceLookup({ databasePath: wofPaths.length === 1 ? wofPaths[0]! : wofPaths })
+const resolver = createWofResolver(backend as never)
+
+const results: Array<{ row: Row; flag: boolean; ok: boolean }> = []
+for (const row of rows) {
+	const roots: AddressNode[] = []
+	if (row.components.locality) roots.push(node("locality", row.components.locality))
+	if (row.components.postcode) roots.push(node("postcode", row.components.postcode))
+	const resolved = await resolver.resolveTree({ raw: row.input, roots }, { defaultCountry: "DE" })
+	const flag = flagged(resolved)
+	results.push({ row, flag, ok: flag === row.expect_flag })
+}
+
+const conflicts = results.filter((r) => r.row.conflict)
+const controls = results.filter((r) => !r.row.conflict)
+const recall = conflicts.filter((r) => r.flag).length / (conflicts.length || 1)
+const specificity = controls.filter((r) => !r.flag).length / (controls.length || 1)
+
+const lines: string[] = []
+lines.push(`# Postcode/city conflict falsehoods (#276)\n`)
+lines.push(`Conflict recall (flagged the wrong-postcode): **${(100 * recall).toFixed(0)}%** (${conflicts.filter((r) => r.flag).length}/${conflicts.length})`)
+lines.push(`Control specificity (did NOT false-flag correct/abutting): **${(100 * specificity).toFixed(0)}%** (${controls.filter((r) => !r.flag).length}/${controls.length})\n`)
+lines.push(`| input | kind | expect flag | got flag | ok |`)
+lines.push(`|---|---|:--:|:--:|:--:|`)
+for (const r of results) {
+	lines.push(`| ${r.row.input} | ${r.row.conflict ? "conflict" : "control"} | ${r.row.expect_flag} | ${r.flag} | ${r.ok ? "✅" : "❌"} |`)
+}
+const report = lines.join("\n")
+console.log(report)
+if (arg("out-md")) {
+	writeFileSync(arg("out-md"), report + "\n")
+	console.error(`wrote markdown → ${arg("out-md")}`)
+}
+backend.close?.()
+process.exit(results.every((r) => r.ok) ? 0 : 1)


### PR DESCRIPTION
The falsehood-detection differentiator BM25 geocoders can't offer.

When coord-first picks the named city but the postcode's geographic anchor is >50km away, the postcode and parsed city **disagree** (transposed / wrong-for-the-city postcode). The resolver keeps the named city but raises `postcode_city_mismatch` on the node metadata — so callers can warn instead of silently mislocating. The 50km threshold ignores city-state Ortsteile (~15km) and abutting towns (~few km).

**New eval** `data/eval/falsehoods/postcode-city-conflicts.jsonl` (5 conflict + 4 control incl. the abutting Königswartha case) + `scripts/eval/postcode-conflict-eval.ts`:

| metric | result |
|---|--:|
| Conflict recall (flagged the wrong-postcode) | **100%** (5/5) |
| Control specificity (no false-flag on correct/abutting) | **100%** (4/4) |

Ranking is unchanged (the flag is additive metadata) — DE containment stays 92.6%. resolver-wof-sqlite 117 + core resolver 19 tests pass. Closes #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)