### PR TITLE
feat(train): v0.9.4 dual-injection anchor (#327)

### DIFF
--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -115,6 +115,12 @@ class ModelConfig:
     # global FiLM lacked). Robustness is the confidence curriculum applied corpus-side (see the data
     # loader). Default False keeps existing numerics. Composes with ``use_locale_conditioning``.
     use_postcode_anchor: bool = False
+    # Dual-injection (#327, v0.9.4): when the anchor is on, ALSO inject the pooled postcode anchor at
+    # position 0 — an order-INDEPENDENT global cue the locality can attend back to regardless of where
+    # the postcode sits. Fixes the anchor's positional harm on international word order (postcode AFTER
+    # the city), where the per-token-only injection fired on the wrong side of the locality. Default
+    # False (no change); requires use_postcode_anchor.
+    inject_first_token: bool = False
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/configs/v0.9.4-de-dualanchor.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0.9.4-de-dualanchor.yaml
@@ -1,0 +1,160 @@
+# Order-robustness retrain — v0.9.4 (#327, the v0.9.3 follow-up). ONE variable vs v0.9.3-de-regiontail:
+# DUAL-INJECTION of the postcode anchor (model.inject_first_token=true) — the anchor is pooled and ALSO
+# injected at position 0, not only at the postcode span. SAME corpus (v0.4.3-de-regiontail, region tail),
+# anchor ON, self-cond ON, v0.7.2 recipe, seed 42. Only the model flag changes.
+#
+# WHY. v0.9.2 (both-order) + v0.9.3 (region tail) BOTH left the anchor-ON international gap ~flat (intl
+# 44.5/44.7 vs native 82-84). The corpus lever is EXHAUSTED: three lines agree the ceiling is the
+# anchor's STRUCTURE, not the data — anchor-OFF is order-agnostic (~48% both orders), forcing the
+# posterior to DE=1.0 left intl at 44.5%, and the region tail moved region-tagging (0→~40%) but not
+# locality. The per-token anchor at the TRAILING postcode (international order) fires on the wrong side
+# of the locality. PIP-containment confirms the intl gap is a REAL geographic miss (57% vs native 96%),
+# not a name-match artifact. DeepSeek (2026-06-06, 2 turns) signed off dual-injection as the fix: the
+# first-token anchor is an order-INDEPENDENT global cue the locality can attend back to. Full analysis:
+# docs/articles/evals/2026-06-06-v0.9.2-eval.md (the v0.9.3 follow-up section).
+#
+# SINGLE VARIABLE: identical to v0.9.3-de-regiontail EXCEPT model.inject_first_token=true. NO corpus,
+# data-pipeline, or inference change — the model pools the per-token anchor (gather by max-confidence,
+# the postcode span) and adds it at position 0, gated by that confidence so the c=0 identity holds. The
+# ONNX captures it (4-input, unchanged inference). De-risked: corpus-python test_anchor_channel.py
+# (c=0 identity + position-0 signal + save/load + export-equivalent to the per-token-only baseline).
+#
+# PRE-REGISTERED GATE (DeepSeek-signed; stop at 20k):
+#   - anchor-ON international >= anchor-ON native - 10pp (gap <= 10pp) — SUCCESS: dual-injection works,
+#     the first-token cue lets the anchor help international order too.
+#   - NATIVE-order DE locality >= 80% (hold ~83) · US/FR within ~1pp · cross_pollution < 1% — no
+#     regression on what already works (the position-0 cue must not hurt native/US/FR).
+#   - If intl-ON still trails by >10pp: dual-injection insufficient -> reconsider the always-on anchor
+#     design (order-conditioned anchor), operator's call.
+# Measure with scripts/eval/de-order-eval.sh (the 2×2 native/intl × anchor on/off + US/FR harness).
+#
+# CORPUS: v0.4.3-de-regiontail — v0.4.0 (US/FR) base overlaid with a BOTH-ORDER synth-german shard
+# (200K train + 4K val, real OpenAddresses Berlin/Saxony tuples). Reproduce + deploy to the Modal volume:
+#   node scripts/build-german-shard.mjs --output /tmp/german-train.jsonl --count 200000 --seed 42 --intl-fraction 0.4
+#   node scripts/build-german-shard.mjs --output /tmp/german-val.jsonl   --count 4000   --seed 99 --intl-fraction 0.4
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-train.jsonl --output /tmp/part-german-train.parquet
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/german-val.jsonl   --output /tmp/part-german-val.parquet
+#   # Assemble the overlay MANIFEST (v0.4.0 shards + the 2 German shards) — mirror v0.4.1-de via
+#   # scripts/assemble-de-overlay-manifest.py (point it at v0.4.3-de-regiontail), then:
+#   modal volume put mailwoman-training /tmp/part-german-train.parquet corpus/versioned/v0.4.3-de-regiontail/corpus-v0.4.3-de-regiontail/train/part-german-train.parquet
+#   modal volume put mailwoman-training /tmp/part-german-val.parquet   corpus/versioned/v0.4.3-de-regiontail/corpus-v0.4.3-de-regiontail/val/part-german-val.parquet
+#   modal volume put mailwoman-training <MANIFEST.json>                corpus/versioned/v0.4.3-de-regiontail/corpus-v0.4.3-de-regiontail/MANIFEST.json
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0.9.2-de-bothorder.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.3-de-regiontail/corpus-v0.4.3-de-regiontail
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+    # German at ~18% of the mix — same weight as v0.9.1; the ONLY change is the shard now carries both
+    # orders. THE key tunable if a gate lags: raise for more DE, lower if US/FR slip the 1pp tripwire.
+    synth-german: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  # v0.9.4 (#327): dual-injection — pool the anchor at the postcode AND inject it at position 0
+  # (an order-independent cue), to fix the anchor's positional harm on international word order.
+  inject_first_token: true
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v094-de-dualanchor-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 20000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.9.4-de-dualanchor-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/model.py
+++ b/corpus-python/src/mailwoman_train/model.py
@@ -163,6 +163,7 @@ class MailwomanCoarseEncoder(nn.Module):
         locale_loss_weight: float = 0.0,
         use_postcode_anchor: bool = False,
         anchor_feature_dim: int = NUM_LOCALES + 2,
+        inject_first_token: bool = False,
     ) -> None:
         super().__init__()
         self.pad_token_id = pad_token_id
