### PR TITLE
eval(postcode): A/B the anchor country posterior — uniform stays (#240)

### DIFF
--- a/docs/articles/evals/2026-06-05-postcode-posterior-ab.md
+++ b/docs/articles/evals/2026-06-05-postcode-posterior-ab.md
@@ -1,0 +1,38 @@
+# The better posterior was confidently wrong
+
+**Date:** 2026-06-05
+**Scope:** the postcode anchor's country posterior (#240) — uniform vs a de-biased Bayesian weighting, decided on held-out real collisions before changing a line of shipped code.
+
+The postcode anchor turns a code like `75001` into a distribution over the countries it could belong to. The shipped version uses a **uniform** posterior: `1/k` over the countries a code exists in. `75001` is in both France and the US, so it comes back `{FR: 0.5, US: 0.5}` — an honest shrug that leaves the disambiguation to the parser and the resolver.
+
+That shrug throws away real information, and we knew it. The _true_ posterior is `P(country | postcode) ∝ N_c(x)` — the actual address-count ratio. `75001` is the 1st arrondissement of Paris, dense and central; it is also Addison, Texas, a quiet suburb. Those don't have equal address counts, so the honest answer isn't 50/50. A de-biased Bayesian posterior — within-country frequency times a real-world address-volume prior — targets that ratio directly, and on paper it's the more correct shape. So we went to adopt it. Then we did the thing our earlier postcode-country investigation was entirely about: we measured the load-bearing assumption before building on it.
+
+## The measurement
+
+We A/B'd three posteriors on the canonical collision — **US ↔ FR**, the literal `75001` case, and the one pair where we have rich frequency data on both sides:
+
+- **`f̂` (train):** corpus v0.1.0 — 4.4M real addresses — counting `(country, postcode)`.
+- **candidate set:** the 13,186 five-digit postcodes that exist in _both_ the US and FR postal gazetteers.
+- **test (held-out):** `openaddresses-{us,fr}-sample.jsonl` — a different extraction, so `f̂` is never graded on the data it was fit to.
+
+Three posteriors, scored per true country and **balanced** (so a US-leaning prior can't win by exploiting that US collisions outnumber FR in the test):
+
+| posterior                   | balanced logloss | balanced top-1 | high-conf errors (true-FR) |
+| --------------------------- | ---------------: | -------------: | -------------------------: |
+| **uniform** (shipped)       |       **0.6931** |          50.0% |                   **0.0%** |
+| naive-count                 |           0.7555 |          39.4% |                       0.0% |
+| de-biased (the "smart" one) |           2.2292 |          51.6% |                  **96.9%** |
+
+De-biased is **three times worse-calibrated** than the shrug, and **confidently wrong about the minority country 97% of the time.** Its one bragging point — `+1.6pp` top-1 — is pure test-imbalance arbitrage: it nails the abundant US cases and immolates the FR ones. naive-count, the control, comes in worse than uniform too, exactly as the raw-count skeptics warned.
+
+## Why — and it isn't the math
+
+The de-biasing math is sound. The data underneath it is half-broken. `f̂` needs per-country address _frequency_ on both sides of a collision, and we only have it on one. France arrives as 1.13M real street addresses (`ban`, the national address base), so a busy Paris postcode genuinely shows up thousands of times. The US arrives as 58k rows from `wof-postalcode` — essentially a _membership list_, one row per code, no frequency signal at all (97.5% of v0.1.0's US rows are `wof-admin` places that carry no postcode). So `f̂_US` is estimated off a tiny, flat denominator and comes out systematically inflated; multiply by a US-favoring volume prior and the posterior screams "US" at nearly every collision, right or wrong.
+
+Feed sound math a lopsided `f̂` and you don't get a slightly-off posterior — you get a _confidently_ wrong one. And a confidently-wrong soft prior is the single thing that corrupts the resolver re-rank we're building toward: uniform's honest 0.5 gets gated out when the resolver is already sure, but a 0.97-to-the-wrong-country prior sails through the confidence gate and flips a correct answer. The shrug is worse on paper and far safer in practice.
+
+## Verdict
+
+**Uniform stays.** Not because de-biasing is the wrong idea, but because we can't feed it. This is a data-availability finding wearing a posterior-design costume: the day we have balanced per-country address frequency — bulk OpenAddresses for the US, or census ZIP-population weights, neither on disk today — it's worth re-measuring, because the _shape_ it targets really is the correct one. Until then, weighting the guess makes it worse.
+
+The measurement is `scripts/eval/postcode-posterior-ab.py`; re-run it when the data changes. It cost an afternoon and saved us from shipping a posterior that is wrong with conviction — which is the only kind of wrong a soft anchor can't afford to be.

--- a/scripts/eval/postcode-posterior-ab.py
+++ b/scripts/eval/postcode-posterior-ab.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""A/B the postcode-anchor country posterior: UNIFORM vs frequency-weighted, decided on held-out real
+collisions (#240, measure-before-you-build for the uniform-vs-de-biased question).
+
+The shipped anchor (`neural/postcode-anchor.ts`) uses a UNIFORM posterior: 1/k over the countries a
+postcode exists in. An earlier DeepSeek consult chose uniform to dodge the bias of raw-count weighting.
+A later consult argued for a DE-BIASED Bayesian posterior. They disagree, so we measure it instead of
+arguing.
+
+The true posterior is P(country | postcode) ∝ N_c(x) — the real address-count ratio. We can't observe
+N_c(x) directly, but we can estimate it and check which posterior predicts the true country of a
+held-out real address whose postcode collides across countries.
+
+Canonical testbed: US ↔ FR 5-digit collisions (75001 is both central Paris and Addison, TX). It is the
+collision case AND the one where we have rich frequency data on both sides.
+
+  - f̂ source (TRAIN):  corpus v0.1.0 (4.4M real addresses; US ~2.3M, FR ~2.1M) — count(country, postcode).
+  - candidate set:      US ∩ FR 5-digit postcodes (the postal-DB membership the runtime extractor sees).
+  - test (HELD-OUT):    data/eval/external/openaddresses-{us,fr}-sample.jsonl — a DIFFERENT extraction,
+                        so f̂ is never graded on the data it was fit to.
+
+Three posteriors over the candidate set {US, FR}:
+  A. uniform          p_c = 1/k
+  B. naive-count      p_c ∝ count(c, x)                          (raw counts — the bias the earlier consult feared)
+  C. de-biased        p_c ∝ f̂_c(x) · prior(c),  f̂_c(x)=(count+α)/(total+α),  prior=address-volume
+
+Metrics on held-out collision addresses, reported PER TRUE COUNTRY and BALANCED (so a country-skewed
+prior can't win by exploiting the 10k-US-vs-3k-FR test imbalance): log-loss, top-1 accuracy, and the
+high-confidence error rate (p_argmax > 0.8 but wrong — the failure mode that hurts the resolver re-rank).
+
+Usage:  python3 scripts/eval/postcode-posterior-ab.py
+"""
+import collections
+import glob
+import json
+import math
+
+import pyarrow.parquet as pq
+
+V010 = "/mnt/playpen/mailwoman-data/corpus/versioned/v0.1.0/corpus-v0.1.0/train"
+US_DB = "/mnt/playpen/mailwoman-data/wof/postalcode-us.db"
+INTL_DB = "/mnt/playpen/mailwoman-data/wof/postalcode-intl.db"
+OA = "data/eval/external/openaddresses-{}-sample.jsonl"
+
+# Real-world address-volume prior (order-of-magnitude; postal-union / census figures). Only the RATIO
+# matters, and only across the candidate set.
+ADDR_VOLUME = {"US": 160e6, "FR": 35e6}
+ALPHA = 0.5  # add-α smoothing for f̂
+
+
+def five_digit(pc: str) -> str | None:
+	pc = (pc or "").strip()
+	return pc if len(pc) == 5 and pc.isdigit() else None
+
+
+def collision_set() -> set[str]:
+	import sqlite3
+
+	us = {r[0] for r in sqlite3.connect(US_DB).execute("SELECT name FROM spr WHERE placetype='postalcode'")}
+	fr = {
+		r[0]
+		for r in sqlite3.connect(INTL_DB).execute(
+			"SELECT name FROM spr WHERE placetype='postalcode' AND country='FR'"
+		)
+	}
+	us5 = {p for p in us if five_digit(p)}
+	fr5 = {p for p in fr if five_digit(p)}
+	return us5 & fr5
+
+
+def build_fhat() -> tuple[dict, dict]:
+	"""count[(country, postcode)] and total[country] over v0.1.0 real addresses (US/FR, 5-digit)."""
+	count: dict[tuple[str, str], int] = collections.defaultdict(int)
+	total: dict[str, int] = collections.defaultdict(int)
+	for shard in sorted(glob.glob(f"{V010}/*.parquet")):
+		pf = pq.ParquetFile(shard)
+		for batch in pf.iter_batches(columns=["tokens", "labels", "country"], batch_size=50000):
+			d = batch.to_pydict()
+			for toks, labs, ctry in zip(d["tokens"], d["labels"], d["country"]):
+				if ctry not in ("US", "FR"):
+					continue
+				parts = [t for t, l in zip(toks, labs) if l in ("B-postcode", "I-postcode")]
+				pc = five_digit("".join(parts))
+				if pc:
+					count[(ctry, pc)] += 1
+					total[ctry] += 1
+	return count, total
+
+
+def posteriors(pc: str, count: dict, total: dict) -> dict[str, dict[str, float]]:
+	cands = ["US", "FR"]
+	out = {}
+	# A. uniform
+	out["uniform"] = {c: 0.5 for c in cands}
+	# B. naive count-weighted
+	raw = {c: count.get((c, pc), 0) + ALPHA for c in cands}
+	z = sum(raw.values())
+	out["naive_count"] = {c: raw[c] / z for c in cands}
+	# C. de-biased: f̂ · prior
+	prior_z = sum(ADDR_VOLUME[c] for c in cands)
+	deb = {}
+	for c in cands:
+		fhat = (count.get((c, pc), 0) + ALPHA) / (total[c] + ALPHA)
+		deb[c] = fhat * (ADDR_VOLUME[c] / prior_z)
+	z = sum(deb.values())
+	out["de_biased"] = {c: deb[c] / z for c in cands}
+	return out
+
+
+def load_test(coll: set[str]) -> list[tuple[str, str]]:
+	"""(postcode, true_country) for held-out OA addresses whose postcode is a collision."""
+	rows = []
+	for cc, country in (("us", "US"), ("fr", "FR")):
+		with open(OA.format(cc), encoding="utf-8") as fh:
+			for line in fh:
+				try:
+					pc = five_digit(json.loads(line).get("expected", {}).get("postcode", ""))
+				except json.JSONDecodeError:
+					continue
+				if pc and pc in coll:
+					rows.append((pc, country))
+	return rows
+
+
+def main() -> None:
+	print("building collision set + f̂ (this reads v0.1.0, ~30s)…")
+	coll = collision_set()
+	count, total = build_fhat()
+	print(f"  collisions(US∩FR 5-digit): {len(coll):,}   f̂ totals: US={total['US']:,} FR={total['FR']:,}")
+
+	test = load_test(coll)
+	by_country = collections.Counter(c for _, c in test)
+	print(f"  held-out collision test addresses: {len(test):,}  (US={by_country['US']:,}, FR={by_country['FR']:,})\n")
+
+	methods = ["uniform", "naive_count", "de_biased"]
+	# per (method, true_country): [logloss_sum, n, top1, highconf_err]
+	agg = {m: {c: [0.0, 0, 0, 0] for c in ("US", "FR")} for m in methods}
+	for pc, truth in test:
+		post = posteriors(pc, count, total)
+		for m in methods:
+			p = post[m]
+			a = agg[m][truth]
+			a[0] += -math.log(max(p[truth], 1e-12))
+			a[1] += 1
+			arg = max(p, key=p.get)
+			if arg == truth:
+				a[2] += 1
+			elif p[arg] > 0.8:
+				a[3] += 1
+
+	def line(label: str, ll: float, n: int, t1: int, hce: int) -> str:
+		return f"    {label:<8} logloss={ll / max(n,1):.4f}  top1={100*t1/max(n,1):5.1f}%  highconf-err={100*hce/max(n,1):4.1f}%  (n={n})"
+
+	print("=" * 78)
+	for m in methods:
+		us, fr = agg[m]["US"], agg[m]["FR"]
+		bal_ll = 0.5 * (us[0] / max(us[1], 1) + fr[0] / max(fr[1], 1))
+		bal_t1 = 0.5 * (us[2] / max(us[1], 1) + fr[2] / max(fr[1], 1))
+		print(f"\n[{m}]")
+		print(line("true=US", *us))
+		print(line("true=FR", *fr))
+		print(f"    BALANCED logloss={bal_ll:.4f}  top1={100*bal_t1:.1f}%   <-- the fair number")
+	print("\n" + "=" * 78)
+	print("Lower balanced logloss = better-calibrated posterior. Higher balanced top1 = picks the right")
+	print("country more often on genuine collisions. de_biased should beat uniform; naive_count is the")
+	print("control showing why raw counts were feared.")
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
Measure-before-you-build for the **uniform vs de-biased** posterior question (#240) — the two DeepSeek consults disagreed, so we let the number decide instead of arguing.

## Result (held-out US↔FR collisions, scored per-true-country + balanced)
| posterior | balanced logloss | high-conf errors (true-FR) |
| --- | ---: | ---: |
| **uniform** (shipped) | **0.6931** | **0.0%** |
| naive-count | 0.7555 | 0.0% |
| de-biased | 2.2292 | **96.9%** |

De-biased is 3× worse-calibrated and **confidently wrong on the minority country 97% of the time.**

## Why — it's the data, not the math
`f̂` needs per-country address **frequency** on both sides of a collision. We have it for FR (`ban`, 1.13M real addresses) but only a **membership list** for US (`wof-postalcode`, ~1 row/code — 97.5% of v0.1.0 US rows are postcode-less `wof-admin`). So `f̂_US` is estimated off a tiny flat denominator → inflated → the posterior screams "US". A confidently-wrong soft prior is exactly what corrupts the (planned) resolver re-rank; uniform's honest 0.5 is strictly safer.

## Verdict
**Keep uniform.** Revisit only if balanced per-country address-frequency data is acquired (bulk OA US / census ZIP populations — neither on disk today). The de-biased *shape* is theoretically correct; we just can't feed it.

Adds the reusable measurement (`scripts/eval/postcode-posterior-ab.py`) + writeup. No code-path changes — the shipped uniform posterior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)