### PR TITLE
fix(resolver): population + exact-name ranking in the WASM resolver (no more West New York)

### DIFF
--- a/resolver-wof-wasm/lookup.test.ts
+++ b/resolver-wof-wasm/lookup.test.ts
@@ -41,10 +41,23 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO spr VALUES (300, 201, '62701', 'postalcode', 'US', 39.81, -89.65, 39.80, 39.82, -89.66, -89.64, -1, 0);
 		INSERT INTO spr VALUES (301, 200, '60601', 'postalcode', 'US', 41.88, -87.62, 41.87, 41.89, -87.63, -87.61, -1, 0);
 
+		-- Two same-name localities: the SMALL one has the LOWER id, so on raw bm25 (identical FTS
+		-- doc -> tie -> rowid order) it would surface first. The population boost must flip this so
+		-- the larger Greenville wins -- the regression guard for the "New York -> West New York" bug.
+		INSERT INTO spr VALUES (210, 101, 'Greenville', 'locality', 'US', 34.85, -82.39, 34.7, 35.0, -82.5, -82.2, -1, 0);
+		INSERT INTO spr VALUES (211, 101, 'Greenville', 'locality', 'US', 35.61, -77.37, 35.5, 35.7, -77.5, -77.2, -1, 0);
+		-- Exact-name tiering must beat population: 'York' (tiny) outranks 'New York' (huge) for "York".
+		INSERT INTO spr VALUES (220, 101, 'York', 'locality', 'US', 39.96, -76.73, 39.9, 40.0, -76.8, -76.6, -1, 0);
+		INSERT INTO spr VALUES (221, 101, 'New York', 'locality', 'US', 40.71, -74.0, 40.5, 40.9, -74.2, -73.7, -1, 0);
+
 		INSERT INTO names (id, language, name) VALUES (100, 'eng', 'America');
 		INSERT INTO names (id, language, name) VALUES (200, 'eng', 'Chicago');
 		INSERT INTO names (id, language, name) VALUES (201, 'eng', 'Springfield');
 		INSERT INTO names (id, language, name) VALUES (300, 'eng', 'Springfield ZIP');
+		INSERT INTO names (id, language, name) VALUES (210, 'eng', 'Greenville');
+		INSERT INTO names (id, language, name) VALUES (211, 'eng', 'Greenville');
+		INSERT INTO names (id, language, name) VALUES (220, 'eng', 'York');
+		INSERT INTO names (id, language, name) VALUES (221, 'eng', 'New York');
 
 		INSERT INTO geojson VALUES (100, '{"properties":{"wof:population":331000000}}');
 		INSERT INTO geojson VALUES (101, '{"properties":{"wof:population":12700000}}');
@@ -52,6 +65,10 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO geojson VALUES (201, '{"properties":{"wof:population":114000}}');
 		INSERT INTO geojson VALUES (300, '{"properties":{}}');
 		INSERT INTO geojson VALUES (301, '{"properties":{}}');
