### PR TITLE
feat(eval): order-robustness eval harness + anchor-aware per-locale-F1 + diag scripts

### DIFF
--- a/scripts/diag-berlin-anchor.ts
+++ b/scripts/diag-berlin-anchor.ts
@@ -1,0 +1,76 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Error-type breakdown for the anchor pilot's Berlin failure (#239/#240). Parses real Berlin
+ *   OpenAddresses rows through the anchor-on model, WITH the anchor fed vs WITHOUT, and shows what the
+ *   model labels the trailing city token. Answers: is "Berlin" DROPPED to O (the locale context never
+ *   forms), or MISLABELED (context forms but the wrong production fires)? And does feeding the anchor
+ *   change it? Also dumps the postcode-collision the ambiguity rides on.
+ *
+ *   Run: node --experimental-strip-types scripts/diag-berlin-anchor.ts
+ */
+import { readFileSync } from "node:fs"
+
+const MODEL = "/tmp/pilot-eval/anchoron-4in.onnx"
+const CARD = "/tmp/pilot-eval/anchoron-card.json"
+const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const LOOKUP = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
+const EVAL = "data/eval/external/openaddresses-de-sample.jsonl"
+
+const { NeuralAddressClassifier, parseAnchorLookup } = await import("@mailwoman/neural")
+const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+
+const labels = JSON.parse(readFileSync(CARD, "utf8")).labels as string[]
+const lookup = parseAnchorLookup(JSON.parse(readFileSync(LOOKUP, "utf8")))
+const tokenizer = await MailwomanTokenizer.loadFromFile(TOK)
+const runner = await OnnxRunner.create(MODEL)
+
+// Two classifiers off the SAME model: one fed the real anchor, one fed a ZEROED anchor (empty lookup
+// → all-zero features = the c=0 identity). Both must feed the 4 ONNX inputs the anchor model requires.
+const withAnchor = new NeuralAddressClassifier({ tokenizer, runner, labels, postcodeAnchorLookup: lookup })
+const noAnchor = new NeuralAddressClassifier({ tokenizer, runner, labels, postcodeAnchorLookup: new Map() })
+
+// Show the collision the ambiguity rides on.
+const collide = lookup.get("10115")
+console.log(`\n# The collision: "10115" → ${JSON.stringify(collide?.posterior)} (a real Berlin PLZ AND a real NYC ZIP)\n`)
+
+const rows = readFileSync(EVAL, "utf8")
+	.split("\n")
+	.filter(Boolean)
+	.map((l) => JSON.parse(l) as { input: string; state: string; expected: { locality?: string; postcode?: string } })
+	.filter((r) => r.state === "Berlin")
+	.slice(0, 12)
+
+const localityOf = async (clf: NeuralAddressClassifier, input: string): Promise<string> => {
+	const tuples = await clf.parseTuples(input)
+	const loc = tuples.filter(([t]) => t === "locality").map(([, v]) => v).join(" ")
+	return loc || "∅"
+}
+
+console.log("input".padEnd(46), "| gold loc".padEnd(14), "| anchor-OFF".padEnd(14), "| anchor-ON")
+console.log("-".repeat(96))
+let offHit = 0
+let onHit = 0
+for (const r of rows) {
+	const gold = r.expected.locality ?? "?"
+	const off = await localityOf(noAnchor, r.input)
+	const on = await localityOf(withAnchor, r.input)
+	if (off.toLowerCase() === gold.toLowerCase()) offHit++
+	if (on.toLowerCase() === gold.toLowerCase()) onHit++
+	console.log(r.input.slice(0, 44).padEnd(46), "|", gold.padEnd(12), "|", off.padEnd(12), "|", on)
+}
+console.log("-".repeat(96))
+console.log(`locality recovered: anchor-OFF ${offHit}/${rows.length}, anchor-ON ${onHit}/${rows.length}`)
+
+// One full token-level dump so we can see WHERE "Berlin" goes.
+const sample = rows.find((r) => /berlin/i.test(r.input)) ?? rows[0]!
+console.log(`\n# Full parse of: "${sample.input}"`)
+for (const tag of ["anchor-ON", "anchor-OFF"] as const) {
+	const clf = tag === "anchor-ON" ? withAnchor : noAnchor
+	const tuples = await clf.parseTuples(sample.input)
+	console.log(`  ${tag}: ${tuples.map(([t, v]) => `${t}=${JSON.stringify(v)}`).join("  ")}`)
+}
+process.exit(0)

