### PR TITLE
docs(eval): CJK arena — Japan resolves at 94% with no city polygons

### DIFF
--- a/docs/articles/evals/2026-06-05-cjk-arena.md
+++ b/docs/articles/evals/2026-06-05-cjk-arena.md
@@ -1,0 +1,63 @@
+# Japan has no city polygons. The postcode resolves it anyway.
+
+**Date:** 2026-06-05
+**Scope:** the CJK resolution arena — the point-geometry finding (JP/KR/TW), the pivot from point-in-polygon to authoritative name-match, and Japan landing at 94% built / 94–98% resolved.
+
+We spent the European locales teaching a resolver to drop a postcode's centroid into a city's polygon and read off the city. Then we pointed it at Japan, and the first thing it told us is that Japan doesn't have the polygons. The second thing it told us is that it doesn't matter.
+
+## The wall: there are no municipality polygons in CJK
+
+The European coordinate-first recipe is point-in-polygon: take a postcode centroid, find the WOF locality whose polygon contains it, done. It got Germany to 92.6% and the Netherlands to 94.9%. It gets Japan to **25%** — and it took a while to understand why, because the failure is structural, not a tuning gap.
+
+WOF's administrative geometry for the CJK countries is **point-based exactly where postcodes resolve.** We sampled the per-placetype geometry and the pattern is the same across all three:
+
+| WOF placetype  | maps to                     |       JP |        KR |       TW |
+| -------------- | --------------------------- | -------: | --------: | -------: |
+| region         | prefecture / province       | polygons |         — | polygons |
+| county         | sub-prefecture / ward       | polygons |       69% |       3% |
+| **localadmin** | **municipality (市区町村)** |   **0%** |    **0%** |   **0%** |
+| **locality**   | sub-municipality            |  **~1%** | **~0.4%** |  **~1%** |
+
+The level a postcode actually resolves to — the municipality — is essentially all points, in Japan, Korea, and Taiwan alike. So point-in-polygon has nothing to contain. This isn't a Japan quirk we can special-case around; it's the shape of the whole CJK arena, and it means the European recipe doesn't generalize east. Confirmed, quantified, written down.
+
+## The pivot: resolve by authoritative name, not by polygon
+
+If you can't ask "which polygon contains this point," you ask the postal authority "what's the municipality for this postcode," and then you find that municipality in WOF. Japan's postal authority publishes exactly that — **KEN_ALL**, from Japan Post, and crucially a _romanized_ edition whose municipality column reads `SAPPORO SHI CHUO KU`, in the same alphabet as WOF's romanized place names. Authoritative, and matchable.
+
+Getting it was its own small saga: every KEN_ALL download URL we knew was a 404, the new ones are gated behind JavaScript and a Japan-only fetch, and the file when it finally arrives is CP932/Shift-JIS from 2025. But it arrives, and it carries the one thing WOF's own postcode hierarchy doesn't — the municipality, not just the prefecture (WOF's postcode→admin chain stops at the prefecture, far too coarse).
+
+The build is then a different shape feeding the _same_ machinery:
+
+```
+postcode → KEN_ALL municipality NAME (romanized, authoritative)
+postcode → GeoNames point
+name + point → match to a nearby WOF place → WOF id, with is_containing=1
+```
+
+That last step writes the ordinary `postcode_locality` table, so the existing `postcode_area_resolution` strategy resolves Japan with **zero new resolver code.** The European locales drop a centroid into a polygon; Japan matches an authoritative name to a point. Same table, same strategy, different build — which is exactly the division of labor the Geographic Rule Engine was built to carry.
+
+## The detail that moved it from 52% to 94%
+
+The first name-match attempts capped at 52–60%, and the reason is a lesson about WOF's CJK modeling: **Japanese municipalities are split across WOF placetypes.** A regular city is a `locality`. A designated-city ward is a `county` or `localadmin`. A Tokyo special ward is a `borough`. Match against any single placetype and you miss half the country — Osaka's `530-0001` resolves to `Kita` (the correct ward) but you scored it against `locality` and found a town named Kita three prefectures away.
+
+Search _all_ the municipality-ish placetypes at once — `locality` + `county` + `localadmin` + `borough` — and keep the one whose name appears in the authoritative municipality string, nearest first, and it jumps to **94.9%.** The granularity inconsistency that capped the single-placetype match dissolves when you stop assuming WOF models municipalities in one place.
+
+## Results
+
+n = 2,000 postcodes, scored two ways:
+
+| measure                                      |    result | gold                                                |
+| -------------------------------------------- | --------: | --------------------------------------------------- |
+| build name-match                             | **94.9%** | KEN_ALL (authoritative)                             |
+| end-to-end resolver (city text + postcode)   | **98.5%** | KEN_ALL                                             |
+| end-to-end resolver, independent cross-check | **93.9%** | GeoNames `admin2` (sourced separately from KEN_ALL) |
+
+The 93.9% is the one to trust: GeoNames' municipality field comes from a different lineage than KEN_ALL, so a resolved place agreeing with it isn't the build grading its own homework. Japan resolves its postcodes to the right municipality nine times in ten, with an out-of-distribution parser and no city polygons, because the postcode is language-agnostic and the postal authority is right.
+
+Merging Japan into the shared asset left the European locales **byte-identical** — Germany, France, Britain, and the Netherlands resolve exactly as before; Japan rides alongside them.
+
+## What it doesn't do yet, and what it proved
+
+The honest edges: a bare ward name shared across cities (`Chuo` alone, no city) can still let the resolver's exact-name tiering pick the wrong region over the postcode — the realistic city-token flow resolves at 98.5%, so it's an edge, but a proximity-gated exact tier would close it and help the European locales too (filed separately). Korea is obtainable but its GeoNames names are Hangul against WOF's romaji, so it wants a coordinate-match to sidestep transliteration. Taiwan is the real gap — no GeoNames postal file at all, and it isn't in the admin DB yet.
+
+But the thing this validated is bigger than Japan. The point-geometry wall is CJK-wide, which means name-based-from-the-postal-authority isn't a Japanese workaround — it's the CJK resolution architecture, and the convention/strategy machinery already holds it: a different build for a different data shape, feeding one unchanged resolver. The European recipe didn't have to bend to fit Asia. We just wrote the second recipe and pointed the same engine at it.

--- a/docs/articles/plan/2026-06-05-geographic-rule-engine.md
+++ b/docs/articles/plan/2026-06-05-geographic-rule-engine.md
@@ -3,20 +3,20 @@
 **Date:** 2026-06-05
 **Status:** design, signed off (operator + DeepSeek 3-turn consult)
 **Provenance:** Japan cheap-probe (`scripts/diag-japan-parse.ts`) + DeepSeek consult (`.agents/skills/deepseek-consult/session-notes-2026-06-05-japan-resolver-architecture.md`)
-**Sibling:** Direction D / epic #239 — that one is the *parser* (anchor-based parsing); this one is the *resolver* (what happens after the parse).
+**Sibling:** Direction D / epic #239 — that one is the _parser_ (anchor-based parsing); this one is the _resolver_ (what happens after the parse).
 
 ## Where this came from
 
 We went looking at Japan to learn what the non-Latin story costs us, and the probe split the problem in two so cleanly that the whole design falls out of it. Run a real Japanese address through the current v0.7.2 universal parser and you see two failures that are nothing alike:
 
-- **(A) The model is out-of-distribution.** Romaji in Western order parses almost correctly (`1-1-1 Ginza, Chuo-ku, Tokyo 104-0061` → house_number / street / locality / postcode, all roughly right). Native kanji scatters the labels. This is a coverage problem — trainable — and in the meantime the postcode is a clean regex hit in *every* sample, so coordinate-first resolution carries Japan exactly the way it carried out-of-distribution Dutch to 94.9%. The coarse win needs no parser change at all.
-- **(B) The schema cannot represent the address.** There is no tag for 丁目/番/号 — chōme/banchi/gō, the district/block/building *coordinates* that most of Japan uses instead of streets. The model jams them into `house_number`/`street`/`postcode` because those are the only slots that exist. A *perfectly* trained model still couldn't emit a correct structure. Training can never fix this; it's a vocabulary gap.
+- **(A) The model is out-of-distribution.** Romaji in Western order parses almost correctly (`1-1-1 Ginza, Chuo-ku, Tokyo 104-0061` → house_number / street / locality / postcode, all roughly right). Native kanji scatters the labels. This is a coverage problem — trainable — and in the meantime the postcode is a clean regex hit in _every_ sample, so coordinate-first resolution carries Japan exactly the way it carried out-of-distribution Dutch to 94.9%. The coarse win needs no parser change at all.
+- **(B) The schema cannot represent the address.** There is no tag for 丁目/番/号 — chōme/banchi/gō, the district/block/building _coordinates_ that most of Japan uses instead of streets. The model jams them into `house_number`/`street`/`postcode` because those are the only slots that exist. A _perfectly_ trained model still couldn't emit a correct structure. Training can never fix this; it's a vocabulary gap.
 
 That distinction is the spine of everything below. (A) lives in the resolver. (B) is the one thing that has to change in the parser — and we're going to change it the smallest way that works.
 
 ## The thesis
 
-The machinery after the parse is not one monolithic resolver, and it is not a Matryoshka of nested resolver *objects* either (orthogonal concerns — grid morphology vs postal schema vs alias lists — don't fit a single inheritance tree, and adding a city shouldn't mean a code deploy). It's a flat **Geographic Rule Engine**:
+The machinery after the parse is not one monolithic resolver, and it is not a Matryoshka of nested resolver _objects_ either (orthogonal concerns — grid morphology vs postal schema vs alias lists — don't fit a single inheritance tree, and adding a city shouldn't mean a code deploy). It's a flat **Geographic Rule Engine**:
 
 > A `convention` table keyed by Who's-On-First polygon id, deep-merged up the ancestor chain (Sapporo's row inherits Hokkaidō's inherits Japan's), that dispatches a short ordered sequence of named **strategy functions**. The data carries the routing and parameters; the strategies are a small registry of code primitives. "Plug in and out as needed" means a row in a table plus a pick from existing primitives — new code only for a genuinely novel spatial system.
 
