### PR TITLE
feat(train): gold-span anchor→subtoken alignment (de-risk pilot, #239/#240)

### DIFF
--- a/corpus-python/src/mailwoman_train/test_anchor_alignment.py
+++ b/corpus-python/src/mailwoman_train/test_anchor_alignment.py
@@ -1,0 +1,73 @@
+"""Alignment tests for the gold-span anchor projection (#239/#240 de-risk pilot).
+
+DeepSeek flagged a span→sub-token off-by-one as the silent run-killer, so this nails the one
+property that matters: the anchor confidence/features land on EXACTLY the SP pieces the postcode
+covers, and nowhere else — by reusing the same char→piece projection as the BIO labels. Uses mock
+``PieceSpan``s (explicit char offsets) so no SentencePiece model is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mailwoman_train.labels import LOCALE_TO_ID, NUM_LOCALES
+from mailwoman_train.tokenizer import (
+    ANCHOR_FEATURE_DIM,
+    PieceSpan,
+    anchor_feature_vector,
+    realign_anchor_to_pieces,
+)
+
+# "Strasse 12 10115 Berlin" — the postcode "10115" sits at chars [11, 16).
+RAW = "Strasse 12 10115 Berlin"
+TOKENS = ["Strasse", "12", "10115", "Berlin"]
+LABELS = ["B-street", "B-house_number", "B-postcode", "B-locality"]
+LOOKUP = {"10115": ({"DE": 1.0}, 52.53, 13.40)}
+
+
+def _piece(text: str, begin: int, end: int) -> PieceSpan:
+    return PieceSpan(piece=text, piece_id=0, char_begin=begin, char_end=end)
+
+
+# Pieces: Strasse, _12, then the postcode split across two pieces (101 | 15), then Berlin.
+PIECES = [
+    _piece("Strasse", 0, 7),
+    _piece("12", 8, 10),
+    _piece("101", 11, 14),  # first half of the postcode
+    _piece("15", 14, 16),  # second half of the postcode
+    _piece("Berlin", 17, 23),
+]
+
+
+def test_anchor_lands_on_exactly_the_postcode_pieces():
+    feats, confs = realign_anchor_to_pieces(RAW, TOKENS, LABELS, PIECES, LOOKUP)
+    # Confidence 1.0 on the two postcode pieces (idx 2, 3), 0 everywhere else.
+    assert confs == [0.0, 0.0, 1.0, 1.0, 0.0]
+    # Both postcode pieces carry the SAME DE feature vector; non-postcode pieces are all-zero.
+    de_vec = anchor_feature_vector({"DE": 1.0}, 52.53, 13.40)
+    assert feats[2] == de_vec and feats[3] == de_vec
+    assert feats[0] == [0.0] * ANCHOR_FEATURE_DIM
+    assert feats[4] == [0.0] * ANCHOR_FEATURE_DIM
+
+
+def test_unknown_postcode_yields_no_anchor():
+    feats, confs = realign_anchor_to_pieces(RAW, TOKENS, LABELS, PIECES, {})  # empty lookup
+    assert confs == [0.0] * len(PIECES)
+    assert all(f == [0.0] * ANCHOR_FEATURE_DIM for f in feats)
+
+
+def test_feature_vector_shape_and_content():
+    vec = anchor_feature_vector({"DE": 1.0}, 52.53, 13.40)
+    assert len(vec) == ANCHOR_FEATURE_DIM == NUM_LOCALES + 2
+    assert vec[LOCALE_TO_ID["DE"]] == pytest.approx(1.0)
+    assert vec[-2] == pytest.approx(52.53 / 90.0)  # normalized lat
+    assert vec[-1] == pytest.approx(13.40 / 180.0)  # normalized lon
+    assert sum(vec[:NUM_LOCALES]) == pytest.approx(1.0)  # posterior renormalized over the in-set mass
+
+
+def test_collision_posterior_is_uniform_and_renormalized():
+    # 75001 ∈ {FR, US} → uniform 0.5/0.5 over the two in-set locales.
+    vec = anchor_feature_vector({"FR": 0.5, "US": 0.5}, 48.86, 2.33)
+    assert vec[LOCALE_TO_ID["FR"]] == pytest.approx(0.5)
+    assert vec[LOCALE_TO_ID["US"]] == pytest.approx(0.5)
+    assert sum(vec[:NUM_LOCALES]) == pytest.approx(1.0)

--- a/corpus-python/src/mailwoman_train/tokenizer.py
+++ b/corpus-python/src/mailwoman_train/tokenizer.py
@@ -30,7 +30,11 @@ from typing import Iterable, Sequence
 
 import sentencepiece as spm  # type: ignore[import-not-found]
 
-from .labels import IGNORE_INDEX, LABEL_TO_ID, collapse_label
+from .labels import IGNORE_INDEX, LABEL_TO_ID, LOCALE_TO_ID, NUM_LOCALES, collapse_label
+
+# Anchor feature width: a uniform country posterior over the locale set + a 2-d normalized centroid.
+# Must equal the model's ``anchor_feature_dim`` default (NUM_LOCALES + 2) — single source of truth.
+ANCHOR_FEATURE_DIM = NUM_LOCALES + 2
 
 
 @dataclass(frozen=True)
@@ -179,6 +183,84 @@ def realign_labels_to_pieces(
             out.append(f"B-{tag}")
         prev_tag = tag
     return out
+
+
+def anchor_feature_vector(posterior: dict[str, float], lat: float, lon: float) -> list[float]:
+    """Build the fixed-width anchor feature vector: a uniform country posterior over the locale set
+    (0 for countries outside it, renormalized over the in-set mass) + a normalized centroid
+    (lat/90, lon/180 ∈ [-1, 1]). Width = ANCHOR_FEATURE_DIM."""
+    vec = [0.0] * NUM_LOCALES
+    total = 0.0
+    for country, weight in posterior.items():
+        idx = LOCALE_TO_ID.get(country.strip().upper())
+        if idx is not None:
+            vec[idx] = float(weight)
+            total += float(weight)
+    if total > 0:
+        vec = [v / total for v in vec]
+    vec.append(max(-1.0, min(1.0, lat / 90.0)))
+    vec.append(max(-1.0, min(1.0, lon / 180.0)))
+    return vec
+
+
+def realign_anchor_to_pieces(
+    raw: str,
+    tokens: Sequence[str],
+    labels: Sequence[str],
+    pieces: Sequence[PieceSpan],
+    anchor_lookup: "dict[str, tuple[dict[str, float], float, float]]",
+) -> tuple[list[list[float]], list[float]]:
+    """Project gold postcode-span anchor features onto SP pieces (de-risk pilot #239/#240).
+
+    Mirrors {@linkcode realign_labels_to_pieces} EXACTLY — same char→piece projection (each piece
+    inherits the value of the first non-whitespace char it covers) — so the anchor lands on precisely
+    the sub-tokens the postcode labels do. That char-based reuse is what guarantees the alignment can't
+    drift (the off-by-one DeepSeek flagged as the silent run-killer).
+
+    Gold-span: the postcode span is read from the row's own ``B/I-postcode`` labels. Each contiguous
+    postcode entity's surface is normalized and looked up in ``anchor_lookup`` (postcode →
+    ({country: weight}, lat, lon)); a hit yields a confidence-1.0 anchor on those chars, a miss yields
+    no anchor (confidence 0). Returns ``(features[n_pieces][ANCHOR_FEATURE_DIM], confidence[n_pieces])``.
+    """
+    zero = [0.0] * ANCHOR_FEATURE_DIM
+    # Per-char anchor: feature vector + confidence for chars inside a looked-up postcode entity.
+    char_feat: list[list[float]] = [zero] * len(raw)
+    char_conf: list[float] = [0.0] * len(raw)
+    spans = whitespace_spans(raw, tokens)
+    i = 0
+    while i < len(labels):
+        if labels[i].endswith("-postcode") and labels[i].startswith("B"):
+            # Gather this contiguous postcode entity (B then any I-postcode).
+            j = i + 1
+            while j < len(labels) and labels[j] == "I-postcode":
+                j += 1
+            begin = spans[i][0]
+            end = spans[j - 1][1]
+            postcode = raw[begin:end].replace(" ", "").upper()
+            hit = anchor_lookup.get(postcode)
+            if hit is not None:
+                posterior, lat, lon = hit
+                feat = anchor_feature_vector(posterior, lat, lon)
+                for c in range(begin, end):
+                    char_feat[c] = feat
+                    char_conf[c] = 1.0
+            i = j
+        else:
+            i += 1
+
+    feats: list[list[float]] = []
+    confs: list[float] = []
+    for piece in pieces:
+        chosen_feat = zero
+        chosen_conf = 0.0
+        for c in range(piece.char_begin, piece.char_end):
+            if c < len(raw) and not raw[c].isspace():
+                chosen_feat = char_feat[c]
+                chosen_conf = char_conf[c]
+                break
+        feats.append(chosen_feat)
+        confs.append(chosen_conf)
+    return feats, confs
 
 
 def encode_row(


### PR DESCRIPTION
The **de-risking data piece** of the pilot — the one DeepSeek flagged twice as the silent run-killer.

`realign_anchor_to_pieces` projects the postcode anchor onto SP pieces by the **same char→piece map** `realign_labels_to_pieces` uses, so the anchor lands on **exactly** the sub-tokens the postcode labels do. No off-by-one possible — it reuses the proven label projection.

- **Gold-span (pilot):** the postcode span comes from the row's own `B/I-postcode` labels; each contiguous entity is looked up (`postcode → ({country: weight}, lat, lon)`) → confidence-1.0 anchor on those chars, a miss → no anchor.
- `anchor_feature_vector`: uniform country posterior over the locale set (renormalized over in-set mass) + normalized centroid. `ANCHOR_FEATURE_DIM = NUM_LOCALES+2`, matching the merged model channel (#318).

**4 alignment tests** (lands-on-exactly-the-postcode-pieces, unknown→no-anchor, feature shape/content, collision uniform+renormalized) — pure, tokenizer-free via mock `PieceSpan`s. **9/9 anchor tests green** (with the channel). Not yet wired into the loader — that's the next step.

Remaining pilot pieces: lookup-table build (postal DBs → postcode→anchor) · loader wiring (call this in `encode_row`) · training-loop confidence curriculum · DE/FR/US corpus · the ~\$8 A/B run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)