+		INSERT INTO geojson VALUES (210, '{"properties":{"wof:population":8000}}');
+		INSERT INTO geojson VALUES (211, '{"properties":{"wof:population":580000}}');
+		INSERT INTO geojson VALUES (220, '{"properties":{"wof:population":1700}}');
+		INSERT INTO geojson VALUES (221, '{"properties":{"wof:population":8400000}}');
 	`)
 	db.close()
 }
@@ -92,6 +109,32 @@ describe("WofWasmPlaceLookup", () => {
 			const matches = await lookup.findPlace({ text: "62701", placetype: "postalcode" })
 			expect(matches.length).toBe(1)
 			expect(matches[0]?.name).toBe("62701")
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("population surfaces the larger of two same-name localities", async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			const matches = await lookup.findPlace({ text: "Greenville", placetype: "locality", country: "US", limit: 5 })
+			// Both are exact-name matches (same tier), so the population boost is the tiebreak. The
+			// larger Greenville (id 211) must beat the lower-id small one (210) that raw bm25 favors.
+			expect(matches[0]?.id).toBe(211)
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("exact-name match outranks a larger partial-name place", async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			// "York" matches both 'York' and 'New York'; exact-name tiering must keep 'York' on top
+			// even though 'New York' has a far larger population (the ME->Maine-not-Missouri guard).
+			const matches = await lookup.findPlace({ text: "York", placetype: "locality", country: "US", limit: 5 })
+			expect(matches[0]?.name).toBe("York")
 		} finally {
 			lookup.close()
 		}

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -27,11 +27,38 @@ export interface WofWasmPlaceLookupOpts {
 	db: Database
 }
 
+/**
+ * Population-boost tunables, mirroring `resolver-wof-sqlite/lookup.ts` defaults. The boost is
+ * `POPULATION_BOOST * min(1, log10(1 + pop) / POPULATION_SCALE_LOG10)`, subtracted from bm25 (lower =
+ * better, matching SQLite's convention). A 1M-population city earns the full boost — enough to
+ * surface the famous same-name place ("New York" over "West New York") without steamrolling a
+ * clearly-better text match, because exact-name tiering is consulted FIRST.
+ */
+const POPULATION_BOOST = 4.0
+const POPULATION_SCALE_LOG10 = 6.0
+
+/** Normalize a name/query for exact-match tiering: lowercase, trim, collapse internal whitespace. */
+function normalizeName(s: string): string {
+	return s.toLowerCase().trim().replace(/\s+/g, " ")
+}
+
 export class WofWasmPlaceLookup implements PlaceLookup {
 	readonly #db: Database
+	#hasPopulationCache?: boolean
 
 	constructor(opts: WofWasmPlaceLookupOpts) {
 		this.#db = opts.db
+	}
+
+	/** Lazily probe (once) whether the slim DB carries the `place_population` aux table. */
+	#hasPopulation(): boolean {
+		if (this.#hasPopulationCache === undefined) {
+			const r = this.#db.selectObjects(
+				`SELECT 1 FROM sqlite_master WHERE type='table' AND name='place_population' LIMIT 1`
+			)
+			this.#hasPopulationCache = r.length > 0
+		}
+		return this.#hasPopulationCache
 	}
 
 	async findPlace(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
@@ -43,11 +70,8 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 
 		const limit = Math.max(1, query.limit ?? 10)
 
-		// v1 query: FTS5 MATCH on place_search joined to spr. BM25 ordering. Placetype + country
-		// filters are pushed into the WHERE clause because they reduce candidate count cheaply.
-		// Boosts (placetype-match boost, locality implicit boost, population weighting) deliberately
-		// omitted — they need the same ranking weights / constants as lookup.ts and that's a shared
-		// query-builder PR away.
+		// FTS5 MATCH on place_search joined to spr. Placetype + country filters are pushed into the
+		// WHERE clause because they reduce candidate count cheaply.
 		const conditions: string[] = ["place_search MATCH ?", "spr.is_current != 0", "spr.is_deprecated = 0"]
 		const params: Array<string | number> = [ftsQuery]
 
@@ -61,14 +85,24 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 			params.push(query.country.toUpperCase())
 		}
 
+		// Over-fetch a pool ordered by raw BM25, then re-rank in JS (exact-name tier, then
+		// population-weighted bm25). The over-fetch is load-bearing: a famous place can sit a few rows
+		// below a tiny same-name town on raw BM25 ("New York" loses to "West New York" by a hair), so a
+		// tight LIMIT on bm25 alone would truncate it before the re-rank could pull it up. This mirrors
+		// the post-scoring tier + population boost in resolver-wof-sqlite/lookup.ts. (v1 issued pure
+		// bm25, which is why the demo targeted West New York for "New York, NY".)
+		const hasPop = this.#hasPopulation()
+		const pool = Math.max(limit, 50)
 		const sql =
 			`SELECT spr.id, spr.name, spr.placetype, spr.country, spr.latitude, spr.longitude, spr.parent_id, ` +
-			`spr.min_latitude, spr.max_latitude, spr.min_longitude, spr.max_longitude, bm25(place_search) AS bm25 ` +
+			`spr.min_latitude, spr.max_latitude, spr.min_longitude, spr.max_longitude, ` +
+			`${hasPop ? "pp.population" : "NULL"} AS population, bm25(place_search) AS bm25 ` +
 			`FROM place_search JOIN spr ON spr.id = place_search.wof_id ` +
+			`${hasPop ? "LEFT JOIN place_population pp ON pp.id = spr.id " : ""}` +
 			`WHERE ${conditions.join(" AND ")} ` +
 			`ORDER BY bm25(place_search) ASC ` +
 			`LIMIT ?`
-		params.push(limit)
+		params.push(pool)
 
 		const rows = this.#db.selectObjects(sql, params) as Array<{
 			id: number
@@ -82,30 +116,48 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 			max_latitude: number | null
 			min_longitude: number | null
 			max_longitude: number | null
+			population: number | null
 			bm25: number
 		}>
 
-		return rows.map((row) => ({
-			id: row.id,
-			name: row.name,
-			placetype: row.placetype as WofPlacetype,
-			country: row.country,
-			lat: row.latitude,
-			lon: row.longitude,
-			parent_id: row.parent_id ?? undefined,
-			bbox:
-				row.min_latitude != null && row.max_latitude != null && row.min_longitude != null && row.max_longitude != null
-					? {
-							minLat: row.min_latitude,
-							maxLat: row.max_latitude,
-							minLon: row.min_longitude,
-							maxLon: row.max_longitude,
-						}
-					: undefined,
-			// BM25 is negative (better = more negative). Flip sign so higher = better, matching the
-			// PlaceLookup contract.
-			score: -row.bm25,
-		}))
+		const normQuery = normalizeName(text)
+		return rows
+			.map((row) => {
+				const exactTier = normalizeName(row.name) === normQuery ? 0 : 1
+				const popBoost =
+					row.population && row.population > 0
+						? POPULATION_BOOST * Math.min(1, Math.log10(1 + row.population) / POPULATION_SCALE_LOG10)
+						: 0
+				// Lower adjScore = better, matching SQLite's bm25 convention (more negative = better).
+				const adjScore = row.bm25 - popBoost
+				return { row, exactTier, adjScore }
+			})
+			.sort((a, b) => a.exactTier - b.exactTier || a.adjScore - b.adjScore)
+			.slice(0, limit)
+			.map(({ row, adjScore }) => ({
+				id: row.id,
+				name: row.name,
+				placetype: row.placetype as WofPlacetype,
+				country: row.country,
+				lat: row.latitude,
+				lon: row.longitude,
+				parent_id: row.parent_id ?? undefined,
+				bbox:
+					row.min_latitude != null &&
+					row.max_latitude != null &&
+					row.min_longitude != null &&
+					row.max_longitude != null
+						? {
+								minLat: row.min_latitude,
+								maxLat: row.max_latitude,
+								minLon: row.min_longitude,
+								maxLon: row.max_longitude,
+							}
+						: undefined,
+				// Flip sign so higher = better (PlaceLookup contract). The adjusted, population-aware
+				// score is what we sorted by, so callers see the same ordering they're shown.
+				score: -adjScore,
+			}))
 	}
 
 	close(): void {


### PR DESCRIPTION
## The bug

Geocoding **"350 5th Ave, New York, NY 10118"** (Empire State Building) parsed correctly but the map targeted **West New York, NJ** — a 50K-person town across the Hudson — instead of New York City. The crisp polygon was drawn faithfully... for the wrong candidate, and the whole "other candidates" list was misordered.

**Root cause:** the browser resolver (`WofWasmPlaceLookup`) issued **pure BM25** — no population, no exact-name boost (it was v1 scope, deferred to "a shared query-builder PR away"). On raw BM25, the tiny town edged out NYC by a hair (`-25.06` vs `-24.77`). The postcode `10118` carries WOF placeholder `0,0` coords, so the cascade correctly fell through to the locality lookup — which then mis-ranked.

## The fix

Port the post-scoring the **Node resolver** (`resolver-wof-sqlite`) has done all along:

- Over-fetch a BM25 candidate pool, then re-rank in JS by **exact-name tier first**, then **population-adjusted BM25** (`boost = 4.0 · min(1, log10(1+pop)/6)`).
- Exact-name tiering is consulted *before* population, so a clear text match is never steamrolled by a bigger same-substring place (the `ME → Maine`, not Missouri, guard).
- `LEFT JOIN place_population` (lazily probed once; absent → boost 0, pure BM25 + tier — older slim DBs degrade cleanly).

## Verification

- **Real deployed US+DE points DB:** `"New York"` now returns **New York (NYC, 8.8M) #1, West New York (50K) #2** — the full candidate list reorders.
- **Regression tests (6/6 pass):** a larger same-name locality must surface over a lower-id small one (population tiebreak); an exact `'York'` must outrank `'New York'` for query `"York"` (tier beats population).
- `tsc --noEmit` clean.

Pure resolver-code fix — no DB rebuild (the deployed `wof-hot.db` already ships `place_population`). Ships with the next docs-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)