### PR TITLE
train(corpus): bare-street v2 — fix the no-house-number gap

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0_8_1-street-bare-v2.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0_8_1-street-bare-v2.yaml
@@ -1,0 +1,121 @@
+# v0.8.0 candidate — bare-street harness lever.
+#
+# SINGLE VARIABLE vs v0_7_2-intersection-bare.yaml: add the synth-street-bare shard (weight 0.2).
+# The harness functional.test.ts cluster (32/34 fail on v0.7.2) is bare street names ("10th Ave",
+# "Main St", "1 Main Pl") mislabeled as `locality` — because synthesizeStreetRow only ever emitted
+# streets WITH a ", City, ST ZIP" tail. The new shard (scripts/build-street-bare-shard.mjs, ~65% bare)
+# teaches bare streets → street, the bare-format analogue of the intersection-bare fix. SAFE: US,
+# in-distribution, no German-collapse risk (does not touch multi-locale).
+#
+# Expectation: harness functional + some usa/intersection up (potentially +5-8pp toward the 25% bar);
+# no regression to existing tags (street suffix is the signal, so bare localities are unaffected).
+# Promote only if harness improves meaningfully AND no tag regresses >2pp.
+#
+# Launch: modal run -d scripts/modal/train_remote.py --config v0_8_0-street-bare.yaml --resume none --trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.0/corpus-v0.4.0
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    deepseek-translit-armn: 0.5
+    deepseek-translit-cyrl: 0.5
+    deepseek-translit-hang: 0.5
+    deepseek-translit-hans: 0.5
+    deepseek-translit-jpan: 0.5
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+    synth-street-bare: 0.2
+  train_rows_per_epoch: 1000000
+  val_rows: 2048
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  label_smoothing: 0.0
+  crf_normalization: per_sequence
+  crf_loss_weight: 0.0
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v080-streetbare/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 130000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/scripts/build-street-bare-shard.mjs
+++ b/scripts/build-street-bare-shard.mjs
@@ -22,7 +22,7 @@ import { alignRow, DEFAULT_US_BASES, stableSourceId, synthesizeStreetRow } from 
 
 function parseArgs() {
 	const args = process.argv.slice(2)
-	const out = { count: 3000, seed: 42, source: "synth-street-bare", bareProb: 0.6 }
+	const out = { count: 3000, seed: 42, source: "synth-street-bare", bareProb: 0.6, hnProb: 0.85 }
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i]
 		if (a === "--output") out.output = args[++i]
@@ -30,6 +30,7 @@ function parseArgs() {
 		else if (a === "--seed") out.seed = parseInt(args[++i], 10)
 		else if (a === "--source-name") out.source = args[++i]
 		else if (a === "--bare-prob") out.bareProb = parseFloat(args[++i])
+		else if (a === "--hn-prob") out.hnProb = parseFloat(args[++i])
 	}
 	if (!out.output) {
 		console.error("Usage: node scripts/build-street-bare-shard.mjs --output <jsonl> [--count 3000] [--seed 42] [--bare-prob 0.6]")
@@ -61,7 +62,7 @@ async function main() {
 	let guard = 0
 	while (emitted < opts.count && guard++ < opts.count * 5) {
 		const base = DEFAULT_US_BASES[emitted % DEFAULT_US_BASES.length]
-		const synth = synthesizeStreetRow(base, { random, bareProb: opts.bareProb })
+		const synth = synthesizeStreetRow(base, { random, bareProb: opts.bareProb, includeHouseNumberProb: opts.hnProb })
 		if (!synth) {
 			skipped++
 			continue


### PR DESCRIPTION
v1's bare-street shard had house numbers in 85% of bare rows, so the pure-bare functional pattern (`10th Ave` alone) was undertrained (~9% of shard) and the functional cluster didn't move. v2 adds a `--hn-prob` flag; at 0.3 the pure-bare streets are **47% of the shard**. Continue-trained the v1 step-100000 checkpoint on the corrected shard.

**Result: NEGATIVE, not promoted.** At +4k steps the functional cluster still did not budge (`main pl` / `10th ave` → `locality`, 1/34). The bare-format-shard approach has now failed twice — the model's bare-input→`locality` prior is immovable at the data layer. Full writeup in `docs/articles/evals/2026-06-05-night-6-postmortem.md` (the five-lever exhaustion; merged via #311). ⚠️ The continue-train ran pathologically slowly before being stopped — see the budget caution in the postmortem.

What this PR keeps is durable: the `--hn-prob` synthesizer plumbing (a strict improvement over #308's script) and the experiment config for provenance / a future fresh-run retry. v0.7.2 stays the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)