### PR TITLE
feat(train): postcode-anchor conditioning channel (de-risk pilot, #239/#240)

### DIFF
--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -104,6 +104,13 @@ class ModelConfig:
     # unsupervised, which is rarely what you want); a value like 0.3 keeps the locale signal a
     # genuine but secondary objective behind the per-token BIO task.
     locale_loss_weight: float = 0.0
+    # Postcode-anchor conditioning channel (#239/#240 de-risk pilot). When True, the encoder takes a
+    # per-token ``(B, S, NUM_LOCALES+2)`` anchor-feature tensor (uniform country posterior + centroid)
+    # and a ``(B, S)`` confidence scalar, and injects ``c·(W·features + v_ANCHOR)`` at the input
+    # embedding — a position-local hard cue at the postcode span (the property self-conditioning's
+    # global FiLM lacked). Robustness is the confidence curriculum applied corpus-side (see the data
+    # loader). Default False keeps existing numerics. Composes with ``use_locale_conditioning``.
+    use_postcode_anchor: bool = False
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/model.py
+++ b/corpus-python/src/mailwoman_train/model.py
@@ -161,6 +161,8 @@ class MailwomanCoarseEncoder(nn.Module):
         use_locale_conditioning: bool = False,
         num_locales: int = NUM_LOCALES,
         locale_loss_weight: float = 0.0,
+        use_postcode_anchor: bool = False,
+        anchor_feature_dim: int = NUM_LOCALES + 2,
     ) -> None:
         super().__init__()
         self.pad_token_id = pad_token_id
@@ -182,6 +184,19 @@ class MailwomanCoarseEncoder(nn.Module):
         # so the phrase-prior contribution can be ablated cleanly.
         self.use_phrase_priors = use_phrase_priors
         self.phrase_feature_dim = int(phrase_feature_dim) if use_phrase_priors else 0
+        # Postcode-anchor conditioning channel (de-risk pilot, #239/#240; DeepSeek 2026-06-05).
+        # A per-token additive injection at the postcode span: a_i = c_i · (W·anchor_features +
+        # v_ANCHOR), added to the token+position embedding. anchor_features is a fixed-width
+        # ``(B, S, anchor_feature_dim)`` vector — a uniform country posterior over the NUM_LOCALES
+        # locale set (0 outside member countries) plus a 2-d centroid — and ``anchor_confidence`` is
+        # the per-token ``(B, S)`` confidence scalar (0 outside any postcode span). Robustness is the
+        # confidence CURRICULUM applied UPSTREAM (data loader perturbs the scalar by training step);
+        # the model is perturbation-agnostic, so absent / zero-confidence anchors are just the c=0
+        # tail of a continuum — no discrete [NO-ANCHOR] embedding, no regime switch. Position-local
+        # by construction: this is the property self-conditioning's global FiLM lacked (it composes
+        # with that FiLM cleanly — anchor at the INPUT, FiLM on the hidden states after the blocks).
+        self.use_postcode_anchor = use_postcode_anchor
+        self.anchor_feature_dim = int(anchor_feature_dim) if use_postcode_anchor else 0
         # v0.3.0 additions: CRF decoder for structural validity + learned tag dynamics,
         # label smoothing on the per-token CE leg for calibration. Both gate-able for
         # ablation studies via the kwargs above.
@@ -239,6 +254,17 @@ class MailwomanCoarseEncoder(nn.Module):
             )
         else:
             self.phrase_input_projection = None
+
+        # Postcode-anchor projection W ((k+2)→hidden) + the shared learned v_ANCHOR cue. None when
+        # the channel is off (forward skips it → bit-identical to a no-anchor encoder).
+        self.anchor_projection: nn.Linear | None
+        self.anchor_token_embedding: nn.Parameter | None
+        if self.use_postcode_anchor:
+            self.anchor_projection = nn.Linear(self.anchor_feature_dim, hidden_size, bias=True)
+            self.anchor_token_embedding = nn.Parameter(torch.zeros(hidden_size))
+        else:
+            self.anchor_projection = None
+            self.anchor_token_embedding = None
 
         self.blocks = nn.ModuleList(
             [
@@ -319,6 +345,8 @@ class MailwomanCoarseEncoder(nn.Module):
         labels: torch.Tensor | None = None,
         phrase_features: torch.Tensor | None = None,
         locale_ids: torch.Tensor | None = None,
+        anchor_features: torch.Tensor | None = None,
+        anchor_confidence: torch.Tensor | None = None,
     ) -> "_CoarseEncoderOutput":
         bsz, seq = input_ids.shape
         if seq > self.max_position_embeddings:
@@ -356,6 +384,30 @@ class MailwomanCoarseEncoder(nn.Module):
                 "phrase_features supplied but use_phrase_priors=False — rebuild the "
                 "encoder with use_phrase_priors=True or drop the features argument"
             )
