### PR TITLE
feat(demo): per-stage timing breakdown panel (S37)

### DIFF
--- a/docs/src/components/ResultPanel/ResultPanel.tsx
+++ b/docs/src/components/ResultPanel/ResultPanel.tsx
@@ -5,6 +5,7 @@ import { CandidatePicker } from "../CandidatePicker/CandidatePicker.tsx"
 import { FailureDiagnostic } from "../FailureDiagnostic/FailureDiagnostic.tsx"
 import { KindBadge } from "../KindBadge/KindBadge.tsx"
 import { SpanHighlight } from "../SpanHighlight/SpanHighlight.tsx"
+import { TimingPanel } from "../TimingPanel/TimingPanel.tsx"
 
 import styles from "./styles.module.css"
 
@@ -98,6 +99,7 @@ export const ResultPanel: React.FC<ResultPanelProps> = ({ result, selectedCandid
 					))}
 				</tbody>
 			</table>
+			{result.timing ? <TimingPanel timing={result.timing} /> : null}
 			{selected ? (
 				<>
 					<div className={styles.resolved}>

--- a/docs/src/components/TimingPanel/TimingPanel.tsx
+++ b/docs/src/components/TimingPanel/TimingPanel.tsx
@@ -1,0 +1,61 @@
+import type { StageTiming } from "../../shared/resources.tsx"
+
+import styles from "./styles.module.css"
+
+export interface TimingPanelProps {
+	timing: StageTiming
+}
+
+const STAGES: Array<{ key: keyof StageTiming; label: string; cls: string }> = [
+	{ key: "shape", label: "shape + kind", cls: styles.shape },
+	{ key: "classify", label: "classify", cls: styles.classify },
+	{ key: "resolve", label: "resolve", cls: styles.resolve },
+]
+
+function fmt(ms: number): string {
+	return ms >= 100 ? `${Math.round(ms)} ms` : `${ms.toFixed(1)} ms`
+}
+
+/**
+ * Per-stage timing breakdown for a parse — a stacked bar (shape+kind / classify / resolve) sized by
+ * each stage's wall-clock, with a small legend showing the split in ms. Companion to the
+ * FailureDiagnostic: turns the demo into a teaching tool (you see the model inference dominate) and
+ * surfaces perf regressions at a glance. The DB-load cost is deliberately excluded — only the
+ * per-parse cascade is timed.
+ */
+export const TimingPanel: React.FC<TimingPanelProps> = ({ timing }) => {
+	const present = STAGES.filter((s) => typeof timing[s.key] === "number") as Array<(typeof STAGES)[number]>
+	const total = present.reduce((sum, s) => sum + (timing[s.key] as number), 0)
+	if (total <= 0) return null
+
+	return (
+		<div className={styles.timingPanel}>
+			<div className={styles.heading}>
+				Timing <span className={styles.total}>{fmt(total)} total</span>
+			</div>
+			<div className={styles.bar}>
+				{present.map((s) => {
+					const ms = timing[s.key] as number
+					const pct = (ms / total) * 100
+					// Floor the rendered width so a sub-millisecond stage stays visible as a sliver.
+					return (
+						<div
+							key={s.key}
+							className={`${styles.seg} ${s.cls}`}
+							style={{ width: `${Math.max(pct, 1.5)}%` }}
+							title={`${s.label}: ${fmt(ms)}`}
+						/>
+					)
+				})}
+			</div>
+			<div className={styles.legend}>
+				{present.map((s) => (
+					<span key={s.key} className={styles.legendItem}>
+						<span className={`${styles.swatch} ${s.cls}`} />
+						{s.label} <span className={styles.legendMs}>{fmt(timing[s.key] as number)}</span>
+					</span>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/docs/src/components/TimingPanel/styles.module.css
+++ b/docs/src/components/TimingPanel/styles.module.css
@@ -1,0 +1,76 @@
+/* Per-stage timing breakdown — a stacked bar sized by each stage's wall-clock, plus a legend.
+   Stage colours are distinct hues (NOT the confidence red/amber/green — these encode pipeline
+   stage, not quality). */
+
+.timingPanel {
+	margin: 1rem 0;
+	font-size: 0.8rem;
+}
+
+.heading {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--ifm-color-emphasis-700);
+	margin-bottom: 0.35rem;
+}
+
+.total {
+	font-family: var(--ifm-font-family-monospace);
+	text-transform: none;
+	letter-spacing: 0;
+	color: var(--ifm-color-emphasis-600);
+}
+
+.bar {
+	display: flex;
+	width: 100%;
+	height: 0.7rem;
+	border-radius: 4px;
+	overflow: hidden;
+	background: var(--ifm-color-emphasis-200);
+}
+
+.seg {
+	height: 100%;
+}
+
+.legend {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.25rem 1rem;
+	margin-top: 0.4rem;
+	color: var(--ifm-color-emphasis-700);
+}
+
+.legendItem {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
+}
+
+.legendMs {
+	font-family: var(--ifm-font-family-monospace);
+	color: var(--ifm-color-emphasis-600);
+}
+
+.swatch {
+	display: inline-block;
+	width: 0.7rem;
+	height: 0.7rem;
+	border-radius: 2px;
+}
+
+.shape {
+	background: #3578e5;
+}
+
+.classify {
+	background: #8b5cf6;
+}
+
+.resolve {
+	background: #14b8a6;
+}

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -383,10 +383,13 @@ const DemoApp: React.FC = () => {
 					import("@mailwoman/query-shape"),
 					import("@mailwoman/kind-classifier"),
 				])
+				const tStart = performance.now()
 				const queryShape = computeQueryShape(text)
 				const kindResult = classifyKindSync({ raw: text, normalized: text }, queryShape)
+				const tShape = performance.now()
 
 				const tree = await classifier.parse(text, { queryShape, fst: fstMatcher ?? undefined })
+				const tClassify = performance.now()
 				const nodes = flattenTree(tree)
 				const localityNode = nodes.find((n) => n.tag === "locality" || n.tag === "city")
 				const stateNode = nodes.find((n) => n.tag === "region" || n.tag === "state")
@@ -404,13 +407,17 @@ const DemoApp: React.FC = () => {
 						kindResult,
 						fstActive: fstMatcher !== null,
 						fstProvenance,
+						timing: { shape: tShape - tStart, classify: tClassify - tShape },
 					})
 					return
 				}
 
 				// Cascade: postcode first (most precise), fall back to locality, then raw text.
 				// Drop (lat=0, lon=0) hits — WOF ships placeholder zeros on ~22% of US postcodes.
+				// Timed from here so the one-time DB load above doesn't skew the resolve number.
+				const tBeforeResolve = performance.now()
 				const cascadeHits = await runCascade(wofLookup, postcodeNode, localityNode, text)
+				const tResolve = performance.now()
 				const candidates: ResolvedHit[] = cascadeHits.map((c) => ({
 					id: c.id,
 					name: c.name,
@@ -435,6 +442,7 @@ const DemoApp: React.FC = () => {
 					kindResult,
 					fstActive: fstMatcher !== null,
 					fstProvenance,
+					timing: { shape: tShape - tStart, classify: tClassify - tShape, resolve: tResolve - tBeforeResolve },
 				})
 			} catch (parsingError) {
 				console.error("Error parsing input", parsingError)

--- a/docs/src/shared/resources.tsx
+++ b/docs/src/shared/resources.tsx
@@ -61,6 +61,16 @@ export interface ResultNode {
 	end?: number
 }
 
+/** Per-stage wall-clock for one parse (ms). `resolve` is absent when the lookup is skipped. */
+export interface StageTiming {
+	/** QueryShape + kind classification (pure, ~µs). */
+	shape: number
+	/** Neural BIO classify + tree decode — the model inference. */
+	classify: number
+	/** WOF cascade lookup. Excludes the one-time DB load. */
+	resolve?: number
+}
+
 export interface DemoResult {
 	/** The raw text handed to the parser — the offsets in `nodes[].start/end` index into this string. */
 	input: string
@@ -70,6 +80,8 @@ export interface DemoResult {
 	candidates: ResolvedHit[]
 	stateHint?: string
 	kindResult?: KindResult
+	/** Per-stage timing for the breakdown panel; absent on older render paths. */
+	timing?: StageTiming
 	fstActive: boolean
 	fstProvenance?: FstProvenanceLike | null
 }


### PR DESCRIPTION
## What

A **timing breakdown** under the parsed components: a stacked bar (shape+kind / classify / resolve) sized by each stage's wall-clock, with a legend in ms and a total. The neural inference (`classify`) visibly dominates — it turns the demo into a teaching tool and surfaces perf regressions at a glance, the companion to the existing `FailureDiagnostic`.

This is **S37** from the night-shift plan's demo tier — the "visualizer breakdown of the results" the operator asked for.

## How

The demo pipeline didn't expose timing, so we measure it where the stages already run in the demo, with `performance.now()`:

- `shape` — QueryShape + kind classification (pure, ~µs)
- `classify` — the neural BIO classify + tree decode (the model)
- `resolve` — the WOF cascade lookup

The **one-time DB load is deliberately excluded** from the resolve number — the clock starts right before `runCascade`, so a cold first lookup doesn't skew it. `StageTiming` rides on `DemoResult.timing`; the no-lookup path reports `shape`/`classify` only, and `TimingPanel` renders `null` when timing is absent.

## Safety

- Additive — the component table, resolved `dl`, and map are untouched; the e2e fixture selectors (`tbody tr`, `dt`/`dd`) don't match the panel.
- `yarn tsc --noEmit` clean; Prettier clean.
- Stage colours are distinct hues (blue/purple/teal), intentionally NOT the confidence red/amber/green — these encode pipeline stage, not quality.

Stacks cleanly on #338 (the S34 span highlight), already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)