### PR TITLE
feat(train): wire the anchor channel through the data pipeline + curriculum (#239/#240)

### DIFF
--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -35,6 +35,10 @@ class DataConfig:
     # Probability (0-1) that each augmentation fires per row. 0 = disabled.
     augment_directional_prob: float = 0.0
     augment_region_prob: float = 0.0
+    # Postcode-anchor lookup (#239/#240). Path to the JSON {postcode: [posterior, lat, lon]} table
+    # (built by scripts/build-pilot-anchor-lookup.py). When set AND model.use_postcode_anchor is on,
+    # the loader projects per-piece anchor features onto each row. None → no anchor features.
+    anchor_lookup_path: str | None = None
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/configs/v0.9.1-pilot-anchor-off.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0.9.1-pilot-anchor-off.yaml
@@ -1,0 +1,159 @@
+# Anchor pilot — ANCHOR-OFF CONTROL (#239/#240): self-cond + German collapse recipe, anchor OFF, 3k steps.
+# Confirms the collapse still appears with THIS code+corpus (early-kill: P(B-locality|after postcode)<0.3).
+# Byte-identical to v0.9.0-pilot-selfcond except max_steps; anchor channel is default-off. The A/B control.
+#
+# Tests ONE hypothesis: a model that infers the country from the whole address (an auxiliary
+# locale head over the pooled sequence) and FiLM-conditions its own per-token labeling on it
+# parses better and stops the Saint-Albans cross-tag collapse — WITHOUT regressing US/FR. The
+# probe behind PR3 (docs/articles/plan/2026-06-04-pr3-self-conditioned-retrain.md) showed the
+# postcode alone pins the country only 28-44% of the time, so the city/street evidence the model
+# reads is genuinely load-bearing.
+#
+# SINGLE VARIABLE: this is the v0.7.2-PROVEN recipe (1.5e-4 constant / 1k warmup, ls 0.1, CRF off,
+# bf16) with self-conditioning the ONLY addition. Any delta is attributable to the conditioning,
+# not the recipe — the same A/B discipline as the v0.8.x MLM arms.
+#
+# STOP AT 20k (the early gate). Pre-registered, from the design doc:
+#   - cross_pollution < 1% per locale (the live tripwire — watch it on the dashboard)
+#   - DE locality F1 >= 70% and rising
+#   - US/FR within ~1pp of v0.7.2 (no-regression on the incumbents)
+#   - locale_acc climbing (the aux head is actually learning "which country")
+# If the gate holds, a follow-up extends to a full 100k run; if it fails, stop and diagnose ONE
+# knob (NaN protocol).
+#
+# CORPUS: v0.4.1-de — the v0.4.0 (US/FR) base overlaid with a German synth-german shard (200K train
+# + 4K val rows, real OpenAddresses Berlin/Saxony tuples rendered German-order via build-german-shard.mjs,
+# 40x the v0.8.0 continue-train supplement so a FROM-SCRATCH model can actually learn German). Assembled
+# 2026-06-04. Reproduce + deploy to the Modal volume:
+#   node scripts/build-german-shard.mjs --output /tmp/german-train.jsonl --count 200000 --seed 42
+#   node scripts/build-german-shard.mjs --output /tmp/german-val.jsonl   --count 4000   --seed 99
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-train.jsonl --output /tmp/part-german-train.parquet
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-val.jsonl   --output /tmp/part-german-val.parquet
+#   # then the overlay MANIFEST (v0.4.0 shards + the 2 German shards) — see the build-log doc — and:
+#   modal volume put mailwoman-training /tmp/part-german-train.parquet corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/train/part-german-train.parquet
+#   modal volume put mailwoman-training /tmp/part-german-val.parquet   corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/val/part-german-val.parquet
+#   modal volume put mailwoman-training <MANIFEST.json>                corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/MANIFEST.json
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0.9.0-pilot-selfcond.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.1-de/corpus-v0.4.1-de
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  # US/FR/DE — the three-way pilot. FR comes from the `ban` source (Base Adresse Nationale),
+  # DE from `synth-german`. country_weights is an acceptance filter, not a count balancer; the MIX
+  # is steered by source_weights below.
+  country_weights:
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+    # German at ~18% of the mix (6.0 of a ~34 total) — enough for a from-scratch model to learn it,
+    # while staying within the synthesis-as-supplement guideline. THE key tunable: raise it if DE
+    # locality F1 lags the 70% gate, lower it if US/FR slip past the 1pp tripwire.
+    synth-german: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096 # the per-locale cross_pollution tripwire now has DE val support (the 4K German val shard)
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  # CRF off via zero weight — head exists (parity) but contributes no loss. Avoids the
+  # CRF-under-bf16 NaN; keeps self-conditioning the only new behaviour in the loss.
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  # PR3: the headline change. Self-conditioning on; the aux locale loss is a genuine but
+  # secondary objective behind the per-token BIO task. num_locales is derived from labels, not set
+  # here (it can't drift from the aux-target vocabulary).
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v091-anchor-off-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  # Stop at the 20k early gate. Extend to 100k in a follow-up config only if the gate holds.
+  max_steps: 3000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.9.1-anchor-off-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/configs/v0.9.1-pilot-anchor-on.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0.9.1-pilot-anchor-on.yaml
@@ -1,0 +1,164 @@
+# Anchor pilot — ANCHOR-ON (#239/#240): self-cond + German recipe + the postcode-anchor channel, 20k.
+# The ONE variable vs v0.9.1-pilot-anchor-off (same seed/corpus/recipe). Tests whether the anchor breaks
+# the German end-of-string collapse that self-conditioning alone did not. Early-kill at ~2k (P>0.8).
+#
+# Tests ONE hypothesis: a model that infers the country from the whole address (an auxiliary
+# locale head over the pooled sequence) and FiLM-conditions its own per-token labeling on it
+# parses better and stops the Saint-Albans cross-tag collapse — WITHOUT regressing US/FR. The
+# probe behind PR3 (docs/articles/plan/2026-06-04-pr3-self-conditioned-retrain.md) showed the
+# postcode alone pins the country only 28-44% of the time, so the city/street evidence the model
+# reads is genuinely load-bearing.
+#
+# SINGLE VARIABLE: this is the v0.7.2-PROVEN recipe (1.5e-4 constant / 1k warmup, ls 0.1, CRF off,
+# bf16) with self-conditioning the ONLY addition. Any delta is attributable to the conditioning,
+# not the recipe — the same A/B discipline as the v0.8.x MLM arms.
+#
+# STOP AT 20k (the early gate). Pre-registered, from the design doc:
+#   - cross_pollution < 1% per locale (the live tripwire — watch it on the dashboard)
+#   - DE locality F1 >= 70% and rising
+#   - US/FR within ~1pp of v0.7.2 (no-regression on the incumbents)
+#   - locale_acc climbing (the aux head is actually learning "which country")
+# If the gate holds, a follow-up extends to a full 100k run; if it fails, stop and diagnose ONE
+# knob (NaN protocol).
+#
+# CORPUS: v0.4.1-de — the v0.4.0 (US/FR) base overlaid with a German synth-german shard (200K train
+# + 4K val rows, real OpenAddresses Berlin/Saxony tuples rendered German-order via build-german-shard.mjs,
+# 40x the v0.8.0 continue-train supplement so a FROM-SCRATCH model can actually learn German). Assembled
+# 2026-06-04. Reproduce + deploy to the Modal volume:
+#   node scripts/build-german-shard.mjs --output /tmp/german-train.jsonl --count 200000 --seed 42
+#   node scripts/build-german-shard.mjs --output /tmp/german-val.jsonl   --count 4000   --seed 99
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-train.jsonl --output /tmp/part-german-train.parquet
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-val.jsonl   --output /tmp/part-german-val.parquet
+#   # then the overlay MANIFEST (v0.4.0 shards + the 2 German shards) — see the build-log doc — and:
+#   modal volume put mailwoman-training /tmp/part-german-train.parquet corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/train/part-german-train.parquet
+#   modal volume put mailwoman-training /tmp/part-german-val.parquet   corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/val/part-german-val.parquet
+#   modal volume put mailwoman-training <MANIFEST.json>                corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/MANIFEST.json
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0.9.0-pilot-selfcond.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.1-de/corpus-v0.4.1-de
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  # US/FR/DE — the three-way pilot. FR comes from the `ban` source (Base Adresse Nationale),
+  # DE from `synth-german`. country_weights is an acceptance filter, not a count balancer; the MIX
+  # is steered by source_weights below.
+  country_weights:
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+    # German at ~18% of the mix (6.0 of a ~34 total) — enough for a from-scratch model to learn it,
+    # while staying within the synthesis-as-supplement guideline. THE key tunable: raise it if DE
+    # locality F1 lags the 70% gate, lower it if US/FR slip past the 1pp tripwire.
+    synth-german: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096 # the per-locale cross_pollution tripwire now has DE val support (the 4K German val shard)
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  # Postcode-anchor lookup (built by scripts/build-pilot-anchor-lookup.py, modal-volume-put to /data/anchor/).
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  # CRF off via zero weight — head exists (parity) but contributes no loss. Avoids the
+  # CRF-under-bf16 NaN; keeps self-conditioning the only new behaviour in the loss.
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  # PR3: the headline change. Self-conditioning on; the aux locale loss is a genuine but
+  # secondary objective behind the per-token BIO task. num_locales is derived from labels, not set
+  # here (it can't drift from the aux-target vocabulary).
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  # Postcode-anchor channel (#239/#240) — the ONE variable vs the control. Per-token injection at
+  # the postcode span + the confidence curriculum (train.py). Composes with self-conditioning.
+  use_postcode_anchor: true
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v091-anchor-on-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  # Stop at the 20k early gate. Extend to 100k in a follow-up config only if the gate holds.
+  max_steps: 20000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.9.1-anchor-on-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -25,6 +25,7 @@ Per Phase 2 §2:
 
 from __future__ import annotations
 
+import json
 import logging
 import random
 from dataclasses import dataclass
@@ -52,6 +53,23 @@ class EncodedExample:
     # when unmapped. The aux locale head's per-row target. Defaults to IGNORE_INDEX so encoders
     # built without locale conditioning are unaffected.
     locale_id: int = IGNORE_INDEX
+    # Postcode-anchor channel (#239/#240). Per-piece ``(max_length, ANCHOR_FEATURE_DIM)`` features +
+    # ``(max_length,)`` confidence, or None when no anchor lookup is configured (back-compat).
+    anchor_features: list[list[float]] | None = None
+    anchor_confidence: list[float] | None = None
+
+
+def load_anchor_lookup(path: str) -> dict[str, tuple[dict[str, float], float, float]]:
+    """Load the postcode→anchor lookup (#239/#240) from JSON, once at loader init.
+
+    Format: ``{normalized_postcode: [posterior_dict, lat, lon]}`` where ``posterior_dict`` is
+    ``{country: weight}`` (uniform over the countries the code exists in). Returns the tuple form
+    ``realign_anchor_to_pieces`` consumes. Built offline by ``scripts/build-pilot-anchor-lookup.py``
+    so the training loop carries no gazetteer dependency.
+    """
+    with open(path, encoding="utf-8") as fh:
+        raw = json.load(fh)
+    return {pc: (post, float(lat), float(lon)) for pc, (post, lat, lon) in raw.items()}
 
 
 def _shard_paths(corpus_dir: Path, split: str) -> list[Path]:
@@ -432,6 +450,9 @@ def iter_encoded(
     bugs (per Phase 2 §2.3). Cap at the model's ``max_position_embeddings``.
     """
     rng = rng or random.Random(0)
+    # Postcode-anchor lookup (#239/#240): loaded once, passed to every encode_row. None → no anchor
+    # features produced (back-compat). See load_anchor_lookup.
+    anchor_lookup = load_anchor_lookup(cfg_data.anchor_lookup_path) if cfg_data.anchor_lookup_path else None
     for row in iter_rows(
         Path(cfg_data.corpus_dir),
         split,
@@ -449,6 +470,7 @@ def iter_encoded(
             row["tokens"],
             row["labels"],
             max_length=cfg_data.max_length,
+            anchor_lookup=anchor_lookup,
         )
         # Drop rows whose non-padding length exceeds max_length (length filter §2).
         non_pad = sum(enc["attention_mask"])
@@ -461,17 +483,26 @@ def iter_encoded(
             attention_mask=enc["attention_mask"],
             labels=enc["labels"],
             locale_id=locale_id(row.get("country")),
+            anchor_features=enc.get("anchor_features"),
+            anchor_confidence=enc.get("anchor_confidence"),
         )
 
 
 def collate(batch: list[EncodedExample]) -> dict:
     """Stack a list of ``EncodedExample`` into batched lists. Caller wraps in torch tensors."""
-    return {
+    out = {
         "input_ids": [ex.input_ids for ex in batch],
         "attention_mask": [ex.attention_mask for ex in batch],
         "labels": [ex.labels for ex in batch],
         "locale_ids": [ex.locale_id for ex in batch],
     }
+    # Postcode-anchor channel (#239/#240): only present when every example carries anchor features
+    # (i.e. an anchor lookup is configured). Absent → omitted, so the trainer's tensor-conversion
+    # skips it and the model runs anchor-free (back-compat).
+    if batch and batch[0].anchor_features is not None:
+        out["anchor_features"] = [ex.anchor_features for ex in batch]
+        out["anchor_confidence"] = [ex.anchor_confidence for ex in batch]
+    return out
 
 
 def iter_batches(

--- a/corpus-python/src/mailwoman_train/test_anchor_alignment.py
+++ b/corpus-python/src/mailwoman_train/test_anchor_alignment.py
@@ -71,3 +71,20 @@ def test_collision_posterior_is_uniform_and_renormalized():
     assert vec[LOCALE_TO_ID["FR"]] == pytest.approx(0.5)
     assert vec[LOCALE_TO_ID["US"]] == pytest.approx(0.5)
     assert sum(vec[:NUM_LOCALES]) == pytest.approx(1.0)
+
+
+def test_confidence_curriculum_no_op_early_perturbs_late():
+    """The robustness curriculum is a no-op before 25% of max_steps, then perturbs downward + zeros
+    whole rows after — never above 1.0, never a discrete regime (#239/#240)."""
+    torch = pytest.importorskip("torch")
+    from mailwoman_train.train import perturb_anchor_confidence
+
+    conf = torch.ones(128, 6)
+    assert torch.equal(perturb_anchor_confidence(conf, 0, 20000), conf)  # 0% → untouched
+    assert torch.equal(perturb_anchor_confidence(conf, 4999, 20000), conf)  # <25% → untouched
+    torch.manual_seed(0)
+    late = perturb_anchor_confidence(conf, 15000, 20000)  # >50% → full perturbation
+    assert not torch.equal(late, conf)
+    assert float(late.max()) <= 1.0 and float(late.min()) >= 0.0
+    zeroed_rows = int((late.sum(dim=1) == 0).sum().item())
+    assert 0 < zeroed_rows < 128  # some rows fully zeroed (anchor "absent"), not all

--- a/corpus-python/src/mailwoman_train/tokenizer.py
+++ b/corpus-python/src/mailwoman_train/tokenizer.py
@@ -269,11 +269,17 @@ def encode_row(
     tokens: Sequence[str],
     labels: Sequence[str],
     max_length: int,
-) -> dict[str, list[int]]:
+    anchor_lookup: "dict[str, tuple[dict[str, float], float, float]] | None" = None,
+) -> dict[str, list]:
     """Encode a single row into ``input_ids`` + ``attention_mask`` + ``label_ids``.
 
     Truncates to ``max_length`` SP pieces. Pads to ``max_length`` with the SP ``pad_id`` and
     fills the label tail with ``IGNORE_INDEX`` so cross-entropy ignores the padding.
+
+    When ``anchor_lookup`` is supplied (the postcode-anchor pilot, #239/#240), also returns
+    ``anchor_features`` ``(max_length, ANCHOR_FEATURE_DIM)`` and ``anchor_confidence``
+    ``(max_length,)``, projected onto the SAME pieces as the labels (so a postcode anchor lands on
+    exactly its sub-tokens) and zero-padded. Absent → those keys are omitted (back-compat).
     """
     spans = tokenizer.encode_with_spans(raw)
     bio_labels = realign_labels_to_pieces(raw, tokens, labels, spans)
@@ -285,4 +291,16 @@ def encode_row(
         ids.extend([tokenizer.pad_id] * pad_needed)
         attention.extend([0] * pad_needed)
         label_ids.extend([IGNORE_INDEX] * pad_needed)
-    return {"input_ids": ids, "attention_mask": attention, "labels": label_ids}
+    out: dict[str, list] = {"input_ids": ids, "attention_mask": attention, "labels": label_ids}
+
+    if anchor_lookup is not None:
+        feats, confs = realign_anchor_to_pieces(raw, tokens, labels, list(spans), anchor_lookup)
+        feats = feats[:max_length]
+        confs = confs[:max_length]
+        zero = [0.0] * ANCHOR_FEATURE_DIM
+        if pad_needed > 0:
+            feats = feats + [zero] * pad_needed
+            confs = confs + [0.0] * pad_needed
+        out["anchor_features"] = feats
+        out["anchor_confidence"] = confs
+    return out

--- a/corpus-python/src/mailwoman_train/train.py
+++ b/corpus-python/src/mailwoman_train/train.py
@@ -54,7 +54,37 @@ def _to_tensor_batch(batch: dict, device: torch.device) -> dict:
     # ignores it unless built with use_locale_conditioning.
     if "locale_ids" in batch:
         tb["locale_ids"] = torch.tensor(batch["locale_ids"], dtype=torch.long, device=device)
+    # Postcode-anchor channel (#239/#240): per-piece features + confidence. Present only when an
+    # anchor lookup is configured; the model ignores them unless built with use_postcode_anchor.
+    if "anchor_features" in batch:
+        tb["anchor_features"] = torch.tensor(batch["anchor_features"], dtype=torch.float32, device=device)
+        tb["anchor_confidence"] = torch.tensor(batch["anchor_confidence"], dtype=torch.float32, device=device)
     return tb
+
+
+# Anchor-confidence robustness curriculum (#239/#240, DeepSeek 2026-06-05): the model sees the full
+# anchor early (break the German collapse, build the basin), then a ramped perturbation so it can't
+# launder the anchor. No discrete [NO-ANCHOR] mode — "absent" is the c=0 tail of a continuum.
+ANCHOR_CURRICULUM_START_FRAC = 0.25  # ≤ this fraction of max_steps: no perturbation
+ANCHOR_CURRICULUM_RAMP_FRAC = 0.50   # by this fraction: full perturbation
+ANCHOR_ZERO_OUT_MAX = 0.15           # peak per-row zero-out probability
+
+
+def perturb_anchor_confidence(conf: torch.Tensor, step: int, max_steps: int) -> torch.Tensor:
+    """Curriculum-perturb the per-token anchor confidence ``(B, S)`` by training step.
+
+    0 → 25% of max_steps: untouched. 25% → 50%: ramp in per-token multiplicative noise α∼U(0.8,1.2)
+    and per-ROW zero-out (prob → ANCHOR_ZERO_OUT_MAX). 50%+: hold. Per-row (not per-token) zero-out
+    keeps an "absent anchor" coherent across a postcode's sub-tokens.
+    """
+    start = ANCHOR_CURRICULUM_START_FRAC * max_steps
+    if step < start:
+        return conf
+    ramp = min(1.0, (step - start) / max(1.0, (ANCHOR_CURRICULUM_RAMP_FRAC - ANCHOR_CURRICULUM_START_FRAC) * max_steps))
+    alpha = 0.8 + 0.4 * torch.rand_like(conf)  # per-token U(0.8, 1.2)
+    out = (conf * alpha).clamp(0.0, 1.0)
+    row_zero = (torch.rand(conf.shape[0], device=conf.device) < ANCHOR_ZERO_OUT_MAX * ramp).unsqueeze(1)
+    return out.masked_fill(row_zero, 0.0)
 
 
 def _cosine_with_warmup(optimizer: AdamW, warmup_steps: int, max_steps: int) -> LambdaLR:
@@ -420,6 +450,12 @@ def train(cfg: Config, *, resume_from: str | Path | None = None) -> None:
                     break
                 model.train()
                 tb = _to_tensor_batch(batch, device)
+                # Postcode-anchor confidence curriculum (#239/#240): perturb by optimizer step so the
+                # model can't launder the anchor (no-op until 25% of max_steps).
+                if "anchor_confidence" in tb:
+                    tb["anchor_confidence"] = perturb_anchor_confidence(
+                        tb["anchor_confidence"], step, cfg.train.max_steps
+                    )
                 # Optimizer step happens every ``accum`` micro-batches; gradients accumulate
                 # across the micro-batches in between. ``step`` counts *optimizer* steps,
                 # not micro-steps, so it lines up with the cfg.train.max_steps budget.

--- a/scripts/build-pilot-anchor-lookup.py
+++ b/scripts/build-pilot-anchor-lookup.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Build the postcode→anchor lookup for the de-risk pilot (#239/#240).
+
+Emits a JSON ``{normalized_postcode: [posterior_dict, lat, lon]}`` for the pilot locales (DE/FR/US),
+loaded once at training-loader init (``data.anchor_lookup_path``) so the training loop carries no
+gazetteer dependency. This is the offline, deterministic precompute DeepSeek recommended.
+
+- **posterior**: UNIFORM over the countries whose postal gazetteer contains the code (the posterior
+  the A/B measurement settled on — `docs/articles/evals/2026-06-05-postcode-posterior-ab.md`). A
+  German PLZ that collides with a US ZIP (e.g. 10115) comes back ``{"DE": 0.5, "US": 0.5}``.
+- **centroid**: taken from the first source that has a real centroid, in DE→FR→US order, so the
+  collapse-relevant European rows get a European centroid on a collision. The centroid is the
+  secondary signal (the posterior + the categorical anchor cue do the work); the pilot doesn't lean
+  on it.
+
+Sources (build-from-source, never prebuilt): postalcode-intl.db (DE/FR, inline centroids) +
+postalcode-us.db (US set + place_bbox midpoints, since its spr centroids are 0).
+
+Usage:
+  python3 scripts/build-pilot-anchor-lookup.py --output /mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json
+"""
+import argparse
+import json
+import sqlite3
+
+WOF = "/mnt/playpen/mailwoman-data/wof"
+
+
+def five_digit(name: str) -> str | None:
+    name = (name or "").strip().upper()
+    return name if len(name) == 5 and name.isdigit() else None
+
+
+def load_intl(country: str) -> dict[str, tuple[float, float]]:
+    """DE/FR postcodes → centroid from postalcode-intl.db (inline lat/lon)."""
+    out: dict[str, tuple[float, float]] = {}
+    con = sqlite3.connect(f"{WOF}/postalcode-intl.db")
+    for name, lat, lon in con.execute(
+        "SELECT name, latitude, longitude FROM spr WHERE placetype='postalcode' AND country=?", (country,)
+    ):
+        pc = five_digit(name)
+        if pc:
+            out[pc] = (float(lat), float(lon))
+    con.close()
+    return out
+
+
+def load_us() -> dict[str, tuple[float, float]]:
+    """US postcodes → place_bbox midpoint (spr lat/lon are 0 in postalcode-us.db)."""
+    out: dict[str, tuple[float, float]] = {}
+    con = sqlite3.connect(f"{WOF}/postalcode-us.db")
+    # place_bbox rows: (id, min_lat, max_lat, min_lon, max_lon) keyed to spr.id.
+    bbox = {
+        r[0]: ((r[1] + r[2]) / 2.0, (r[3] + r[4]) / 2.0)
+        for r in con.execute("SELECT id, min_latitude, max_latitude, min_longitude, max_longitude FROM place_bbox")
+    } if _has_bbox_cols(con) else {}
+    for pid, name in con.execute("SELECT id, name FROM spr WHERE placetype='postalcode'"):
+        pc = five_digit(name)
+        if pc:
+            out[pc] = bbox.get(pid, (0.0, 0.0))
+    con.close()
+    return out
+
+
+def _has_bbox_cols(con: sqlite3.Connection) -> bool:
+    cols = {r[1] for r in con.execute("PRAGMA table_info(place_bbox)")}
+    return {"id", "min_latitude", "max_latitude", "min_longitude", "max_longitude"} <= cols
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
+
+    sources = [("DE", load_intl("DE")), ("FR", load_intl("FR")), ("US", load_us())]  # centroid priority order
+    all_codes: set[str] = set()
+    for _c, d in sources:
+        all_codes |= set(d.keys())
+
+    lookup: dict[str, list] = {}
+    collisions = 0
+    for pc in all_codes:
+        members = [c for c, d in sources if pc in d]
+        k = len(members)
+        posterior = {c: 1.0 / k for c in members}
+        if k > 1:
+            collisions += 1
+        # centroid: first source (DE→FR→US) with a non-zero centroid.
+        lat = lon = 0.0
+        for c, d in sources:
+            if pc in d and (d[pc][0] != 0.0 or d[pc][1] != 0.0):
+                lat, lon = d[pc]
+                break
+        lookup[pc] = [posterior, round(lat, 5), round(lon, 5)]
+
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(lookup, fh, ensure_ascii=False)
+
+    by_country = {c: sum(1 for v in lookup.values() if c in v[0]) for c, _ in sources}
+    print(
+        f"{len(lookup):,} postcodes → {args.output}  "
+        f"(DE {by_country['DE']:,}, FR {by_country['FR']:,}, US {by_country['US']:,}; "
+        f"{collisions:,} collisions; {sum(1 for v in lookup.values() if v[1]==0.0 and v[2]==0.0):,} no-centroid)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/modal/train_remote.py
+++ b/scripts/modal/train_remote.py
@@ -418,3 +418,81 @@ def diagnose_corpus(
             print(f"  country={r['country']} locale_id={locale_id(r['country'])} raw={r['raw'][:60]}")
         if not rows:
             print("  !! ZERO rows — the run would train on nothing. Do NOT launch.")
+
+
+@app.function(
+    volumes={VOL_MOUNT: vol},
+    image=training_image,
+    timeout=900,
+)
+def eval_de(
+    output_dir: str,
+    step: str,
+    anchor_lookup: str = "",
+    anchor_off: bool = False,
+    val_path: str = "/data/corpus/versioned/v0.4.1-de/corpus-v0.4.1-de/val/part-german-val.parquet",
+    tokenizer_path: str = "/data/models/tokenizer/v0.6.0-a0/tokenizer.model",
+    max_rows: int = 4000,
+):
+    """DE-locality readout for the anchor pilot (#239/#240): per-tag PARSER F1 on the German val for
+    one checkpoint. The German collapse shows as a low locality/postcode F1 (with street/house# up);
+    the anchor fix as a recovered locality. ``anchor_lookup`` set → feed the real anchor;
+    ``anchor_off=True`` → feed the features but force confidence 0 (the anchor-free degradation gate).
+    Forwards + argmax (CRF weight is 0, so the trained signal is in the emissions)."""
+    import sys
+    from pathlib import Path
+
+    vol.reload()
+    sys.path.insert(0, "/data/corpus-python/src")
+    import torch
+    import pyarrow.parquet as pq
+
+    from mailwoman_train.model import MailwomanCoarseEncoder
+    from mailwoman_train.tokenizer import Tokenizer, encode_row
+    from mailwoman_train.train import _token_f1
+    from mailwoman_train.data_loader import load_anchor_lookup
+    from mailwoman_train.labels import ACTIVE_BIO_LABELS
+
+    ck = Path(f"{output_dir}/checkpoints/step-{step}")
+    tok = Tokenizer(Path(tokenizer_path))
+    _orig = torch.load
+    torch.load = lambda *a, **kw: _orig(*a, **{**kw, "map_location": "cpu"})
+    model = MailwomanCoarseEncoder.from_pretrained(ck).eval()
+    torch.load = _orig
+    lookup = load_anchor_lookup(anchor_lookup) if anchor_lookup else None
+
+    rows = pq.read_table(val_path).to_pylist()[:max_rows]
+    all_preds, all_labels = [], []
+    B = 128
+    for i in range(0, len(rows), B):
+        chunk = rows[i : i + B]
+        ids, masks, labs, afeats, aconfs = [], [], [], [], []
+        for r in chunk:
+            enc = encode_row(tok, r["raw"], r["tokens"], r["labels"], 128, anchor_lookup=lookup)
+            ids.append(enc["input_ids"])
+            masks.append(enc["attention_mask"])
+            labs.append(enc["labels"])
+            if lookup:
+                afeats.append(enc["anchor_features"])
+                aconfs.append([0.0] * 128 if anchor_off else enc["anchor_confidence"])
+        kw = {}
+        if lookup:
+            kw = {
+                "anchor_features": torch.tensor(afeats, dtype=torch.float32),
+                "anchor_confidence": torch.tensor(aconfs, dtype=torch.float32),
+            }
+        with torch.no_grad():
+            out = model(torch.tensor(ids), attention_mask=torch.tensor(masks), **kw)
+        all_preds.append(out.logits.argmax(-1))
+        all_labels.append(torch.tensor(labs))
+
+    preds = torch.cat(all_preds)
+    labels = torch.cat(all_labels)
+    m = _token_f1(preds, labels, num_labels=len(ACTIVE_BIO_LABELS))
+    g = lambda t: m.get(f"f1_tag.{t}", float("nan"))
+    mode = "anchor-OFF" if (anchor_off or not lookup) else "anchor-ON "
+    print(
+        f"[DE eval] {ck.name} {mode}: locality={g('locality'):.3f}  postcode={g('postcode'):.3f}  "
+        f"region={g('region'):.3f}  street={g('street'):.3f}  house_number={g('house_number'):.3f}  "
+        f"macro_f1={m.get('macro_f1', float('nan')):.3f}  (n={len(rows)})"
+    )


### PR DESCRIPTION
Threads the postcode anchor from corpus → model, all gated on `data.anchor_lookup_path` (None → no anchor features → **bit-identical, back-compat**).

- **`encode_row(anchor_lookup=…)`** → per-piece `anchor_features` + `anchor_confidence`, projected onto the same SP pieces as the labels, zero-padded.
- **`load_anchor_lookup`** reads the JSON `{postcode: [posterior, lat, lon]}` once at loader init — no gazetteer dep in the training loop.
- **`EncodedExample` + `collate` + `_to_tensor_batch`** carry/convert the anchor tensors.
- **`perturb_anchor_confidence`** — the robustness curriculum by optimizer step: no-op until 25% of `max_steps`, then ramped α∼U(0.8,1.2) per-token + per-**row** zero-out (→15%), held after 50%. Per-row zero-out keeps an "absent anchor" coherent across a postcode's sub-tokens; no discrete `[NO-ANCHOR]` mode.

**10 anchor tests green** (alignment + curriculum + model channel); `train`/`data_loader` import-clean. Default-off → zero effect on current runs.

Remaining pilot pieces: the lookup-table build script · the DE/FR/US corpus · the A/B Modal runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)