+
+        # Postcode-anchor injection (#239/#240). Per-token additive: a_i = c_i · (W·features +
+        # v_ANCHOR), added to the input embedding. anchor_confidence carries the curriculum-perturbed
+        # confidence (0 outside any postcode span / absent postcode), so c=0 tokens get a_i=0 with no
+        # regime switch. Absent features default to zeros — the well-defined "no anchor" inference path.
+        if self.anchor_projection is not None and self.anchor_token_embedding is not None:
+            if anchor_features is None or anchor_confidence is None:
+                anchor_features = torch.zeros(
+                    bsz, seq, self.anchor_feature_dim, dtype=h.dtype, device=h.device
+                )
+                anchor_confidence = torch.zeros(bsz, seq, dtype=h.dtype, device=h.device)
+            elif anchor_features.shape != (bsz, seq, self.anchor_feature_dim):
+                raise ValueError(
+                    f"anchor_features shape {tuple(anchor_features.shape)} != "
+                    f"({bsz}, {seq}, {self.anchor_feature_dim})"
+                )
+            anchor_vec = self.anchor_projection(anchor_features.to(h.dtype)) + self.anchor_token_embedding
+            h = h + anchor_confidence.to(h.dtype).unsqueeze(-1) * anchor_vec
+        elif anchor_features is not None:
+            raise ValueError(
+                "anchor_features supplied but use_postcode_anchor=False — rebuild the "
+                "encoder with use_postcode_anchor=True or drop the anchor arguments"
+            )
+
         h = self.input_dropout(self.input_ln(h))
 
         # nn.MultiheadAttention key_padding_mask: True = mask (ignore), False = keep.
@@ -606,6 +658,10 @@ class MailwomanCoarseEncoder(nn.Module):
             "use_locale_conditioning": bool(self.use_locale_conditioning),
             "num_locales": int(self.num_locales),
             "locale_loss_weight": float(self.locale_loss_weight),
+            # Postcode-anchor channel (#239/#240). False/0 on pre-anchor weights; loaders branch on
+            # the flag to materialize anchor_projection / anchor_token_embedding at the feature width.
+            "use_postcode_anchor": bool(self.use_postcode_anchor),
+            "anchor_feature_dim": int(self.anchor_feature_dim),
             "id2label": dict(ID_TO_LABEL),
             "label2id": dict(LABEL_TO_ID),
         }
@@ -653,6 +709,9 @@ class MailwomanCoarseEncoder(nn.Module):
             use_locale_conditioning=cfg.get("use_locale_conditioning", False),
             num_locales=cfg.get("num_locales", NUM_LOCALES),
             locale_loss_weight=cfg.get("locale_loss_weight", 0.0),
+            # Postcode-anchor fields. Default off for back-compat with pre-anchor checkpoints.
+            use_postcode_anchor=cfg.get("use_postcode_anchor", False),
+            anchor_feature_dim=cfg.get("anchor_feature_dim", NUM_LOCALES + 2),
         )
         # Use weights_only=True if available (torch 2.4+) to avoid pickle-arbitrary-code warning.
         try:
@@ -701,6 +760,10 @@ def build_model(cfg: Config, vocab_size: int, pad_token_id: int) -> MailwomanCoa
         use_locale_conditioning=getattr(cfg.model, "use_locale_conditioning", False),
         num_locales=NUM_LOCALES,
         locale_loss_weight=getattr(cfg.model, "locale_loss_weight", 0.0),
+        # Postcode-anchor channel (#239/#240). anchor_feature_dim derived from NUM_LOCALES (posterior
+        # over the locale set) + 2 (centroid) — single source of truth, can't drift from the loader.
+        use_postcode_anchor=getattr(cfg.model, "use_postcode_anchor", False),
+        anchor_feature_dim=NUM_LOCALES + 2,
     )
 
 