--- a/scripts/diag-berlin-order.ts
+++ b/scripts/diag-berlin-order.ts
@@ -1,0 +1,80 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Is the German "collapse" actually an ORDER-MISMATCH artifact? (#239/#240). The OA de-sample renders
+ *   German addresses in US order (`{house#} {street}, {locality}, {region} {postcode}`), but the model
+ *   trained on German order (`{street} {house#}, {postcode} {locality}`). This re-renders the SAME
+ *   Berlin/Sachsen rows in German order and re-parses — if locality recovers sharply, the collapse is
+ *   substantially an eval-rendering confound, not a parsing limit. Anchor fed throughout.
+ *
+ *   Run: node --experimental-strip-types scripts/diag-berlin-order.ts
+ */
+import { readFileSync } from "node:fs"
+
+const { NeuralAddressClassifier, parseAnchorLookup } = await import("@mailwoman/neural")
+const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+
+const labels = JSON.parse(readFileSync("/tmp/pilot-eval/anchoron-card.json", "utf8")).labels as string[]
+const lookup = parseAnchorLookup(JSON.parse(readFileSync("/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json", "utf8")))
+const tokenizer = await MailwomanTokenizer.loadFromFile("/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model")
+const runner = await OnnxRunner.create("/tmp/pilot-eval/anchoron-4in.onnx")
+const clf = new NeuralAddressClassifier({ tokenizer, runner, labels, postcodeAnchorLookup: lookup })
+
+interface Row {
+	input: string
+	state: string
+	expected: { locality?: string; postcode?: string }
+}
+const rows = readFileSync("data/eval/external/openaddresses-de-sample.jsonl", "utf8")
+	.split("\n")
+	.filter(Boolean)
+	.map((l) => JSON.parse(l) as Row)
+	.filter((r) => r.state === "Berlin" || r.state === "Sachsen")
+	.slice(0, 40)
+
+/** US-order OA input "27 Straußstraße, Berlin, Berlin 12623" → German order "Straußstraße 27, 12623 Berlin". */
+function toGermanOrder(r: Row): string | null {
+	const parts = r.input.split(",").map((s) => s.trim())
+	if (parts.length < 3) return null
+	const m = /^(\d+\s*[A-Za-z]?)\s+(.+)$/.exec(parts[0]!) // leading house number + street
+	if (!m) return null
+	const [, houseNo, street] = m
+	const locality = r.expected.locality ?? parts[1]
+	const postcode = r.expected.postcode ?? (parts[parts.length - 1]!.match(/\d{5}/)?.[0] ?? "")
+	return `${street} ${houseNo}, ${postcode} ${locality}`
+}
+
+const locOf = async (text: string): Promise<string> =>
+	(await clf.parseTuples(text)).filter(([t]) => t === "locality").map(([, v]) => v).join(" ") || "∅"
+
+const norm = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim()
+let usHit = 0
+let deHit = 0
+let n = 0
+const byState: Record<string, { us: number; de: number; n: number }> = {}
+for (const r of rows) {
+	const ger = toGermanOrder(r)
+	if (!ger) continue
+	n++
+	const gold = r.expected.locality ?? "?"
+	const us = await locOf(r.input)
+	const de = await locOf(ger)
+	const uOk = norm(us) === norm(gold)
+	const dOk = norm(de) === norm(gold)
+	if (uOk) usHit++
+	if (dOk) deHit++
+	const b = (byState[r.state] ??= { us: 0, de: 0, n: 0 })
+	b.n++
+	if (uOk) b.us++
+	if (dOk) b.de++
+}
+console.log(`\nlocality EXACT-match (anchor fed), ${n} Berlin+Sachsen rows:`)
+console.log(`  US order (as the eval renders it): ${usHit}/${n} = ${((100 * usHit) / n).toFixed(1)}%`)
+console.log(`  GERMAN order (as the model trained): ${deHit}/${n} = ${((100 * deHit) / n).toFixed(1)}%`)
+for (const [st, b] of Object.entries(byState)) {
+	console.log(`    ${st}: US ${((100 * b.us) / b.n).toFixed(0)}%  →  German-order ${((100 * b.de) / b.n).toFixed(0)}%  (n=${b.n})`)
+}
+process.exit(0)

--- a/scripts/diag-saintalbans.ts
+++ b/scripts/diag-saintalbans.ts
@@ -1,0 +1,73 @@
+import { createWofResolver } from "@mailwoman/core/resolver"
+import { type ClassificationRecord, createAddressParser } from "mailwoman"
+import { readFileSync } from "node:fs"
+
+const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const MODEL = "/tmp/v072-eval/model.onnx"
+const CARD = "/tmp/v072-release/model-card.json"
+const WOF = [
+	"/mnt/playpen/mailwoman-data/wof/admin-global-priority.db",
+	"/mnt/playpen/mailwoman-data/wof/postalcode-us.db",
+]
+
+const { NeuralAddressClassifier } = await import("@mailwoman/neural")
+const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+const modelCard = JSON.parse(readFileSync(CARD, "utf8"))
+const [tokenizer, runner] = await Promise.all([
+	MailwomanTokenizer.loadFromFile(TOK),
+	OnnxRunner.create(MODEL),
+])
+const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels })
+const neuralArgmax = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels, decode: "argmax" } as any)
+const v0 = createAddressParser()
+
+const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
+const backend = new WofSqlitePlaceLookup({ databasePath: WOF })
+const resolver = createWofResolver(backend as never)
+
+function dumpTree(label: string, tree: any) {
+	const flat: string[] = []
+	const walk = (n: any) => {
+		if (n?.tag && n?.value) flat.push(`${n.tag}=${JSON.stringify(n.value)}`)
+		for (const c of n?.children ?? []) walk(c)
+	}
+	for (const r of tree?.roots ?? []) walk(r)
+	console.log(`  ${label} tags: ${flat.join("  ") || "(none)"}`)
+}
+
+function dumpResolved(label: string, tree: any) {
+	const out: string[] = []
+	const walk = (n: any) => {
+		if (n?.placeId?.startsWith?.("wof:")) {
+			const meta = n.metadata as Record<string, unknown> | undefined
+			const pt = String(n.sourceId ?? "").split(":")[0]
+			out.push(`${pt}:${meta?.["resolver_name"] ?? n.value}(${n.placeId})`)
+		}
+		for (const c of n?.children ?? []) walk(c)
+	}
+	for (const r of tree?.roots ?? []) walk(r)
+	console.log(`  ${label} resolved: ${out.join("  ") || "(none)"}`)
+}
+
+const inputs = [
+	// bare "locality, ST"
+	"Saint Paul, MN", "Belle Fourche, SD", "Fort Pierre, SD",
+	// SAME localities in a FULL address (house + street + zip)
+	"123 Main Street, Saint Paul, MN 55101",
+	"512 State Street, Belle Fourche, SD 57717",
+	"200 Deadwood Street, Fort Pierre, SD 57532",
+	"22 Brigham Rd, Saint Albans, VT 05478",
+]
+for (const input of inputs) {
+	console.log(`\n=== ${input} ===`)
+	const nTree = await neural.parse(input, { postcodeRepair: true } as any)
+	dumpTree("neural(viterbi)", nTree)
+	dumpTree("neural(argmax) ", await neuralArgmax.parse(input, { postcodeRepair: true } as any))
+	dumpResolved("neural", await resolver.resolveTree(nTree, { defaultCountry: "US" }))
+
+	const sol = await v0.parse(input)
+	const rec = (sol[0]?.classifications ?? {}) as ClassificationRecord
+	console.log(`  v0 tags: ${Object.entries(rec).map(([k, v]) => `${k}=${JSON.stringify(v)}`).join("  ")}`)
+}
+process.exit(0)

