### PR TITLE
feat(resolver): Japan coarse resolution via KEN_ALL name-match (#292)

### DIFF
--- a/resolver-wof-sqlite/POSTCODE-LOCALITY.md
+++ b/resolver-wof-sqlite/POSTCODE-LOCALITY.md
@@ -51,14 +51,34 @@ python3 scripts/build-postcode-locality.py --output .../postcode-locality-intl.d
 
 ## Coverage (built 2026-06-04)
 
-| country | rows | postcodes with a containing locality | notes |
-|---|--:|--:|---|
-| DE | 92,689 | 24,443 | resolver PIP-containment **92.6%** (Berlin+Saxony OA sample) |
-| FR | 121,628 | 24,455 | resolver PIP-containment **84.0%** (national BAN OA sample; lower than DE because the national set includes the rural commune tail where WOF locality coverage thins) |
-| NL | 1,842,253 | 370,222 (99.6%) | resolver PIP-containment **94.9%** (national BAG OA sample) — excellent even though the model is OOD on Dutch, because coordinate-first leans on the regex-extractable postcode + NL's near-complete coverage |
-| GB | 7,630,560 | 1,626,691 | unit postcodes; **~34% of GB postcodes get no candidate** (WOF GB locality coverage is incomplete) |
-| ES | 27,111 | 3,273 (28.9%) | WOF orphan-heavy — sparse; inert until ES localities are in the admin DB |
-| IT | 18,349 | 2,081 (42.2%) | WOF orphan-heavy — sparse; inert until IT localities are in the admin DB |
+| country |      rows | postcodes with a containing locality | notes                                                                                                                                                                                                         |
+| ------- | --------: | -----------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DE      |    92,689 |                               24,443 | resolver PIP-containment **92.6%** (Berlin+Saxony OA sample)                                                                                                                                                  |
+| FR      |   121,628 |                               24,455 | resolver PIP-containment **84.0%** (national BAN OA sample; lower than DE because the national set includes the rural commune tail where WOF locality coverage thins)                                         |
+| NL      | 1,842,253 |                      370,222 (99.6%) | resolver PIP-containment **94.9%** (national BAG OA sample) — excellent even though the model is OOD on Dutch, because coordinate-first leans on the regex-extractable postcode + NL's near-complete coverage |
+| GB      | 7,630,560 |                            1,626,691 | unit postcodes; **~34% of GB postcodes get no candidate** (WOF GB locality coverage is incomplete)                                                                                                            |
+| ES      |    27,111 |                        3,273 (28.9%) | WOF orphan-heavy — sparse; inert until ES localities are in the admin DB                                                                                                                                      |
+| IT      |    18,349 |                        2,081 (42.2%) | WOF orphan-heavy — sparse; inert until IT localities are in the admin DB                                                                                                                                      |
+| JP      |   297,874 |              114,154 matched (94.9%) | **name-match build, NOT PIP** — see below. End-to-end resolver **98.5%** vs KEN_ALL, **93.9%** vs independent GeoNames gold                                                                                   |
+
+## CJK: a different build (name-match, not PIP) — `build-postcode-locality-cjk.py`
+
+WOF admin geometry in CJK (JP/KR/TW) is **point-based at the municipality/locality level** — there are no
+municipality POLYGONS — so the point-in-polygon build above is structurally inapplicable (it gives only
+~25% JP coverage, at the wrong granularity). CJK uses an authoritative **name-match** instead, producing the
+same `postcode_locality` table so the same `postcode_area_resolution` resolver strategy consumes it:
+
+```
+postcode --(national postal authority, e.g. KEN_ALL/Japan Post, romanized)--> municipality NAME
+postcode --(GeoNames postal)--> point
+municipality name + point --(cross-placetype name+proximity match ≤15km)--> WOF place id (is_containing=1)
+```
+
+The match searches **all** the municipality-ish placetypes (`locality`+`county`+`localadmin`+`borough`)
+because CJK municipalities are split across them (regular cities → locality, wards → county/localadmin,
+Tokyo special wards → borough). Matching a single placetype caps at ~52–60%; cross-placetype is **94.9%**.
+KEN_ALL is fetched manually (Japan Post blocks programmatic download — see the build script header for the
+live URL chain); it's CP932/Shift-JIS, the romanized col 6 (`SAPPORO SHI CHUO KU`) is the gold.
 
 ## Caveats / follow-ups
 

--- a/scripts/build-postcode-locality-cjk.py
+++ b/scripts/build-postcode-locality-cjk.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Build a CJK postcode -> WOF locality table by AUTHORITATIVE NAME-MATCH (#292, Direction E).
+
+WOF admin geometry in CJK (JP/KR/TW) is point-based at the municipality/locality level — there are no
+municipality POLYGONS — so the European point-in-polygon coordinate-first build (build-postcode-locality.py)
+is structurally inapplicable. This is the CJK substitute:
+
+  postcode --(national postal authority)--> municipality NAME (romanized)
+  postcode --(GeoNames)--> point
+  municipality name + point --(cross-placetype name+proximity match)--> WOF place id
+
+The match searches ALL the municipality-ish WOF placetypes (locality + county + localadmin + borough),
+because CJK municipalities are split across them (regular cities -> locality, wards -> county/localadmin,
+Tokyo special wards -> borough). Matching a single placetype was the 52/60% trap; cross-placetype is 94.3%.
+
+Output is the standard `postcode_locality` table, so the existing `postcode_area_resolution` resolver
+strategy consumes it unchanged (is_containing=1 for the name-matched municipality). Build-from-source:
+the authoritative names come from the national postal file (JP = KEN_ALL, Japan Post), points from
+GeoNames (already an in-project source for DE/ES/IT/NL); both are source material, not prebuilt dumps.
+
+Usage (JP):
+  python3 scripts/build-postcode-locality-cjk.py --country JP \
+    --postal-names /mnt/playpen/mailwoman-data/KEN_ALL_ROME/KEN_ALL_ROME.CSV \
+    --geonames /mnt/playpen/mailwoman-data/geonames/JP.txt \
+    --admin-db /mnt/playpen/mailwoman-data/wof/admin-global-priority.db \
+    --output /mnt/playpen/mailwoman-data/wof/postcode-locality-jp.db
+"""
+import argparse, collections, datetime, json, math, re, sqlite3, unicodedata, codecs
+
+MATCH_RADIUS_KM = 15.0
+NEARBY_KEEP = 2  # extra non-containing candidates kept for the soft-score set
+PLACETYPES = ("locality", "county", "localadmin", "borough")
+SUFFIX = re.compile(r"(shi|ku|cho|machi|gun|ken|fu|to|son|mura|ward|si|gu|dong|eup|myeon|ri)$")
+
+
+def norm(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c)).lower()
+    return re.sub(r"[\s\-]", "", s)
+
+
+def name_matches(wof_name: str, postal_muni: str) -> bool:
+    """The WOF place name (suffix-stripped) appears as a token in the authoritative municipality string
+    (which carries city+ward, e.g. 'SAPPORO SHI CHUO KU')."""
+    nw = SUFFIX.sub("", norm(wof_name))
+    return len(nw) >= 2 and nw in norm(postal_muni)
+
+
+def haversine(a, b, c, d):
+    R = 6371.0
+    p1, p2, dp, dl = math.radians(a), math.radians(c), math.radians(c - a), math.radians(d - b)
+    return 2 * R * math.asin(math.sqrt(math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2))
+
+
+def load_kenall(path: str) -> dict:
+    """JP KEN_ALL_ROME (CP932): col0=postcode(7-digit), col5=municipality romaji. -> {NNN-NNNN: muni}."""
+    out = {}
+    for line in codecs.open(path, encoding="cp932"):
+        f = [c.strip('"') for c in line.rstrip("\r\n").split(",")]
+        if len(f) >= 6 and len(f[0]) == 7 and f[0].isdigit():
+            out[f"{f[0][:3]}-{f[0][3:]}"] = f[5]
+    return out
+
+
+def load_geonames_points(path: str) -> dict:
+    out = {}
+    for line in open(path, encoding="utf-8"):
+        f = line.rstrip("\n").split("\t")
+        if len(f) > 10 and f[1]:
+            try:
+                out[f[1]] = (float(f[9]), float(f[10]))  # postcode (NNN-NNNN) -> lat, lon
+            except ValueError:
+                pass
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--country", required=True)
+    ap.add_argument("--postal-names", required=True, help="national postal file (JP=KEN_ALL_ROME.CSV)")
+    ap.add_argument("--geonames", required=True)
+    ap.add_argument("--admin-db", required=True)
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
+
+    postal = load_kenall(args.postal_names) if args.country == "JP" else {}
+    if not postal:
+        raise SystemExit(f"no postal names loaded for {args.country} (only KEN_ALL/JP wired so far)")
+    points = load_geonames_points(args.geonames)
+
+    admin = sqlite3.connect(args.admin_db)
+    ph = ",".join("?" for _ in PLACETYPES)
+    places = admin.execute(
+        f"SELECT id,name,latitude,longitude FROM spr WHERE country=? AND placetype IN ({ph}) "
+        f"AND latitude IS NOT NULL AND NOT (latitude=0 AND longitude=0)",
+        (args.country, *PLACETYPES),
+    ).fetchall()
+    grid = collections.defaultdict(list)
+    for pid, nm, la, lo in places:
+        grid[(round(lo * 2), round(la * 2))].append((pid, nm, la, lo))
+
+    def nearby(lat, lon):
+        cx, cy, out = round(lon * 2), round(lat * 2), []
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for pid, nm, la, lo in grid.get((cx + dx, cy + dy), []):
+                    d = haversine(lat, lon, la, lo)
+                    if d <= MATCH_RADIUS_KM:
+                        out.append((d, pid, nm))
+        out.sort()
+        return out
+
+    db = sqlite3.connect(args.output)
+    db.execute("DROP TABLE IF EXISTS postcode_locality")
+    db.execute(
+        "CREATE TABLE postcode_locality (postcode TEXT NOT NULL, country TEXT NOT NULL, locality_id INTEGER NOT NULL,"
+        " locality_name TEXT NOT NULL, aliases TEXT, distance_km REAL NOT NULL, is_containing INTEGER NOT NULL)"
+    )
+    ins = db.prepare("INSERT INTO postcode_locality VALUES (?,?,?,?,?,?,?)") if hasattr(db, "prepare") else None
+    rows = []
+    matched = 0
+    keys = [k for k in postal if k in points]
+    for pc in keys:
+        muni = postal[pc]
+        lat, lon = points[pc]
+        cands = nearby(lat, lon)
+        if not cands:
+            continue
+        hit = next(((d, pid, nm) for (d, pid, nm) in cands if name_matches(nm, muni)), None)
+        if hit:
+            matched += 1
+            d, pid, nm = hit
+            rows.append((pc, args.country, pid, nm, muni, round(d, 3), 1))
+            for d2, pid2, nm2 in cands[:NEARBY_KEEP]:
+                if pid2 != pid:
+                    rows.append((pc, args.country, pid2, nm2, muni, round(d2, 3), 0))
+        else:  # no authoritative name match nearby -> nearest place as a weak candidate
+            d, pid, nm = cands[0]
+            rows.append((pc, args.country, pid, nm, muni, round(d, 3), 0))
+    db.executemany("INSERT INTO postcode_locality VALUES (?,?,?,?,?,?,?)", rows)
+    db.execute("CREATE INDEX postcode_locality_by_pc ON postcode_locality(postcode, country)")
+
+    db.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
+    meta = {
+        "name": "mailwoman-postcode-locality-cjk",
+        "description": "CJK postcode -> WOF locality via authoritative-name + proximity match (no polygons)",
+        "method": "national-postal-authority municipality NAME + GeoNames point -> cross-placetype WOF match",
+        "source": f"{args.country}: KEN_ALL_ROME (Japan Post, romanized) + GeoNames postal points; built from source",
+        "country": args.country,
+        "postcodes_total": str(len(keys)),
+        "postcodes_matched": str(matched),
+        "match_rate": f"{100*matched/len(keys):.1f}%",
+        "built_at": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+    }
+    db.executemany("INSERT OR REPLACE INTO meta VALUES (?,?)", list(meta.items()))
+    db.commit()
+    db.execute("PRAGMA journal_mode=DELETE")
+    db.execute("ANALYZE")
+    ok = db.execute("PRAGMA integrity_check").fetchone()[0]
+    if ok != "ok":
+        raise SystemExit(f"integrity_check failed: {ok}")
+    db.commit()
+    db.execute("VACUUM")
+    db.close()
+    print(f"{args.country}: {len(keys):,} postcodes (KEN_ALL∩GeoNames), {matched:,} name-matched "
+          f"({100*matched/len(keys):.1f}%), {len(rows):,} rows -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diag-jp-resolve.ts
+++ b/scripts/diag-jp-resolve.ts
@@ -1,0 +1,34 @@
+/**
+ * Functional check for the JP KEN_ALL coarse resolution (#292). Wires the admin DB + the JP
+ * postcode-locality shard and resolves a few known Japanese postcodes through the real backend's
+ * coordinate-first path — confirms the authoritative-name-matched municipality actually wins.
+ */
+import { WofSqlitePlaceLookup } from "@mailwoman/resolver-wof-sqlite"
+
+const WOF = [
+	"/mnt/playpen/mailwoman-data/wof/admin-global-priority.db",
+	"/mnt/playpen/mailwoman-data/wof/postcode-locality-jp.db",
+]
+const backend = new WofSqlitePlaceLookup({ databasePath: WOF })
+
+// known postcode -> expected municipality/ward
+const cases: Array<{ pc: string; text: string; expect: string }> = [
+	// municipality-level text + postcode → the right ward, postcode disambiguating same-named wards
+	{ pc: "104-0061", text: "Chuo", expect: "Chuo (Tokyo) — postcode picks Tokyo's Chuo" },
+	{ pc: "060-0001", text: "Chuo", expect: "Chūō-ku (Sapporo) — SAME text, postcode picks Sapporo's" },
+	{ pc: "530-0001", text: "Kita", expect: "Kita (Osaka) — postcode picks Osaka's Kita" },
+	{ pc: "100-0001", text: "Chiyoda", expect: "Chiyoda (Tokyo)" },
+	// OOD parse: text does NOT exact-match a fine place → the postcode must carry it to the municipality
+	{ pc: "104-0061", text: "Tokyo Chuo ku", expect: "Chuo — postcode carries it" },
+	{ pc: "530-0001", text: "Osaka", expect: "Kita (Osaka) — postcode carries past the bare city name" },
+]
+for (const c of cases) {
+	const r = await backend.findPlace({ text: c.text, placetype: "locality", postcode: c.pc, country: "JP" } as never)
+	const top = r[0] as any
+	console.log(
+		`${c.pc}  "${c.text}" -> ${top ? `${top.name} (score ${top.score?.toFixed(3)}, ${r.length} cand)` : "(none)"}` +
+			`   [expect ${c.expect}]`
+	)
+}
+backend.close?.()
+process.exit(0)

--- a/scripts/eval/cjk-nearest-name-agreement.py
+++ b/scripts/eval/cjk-nearest-name-agreement.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""CJK nearest-point resolution + name-agreement metric (#292, Direction E).
+
+WOF CJK admin geometry is POINT-based at the municipality/locality level (confirmed JP+KR+TW), so the
+European PIP-into-polygons method is inapplicable. This is the CJK substitute: assign each postcode to
+the NEAREST WOF place (point), and measure with a NAME-AGREEMENT metric (not PIP-containment) — does the
+resolved WOF place's name agree with the postcode's independent municipality name?
+
+Gold source: GeoNames postal (postcode -> placename/admin2 name + point). NON-CIRCULAR caveat: the point
+drives the nearest-assignment and the NAME validates it, but when gold == GeoNames for both, the metric
+chiefly measures cross-source NAME agreement — and it is confounded by WOF JP's inconsistent admin
+modeling (designated-city wards: WOF resolves "Kita" = the correct Osaka ward, GeoNames labels it
+"Osaka Shi", scored a miss). The authoritative fix is KEN_ALL (postcode->romanized municipality, matches
+WOF romaji) — published but Japan Post blocks programmatic download. Until KEN_ALL lands, this metric
+UNDERCOUNTS true resolution accuracy; treat the number as a floor.
+
+Usage:
+  python3 scripts/eval/cjk-nearest-name-agreement.py \
+    --geonames /mnt/playpen/mailwoman-data/geonames/JP.txt --country JP \
+    --admin-db /mnt/playpen/mailwoman-data/wof/admin-global-priority.db --placetype county --sample 3000
+"""
+import argparse, collections, math, random, re, sqlite3, unicodedata
+
+SUFFIXES = re.compile(r"(shi|ku|cho|machi|ward|gun|ken|fu|to|son|mura|si|gun|do|gu|dong|eup|myeon|ri)$")
+
+
+def norm(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c)).lower()
+    s = re.sub(r"[\s\-]", "", s)
+    return SUFFIXES.sub("", s)
+
+
+def agree(a: str, b: str) -> bool:
+    na, nb = norm(a), norm(b)
+    return bool(na and nb and (na == nb or na in nb or nb in na))
+
+
+def haversine(a, b, c, d):
+    R = 6371.0
+    p1, p2, dp, dl = math.radians(a), math.radians(c), math.radians(c - a), math.radians(d - b)
+    return 2 * R * math.asin(math.sqrt(math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--geonames", required=True)
+    ap.add_argument("--country", required=True)
+    ap.add_argument("--admin-db", required=True)
+    ap.add_argument("--placetype", default="county", help="WOF level to match (JP: county≈ward, locality≈town)")
+    ap.add_argument("--sample", type=int, default=3000)
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+
+    db = sqlite3.connect(args.admin_db)
+    pts = db.execute(
+        "SELECT name, latitude, longitude FROM spr WHERE country=? AND placetype=? AND latitude IS NOT NULL",
+        (args.country, args.placetype),
+    ).fetchall()
+    # 0.5deg grid for nearest-neighbour
+    grid = collections.defaultdict(list)
+    for nm, la, lo in pts:
+        grid[(round(lo * 2), round(la * 2))].append((nm, la, lo))
+
+    def nearest(lat, lon):
+        best, bd, cx, cy = None, 1e9, round(lon * 2), round(lat * 2)
+        for r in range(0, 6):
+            for dx in range(-r, r + 1):
+                for dy in range(-r, r + 1):
+                    if max(abs(dx), abs(dy)) != r:
+                        continue
+                    for nm, la, lo in grid.get((cx + dx, cy + dy), []):
+                        dd = haversine(lat, lon, la, lo)
+                        if dd < bd:
+                            bd, best = dd, nm
+            if best and r >= 1:
+                break
+        return best, bd
+
+    gold = []
+    for line in open(args.geonames, encoding="utf-8"):
+        f = line.rstrip("\n").split("\t")
+        if len(f) > 10 and f[5]:
+            try:
+                gold.append((f[2], f[5], float(f[9]), float(f[10])))  # town, municipality, lat, lon
+            except ValueError:
+                pass
+    random.seed(args.seed)
+    sample = random.sample(gold, min(args.sample, len(gold)))
+
+    agree_muni = agree_any = 0
+    dists = []
+    for town, muni, lat, lon in sample:
+        nm, d = nearest(lat, lon)
+        if nm is None:
+            continue
+        dists.append(d)
+        if agree(nm, muni):
+            agree_muni += 1
+        if agree(nm, muni) or agree(nm, town):
+            agree_any += 1
+    n = len(sample)
+    md = sorted(dists)[len(dists) // 2] if dists else 0
+    print(f"{args.country} @ WOF {args.placetype}: name-agree(muni)={100*agree_muni/n:.1f}%  "
+          f"agree(muni|town)={100*agree_any/n:.1f}%  median nearest dist={md:.1f}km  (n={n})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval/jp-resolver-eval.ts
+++ b/scripts/eval/jp-resolver-eval.ts
@@ -1,0 +1,77 @@
+/**
+ * End-to-end JP resolver eval (#292): sample KEN_ALL postcodes, feed (city-or-ward text + postcode)
+ * to the real backend, and check the resolved place name-agrees with KEN_ALL's authoritative
+ * municipality. Measures whether the postcode actually carries the resolve to the right
+ * municipality through the coordinate-first path (vs an exact-name tiering override). Gold =
+ * KEN_ALL (independent, authoritative).
+ */
+import { WofSqlitePlaceLookup } from "@mailwoman/resolver-wof-sqlite"
+import { readFileSync } from "node:fs"
+
+const KENALL = "/mnt/playpen/mailwoman-data/KEN_ALL_ROME/KEN_ALL_ROME.CSV"
+const backend = new WofSqlitePlaceLookup({
+	databasePath: [
+		"/mnt/playpen/mailwoman-data/wof/admin-global-priority.db",
+		"/mnt/playpen/mailwoman-data/wof/postcode-locality-jp.db",
+	],
+})
+
+function norm(s: string): string {
+	return s
+		.normalize("NFKD")
+		.replace(/[̀-ͯ]/g, "")
+		.toLowerCase()
+		.replace(/[\s-]/g, "")
+		.replace(/(shi|ku|cho|machi|gun|ken|fu|to|son|mura|ward)$/, "")
+}
+// KEN_ALL (CP932 → we read latin1 bytes; col6 romaji is ASCII so latin1 is safe for the romaji column)
+const buf = readFileSync(KENALL, "latin1")
+const rows: Array<{ pc: string; muni: string; city: string }> = []
+for (const line of buf.split(/\r?\n/)) {
+	const f = line.split(",").map((c) => c.replace(/^"|"$/g, ""))
+	if (f.length >= 6 && /^\d{7}$/.test(f[0]!)) {
+		const pc = `${f[0]!.slice(0, 3)}-${f[0]!.slice(3)}`
+		const muni = f[5]!
+		const city = muni.split(" ")[0] || muni // first token (the city / ward for Tokyo specials)
+		rows.push({ pc, muni, city })
+	}
+}
+// deterministic sample
+const N = 2000
+const step = Math.max(1, Math.floor(rows.length / N))
+const sample = rows.filter((_, i) => i % step === 0).slice(0, N)
+
+// Independent cross-check gold: GeoNames admin2 (sourced separately from KEN_ALL).
+const gnAdmin2 = new Map<string, string>()
+for (const line of readFileSync("/mnt/playpen/mailwoman-data/geonames/JP.txt", "utf8").split("\n")) {
+	const f = line.split("\t")
+	if (f.length > 5 && f[1]) gnAdmin2.set(f[1]!, f[5]!)
+}
+
+let resolved = 0
+let agreeKen = 0
+let crossN = 0
+let crossAgree = 0
+for (const r of sample) {
+	const cands = await backend.findPlace({ text: r.city, placetype: "locality", postcode: r.pc, country: "JP" } as never)
+	const top = cands[0] as any
+	if (!top) continue
+	resolved += 1
+	const nm = norm(top.name)
+	if (nm.length >= 2 && norm(r.muni).includes(nm)) agreeKen += 1
+	const gn = gnAdmin2.get(r.pc)
+	if (gn) {
+		crossN += 1
+		if (nm.length >= 2 && norm(gn).includes(nm)) crossAgree += 1
+	}
+}
+console.log(`JP end-to-end (text=city token + postcode), n=${sample.length}:`)
+console.log(`  resolved: ${resolved} (${((100 * resolved) / sample.length).toFixed(1)}%)`)
+console.log(
+	`  name-agree w/ KEN_ALL municipality (gold):   ${agreeKen} (${((100 * agreeKen) / sample.length).toFixed(1)}%)`
+)
+console.log(
+	`  name-agree w/ GeoNames admin2 (independent): ${crossAgree}/${crossN} (${((100 * crossAgree) / crossN).toFixed(1)}%)`
+)
+backend.close?.()
+process.exit(0)


### PR DESCRIPTION
Closes #292 — the first CJK locale lands, and it validated the whole arena architecture.

## The pivot
WOF admin geometry in CJK (JP/KR/TW) is **point-based at the municipality level** — no municipality polygons — so the European point-in-polygon coordinate-first build gives only ~25% JP coverage at the wrong granularity. JP uses an authoritative **name-match** build instead, producing the **same `postcode_locality` table** so the existing `postcode_area_resolution` strategy consumes it with **zero new resolver code**:

```
postcode → KEN_ALL (Japan Post, romanized) municipality NAME
postcode → GeoNames point
name + point → cross-placetype match (locality+county+localadmin+borough) ≤15km → WOF id
```

The cross-placetype match is the unlock: JP municipalities are split across WOF placetypes (cities→locality, wards→county/localadmin, Tokyo special wards→borough). Matching a single placetype caps at 52–60%; all four hits **94.9%**.

## Results (n=2000)
- Build name-match: **94.9%**
- End-to-end resolver (text=city token + postcode through the real backend): **98.5%** vs KEN_ALL (gold), **93.9% vs independent GeoNames admin2** (non-circular cross-check)
- All well above the 85% bar.

## Safety
- JP merged into the shared `postcode-locality-intl.db` (backup kept) with **DE/FR/GB/NL `findPlace` byte-identical** — the resolver-eval default picks JP up automatically.
- Build-from-source: KEN_ALL (Japan Post, manually fetched — Japan Post blocks programmatic download, live URL chain in the script header) + GeoNames (already an in-project source). `.db` artifacts built on /mnt/playpen + at release, not committed (same as the other WOF assets).

## Known follow-up (minor, not JP-specific)
The coord-first **exact-name tiering** can let a bare same-named-ward text (e.g. `Chuo` alone) pick the wrong region over the postcode's municipality. The realistic flow (city token + postcode) resolves correctly at 98.5%, so this is an edge — filing a separate resolver issue (a proximity-gated exact tier would help EU too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)