### PR TITLE
feat(demo): span-highlight visualizer — tint the raw input by parse confidence (S34)

### DIFF
--- a/docs/src/components/ResultPanel/ResultPanel.tsx
+++ b/docs/src/components/ResultPanel/ResultPanel.tsx
@@ -4,6 +4,7 @@ import { DemoResult } from "../../shared/resources.tsx"
 import { CandidatePicker } from "../CandidatePicker/CandidatePicker.tsx"
 import { FailureDiagnostic } from "../FailureDiagnostic/FailureDiagnostic.tsx"
 import { KindBadge } from "../KindBadge/KindBadge.tsx"
+import { SpanHighlight } from "../SpanHighlight/SpanHighlight.tsx"
 
 import styles from "./styles.module.css"
 
@@ -76,6 +77,7 @@ export const ResultPanel: React.FC<ResultPanelProps> = ({ result, selectedCandid
 				</details>
 			) : null}
 			{showXml && xml ? <CodeBlock language="xml">{xml}</CodeBlock> : null}
+			<SpanHighlight input={result.input} nodes={result.nodes} />
 			<table className={styles.componentTable}>
 				<thead>
 					<tr>

--- a/docs/src/components/SpanHighlight/SpanHighlight.tsx
+++ b/docs/src/components/SpanHighlight/SpanHighlight.tsx
@@ -1,0 +1,95 @@
+import type { ResultNode } from "../../shared/resources.tsx"
+
+import styles from "./styles.module.css"
+
+export interface SpanHighlightProps {
+	/** The raw text handed to the parser — `nodes[].start/end` index into this. */
+	input: string
+	/** Flattened parse nodes; only those with numeric `start`/`end` are rendered. */
+	nodes: ResultNode[]
+}
+
+type Segment = { text: string; node: ResultNode | null }
+
+/** ConfidenceCell's tiers, verbatim — keep these thresholds and the swatch colours in sync. */
+function tier(confidence?: number): "high" | "mid" | "low" {
+	if (confidence == null) return "mid"
+	return confidence >= 0.8 ? "high" : confidence >= 0.5 ? "mid" : "low"
+}
+
+/**
+ * Render the raw input as a displaCy-style ribbon: each character span the parser tagged is tinted
+ * by its confidence (red→amber→green, the same tiering as the table's ConfidenceCell) and labelled
+ * with its tag underneath. Delimiters and any unparsed characters fall through as plain text, so a
+ * dropped span reads as a literal gap in the colour. Returns null when no node carries offsets
+ * (older models, or an all-O parse) — the table alone still tells the story.
+ */
+export const SpanHighlight: React.FC<SpanHighlightProps> = ({ input, nodes }) => {
+	if (!input) return null
+
+	// Keep only well-formed spans that actually index into the input.
+	const spans = nodes.filter(
+		(n): n is ResultNode & { start: number; end: number } =>
+			typeof n.start === "number" &&
+			typeof n.end === "number" &&
+			n.start >= 0 &&
+			n.end > n.start &&
+			n.end <= input.length
+	)
+	if (spans.length === 0) return null
+
+	// Per-character owner = the most specific (shortest) span covering it. Robust to any parent/child
+	// span nesting the tree hands us — the leaf always wins, so every character renders once.
+	const owner = new Array<number>(input.length).fill(-1)
+	for (let i = 0; i < input.length; i++) {
+		let best = -1
+		let bestLen = Infinity
+		for (let s = 0; s < spans.length; s++) {
+			const sp = spans[s]
+			if (i >= sp.start && i < sp.end && sp.end - sp.start < bestLen) {
+				bestLen = sp.end - sp.start
+				best = s
+			}
+		}
+		owner[i] = best
+	}
+
+	// Coalesce runs of the same owner into segments.
+	const segments: Segment[] = []
+	let from = 0
+	for (let i = 1; i <= input.length; i++) {
+		if (i === input.length || owner[i] !== owner[from]) {
+			segments.push({ text: input.slice(from, i), node: owner[from] === -1 ? null : spans[owner[from]] })
+			from = i
+		}
+	}
+
+	return (
+		<div className={styles.spanHighlight}>
+			<div className={styles.legend}>
+				<span>confidence</span>
+				<span className={`${styles.swatch} ${styles.low}`} /> low
+				<span className={`${styles.swatch} ${styles.mid}`} /> mid
+				<span className={`${styles.swatch} ${styles.high}`} /> high
+			</div>
+			<div className={styles.track}>
+				{segments.map((seg, i) =>
+					seg.node ? (
+						<span
+							key={i}
+							className={`${styles.seg} ${styles[tier(seg.node.confidence)]}`}
+							title={`${seg.node.tag}${seg.node.confidence != null ? ` · ${seg.node.confidence.toFixed(2)}` : ""}`}
+						>
+							<span className={styles.segText}>{seg.text}</span>
+							<span className={styles.segTag}>{seg.node.tag}</span>
+						</span>
+					) : (
+						<span key={i} className={styles.gap}>
+							{seg.text}
+						</span>
+					)
+				)}
+			</div>
+		</div>
+	)
+}

