### PR TITLE
ci(docs): rebuild the demo on resolver changes + workflow_dispatch

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -11,17 +11,27 @@
 name: Docs
 
 on:
+  # The demo BUNDLES these workspaces (neural-web pulls in the resolver), so a change to the
+  # resolver must rebuild + redeploy the demo — otherwise a merged resolver fix sits on main while
+  # the live demo serves the old bundle (which is exactly how the "New York → West New York" fix
+  # almost shipped invisibly). workflow_dispatch is the manual escape hatch when a dependency
+  # outside these paths changes.
+  workflow_dispatch: {}
   pull_request:
     branches: [main]
     paths:
       - "docs/**"
       - "neural-web/**"
+      - "resolver-wof-wasm/**"
+      - "resolver-wof-sqlite/**"
       - "*.md"
   push:
     branches: [main]
     paths:
       - "docs/**"
       - "neural-web/**"
+      - "resolver-wof-wasm/**"
+      - "resolver-wof-sqlite/**"
       - "*.md"
 
 permissions:
@@ -62,13 +72,13 @@ jobs:
         run: cd docs && npm run build
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs/build
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Why

The `docs-build` path filter watched only `docs/**`, `neural-web/**`, `*.md`. But the demo **bundles the resolver** (`neural-web` → `resolver-wof-wasm`), so a merged resolver fix sits on `main` while the live demo keeps serving the *old* bundle. That's exactly how the "New York → West New York" ranking fix (#353) nearly shipped invisibly — it merged green but never redeployed the demo.

## What

- Add `resolver-wof-wasm/**` + `resolver-wof-sqlite/**` to the push + pull_request path filters.
- Add `workflow_dispatch` as a manual escape hatch for dependency changes outside these paths, and let it deploy too (the Upload-Pages + deploy gates now accept `workflow_dispatch` on `main`).

After merge I'll dispatch one run to deploy `main`'s current state (which includes #353).

🤖 Generated with [Claude Code](https://claude.com/claude-code)