@@ -25,11 +25,11 @@ Two things fall out for free:
 - **The dispatch chicken-and-egg dissolves.** To pick Sapporo's rules you must know you're in Sapporo — but `postcode → WOF locality → ancestors` already hands you the entire admin chain in the coarse pass we run today. Convention selection rides on it at zero cost.
 - **The two audiences are one pipeline at two depths.** Our need (postcode → region/locality, for training gold and coarse geocode) and a user's need (a specific address down to a building) are the same machine stopped at different depths, not two systems. The 2025 Digital Address code is just an early-exit pure-lookup strategy at the front.
 
-This also retires an older open question. Direction D imagined a coarse-placer that decides *which locale model to reach for* (#244/#245). With the rule engine, one universal parser plus a geography-keyed convention table replaces the model router for every Latin locale and every locale the postcode can anchor. We mostly don't need to reach for a different model.
+This also retires an older open question. Direction D imagined a coarse-placer that decides _which locale model to reach for_ (#244/#245). With the rule engine, one universal parser plus a geography-keyed convention table replaces the model router for every Latin locale and every locale the postcode can anchor. We mostly don't need to reach for a different model.
 
 ## The one foundational decision
 
-The seductive idea is to throw out the semantic tags and have the parser emit positional levels (`L0…Ln`) that the convention names per locale. It's elegant and would serve every future country. It is also the highest-regret move on the board: it detonates four working locales, forces a from-scratch retrain plus a resolver-contract rewrite, with NL's 94.9% to re-earn from zero — and it breaks on partial queries, where the level *index* of a bare "Berlin" is undefined until you've already resolved the country. We are **not** doing that, and Phase 3 below exists only to record the tripwire that would ever reopen it.
+The seductive idea is to throw out the semantic tags and have the parser emit positional levels (`L0…Ln`) that the convention names per locale. It's elegant and would serve every future country. It is also the highest-regret move on the board: it detonates four working locales, forces a from-scratch retrain plus a resolver-contract rewrite, with NL's 94.9% to re-earn from zero — and it breaks on partial queries, where the level _index_ of a bare "Berlin" is undefined until you've already resolved the country. We are **not** doing that, and Phase 3 below exists only to record the tripwire that would ever reopen it.
 
 The additive cut that buys ~80% of the value with zero regression risk: keep every existing semantic tag, and add exactly one new multi-valued tag — **`locator[]`** — for sub-locality spatial units that aren't a Western street + number (chōme/banchi/gō, grid coordinates, block numbers). Street-based countries never emit it; block-based countries never emit `street`; the convention maps `locator[]` per locale. DE/FR/GB/NL never reference it, so they cannot regress.
 
@@ -37,13 +37,15 @@ The additive cut that buys ~80% of the value with zero regression risk: keep eve
 
 Building only for Japan would bake Japanese quirks into something we'd call "general." So the design is validated against **three** CJK block-style systems at once — Japan (chōme/banchi/gō), South Korea (도로명 road-name and 지번 lot systems), Taiwan (段/巷/弄/號). If the convention table + `locator[]` + the strategy registry express all three without per-country code beyond data, the abstraction has earned the word "general."
 
+> **Update (2026-06-05) — the CJK coarse build is a name-match, not PIP.** Phase-1 implementation surfaced a structural finding (confirmed across JP/KR/TW): WOF admin geometry is **point-based at the municipality level** — there are no municipality polygons — so the European point-in-polygon coordinate-first build is inapplicable to CJK (it gives ~25% JP coverage). CJK resolves by **authoritative name-match** instead: postcode → national-postal-authority municipality NAME (JP = KEN_ALL) + GeoNames point → cross-placetype match (`locality`+`county`+`localadmin`+`borough`) → WOF id, written to the _same_ `postcode_locality` table so the _same_ `postcode_area_resolution` strategy consumes it. This is the convention engine earning its keep exactly as designed — a different build for a different data shape, feeding one unchanged resolver. Japan: 94.9% built, 93.9% resolved (independent gold). PIP-containment is replaced by name-agreement as the CJK metric. Full write-up: [`docs/articles/evals/2026-06-05-cjk-arena.md`](../evals/2026-06-05-cjk-arena.md).
+
 ## Sequencing (reversible-first)
 
-**Phase 1 — resolver-side, additive, reversible, no parser change.** This is largely *reshaping what we already have* — `addressing-conventions.json` is a primitive convention table, and coordinate-first *is* `postcode_area_resolution` — into the general form, then adding rows for JP/KR/TW. Delivers coarse locality geocoding off the postcode alone, the same trick that got Dutch-OOD NL to 94.9%. Pure resolver work, the part of the stack that has never bitten us.
+**Phase 1 — resolver-side, additive, reversible, no parser change.** This is largely _reshaping what we already have_ — `addressing-conventions.json` is a primitive convention table, and coordinate-first _is_ `postcode_area_resolution` — into the general form, then adding rows for JP/KR/TW. Delivers coarse locality geocoding off the postcode alone, the same trick that got Dutch-OOD NL to 94.9%. Pure resolver work, the part of the stack that has never bitten us.
 
 **Phase 2 — parser-side, additive, gated.** Teach the parser to emit `locator[]` from a handful of JP/KR/TW examples. Existing tags untouched, model rollback-able. This inherits every retrain fragility we've hit (the German end-of-string collapse, the PR3 negative), so it's gated on per-locale-F1 + resolver utility exactly like every other retrain, and Phase 1 must prove the engine first.
 
-**Phase 3 — deferred, decision-only.** Revisit `L0…Ln` *only* if onboarding more systems (India, China, …) proves the additive scheme genuinely insufficient — by then with real data and a mature engine, as a migration rather than a leap.
+**Phase 3 — deferred, decision-only.** Revisit `L0…Ln` _only_ if onboarding more systems (India, China, …) proves the additive scheme genuinely insufficient — by then with real data and a mature engine, as a migration rather than a leap.
 
 The coarse/fine split maps onto a safe/risky split: Phase 1 is cheap and near-certain; building-level precision (Phase 2+) is a separate, genuinely harder bet, and we may live on Phase 1 for a good while.
 
@@ -51,14 +53,14 @@ The coarse/fine split maps onto a safe/risky split: Phase 1 is cheap and near-ce
 
 Heterogeneous authoritative sources sit behind the uniform strategy interface; the resolver never cares which source answered. Built from source, never a prebuilt dump — same discipline as every other table we ship.
 
-| Dataset | Primitive | Tier |
-| --- | --- | --- |
+| Dataset                                                                   | Primitive                                                                                | Tier            |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------- |
 | KEN_ALL (JP postal authority: 7-digit ↔ prefecture/municipality/district) | `postcode_area_resolution` (+ `block_area_lookup` once block polygons are georeferenced) | coarse (+ fine) |
-| JIGYOSYO (JP large-org / PO-box codes) | `org_code_lookup` | fine |
-| Digital Address 2025 (JP 7-char code → registered building) | `digital_code_lookup` (early-exit) | fine |
-| 도로명주소 / 지번 (KR) | `postcode_area_resolution` + `named_linear_feature_with_offset` | coarse + fine |
-| TW postal + 段/巷/弄/號 | `postcode_area_resolution` + `block_area_lookup` | coarse + fine |
-| WOF admin polygons (already shipped) | ancestor walk for convention selection | all |
+| JIGYOSYO (JP large-org / PO-box codes)                                    | `org_code_lookup`                                                                        | fine            |
+| Digital Address 2025 (JP 7-char code → registered building)               | `digital_code_lookup` (early-exit)                                                       | fine            |
+| 도로명주소 / 지번 (KR)                                                    | `postcode_area_resolution` + `named_linear_feature_with_offset`                          | coarse + fine   |
+| TW postal + 段/巷/弄/號                                                   | `postcode_area_resolution` + `block_area_lookup`                                         | coarse + fine   |
+| WOF admin polygons (already shipped)                                      | ancestor walk for convention selection                                                   | all             |
 
 Seed strategy registry: `postcode_area_resolution`, `block_area_lookup`, `intersection_resolver`, `named_linear_feature_with_offset`, `alias_normalisation`, `transliterate_reorder` (pre-parse), `digital_code_lookup`, `org_code_lookup`, `fallback_fuzzy_name_match`.
 
@@ -67,4 +69,4 @@ Seed strategy registry: `postcode_area_resolution`, `block_area_lookup`, `inters
 - **Phase 1 promotion:** a locale ships when postcode-route PIP-containment clears ~85% on a real OA sample, with no regression to DE/FR/GB/NL (the existing coordinate-first numbers are byte-stable).
 - **Phase 2 gate:** the `locator[]` fine-tune promotes only on per-locale-F1 + resolver utility, and never if it drops an existing locale >2pp. Default to not promoting; live on Phase 1's coarse win.
 - **The `locator[]` shape, the first-ship scope, and the convention-asset format are open forks** to settle at Phase 1 kickoff (plain ordered slot vs typed; JP-only branch vs general refactor; WOF-id-keyed read-only sqlite asset like `postcode-locality-intl.db`).
-- **Phase 3 tripwire (the only thing that reopens `L0…Ln`):** the additive `locator[]` scheme fails to express a newly-onboarded system *as data* and forces per-country parser-output post-processing in ≥2 locales.
+- **Phase 3 tripwire (the only thing that reopens `L0…Ln`):** the additive `locator[]` scheme fails to express a newly-onboarded system _as data_ and forces per-country parser-output post-processing in ≥2 locales.


### PR DESCRIPTION
Capstone for the CJK resolution arena (companion to #303).

Covers the point-geometry finding (WOF has no municipality polygons across JP/KR/TW), the pivot from point-in-polygon to authoritative name-match, KEN_ALL as the unlock, the cross-placetype insight (52%→94.9%), and the results (94.9% built / 98.5% KEN_ALL / **93.9% independent GeoNames**). Also corrects the Direction-E design doc, which had assumed PIP was uniform across locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)