@@ -197,6 +198,9 @@ class MailwomanCoarseEncoder(nn.Module):
         # with that FiLM cleanly — anchor at the INPUT, FiLM on the hidden states after the blocks).
         self.use_postcode_anchor = use_postcode_anchor
         self.anchor_feature_dim = int(anchor_feature_dim) if use_postcode_anchor else 0
+        # Dual-injection (#327): also place the pooled anchor at position 0. Only meaningful with the
+        # anchor on; harmlessly ignored otherwise.
+        self.inject_first_token = bool(inject_first_token) and use_postcode_anchor
         # v0.3.0 additions: CRF decoder for structural validity + learned tag dynamics,
         # label smoothing on the per-token CE leg for calibration. Both gate-able for
         # ablation studies via the kwargs above.
@@ -402,6 +406,21 @@ class MailwomanCoarseEncoder(nn.Module):
                 )
             anchor_vec = self.anchor_projection(anchor_features.to(h.dtype)) + self.anchor_token_embedding
             h = h + anchor_confidence.to(h.dtype).unsqueeze(-1) * anchor_vec
+            if self.inject_first_token:
+                # Dual-injection (#327, v0.9.4): ALSO inject the pooled anchor at position 0 — an
+                # order-INDEPENDENT global cue the locality can attend back to regardless of where the
+                # postcode sits. Pool each sequence by its max-confidence token (the postcode span) via
+                # gather (ONNX-clean), scale by that confidence so an all-zero (no-anchor) sequence stays
+                # the EXACT c=0 identity, and add it only at position 0 (functional cat, no in-place).
+                conf = anchor_confidence.to(h.dtype)
+                max_conf, max_idx = conf.max(dim=1)  # (B,), (B,)
+                idx = max_idx.view(bsz, 1, 1).expand(bsz, 1, h.shape[-1])  # (B, 1, hidden)
+                pooled_vec = anchor_vec.gather(1, idx).squeeze(1)  # (B, hidden) — the postcode token's anchor_vec
+                pos0_add = (max_conf.unsqueeze(-1) * pooled_vec).unsqueeze(1)  # (B, 1, hidden)
+                # Place it ONLY at position 0 via a position-0 indicator broadcast — avoids a dynamic
+                # `seq-1` cat that trips the ONNX opset version-converter. (1, S, 1) × (B, 1, hidden).
+                pos_indicator = (torch.arange(seq, device=h.device) == 0).to(h.dtype).view(1, seq, 1)
+                h = h + pos0_add * pos_indicator
         elif anchor_features is not None:
             raise ValueError(
                 "anchor_features supplied but use_postcode_anchor=False — rebuild the "
@@ -662,6 +681,7 @@ class MailwomanCoarseEncoder(nn.Module):
             # the flag to materialize anchor_projection / anchor_token_embedding at the feature width.
             "use_postcode_anchor": bool(self.use_postcode_anchor),
             "anchor_feature_dim": int(self.anchor_feature_dim),
+            "inject_first_token": bool(self.inject_first_token),
             "id2label": dict(ID_TO_LABEL),
             "label2id": dict(LABEL_TO_ID),
         }
@@ -712,6 +732,7 @@ class MailwomanCoarseEncoder(nn.Module):
             # Postcode-anchor fields. Default off for back-compat with pre-anchor checkpoints.
             use_postcode_anchor=cfg.get("use_postcode_anchor", False),
             anchor_feature_dim=cfg.get("anchor_feature_dim", NUM_LOCALES + 2),
+            inject_first_token=cfg.get("inject_first_token", False),
         )
         # Use weights_only=True if available (torch 2.4+) to avoid pickle-arbitrary-code warning.
         try:
