### PR TITLE
docs(eval): v0.9.3 region-tail follow-up — corpus lever exhausted

### DIFF
--- a/docs/articles/evals/2026-06-06-v0.9.2-eval.md
+++ b/docs/articles/evals/2026-06-06-v0.9.2-eval.md
@@ -75,6 +75,36 @@ order now fight. **v0.9.2 is not shipped.** What it bought us is two precise, ch
 2. **Make the anchor word-order-aware**, or down-weight it when the postcode trails the locality — it helps
    when the postcode leads (native) and hurts when it trails (international).
 
-Artifacts: corpus `v0.4.2-de-bothorder`; config `v0.9.2-de-bothorder.yaml`; the 2×2 harness
-`scripts/eval/de-order-eval.sh`; per-eval `.md` in `/tmp/v092-eval`. Sibling: the order-artifact correction in
-`2026-06-06-anchor-pilot.md`.
+## v0.9.3 follow-up: we rendered the region tail. The corpus wasn't the ceiling.
+
+We took the first fix — render the `City, Region Postcode` tail the synth had been dropping — and retrained
+(v0.9.3, single variable, DeepSeek-signed). The 2×2 came back almost identical to v0.9.2:
+
+| v0.9.3 DE locality | anchor OFF | anchor ON |
+| ------------------ | ---------: | --------: |
+| native             |       48.3 | **83.6**  |
+| international       |       47.1 |      44.7 |
+
+US 97.2 / FR 84.9 held; no collapse. The region tail did _exactly_ what it was designed to — international
+**region-match went 0% → ~40%** (Berlin 45.6, Sachsen 30.9), and Berlin's international locality nudged
+34.4 → 38.7 — but **locality stayed flat**. The model now segments the tail correctly; it just doesn't move
+the number we care about, because the number we care about was never capped by the tail. The anchor-on
+international gap is `83.6 − 44.7 = 38.9pp`, four times the 10pp the pre-registered gate allowed.
+
+So the corpus lever — both-order rendering, then the region tail — is **exhausted** for the anchor-on
+international gap. Three independent lines now point at the same place: anchor-off is order-agnostic at ~48%,
+forcing the posterior to `DE=1.0` changed nothing, and rendering the region tail changed nothing. The ceiling
+is the anchor's _structure_ — an additive vector injected at the postcode token, which lands on the wrong side
+of the locality when the postcode trails it.
+
+**Next is architectural, and it's the operator's call.** The designed fix (v0.9.4) is **dual-injection**:
+inject the same anchor at the postcode token _and_ the first token, an order-independent global signal the
+locality can attend back to. It's a training-code change, not model surgery — the model already adds the
+anchor per-token, so it's a matter of placing one at position 0. But three iterations in without a promotion,
+the honest question DeepSeek raised is whether a trained-in _always-on_ anchor is the right design at all:
+it's a +35pp native win and a −4pp international loss, and an order-conditioned anchor is the alternative.
+That fork is staged, not taken. v0.6.0 stays the production default throughout.
+
+Artifacts: corpus `v0.4.2-de-bothorder` + `v0.4.3-de-regiontail`; configs `v0.9.2-de-bothorder.yaml` +
+`v0.9.3-de-regiontail.yaml`; the 2×2 harness `scripts/eval/de-order-eval.sh`; follow-up issue #327. Sibling:
+the order-artifact correction in `2026-06-06-anchor-pilot.md`.


### PR DESCRIPTION
Completes the order-robustness retrain record. v0.9.3 rendered the region tail v0.9.2 dropped; ≈ v0.9.2 on every locality metric (native 83.6 beats Pelias, intl-on 44.7, US/FR held), region-match 0→~40% as designed but locality flat. The anchor-on intl gap (38.9pp) is the anchor's positional structure — three independent lines agree. Next is architectural (v0.9.4 dual-injection), staged for the operator (#327).

🤖 Generated with [Claude Code](https://claude.com/claude-code)