### PR TITLE
train(config): v0.8.0 calibration candidate (v0.7.2 + ls=0.05)

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0_8_0-calibration-ls005.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_8_0-calibration-ls005.yaml
@@ -1,0 +1,124 @@
+# v0.8.0 candidate — label_smoothing calibration fork.
+#
+# SINGLE VARIABLE vs v0_7_2-intersection-bare.yaml (the current default): label_smoothing
+# 0.0 → 0.05. Everything else (corpus, weights, intersection-bare shard, CRF-off) is held.
+#
+# Why 0.05, not 0.1: v0.7.0 calibration at ls=0.1 cut overconfidence 86→67% but left the
+# harness pass rate FLAT and dropped house_number ~6pp (NOT promoted — see
+# project-v07-calibration-result). 0.05 is the gentler middle ground (the staged fork): the
+# hypothesis is it recovers most of the calibration gain without the house_number damage.
+#
+# HONEST expectation (articulated before launch, per night-shift iteration discipline):
+# calibration improves (overconfidence down), harness ~flat-to-slightly-up, house_number
+# neutral-vs-0.1, resolver/differentiators stable (calibration barely moves ranking). This is
+# UNLIKELY to clear the operator's "significant harness gain" bar — it's a clean data point
+# that closes the staged ls=0.05 fork, run within budget. Promote ONLY if harness improves
+# meaningfully AND no tag regresses >2pp; else ship experimental / don't promote.
+#
+# Launch: modal run -d scripts/modal/train_remote.py --config v0_8_0-calibration-ls005.yaml --resume none --trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  label_smoothing: 0.05
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v080-ls005/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 100000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""


### PR DESCRIPTION
Provenance for the calibration run launched this night shift (detached Modal A100). Single-variable fork of v0.7.2: `label_smoothing` 0.0→0.05. Honest expectation in the config header — a data point closing the staged ls=0.05 fork, unlikely to clear the promote bar. Gated post-run on harness + per-tag + differentiators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)