### PR TITLE
feat(corpus): v0.9.3 region-tail — international German renders City, Region Postcode

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0.9.3-de-regiontail.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0.9.3-de-regiontail.yaml
@@ -1,0 +1,154 @@
+# Order-robustness retrain — v0.9.3 (#327, the v0.9.2 follow-up). ONE variable vs v0.9.2-de-bothorder:
+# the international-order German rows now carry the REGION in the tail ("City, Region Postcode"), the
+# layout real US/feed renderings (and our eval) use. Everything else held — anchor ON, self-cond ON,
+# v0.7.2 recipe, seed 42, --intl-fraction 0.4.
+#
+# WHY. v0.9.2 (both-order, no region tail) MOVED the model's intrinsic international parsing
+# (anchor-OFF intl 35.9 -> 48.4, +12.5pp) but the production anchor-ON config stayed flat (intl 44.5).
+# A parse diagnostic showed why: the eval feeds "27 Straußstraße, Berlin, Berlin 12623" (region in the
+# tail), but the v0.9.2 synth DROPPED the region — so the model never learned to segment a German
+# "City, Region Postcode" tail and mangled it (region absorbed into locality / locality dropped). This
+# run renders that tail. A DeepSeek consult (2026-06-06) signed off region-tail as the single variable.
+# Full analysis: docs/articles/evals/2026-06-06-v0.9.2-eval.md.
+#
+# SINGLE VARIABLE: identical to v0.9.2-de-bothorder EXCEPT the international synth now includes the
+# region tail (synthesize-german.ts; build-german-shard.mjs sets the Bundesland per source since OA's
+# REGION column is empty for DE). Corpus v0.4.3-de-regiontail.
+#
+# PRE-REGISTERED GATE (DeepSeek-signed; stop at 20k):
+#   - anchor-OFF international >= anchor-OFF native (both >= ~48%) — the region tail must lift the
+#     intrinsic intl ceiling (else the region rendering is broken; fix alignment + rerun).
+#   - anchor-ON international >= anchor-ON native - 10pp (gap <= 10pp) — SUCCESS: keep the anchor.
+#     If the gap stays > 10pp, the anchor's positional harm is hard-coded -> v0.9.4 = dual-injection
+#     anchor (inject at the postcode AND the first token; the structural harm is NOT a posterior
+#     artifact — forcing DE=1.0 posterior on v0.9.2 left intl unchanged at 44.5%).
+#   - NATIVE-order DE locality >= 80% (hold 82.1) · US/FR within ~1pp · cross_pollution < 1%.
+# Measure with scripts/eval/de-order-eval.sh (the 2×2 native/intl × anchor on/off + US/FR harness).
+#
+# CORPUS: v0.4.3-de-regiontail — v0.4.0 (US/FR) base overlaid with a BOTH-ORDER synth-german shard
+# (200K train + 4K val, real OpenAddresses Berlin/Saxony tuples). Reproduce + deploy to the Modal volume:
+#   node scripts/build-german-shard.mjs --output /tmp/german-train.jsonl --count 200000 --seed 42 --intl-fraction 0.4
+#   node scripts/build-german-shard.mjs --output /tmp/german-val.jsonl   --count 4000   --seed 99 --intl-fraction 0.4
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-train.jsonl --output /tmp/part-german-train.parquet
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-val.jsonl   --output /tmp/part-german-val.parquet
+#   # Assemble the overlay MANIFEST (v0.4.0 shards + the 2 German shards) — mirror v0.4.1-de via
+#   # scripts/assemble-de-overlay-manifest.py (point it at v0.4.3-de-regiontail), then:
+#   modal volume put mailwoman-training /tmp/part-german-train.parquet corpus/versioned/v0.4.3-de-regiontail/corpus-v0.4.3-de-regiontail/train/part-german-train.parquet
+#   modal volume put mailwoman-training /tmp/part-german-val.parquet   corpus/versioned/v0.4.3-de-regiontail/corpus-v0.4.3-de-regiontail/val/part-german-val.parquet
+#   modal volume put mailwoman-training <MANIFEST.json>                corpus/versioned/v0.4.3-de-regiontail/corpus-v0.4.3-de-regiontail/MANIFEST.json
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0.9.2-de-bothorder.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.3-de-regiontail/corpus-v0.4.3-de-regiontail
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+    # German at ~18% of the mix — same weight as v0.9.1; the ONLY change is the shard now carries both
+    # orders. THE key tunable if a gate lags: raise for more DE, lower if US/FR slip the 1pp tripwire.
+    synth-german: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v093-de-regiontail-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 20000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.9.3-de-regiontail-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus/src/synthesize-german.test.ts
+++ b/corpus/src/synthesize-german.test.ts
@@ -72,30 +72,46 @@ describe("synthesizeLocaleRow (generic)", () => {
 	})
 })
 
