### PR TITLE
docs(shift): finalize night-7 postmortem — arc concluded + demo tier

### DIFF
--- a/docs/articles/evals/2026-06-06-night-7-postmortem.md
+++ b/docs/articles/evals/2026-06-06-night-7-postmortem.md
@@ -1,6 +1,8 @@
-# Night Shift 7 — 2026-06-06 (order robustness: ship the v0.9.2 both-order retrain)
+# Night Shift 7 — 2026-06-06 (order-robustness arc, concluded — plus a demo-refinement tier)
 
-_Draft, written as the shift runs. Numbers self-emitted; the v0.9.2 result lands at the gate (~05:00 UTC)._
+_Final. Numbers self-emitted. The shift opened on a single question — does both-order training close the German
+international-order gap? — and closed it across three retrains; the back half turned to the demo-refinement
+tier the operator asked for once DeepSeek (delegated authority) called "no more GPU."_
 
 ## What shipped
 
@@ -22,18 +24,45 @@ _Draft, written as the shift runs. Numbers self-emitted; the v0.9.2 result lands
   tail the eval feeds — the v0.9.3 fix.
 - **#326 — v0.9.2 eval report** (merged). The 2×2 + the anchor-vs-word-order finding + the region-tail
   mechanism. Issue **#327** filed for the v0.9.3 direction.
-- **DeepSeek consult (2 turns)** — pressure-tested the anchor-vs-word-order mechanism and signed off
-  region-tail as the v0.9.3 single variable. A posterior-ablation diagnostic it suggested (force DE=1.0)
-  left v0.9.2 intl at 44.5% → the anchor harm is **structural-positional, not posterior**. Designed v0.9.4
-  (dual-injection anchor: inject at the postcode AND the first token) as the fallback if v0.9.3 leaves a gap.
-- **#328 — v0.9.3 region-tail** (merged, trained, evaluated, **not shipped**). International German renders
-  `City, Region Postcode` now. **Clean negative:** ≈ v0.9.2 on every locality metric (native off/on 48.3/83.6
-  beats Pelias, intl off/on 47.1/44.7, US 97.2 / FR 84.9 held). The region tail did exactly its job —
+- **DeepSeek consult (3 turns, delegated authority)** — turn 1–2 pressure-tested the anchor-vs-word-order
+  mechanism, signed off region-tail as the v0.9.3 single variable, and prescribed a posterior-ablation
+  diagnostic (force DE=1.0) that left v0.9.2 intl at 44.5% → the anchor harm is **structural-positional, not
+  posterior**; it designed v0.9.4 (dual-injection) as the fallback. Turn 3, after v0.9.4 also failed, **made
+  the strategic call** (the operator was away and had delegated authority for the shift): accept the asymmetry,
+  no more GPU, and the multi-locale plan survives via a country-conditioned anchor. See #337.
+- **#328 / #329 — v0.9.3 region-tail** (merged, trained, evaluated, **not shipped**). International German
+  renders `City, Region Postcode` now. **Clean negative:** ≈ v0.9.2 on every locality metric (native off/on
+  48.3/83.6 beats Pelias, intl off/on 47.1/44.7, US 97.2 / FR 84.9 held). The region tail did exactly its job —
   international region-match 0% → ~40%, Berlin intl-loc 34.4→38.7 — but locality stayed flat. The anchor-on
   intl gap (38.9pp) is the anchor's **positional** harm, not the corpus (the posterior diagnostic already
