### PR TITLE
feat(corpus): bare-street synth shard — v0.8.0 harness lever

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0_8_0-street-bare.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_8_0-street-bare.yaml
@@ -1,0 +1,121 @@
+# v0.8.0 candidate — bare-street harness lever.
+#
+# SINGLE VARIABLE vs v0_7_2-intersection-bare.yaml: add the synth-street-bare shard (weight 0.2).
+# The harness functional.test.ts cluster (32/34 fail on v0.7.2) is bare street names ("10th Ave",
+# "Main St", "1 Main Pl") mislabeled as `locality` — because synthesizeStreetRow only ever emitted
+# streets WITH a ", City, ST ZIP" tail. The new shard (scripts/build-street-bare-shard.mjs, ~65% bare)
+# teaches bare streets → street, the bare-format analogue of the intersection-bare fix. SAFE: US,
+# in-distribution, no German-collapse risk (does not touch multi-locale).
+#
+# Expectation: harness functional + some usa/intersection up (potentially +5-8pp toward the 25% bar);
+# no regression to existing tags (street suffix is the signal, so bare localities are unaffected).
+# Promote only if harness improves meaningfully AND no tag regresses >2pp.
+#
+# Launch: modal run -d scripts/modal/train_remote.py --config v0_8_0-street-bare.yaml --resume none --trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+    synth-street-bare: 0.2
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  label_smoothing: 0.0
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v080-streetbare/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 100000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus/src/synthesize-street.ts
+++ b/corpus/src/synthesize-street.ts
@@ -167,6 +167,15 @@ export interface StreetSynthesisOpts {
 	random?: () => number
 	/** Probability of emitting house_number alongside the street. Default 0.85. */
 	includeHouseNumberProb?: number
+	/**
+	 * Probability of emitting the street BARE — no `, City, ST ZIP` tail and no region/locality/
+	 * postcode components (just `street_prefix`/`street`/`street_suffix` + optional `house_number`).
+	 * Default 0 (preserves the original full-address behavior exactly, including the RNG sequence).
+	 * Set >0 to teach the model that a bare `10th Ave` / `Main St` is a STREET, not a locality — the
+	 * functional-test failure cluster (bare streets mislabeled `locality`), the bare-format analogue of
+	 * the v0.7.x intersection-bare fix.
+	 */
+	bareProb?: number
 }
 
 function pick<T>(arr: ReadonlyArray<T>, random: () => number): T {
@@ -213,11 +222,18 @@ export function synthesizeStreetRow(
 	// string, and the aligner's fuzzy match (edit distance 2) will spuriously match
 	// "US" against any 2-char token (e.g. a house number "45" is exactly 2 substitutions
 	// from "US"). The PO box synthesizer skips country for the same reason.
-	const components: CanonicalRow["components"] = {
-		region: base.region,
-		locality: base.locality,
-		postcode: base.postcode,
-	}
+	// Bare mode is guarded by `> 0` so the default (bareProb=0) consumes no RNG and reproduces the
+	// original full-address output byte-for-byte.
+	const bareProb = opts.bareProb ?? 0
+	const bare = bareProb > 0 && random() < bareProb
+
+	const components: CanonicalRow["components"] = bare
+		? {}
+		: {
+				region: base.region,
+				locality: base.locality,
+				postcode: base.postcode,
+			}
 	if (decomposed.prefix) components.street_prefix = decomposed.prefix
 	if (decomposed.street) components.street = decomposed.street
 	if (decomposed.suffix) components.street_suffix = decomposed.suffix
@@ -226,9 +242,9 @@ export function synthesizeStreetRow(
 	if (random() < includeHN) {
 		const hn = randomHouseNumber(random)
 		components.house_number = hn
-		raw = `${hn} ${fullStreet}, ${base.locality}, ${base.region} ${base.postcode}`
+		raw = bare ? `${hn} ${fullStreet}` : `${hn} ${fullStreet}, ${base.locality}, ${base.region} ${base.postcode}`
 	} else {
-		raw = `${fullStreet}, ${base.locality}, ${base.region} ${base.postcode}`
+		raw = bare ? fullStreet : `${fullStreet}, ${base.locality}, ${base.region} ${base.postcode}`
 	}
 
 	return { raw, components, locale: "en-US" }

--- a/scripts/build-street-bare-shard.mjs
+++ b/scripts/build-street-bare-shard.mjs
@@ -1,0 +1,109 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Synthesize a BARE-STREET shard (v0.8.0 harness lever, 2026-06-05). The harness `functional.test.ts`
+ *   cluster (32/34 fail on v0.7.2) is bare street names — "10th Ave", "Main St", "1 Main Pl" — that the
+ *   model mislabels as `locality`, because `synthesizeStreetRow` only ever emitted streets WITH a
+ *   ", City, ST ZIP" tail. This shard emits streets BARE (60%) — no tail, only `street_prefix`/`street`/
+ *   `street_suffix` (+ optional `house_number`) — the bare-format analogue of the v0.7.x intersection-bare
+ *   fix. Safe (US, in-distribution, no German-collapse risk).
+ *
+ *   Pipeline (same as the intersection shard):
+ *     1. node scripts/build-street-bare-shard.mjs --output /tmp/street-bare-labeled.jsonl --count 3000 --seed 42
+ *     2. python3 scripts/jsonl-to-parquet.py --input /tmp/street-bare-labeled.jsonl --output /tmp/part-street-bare.parquet
+ *     3. modal volume put mailwoman-training /tmp/part-street-bare.parquet corpus/versioned/v0.4.0/corpus-v0.4.0/train/part-street-bare.parquet
+ *     4. add `synth-street-bare: 0.2` to the training config source_weights, then train.
+ */
+import { createWriteStream } from "node:fs"
+
+import { alignRow, DEFAULT_US_BASES, stableSourceId, synthesizeStreetRow } from "@mailwoman/corpus"
+
+function parseArgs() {
+	const args = process.argv.slice(2)
+	const out = { count: 3000, seed: 42, source: "synth-street-bare", bareProb: 0.6 }
+	for (let i = 0; i < args.length; i++) {
+		const a = args[i]
+		if (a === "--output") out.output = args[++i]
+		else if (a === "--count") out.count = parseInt(args[++i], 10)
+		else if (a === "--seed") out.seed = parseInt(args[++i], 10)
+		else if (a === "--source-name") out.source = args[++i]
+		else if (a === "--bare-prob") out.bareProb = parseFloat(args[++i])
+	}
+	if (!out.output) {
+		console.error("Usage: node scripts/build-street-bare-shard.mjs --output <jsonl> [--count 3000] [--seed 42] [--bare-prob 0.6]")
+		process.exit(1)
+	}
+	return out
+}
+
+/** mulberry32 — matches the synthesizer's test PRNG for reproducibility. */
+function mulberry32(seed) {
+	let a = seed >>> 0
+	return () => {
+		a |= 0
+		a = (a + 0x6d2b79f5) | 0
+		let t = Math.imul(a ^ (a >>> 15), 1 | a)
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+	}
+}
+
+async function main() {
+	const opts = parseArgs()
+	const random = mulberry32(opts.seed)
+	const outStream = createWriteStream(opts.output, { encoding: "utf8" })
+
+	let emitted = 0
+	let skipped = 0
+	let bare = 0
+	let guard = 0
+	while (emitted < opts.count && guard++ < opts.count * 5) {
+		const base = DEFAULT_US_BASES[emitted % DEFAULT_US_BASES.length]
+		const synth = synthesizeStreetRow(base, { random, bareProb: opts.bareProb })
+		if (!synth) {
+			skipped++
+			continue
+		}
+		const isBare = synth.components.region === undefined
+		if (isBare) bare++
+
+		const sourceId = stableSourceId(opts.source, {
+			street: synth.components.street,
+			street_suffix: synth.components.street_suffix,
+			house_number: synth.components.house_number,
+			bare: String(isBare),
+			n: String(emitted),
+		})
+
+		const canonical = {
+			raw: synth.raw,
+			components: synth.components,
+			country: base.country,
+			locale: synth.locale,
+			source: opts.source,
+			source_id: sourceId,
+			corpus_version: "0.4.0",
+			license: "Synthetic — US street templates, public-domain street/city pools",
+		}
+
+		const aligned = alignRow(canonical)
+		if (aligned.kind !== "labeled" || !aligned.row) {
+			skipped++
+			continue
+		}
+
+		outStream.write(JSON.stringify({ ...aligned.row, synth_method: "street-bare", synth_base_id: null }) + "\n")
+		emitted++
+	}
+
+	outStream.end()
+	await new Promise((resolve) => outStream.on("finish", resolve))
+	console.error(`Done: emitted ${emitted} street rows (${bare} bare, ${(100 * bare) / emitted}%), skipped ${skipped}. → ${opts.output}`)
+}
+
+main().catch((err) => {
+	console.error(err)
+	process.exit(1)
+})


### PR DESCRIPTION
The harness `functional.test.ts` cluster (32/34 fail on v0.7.2) is bare street names mislabeled as `locality`, because `synthesizeStreetRow` only ever emitted streets with a full-address tail. Adds a guarded `bareProb` option + a shard builder that teaches bare streets → street — the bare-format analogue of the intersection-bare fix. Safe (US, in-distribution). Launched detached on Modal this shift (concurrent with the ls=0.05 calibration run); eval + promote decision pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)