### PR TITLE
chore(eval): coord-first on by default in the resolver evals

### DIFF
--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -38,9 +38,12 @@
  *   --eval data/eval/external/openaddresses-us-sample.jsonl --limit 2000\
  *   --model /tmp/v072-eval/model.onnx\
  *   --tokenizer /mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model\
- *   --model-card /tmp/v072-eval/model-card.json\
- *   --wof
- *   /mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postalcode-us.db
+ *   --model-card /tmp/v072-eval/model-card.json
+ *
+ *   `--wof` defaults to `admin-global-priority.db,postcode-locality-intl.db` — coordinate-first locality
+ *   resolution is ON by default (no-op where the candidate table has no rows, e.g. US). Pass `--wof
+ *   <admin.db>` alone for the admin-only baseline, or append a postcode shard (postalcode-*.db) to also
+ *   resolve the postcode node.
  */
 
 import { lookupGermanState } from "@mailwoman/codex/de"
@@ -248,7 +251,14 @@ function percentile(xs: number[], p: number): number | null {
 async function main(): Promise<void> {
 	const evalPath = arg("eval", "data/eval/external/openaddresses-us-sample.jsonl")
 	const limit = Number(arg("limit", "0")) || Infinity
-	const wofPaths = arg("wof", "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db")
+	// Default attaches the coordinate-first candidate shard (postcode-locality-intl.db) alongside the
+	// admin gazetteer, so locality resolution is coordinate-first by default for the locales it covers
+	// (DE/FR/GB/NL functional). It no-ops where the table has no rows (e.g. US), so US stays unchanged.
+	// Override `--wof` to measure the admin-only baseline.
+	const wofPaths = arg(
+		"wof",
+		"/mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postcode-locality-intl.db"
+	)
 		.split(",")
 		.map((s) => s.trim())
 

--- a/scripts/eval/postcode-conflict-eval.ts
+++ b/scripts/eval/postcode-conflict-eval.ts
@@ -13,9 +13,8 @@
  *   eval isolates the RESOLVER's conflict detection, independent of the parser.
  *
  *   Run: node --experimental-strip-types scripts/eval/postcode-conflict-eval.ts \
- *     --eval data/eval/falsehoods/postcode-city-conflicts.jsonl \
- *     --wof /mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postcode-locality-de.db \
- *     [--out-md <path>]
+ *     --eval data/eval/falsehoods/postcode-city-conflicts.jsonl [--out-md <path>]
+ *   (`--wof` defaults to admin-global-priority.db + postcode-locality-intl.db — coord-first on.)
  */
 import { createWofResolver } from "@mailwoman/core/resolver"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
@@ -56,7 +55,10 @@ const rows: Row[] = readFileSync(arg("eval", "data/eval/falsehoods/postcode-city
 	.filter(Boolean)
 	.map((l) => JSON.parse(l))
 
-const wofPaths = arg("wof", "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db").split(",")
+const wofPaths = arg(
+	"wof",
+	"/mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postcode-locality-intl.db"
+).split(",")
 const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
 const backend = new WofSqlitePlaceLookup({ databasePath: wofPaths.length === 1 ? wofPaths[0]! : wofPaths })
 const resolver = createWofResolver(backend as never)


### PR DESCRIPTION
The resolver evals (`oa-resolver-eval.ts`, `postcode-conflict-eval.ts`) now default `--wof` to `admin-global-priority.db,postcode-locality-intl.db` — so coordinate-first locality resolution + the postcode/city conflict flag are **on by default** for the covered locales (DE/FR/GB/NL). No-ops where the candidate table has no rows (US unchanged); pass `--wof <admin.db>` alone for the admin-only baseline.

Verified: conflict eval with no `--wof` → recall 92% / specificity 100%; oa-resolver-eval reports `WOF shards: 2` by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)