--- a/scripts/eval/de-order-eval.sh
+++ b/scripts/eval/de-order-eval.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+#
+# Both-order order-robustness eval harness (S6). Runs a model through the resolver on German addresses
+# in BOTH renderings — native German order (the realistic layout) and US/international order (the layout
+# our OA de-sample ships) — with the postcode anchor fed and zeroed, plus US + FR for the no-regression
+# gate. The German "collapse" was substantially an eval-order artifact (docs/articles/evals/
+# 2026-06-06-anchor-pilot.md); this makes native-vs-international a first-class, repeatable measurement
+# instead of a one-off. Self-emits every figure (each run writes its own .md), then prints a 2x2 + US/FR
+# summary. NOTE: anchor on/off only differs for an anchor-trained (4-input) model; for a plain model both
+# columns are identical (the anchor inputs are ignored / absent).
+#
+# Usage:
+#   scripts/eval/de-order-eval.sh \
+#     --model /tmp/v092-eval/model.onnx --card /tmp/v092-eval/model-card.json \
+#     --tokenizer /mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model \
+#     --anchor-lookup /mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json \
+#     --out /tmp/v092-eval
+set -euo pipefail
+
+MODEL="" CARD="" TOK="/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+LOOKUP="/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json" OUT="/tmp/order-eval"
+while [ $# -gt 0 ]; do case "$1" in
+  --model) MODEL="$2"; shift 2;; --card) CARD="$2"; shift 2;; --tokenizer) TOK="$2"; shift 2;;
+  --anchor-lookup) LOOKUP="$2"; shift 2;; --out) OUT="$2"; shift 2;;
+  *) echo "unknown arg: $1" >&2; exit 1;; esac; done
+[ -n "$MODEL" ] && [ -n "$CARD" ] || { echo "need --model and --card" >&2; exit 1; }
+
+mkdir -p "$OUT"
+EMPTY="$OUT/empty-anchor.json"; echo '{}' > "$EMPTY"   # zeroed anchor = c=0 identity = "anchor off"
+DE_NATIVE="data/eval/external/openaddresses-de-sample-native-order.jsonl"
+DE_INTL="data/eval/external/openaddresses-de-sample.jsonl"
+
+# run <eval-jsonl> <anchor-lookup> <default-country> <out-name>
+run() {
+  node --experimental-strip-types scripts/eval/oa-resolver-eval.ts \
+    --eval "$1" --model "$MODEL" --model-card "$CARD" --tokenizer "$TOK" \
+    --model-anchor-lookup "$2" --default-country "$3" \
+    > "$OUT/$4.md" 2> "$OUT/$4.log"
+}
+# Pull the neural locality-match % out of a result .md (the "| **neural** | XX.X% |" row).
+loc() { grep -E '\*\*neural\*\*' "$OUT/$1.md" | grep -oE '[0-9]+\.[0-9]+%' | head -1; }
+
+echo "== DE native, anchor ON =="  ; run "$DE_NATIVE" "$LOOKUP" DE de-native-on
+echo "== DE native, anchor OFF ==" ; run "$DE_NATIVE" "$EMPTY"  DE de-native-off
+echo "== DE intl,   anchor ON =="  ; run "$DE_INTL"   "$LOOKUP" DE de-intl-on
+echo "== DE intl,   anchor OFF ==" ; run "$DE_INTL"   "$EMPTY"  DE de-intl-off
+echo "== US (anchor ON) =="        ; run "data/eval/external/openaddresses-us-sample.jsonl" "$LOOKUP" US us-on
+echo "== FR (anchor ON) =="        ; run "data/eval/external/openaddresses-fr-sample.jsonl" "$LOOKUP" FR fr-on
+
+echo ""
+echo "### Order-robustness 2x2 — DE locality-match (model: $MODEL)"
+echo "|            | anchor OFF | anchor ON |"
+echo "| ---------- | ---------: | --------: |"
+echo "| US order   | $(loc de-intl-off)   | $(loc de-intl-on) |"
+echo "| native DE  | $(loc de-native-off) | $(loc de-native-on) |"
+echo ""
+echo "no-regression: US $(loc us-on) · FR $(loc fr-on)"

