### PR TITLE
feat(demo): copy-result-as-JSON button (S40)

### DIFF
--- a/docs/src/components/ResultPanel/ResultPanel.tsx
+++ b/docs/src/components/ResultPanel/ResultPanel.tsx
@@ -39,6 +39,7 @@ export interface ResultPanelProps {
 export const ResultPanel: React.FC<ResultPanelProps> = ({ result, selectedCandidateIndex, onSelectCandidate }) => {
 	const [showXml, setShowXml] = useState(false)
 	const [xml, setXml] = useState<string | null>(null)
+	const [copied, setCopied] = useState(false)
 	const selected = result.candidates[selectedCandidateIndex] ?? result.candidates[0] ?? null
 
 	const onToggle = useCallback(async () => {
@@ -51,13 +52,62 @@ export const ResultPanel: React.FC<ResultPanelProps> = ({ result, selectedCandid
 		setShowXml(true)
 	}, [xml, result.tree])
 
+	// Copy the parse + resolve as a clean JSON object — the thing a developer actually wants to paste
+	// into an issue or a test. Mirrors PermalinkButton's clipboard-with-textarea-fallback + 1.5s tick.
+	const onCopy = useCallback(async () => {
+		const payload = {
+			input: result.input,
+			components: result.nodes.map((n) => ({
+				tag: n.tag,
+				value: n.value ?? null,
+				confidence: n.confidence ?? null,
+				start: n.start ?? null,
+				end: n.end ?? null,
+			})),
+			resolved: selected
+				? {
+						name: selected.name,
+						placetype: selected.placetype,
+						id: selected.id,
+						lat: selected.lat,
+						lon: selected.lon,
+						score: selected.score,
+					}
+				: null,
+		}
+		const json = JSON.stringify(payload, null, 2)
+		try {
+			await navigator.clipboard.writeText(json)
+		} catch {
+			const ta = document.createElement("textarea")
+			ta.value = json
+			ta.style.position = "fixed"
+			ta.style.opacity = "0"
+			document.body.appendChild(ta)
+			ta.select()
+			try {
+				document.execCommand("copy")
+			} catch {
+				/* nothing more we can do */
+			}
+			document.body.removeChild(ta)
+		}
+		setCopied(true)
+		window.setTimeout(() => setCopied(false), 1500)
+	}, [result, selected])
+
 	return (
 		<div className={styles.resultPanel}>
 			<div className={styles.resultHeader}>
 				<h2>Parsed components</h2>
-				<button type="button" className={styles.debugBtn} onClick={onToggle}>
-					{showXml ? "Hide XML" : "Show XML"}
-				</button>
+				<div className={styles.resultActions}>
+					<button type="button" className={styles.debugBtn} onClick={onCopy}>
+						{copied ? "✓ Copied" : "Copy JSON"}
+					</button>
+					<button type="button" className={styles.debugBtn} onClick={onToggle}>
+						{showXml ? "Hide XML" : "Show XML"}
+					</button>
+				</div>
 			</div>
 			{result.kindResult ? <KindBadge kindResult={result.kindResult} /> : null}
 			{result.fstActive ? (

--- a/docs/src/components/ResultPanel/styles.module.css
+++ b/docs/src/components/ResultPanel/styles.module.css
@@ -55,6 +55,11 @@
 	justify-content: space-between;
 }
 
+.resultActions {
+	display: flex;
+	gap: 0.4rem;
+}
+
 .debugBtn {
 	font-size: 0.75rem;
 	padding: 0.2rem 0.5rem;


### PR DESCRIPTION
## What

A **Copy JSON** button beside "Show XML" in the result header. It copies the parse + resolve as a clean object — `input`, `components` (each with tag / value / confidence / char offsets), and the `resolved` place — so a developer can paste it straight into an issue or a test fixture.

This is **S40** from the night-shift demo tier. The rest of S40 turned out already-covered: the address input is a `<form>` (Enter submits) and `SplashScreen` handles the loading state — so the copy button is the one genuinely-new polish win.

## How

Mirrors `PermalinkButton`'s clipboard-with-`textarea`-fallback and 1.5s confirmation tick (`Copy JSON` → `✓ Copied`). The two header buttons are grouped in a `.resultActions` flex row.

## Safety

- Additive, demo-only. `yarn tsc --noEmit` clean; Prettier clean.
- Rebased onto the #339-inclusive `main`, so the diff is the copy button alone and CI tests the real combined demo (span highlight + timing panel + copy button).

Completes the demo-refinement tier requested this shift: span highlight (#338), timing breakdown (#339), copy JSON (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)