### PR TITLE
feat(resolver): generalize postcode→locality to FR + multi-locale shared table

### DIFF
--- a/data/eval/falsehoods/postcode-city-conflicts.jsonl
+++ b/data/eval/falsehoods/postcode-city-conflicts.jsonl
@@ -7,3 +7,8 @@
 {"input": "01069 Dresden", "locale": "de-DE", "components": {"locality": "Dresden", "postcode": "01069"}, "falsehood": "control — correct Dresden postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
 {"input": "80333 München", "locale": "de-DE", "components": {"locality": "München", "postcode": "80333"}, "falsehood": "control — correct München postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
 {"input": "02699 Königswartha", "locale": "de-DE", "components": {"locality": "Königswartha", "postcode": "02699"}, "falsehood": "control — abutting postcode (centroid in neighbouring Neschwitz); the named town wins, NOT a conflict", "conflict": false, "expect_flag": false}
+{"input": "75001 Lyon", "locale": "fr-FR", "components": {"locality": "Lyon", "postcode": "75001"}, "falsehood": "Paris postcode on a Lyon address — wrong city for postcode", "conflict": true, "expect_flag": true}
+{"input": "69001 Paris", "locale": "fr-FR", "components": {"locality": "Paris", "postcode": "69001"}, "falsehood": "Lyon postcode on a Paris address", "conflict": true, "expect_flag": true}
+{"input": "13001 Bordeaux", "locale": "fr-FR", "components": {"locality": "Bordeaux", "postcode": "13001"}, "falsehood": "Marseille postcode on a Bordeaux address", "conflict": true, "expect_flag": true}
+{"input": "75001 Paris", "locale": "fr-FR", "components": {"locality": "Paris", "postcode": "75001"}, "falsehood": "control — correct Paris postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
+{"input": "69001 Lyon", "locale": "fr-FR", "components": {"locality": "Lyon", "postcode": "69001"}, "falsehood": "control — correct Lyon postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}

--- a/scripts/build-postcode-locality.py
+++ b/scripts/build-postcode-locality.py
@@ -106,11 +106,14 @@ def main():
     print(f"  {len(postcodes)} {args.country} postcode centroids")
 
     out = sqlite3.connect(args.output)
-    out.execute("DROP TABLE IF EXISTS postcode_locality")
-    out.execute("""CREATE TABLE postcode_locality (
+    # Accumulate per country into one shared DB (the resolver attaches a SINGLE postcode_locality
+    # shard and country-filters at query time). CREATE-IF-NOT-EXISTS + DELETE-this-country makes each
+    # --country run idempotent, so `--output postcode-locality-intl.db` can be filled DE, FR, … in turn.
+    out.execute("""CREATE TABLE IF NOT EXISTS postcode_locality (
         postcode TEXT NOT NULL, country TEXT NOT NULL, locality_id INTEGER NOT NULL,
         locality_name TEXT NOT NULL, aliases TEXT, distance_km REAL NOT NULL,
         is_containing INTEGER NOT NULL)""")
+    out.execute("DELETE FROM postcode_locality WHERE country = ?", (args.country,))
 
     rows, n_contained = 0, 0
     for (pc, plat, plon) in postcodes:
@@ -142,7 +145,7 @@ def main():
             out.execute("INSERT INTO postcode_locality VALUES (?,?,?,?,?,?,?)",
                         (pc, args.country, l["id"], l["name"], "|".join(l["aliases"]), round(d, 3), isc))
             rows += 1
-    out.execute("CREATE INDEX postcode_locality_by_pc ON postcode_locality(postcode, country)")
+    out.execute("CREATE INDEX IF NOT EXISTS postcode_locality_by_pc ON postcode_locality(postcode, country)")
     out.commit()
     print(f"  wrote {rows} rows ({n_contained}/{len(postcodes)} postcodes have a containing locality) → {args.output}")
     out.close()

--- a/scripts/eval/postcode-conflict-eval.ts
+++ b/scripts/eval/postcode-conflict-eval.ts
@@ -28,6 +28,7 @@ function arg(name: string, fallback = ""): string {
 
 interface Row {
 	input: string
+	locale?: string
 	components: { locality?: string; postcode?: string }
 	falsehood: string
 	conflict: boolean
@@ -65,7 +66,9 @@ for (const row of rows) {
 	const roots: AddressNode[] = []
 	if (row.components.locality) roots.push(node("locality", row.components.locality))
 	if (row.components.postcode) roots.push(node("postcode", row.components.postcode))
-	const resolved = await resolver.resolveTree({ raw: row.input, roots }, { defaultCountry: "DE" })
+	// Country from the row's locale tag ("de-DE" → "DE") so the test set can mix locales.
+	const defaultCountry = (row.locale?.split("-")[1] ?? "").toUpperCase() || undefined
+	const resolved = await resolver.resolveTree({ raw: row.input, roots }, { defaultCountry })
 	const flag = flagged(resolved)
 	results.push({ row, flag, ok: flag === row.expect_flag })
 }


### PR DESCRIPTION
Generalizes the coordinate-first candidate table to FR and makes the build multi-locale.

- **FR table built from source** (whosonfirst-data-admin-fr GeoJSON × FR postcodes in our custom postalcode-intl.db → 121,628 rows, 90.2% with a containing locality).
- **Shared table:** the build now accumulates per country into one `postcode-locality-intl.db` (idempotent: CREATE-IF-NOT-EXISTS + DELETE-this-country), so the resolver attaches a single shard (DE+FR, country-filtered) rather than one DB per locale.
- **Multi-locale conflict eval** (country from each row's locale) + FR cases: **conflict recall 100% (8/8), control specificity 100% (6/6)**. Paris arrondissements handled like Berlin's Ortsteile (exact-name tiering).

**GB blocked on source:** the WOF `whosonfirst-data-postalcode-gb` repo exists (feb-2024-sync) but isn't on disk and GB postcodes aren't in our custom DB. Per the build-from-source rule (no prebuilt dumps), GB needs that ~1.7M-record repo cloned first — a heavy acquisition flagged for the operator's call.

Spot-checked: 75001→Paris, 69001→Lyon, 13001→Marseille, 31000→Toulouse. (A full FR PIP-containment number awaits an FR OpenAddresses sample — none on disk yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)