--- a/docs/src/components/SpanHighlight/styles.module.css
+++ b/docs/src/components/SpanHighlight/styles.module.css
@@ -1,0 +1,98 @@
+/* displaCy-style span ribbon. Each tagged span is a column: the raw text on top (tinted by the
+   confidence tier — colours mirror ResultPanel's .conf_high/_mid/_low) and the tag label beneath.
+   Gaps (delimiters, unparsed chars) fall through as plain inline text so a dropped span is visible
+   as a literal break in the colour. */
+
+.spanHighlight {
+	margin: 0.5rem 0 1rem 0;
+}
+
+.legend {
+	display: flex;
+	align-items: center;
+	gap: 0.35rem;
+	font-size: 0.7rem;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--ifm-color-emphasis-600);
+	margin-bottom: 0.5rem;
+}
+
+.swatch {
+	display: inline-block;
+	width: 0.8rem;
+	height: 0.8rem;
+	border-radius: 2px;
+	margin-left: 0.4rem;
+}
+
+.track {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-end;
+	row-gap: 1.5rem;
+	padding: 0.5rem 0.6rem;
+	border: 1px solid var(--ifm-color-emphasis-200);
+	border-radius: 6px;
+	background: var(--ifm-background-surface-color);
+	font-family: var(--ifm-font-family-monospace);
+	font-size: 0.9rem;
+	line-height: 1.4;
+}
+
+.seg {
+	display: inline-flex;
+	flex-direction: column;
+	align-items: stretch;
+}
+
+.segText {
+	padding: 0.05rem 0.1rem;
+	border-bottom: 2px solid transparent;
+	white-space: pre;
+}
+
+.segTag {
+	margin-top: 0.15rem;
+	font-size: 0.6rem;
+	line-height: 1;
+	text-align: center;
+	letter-spacing: 0.02em;
+	color: var(--ifm-color-emphasis-600);
+	white-space: nowrap;
+}
+
+.gap {
+	display: inline-flex;
+	align-items: flex-start;
+	white-space: pre;
+	color: var(--ifm-color-emphasis-500);
+}
+
+/* Tier tints — keep in sync with ResultPanel .conf_high/_mid/_low. */
+.high .segText {
+	background: rgba(26, 168, 77, 0.18);
+	border-bottom-color: #1aa84d;
+}
+
+.mid .segText {
+	background: rgba(230, 168, 0, 0.18);
+	border-bottom-color: #e6a800;
+}
+
+.low .segText {
+	background: rgba(216, 80, 74, 0.18);
+	border-bottom-color: #d8504a;
+}
+
+.swatch.high {
+	background: #1aa84d;
+}
+
+.swatch.mid {
+	background: #e6a800;
+}
+
+.swatch.low {
+	background: #d8504a;
+}

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -395,6 +395,7 @@ const DemoApp: React.FC = () => {
 				const wofLookup = await ensureLookup()
 				if (!wofLookup) {
 					setResult({
+						input: text,
 						tree,
 						nodes,
 						resolved: null,
@@ -425,6 +426,7 @@ const DemoApp: React.FC = () => {
 				// clearing stale marker/bbox AND rendering the new selection.
 				setSelectedCandidateIndex(0)
 				setResult({
+					input: text,
 					tree,
 					nodes,
 					resolved: candidates[0] ?? null,
@@ -651,18 +653,29 @@ async function runCascade(
 	return usable(await lookup.findPlace({ text: rawText, country: "US", limit: 5 }))
 }
 
-function flattenTree(tree: unknown): Array<{ tag: string; value?: unknown; confidence?: number }> {
-	const out: Array<{ tag: string; value?: unknown; confidence?: number }> = []
+type TreeNode = {
+	tag?: string
+	value?: unknown
+	confidence?: number
+	start?: number
+	end?: number
+	children?: unknown[]
+}
+
+function flattenTree(
+	tree: unknown
+): Array<{ tag: string; value?: unknown; confidence?: number; start?: number; end?: number }> {
+	const out: Array<{ tag: string; value?: unknown; confidence?: number; start?: number; end?: number }> = []
 	const roots = (tree as { roots?: unknown[] } | null | undefined)?.roots ?? []
-	const stack = [...(roots as Array<{ tag?: string; value?: unknown; confidence?: number; children?: unknown[] }>)]
+	const stack = [...(roots as TreeNode[])]
 	while (stack.length) {
 		const n = stack.pop()!
 		if (typeof n.tag === "string") {
-			out.push({ tag: n.tag, value: n.value, confidence: n.confidence })
+			out.push({ tag: n.tag, value: n.value, confidence: n.confidence, start: n.start, end: n.end })
 		}
 		if (Array.isArray(n.children)) {
 			for (const c of n.children) {
-				stack.push(c as { tag?: string; value?: unknown; confidence?: number; children?: unknown[] })
+				stack.push(c as TreeNode)
 			}
 		}
 	}

--- a/docs/src/shared/resources.tsx
+++ b/docs/src/shared/resources.tsx
@@ -55,9 +55,15 @@ export interface ResultNode {
 	tag: string
 	value?: unknown
 	confidence?: number
+	/** Inclusive start char offset into `DemoResult.input`, when the decoder emits one. */
+	start?: number
+	/** Exclusive end char offset into the raw input. */
+	end?: number
 }
 
 export interface DemoResult {
+	/** The raw text handed to the parser — the offsets in `nodes[].start/end` index into this string. */
+	input: string
 	tree: unknown
 	nodes: ResultNode[]
 	resolved: ResolvedHit | null


### PR DESCRIPTION
## What

A displaCy-style **span ribbon** above the demo's component table: the parsed address rendered as the raw input, with each tagged character span tinted by its confidence (red→amber→green — the exact tiering the table's `ConfidenceCell` already uses) and labelled with its tag underneath. Delimiters and any unparsed characters fall through as plain text, so a **dropped span reads as a literal gap in the colour**. The parse is legible at a glance, and low-confidence spans jump out without reading every number.

This is **S34** from the night-shift plan's demo-refinement tier — the highest-value of the bunch.

## How

The decoder's `AddressNode` already carries char offsets (`start`/`end` into the raw input — see `core/decoder/types.ts`); the demo's `flattenTree` was simply dropping them. The change:

- Thread `start`/`end` through `flattenTree` + `ResultNode`.
- Stash the raw `input` on `DemoResult` (the offsets index into it).
- New `SpanHighlight` component renders the ribbon. Per-character owner = the most specific (shortest) covering span, so any parent/child span nesting resolves to the **leaf** and every character renders exactly once.

It **degrades gracefully**: returns `null` when no node carries offsets (older models, or an all-O parse), so the table alone still tells the story.

## Safety

- Additive only — the component table, the resolved `dl`, and the map are untouched.
- The e2e fixture selects `tbody tr` and `dt`/`dd` (`test/e2e/fixtures/DemoFixture.ts`); the ribbon is `<div>/<span>` and matches neither.
- `yarn tsc --noEmit` clean; Prettier clean.
- Segmentation logic validated standalone across clean / nested / dropped-span / no-offset / out-of-range cases (reconstruct == input in every case; leaf-wins on nesting; graceful null).

## Screenshot

_The CI docs build renders it; visual is a tinted run per component (`350` `5th Ave` `New York` `NY` `10118`) with tag labels beneath and commas/spaces as plain gaps._

🤖 Generated with [Claude Code](https://claude.com/claude-code)