+const DRESDEN: LocaleBaseTuple = {
+	house_number: "14",
+	street: "Goetheallee",
+	locality: "Dresden",
+	region: "Sachsen",
+	postcode: "01309",
+}
+
 describe("synthesizeLocaleRow order option (order-robustness)", () => {
-	it("international order renders house-FIRST, postcode-AFTER-city — the inverse of native", () => {
-		// keepAll = 0.5 keeps house# + postcode and picks GB (Math.floor(0.5 * 2) = 1) → a house-first,
-		// postcode-trailing layout, e.g. "27 Straußstraße, Berlin, 12623".
+	it("international order renders house-FIRST, postcode-AFTER-city, region IN THE TAIL", () => {
+		// keepAll = 0.5 keeps house# + postcode; international uses the US template + the region tail →
+		// "27 Straußstraße, Berlin, Berlin 12623" (the layout the eval feeds; v0.9.3 / #327).
 		const row = synthesizeLocaleRow(BERLIN, "DE", { random: keepAll, order: "international" })!
 		expect(row).not.toBeNull()
 		expect(row.raw.indexOf("27")).toBeLessThan(row.raw.indexOf("Straußstraße")) // house BEFORE street
 		expect(row.raw.indexOf("12623")).toBeGreaterThan(row.raw.indexOf("Berlin")) // postcode AFTER city
+		expect(row.components.region).toBe("Berlin") // region carried for international (dropped for native)
+	})
+
+	it("region tail renders with a DISTINCT region (City, Region Postcode)", () => {
+		const row = synthesizeLocaleRow(DRESDEN, "DE", { random: keepAll, order: "international" })!
+		expect(row.raw).toBe("14 Goetheallee, Dresden, Sachsen 01309")
+		expect(row.components.region).toBe("Sachsen")
 	})
 
 	it("keeps the address's own locale tag — only the surface layout changes", () => {
 		const row = synthesizeLocaleRow(BERLIN, "DE", { random: keepAll, order: "international" })!
-		expect(row.locale).toBe("de-DE") // the render template is US/GB, but it's still a German address
+		expect(row.locale).toBe("de-DE") // the render template is US, but it's still a German address
 	})
 
-	it("aligns to international-order BIO: house_number before street, postcode after locality", () => {
-		const row = synthesizeLocaleRow(BERLIN, "DE", { random: keepAll, order: "international" })!
+	it("aligns to international-order BIO: house# before street, region after locality, postcode last", () => {
+		const row = synthesizeLocaleRow(DRESDEN, "DE", { random: keepAll, order: "international" })!
 		const canonical = { ...row, country: "DE", source: "synth-german", source_id: "synth-german:intl" } as CanonicalRow
 		const aligned = alignRow(canonical)
 		expect(aligned.kind).toBe("labeled")
 		const labels = aligned.row!.labels
 		const firstOf = (tag: string) => labels.findIndex((l) => l.includes(tag))
 		expect(firstOf("house_number")).toBeLessThan(firstOf("street")) // inverse of the native test
-		expect(firstOf("postcode")).toBeGreaterThan(firstOf("locality"))
+		expect(firstOf("region")).toBeGreaterThan(firstOf("locality")) // region in the tail, after the city
+		expect(firstOf("postcode")).toBeGreaterThan(firstOf("region")) // postcode last
 	})
 
 	it("native order is unchanged and consumes no extra RNG draw (default stays default)", () => {

--- a/corpus/src/synthesize-german.ts
+++ b/corpus/src/synthesize-german.ts
@@ -59,15 +59,6 @@ export interface LocaleSynthesisOpts {
 /** @deprecated Alias — use LocaleSynthesisOpts. */
 export type GermanSynthesisOpts = LocaleSynthesisOpts
 
-/**
- * House-first, postcode-after-city templates for the `"international"` order. Both are real OpenCage
- * country templates that happen to render any component dict house-number-first with the postcode
- * trailing the city — exactly the US/feed layout a native-order-trained model never saw. We keep two
- * so the international rendering isn't a single memorizable layout (US carries a region slot, GB
- * doesn't).
- */
-const INTERNATIONAL_ORDER_TEMPLATES = ["US", "GB"] as const
-
 /** ISO-3166 alpha-2 → BCP-47 tag for the emitted rows (primary language per country). */
 const LOCALE_TAG: Record<string, string> = {
 	DE: "de-DE",
@@ -98,8 +89,10 @@ function tokenPresent(raw: string, value: string): boolean {
  * postcode some of the time). Returns `null` when the tuple is too thin or a component wouldn't
  * align cleanly.
  *
- * Region is intentionally omitted: these templates absorb the admin region into the postcode/city
- * line, so it rarely renders verbatim, and including it would break BIO alignment.
+ * Region handling is order-dependent: NATIVE order omits it (the native template absorbs the admin
+ * region into the postcode/city line, so it rarely renders verbatim and would break BIO alignment),
+ * while INTERNATIONAL order includes it in the tail ("City, Region Postcode" — the US/feed layout the
+ * eval uses; v0.9.3 / #327).
  *
  * Pass `opts.order: "international"` to render the same components house-first / postcode-after-city
  * instead (see {@link LocaleSynthesisOpts.order}) — the layout international feeds impose on foreign
@@ -119,15 +112,17 @@ export function synthesizeLocaleRow(
 	if (base.house_number && random() < 0.8) components.house_number = base.house_number
 	// ~85% keep the postcode.
 	if (base.postcode && random() < 0.85) components.postcode = base.postcode
+	// International order carries the REGION in the tail ("City, Region Postcode") — the layout real
+	// US/feed renderings (and our OA eval) use. v0.9.2 rendered international order WITHOUT the region,
+	// so the model never learned to segment the tail and mangled it at eval (region absorbed into the
+	// locality / locality dropped); v0.9.3 closes that gap (#327). Native order still drops the region
+	// (the native template absorbs it into the city line, which would break verbatim alignment).
+	if (order === "international" && base.region) components.region = base.region
 
-	// Native order uses the address's own country template; international order borrows a house-first /
-	// postcode-after-city template (US or GB) while keeping the address's own locale tag. The extra
-	// `random()` draw is consumed ONLY on the international branch, so native rendering preserves the
-	// RNG sequence existing callers/tests depend on.
-	const renderCountry =
-		order === "international"
-			? INTERNATIONAL_ORDER_TEMPLATES[Math.floor(random() * INTERNATIONAL_ORDER_TEMPLATES.length)]!
-			: country
+	// Native order uses the address's own country template; international order uses the US template —
+	// house-first, postcode-after-city, with a region slot for the tail. Neither branch consumes a
+	// `random()` draw for the template, so the RNG sequence existing callers/tests depend on is stable.
+	const renderCountry = order === "international" ? "US" : country
 	const raw = formatAddress(components, renderCountry, { separator: ", " })
 	if (!raw) return null
 

--- a/scripts/build-german-shard.mjs
+++ b/scripts/build-german-shard.mjs
@@ -35,9 +35,12 @@ import { createWriteStream } from "node:fs"
 
 import { alignRow, stableSourceId, synthesizeGermanRow } from "@mailwoman/corpus"
 
+// `region` is the Bundesland the source covers. OA's REGION column is empty for DE, but the region is
+// implied by the per-state file — and the international order needs it for the "City, Region Postcode"
+// tail (v0.9.3 / #327). berlin.csv → Berlin (a city-state, region==locality); sn/statewide → Sachsen.
 const SOURCES = [
-	{ zip: "/tmp/oa-cache/de__berlin.zip", csv: "de/berlin.csv" },
-	{ zip: "/tmp/oa-cache/de__sn__statewide.zip", csv: "de/sn/statewide.csv" },
+	{ zip: "/tmp/oa-cache/de__berlin.zip", csv: "de/berlin.csv", region: "Berlin" },
+	{ zip: "/tmp/oa-cache/de__sn__statewide.zip", csv: "de/sn/statewide.csv", region: "Sachsen" },
 ]
 
 function parseArgs() {
@@ -126,7 +129,8 @@ function readTuples(source) {
 		if (!street || !locality) continue
 		const house_number = get(cells, iNum)
 		const postcode = get(cells, iPost)
-		const region = get(cells, iRegion)
+		// OA's REGION column is empty for DE — fall back to the source's Bundesland (set per file).
+		const region = get(cells, iRegion) || source.region || ""
 		const key = `${house_number}|${street}|${locality}|${postcode}`.toLowerCase()
 		if (seen.has(key)) continue
 		seen.add(key)


### PR DESCRIPTION
The v0.9.2 follow-up (#327). v0.9.2 both-order training moved the model's _intrinsic_ international German (+12.5pp anchor-off) but the production anchor-on config stayed flat — a parse diagnostic showed the model mangles the **region tail** the eval feeds (`…Berlin, Berlin 12623`), because the v0.9.2 synth **dropped the region**. DeepSeek signed off region-tail as the single-variable v0.9.3.

- **`synthesize-german`**: international order now includes the region in the tail (US template's region slot → `City, Region Postcode`); native order still drops it (the native template absorbs region, breaking verbatim alignment). Dropped the US/GB template pick — international is always US-with-region now, matching the eval. +2 region-tail tests (incl. the degenerate `Berlin, Berlin` city-state, which `alignRow` segments correctly: first→locality, second→region).
- **`build-german-shard`**: set the Bundesland per source (Berlin/Sachsen) — OA's REGION column is empty for DE, so region is implied by the per-state file. 100% of international rows now carry the region tail.
- **`v0.9.3-de-regiontail.yaml`**: single-variable retrain (vs v0.9.2, only the region tail) with the DeepSeek-signed gate — anchor-off intl ≥ native; anchor-on gap ≤ 10pp or → v0.9.4 dual-injection anchor (the harm is positional, not posterior: forcing DE=1.0 left v0.9.2 intl at 44.5%).

Corpus `v0.4.3-de-regiontail` built + on the volume; retrain launched. Eval via `de-order-eval.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)