@@ -764,6 +785,7 @@ def build_model(cfg: Config, vocab_size: int, pad_token_id: int) -> MailwomanCoa
         # over the locale set) + 2 (centroid) — single source of truth, can't drift from the loader.
         use_postcode_anchor=getattr(cfg.model, "use_postcode_anchor", False),
         anchor_feature_dim=NUM_LOCALES + 2,
+        inject_first_token=getattr(cfg.model, "inject_first_token", False),
     )
 
 

--- a/corpus-python/src/mailwoman_train/test_anchor_channel.py
+++ b/corpus-python/src/mailwoman_train/test_anchor_channel.py
@@ -85,3 +85,49 @@ def test_save_load_round_trips_the_channel():
     assert reloaded.use_postcode_anchor and reloaded.anchor_feature_dim == ANCHOR_DIM
     got = reloaded(ids, attention_mask=mask, anchor_features=feats, anchor_confidence=conf).logits
     assert torch.allclose(got, expected, atol=1e-5)
+
+
+# --- Dual-injection (#327, v0.9.4): the SAME anchor also at position 0 -------------------------------
+
+def _dual_fixture():
+    """A dual-injection model sharing a single-injection model's weights (flag is the ONLY difference)."""
+    torch.manual_seed(0)
+    single = MailwomanCoarseEncoder(**_COMMON, use_postcode_anchor=True, inject_first_token=False).eval()
+    dual = MailwomanCoarseEncoder(**_COMMON, use_postcode_anchor=True, inject_first_token=True).eval()
+    dual.load_state_dict(single.state_dict())  # identical weights; differ only in the injection
+    ids = torch.randint(1, 100, (2, 8))
+    mask = torch.ones(2, 8, dtype=torch.long)
+    feats = torch.randn(2, 8, ANCHOR_DIM)
+    return single, dual, ids, mask, feats
+
+
+def test_dual_injection_zero_confidence_is_exact_identity():
+    """The load-bearing property must survive dual-injection: c=0 everywhere → exact no-anchor identity
+    (the max-confidence gate makes the position-0 add 0 when there's no anchor)."""
+    _, dual, ids, mask, feats = _dual_fixture()
+    with_zero = dual(ids, attention_mask=mask, anchor_features=feats, anchor_confidence=torch.zeros(2, 8))
+    no_anchor = dual(ids, attention_mask=mask)
+    assert torch.equal(with_zero.logits, no_anchor.logits)
+
+
+def test_dual_injection_adds_a_position0_signal():
+    """With a TRAILING-postcode anchor, dual-injection changes emissions vs per-token-only (same weights)
+    — the order-independent position-0 cue that per-token injection lacked."""
+    single, dual, ids, mask, feats = _dual_fixture()
+    conf = torch.zeros(2, 8)
+    conf[:, 5] = 1.0  # postcode trails the city (the international-order failure case)
+    s = single(ids, attention_mask=mask, anchor_features=feats, anchor_confidence=conf).logits
+    d = dual(ids, attention_mask=mask, anchor_features=feats, anchor_confidence=conf).logits
+    assert (s - d).abs().max() > 1e-4
+
+
+def test_inject_first_token_round_trips_and_needs_anchor():
+    """The flag persists through save/load, and is inert (False) without the anchor."""
+    _, dual, *_ = _dual_fixture()
+    with tempfile.TemporaryDirectory() as d:
+        dual.save_pretrained(d)
+        reloaded = MailwomanCoarseEncoder.from_pretrained(pathlib.Path(d)).eval()
+    assert reloaded.inject_first_token is True
+    # inert without use_postcode_anchor
+    off = MailwomanCoarseEncoder(**_COMMON, use_postcode_anchor=False, inject_first_token=True)
+    assert off.inject_first_token is False


### PR DESCRIPTION
The #327 fork, taken (DeepSeek delegated authority + signed off dual-injection). v0.9.2 (both-order) and v0.9.3 (region-tail) both left the anchor-on international gap flat — the corpus lever is exhausted and three lines agree the ceiling is the anchor's **structure** (anchor-off order-agnostic ~48%; DE=1.0 posterior no-op; region tail moves region-tagging not locality). PIP-containment confirms the intl gap is a **real geographic miss** (57% vs native 96%), not a name artifact.

**Dual-injection:** `model.inject_first_token` pools the per-token anchor (gather by max-confidence = the postcode span) and ALSO injects it at position 0 — an order-independent global cue the locality attends back to. Gated by max-confidence so the c=0 identity holds. **No corpus / data / inference change**, no new parameters (param_count unchanged), the ONNX captures it. +3 tests (c=0 identity survives dual, position-0 signal fires on a trailing postcode, save/load); export verified equivalent to the per-token baseline. Same v0.4.3-de-regiontail corpus, one flag.

Training launched (`ap-Gxz98bZDTS32pnHNQpE8xO`). Gate: anchor-on intl ≥ native − 10pp, native/US/FR held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)