### PR TITLE
feat(demo): crisp admin-boundary polygons — second DB, drawn instead of the bbox

### DIFF
--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -65,6 +65,8 @@ interface ReleaseInfo {
 	hasWofDb: boolean
 	/** Anchor-trained bundle (#239/#240) — ships postcode-*.bin so the demo feeds the postcode anchor. */
 	hasAnchor?: boolean
+	/** Ships a `wof-polygons.db` sibling — the demo draws the crisp admin boundary instead of the bbox. */
+	hasPolygons?: boolean
 }
 
 interface ReleasesManifest {
@@ -128,6 +130,10 @@ const DemoApp: React.FC = () => {
 	const mapContainerRef = useRef<HTMLDivElement>(null)
 	const mapRef = useRef<MapLibreMap | null>(null)
 	const markerRef = useRef<{ remove: () => void } | null>(null)
+	// Lazily-loaded crisp-polygon DB (id → simplified admin geometry). Loaded once per version on the
+	// first resolve, reset when the selected version changes. Held as the in-flight promise so concurrent
+	// resolves share one fetch.
+	const polygonDbRef = useRef<Promise<PolygonDb> | null>(null)
 
 	// Sync ?q= when the operator edits the address. replaceState avoids polluting back-button
 	// history with every keystroke; only the latest state lands in the URL.
@@ -221,6 +227,7 @@ const DemoApp: React.FC = () => {
 				setFstProvenance(null)
 				setLookup(null)
 				setLookupLoader(null)
+				polygonDbRef.current = null
 				setResult(null)
 				setLoadingProgress(`Loading ${selectedVersion} model (~${release?.modelSize ?? "?"})…`)
 
@@ -348,6 +355,37 @@ const DemoApp: React.FC = () => {
 			const maplibre = await import("maplibre-gl")
 			const marker = new maplibre.Marker({ color: "#e0367c" }).setLngLat([candidate.lon, candidate.lat]).addTo(map)
 			markerRef.current = marker
+
+			// Prefer the crisp admin polygon (lazily-loaded sibling DB) over the bbox rectangle. The points
+			// DB only carries min/max lat-lon, so without this the map draws a box around the place; the
+			// polygon DB ships the real, simplified boundary keyed by the same WOF id.
+			const release = manifest?.releases.find((r) => r.version === selectedVersion)
+			if (release?.hasPolygons && selectedVersion && candidate.id) {
+				try {
+					if (!polygonDbRef.current) {
+						polygonDbRef.current = loadPolygonDb(assetUrl(DEFAULT_LOCALE, selectedVersion, "wof-polygons.db"))
+					}
+					const geom = (await polygonDbRef.current).get(candidate.id)
+					if (geom) {
+						drawPlaceGeometry(map, geom)
+						const gb = geomBounds(geom)
+						map.fitBounds(
+							[
+								[gb.minLon, gb.minLat],
+								[gb.maxLon, gb.maxLat],
+							],
+							{ padding: 40 }
+						)
+						return
+					}
+				} catch (err) {
+					// Postcodes (point geometry) and any id absent from the polygon DB land here — fall
+					// through to the bbox. Null the ref so a transient fetch failure can retry next resolve.
+					console.error("Crisp polygon unavailable; falling back to bbox", err)
+					polygonDbRef.current = null
+				}
+			}
+
 			const b = candidate.bbox
 			if (b && Math.max(b.maxLat - b.minLat, b.maxLon - b.minLon) > 0.001) {
 				drawBbox(map, b)
@@ -362,7 +400,7 @@ const DemoApp: React.FC = () => {
 				map.flyTo({ center: [candidate.lon, candidate.lat], zoom: 12 })
 			}
 		})()
-	}, [result, selectedCandidateIndex])
+	}, [result, selectedCandidateIndex, selectedVersion, manifest])
 
 	const ensureLookup = useCallback(async (): Promise<MailwomanLookupLike | null> => {
 		if (lookup) return lookup
@@ -588,23 +626,19 @@ function whenStyleReady(map: MapLibreMap, fn: () => void): void {
 	map.once("styledata", () => whenStyleReady(map, fn))
 }
 
-function drawBbox(map: MapLibreMap, bbox: { minLat: number; maxLat: number; minLon: number; maxLon: number }): void {
-	const ring: Array<[number, number]> = [
-		[bbox.minLon, bbox.minLat],
-		[bbox.maxLon, bbox.minLat],
-		[bbox.maxLon, bbox.maxLat],
-		[bbox.minLon, bbox.maxLat],
-		[bbox.minLon, bbox.minLat],
-	]
+/** A GeoJSON Polygon / MultiPolygon — what the polygon DB stores and the map draws as the place outline. */
+type PlaceGeometry =
+	| { type: "Polygon"; coordinates: number[][][] }
+	| { type: "MultiPolygon"; coordinates: number[][][][] }
+
+/**
+ * Shared source/layer plumbing for the resolved-place outline. Both the bbox rectangle and the crisp
+ * admin polygon funnel through here so they reuse one source (`setData` swaps the geometry in place).
+ */
+function setPlaceOutline(map: MapLibreMap, geometry: PlaceGeometry): void {
 	const geojson = {
 		type: "FeatureCollection" as const,
-		features: [
-			{
-				type: "Feature" as const,
-				geometry: { type: "Polygon" as const, coordinates: [ring] },
-				properties: {},
-			},
-		],
+		features: [{ type: "Feature" as const, geometry, properties: {} }],
 	}
 	whenStyleReady(map, () => {
 		const existing = map.getSource(BBOX_SOURCE) as { setData?: (g: unknown) => void } | undefined
@@ -626,6 +660,69 @@ function drawBbox(map: MapLibreMap, bbox: { minLat: number; maxLat: number; minL
 			paint: { "line-color": "#e0367c", "line-width": 2 },
 		})
 	})
+}
+
+function drawBbox(map: MapLibreMap, bbox: { minLat: number; maxLat: number; minLon: number; maxLon: number }): void {
+	const ring: number[][] = [
+		[bbox.minLon, bbox.minLat],
+		[bbox.maxLon, bbox.minLat],
+		[bbox.maxLon, bbox.maxLat],
+		[bbox.minLon, bbox.maxLat],
+		[bbox.minLon, bbox.minLat],
+	]
+	setPlaceOutline(map, { type: "Polygon", coordinates: [ring] })
+}
+
+/** Draw the crisp admin polygon straight from the polygon DB's GeoJSON geometry. */
+function drawPlaceGeometry(map: MapLibreMap, geometry: PlaceGeometry): void {
+	setPlaceOutline(map, geometry)
+}
+
+/** Bounding box of a Polygon / MultiPolygon, for fitBounds. Walks the nested coordinate arrays. */
+function geomBounds(geometry: PlaceGeometry): { minLon: number; minLat: number; maxLon: number; maxLat: number } {
+	let minLon = Infinity
+	let minLat = Infinity
+	let maxLon = -Infinity
+	let maxLat = -Infinity
+	const visit = (node: unknown): void => {
+		if (Array.isArray(node) && typeof node[0] === "number") {
+			const [lon, lat] = node as number[]
+			if (lon < minLon) minLon = lon
+			if (lon > maxLon) maxLon = lon
+			if (lat < minLat) minLat = lat
+			if (lat > maxLat) maxLat = lat
+			return
+		}
+		if (Array.isArray(node)) for (const child of node) visit(child)
+	}
+	visit(geometry.coordinates)
+	return { minLon, minLat, maxLon, maxLat }
+}
+
+/** id → simplified admin geometry, backed by the lazily-loaded `wof-polygons.db`. */
+interface PolygonDb {
+	get(id: number): PlaceGeometry | null
+}
+
+/**
+ * Open the crisp-polygon DB (a normal SQLite, built by scripts/build-wof-polygons.mjs) in sqlite-wasm
+ * and expose an id → geometry lookup. Reuses the resolver's loader — the file is just bytes to
+ * deserialize, with no schema coupling to the WOF resolver tables.
+ */
+async function loadPolygonDb(url: string): Promise<PolygonDb> {
+	const resolverWasm = await import("@mailwoman/resolver-wof-wasm")
+	const { db } = await resolverWasm.loadSlimWofDatabase({ source: url })
+	return {
+		get(id: number): PlaceGeometry | null {
+			const rows = db.selectObjects("SELECT geom FROM polygons WHERE id = ?", [id]) as Array<{ geom: string }>
+			if (rows.length === 0) return null
+			try {
+				return JSON.parse(rows[0].geom) as PlaceGeometry
+			} catch {
+				return null
+			}
+		},
+	}
 }
 
 function clearBbox(map: MapLibreMap): void {

--- a/scripts/build-wof-polygons.mjs
+++ b/scripts/build-wof-polygons.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build the crisp-polygon sibling of the points DB (build-wof-points). The demo's map draws the WOF
+ *   bounding RECTANGLE (`place_bbox`) today; this packs the real admin geometry — simplified — so the
+ *   demo can draw an actual boundary, loaded lazily only when a result is shown.
+ *
+ *   Source: the per-id WOF GeoJSON repos at
+ *   `repos/whosonfirst-data/whosonfirst-data-admin-<cc>/data/<id-sharded>/<id>.geojson`, where the
+ *   shard path is the id split into 3-char chunks (101909779 → 101/909/779/101909779.geojson). Only
+ *   ADMIN placetypes carry polygons; postcodes resolve to a point marker, so they're skipped. We pull
+ *   the in-scope ids straight from the already-built points DB so the two stay in lockstep.
+ *
+ *   Each ring is Douglas-Peucker simplified (default tol ~0.004° ≈ 400 m) to keep the file shippable —
+ *   admin polygons are huge at full resolution. Output: `polygons(id INTEGER PRIMARY KEY, geom TEXT)`
+ *   where geom is a GeoJSON geometry the demo feeds straight into a MapLibre source.
+ *
+ *   Usage: node scripts/build-wof-polygons.mjs --points <wof-hot.db> --out <wof-polygons.db> [--tol 0.004]
+ */
+
+import { existsSync, readFileSync, rmSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+
+const REPOS = "/mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data"
+const ADMIN_PLACETYPES = new Set(["locality", "localadmin", "region", "county", "borough", "macroregion", "country"])
+
+function parseArgs() {
+	const a = process.argv.slice(2)
+	const o = { points: "", output: "", tol: 0.004 }
+	for (let i = 0; i < a.length; i++) {
+		if (a[i] === "--points") o.points = a[++i]
+		else if (a[i] === "--out") o.output = a[++i]
+		else if (a[i] === "--tol") o.tol = parseFloat(a[++i])
+	}
+	if (!o.points || !o.output) {
+		console.error("usage: build-wof-polygons.mjs --points <wof-hot.db> --out <wof-polygons.db> [--tol 0.004]")
+		process.exit(2)
+	}
+	return o
+}
+
+/** WOF shard path: id split into 3-char chunks, then the full id. */
+function geojsonPath(country, id) {
+	const s = String(id)
+	const shard = s.match(/.{1,3}/g).join("/")
+	return `${REPOS}/whosonfirst-data-admin-${country.toLowerCase()}/data/${shard}/${s}.geojson`
+}
+
+/** Perpendicular distance from point p to segment a–b (planar — fine at admin scale). */
+function segDist(p, a, b) {
+	const dx = b[0] - a[0]
+	const dy = b[1] - a[1]
+	if (dx === 0 && dy === 0) return Math.hypot(p[0] - a[0], p[1] - a[1])
+	const t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / (dx * dx + dy * dy)
+	const tc = Math.max(0, Math.min(1, t))
+	return Math.hypot(p[0] - (a[0] + tc * dx), p[1] - (a[1] + tc * dy))
+}
+
+/** Douglas-Peucker on a ring of [lon,lat]. Keeps endpoints; preserves closure. */
+function dp(ring, tol) {
+	if (ring.length <= 3) return ring
+	const keep = new Uint8Array(ring.length)
+	keep[0] = keep[ring.length - 1] = 1
+	const stack = [[0, ring.length - 1]]
+	while (stack.length) {
+		const [lo, hi] = stack.pop()
+		let maxD = -1
+		let idx = -1
+		for (let i = lo + 1; i < hi; i++) {
+			const d = segDist(ring[i], ring[lo], ring[hi])
+			if (d > maxD) {
+				maxD = d
+				idx = i
+			}
+		}
+		if (maxD > tol && idx > 0) {
+			keep[idx] = 1
+			stack.push([lo, idx], [idx, hi])
+		}
+	}
+	const out = []
+	for (let i = 0; i < ring.length; i++) if (keep[i]) out.push(ring[i])
+	// A degenerate ring (<4 pts after simplify) can't render — drop it by signalling null.
+	return out.length >= 4 ? out : null
+}
+
+/** Simplify a Polygon / MultiPolygon geometry; drop rings that collapse. Returns null if nothing left. */
+function simplify(geom, tol) {
+	const ringSet = (poly) => poly.map((ring) => dp(ring, tol)).filter(Boolean)
+	if (geom.type === "Polygon") {
+		const rings = ringSet(geom.coordinates)
+		return rings.length ? { type: "Polygon", coordinates: rings } : null
+	}
+	if (geom.type === "MultiPolygon") {
+		const polys = geom.coordinates.map((p) => ringSet(p)).filter((rings) => rings.length)
+		return polys.length ? { type: "MultiPolygon", coordinates: polys } : null
+	}
+	return null // Points / lines: no polygon to draw.
+}
+
+const opts = parseArgs()
+if (existsSync(opts.output)) rmSync(opts.output)
+
+const pts = new DatabaseSync(opts.points, { readOnly: true })
+const rows = pts
+	.prepare(`SELECT id, country, placetype FROM spr WHERE placetype NOT IN ('postalcode') ORDER BY id`)
+	.all()
+	.filter((r) => ADMIN_PLACETYPES.has(r.placetype))
+pts.close()
+
+const out = new DatabaseSync(opts.output)
+out.exec(`CREATE TABLE polygons (id INTEGER PRIMARY KEY, geom TEXT NOT NULL);`)
+const insert = out.prepare(`INSERT OR IGNORE INTO polygons (id, geom) VALUES (?, ?)`)
+
+let done = 0
+let missing = 0
+let dropped = 0
+out.exec("BEGIN")
+for (const r of rows) {
+	const path = geojsonPath(r.country, r.id)
+	if (!existsSync(path)) {
+		missing++
+		continue
+	}
+	try {
+		const feat = JSON.parse(readFileSync(path, "utf8"))
+		const simp = feat.geometry ? simplify(feat.geometry, opts.tol) : null
+		if (!simp) {
+			dropped++
+			continue
+		}
+		insert.run(r.id, JSON.stringify(simp))
+		done++
+	} catch {
+		dropped++
+	}
+	if ((done + missing + dropped) % 2000 === 0) console.error(`  …${done} packed, ${missing} missing, ${dropped} dropped`)
+}
+out.exec("COMMIT")
+out.exec("VACUUM")
+const bytes = out.prepare(`SELECT count(*) n, sum(length(geom)) b FROM polygons`).get()
+out.close()
+console.error(
+	`✓ ${opts.output}: ${done} polygons (${missing} no-geometry, ${dropped} dropped), ~${Math.round((bytes.b || 0) / 1024 / 1024)} MB geom`
+)

--- a/scripts/publish-release-to-hf.mjs
+++ b/scripts/publish-release-to-hf.mjs
@@ -131,6 +131,14 @@ async function main() {
 		if (!existsSync(localPath) || statSync(localPath).size === 0) fail(`postcode binary ${localPath} missing/empty`)
 	}
 
+	// Optional crisp-polygon DB (build-wof-polygons.mjs): a single --polygons path. Uploaded as
+	// wof-polygons.db; the demo draws the real admin boundary instead of the bbox when `hasPolygons`
+	// is set. Sibling of wof-hot.db, keyed by the same WOF ids.
+	const polygonsDb = args.polygons || null
+	if (polygonsDb && (!existsSync(polygonsDb) || statSync(polygonsDb).size === 0)) {
+		fail(`polygon DB ${polygonsDb} missing/empty`)
+	}
+
 	// --- Phase 2: upload to bucket ---
 	const remoteBase = `${args.locale}/${args.version}`
 	for (const f of REQUIRED_FILES) {
@@ -145,6 +153,11 @@ async function main() {
 		const dst = `${BUCKET_PATH}/${remoteBase}/${remoteName}`
 		console.error(`  → ${dst}`)
 		run("hf", ["buckets", "cp", localPath, dst])
+	}
+	if (polygonsDb) {
+		const dst = `${BUCKET_PATH}/${remoteBase}/wof-polygons.db`
+		console.error(`  → ${dst}`)
+		run("hf", ["buckets", "cp", polygonsDb, dst])
 	}
 
 	// --- Phase 3: verify each artifact is reachable via the resolve URL ---
@@ -172,6 +185,7 @@ async function main() {
 		hasFst: true,
 		hasWofDb: true,
 		hasAnchor: postcodeBins.length > 0,
+		hasPolygons: !!polygonsDb,
 	}
 
 	releases.releases = [newEntry, ...releases.releases.filter((r) => r.version !== args.version)]


### PR DESCRIPTION
## What

The demo's map drew a **rectangle** (`place_bbox`, from the points DB's min/max lat-lon) around every resolved place — the box you noticed around each address. This ships the **real admin boundary** as a separate, lazily-loaded sibling DB, so the resolver DB stays points-only and small while the polygon DB carries the crisp geometry.

## How

- **`scripts/build-wof-polygons.mjs`** — reads the in-scope admin ids straight from the points DB (lockstep with `build-wof-points.mjs`), pulls each id's GeoJSON from the WOF repos (`whosonfirst-data-admin-<cc>/data/<id-sharded>/<id>.geojson`), Douglas-Peucker simplifies every ring (~0.004° ≈ 400 m), and packs `polygons(id, geom)` into `wof-polygons.db`. US+DE → **13,321 polygons, 14 MB** (Berlin 26K→2.7K coords, ~10×).
- **`docs/src/pages/demo/index.tsx`** — `ReleaseInfo.hasPolygons` + a lazily-loaded polygon DB (sqlite-wasm, reusing the schema-agnostic resolver loader). On resolve it draws the crisp geometry keyed by `candidate.id` and `fitBounds` to it. Any id absent from the polygon DB (postcodes are point geometry; ~6% of US localities dropped as degenerate) **falls back to the existing bbox path unchanged** — purely additive.
- **`scripts/publish-release-to-hf.mjs`** — `--polygons` flag uploads `wof-polygons.db` and sets `hasPolygons` in `releases.json` for future releases.

## Live for v4.0.0

`wof-polygons.db` is already pushed to HF (`en-us/v4.0.0/`) and `releases.json` has `hasPolygons=true`. The deployed demo ignores the flag until this code ships, so the ordering is safe. Coverage: **DE 4998/5000, US 4685/5000**; misses degrade to bbox.

## Verification

- `node --check` + `tsc --noEmit -p docs/tsconfig.json` clean.
- Polygon DB reachable on HF (HTTP 200, 13.8 MB), Berlin + US localities (Tuscumbia/Sheffield/Muscle Shoals) render real geometry.
- **Browser render verification is the operator's** — the demo needs a real browser + the asset bundle, which I can't drive from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)