### PR TITLE
feat(resolver): Geographic Rule Engine core — convention dispatch (#289)

### DIFF
--- a/resolver-wof-sqlite/convention.test.ts
+++ b/resolver-wof-sqlite/convention.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Geographic Rule Engine convention model (Direction E, #289). Two layers of tests:
+ *
+ *   1. The pure engine — `mergeConventions` / `resolveConvention` / `SeedConventionSource`: deep-merge
+ *        precedence over a country → region → locality ancestor chain (most-specific wins, weights
+ *        merge key-by-key). This is the mechanism the EU locales never exercise (they ride
+ *        WORLD_DEFAULT).
+ *   2. Live dispatch — a `WofSqlitePlaceLookup` with an INJECTED convention, keyed by the country's WOF
+ *        id, proving the merged convention actually reroutes `findPlace`'s strategy dispatch.
+ */
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+	type Convention,
+	mergeConventions,
+	resolveConvention,
+	SeedConventionSource,
+	WORLD_DEFAULT,
+} from "./convention.js"
+import { WofSqlitePlaceLookup } from "./lookup.js"
+
+describe("convention engine — merge + resolve", () => {
+	it("WORLD_DEFAULT reproduces the pre-engine coordinate-first dispatch", () => {
+		expect(WORLD_DEFAULT.candidateStrategies).toEqual(["postcode_area_resolution", "fallback_fuzzy_name_match"])
+		expect(WORLD_DEFAULT.scoringWeights).toEqual({ pc: 0.6, name: 0.3, pop: 0.1 })
+	})
+
+	it("replaces candidateStrategies wholesale (a convention names its full list, never appends)", () => {
+		const out = mergeConventions(WORLD_DEFAULT, {
+			candidateStrategies: ["digital_code_lookup", "postcode_area_resolution"],
+		})
+		expect(out.candidateStrategies).toEqual(["digital_code_lookup", "postcode_area_resolution"])
+	})
+
+	it("merges scoringWeights key-by-key so a layer can nudge one weight and inherit the rest", () => {
+		const merged = resolveConvention(new SeedConventionSource({ 1: { scoringWeights: { pc: 0.8 } } }), [1])
+		expect(merged.scoringWeights).toEqual({ pc: 0.8, name: 0.3, pop: 0.1 })
+	})
+
+	it("ignores undefined layers (an ancestor with no override row)", () => {
+		const out = mergeConventions(WORLD_DEFAULT, undefined, { scoringWeights: { name: 0.5 } }, undefined)
+		expect(out.candidateStrategies).toEqual(WORLD_DEFAULT.candidateStrategies)
+		expect(out.scoringWeights).toEqual({ pc: 0.6, name: 0.5, pop: 0.1 })
+	})
+
+	it("an empty ancestor chain resolves to WORLD_DEFAULT (the EU locales' path)", () => {
+		const out = resolveConvention(new SeedConventionSource(), [])
+		expect(out).toEqual(WORLD_DEFAULT)
+	})
+
+	it("deep-merges country → region → locality with most-specific winning", () => {
+		// country sets a base strategy list + pc weight; region overrides the strategy list; locality
+		// nudges name weight. The resolved convention reflects the most-specific value per field.
+		const source = new SeedConventionSource({
+			100: { candidateStrategies: ["postcode_area_resolution"], scoringWeights: { pc: 0.7 } }, // country (JP)
+			200: { candidateStrategies: ["grid_interpolation", "postcode_area_resolution"] }, // region (Hokkaido)
+			300: { scoringWeights: { name: 0.4 } }, // locality (Sapporo)
+		} satisfies Record<number, Convention>)
+		// chain ordered MOST-GENERAL → MOST-SPECIFIC
+		const out = resolveConvention(source, [100, 200, 300])
+		expect(out.candidateStrategies).toEqual(["grid_interpolation", "postcode_area_resolution"]) // region won
+		expect(out.scoringWeights).toEqual({ pc: 0.7, name: 0.4, pop: 0.1 }) // country pc + locality name + base pop
+	})
+
+	it("SeedConventionSource returns rows by id and undefined for misses", () => {
+		const src = new SeedConventionSource({ 42: { candidateStrategies: ["x"] } })
+		expect(src.get(42)).toEqual({ candidateStrategies: ["x"] })
+		expect(src.get(99)).toBeUndefined()
+	})
+})
+
+// --- Live dispatch: an injected convention reroutes findPlace -------------------------------------
+
+function buildDb(): DatabaseSync {
+	const db = new DatabaseSync(":memory:")
+	db.exec(`
+		CREATE TABLE spr (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL, min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER NOT NULL, language TEXT, name TEXT NOT NULL);
+		CREATE TABLE place_population (id INTEGER PRIMARY KEY, population INTEGER);
+		CREATE TABLE postcode_locality (postcode TEXT, country TEXT, locality_id INTEGER, locality_name TEXT,
+			aliases TEXT, distance_km REAL, is_containing INTEGER);
+	`)
+	const spr = db.prepare(
+		`INSERT INTO spr (id,parent_id,name,placetype,country,latitude,longitude,min_latitude,max_latitude,min_longitude,max_longitude,is_current,is_deprecated)
+		 VALUES (?,?,?,?,?,?,?,?,?,?,?,-1,0)`
+	)
+	// id 90 is the DE country polygon (the convention key); 3 is the small Saxon town "Plauen".
+	spr.run(90, 0, "Germany", "country", "DE", 51.0, 10.0, 47.0, 55.0, 6.0, 15.0)
+	spr.run(3, 90, "Plauen", "locality", "DE", 50.49, 12.14, 50.4, 50.6, 12.0, 12.3)
+	db.prepare(`INSERT INTO postcode_locality VALUES (?,?,?,?,?,?,?)`).run("08523", "DE", 3, "Plauen", "", 0.0, 1)
+	return db
+}
+
+describe("convention engine — live dispatch", () => {
+	let db: DatabaseSync
+	beforeEach(() => {
+		db = buildDb()
+	})
+	afterEach(() => {
+		// lookup.close() in each test closes db; nothing else to do.
+	})
+
+	it("default (empty source) → coordinate-first recovers the postcode's town from a typo", async () => {
+		const lookup = new WofSqlitePlaceLookup({ database: db, buildFts: true })
+		// "Plaun" won't FTS-match; postcode_area_resolution injects Plauen from the postcode.
+		const r = await lookup.findPlace({ text: "Plaun", placetype: "locality", postcode: "08523", country: "DE" })
+		expect(r[0]?.name).toBe("Plauen")
+		lookup.close()
+	})
+
+	it("an injected country convention that drops postcode_area_resolution reroutes dispatch", async () => {
+		// Key the convention by the DE country WOF id (90). Removing postcode_area_resolution from the
+		// strategy list means the typo no longer recovers Plauen — proof the merged convention controls
+		// findPlace dispatch through the live country → WOF-id → convention path.
+		const lookup = new WofSqlitePlaceLookup({
+			database: db,
+			buildFts: true,
+			conventions: { 90: { candidateStrategies: ["fallback_fuzzy_name_match"] } },
+		})
+		const r = await lookup.findPlace({ text: "Plaun", placetype: "locality", postcode: "08523", country: "DE" })
+		expect(r[0]?.name).not.toBe("Plauen")
+		lookup.close()
+	})
+})

--- a/resolver-wof-sqlite/convention.ts
+++ b/resolver-wof-sqlite/convention.ts
@@ -1,0 +1,133 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The **Geographic Rule Engine** convention model (Direction E, #289 — see
+ *   `docs/articles/plan/2026-06-05-geographic-rule-engine.md` and epic #288).
+ *
+ *   A `Convention` is a declarative resolution profile attached to a Who's-On-First admin polygon.
+ *   The engine deep-merges the conventions along a resolved place's ancestor chain — country →
+ *   region → … → locality, most-specific winning — and the backend dispatches the named strategies
+ *   in `candidateStrategies`, first to return candidates wins.
+ *
+ *   This module is the backend-agnostic core: the convention TYPES, the deep-merge, and the seed
+ *   source. The strategy IMPLEMENTATIONS are SQL-bound and live in `lookup.ts`, registered by
+ *   name.
+ *
+ *   For the existing EU locales (DE/FR/GB/NL) the seed source is empty, so every query resolves to
+ *   `WORLD_DEFAULT` and the dispatch is byte-identical to the pre-engine coordinate-first path. JP
+ *   / KR / TW add rows here (and #290 swaps the seed map for a build-from-source sqlite-backed
+ *   source).
+ */
+
+import type { FindPlaceQuery, PlaceCandidate } from "./types.js"
+
+/** Soft-scoring weights for the `postcode_area_resolution` strategy: `pc·S_pc + name·S_name +
+pop·S_pop`. */
+export interface ScoringWeights {
+	pc: number
+	name: number
+	pop: number
+}
+
+/**
+ * A geographically-scoped resolution profile. Namespaced sections grow per phase; #289 ships the
+ * dispatch + scoring slice (`candidateStrategies` + `scoringWeights`). Later phases add
+ * `fieldMapping` (locale semantics for `locator[]`), `tokenNormalization`, etc.
+ */
+export interface Convention {
+	/** Ordered strategy names the dispatcher runs; the first to return a non-null result wins. */
+	candidateStrategies?: string[]
+	/**
+	 * Weights for `postcode_area_resolution`'s soft-score. Partial — a layer may nudge one weight and
+	 * inherit the rest from the layers below it (`resolveConvention` fills any gaps from
+	 * WORLD_DEFAULT).
+	 */
+	scoringWeights?: Partial<ScoringWeights>
+}
+
+/**
+ * A fully-resolved convention: every field present, weights complete. What `resolveConvention`
+ * returns and what strategies consume.
+ */
+export interface ResolvedConvention {
+	candidateStrategies: string[]
+	scoringWeights: ScoringWeights
+}
+
+/**
+ * The base layer every ancestor chain starts from. Reproduces the pre-engine coordinate-first
+ * behavior exactly: try `postcode_area_resolution`, else fall back to fuzzy name match; soft-score
+ * weights 0.6 / 0.3 / 0.1. Changing these changes EU behavior — don't, without a byte-stability
+ * run.
+ */
+export const WORLD_DEFAULT: ResolvedConvention = {
+	candidateStrategies: ["postcode_area_resolution", "fallback_fuzzy_name_match"],
+	scoringWeights: { pc: 0.6, name: 0.3, pop: 0.1 },
+}
+
+/**
+ * A named resolution primitive. Returns `null` to abstain (gate unmet / no data) → the dispatcher
+ * tries the next strategy; returns an array (possibly empty) to claim the result.
+ */
+export type Strategy = (query: FindPlaceQuery, convention: ResolvedConvention) => Promise<PlaceCandidate[] | null>
+
+/** Look up a convention record by WOF polygon id. Returns `undefined` when the polygon has no
+override. */
+export interface ConventionSource {
+	get(wofId: number): Convention | undefined
+}
+
+/**
+ * In-memory convention source seeded from a `{ wofId: Convention }` map. Empty for the EU locales
+ * (they ride `WORLD_DEFAULT`); JP / KR / TW add rows. #290 replaces this with a sqlite-backed
+ * source built from source, same distributable-asset discipline as `postcode-locality-intl.db`.
+ */
+export class SeedConventionSource implements ConventionSource {
+	readonly #rows: Map<number, Convention>
+
+	constructor(rows: Record<number, Convention> = {}) {
+		this.#rows = new Map(Object.entries(rows).map(([k, v]) => [Number(k), v]))
+	}
+
+	get(wofId: number): Convention | undefined {
+		return this.#rows.get(wofId)
+	}
+}
+
+/**
+ * Deep-merge convention layers, later (more-specific) layers winning per field.
+ * `candidateStrategies` is replaced wholesale — a convention names its full ordered list, it does
+ * not append. `scoringWeights` is merged key-by-key so a locality can nudge one weight without
+ * restating the others.
+ */
+export function mergeConventions(base: Convention, ...overrides: Array<Convention | undefined>): Convention {
+	const out: Convention = {
+		candidateStrategies: base.candidateStrategies ? [...base.candidateStrategies] : undefined,
+		scoringWeights: base.scoringWeights ? { ...base.scoringWeights } : undefined,
+	}
+	for (const o of overrides) {
+		if (!o) continue
+		if (o.candidateStrategies !== undefined) out.candidateStrategies = [...o.candidateStrategies]
+		if (o.scoringWeights !== undefined) {
+			out.scoringWeights = { ...(out.scoringWeights ?? WORLD_DEFAULT.scoringWeights), ...o.scoringWeights }
+		}
+	}
+	return out
+}
+
+/**
+ * Resolve the effective convention for a place given its ancestor chain, ordered MOST-GENERAL →
+ * MOST-SPECIFIC (country, region, …, locality). Starts from `WORLD_DEFAULT` so every field is
+ * defined regardless of which (if any) ancestors carry an override.
+ */
+export function resolveConvention(source: ConventionSource, ancestorIds: readonly number[]): ResolvedConvention {
+	const layers = ancestorIds.map((id) => source.get(id))
+	const merged = mergeConventions(WORLD_DEFAULT, ...layers)
+	return {
+		candidateStrategies: merged.candidateStrategies ?? WORLD_DEFAULT.candidateStrategies,
+		// Fill any weight gaps from the base so strategies always see a complete set.
+		scoringWeights: { ...WORLD_DEFAULT.scoringWeights, ...merged.scoringWeights },
+	}
+}

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -10,6 +10,17 @@ export type { AncestorsTable, GeojsonTable, NamesTable, PlaceSearchTable, SprTab
 
 export { WofSqlitePlaceLookup, type RankingWeights, type WofSqlitePlaceLookupOpts } from "./lookup.js"
 
+export {
+	SeedConventionSource,
+	WORLD_DEFAULT,
+	mergeConventions,
+	resolveConvention,
+	type Convention,
+	type ConventionSource,
+	type ScoringWeights,
+	type Strategy,
+} from "./convention.js"
+
 export { WofPostcodeLookup, type PostcodePlace } from "./postcode-point-lookup.js"
 
 export {

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -16,6 +16,14 @@ import { DatabaseSync, type SQLInputValue } from "node:sqlite"
 import { SqliteDialect } from "@mailwoman/core/kysley/dialect"
 
 import {
+	resolveConvention,
+	SeedConventionSource,
+	type Convention,
+	type ConventionSource,
+	type ResolvedConvention,
+	type Strategy,
+} from "./convention.js"
+import {
 	buildPlaceSearchFts,
 	PLACE_BBOX_TABLE,
 	PLACE_POPULATION_TABLE,
@@ -59,6 +67,13 @@ export interface WofSqlitePlaceLookupOpts {
 	 * must be pre-built via `mailwoman-wof-build-fts` — operator script for predictable cost.
 	 */
 	buildFts?: boolean
+	/**
+	 * Geographic Rule Engine convention source (Direction E, #289). Per-WOF-polygon resolution
+	 * profiles, either as a ready `ConventionSource` or a plain `{ wofId: Convention }` seed map.
+	 * Default empty — every query rides `WORLD_DEFAULT` (the EU coordinate-first behavior). JP/KR/TW
+	 * add rows; #290 wires a build-from-source sqlite-backed source here.
+	 */
+	conventions?: ConventionSource | Record<number, Convention>
 }
 
 /**
@@ -108,20 +123,21 @@ export interface RankingWeights {
 	 * Why this is needed (and why it ALIGNS with — rather than overrides — the population/importance
 	 * signal): the weighted sum adds population as a large additive boost (`populationBoost`, up to
 	 * +4) so that famous places surface for unambiguous full-name queries. But population is a
-	 * *prominence prior* — its job is to break ties among candidates that match the query EQUALLY
+	 * _prominence prior_ — its job is to break ties among candidates that match the query EQUALLY
 	 * WELL (e.g. "Springfield" → Springfield IL over Springfield MA, both exact name matches). It was
 	 * never meant to promote a place that matches the query WORSE. For a 2-letter region abbreviation
 	 * that backfires: querying "ME" returns Maine (which has the exact alias `ME`) AND Missouri/
 	 * Michigan/etc. (which do not), and Missouri's larger population (+4) overcomes Maine's bm25 edge
 	 * — so "Portland, ME" resolves its region to Missouri and the locality then cascades to the wrong
 	 * state. Tiering restores the intended ordering: **match quality is the primary key, prominence
-	 * (population) the secondary key WITHIN a tier.** Springfield-IL-over-MA still works (both exact →
-	 * same tier → population decides); ME→Maine now works (only Maine is exact → higher tier →
-	 * population never gets to override it). See docs/articles/evals/2026-05-30-resolver-exact-match.md.
+	 * (population) the secondary key WITHIN a tier.** Springfield-IL-over-MA still works (both exact
+	 * → same tier → population decides); ME→Maine now works (only Maine is exact → higher tier →
+	 * population never gets to override it). See
+	 * docs/articles/evals/2026-05-30-resolver-exact-match.md.
 	 *
 	 * Note: tiering re-ranks within the over-fetched candidate window (`limit * 4`); a pathological
-	 * exact match that falls outside that window is not rescued. For the region-abbrev case the window
-	 * is comfortably sufficient (a handful of states match a 2-letter query).
+	 * exact match that falls outside that window is not rescued. For the region-abbrev case the
+	 * window is comfortably sufficient (a handful of states match a 2-letter query).
 	 */
 	exactMatchTiering: boolean
 }
@@ -165,23 +181,26 @@ interface RawSearchRow {
 	population: number | null // from the place_population aux table; null when missing
 }
 
-/** The coordinate-first candidate table (scripts/build-postcode-locality.py): postcode → containing +
- * nearby localities with WOF alt-name aliases. */
+/**
+ * The coordinate-first candidate table (scripts/build-postcode-locality.py): postcode → containing
+ * + nearby localities with WOF alt-name aliases.
+ */
 const POSTCODE_LOCALITY_TABLE = "postcode_locality"
 
-/** Soft-score weights for the coordinate-first locality path. `Score = PC·S_pc + NAME·S_name +
- * POP·S_pop`, each S in [0,1]. Postcode-proximity weighted highest (it's the strongest single signal
- * when the name-match misses a small town), name next, population a tiebreak. The conflict flag fires
- * when |S_pc − S_name| exceeds MISMATCH_DELTA. PC_DECAY_KM sets how fast S_pc falls with distance. */
-const CF_PC = 0.6
-const CF_NAME = 0.3
-const CF_POP = 0.1
+/**
+ * Tunables for the coordinate-first locality soft-score `Score = pc·S_pc + name·S_name + pop·S_pop`
+ * (each S in [0,1]). The pc/name/pop WEIGHTS now come from the resolved convention's
+ * `scoringWeights` (`WORLD_DEFAULT` = 0.6/0.3/0.1 — the EU values), so a locale can retune them as
+ * data. PC_DECAY_KM sets how fast S_pc falls with distance.
+ */
 const CF_PC_DECAY_KM = 8
-/** The chosen locality must be within this distance of the postcode's containing locality, else the
+/**
+ * The chosen locality must be within this distance of the postcode's containing locality, else the
  * postcode and the parsed city name are judged to disagree (a transposed / wrong-for-the-city
- * postcode) and the `mismatch` flag fires. Generous enough that a city-state Ortsteil (~15km from the
- * city centroid) and an abutting town (~few km) are NOT flagged, tight enough to catch a wrong city
- * (hundreds of km). */
+ * postcode) and the `mismatch` flag fires. Generous enough that a city-state Ortsteil (~15km from
+ * the city centroid) and an abutting town (~few km) are NOT flagged, tight enough to catch a wrong
+ * city (hundreds of km).
+ */
 const CF_MISMATCH_KM = 50
 const CF_MISMATCH_DELTA = 0.5
 
@@ -203,8 +222,10 @@ function trigrams(s: string): Set<string> {
 	return out
 }
 
-/** Character-trigram Jaccard ∈ [0,1] — tolerant of the swallowed-leading-char fragments ("auen" vs
- * "plauen") and minor misspellings without a heavyweight edit-distance pass. */
+/**
+ * Character-trigram Jaccard ∈ [0,1] — tolerant of the swallowed-leading-char fragments ("auen" vs
+ * "plauen") and minor misspellings without a heavyweight edit-distance pass.
+ */
 function trigramJaccard(a: string, b: string): number {
 	const A = trigrams(a)
 	const B = trigrams(b)
@@ -248,8 +269,8 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 */
 	readonly #hasPopulationIndex: Map<string, boolean>
 	/**
-	 * Per-shard probe for the `postcode_locality` table (the coordinate-first candidate table, built by
-	 * scripts/build-postcode-locality.py). Cached at construction; null'd out when absent so the
+	 * Per-shard probe for the `postcode_locality` table (the coordinate-first candidate table, built
+	 * by scripts/build-postcode-locality.py). Cached at construction; null'd out when absent so the
 	 * coord-first path silently no-ops on a deployment that didn't ship the table.
 	 */
 	readonly #postcodeLocalityShard: string | null
@@ -258,6 +279,17 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 * their own derived (or override) schema names.
 	 */
 	readonly #shards: ResolvedShard[]
+	/**
+	 * The Geographic Rule Engine (Direction E, #289). `#conventionSource` supplies per-WOF-polygon
+	 * resolution profiles; `#strategies` is the named-primitive registry the merged convention
+	 * dispatches. Empty source → every query resolves to `WORLD_DEFAULT` → byte-identical to the
+	 * pre-engine coordinate-first path. `#countryWofIdCache` memoizes the country-code →
+	 * country-WOF-id lookup that seeds the convention ancestor chain (one query per country, then
+	 * cached).
+	 */
+	readonly #conventionSource: ConventionSource
+	readonly #strategies: Map<string, Strategy>
+	readonly #countryWofIdCache = new Map<string, number | null>()
 
 	constructor(opts: WofSqlitePlaceLookupOpts, weights?: Partial<RankingWeights>) {
 		if (opts.database && opts.databasePath) {
@@ -309,6 +341,19 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		// `postcode-locality-<cc>.db`). Find the first shard that has it; null = coord-first disabled.
 		this.#postcodeLocalityShard =
 			this.#shards.find((s) => this.#shardHasTable(s.schemaName, POSTCODE_LOCALITY_TABLE))?.schemaName ?? null
+
+		// The Geographic Rule Engine. Source defaults empty (EU rides WORLD_DEFAULT); callers inject
+		// per-WOF-polygon profiles via `opts.conventions` (#290 wires a sqlite-backed source, JP/KR/TW add
+		// rows). The registry binds strategy NAMES to the SQL-bound primitives below — adding a strategy
+		// is registering it here.
+		this.#conventionSource =
+			opts.conventions && "get" in opts.conventions && typeof opts.conventions.get === "function"
+				? opts.conventions
+				: new SeedConventionSource((opts.conventions as Record<number, Convention>) ?? {})
+		this.#strategies = new Map<string, Strategy>([
+			["postcode_area_resolution", (q, c) => this.#postcodeAreaResolution(q, c)],
+			["fallback_fuzzy_name_match", (q) => this.#fuzzyNameMatch(q)],
+		])
 	}
 
 	#shardHasTable(schemaName: string, tableName: string): boolean {
@@ -325,15 +370,40 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	}
 
 	async findPlace(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
-		// Coordinate-first locality path. Strictly gated: a sibling postcode AND a postcode_locality
-		// table AND a locality query. Injects postcode-proximal candidates (which the name-match FTS
-		// can't generate for an under-indexed small town) and soft-scores the union. Returns null to
-		// fall through to the unchanged FTS path when the postcode isn't in the table.
-		if (query.postcode && this.#postcodeLocalityShard && this.#isLocalityQuery(query)) {
-			const cf = await this.#findLocalityCoordFirst(query, this.#postcodeLocalityShard)
-			if (cf) return cf
+		// Geographic Rule Engine dispatch (#289). Resolve the effective convention for this query
+		// (WORLD_DEFAULT for the EU locales — the seed source is empty) and run its candidate strategies
+		// in order; the first to return a non-null result wins. The default list,
+		// [postcode_area_resolution, fallback_fuzzy_name_match], reproduces the pre-engine coordinate-
+		// first → FTS fall-through exactly. Unknown strategy names are skipped, so a convention may name
+		// a primitive a future phase will register.
+		const convention = this.#conventionFor(query)
+		for (const name of convention.candidateStrategies) {
+			const strategy = this.#strategies.get(name)
+			if (!strategy) continue
+			const result = await strategy(query, convention)
+			if (result !== null) return result
 		}
+		return []
+	}
 
+	/**
+	 * Strategy `postcode_area_resolution` — the coordinate-first locality path, strictly gated (a
+	 * sibling postcode AND a postcode_locality table AND a locality query). Returns `null` — so the
+	 * dispatcher falls through to the next strategy — when the gate is unmet or the postcode isn't in
+	 * the table; otherwise the soft-scored postcode∪name candidate set.
+	 */
+	#postcodeAreaResolution(query: FindPlaceQuery, convention: ResolvedConvention): Promise<PlaceCandidate[] | null> {
+		if (!(query.postcode && this.#postcodeLocalityShard && this.#isLocalityQuery(query))) {
+			return Promise.resolve(null)
+		}
+		return this.#findLocalityCoordFirst(query, this.#postcodeLocalityShard, convention)
+	}
+
+	/**
+	 * Strategy `fallback_fuzzy_name_match` — the BM25 FTS name-match over the gazetteer, the
+	 * universal fallback. Always returns an array (never null), so it terminates the dispatch chain.
+	 */
+	async #fuzzyNameMatch(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
 		const limit = query.limit ?? 10
 		const ftsLimit = limit * 4 // over-fetch so post-scoring has room to re-rank
 
@@ -519,14 +589,58 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	}
 
 	/**
-	 * Coordinate-first locality resolution. The postcode_locality table maps the sibling postcode to the
-	 * locality whose polygon contains the postcode centroid (+ a few nearby ones for the abutting-
-	 * postcode case). We union those COORDINATE candidates with the FTS NAME candidates and soft-score
-	 * the union `0.6·S_pc + 0.3·S_name + 0.1·S_pop` — so a small town the name-match never finds is
-	 * recovered by the postcode, while an unambiguous name (Berlin) still wins on name + population.
-	 * Returns null when the postcode isn't in the table (→ caller falls back to the FTS path).
+	 * Resolve the effective convention for a query (the Geographic Rule Engine entry point). The
+	 * ancestor chain is keyed by WOF polygon id; for #289 it carries just the country level —
+	 * resolved from `query.country` via the cached code→WOF-id lookup — so the EU locales, which have
+	 * no override rows, resolve to `WORLD_DEFAULT` and dispatch is byte-identical to the pre-engine
+	 * path. E4 (JP) extends the chain with the resolved locality's `ancestors` row, so a
+	 * region/locality-level convention (e.g. Sapporo's grid) deep-merges over the country one.
 	 */
-	async #findLocalityCoordFirst(query: FindPlaceQuery, sch: string): Promise<PlaceCandidate[] | null> {
+	#conventionFor(query: FindPlaceQuery): ResolvedConvention {
+		const chain: number[] = []
+		if (query.country) {
+			const cid = this.#countryWofId(query.country)
+			if (cid !== null) chain.push(cid)
+		}
+		return resolveConvention(this.#conventionSource, chain)
+	}
+
+	/**
+	 * Country ISO code → its WOF polygon id (the coarsest convention key). Cached — one indexed `spr`
+	 * query per distinct country, then memoized (including a not-found `null`) so findPlace never
+	 * pays for it twice.
+	 */
+	#countryWofId(code: string): number | null {
+		const cached = this.#countryWofIdCache.get(code)
+		if (cached !== undefined) return cached
+		let id: number | null = null
+		try {
+			const row = this.#db
+				.prepare(`SELECT id FROM main.spr WHERE placetype = 'country' AND country = ? AND is_current != 0 LIMIT 1`)
+				.get(code) as { id: number } | undefined
+			id = row?.id ?? null
+		} catch {
+			id = null
+		}
+		this.#countryWofIdCache.set(code, id)
+		return id
+	}
+
+	/**
+	 * Coordinate-first locality resolution. The postcode_locality table maps the sibling postcode to
+	 * the locality whose polygon contains the postcode centroid (+ a few nearby ones for the
+	 * abutting- postcode case). We union those COORDINATE candidates with the FTS NAME candidates and
+	 * soft-score the union `0.6·S_pc + 0.3·S_name + 0.1·S_pop` — so a small town the name-match never
+	 * finds is recovered by the postcode, while an unambiguous name (Berlin) still wins on name +
+	 * population. Returns null when the postcode isn't in the table (→ caller falls back to the FTS
+	 * path).
+	 */
+	async #findLocalityCoordFirst(
+		query: FindPlaceQuery,
+		sch: string,
+		convention: ResolvedConvention
+	): Promise<PlaceCandidate[] | null> {
+		const w = convention.scoringWeights
 		const pc = query.postcode!.trim()
 		const pcWhere = query.country ? "postcode = ? AND country = ?" : "postcode = ?"
 		const pcParams: SQLInputValue[] = query.country ? [pc, query.country] : [pc]
@@ -558,7 +672,7 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			const sPc = info ? (info.containing ? 1 : Math.exp(-info.dist / CF_PC_DECAY_KM)) : 0
 			const sName = softNameScore(query.text, cand.name, info?.aliases ?? [])
 			const sPop = cand.population && cand.population > 0 ? Math.min(1, Math.log10(1 + cand.population) / 6) : 0
-			scored.push({ ...cand, score: CF_PC * sPc + CF_NAME * sName + CF_POP * sPop, exact: sName >= 1 })
+			scored.push({ ...cand, score: w.pc * sPc + w.name * sName + w.pop * sPop, exact: sName >= 1 })
 		}
 		// Exact-name tiering (same philosophy as the FTS path): an EXACT name/alias match tiers above
 		// coordinate-only candidates, with the soft-score breaking ties WITHIN a tier. This keeps an
@@ -624,8 +738,9 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 
 	/**
 	 * Among `ids`, return the subset whose name OR any alias equals `text` case-insensitively — the
-	 * exact-match tier for ranking. One indexed query over `<schema>.names`. Returns an empty set when
-	 * the shard has no `names` table (e.g. a postcode-only shard), so tiering silently no-ops there.
+	 * exact-match tier for ranking. One indexed query over `<schema>.names`. Returns an empty set
+	 * when the shard has no `names` table (e.g. a postcode-only shard), so tiering silently no-ops
+	 * there.
 	 */
 	#exactMatchIds(schemaName: string, ids: number[], text: string): Set<number> {
 		const out = new Set<number>()

--- a/scripts/diag-findplace-dump.ts
+++ b/scripts/diag-findplace-dump.ts
@@ -1,0 +1,67 @@
+/**
+ * Byte-stability harness for the #289 rule-engine refactor. Dumps `findPlace` output for a fixed
+ * set of DE/FR/GB/NL queries (coord-first, FTS-fallback, exact-name-tiering, conflict-flag, and
+ * non-locality paths) against the real WOF DBs. Run before and after the refactor and diff — the
+ * output must be byte-identical (the refactor changes dispatch shape, not behavior).
+ *
+ * Usage: node --experimental-strip-types scripts/diag-findplace-dump.ts >
+ * /tmp/jp-probe/fp-<tag>.json
+ */
+import { WofSqlitePlaceLookup } from "@mailwoman/resolver-wof-sqlite"
+
+const WOF = [
+	"/mnt/playpen/mailwoman-data/wof/admin-global-priority.db",
+	"/mnt/playpen/mailwoman-data/wof/postcode-locality-intl.db",
+]
+
+const backend = new WofSqlitePlaceLookup({ databasePath: WOF })
+
+// Fixed query set spanning every findPlace branch the refactor touches.
+const queries: Array<Record<string, unknown>> = [
+	// coord-first, postcode in table (small town the FTS misses)
+	{ text: "Plauen", country: "DE", postcode: "08523", placetype: "locality" },
+	// coord-first + exact-name tiering (unambiguous big city)
+	{ text: "Berlin", country: "DE", postcode: "10115", placetype: "locality" },
+	// conflict flag (Munich postcode under "Berlin")
+	{ text: "Berlin", country: "DE", postcode: "80331", placetype: "locality" },
+	// locality, NO postcode → FTS path
+	{ text: "Berlin", country: "DE", placetype: "locality" },
+	// FR coord-first
+	{ text: "Paris", country: "FR", postcode: "75001", placetype: "locality" },
+	{ text: "Lyon", country: "FR", postcode: "69001", placetype: "locality" },
+	// GB
+	{ text: "Edinburgh", country: "GB", postcode: "EH1 1AA", placetype: "locality" },
+	{ text: "London", country: "GB", placetype: "locality" },
+	// NL coord-first
+	{ text: "Amstelveen", country: "NL", postcode: "1187LM", placetype: "locality" },
+	{ text: "Amsterdam", country: "NL", postcode: "1012LG", placetype: "locality" },
+	// postcode NOT in table → coord-first returns null → FTS fallback
+	{ text: "Berlin", country: "DE", postcode: "00000", placetype: "locality" },
+	// non-locality query (region) → never coord-first
+	{ text: "Bayern", country: "DE", placetype: "region" },
+	// no country filter
+	{ text: "Springfield", placetype: "locality" },
+]
+
+const out: unknown[] = []
+for (const q of queries) {
+	const cands = await backend.findPlace(q as never)
+	out.push({
+		q,
+		candidates: cands.map((c: any) => ({
+			id: c.id,
+			name: c.name,
+			placetype: c.placetype,
+			country: c.country,
+			score: c.score,
+			lat: c.lat,
+			lon: c.lon,
+			population: c.population ?? null,
+			distanceKm: c.distanceKm ?? null,
+			mismatch: c.mismatch ?? null,
+		})),
+	})
+}
+console.log(JSON.stringify(out, null, 1))
+backend.close?.()
+process.exit(0)

--- a/scripts/diag-japan-parse.ts
+++ b/scripts/diag-japan-parse.ts
@@ -1,0 +1,81 @@
+/**
+ * Japan parse-look (probe, 2026-06-05). Part 2 of the JP cheap probe: does the CURRENT universal
+ * parser (v0.7.2, US+FR trained, OOD on Japanese) produce a usable component breakdown for a
+ * STREET-LESS, block-coordinate, descending-order Japanese address?
+ *
+ * Dumps raw per-token BIO (the honest coverage view — argmax, no tree post-processing) plus the
+ * assembled component tree, for native-kanji, romaji, Sapporo-grid, and Kyoto intersection forms.
+ * No resolver (no JP postcode db yet); this is purely "what does the model label." Run: node
+ * --experimental-strip-types scripts/diag-japan-parse.ts
+ */
+import { type ClassificationRecord, createAddressParser } from "mailwoman"
+import { readFileSync } from "node:fs"
+
+const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const MODEL = "/tmp/v072-eval/model.onnx"
+const CARD = "/tmp/v072-release/model-card.json"
+
+const { NeuralAddressClassifier } = await import("@mailwoman/neural")
+const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+const modelCard = JSON.parse(readFileSync(CARD, "utf8"))
+const labels: string[] = modelCard.labels
+const [tokenizer, runner] = await Promise.all([MailwomanTokenizer.loadFromFile(TOK), OnnxRunner.create(MODEL)])
+const neural = new NeuralAddressClassifier({ tokenizer, runner, labels })
+const v0 = createAddressParser()
+
+function argmax(row: number[]): number {
+	let bi = 0
+	for (let i = 1; i < row.length; i++) if (row[i]! > row[bi]!) bi = i
+	return bi
+}
+
+// Raw per-token BIO straight from the model — no tree, no repair. This is the coverage truth.
+async function rawBio(text: string): Promise<string> {
+	const { pieces, ids } = tokenizer.encode(text)
+	const { logits } = await runner.infer(ids)
+	return pieces
+		.map((p: any, i: number) => {
+			const lab = labels[argmax(logits[i]!)] ?? "O"
+			return lab === "O" ? `${p.piece}·O` : `${p.piece}·${lab}`
+		})
+		.join("  ")
+}
+
+function dumpTree(tree: any): string {
+	const flat: string[] = []
+	const walk = (n: any) => {
+		if (n?.tag && n?.value) flat.push(`${n.tag}=${JSON.stringify(n.value)}`)
+		for (const c of n?.children ?? []) walk(c)
+	}
+	for (const r of tree?.roots ?? []) walk(r)
+	return flat.join("  ") || "(none)"
+}
+
+const inputs: Array<{ label: string; text: string }> = [
+	{ label: "Tokyo, kanji native", text: "東京都中央区銀座1-1-1" },
+	{ label: "Tokyo, w/ postcode", text: "〒104-0061 東京都中央区銀座1丁目1番1号" },
+	{ label: "Tokyo, romaji", text: "1-1-1 Ginza, Chuo-ku, Tokyo 104-0061" },
+	{ label: "Sapporo GRID, kanji", text: "北海道札幌市中央区北1条西2丁目" },
+	{ label: "Sapporo GRID, w/ pc", text: "〒060-0001 北海道札幌市中央区北1条西2丁目1-1" },
+	{ label: "Sapporo GRID, romaji", text: "Kita 1-jo Nishi 2-chome, Chuo-ku, Sapporo, Hokkaido 060-0001" },
+	{ label: "Kyoto intersection", text: "京都府京都市中京区寺町通御池上る上本能寺前町488" },
+	{ label: "Gov bldg, kanji", text: "〒163-8001 東京都新宿区西新宿2-8-1" },
+]
+
+for (const { label, text } of inputs) {
+	console.log(`\n=== ${label} ===`)
+	console.log(`  input: ${text}`)
+	console.log(`  raw BIO : ${await rawBio(text)}`)
+	console.log(`  tree    : ${dumpTree(await neural.parse(text, { postcodeRepair: true } as any))}`)
+	const sol = await v0.parse(text)
+	const rec = (sol[0]?.classifications ?? {}) as ClassificationRecord
+	console.log(
+		`  v0      : ${
+			Object.entries(rec)
+				.map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+				.join("  ") || "(none)"
+		}`
+	)
+}
+process.exit(0)


### PR DESCRIPTION
First implementation piece of **Direction E** (epic #288). Turns the resolver's locality path from a hardcoded coordinate-first → FTS fall-through into **data-driven strategy dispatch keyed by geography** — with the existing locales provably unchanged.

Closes #289.

## What changed
- **`convention.ts`** (new, backend-agnostic engine): `Convention` / `ResolvedConvention` types, a `WORLD_DEFAULT` base layer, `ConventionSource` + `SeedConventionSource`, and deep-merge (`mergeConventions` / `resolveConvention`) over a **country → region → locality** ancestor chain — most-specific wins, `scoringWeights` merge key-by-key.
- **`lookup.ts`**: `findPlace` resolves the effective convention (keyed by the country's WOF id, cached) and dispatches its `candidateStrategies` in order, first non-null wins. The coord-first body is now the **`postcode_area_resolution`** strategy (reading its soft-score weights from the convention); the FTS body is **`fallback_fuzzy_name_match`**; both registered by name. Conventions injectable via `opts.conventions` — #290 wires the build-from-source sqlite asset.
- The EU locales have **no convention rows**, so every query resolves to `WORLD_DEFAULT` and dispatch is byte-identical to the pre-engine path.

## Acceptance (all met)
- **DE/FR/GB/NL byte-identical.** `findPlace` output is bit-for-bit unchanged across a 13-query harness spanning every branch — coord-first, FTS-fallback, exact-name tiering, the Munich-postcode conflict flag, non-locality, no-country (`scripts/diag-findplace-dump.ts`, baseline captured before any edit).
- **Convention lookup keyed by WOF id deep-merges country→region→locality.** Unit-tested precedence.
- **Strategy dispatch is data-driven.** A live test injects a convention that drops `postcode_area_resolution` and proves the typo-recovery stops — dispatch flows through the real country→WOF-id→convention path.
- Full resolver suite green (126) + core/resolver (19); +9 new convention tests.

Open forks from the design doc (`locator[]` shape, convention-asset format) are untouched here — this PR is the dispatch skeleton the rest of Phase 1 hangs off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)