### PR TITLE
feat: inference-side postcode-anchor channel — the verdict build (#239/#240)

### DIFF
--- a/corpus-python/src/mailwoman_train/export_onnx.py
+++ b/corpus-python/src/mailwoman_train/export_onnx.py
@@ -39,8 +39,22 @@ def export_to_onnx(
     dummy_ids[0, 0] = 1  # ensure at least one non-pad slot
     dummy_mask = torch.ones((1, max_length), dtype=torch.long)
 
+    # Postcode-anchor channel (#239/#240): when the model carries it, export the anchor inputs so the
+    # inference runtime can FEED the anchor (without them the ONNX would be hard-wired anchor-free, the
+    # c=0 identity — which is exactly the "anchor not fed" path, not the channel under test).
+    has_anchor = bool(getattr(model_cpu, "use_postcode_anchor", False))
+    anchor_dim = int(getattr(model_cpu, "anchor_feature_dim", 0))
+
     # ONNX exporter prefers plain-tensor outputs; wrap the model so forward returns just logits.
     class _LogitsOnly(nn.Module):
+        def __init__(self, inner: nn.Module) -> None:
+            super().__init__()
+            self.inner = inner
+
+        def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+            return self.inner(input_ids=input_ids, attention_mask=attention_mask).logits
+
+    class _LogitsOnlyAnchor(nn.Module):
         def __init__(self, inner: nn.Module) -> None:
             super().__init__()
             self.inner = inner
@@ -49,10 +63,39 @@ def export_to_onnx(
             self,
             input_ids: torch.Tensor,
             attention_mask: torch.Tensor,
+            anchor_features: torch.Tensor,
+            anchor_confidence: torch.Tensor,
         ) -> torch.Tensor:
-            return self.inner(input_ids=input_ids, attention_mask=attention_mask).logits
+            return self.inner(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                anchor_features=anchor_features,
+                anchor_confidence=anchor_confidence,
+            ).logits
 
-    export_model = _LogitsOnly(model_cpu).eval()
+    if has_anchor:
+        export_model = _LogitsOnlyAnchor(model_cpu).eval()
+        args = (
+            dummy_ids,
+            dummy_mask,
+            torch.zeros((1, max_length, anchor_dim), dtype=torch.float32),
+            torch.zeros((1, max_length), dtype=torch.float32),
+        )
+        input_names = ["input_ids", "attention_mask", "anchor_features", "anchor_confidence"]
+        dynamic_shapes = {
+            "input_ids": {0: "batch", 1: "sequence"},
+            "attention_mask": {0: "batch", 1: "sequence"},
+            "anchor_features": {0: "batch", 1: "sequence"},  # dim 2 (anchor_feature_dim) is fixed
+            "anchor_confidence": {0: "batch", 1: "sequence"},
+        }
+    else:
+        export_model = _LogitsOnly(model_cpu).eval()
+        args = (dummy_ids, dummy_mask)
+        input_names = ["input_ids", "attention_mask"]
+        dynamic_shapes = {
+            "input_ids": {0: "batch", 1: "sequence"},
+            "attention_mask": {0: "batch", 1: "sequence"},
+        }
 
     # Use the dynamo exporter (``dynamo=True``). The legacy TorchScript path hits
     # ``IndexError: tuple index out of range`` inside transformers ≥5's ``masking_utils``
@@ -60,15 +103,12 @@ def export_to_onnx(
     # The dynamo path traces through correctly via FX.
     torch.onnx.export(
         export_model,
-        (dummy_ids, dummy_mask),
+        args,
         str(output_path),
-        input_names=["input_ids", "attention_mask"],
+        input_names=input_names,
         output_names=["logits"],
         opset_version=opset,
-        dynamic_shapes={
-            "input_ids": {0: "batch", 1: "sequence"},
-            "attention_mask": {0: "batch", 1: "sequence"},
-        },
+        dynamic_shapes=dynamic_shapes,
         dynamo=True,
         external_data=False,
     )

--- a/neural/anchor-inference.test.ts
+++ b/neural/anchor-inference.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Cross-language guard for the inference-side anchor features (#239/#240). The feature layout MUST
+ *   match the Python training pipeline (`mailwoman_train/tokenizer.py::anchor_feature_vector`), or the
+ *   model is fed garbage at inference. These vectors are pinned to values emitted by the Python
+ *   function — if the TS drifts (locale order, centroid scale, renormalization), this fails.
+ */
+import { describe, expect, it } from "vitest"
+
+import {
+	ANCHOR_FEATURE_DIM,
+	LOCALE_ORDER,
+	anchorFeatureVector,
+	buildAnchorFeatures,
+	type AnchorLookup,
+} from "./anchor-inference.js"
+import type { TokenizedPiece } from "./tokenizer.js"
+
+describe("anchorFeatureVector — pinned to Python anchor_feature_vector", () => {
+	it("locale order matches Python LOCALE_COUNTRIES", () => {
+		expect([...LOCALE_ORDER]).toEqual(["US", "FR", "DE", "CA", "GB", "JP", "ES", "IT", "NL"])
+		expect(ANCHOR_FEATURE_DIM).toBe(11)
+	})
+
+	it("a DE+US collision (10115) byte-matches Python", () => {
+		// python: anchor_feature_vector({"DE":0.5,"US":0.5}, 52.5323, 13.3846)
+		const v = anchorFeatureVector({ DE: 0.5, US: 0.5 }, 52.5323, 13.3846)
+		const expected = [0.5, 0, 0.5, 0, 0, 0, 0, 0, 0, 0.583692, 0.074359]
+		expected.forEach((e, i) => expect(v[i]!).toBeCloseTo(e, 5))
+	})
+
+	it("a DE-only code byte-matches Python", () => {
+		const v = anchorFeatureVector({ DE: 1.0 }, 49.4848, 8.4668)
+		const expected = [0, 0, 1.0, 0, 0, 0, 0, 0, 0, 0.549831, 0.047038]
+		expected.forEach((e, i) => expect(v[i]!).toBeCloseTo(e, 5))
+	})
+
+	it("renormalizes over the in-set mass (ignores out-of-set countries)", () => {
+		const v = anchorFeatureVector({ DE: 0.5, ZZ: 0.5 }, 0, 0) // ZZ not in the locale set
+		expect(v[LOCALE_ORDER.indexOf("DE")]!).toBeCloseTo(1.0, 6) // DE renormalized to full mass
+	})
+})
+
+describe("buildAnchorFeatures — alignment onto SP pieces", () => {
+	// "Strasse 12 10115 Berlin" — the postcode "10115" is chars [11, 16).
+	const TEXT = "Strasse 12 10115 Berlin"
+	const piece = (p: string, start: number, end: number): TokenizedPiece =>
+		({ piece: p, id: 0, start, end }) as unknown as TokenizedPiece
+	// pieces, with the postcode split across two (101 | 15)
+	const PIECES = [
+		piece("▁Strasse", 0, 7),
+		piece("▁12", 8, 10),
+		piece("▁101", 11, 14),
+		piece("15", 14, 16),
+		piece("▁Berlin", 17, 23),
+	]
+	const LOOKUP: AnchorLookup = new Map([["10115", { posterior: { DE: 0.5, US: 0.5 }, lat: 52.5323, lon: 13.3846 }]])
+
+	it("lands confidence + features on exactly the postcode pieces", () => {
+		const { features, confidence } = buildAnchorFeatures(TEXT, PIECES, LOOKUP)
+		expect(confidence).toEqual([0, 0, 1, 1, 0])
+		const de = anchorFeatureVector({ DE: 0.5, US: 0.5 }, 52.5323, 13.3846)
+		expect(features[2]).toEqual(de)
+		expect(features[3]).toEqual(de)
+		expect(features[0]).toEqual(new Array(ANCHOR_FEATURE_DIM).fill(0))
+		expect(features[4]).toEqual(new Array(ANCHOR_FEATURE_DIM).fill(0))
+	})
+
+	it("yields no anchor when the postcode isn't in the lookup", () => {
+		const { confidence } = buildAnchorFeatures("Nowhere 99999 City", PIECES, LOOKUP)
+		expect(confidence.every((c) => c === 0)).toBe(true)
+	})
+})

--- a/neural/anchor-inference.ts
+++ b/neural/anchor-inference.ts
@@ -1,0 +1,111 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Inference-side postcode-anchor features (#239/#240) — the mirror of the Python training pipeline
+ *   (`mailwoman_train/tokenizer.py::anchor_feature_vector` + `realign_anchor_to_pieces`). At inference
+ *   the model conditions on per-piece anchor features fed alongside `input_ids`; this builds them from
+ *   a raw address + its SentencePiece pieces, using the SAME postcode→anchor lookup the model trained
+ *   against (`scripts/build-pilot-anchor-lookup.py`), so the feature layout matches byte-for-byte.
+ *
+ *   The layout is LOAD-BEARING and cross-language: a wrong locale order or centroid scale feeds the
+ *   model garbage. `anchor-inference.test.ts` pins both `LOCALE_ORDER` and the vector to values emitted
+ *   by the Python `anchor_feature_vector` — any drift fails the test.
+ */
+
+import type { TokenizedPiece } from "./tokenizer.js"
+
+/**
+ * The locale class order — MUST match Python `mailwoman_train/labels.py::LOCALE_COUNTRIES`. The
+ * posterior occupies indices `[0, LOCALE_ORDER.length)`; the normalized centroid the last two.
+ * (Pinned by the test; do not reorder.)
+ */
+export const LOCALE_ORDER = ["US", "FR", "DE", "CA", "GB", "JP", "ES", "IT", "NL"] as const
+
+/** Anchor feature width = posterior over the locale set + a 2-d centroid. */
+export const ANCHOR_FEATURE_DIM = LOCALE_ORDER.length + 2
+
+/** One postcode's anchor record (from the pilot lookup): country posterior + a single centroid. */
+export interface AnchorEntry {
+	posterior: Record<string, number>
+	lat: number
+	lon: number
+}
+
+export type AnchorLookup = Map<string, AnchorEntry>
+
+/**
+ * Build the fixed-width anchor feature vector — the exact mirror of Python `anchor_feature_vector`:
+ * a uniform country posterior over {@linkcode LOCALE_ORDER} (renormalized over the in-set mass) + a
+ * normalized centroid (`lat/90`, `lon/180` ∈ [-1, 1]).
+ */
+export function anchorFeatureVector(posterior: Record<string, number>, lat: number, lon: number): number[] {
+	const vec = new Array<number>(ANCHOR_FEATURE_DIM).fill(0)
+	let total = 0
+	for (const [country, weight] of Object.entries(posterior)) {
+		const idx = LOCALE_ORDER.indexOf(country.toUpperCase() as (typeof LOCALE_ORDER)[number])
+		if (idx >= 0) {
+			vec[idx] = weight
+			total += weight
+		}
+	}
+	if (total > 0) {
+		for (let i = 0; i < LOCALE_ORDER.length; i++) vec[i]! /= total
+	}
+	vec[LOCALE_ORDER.length] = Math.max(-1, Math.min(1, lat / 90))
+	vec[LOCALE_ORDER.length + 1] = Math.max(-1, Math.min(1, lon / 180))
+	return vec
+}
+
+/**
+ * Parse the pilot postcode→anchor lookup JSON (`{postcode: [posterior, lat, lon]}`) into a Map. Pure
+ * (takes the parsed object, not a path) so this module stays browser-safe — the file read lives in
+ * the Node-side caller (the eval).
+ */
+export function parseAnchorLookup(raw: Record<string, [Record<string, number>, number, number]>): AnchorLookup {
+	const out: AnchorLookup = new Map()
+	for (const [pc, [posterior, lat, lon]] of Object.entries(raw)) out.set(pc, { posterior, lat, lon })
+	return out
+}
+
+/**
+ * Per-piece anchor features + confidence for `text`, projected onto its SP `pieces` by the SAME
+ * char→piece rule the labels use (a piece takes the anchor of the postcode span its first
+ * non-whitespace char falls inside) — so the anchor lands on exactly the postcode's sub-tokens.
+ *
+ * Postcode spans are the alphanumeric runs in `text` that the lookup recognizes (gold-equivalent on
+ * clean rendered addresses); a recognized span yields a confidence-1.0 anchor, like training's
+ * gold-span. Returns `(pieces × ANCHOR_FEATURE_DIM)` features + `(pieces,)` confidence.
+ */
+export function buildAnchorFeatures(
+	text: string,
+	pieces: ReadonlyArray<TokenizedPiece>,
+	lookup: AnchorLookup
+): { features: number[][]; confidence: number[] } {
+	const features: number[][] = pieces.map(() => new Array<number>(ANCHOR_FEATURE_DIM).fill(0))
+	const confidence: number[] = pieces.map(() => 0)
+
+	const tokenRe = /[A-Za-z0-9]+/g
+	let m: RegExpExecArray | null
+	while ((m = tokenRe.exec(text)) !== null) {
+		const entry = lookup.get(m[0].toUpperCase())
+		if (!entry) continue
+		const spanBegin = m.index
+		const spanEnd = m.index + m[0].length
+		const vec = anchorFeatureVector(entry.posterior, entry.lat, entry.lon)
+		for (let i = 0; i < pieces.length; i++) {
+			const p = pieces[i]!
+			for (let c = p.start; c < p.end; c++) {
+				if (c < text.length && !/\s/.test(text[c]!)) {
+					if (c >= spanBegin && c < spanEnd) {
+						features[i] = vec
+						confidence[i] = 1.0
+					}
+					break // first non-whitespace char of the piece decides (mirrors realign_anchor_to_pieces)
+				}
+			}
+		}
+	}
+	return { features, confidence }
+}

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -27,6 +27,7 @@ import { repairUnitLabels } from "./unit-repair.js"
 import { addEmissionMatrix, buildEmissionPriors, type QueryShapeLike } from "./query-shape-prior.js"
 import { buildStreetMorphologyEmissionPriors, type StreetMorphologyPriorOpts } from "./street-morphology-prior.js"
 import { MailwomanTokenizer } from "./tokenizer.js"
+import { buildAnchorFeatures, type AnchorLookup } from "./anchor-inference.js"
 import { buildBioEndMask, buildBioStartMask, buildBioTransitionMask, softmax, viterbi } from "./viterbi.js"
 import type { ResolveWeightsOpts, ResolvedWeights } from "./weights.js"
 
@@ -36,7 +37,10 @@ import type { ResolveWeightsOpts, ResolvedWeights } from "./weights.js"
  * the classifier only ever calls `infer(ids)`.
  */
 export interface NeuralRunner {
-	infer(tokenIds: number[]): Promise<InferResult>
+	infer(
+		tokenIds: number[],
+		anchor?: { features: ReadonlyArray<ReadonlyArray<number>>; confidence: ReadonlyArray<number> }
+	): Promise<InferResult>
 }
 
 export interface NeuralAddressClassifierConfig {
@@ -67,6 +71,13 @@ export interface NeuralAddressClassifierConfig {
 	startTransitions?: number[]
 	/** Optional learned end-of-sequence transition scores per label. */
 	endTransitions?: number[]
+	/**
+	 * Optional postcode-anchor lookup (#239/#240). When set, `parse` builds per-piece anchor features
+	 * from the text + this lookup and feeds them to the runner — for models trained with the anchor
+	 * channel (exported with the `anchor_features`/`anchor_confidence` ONNX inputs). Omit for plain
+	 * models. Load via `loadAnchorLookup` from `./anchor-inference.js`.
+	 */
+	postcodeAnchorLookup?: AnchorLookup
 }
 
 export class NeuralAddressClassifier {
@@ -133,7 +144,12 @@ export class NeuralAddressClassifier {
 		if (text.length === 0) return { raw: text, roots: [] }
 
 		const { pieces, ids } = this.cfg.tokenizer.encode(text)
-		const { logits } = await this.cfg.runner.infer(ids)
+		// Postcode-anchor channel (#239/#240): build per-piece anchor features from the same lookup the
+		// model trained on, fed alongside the ids. No-op when no lookup is configured.
+		const anchor = this.cfg.postcodeAnchorLookup
+			? buildAnchorFeatures(text, pieces, this.cfg.postcodeAnchorLookup)
+			: undefined
+		const { logits } = await this.cfg.runner.infer(ids, anchor)
 
 		this.assertEmissionWidth(logits)
 
@@ -209,7 +225,12 @@ export class NeuralAddressClassifier {
 			return { tree: { raw: text, roots: [] }, logits: [], pieces: [] }
 		}
 		const { pieces, ids } = this.cfg.tokenizer.encode(text)
-		const { logits } = await this.cfg.runner.infer(ids)
+		// Postcode-anchor channel (#239/#240): build per-piece anchor features from the same lookup the
+		// model trained on, fed alongside the ids. No-op when no lookup is configured.
+		const anchor = this.cfg.postcodeAnchorLookup
+			? buildAnchorFeatures(text, pieces, this.cfg.postcodeAnchorLookup)
+			: undefined
+		const { logits } = await this.cfg.runner.infer(ids, anchor)
 
 		this.assertEmissionWidth(logits)
 

--- a/neural/index.ts
+++ b/neural/index.ts
@@ -4,6 +4,7 @@
  * @author Teffen Ellis, et al.
  */
 
+export * from "./anchor-inference.js"
 export * from "./classifier.js"
 export * from "./labels.js"
 export * from "./onnx-runner.js"

--- a/neural/onnx-runner.ts
+++ b/neural/onnx-runner.ts
@@ -88,8 +88,15 @@ export class OnnxRunner {
 	 * back to the actual input length.
 	 *
 	 * @param tokenIds The id sequence produced by the tokenizer (no special tokens added).
+	 * @param anchor Optional postcode-anchor channel (#239/#240). When supplied (only for anchor
+	 *   models — exported with the `anchor_features`/`anchor_confidence` inputs), per-piece features
+	 *   `(seqLen × dim)` + confidence `(seqLen,)` are fed, zero-padded to `fixedSeqLen`. Omit for plain
+	 *   models, whose ONNX has no anchor inputs.
 	 */
-	async infer(tokenIds: number[]): Promise<InferResult> {
+	async infer(
+		tokenIds: number[],
+		anchor?: { features: ReadonlyArray<ReadonlyArray<number>>; confidence: ReadonlyArray<number> }
+	): Promise<InferResult> {
 		const session = await this.ensureSession()
 		const seqLen = Math.min(tokenIds.length, this.fixedSeqLen)
 		const padded = new BigInt64Array(this.fixedSeqLen)
@@ -102,6 +109,19 @@ export class OnnxRunner {
 		const feeds: Record<string, ort.Tensor> = {
 			input_ids: new ort.Tensor("int64", padded, [1, this.fixedSeqLen]),
 			attention_mask: new ort.Tensor("int64", mask, [1, this.fixedSeqLen]),
+		}
+
+		if (anchor) {
+			const dim = anchor.features[0]?.length ?? 0
+			const af = new Float32Array(this.fixedSeqLen * dim)
+			const ac = new Float32Array(this.fixedSeqLen)
+			for (let i = 0; i < seqLen; i++) {
+				ac[i] = anchor.confidence[i] ?? 0
+				const row = anchor.features[i]
+				if (row) for (let d = 0; d < dim; d++) af[i * dim + d] = row[d] ?? 0
+			}
+			feeds.anchor_features = new ort.Tensor("float32", af, [1, this.fixedSeqLen, dim])
+			feeds.anchor_confidence = new ort.Tensor("float32", ac, [1, this.fixedSeqLen])
 		}
 
 		const output = await session.run(feeds)

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -276,7 +276,15 @@ async function main(): Promise<void> {
 		MailwomanTokenizer.loadFromFile(arg("tokenizer")),
 		OnnxRunner.create(arg("model")),
 	])
-	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels })
+	// Model-side postcode anchor (#239/#240): feed the parser per-piece anchor features from the same
+	// lookup it trained on. Only for anchor models (ONNX exported with the anchor inputs). The verdict
+	// run: `--model-anchor-lookup /path/pilot-anchor-lookup.json` on the anchor-on model.
+	const modelAnchorPath = arg("model-anchor-lookup", "")
+	const postcodeAnchorLookup = modelAnchorPath
+		? (await import("@mailwoman/neural")).parseAnchorLookup(JSON.parse(readFileSync(modelAnchorPath, "utf8")))
+		: undefined
+	if (modelAnchorPath) console.error(`[model-anchor] feeding anchor from ${modelAnchorPath} (${postcodeAnchorLookup!.size} codes)`)
+	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels, postcodeAnchorLookup })
 
 	// v0 = our TypeScript port of the Pelias parser. Scoring it through the same resolver makes this a
 	// real "neural vs Pelias parser" head-to-head on non-circular addresses.


### PR DESCRIPTION
The inference mirror of the training channel, which let us run the verdict A/B.

- **`export_onnx`** detects the anchor model → exports a 4-input ONNX (`+anchor_features, anchor_confidence`).
- **`OnnxRunner.infer(ids, anchor?)`** feeds the anchor tensors.
- **`anchor-inference.ts`** — `anchorFeatureVector` (byte-matches Python `anchor_feature_vector`, pinned by a cross-language test) + `buildAnchorFeatures` (per-piece projection mirroring `realign_anchor_to_pieces`) + `parseAnchorLookup` (pure/browser-safe).
- **`NeuralAddressClassifier`** gains `postcodeAnchorLookup` → `parse` builds + feeds the anchor.
- **`oa-resolver-eval --model-anchor-lookup`** feeds the model anchor.

**The verdict:** same checkpoint, anchor off `35.9%` → anchor fed `45.8%` DE locality (+9.9pp, clean). Real + load-bearing, partial fix, gated by postcode ambiguity. Writeup in `docs/articles/evals/2026-06-06-anchor-pilot.md` (#321). 6 cross-language guard tests; neural tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)