--- a/corpus-python/src/mailwoman_train/test_anchor_channel.py
+++ b/corpus-python/src/mailwoman_train/test_anchor_channel.py
@@ -1,0 +1,87 @@
+"""Tests for the postcode-anchor conditioning channel (#239/#240 de-risk pilot).
+
+The load-bearing property is the NO-REGIME-SWITCH guarantee: a per-token confidence of 0 (an absent
+postcode, or a confidence-zeroed anchor under the training curriculum) must make the injection an
+EXACT identity. That is what lets "absent" be the continuous c=0 tail of a spectrum instead of a
+discrete [NO-ANCHOR] mode (DeepSeek 2026-06-05) — and it is the reason no separate dropout token is
+needed. Also covered: the channel actually does something at c>0, back-compat is bit-identical off,
+the supplied-but-not-built guard fires, and the flags survive save/load.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+
+import pytest
+
+torch = pytest.importorskip("torch")  # training deps (torch) aren't installed in lint-only envs
+
+from mailwoman_train.labels import NUM_LOCALES  # noqa: E402
+from mailwoman_train.model import MailwomanCoarseEncoder  # noqa: E402
+
+ANCHOR_DIM = NUM_LOCALES + 2
+_COMMON = dict(
+    vocab_size=100,
+    hidden_size=32,
+    num_hidden_layers=2,
+    num_attention_heads=4,
+    intermediate_size=64,
+    max_position_embeddings=16,
+    hidden_dropout_prob=0.0,
+    num_labels=9,
+    pad_token_id=0,
+    use_crf=False,
+)
+
+
+def _fixture():
+    torch.manual_seed(0)
+    m = MailwomanCoarseEncoder(**_COMMON, use_postcode_anchor=True).eval()
+    ids = torch.randint(1, 100, (2, 8))
+    mask = torch.ones(2, 8, dtype=torch.long)
+    feats = torch.randn(2, 8, ANCHOR_DIM)
+    return m, ids, mask, feats
+
+
+def test_zero_confidence_is_exact_identity():
+    """c=0 everywhere → logits identical to a no-anchor forward (the no-regime-switch property)."""
+    m, ids, mask, feats = _fixture()
+    with_zero = m(ids, attention_mask=mask, anchor_features=feats, anchor_confidence=torch.zeros(2, 8))
+    no_anchor = m(ids, attention_mask=mask)
+    assert torch.equal(with_zero.logits, no_anchor.logits)
+
+
+def test_positive_confidence_changes_emissions():
+    m, ids, mask, feats = _fixture()
+    active = m(ids, attention_mask=mask, anchor_features=feats, anchor_confidence=torch.ones(2, 8))
+    no_anchor = m(ids, attention_mask=mask)
+    assert (active.logits - no_anchor.logits).abs().max() > 1e-3
+
+
+def test_off_model_with_anchor_args_raises():
+    off = MailwomanCoarseEncoder(**_COMMON, use_postcode_anchor=False).eval()
+    ids = torch.randint(1, 100, (2, 8))
+    mask = torch.ones(2, 8, dtype=torch.long)
+    with pytest.raises(ValueError, match="use_postcode_anchor=False"):
+        off(ids, attention_mask=mask, anchor_features=torch.randn(2, 8, ANCHOR_DIM),
+            anchor_confidence=torch.zeros(2, 8))
+
+
+def test_off_model_is_unchanged():
+    """use_postcode_anchor=False builds no anchor params (back-compat / bit-identical)."""
+    off = MailwomanCoarseEncoder(**_COMMON, use_postcode_anchor=False)
+    assert off.anchor_projection is None and off.anchor_token_embedding is None
+    assert not any("anchor" in n for n, _ in off.named_parameters())
+
+
+def test_save_load_round_trips_the_channel():
+    m, ids, mask, feats = _fixture()
+    conf = torch.ones(2, 8)
+    expected = m(ids, attention_mask=mask, anchor_features=feats, anchor_confidence=conf).logits
+    with tempfile.TemporaryDirectory() as d:
+        m.save_pretrained(d)
+        reloaded = MailwomanCoarseEncoder.from_pretrained(pathlib.Path(d)).eval()
+    assert reloaded.use_postcode_anchor and reloaded.anchor_feature_dim == ANCHOR_DIM
+    got = reloaded(ids, attention_mask=mask, anchor_features=feats, anchor_confidence=conf).logits
+    assert torch.allclose(got, expected, atol=1e-5)


### PR DESCRIPTION
The **model-side half** of the anchor de-risk pilot ([DeepSeek-signed design](../blob/main/.agents/skills/deepseek-consult/session-notes-2026-06-05-anchor-pilot.md)). Tests the hypothesis that the postcode anchor is the ingredient self-conditioning lacked — the thing that breaks the German end-of-string collapse that self-conditioning **failed to stop twice**.

## The injection
Per-token additive at the input embedding, following the `use_phrase_priors` precedent (default-off, back-compat):
```
h_i += c_i · (W · anchor_features_i + v_ANCHOR)
```
- `anchor_features`: `(B,S,NUM_LOCALES+2)` — uniform country posterior + 2-d centroid; `anchor_confidence`: `(B,S)`.
- **Position-local** (the property the global FiLM lacked); composes with self-conditioning FiLM cleanly (anchor at input, FiLM on hidden states after the blocks).
- **No `[NO-ANCHOR]` token.** The load-bearing, tested property: **c=0 is an exact identity**, so an absent / confidence-zeroed anchor is the continuous tail of a spectrum — no regime switch. (This is what dissolves the dropout paradox; the confidence *curriculum* is applied corpus-side.)

## Tests (5, all green; existing tests unaffected)
c=0 identity · c>0 changes emissions · off+anchor-args guard · off-is-bit-identical · save/load round-trip. 416 anchor params on a 32-d test model.

## Scope
Model channel only. Default-off → **zero effect on any current training run.** Remaining pilot pieces (next): anchor-feature precompute over the corpus + data-loader curriculum wiring, the DE/FR/US corpus, the A/B Modal runs (~\$8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)