### PR TITLE
docs(eval): v0.9.2 both-order retrain report

### DIFF
--- a/docs/articles/evals/2026-06-06-v0.9.2-eval.md
+++ b/docs/articles/evals/2026-06-06-v0.9.2-eval.md
@@ -1,0 +1,80 @@
+# v0.9.2 both-order retrain — the anchor and the word order fight over German
+
+**Date:** 2026-06-06 · **Run:** `v0.9.2-de-bothorder` (A100, 20k, from-scratch, single variable vs the v0.9.1
+anchor-on pilot) · **Question:** the German "collapse" was largely an eval-order artifact — the model trained
+native German order, our OA eval renders US/international order. Does training the German shard in **both**
+orders close the international-order gap?
+
+The honest answer: **partly, and not where it counts yet** — and the 2×2 says something more interesting than
+a single number would have.
+
+## The 2×2 (DE locality-match, 3,000 real OpenAddresses points, through the resolver)
+
+The one variable vs the pilot is the German shard's rendering (native-only → ~60/40 native/international,
+`--intl-fraction 0.4`). Everything else is held: anchor on, self-conditioning on, seed 42.
+
+| DE locality | anchor OFF | anchor ON |     | pilot anchor OFF | pilot anchor ON |
+| ----------- | ---------: | --------: | --- | ---------------: | --------------: |
+| **native**  |      48.2% | **82.1%** |     |            48.4% |       **83.8%** |
+| **international (US-order)** | **48.4%** | 44.5% |  |       35.9% |           45.5% |
+
+Two real movements, and they pull in opposite directions:
+
+1. **Both-order training improved the model's _intrinsic_ international parsing.** Anchor-off, international
+   order went **35.9% → 48.4% (+12.5pp)**. The model genuinely learned something about the US/feed layout it
+   had never seen — without the anchor, it now reads both orders at ~48%, where before it could only read the
+   native one.
+2. **But with the anchor fed — the production config — international is unchanged (45.5% → 44.5%), because the
+   anchor now _hurts_ on international order.** Anchor-off international (48.4%) beats anchor-on (44.5%). The
+   anchor still helps native enormously (+34pp), so it's the anchor that creates the whole native/international
+   asymmetry: without it the model is order-agnostic at ~48%; with it, native rockets to 82% and international
+   slips to 44%.
+
+The harm concentrates exactly where you'd predict — **Berlin**, the colliding `10xxx` postcode. Berlin
+international goes 40.5% (anchor off) → 34.4% (anchor on): the ambiguous `{DE, US}` posterior, injected at the
+**trailing** postcode, drags the already-read city toward the US reading. In native order the postcode sits
+_before_ the city and primes it correctly; in international order it trails, and the anchor fires too late, on
+the wrong side of the locality.
+
+## The residual gap has a clear, cheap cause
+
+Why is international still ~48% when native is 82%? The model mangles a tail it was never trained on. Our eval
+renders real US-order German with the **region in the tail** — `27 Straußstraße, Berlin, Berlin 12623`, `1
+Talstraße, Mülsen, Sachsen 08132` — but the international synth **dropped the region** (`…, Berlin, 12623`).
+Parsing the eval's rows through v0.9.2 shows exactly that wound:
+
+```
+27 Straußstraße, Berlin, Berlin 12623  →  street="straße, Berlin"   (locality DROPPED into street)
+1 Talstraße, Mülsen, Sachsen 08132     →  locality="Mü" + "sen, Sachsen"  (split + region absorbed)
+14 Goetheallee, Dresden, Sachsen 01309 →  locality="Dresden" + locality="Sachsen"  (region mis-tagged)
+```
+
+The model never saw a German `City, Region Postcode` tail, so it doesn't know how to segment one — the region
+gets swallowed into the locality or the locality collapses. That is the v0.9.3 fix: render the international
+order **with the region in the tail**, matching real US/feed renderings.
+
+## No collapse, no regression
+
+- **Per-tag val F1** (anchor-aware, both-order val): locality **0.820**, postcode 1.00, street 0.950,
+  house_number 0.998, region 0.703, macro **0.781**. Locality is intact — none of the v0.8.0/PR3 collapse
+  signature. Training was clean (no NaN), `cross_pollution` 0.00% throughout, `locale_acc` 0.965.
+- **Functional check** — all 6 demo presets parse identically to the v0.6.0 default (the both-order German
+  change does not touch US).
+- **No-regression** — US **97.5%** (pilot 96.1%), FR **84.9%** (pilot 85.1%). Both held; the both-order
+  German shard didn't cost the incumbents a thing.
+
+## Verdict — not shipped; a research result that earns its next experiment
+
+This is the multi-locale research line, not the production default (v0.6.0 stays the shipped en-US model), so
+there's no promotion at stake — the gate's job was to tell us whether both-order training works. It does,
+intrinsically (+12.5pp anchor-off), but the production-anchor config is flat because the anchor and the word
+order now fight. **v0.9.2 is not shipped.** What it bought us is two precise, cheap next steps:
+
+1. **Render the region in the international tail** (the synth currently drops it) — the direct fix for the
+   `City, Region Postcode` collapse the diagnostic caught.
+2. **Make the anchor word-order-aware**, or down-weight it when the postcode trails the locality — it helps
+   when the postcode leads (native) and hurts when it trails (international).
+
+Artifacts: corpus `v0.4.2-de-bothorder`; config `v0.9.2-de-bothorder.yaml`; the 2×2 harness
+`scripts/eval/de-order-eval.sh`; per-eval `.md` in `/tmp/v092-eval`. Sibling: the order-artifact correction in
+`2026-06-06-anchor-pilot.md`.


### PR DESCRIPTION
The v0.9.2 gate result. **Not shipped** — a research result, not a production regression.

**Both-order training moved the model's _intrinsic_ international-order German** (anchor-off intl 35.9 → **48.4%, +12.5pp**), but the production-anchor config is flat (intl 45.5 → 44.5) because the postcode anchor — injected at the _trailing_ postcode — now **fights the word order** on international layout (anchor-off 48.4 > anchor-on 44.5, concentrated on colliding-postcode Berlin). Native held (82.1, beats Pelias), US/FR held (97.5 / 84.9), locality F1 0.82, clean training (no NaN, cross_pollution 0%).

The residual international gap traces to a concrete cause: the synth **dropped the region tail** the eval feeds (`…Berlin, Berlin 12623`), so the model never learned to segment `City, Region Postcode` (parse diagnostic in the report). → v0.9.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)