### PR TITLE
feat(corpus): NL postcode normalization (both orders build for NL)

### DIFF
--- a/corpus/src/synthesize-german.test.ts
+++ b/corpus/src/synthesize-german.test.ts
@@ -126,3 +126,17 @@ describe("synthesizeLocaleRow order option (order-robustness)", () => {
 		expect(withNative.raw).toBe(withoutOpt.raw)
 	})
 })
+
+describe("NL postcode normalization", () => {
+	const NL: LocaleBaseTuple = { house_number: "105", street: "De Ruijterkade", locality: "Amsterdam", postcode: "1011AB" }
+	it("canonicalizes the NL postcode to the spaced form so native order aligns (was rejected)", () => {
+		const row = synthesizeLocaleRow(NL, "NL", { random: keepAll, order: "native" })!
+		expect(row).not.toBeNull() // previously NULL — the template's "1011 AB" didn't match unspaced "1011AB"
+		expect(row.components.postcode).toBe("1011 AB")
+		expect(row.raw).toContain("1011 AB")
+	})
+	it("leaves other countries' postcodes untouched", () => {
+		const de = synthesizeLocaleRow(BERLIN, "DE", { random: keepAll })!
+		expect(de.components.postcode).toBe("12623")
+	})
+})

--- a/corpus/src/synthesize-german.ts
+++ b/corpus/src/synthesize-german.ts
@@ -70,6 +70,20 @@ const LOCALE_TAG: Record<string, string> = {
 	US: "en-US",
 }
 
+/**
+ * Canonicalize a postcode to the form the country's template renders, so the stored component aligns
+ * verbatim against `raw`. NL is the case that needs it: OA stores `1011AB` but the OpenCage NL template
+ * emits the conventional spaced `1011 AB` (4 digits + space + 2 letters), which otherwise fails verbatim
+ * alignment and drops the row. Other countries pass through unchanged.
+ */
+function normalizePostcode(postcode: string, country: string): string {
+	if (country === "NL") {
+		const m = /^(\d{4})\s*([A-Za-z]{2})$/.exec(postcode)
+		if (m) return `${m[1]} ${m[2]!.toUpperCase()}`
+	}
+	return postcode
+}
+
 /** True when `value` appears verbatim AND as a standalone token (so BIO alignment lands cleanly). */
 function tokenPresent(raw: string, value: string): boolean {
 	if (!raw.includes(value)) return false
@@ -110,8 +124,8 @@ export function synthesizeLocaleRow(
 	const components: CanonicalRow["components"] = { street: base.street, locality: base.locality }
 	// ~80% keep the house number (the rest are street-only forms, also idiomatic).
 	if (base.house_number && random() < 0.8) components.house_number = base.house_number
-	// ~85% keep the postcode.
-	if (base.postcode && random() < 0.85) components.postcode = base.postcode
+	// ~85% keep the postcode (canonicalized to the country's rendered form — NL spaces it).
+	if (base.postcode && random() < 0.85) components.postcode = normalizePostcode(base.postcode, country)
 	// International order carries the REGION in the tail ("City, Region Postcode") — the layout real
 	// US/feed renderings (and our OA eval) use. v0.9.2 rendered international order WITHOUT the region,
 	// so the model never learned to segment the tail and mangled it at eval (region absorbed into the

--- a/scripts/build-locale-shard.mjs
+++ b/scripts/build-locale-shard.mjs
@@ -20,8 +20,8 @@
  *          the countrywide file spans all départements, so the international rows render WITHOUT a region
  *          tail until a postcode→région mapping is added (follow-up; less critical than DE since the FR
  *          eval differs).
- *     NL — countrywide; INTERNATIONAL order only for now — the NL template reformats `1011AB`→`1011 AB`,
- *          so native-order rows reject on verbatim alignment. Needs postcode normalization (follow-up).
+ *     NL — countrywide; works both orders (postcode canonicalized to the spaced `1011 AB` form so the
+ *          template aligns; OA's REGION column IS populated for NL, so the international tail carries it).
  *     ES/IT — no cached OA yet (fetch + add to COUNTRY_SOURCES to enable).
  *
  *   Pipeline (mirrors build-german-shard.mjs):


### PR DESCRIPTION
Completes `build-locale-shard` locale coverage. The OpenCage NL template renders the conventional spaced `1011 AB`, but OA stores `1011AB` — so NL native-order rows failed verbatim alignment and dropped (the builder was NL-international-only). `normalizePostcode` canonicalizes NL postcodes to the spaced form before rendering; the stored component is now the correct Dutch form. Other countries pass through.

Smoke: NL builds both orders (native `Geuzenstraat 50-3, 1056 KE Amsterdam`; intl `…, Noord-Brabant 5684 LT` — NL's OA REGION column is populated, so the intl tail carries the region too). +2 tests (12 total). build-locale-shard now covers DE (region tail), NL (both orders), FR (streaming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)