### PR TITLE
feat(resolver): GB + NL coordinate-first + ES/IT/NL admin rebuild + read-only asset

### DIFF
--- a/data/eval/falsehoods/postcode-city-conflicts.jsonl
+++ b/data/eval/falsehoods/postcode-city-conflicts.jsonl
@@ -12,3 +12,8 @@
 {"input": "13001 Bordeaux", "locale": "fr-FR", "components": {"locality": "Bordeaux", "postcode": "13001"}, "falsehood": "Marseille postcode on a Bordeaux address", "conflict": true, "expect_flag": true}
 {"input": "75001 Paris", "locale": "fr-FR", "components": {"locality": "Paris", "postcode": "75001"}, "falsehood": "control — correct Paris postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
 {"input": "69001 Lyon", "locale": "fr-FR", "components": {"locality": "Lyon", "postcode": "69001"}, "falsehood": "control — correct Lyon postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
+{"input": "SW1A 1AA Edinburgh", "locale": "en-GB", "components": {"locality": "Edinburgh", "postcode": "SW1A 1AA"}, "falsehood": "London postcode on an Edinburgh address — wrong city for postcode", "conflict": true, "expect_flag": true}
+{"input": "EH1 1AA London", "locale": "en-GB", "components": {"locality": "London", "postcode": "EH1 1AA"}, "falsehood": "Edinburgh postcode on a London address", "conflict": true, "expect_flag": true}
+{"input": "M1 1AE Bristol", "locale": "en-GB", "components": {"locality": "Bristol", "postcode": "M1 1AE"}, "falsehood": "Manchester postcode on a Bristol address", "conflict": true, "expect_flag": true}
+{"input": "SW1A 1AA London", "locale": "en-GB", "components": {"locality": "London", "postcode": "SW1A 1AA"}, "falsehood": "control — correct London postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
+{"input": "EH1 1AA Edinburgh", "locale": "en-GB", "components": {"locality": "Edinburgh", "postcode": "EH1 1AA"}, "falsehood": "control — correct Edinburgh postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}

--- a/data/eval/falsehoods/postcode-city-conflicts.jsonl
+++ b/data/eval/falsehoods/postcode-city-conflicts.jsonl
@@ -17,3 +17,7 @@
 {"input": "M1 1AE Bristol", "locale": "en-GB", "components": {"locality": "Bristol", "postcode": "M1 1AE"}, "falsehood": "Manchester postcode on a Bristol address", "conflict": true, "expect_flag": true}
 {"input": "SW1A 1AA London", "locale": "en-GB", "components": {"locality": "London", "postcode": "SW1A 1AA"}, "falsehood": "control — correct London postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
 {"input": "EH1 1AA Edinburgh", "locale": "en-GB", "components": {"locality": "Edinburgh", "postcode": "EH1 1AA"}, "falsehood": "control — correct Edinburgh postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
+{"input": "1026 Rotterdam", "locale": "nl-NL", "components": {"locality": "Rotterdam", "postcode": "1026"}, "falsehood": "Amsterdam postcode on a Rotterdam address", "conflict": true, "expect_flag": true}
+{"input": "5624CL Utrecht", "locale": "nl-NL", "components": {"locality": "Utrecht", "postcode": "5624CL"}, "falsehood": "Eindhoven postcode on a Utrecht address", "conflict": true, "expect_flag": true}
+{"input": "1026 Amsterdam", "locale": "nl-NL", "components": {"locality": "Amsterdam", "postcode": "1026"}, "falsehood": "control — correct Amsterdam postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}
+{"input": "5624CL Eindhoven", "locale": "nl-NL", "components": {"locality": "Eindhoven", "postcode": "5624CL"}, "falsehood": "control — correct Eindhoven postcode + city (must NOT flag)", "conflict": false, "expect_flag": false}

--- a/resolver-wof-sqlite/POSTCODE-LOCALITY.md
+++ b/resolver-wof-sqlite/POSTCODE-LOCALITY.md
@@ -1,0 +1,73 @@
+# `postcode-locality-intl.db` — the coordinate-first candidate asset
+
+A self-contained, read-only SQLite asset mapping **postcode → containing + nearby WOF locality
+candidates**, consumed by `WofSqlitePlaceLookup`'s coordinate-first path (`findPlace` with a sibling
+`postcode`). It supplies the COORDINATE candidate the FTS name-match can't generate for an
+under-indexed small town — see [`docs/articles/plan/2026-06-04-coordinate-first-resolver.md`](../docs/articles/plan/2026-06-04-coordinate-first-resolver.md).
+
+It's built like our other WOF tables: **from source GeoJSON, never a prebuilt dump**, and frozen into
+a distributable artifact (a `meta` provenance/license table, `journal_mode=DELETE` so there's no
+`-wal`/`-shm` sidecar, `ANALYZE`, an integrity check, and `VACUUM`). You can hand the single `.db` to
+anyone and attach it as a resolver shard.
+
+## Schema
+
+```sql
+postcode_locality(
+  postcode TEXT, country TEXT,           -- key (indexed: postcode_locality_by_pc)
+  locality_id INTEGER, locality_name TEXT, aliases TEXT,  -- WOF locality + alt-name aliases (|-joined)
+  distance_km REAL, is_containing INTEGER -- 0km/1 = the postcode centroid is inside this locality's polygon
+)
+meta(key TEXT, value TEXT)               -- name/source/license/attribution/built_at/countries
+```
+
+The resolver attaches a **single** `postcode_locality` shard and country-filters at query time, so all
+locales live in one DB.
+
+## Build recipe (per locale, then finalize)
+
+`scripts/build-postcode-locality.py` point-in-polygons each postcode centroid against the WOF locality
+polygons (+ a ~10km nearby candidate set), accumulating per country into one DB (idempotent:
+re-running a country replaces just its rows). It needs the country's `whosonfirst-data-admin-<cc>`
+GeoJSON repo (locality polygons) and a postcode SQLite (centroids).
+
+```bash
+# one per country into the shared asset
+python3 scripts/build-postcode-locality.py --country DE \
+  --admin-repo   .../whosonfirst-data/whosonfirst-data-admin-de \
+  --postcode-db  .../postalcode-intl.db \
+  --output       .../postcode-locality-intl.db
+
+# GB: postcodes aren't in postalcode-intl.db — build a GB postcode DB from source first
+node --experimental-strip-types scripts/build-unified-wof.ts \
+  --data .../whosonfirst-data-postalcode-gb --output .../postalcode-gb.db --placetypes postalcode
+python3 scripts/build-postcode-locality.py --country GB \
+  --admin-repo .../whosonfirst-data-admin-gb --postcode-db .../postalcode-gb.db \
+  --output .../postcode-locality-intl.db
+
+# freeze into the read-only distributable asset (meta + VACUUM + integrity)
+python3 scripts/build-postcode-locality.py --output .../postcode-locality-intl.db --finalize
+```
+
+## Coverage (built 2026-06-04)
+
+| country | rows | postcodes with a containing locality | notes |
+|---|--:|--:|---|
+| DE | 92,689 | 24,443 | resolver-validated, DE 77→93% PIP-containment |
+| FR | 121,628 | 24,455 | validated; Paris arrondissements handled like Berlin Ortsteile |
+| NL | 1,842,253 | 370,222 (99.6%) | strong coverage — inert until NL localities are in the admin DB |
+| GB | 7,630,560 | 1,626,691 | unit postcodes; **~34% of GB postcodes get no candidate** (WOF GB locality coverage is incomplete) |
+| ES | 27,111 | 3,273 (28.9%) | WOF orphan-heavy — sparse; inert until ES localities are in the admin DB |
+| IT | 18,349 | 2,081 (42.2%) | WOF orphan-heavy — sparse; inert until IT localities are in the admin DB |
+
+## Caveats / follow-ups
+
+- **The locality must also be in the resolver's admin DB to resolve.** The table can reference a WOF
+  locality id that `admin-global-priority.db` doesn't ship (the admin build globs a different set). DE/FR/GB
+  localities are in the admin DB; **ES/IT/NL are not yet** — their tables are built but inert until the
+  admin DB is rebuilt to include them. The conflict-flag anchor already tolerates this (it anchors to the
+  best candidate that actually resolved).
+- **GB locality coverage is ~66%** of unit postcodes. The missing third (e.g. `EH1 1AA`) can't get a
+  coordinate candidate or a conflict flag. A finer-grained or non-WOF GB locality source would close it.
+- **License:** the data is WOF-derived (CC-BY 4.0; attribution in `meta`). Underlying WOF sources (e.g.
+  GeoNames) carry their own attribution — confirm the exact redistribution terms before publishing.

--- a/scripts/build-postcode-locality.py
+++ b/scripts/build-postcode-locality.py
@@ -59,15 +59,57 @@ def aliases_for(props, canonical):
     out.discard(canonical)
     return sorted(out)
 
+def finalize(output):
+    """Freeze the accumulated table into a self-contained, read-only, distributable sqlite asset (the
+    same shape as our other WOF tables): a provenance/license `meta` table, query-planner stats, an
+    integrity check, a rollback (non-WAL) journal mode so there's no sidecar, and a VACUUM to compact."""
+    import datetime
+    db = sqlite3.connect(output)
+    counts = db.execute(
+        "SELECT country, COUNT(*), SUM(is_containing) FROM postcode_locality GROUP BY country ORDER BY country"
+    ).fetchall()
+    summary = {c: {"rows": n, "containing": int(con or 0)} for (c, n, con) in counts}
+    db.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
+    meta = {
+        "name": "mailwoman-postcode-locality",
+        "description": "postcode → containing + nearby WOF locality candidates (coordinate-first resolution)",
+        "schema_version": "1",
+        "built_at": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+        "source": "Who's On First (whosonfirst.org) — admin locality polygons + postalcode centroids; built from source GeoJSON, not a prebuilt dump",
+        "license": "CC-BY 4.0 (Who's On First) — attribution required on redistribution",
+        "attribution": "Contains data from Who's On First, © Who's On First contributors, CC-BY 4.0",
+        "method": "point-in-polygon of each postcode centroid against WOF locality polygons (+ a ~10km nearby candidate set with alt-name aliases)",
+        "countries": json.dumps(summary, sort_keys=True),
+    }
+    db.executemany("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)", list(meta.items()))
+    db.commit()
+    db.execute("PRAGMA journal_mode = DELETE")  # no -wal/-shm sidecar; the .db is self-contained
+    db.execute("ANALYZE")
+    ok = db.execute("PRAGMA integrity_check").fetchone()[0]
+    if ok != "ok":
+        raise SystemExit(f"integrity_check failed: {ok}")
+    db.commit()
+    db.execute("VACUUM")
+    db.close()
+    print(f"finalized {output}: integrity=ok, countries={summary}")
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--country", required=True)
-    ap.add_argument("--admin-repo", required=True)
-    ap.add_argument("--postcode-db", required=True)
+    ap.add_argument("--country")
+    ap.add_argument("--admin-repo")
+    ap.add_argument("--postcode-db")
     ap.add_argument("--output", required=True)
     ap.add_argument("--radius-km", type=float, default=10.0)
     ap.add_argument("--max-candidates", type=int, default=4)
+    ap.add_argument("--finalize", action="store_true",
+                    help="freeze the accumulated table into a read-only distributable asset (meta + VACUUM + integrity); no rebuild")
     args = ap.parse_args()
+
+    if args.finalize:
+        finalize(args.output)
+        return
+    if not (args.country and args.admin_repo and args.postcode_db):
+        raise SystemExit("build mode needs --country, --admin-repo, --postcode-db (or pass --finalize)")
 
     print(f"loading {args.country} locality polygons from source GeoJSON…")
     locs = []  # dict: id, name, aliases, clat, clon, bbox, geom
@@ -93,10 +135,19 @@ def main():
             pass
     print(f"  {len(locs)} localities")
 
-    # grid index (0.1° cells ≈ 11km) over locality centroids for the radius candidate set.
+    # Two 0.1°-cell (~11km) grid indexes. `grid` (by centroid) drives the radius candidate set; `bgrid`
+    # (by bbox-spanned cells — a locality is registered in every cell its bounding box overlaps) drives
+    # the containing-PIP, so it checks only the localities whose bbox could cover the point instead of a
+    # linear scan over all of them. At GB scale (2.7M postcodes × 11.7K localities) that's the
+    # difference between minutes and ~an hour.
     grid = collections.defaultdict(list)
+    bgrid = collections.defaultdict(list)
     for idx, l in enumerate(locs):
         grid[(round(l["clon"]*10), round(l["clat"]*10))].append(idx)
+        minx, miny, maxx, maxy = l["bbox"]
+        for cx in range(int(math.floor(minx*10)), int(math.floor(maxx*10)) + 1):
+            for cy in range(int(math.floor(miny*10)), int(math.floor(maxy*10)) + 1):
+                bgrid[(cx, cy)].append(idx)
 
     con = sqlite3.connect(args.postcode_db)
     postcodes = con.execute(
@@ -118,9 +169,10 @@ def main():
     rows, n_contained = 0, 0
     for (pc, plat, plon) in postcodes:
         if plat is None or plon is None: continue
-        # containing locality via bbox-prefiltered PIP
+        # containing locality via bbox-grid-prefiltered PIP (only localities whose bbox spans this cell)
         containing_idx = None
-        for idx, l in enumerate(locs):
+        for idx in bgrid.get((int(math.floor(plon*10)), int(math.floor(plat*10))), ()):
+            l = locs[idx]
             minx, miny, maxx, maxy = l["bbox"]
             if minx <= plon <= maxx and miny <= plat <= maxy and in_geom(plon, plat, l["geom"]):
                 containing_idx = idx; break

--- a/scripts/wof-build-manifest.json
+++ b/scripts/wof-build-manifest.json
@@ -11,13 +11,17 @@
     { "name": "whosonfirst-data-admin-gb", "url": "https://github.com/whosonfirst-data/whosonfirst-data-admin-gb", "commit": "574b9aab754d75349b7c4740e9557901ddf00c95", "geojson_files": 72674 },
     { "name": "whosonfirst-data-admin-jp", "url": "https://github.com/whosonfirst-data/whosonfirst-data-admin-jp", "commit": "6ac4e1339705ddb8e99d3d85d5837a23b0cca09b", "geojson_files": 62896 },
     { "name": "whosonfirst-data-admin-kr", "url": "https://github.com/whosonfirst-data/whosonfirst-data-admin-kr", "commit": "132b675fea1e062f92bbdb0ebf5704f1acf895c0", "geojson_files": 54034 },
-    { "name": "whosonfirst-data-admin-us", "url": "https://github.com/whosonfirst-data/whosonfirst-data-admin-us", "commit": "c4e4f9b2233c4b29a6f7124278b635e270d0b87d", "geojson_files": 448570 }
+    { "name": "whosonfirst-data-admin-us", "url": "https://github.com/whosonfirst-data/whosonfirst-data-admin-us", "commit": "c4e4f9b2233c4b29a6f7124278b635e270d0b87d", "geojson_files": 448570 },
+    { "name": "whosonfirst-data-admin-es", "url": "https://github.com/whosonfirst-data/whosonfirst-data-admin-es", "commit": "148ad222206ca465e346eab6364bc369b6f0f938", "geojson_files": 63175, "_added": "2026-06-04 for the coordinate-first postcode→locality work" },
+    { "name": "whosonfirst-data-admin-it", "url": "https://github.com/whosonfirst-data/whosonfirst-data-admin-it", "commit": "c0e2aef6a38f0580acb78815866b0f6b15722558", "geojson_files": 89728, "_added": "2026-06-04 for the coordinate-first postcode→locality work" },
+    { "name": "whosonfirst-data-admin-nl", "url": "https://github.com/whosonfirst-data/whosonfirst-data-admin-nl", "commit": "f7b35802f907eb1eb010f51586586bfaac5bb7e5", "geojson_files": 26349, "_added": "2026-06-04 for the coordinate-first postcode→locality work (NL coord-first now resolves)" }
   ],
-  "total_geojson_files": 1738443,
+  "total_geojson_files": 1917695,
   "expected_output": {
-    "total_places": 1288749,
-    "localities": 1027616,
-    "by_country": { "CN": 678311, "US": 258543, "FR": 114655, "DE": 87074, "JP": 54488, "KR": 52967, "GB": 42711 },
+    "_comment": "Rebuilt 2026-06-04 to add ES/IT/NL (coordinate-first). DE/FR/GB locality counts unchanged (12657/57260/16813); DE PIP-containment held at 92.6%.",
+    "total_places": 1422101,
+    "localities": 1034447,
+    "by_country_localities": { "CN": 676736, "US": 169799, "IT": 62588, "FR": 57260, "KR": 50465, "JP": 43886, "ES": 31321, "GB": 16813, "DE": 12657, "NL": 7358 },
     "tables": ["spr", "names", "concordances", "place_population", "ancestors", "place_search", "place_bbox"],
     "spr_has_bbox_columns": true
   },
@@ -30,9 +34,24 @@
     "expected_output": { "total_places": 42319, "tables": ["spr", "names", "place_population", "ancestors", "place_search", "place_bbox"] },
     "resolver_wiring": "ResolveRouter + WofSqlitePlaceLookup take both DBs (admin-global-priority.db, postalcode-us.db); postalcode queries route to the postcode shard."
   },
+  "postcode_build_gb": {
+    "_comment": "GB postcodes for the coordinate-first postcode→locality table (acquired from source 2026-06-04). 2.72M unit postcodes; geojson is committed directly (only meta CSVs are LFS).",
+    "artifact": "postalcode-gb.db",
+    "build_command": "node --experimental-strip-types scripts/build-unified-wof.ts --data /mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data-postalcode-gb --output /mnt/playpen/mailwoman-data/wof/postalcode-gb.db --placetypes postalcode",
+    "repo": { "name": "whosonfirst-data-postalcode-gb", "url": "https://github.com/whosonfirst-data/whosonfirst-data-postalcode-gb", "commit": "0bf2e994c3369cb37dbf82c5eae23bea45d3b8c8", "geojson_files": 2719772 },
+    "expected_output": { "total_places": 2719772 }
+  },
+  "postcode_locality_asset": {
+    "_comment": "Coordinate-first candidate table (postcode → containing + nearby WOF localities). Read-only distributable asset; see resolver-wof-sqlite/POSTCODE-LOCALITY.md.",
+    "artifact": "postcode-locality-intl.db",
+    "build": "scripts/build-postcode-locality.py --country <CC> --admin-repo <admin-<cc>> --postcode-db <postalcode source> --output postcode-locality-intl.db  (per country), then --finalize",
+    "countries": ["DE", "ES", "FR", "GB", "IT", "NL"],
+    "postcode_sources": { "DE/ES/FR/IT/NL": "postalcode-intl.db", "GB": "postalcode-gb.db" }
+  },
   "notes": [
     "admin-fr was missing from the cloned repos when this manifest was created (only the built admin-fr.db artifact remained); re-cloned 2026-05-30 at the commit above.",
     "Clones are shallow (git clone --depth 1) for the data; the commit hash still pins the snapshot.",
-    "Postcodes: US only so far. Other priority countries' postcodes need their whosonfirst-data-postalcode-<cc> repos cloned + the same --placetypes postalcode build."
+    "Postcodes: US (admin shard) + GB (postcode-build-gb) + DE/ES/FR/IT/NL (postalcode-intl.db) for the coordinate-first table.",
+    "2026-06-04: rebuilt admin-global-priority.db to add ES/IT/NL localities (NL coord-first now resolves). DE/FR/GB unchanged + DE PIP-containment held at 92.6% (no regression). Prior DB backed up as admin-global-priority.db.pre-nl-bak."
   ]
 }


### PR DESCRIPTION
Generalizes the coordinate-first candidate table to **GB** and freezes the shared intl DB into a self-contained, distributable **read-only asset** (like our other WOF tables).

## GB (from source)
Cloned `whosonfirst-data-postalcode-gb` (2.72M unit postcodes; geojson is direct, not LFS) → `postalcode-gb.db` via build-unified-wof (Spliterator, 229s) → table (7.63M rows). GB resolves out of the box — its localities are already in the admin DB. WOF GB locality coverage is ~66% (1.79M of 2.72M postcodes get a candidate).

## Build scaling
bbox-grid prefilter for the containing-PIP (each locality in every cell its bbox spans) replaces the linear scan — minutes not ~an hour at GB scale. Verified it reproduces DE's exact 92,689/24,443.

## Read-only asset (`--finalize`)
Provenance/license `meta` table (WOF-from-source, CC-BY attribution, per-country counts, build date) + journal_mode=DELETE (no sidecar) + ANALYZE + integrity_check + VACUUM. Single self-contained 2.2GB `.db`, attachable as a resolver shard. Doc: `resolver-wof-sqlite/POSTCODE-LOCALITY.md`.

## Validation
Multi-locale conflict eval (DE+FR+GB): **recall 91% (10/11), specificity 100% (8/8)**. The one miss (EH1 1AA London) is a GB coverage gap (that postcode isn't in the table), not a logic bug.

Asset covers DE/ES/FR/GB/IT/NL. NL/ES/IT stay inert until their localities are in the admin DB (the admin-DB rebuild — flagged in the doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)