-  ruled out feature content). **The corpus lever is exhausted for the anchor-on intl gap.** → v0.9.4
-  (dual-injection anchor), staged for the operator (3 iterations deep, none promoted; a change to the anchor
-  mechanism, not data).
+  ruled out feature content). **The corpus lever is exhausted for the anchor-on intl gap.** → v0.9.4.
+- **#334 / #336 — v0.9.4 dual-injection** (merged, trained, evaluated, **not shipped**). DeepSeek's signed-off
+  architectural fix: pool the anchor and inject it _also_ at position 0, an order-independent cue (no new
+  params, `c=0` identity holds, 8/8 anchor tests, ONNX-export-equivalent). It did **nothing** to the intl gap
+  (native off/on 48.3/83.5, intl off/on 47.3/43.7, US 96.4 / FR 84.9 held). Three retrains, one immovable
+  number (~44%). The anchor's native-help (+35) / intl-hurt (−4) asymmetry is **fundamental** — not corpus,
+  not region, not injection position.
+- **#337 — the anchor fork, RESOLVED** (merged). With the operator away, the third DeepSeek turn (delegated
+  authority) made the call: **(b) accept the asymmetry, burn no more GPU.** Its mechanistic read reframes the
+  multi-locale plan — the anchor's direction is _learned per locale_ from the dominant training order, so the
+  next thread is a **country-conditioned anchor vector**, not another tuning pass. Decision record in
+  `2026-06-06-v0.9.2-eval.md` §"accept the asymmetry".
+- **Multi-locale tooling (#332 / #333 / #335)** — `build-locale-shard.mjs` rebuilt registry-driven, with a
+  streaming Algorithm-R reservoir so FR/US-scale OA CSVs (2.5 GB+) sample without OOM; NL postcode
+  normalization; and **Italy OA data acquired** (468 MB countrywide, durable backup on `/mnt/playpen`). DE / NL
+  / FR / IT are shard-ready. ES has no clean OA countrywide aggregate (the `es/countrywide` _source_ exists but
+  its built results 404; the rest is per-municipality numeric keys) → a documented follow-up, not a clean win.
+- **Demo-refinement tier (#338 / #339 / #340)** — the operator's "visualizer breakdown + polish" ask, shipped
+  in three additive demo PRs once GPU was off the table:
+  - **#338 (S34) — span-highlight visualizer.** The raw input rendered as a displaCy-style ribbon, each tagged
+    span tinted by its confidence (the table's red→amber→green tiering) with the tag labelled beneath; dropped
+    spans read as literal colour gaps. The decoder already carried char offsets — `flattenTree` was dropping
+    them.
+  - **#339 (S37) — per-stage timing breakdown.** A stacked bar (shape+kind / classify / resolve) sized by each
+    stage's wall-clock; the neural inference visibly dominates. Measured in the demo via `performance.now()`,
+    the one-time DB load excluded so resolve isn't skewed.
+  - **#340 (S40) — copy-result-as-JSON.** A "Copy JSON" button that yields a clean paste-into-an-issue object
+    (input + components with offsets + resolved place). Enter-submit and the loading splash already existed.
 
 ## What went well
 
@@ -42,6 +71,12 @@ _Draft, written as the shift runs. Numbers self-emitted; the v0.9.2 result lands
   the anchor's role.
 - **The corpus pipeline mirrored v0.4.1-de exactly** — overlay manifest, base shards by reference, no
   rebuild of 677M rows. Clean, fast, verified on the volume before launch.
+- **Pivoting cleanly when GPU was called off.** DeepSeek's "(b), no more GPU" verdict could have read as a dead
+  end; instead it freed the back half for the demo tier the operator had explicitly asked for. Three small
+  additive PRs, each typechecked + logic-validated + e2e-safe, none touching the v0.6.0 production path.
+- **The demo work degraded gracefully by design.** `SpanHighlight` and `TimingPanel` both render `null` when
+  their data is absent (older models with no offsets, an all-O parse), so the table alone always tells the
+  story — no new failure surface.
 
 ## What could've gone better
 
@@ -51,6 +86,13 @@ _Draft, written as the shift runs. Numbers self-emitted; the v0.9.2 result lands
 - **The generalized builder (S3) hit real walls** I should have anticipated: FR's OA CSV is 2.5 GB (over
   the 1 GB buffer → needs streaming + reservoir sampling), NL's template reformats the postcode. DE-parity
   is proven; the rest is held, honestly documented, not half-shipped.
+- **The demo tier serialized on merges.** S34/S37/S40 each touch `ResultPanel.tsx`, so each waited on the
+  previous to merge before it could branch cleanly (the last one rebased onto the prior). It worked, but a
+  single demo PR bundling all three would have spent less wall-clock on merge-poll loops. Worth batching
+  same-file UI changes next time.
+- **I couldn't visually verify the demo in-shift.** The ribbon/timing/copy UI only renders after a real parse
+  (60 MB of model + WOF assets), so I leaned on `tsc` + the docs build + standalone segmentation tests rather
+  than an actual screenshot. Sound, but the operator should eyeball the deployed demo — flagged below.
 
 ## Decisions made autonomously
 
@@ -95,29 +137,44 @@ _Draft, written as the shift runs. Numbers self-emitted; the v0.9.2 result lands
   order check. None of v0.9.2/3/4 promote; v0.6.0 stays production. The operator can revisit the next-thread
   choice; the shift's experimental arc is closed. _(Decision record: `2026-06-06-v0.9.2-eval.md`, §"accept the
   asymmetry"; #327.)_
+- **The next anchor thread is the country-conditioned vector** — pick when you're ready. The shift mapped the
+  ground and #327 now tracks it; it gates the multi-locale retrain program, so it's the lever before any
+  ES/IT/NL/FR retrain. A cheap no-GPU interim (route international-order inputs to the `c=0` path via a
+  lightweight order check) is filed there too.
+- **Eyeball the deployed demo.** The span ribbon / timing bar / copy button were validated by `tsc` + the docs
+  build + standalone tests, but not by an in-shift screenshot (they only render after a real 60 MB parse).
+  A 30-second look at the live demo confirms the visuals land.
+- **The demo's service-worker cache (S38) is the operator's other explicit ask, not yet started.** Today the
+  ~60 MB bundle is HTTP-cache-only ("the browser caches everything" — fragile, no offline, no version
+  awareness). Next session: evaluate `@docusaurus/plugin-pwa` vs a hand-rolled Cache API, precache
+  `model.onnx` + `tokenizer.model` + `wof-hot.db` **keyed by `selectedVersion`** (evict old blobs on switch).
+  Deserves its own focused session with real browser testing — too easy to half-ship at end-of-shift.
 - **FR (#330):** the FR gap is venue (0%) + region (19%) — convention gaps, not basics. Worth a targeted FR
   venue+region corpus supplement on the next multi-locale push?
 - The 19 high + 1 critical dependabot alerts (vitest dev-scope) — bump in a dedicated `chore(deps)` pass?
 
 ## Concrete next steps
 
-- **Decide the #327 fork** → if dual-injection: implement the position-0 anchor in `encode_row` +
-  `anchor-inference.ts` (config-flagged), retrain, gate via `de-order-eval.sh`.
+- **Country-conditioned anchor (#327):** a per-locale anchor direction (DE specializes on postcode-before-city,
+  US on postcode-after-city), so no shared vector is forced to compromise. Its own gate via `de-order-eval.sh`.
+  The interim no-GPU lever (order-check → `c=0` route) is the cheap first move.
+- **Multi-locale shards:** DE / NL / FR / IT are shard-ready via `build-locale-shard.mjs`. ES needs the OA
+  `es/` source-key index discovered first (no clean countrywide aggregate; `es/countrywide` results 404).
+- **Demo S38 — service-worker precache** for the ~60 MB bundle, keyed by `selectedVersion` (see above).
 - **FR (#330):** assemble a venue+region FR shard (real OSM/WOF POIs + FR région forms), measure with
   `per-locale-f1.ts`.
-- **Multi-locale tooling:** finish `build-locale-shard.mjs` (streaming + reservoir for FR/US-scale CSVs;
-  per-source region; NL postcode normalization) — the gating piece for ES/IT/NL/FR shards (#241).
 
 ## Numbers
 
-| metric | value |
-| --- | --- |
-| Shift window | 04:16 UTC → 14:00 UTC |
-| PRs merged | 11 — #323-326, #328, #329, #331-335 |
-| Issues filed / groomed | #327 (anchor fork), #330 (FR gap) / #239, #241 |
-| Models trained | 3 (v0.9.2 both-order, v0.9.3 region-tail, v0.9.4 dual-injection — all 20k, all negative) |
-| Modal spend | ~$12 of $15 _(3 runs)_ |
-| DeepSeek consults | 1 (2 turns, + the posterior-ablation diagnostic it prescribed) |
-| NaN incidents | 0 |
-| CI failures | 0 |
-| Demo regressions | 0 (v0.9.x research line; v0.6.0 production untouched) |
+| metric                  | value                                                                                     |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| Shift window            | 04:16 UTC → 14:00 UTC                                                                     |
+| PRs merged              | 18 — #321-326, #328-329, #331-340 (3 demo: #338 S34, #339 S37, #340 S40)                  |
+| Issues filed / resolved | #327 anchor fork **RESOLVED** (b, DeepSeek delegated authority), #330 FR gap / #239, #241 |
+| Models trained          | 3 (v0.9.2 both-order, v0.9.3 region-tail, v0.9.4 dual-injection — all 20k, all negative)  |
+| Modal spend             | ~$12 of $15 _(3 runs; GPU called off after v0.9.4)_                                       |
+| DeepSeek consults       | 1 session, 3 turns (turn 3 = the delegated-authority decision) + the posterior diagnostic |
+| Data acquired           | Italy OA countrywide (468 MB); DE/NL/FR/IT shard-ready                                    |
+| NaN incidents           | 0                                                                                         |
+| CI failures             | 0                                                                                         |
+| Demo regressions        | 0 (v0.9.x research line + additive demo tier; v0.6.0 production untouched)                |


### PR DESCRIPTION
Finalizes the night-7 shift artifact. The order-robustness arc closed across three retrains (v0.9.2/3/4, all negative on the anchor-on international gap); DeepSeek — holding delegated authority — resolved the #327 fork (accept the asymmetry, no more GPU). The back half delivered the demo-refinement tier the operator asked for.

**Updated:** What shipped (v0.9.4 #334/#336, the decision #337, multi-locale tooling + Italy data #332/#333/#335, the demo tier #338/#339/#340), the 3-turn DeepSeek consult, lessons (serial-merge friction, in-shift visual-verify gap), next steps re-pointed at the country-conditioned anchor (#327) + demo S38 service-worker cache, and the numbers (18 PRs, 3 models, ~\$12/\$15, 0 NaN, 0 CI failures, v0.6.0 untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)