### PR TITLE
feat(cli): parse --default-country to scope the resolver

### DIFF
--- a/mailwoman/commands/parse.tsx
+++ b/mailwoman/commands/parse.tsx
@@ -32,6 +32,15 @@ const ParseConfigSchema = zod.object({
 		.optional()
 		.default("en-US")
 		.describe("Locale tag matching a weights package (en-US, fr-FR). Default en-US."),
+	defaultCountry: zod
+		.string()
+		.optional()
+		.describe(
+			"ISO-3166 country to scope the WOF resolver when the parse carries no resolved country node — " +
+				"e.g. 'US' so a bare 'NY' resolves to the US state, not a higher-priority foreign homonym. " +
+				"Requires --resolve. Defaults from --locale's region subtag (en-US → US); pass 'none' to disable " +
+				"the filter and let ranking alone decide."
+		),
 	isolated: zod
 		.boolean()
 		.optional()
@@ -200,6 +209,34 @@ const ParseCommand: CommandComponent<typeof ParseConfigSchema, typeof ArgumentsS
 	return <Text>{output}</Text>
 }
 
+/**
+ * ISO-3166 country for the resolver's `defaultCountry`, inferred from a BCP-47 locale's region subtag
+ * (en-US → US, fr-FR → FR, de-DE → DE). Returns `undefined` when the locale carries no 2-letter region
+ * subtag (so the resolver stays global rather than guessing from a language alone). Script subtags
+ * (`Hant`, `Latn`) are ignored.
+ */
+export function localeToCountry(locale: string | undefined): string | undefined {
+	if (!locale) return undefined
+	const parts = locale.split("-")
+	const region = parts.length > 1 ? parts[parts.length - 1] : undefined
+	return region && /^[A-Za-z]{2}$/.test(region) ? region.toUpperCase() : undefined
+}
+
+/**
+ * The resolver's `defaultCountry` for this invocation: the explicit `--default-country` if set (with
+ * `none` meaning "no filter"), otherwise inferred from `--locale`. Without it, a bare region
+ * abbreviation (`NY`) resolves to whatever the gazetteer ranks highest globally — often a foreign
+ * homonym (a Scottish locality) rather than the US state. The demo passes `country: "US"`; this gives
+ * the CLI parity.
+ */
+export function resolverDefaultCountry(options: {
+	defaultCountry?: string
+	locale?: string
+}): string | undefined {
+	if (options.defaultCountry === "none") return undefined
+	return options.defaultCountry ?? localeToCountry(options.locale)
+}
+
 function resolveWofPath(options: zod.infer<typeof ParseConfigSchema>): string {
 	const path = options.resolveDb ?? process.env["MAILWOMAN_WOF_DB"]
 	if (!path) {
@@ -238,10 +275,11 @@ async function resolveWithCandidates(
 	tree: AddressTree,
 	options: zod.infer<typeof ParseConfigSchema>
 ): Promise<AddressTree> {
-	if (options.candidates !== undefined) {
-		return resolver.resolveTree(tree, { candidatesPerLookup: options.candidates + 1 })
-	}
-	return resolver.resolveTree(tree)
+	const opts: { candidatesPerLookup?: number; defaultCountry?: string } = {}
+	if (options.candidates !== undefined) opts.candidatesPerLookup = options.candidates + 1
+	const dc = resolverDefaultCountry(options)
+	if (dc) opts.defaultCountry = dc
+	return resolver.resolveTree(tree, opts)
 }
 
 async function withResolver<T>(
@@ -319,11 +357,20 @@ async function runPipeline(input: string, options: zod.infer<typeof ParseConfigS
 	}
 
 	const wantAlternatives = options.candidates !== undefined
-	const pipelineOpts: { locale?: string; resolveOpts?: { candidatesPerLookup?: number } } = {
+	const resolveOpts: { candidatesPerLookup?: number; defaultCountry?: string } = {}
+	if (wantAlternatives) resolveOpts.candidatesPerLookup = (options.candidates ?? 5) + 1
+	// Scope the resolver so a bare region abbreviation (`NY`) resolves to the intended country's place
+	// rather than a higher-priority foreign homonym. Inferred from --locale unless --default-country
+	// overrides (or is `none`). Only meaningful on the --resolve path; harmless otherwise.
+	if (options.resolve) {
+		const dc = resolverDefaultCountry(options)
+		if (dc) resolveOpts.defaultCountry = dc
+	}
+	const pipelineOpts: { locale?: string; resolveOpts?: { candidatesPerLookup?: number; defaultCountry?: string } } = {
 		locale: options.locale,
 	}
-	if (wantAlternatives) {
-		pipelineOpts.resolveOpts = { candidatesPerLookup: (options.candidates ?? 5) + 1 }
+	if (resolveOpts.candidatesPerLookup !== undefined || resolveOpts.defaultCountry !== undefined) {
+		pipelineOpts.resolveOpts = resolveOpts
 	}
 
 	if (options.resolve) {

--- a/mailwoman/test/default-country.test.ts
+++ b/mailwoman/test/default-country.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Regression guard for `parse --default-country` (the resolver country scope). Without a country
+ *   hint the WOF resolver resolves globally, so a bare region abbreviation (`NY`) lands on whatever the
+ *   gazetteer ranks highest — often a foreign homonym (a Scottish locality at lat ~57) rather than the
+ *   US state. The demo passes `country: "US"`; this gives the CLI parity by inferring the country from
+ *   `--locale` (overridable, `none` to disable).
+ *
+ *   The unit tests (the locale→country inference + the override precedence) are CI-safe. The
+ *   end-to-end NY-doesn't-become-Scotland check needs the GLOBAL admin DB (the US-only DB can't
+ *   reproduce the homonym), so it skips when that DB is absent.
+ */
+import { execFile } from "node:child_process"
+import { existsSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+import { describe, expect, test } from "vitest"
+import { localeToCountry, options as parseOptions, resolverDefaultCountry } from "../commands/parse.js"
+
+const exec = promisify(execFile)
+const repoRoot = resolve(fileURLToPath(import.meta.url), "../..")
+const cliBin = resolve(repoRoot, "out", "cli.js")
+const GLOBAL_WOF = process.env["MAILWOMAN_WOF_GLOBAL_DB"] ?? "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+
+describe("localeToCountry", () => {
+	test("infers the ISO country from a BCP-47 region subtag", () => {
+		expect(localeToCountry("en-US")).toBe("US")
+		expect(localeToCountry("fr-FR")).toBe("FR")
+		expect(localeToCountry("de-DE")).toBe("DE")
+	})
+	test("ignores script subtags and language-only tags (no guessing)", () => {
+		expect(localeToCountry("en")).toBeUndefined()
+		expect(localeToCountry("zh-Hant")).toBeUndefined() // 4-letter script subtag, not a region
+		expect(localeToCountry(undefined)).toBeUndefined()
+	})
+	test("reads the trailing region of a multi-subtag tag", () => {
+		expect(localeToCountry("zh-Hant-TW")).toBe("TW")
+	})
+})
+
+describe("resolverDefaultCountry", () => {
+	test("explicit --default-country wins over the locale", () => {
+		expect(resolverDefaultCountry({ defaultCountry: "FR", locale: "en-US" })).toBe("FR")
+	})
+	test("falls back to the locale's country when unset", () => {
+		expect(resolverDefaultCountry({ locale: "de-DE" })).toBe("DE")
+	})
+	test("'none' disables the filter", () => {
+		expect(resolverDefaultCountry({ defaultCountry: "none", locale: "en-US" })).toBeUndefined()
+	})
+})
+
+describe("--default-country schema validation", () => {
+	test("accepts an explicit ISO country", () => {
+		expect(parseOptions.parse({ defaultCountry: "US" }).defaultCountry).toBe("US")
+	})
+	test("is optional (undefined when omitted)", () => {
+		expect(parseOptions.parse({}).defaultCountry).toBeUndefined()
+	})
+})
+
+// End-to-end: needs the GLOBAL admin DB (the US-only DB can't reproduce the foreign homonym).
+const describeIfGlobal = describe.skipIf(!existsSync(GLOBAL_WOF))
+describeIfGlobal(`parse --resolve against the global WOF (${GLOBAL_WOF})`, () => {
+	const NY = "350 5th Ave, New York, NY 10118"
+	const run = (extra: string[]) =>
+		exec("node", [cliBin, "parse", "--neural", "--resolve", "--resolve-db", GLOBAL_WOF, "--format", "xml", ...extra, NY], {
+			env: { ...process.env, NODE_NO_WARNINGS: "1" },
+			maxBuffer: 4 * 1024 * 1024,
+		})
+
+	test("default (US inferred from en-US) resolves New York to the US city, not a foreign homonym", async () => {
+		const { stdout } = await run([])
+		// Locality "New York" resolves to a NYC-range coordinate (lat 40–41).
+		const m = /locality[^>]*lat="(4[01]\.\d+)" lon="(-7[34]\.\d+)"/.exec(stdout)
+		expect(m, `expected a NYC-range locality coordinate, got:\n${stdout}`).not.toBeNull()
+	})
+
+	test("--default-country none reverts to the global homonym (the opt-out is real)", async () => {
+		const { stdout } = await run(["--default-country", "none"])
+		// With no country filter the region NY resolves to a high-latitude foreign place (Scotland ~57).
+		const m = /region[^>]*lat="(5\d\.\d+)"/.exec(stdout)
+		expect(m, `expected a foreign (lat>50) region resolution with --default-country none, got:\n${stdout}`).not.toBeNull()
+	})
+})


### PR DESCRIPTION
## The gap

`parse --resolve` resolved against the WOF gazetteer **globally**, with no country scope. So a bare region abbreviation hit whatever ranked highest worldwide — often a foreign homonym:

```
$ mailwoman parse --neural --resolve "350 5th Ave, New York, NY 10118"   # before
  region NY → wof:1880773131  (lat 57.6, -4.8 — a locality in Scotland)
```

`IL → France`, `WA → Spain`, same cause. Surfaced during the night-shift demo sanity check. The resolver already supports `resolveTree(tree, { defaultCountry })` (`core/resolver/resolve.ts:121` even calls out a bare "IL") and the **demo passes `country: "US"`** — the CLI just never forwarded the hint.

## The fix

- **`--default-country`** flag, inferred from `--locale`'s region subtag when unset (`en-US → US`, `fr-FR → FR`, `de-DE → DE`); pass `none` to disable and let ranking decide.
- `localeToCountry` + `resolverDefaultCountry` helpers, threaded into **both** resolve paths (the pipeline `resolveOpts` and `resolveWithCandidates`).

```
$ mailwoman parse --neural --resolve "350 5th Ave, New York, NY 10118"   # after (US inferred)
  locality New York → wof:85977539  (40.69, -73.93 — NYC ✓)
```

## Tests

10/10 pass. CI-safe units (locale→country inference, override precedence, schema) + a skip-if-global-DB integration guard (NY → NYC by default; `--default-country none` reverts to the homonym). Adjacent resolve tests unregressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)