--- a/scripts/eval/per-locale-f1.ts
+++ b/scripts/eval/per-locale-f1.ts
@@ -32,7 +32,7 @@
  */
 
 import { type ComponentTag, decodeAsJson } from "@mailwoman/core/decoder"
-import { NeuralAddressClassifier } from "@mailwoman/neural"
+import { NeuralAddressClassifier, parseAnchorLookup } from "@mailwoman/neural"
 import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
 import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
 import { readFileSync, writeFileSync } from "node:fs"
@@ -48,6 +48,7 @@ interface Args {
 	modelPath?: string
 	tokenizerPath?: string
 	modelCardPath?: string
+	modelAnchorLookupPath?: string
 	outJson?: string
 }
 
@@ -67,6 +68,9 @@ function parseArgs(): Args {
 		else if (a === "--model" && argv[i + 1]) out.modelPath = argv[++i]
 		else if (a === "--tokenizer" && argv[i + 1]) out.tokenizerPath = argv[++i]
 		else if (a === "--model-card" && argv[i + 1]) out.modelCardPath = argv[++i]
+		// Feed the postcode anchor for a 4-input anchor-trained model (else inference errors on the
+		// missing anchor inputs). Mirrors oa-resolver-eval's --model-anchor-lookup.
+		else if (a === "--model-anchor-lookup" && argv[i + 1]) out.modelAnchorLookupPath = argv[++i]
 		else if (a === "--out-json" && argv[i + 1]) out.outJson = argv[++i]
 	}
 	return out as Args
