### PR TITLE
feat(demo): containment hierarchy tree view (S35)

### DIFF
--- a/docs/src/components/ResultPanel/ResultPanel.tsx
+++ b/docs/src/components/ResultPanel/ResultPanel.tsx
@@ -6,6 +6,7 @@ import { FailureDiagnostic } from "../FailureDiagnostic/FailureDiagnostic.tsx"
 import { KindBadge } from "../KindBadge/KindBadge.tsx"
 import { SpanHighlight } from "../SpanHighlight/SpanHighlight.tsx"
 import { TimingPanel } from "../TimingPanel/TimingPanel.tsx"
+import { TreeView } from "../TreeView/TreeView.tsx"
 
 import styles from "./styles.module.css"
 
@@ -150,6 +151,12 @@ export const ResultPanel: React.FC<ResultPanelProps> = ({ result, selectedCandid
 				</tbody>
 			</table>
 			{result.timing ? <TimingPanel timing={result.timing} /> : null}
+			{(result.tree as { roots?: unknown[] } | null)?.roots?.length ? (
+				<details className={styles.hierarchyDetails}>
+					<summary>Hierarchy</summary>
+					<TreeView tree={result.tree} />
+				</details>
+			) : null}
 			{selected ? (
 				<>
 					<div className={styles.resolved}>

--- a/docs/src/components/ResultPanel/styles.module.css
+++ b/docs/src/components/ResultPanel/styles.module.css
@@ -60,6 +60,20 @@
 	gap: 0.4rem;
 }
 
+.hierarchyDetails {
+	margin: 0.5rem 0 1rem 0;
+	font-size: 0.9rem;
+}
+
+.hierarchyDetails > summary {
+	cursor: pointer;
+	user-select: none;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	font-size: 0.8rem;
+	color: var(--ifm-color-emphasis-700);
+}
+
 .debugBtn {
 	font-size: 0.75rem;
 	padding: 0.2rem 0.5rem;

--- a/docs/src/components/TreeView/TreeView.tsx
+++ b/docs/src/components/TreeView/TreeView.tsx
@@ -1,0 +1,55 @@
+import styles from "./styles.module.css"
+
+/** The slice of the decoder's AddressNode the demo renders. `children` carries the containment
+nesting. */
+interface TreeNode {
+	tag?: string
+	value?: unknown
+	confidence?: number
+	children?: TreeNode[]
+}
+
+export interface TreeViewProps {
+	/** The parser's `AddressTree` (`result.tree`) — we read `.roots` and recurse `.children`. */
+	tree: unknown
+}
+
+/** ConfidenceCell's tiers, verbatim. */
+function tier(confidence?: number): "high" | "mid" | "low" {
+	if (confidence == null) return "mid"
+	return confidence >= 0.8 ? "high" : confidence >= 0.5 ? "mid" : "low"
+}
+
+function renderNode(node: TreeNode, path: string): React.ReactNode {
+	if (typeof node.tag !== "string") return null
+	const kids = Array.isArray(node.children) ? node.children : []
+	return (
+		<li key={path} className={styles.node}>
+			<span className={styles.row}>
+				<span className={`${styles.tag} ${styles[tier(node.confidence)]}`}>{node.tag}</span>
+				{node.value != null && String(node.value) !== "" ? (
+					<span className={styles.value}>{String(node.value)}</span>
+				) : null}
+				{typeof node.confidence === "number" ? <span className={styles.conf}>{node.confidence.toFixed(2)}</span> : null}
+			</span>
+			{kids.length ? <ul className={styles.children}>{kids.map((c, i) => renderNode(c, `${path}.${i}`))}</ul> : null}
+		</li>
+	)
+}
+
+/**
+ * The parse as a containment tree — `region ⊃ locality ⊃ {street ⊃ house_number, postcode}` — the
+ * nesting the flat component table throws away. Each node shows its tag (tinted by confidence, same
+ * red→amber→green as the table), value, and score. Reads the decoder's
+ * `AddressTree.roots`/`children` directly; renders null when the tree is empty so nothing shows for
+ * an unparseable input.
+ */
+export const TreeView: React.FC<TreeViewProps> = ({ tree }) => {
+	const roots = (tree as { roots?: unknown[] } | null | undefined)?.roots
+	if (!Array.isArray(roots) || roots.length === 0) return null
+	return (
+		<ul className={`${styles.children} ${styles.treeView}`}>
+			{(roots as TreeNode[]).map((n, i) => renderNode(n, String(i)))}
+		</ul>
+	)
+}

--- a/docs/src/components/TreeView/styles.module.css
+++ b/docs/src/components/TreeView/styles.module.css
@@ -1,0 +1,62 @@
+/* Containment tree for the parse — nested lists with a guide rail per level. Tag tint mirrors
+   ResultPanel's .conf_high/_mid/_low (confidence), value + score in monospace. */
+
+.treeView {
+	margin: 0.5rem 0 0 0;
+}
+
+.children {
+	list-style: none;
+	margin: 0;
+	padding-left: 1.1rem;
+}
+
+/* Nested levels get a guide rail; the outermost list sits flush. */
+.children .children {
+	border-left: 1px solid var(--ifm-color-emphasis-300);
+	margin-left: 0.3rem;
+}
+
+.node {
+	margin: 0.15rem 0;
+}
+
+.row {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	font-size: 0.85rem;
+}
+
+.tag {
+	font-weight: 600;
+	padding: 0 0.3rem;
+	border-radius: 3px;
+	border-bottom: 2px solid transparent;
+}
+
+.value {
+	font-family: var(--ifm-font-family-monospace);
+}
+
+.conf {
+	font-family: var(--ifm-font-family-monospace);
+	font-size: 0.75rem;
+	color: var(--ifm-color-emphasis-600);
+}
+
+/* Tier tints — keep in sync with ResultPanel .conf_high/_mid/_low. */
+.high {
+	background: rgba(26, 168, 77, 0.18);
+	border-bottom-color: #1aa84d;
+}
+
+.mid {
+	background: rgba(230, 168, 0, 0.18);
+	border-bottom-color: #e6a800;
+}
+
+.low {
+	background: rgba(216, 80, 74, 0.18);
+	border-bottom-color: #d8504a;
+}


### PR DESCRIPTION
## What

The parse rendered as the **containment tree** it actually is — `region ⊃ locality ⊃ {street ⊃ house_number, postcode}` — the nesting the flat component table throws away. Each node shows its tag (tinted by confidence, the same red→amber→green as the table), value, and score, with a guide rail per level.

This is **S35** from the night-shift demo tier. It lives in a collapsed `<details>` below the table, so it enriches the result without cluttering the default view.

## How

Reads the decoder's `AddressTree.roots` / `children` directly — `result.tree` already carries the full nesting; `flattenTree` was the only thing discarding it (the containment rules live in `core/decoder/containment.ts`). Renders `null` for an empty tree.

## Safety

- Additive, demo-only — the component table, resolved `dl`, and the e2e selectors (`tbody tr`, `dt`/`dd`) are untouched.
- `yarn tsc --noEmit` clean; Prettier clean.

Rounds out the demo-refinement tier: span highlight (#338), timing (#339), copy JSON (#340), and now the hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)