### PR TITLE
feat: inference-side anchor channel — make v0.9 anchor models runnable end-to-end (#240)

### DIFF
--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -49,6 +49,7 @@ const EXAMPLE_ADDRESSES: Array<{ label: string; address: string }> = [
 	{ label: "Wrigley Field", address: "1060 W Addison St, Chicago, IL 60613" },
 	{ label: "Space Needle", address: "400 Broad St, Seattle, WA 98109" },
 	{ label: "ZIP only", address: "90210" },
+	{ label: "Berlin (native order)", address: "Straußstraße 27, 12623 Berlin" },
 ]
 
 const BASEMAP_TILEJSON_URL = "https://tiles.sister.software/basemap-v4.json"
@@ -62,6 +63,8 @@ interface ReleaseInfo {
 	steps: number
 	hasFst: boolean
 	hasWofDb: boolean
+	/** Anchor-trained bundle (#239/#240) — ships postcode-*.bin so the demo feeds the postcode anchor. */
+	hasAnchor?: boolean
 }
 
 interface ReleasesManifest {
@@ -227,6 +230,16 @@ const DemoApp: React.FC = () => {
 					tokenizerUrl: assetUrl(DEFAULT_LOCALE, selectedVersion, "tokenizer.model"),
 					modelCardUrl: assetUrl(DEFAULT_LOCALE, selectedVersion, "model-card.json"),
 					runner: { useWebGpu: !forceWasm },
+					// Anchor-trained bundles (v4.0.0+) ship postcode binaries so the demo feeds the postcode
+					// anchor — US + DE cover the demo's example set (incl. the native-order Berlin case).
+					...(release?.hasAnchor
+						? {
+								postcodeBinaryUrls: [
+									assetUrl(DEFAULT_LOCALE, selectedVersion, "postcode-us.bin"),
+									assetUrl(DEFAULT_LOCALE, selectedVersion, "postcode-de.bin"),
+								],
+							}
+						: {}),
 				})
 				setActiveBackend(
 					diagnostics

--- a/neural-web/loader.ts
+++ b/neural-web/loader.ts
@@ -13,7 +13,12 @@
  *   files; for a static deploy, copy them into the public bundle and pass the resulting URLs.
  */
 
-import { MailwomanTokenizer, NeuralAddressClassifier } from "@mailwoman/neural/browser"
+import {
+	type AnchorLookup,
+	MailwomanTokenizer,
+	NeuralAddressClassifier,
+	PostcodeBinaryResolver,
+} from "@mailwoman/neural/browser"
 
 import { WebOnnxRunner, type WebOnnxRunnerDiagnostics, type WebOnnxRunnerOpts } from "./web-onnx-runner.js"
 
@@ -46,8 +51,42 @@ export interface LoadFromUrlsOpts {
 	modelCardUrl?: string
 	/** Runner options (WebGPU toggle, fixed sequence length, WASM path override). */
 	runner?: WebOnnxRunnerOpts
+	/**
+	 * URLs to one or more PCB1 postcode binaries (`postcode-<cc>.bin`). For anchor-trained models
+	 * (#239/#240) these are decoded + merged into the postcode→anchor lookup the classifier feeds at
+	 * inference, so the demo runs the model with the anchor on. Pass the locales the model handles
+	 * (e.g. US + DE). Omit for plain models — the runner then feeds the anchor-off identity.
+	 */
+	postcodeBinaryUrls?: readonly string[]
 	/** Optional fetch override. Defaults to `globalThis.fetch`. */
 	fetchImpl?: typeof fetch
+}
+
+/** Merge per-binary anchor lookups: union the country posteriors per postcode, mean the centroids. */
+function mergeAnchorLookups(lookups: readonly AnchorLookup[]): AnchorLookup {
+	if (lookups.length === 1) return lookups[0]!
+	const merged: AnchorLookup = new Map()
+	for (const lookup of lookups) {
+		for (const [postcode, entry] of lookup) {
+			const existing = merged.get(postcode)
+			if (!existing) {
+				merged.set(postcode, { posterior: { ...entry.posterior }, lat: entry.lat, lon: entry.lon })
+				continue
+			}
+			for (const country of Object.keys(entry.posterior)) existing.posterior[country] = 1
+			// Average a real centroid in; ignore (0,0) placeholders.
+			if (entry.lat !== 0 || entry.lon !== 0) {
+				if (existing.lat === 0 && existing.lon === 0) {
+					existing.lat = entry.lat
+					existing.lon = entry.lon
+				} else {
+					existing.lat = (existing.lat + entry.lat) / 2
+					existing.lon = (existing.lon + entry.lon) / 2
+				}
+			}
+		}
+	}
+	return merged
 }
 
 /**
@@ -67,15 +106,23 @@ export async function loadNeuralClassifierFromUrls(opts: LoadFromUrlsOpts): Prom
 		opts.modelCardUrl ? fetchLabelsFromModelCard(opts.modelCardUrl, fetchImpl) : Promise.resolve(null),
 	])
 
-	const [tokenizer, runner] = await Promise.all([
+	const [tokenizer, runner, postcodeAnchorLookup] = await Promise.all([
 		MailwomanTokenizer.loadFromBase64(toBase64(tokenizerBytes)),
 		WebOnnxRunner.fromBytes(modelBytes, opts.runner),
+		opts.postcodeBinaryUrls?.length
+			? Promise.all(
+					opts.postcodeBinaryUrls.map(async (url) =>
+						new PostcodeBinaryResolver(await fetchBytes(url, fetchImpl)).toAnchorLookup()
+					)
+				).then(mergeAnchorLookups)
+			: Promise.resolve<AnchorLookup | undefined>(undefined),
 	])
 
 	const classifier = new NeuralAddressClassifier({
 		tokenizer,
 		runner,
 		...(labels ? { labels } : {}),
+		...(postcodeAnchorLookup ? { postcodeAnchorLookup } : {}),
 	})
 	await runner.infer([0])
 	return { classifier, diagnostics: runner.diagnostics, labels }

--- a/neural-web/web-onnx-runner.ts
+++ b/neural-web/web-onnx-runner.ts
@@ -22,7 +22,7 @@
  *   `@mailwoman/neural/onnx-runner` for the full export contract this file mirrors.
  */
 
-import type { InferResult, NeuralRunner } from "@mailwoman/neural/browser"
+import { ANCHOR_FEATURE_DIM, type InferResult, type NeuralRunner } from "@mailwoman/neural/browser"
 import * as ort from "onnxruntime-web/webgpu"
 
 export interface WebOnnxRunnerOpts {
@@ -118,7 +118,10 @@ export class WebOnnxRunner implements NeuralRunner {
 		return this.#loadPromise
 	}
 
-	async infer(tokenIds: number[]): Promise<InferResult> {
+	async infer(
+		tokenIds: number[],
+		anchor?: { features: ReadonlyArray<ReadonlyArray<number>>; confidence: ReadonlyArray<number> }
+	): Promise<InferResult> {
 		const session = await this.#ensureSession()
 		const seqLen = Math.min(tokenIds.length, this.fixedSeqLen)
 		const padded = new BigInt64Array(this.fixedSeqLen)
@@ -131,6 +134,30 @@ export class WebOnnxRunner implements NeuralRunner {
 		const feeds: Record<string, ort.Tensor> = {
 			input_ids: new ort.Tensor("int64", padded, [1, this.fixedSeqLen]),
 			attention_mask: new ort.Tensor("int64", mask, [1, this.fixedSeqLen]),
+		}
+
+		// Anchor channel (#239/#240) — mirror of the node OnnxRunner. Feed the per-piece anchor when the
+		// caller supplies it; otherwise, for anchor-trained models (whose ONNX declares the inputs as
+		// mandatory), feed zeros — the confidence=0 identity / anchor-off path. Without this the session
+		// throws on the missing required inputs.
+		if (anchor) {
+			const dim = anchor.features[0]?.length ?? 0
+			const af = new Float32Array(this.fixedSeqLen * dim)
+			const ac = new Float32Array(this.fixedSeqLen)
+			for (let i = 0; i < seqLen; i++) {
+				ac[i] = anchor.confidence[i] ?? 0
+				const row = anchor.features[i]
+				if (row) for (let d = 0; d < dim; d++) af[i * dim + d] = row[d] ?? 0
+			}
+			feeds.anchor_features = new ort.Tensor("float32", af, [1, this.fixedSeqLen, dim])
+			feeds.anchor_confidence = new ort.Tensor("float32", ac, [1, this.fixedSeqLen])
+		} else if (session.inputNames.includes("anchor_features")) {
+			feeds.anchor_features = new ort.Tensor("float32", new Float32Array(this.fixedSeqLen * ANCHOR_FEATURE_DIM), [
+				1,
+				this.fixedSeqLen,
+				ANCHOR_FEATURE_DIM,
+			])
+			feeds.anchor_confidence = new ort.Tensor("float32", new Float32Array(this.fixedSeqLen), [1, this.fixedSeqLen])
 		}
 
 		const output = await session.run(feeds)

--- a/neural/browser.ts
+++ b/neural/browser.ts
@@ -13,6 +13,10 @@
 export * from "./classifier.js"
 export * from "./labels.js"
 export * from "./tokenizer.js"
+// Browser-safe anchor channel (#239/#240): the pure-JS feature builder + the postcode binary resolver
+// (zero-dep) the demo wires together to feed the anchor at inference.
+export * from "./anchor-inference.js"
+export * from "./postcode-binary-resolver.js"
 // Type-only re-export so callers can still type `InferResult` from the browser entry without
 // the implementation module being pulled into the bundle.
 export type { InferResult } from "./onnx-runner.js"

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -19,15 +19,15 @@ import {
 	type ComponentTag,
 	type DecoderToken,
 } from "@mailwoman/core/decoder"
+import { buildAnchorFeatures, type AnchorLookup } from "./anchor-inference.js"
 import { buildFstEmissionPriors, type FstMatcherLike } from "./fst-prior.js"
 import { STAGE2_BIO_LABELS } from "./labels.js"
 import type { InferResult } from "./onnx-runner.js"
 import { repairPostcodeLabels } from "./postcode-repair.js"
-import { repairUnitLabels } from "./unit-repair.js"
 import { addEmissionMatrix, buildEmissionPriors, type QueryShapeLike } from "./query-shape-prior.js"
 import { buildStreetMorphologyEmissionPriors, type StreetMorphologyPriorOpts } from "./street-morphology-prior.js"
 import { MailwomanTokenizer } from "./tokenizer.js"
-import { buildAnchorFeatures, type AnchorLookup } from "./anchor-inference.js"
+import { repairUnitLabels } from "./unit-repair.js"
 import { buildBioEndMask, buildBioStartMask, buildBioTransitionMask, softmax, viterbi } from "./viterbi.js"
 import type { ResolveWeightsOpts, ResolvedWeights } from "./weights.js"
 
@@ -112,7 +112,9 @@ export class NeuralAddressClassifier {
 	 * by `@mailwoman/neural-web`. Calling this method in a browser will throw at runtime — use
 	 * `loadNeuralClassifierFromUrls` from `@mailwoman/neural-web` instead.
 	 */
-	static async loadFromWeights(opts: ResolveWeightsOpts = {}): Promise<NeuralAddressClassifier> {
+	static async loadFromWeights(
+		opts: ResolveWeightsOpts & { postcodeAnchorLookup?: AnchorLookup } = {}
+	): Promise<NeuralAddressClassifier> {
 		// /* webpackIgnore: true */ tells webpack to leave the dynamic import statement intact —
 		// it becomes a runtime native ESM import that resolves in Node (which has onnxruntime-node
 		// + node:fs) and throws cleanly in a browser if called. Without the directive, webpack
@@ -136,6 +138,7 @@ export class NeuralAddressClassifier {
 			transitions: crf?.transitions,
 			startTransitions: crf?.startTransitions,
 			endTransitions: crf?.endTransitions,
+			...(opts.postcodeAnchorLookup ? { postcodeAnchorLookup: opts.postcodeAnchorLookup } : {}),
 		})
 	}
 
@@ -379,11 +382,11 @@ export interface ParseOpts {
 	 */
 	postcodeRepair?: boolean
 	/**
-	 * When true, run the deterministic secondary-unit regex repair pass on the decoded label
-	 * sequence before tree-building. Detects designator-shaped substrings ("Apt 4B", "Ste 12",
-	 * "Unit 9400", bare "#104", …) and snaps/adds the unit span, fixing the unit-drop weakness the
-	 * three-arena capability eval surfaced (postal secondary-unit 0% neural). Off by default —
-	 * opt-in until the v0.7.2 arena re-run quantifies its delta. See `./unit-repair.ts`.
+	 * When true, run the deterministic secondary-unit regex repair pass on the decoded label sequence
+	 * before tree-building. Detects designator-shaped substrings ("Apt 4B", "Ste 12", "Unit 9400",
+	 * bare "#104", …) and snaps/adds the unit span, fixing the unit-drop weakness the three-arena
+	 * capability eval surfaced (postal secondary-unit 0% neural). Off by default — opt-in until the
+	 * v0.7.2 arena re-run quantifies its delta. See `./unit-repair.ts`.
 	 */
 	unitRepair?: boolean
 }

--- a/neural/onnx-runner.ts
+++ b/neural/onnx-runner.ts
@@ -16,6 +16,8 @@
 import { promises as fs } from "node:fs"
 import ort from "onnxruntime-node"
 
+import { ANCHOR_FEATURE_DIM } from "./anchor-inference.js"
+
 export interface OnnxRunnerOpts {
 	/** If true, load the model immediately in `create()`. Default false. */
 	warmup?: boolean
@@ -90,8 +92,8 @@ export class OnnxRunner {
 	 * @param tokenIds The id sequence produced by the tokenizer (no special tokens added).
 	 * @param anchor Optional postcode-anchor channel (#239/#240). When supplied (only for anchor
 	 *   models — exported with the `anchor_features`/`anchor_confidence` inputs), per-piece features
-	 *   `(seqLen × dim)` + confidence `(seqLen,)` are fed, zero-padded to `fixedSeqLen`. Omit for plain
-	 *   models, whose ONNX has no anchor inputs.
+	 *   `(seqLen × dim)` + confidence `(seqLen,)` are fed, zero-padded to `fixedSeqLen`. Omit for
+	 *   plain models, whose ONNX has no anchor inputs.
 	 */
 	async infer(
 		tokenIds: number[],
@@ -122,6 +124,16 @@ export class OnnxRunner {
 			}
 			feeds.anchor_features = new ort.Tensor("float32", af, [1, this.fixedSeqLen, dim])
 			feeds.anchor_confidence = new ort.Tensor("float32", ac, [1, this.fixedSeqLen])
+		} else if (session.inputNames.includes("anchor_features")) {
+			// Anchor-trained model (its ONNX declares the anchor inputs as mandatory) but no anchor data
+			// was supplied: feed zeros. That's the `confidence = 0` identity — the model's anchor-off
+			// behavior. Without it the session throws on the missing required inputs.
+			feeds.anchor_features = new ort.Tensor("float32", new Float32Array(this.fixedSeqLen * ANCHOR_FEATURE_DIM), [
+				1,
+				this.fixedSeqLen,
+				ANCHOR_FEATURE_DIM,
+			])
+			feeds.anchor_confidence = new ort.Tensor("float32", new Float32Array(this.fixedSeqLen), [1, this.fixedSeqLen])
 		}
 
 		const output = await session.run(feeds)

--- a/neural/postcode-binary-resolver.ts
+++ b/neural/postcode-binary-resolver.ts
@@ -24,6 +24,7 @@
  *   convention.
  */
 
+import type { AnchorLookup } from "./anchor-inference.js"
 import type { PostcodePlace } from "./postcode-anchor.js"
 
 const MAGIC = 0x31_42_43_50 // "PCB1" little-endian (P=0x50 C=0x43 B=0x42 1=0x31)
@@ -159,6 +160,64 @@ export class PostcodeBinaryResolver {
 				lat: this.#view.getInt16(base + 1, true) / LAT_Q,
 				lon: this.#view.getInt16(base + 3, true) / LON_Q,
 			})
+		}
+		return out
+	}
+
+	/**
+	 * Decode the whole binary into an {@link AnchorLookup} (`Map<postcode, AnchorEntry>`) for the
+	 * neural anchor channel (#239/#240): each postcode → a uniform posterior over its member
+	 * countries
+	 *
+	 * - The mean of its non-zero centroids. This is the browser-side equivalent of the pilot
+	 *   postcode→anchor lookup the model trained against, built live from the shipped binary instead
+	 *   of a precomputed JSON. Records are stored sorted by (postcode, country), so equal keys are
+	 *   contiguous.
+	 */
+	toAnchorLookup(): AnchorLookup {
+		const out: AnchorLookup = new Map()
+		let i = 0
+		while (i < this.#count) {
+			// Decode this record's postcode key (ASCII, 0x00-right-padded).
+			const keyBase = this.#recBase + i * this.#recSize
+			let postcode = ""
+			for (let j = 0; j < this.#keyWidth; j++) {
+				const c = this.#buf[keyBase + j]!
+				if (c === 0) break
+				postcode += String.fromCharCode(c)
+			}
+			// Walk the contiguous run of records sharing this key (one per member country).
+			const posterior: Record<string, number> = {}
+			let latSum = 0
+			let lonSum = 0
+			let centroidCount = 0
+			let k = i
+			for (; k < this.#count; k++) {
+				const base = this.#recBase + k * this.#recSize
+				let same = true
+				for (let j = 0; j < this.#keyWidth; j++) {
+					if (this.#buf[base + j] !== this.#buf[keyBase + j]) {
+						same = false
+						break
+					}
+				}
+				if (!same) break
+				const tail = base + this.#keyWidth
+				posterior[this.#countries[this.#buf[tail]!]!] = 1 // uniform — anchorFeatureVector renormalizes
+				const lat = this.#view.getInt16(tail + 1, true) / LAT_Q
+				const lon = this.#view.getInt16(tail + 3, true) / LON_Q
+				if (lat !== 0 || lon !== 0) {
+					latSum += lat
+					lonSum += lon
+					centroidCount++
+				}
+			}
+			out.set(postcode, {
+				posterior,
+				lat: centroidCount ? latSum / centroidCount : 0,
+				lon: centroidCount ? lonSum / centroidCount : 0,
+			})
+			i = k
 		}
 		return out
 	}

--- a/scripts/publish-release-to-hf.mjs
+++ b/scripts/publish-release-to-hf.mjs
@@ -118,12 +118,31 @@ async function main() {
 		console.error(`  ✓ ${f.remoteName}: ${localPath} (${(size / 1024 / 1024).toFixed(1)} MB)`)
 	}
 
+	// Optional postcode binaries for the anchor channel (#240): comma-separated --postcodes paths
+	// (e.g. postcode-us.bin,postcode-de.bin). Uploaded under the version dir by basename; the demo
+	// fetches them when the release's `hasAnchor` flag is set.
+	const postcodeBins = args.postcodes
+		? args.postcodes
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean)
+		: []
+	for (const localPath of postcodeBins) {
+		if (!existsSync(localPath) || statSync(localPath).size === 0) fail(`postcode binary ${localPath} missing/empty`)
+	}
+
 	// --- Phase 2: upload to bucket ---
 	const remoteBase = `${args.locale}/${args.version}`
 	for (const f of REQUIRED_FILES) {
 		const flagKey = f.flag.slice(2).replace(/-./g, (m) => m[1].toUpperCase())
 		const localPath = args[flagKey]
 		const dst = `${BUCKET_PATH}/${remoteBase}/${f.remoteName}`
+		console.error(`  → ${dst}`)
+		run("hf", ["buckets", "cp", localPath, dst])
+	}
+	for (const localPath of postcodeBins) {
+		const remoteName = localPath.split("/").pop()
+		const dst = `${BUCKET_PATH}/${remoteBase}/${remoteName}`
 		console.error(`  → ${dst}`)
 		run("hf", ["buckets", "cp", localPath, dst])
 	}
@@ -152,6 +171,7 @@ async function main() {
 		steps: args.steps ? parseInt(args.steps, 10) : 100000,
 		hasFst: true,
 		hasWofDb: true,
+		hasAnchor: postcodeBins.length > 0,
 	}
 
 	releases.releases = [newEntry, ...releases.releases.filter((r) => r.version !== args.version)]


### PR DESCRIPTION
The runtime + demo plumbing that lets an anchor-trained model (the v0.9 line, our 4.0.0 candidate) actually run with the anchor on. Without this, an anchor model throws `input 'anchor_features' is missing` on load and the demo can't use it at all.

## What
- **Runners** (`onnx-runner` + `web-onnx-runner`): feed the anchor when supplied; for anchor-trained models (whose ONNX declares the anchor inputs as mandatory) with no lookup, feed zeros — the confidence=0 identity / anchor-off path. Fixes the hard load failure.
- **`PostcodeBinaryResolver.toAnchorLookup()`**: decode the shipped PCB1 binary into an `AnchorLookup` (uniform posterior over each postcode's member countries + mean centroid) — the browser-side equivalent of the pilot lookup, built live from the binary. Round-trip verified (ambiguous `12345` → `{DE,US}`).
- **Demo wiring**: `loadNeuralClassifierFromUrls` gains `postcodeBinaryUrls` (fetch + merge → `postcodeAnchorLookup`); the demo gates it on a new `ReleaseInfo.hasAnchor` and loads US + DE so the example set (incl. a new native-order `Straußstraße 27, 12623 Berlin`) resolves its anchor.
- **`publish-release-to-hf.mjs`**: `--postcodes` uploads the binaries + flags `hasAnchor` in `releases.json`.
- **`browser.ts`**: export the anchor utils + resolver.

## Verified
- `yarn compile` + docs `tsc` clean.
- v0.9.3 int8 (quantized this session) parses all 6 US presets correctly; per-tag F1 is on par with v0.6.0 (no regression) — see the release thread.
- `toAnchorLookup()` round-trip checked by hand; a committed unit test is a quick follow-up.

Pairs with #347 (release reconcile + 4.0.0). Final visual confirm of the anchor-on demo is post-deploy (the demo needs the 60 MB asset bundle in a browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)