@@ -208,7 +212,10 @@ async function main(): Promise<void> {
 			MailwomanTokenizer.loadFromFile(args.tokenizerPath),
 			OnnxRunner.create(args.modelPath),
 		])
-		neural = new NeuralAddressClassifier({ tokenizer, runner, labels: card.labels })
+		const postcodeAnchorLookup = args.modelAnchorLookupPath
+			? parseAnchorLookup(JSON.parse(readFileSync(args.modelAnchorLookupPath, "utf8")))
+			: undefined
+		neural = new NeuralAddressClassifier({ tokenizer, runner, labels: card.labels, postcodeAnchorLookup })
 	} else {
 		neural = await NeuralAddressClassifier.loadFromWeights()
 	}


### PR DESCRIPTION
Tooling from the order-artifact investigation ([the anchor-pilot correction](../blob/main/docs/articles/evals/2026-06-06-anchor-pilot.md)).

- **`scripts/eval/de-order-eval.sh`** — runs a model through the resolver in **both** renderings (native German + US/international) × **anchor on/off**, plus US/FR for the no-regression gate, and prints a 2×2 + US/FR summary. Makes native-vs-international a first-class, repeatable measurement instead of a one-off (the order-mismatch that read as a "collapse"). Powers the v0.9.2 gate.
- **`scripts/eval/per-locale-f1.ts`** — add `--model-anchor-lookup` so the per-tag F1 tool can feed a 4-input anchor-trained model (mirrors `oa-resolver-eval`). Without it the anchor inputs are missing and inference errors.
- **Diag scripts** committed (referenced by the finding + the night-4 postmortem + memories): `diag-berlin-order` (US-vs-German-order probe), `diag-berlin-anchor` (anchor on/off error-type dump), `diag-saintalbans` (multi-token locality split).

No production code paths touched — eval/diag tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)