### PR TITLE
fix(demo): use parsed region + drop hardcoded US in the resolver cascade

### DIFF
--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -467,7 +467,7 @@ const DemoApp: React.FC = () => {
 				// Drop (lat=0, lon=0) hits — WOF ships placeholder zeros on ~22% of US postcodes.
 				// Timed from here so the one-time DB load above doesn't skew the resolve number.
 				const tBeforeResolve = performance.now()
-				const cascadeHits = await runCascade(wofLookup, postcodeNode, localityNode, text)
+				const cascadeHits = await runCascade(wofLookup, postcodeNode, localityNode, stateNode, text)
 				const tResolve = performance.now()
 				const candidates: ResolvedHit[] = cascadeHits.map((c) => ({
 					id: c.id,
@@ -739,36 +739,39 @@ async function runCascade(
 	lookup: MailwomanLookupLike,
 	postcodeNode: ParsedNode | undefined,
 	localityNode: ParsedNode | undefined,
+	stateNode: ParsedNode | undefined,
 	rawText: string
 ): Promise<Awaited<ReturnType<MailwomanLookupLike["findPlace"]>>> {
 	const usable = (
 		cs: Awaited<ReturnType<MailwomanLookupLike["findPlace"]>>
 	): Awaited<ReturnType<MailwomanLookupLike["findPlace"]>> => cs.filter((c) => !(c.lat === 0 && c.lon === 0))
 
+	// Use the geography the parser found. Country is NOT hardcoded to US — a global search plus the
+	// resolver's population ranking surfaces the famous same-name place ("Berlin" → Berlin, DE 3.7M,
+	// not Berlin, NH 9k). A parsed region/state is resolved to its bbox and used to constrain the
+	// postcode + locality lookups, which disambiguates same-name US localities ("Roseville, Michigan"
+	// → the Roseville inside Michigan's bounds, not the larger Roseville, CA the population boost
+	// would otherwise pick).
+	let regionBbox: { minLat: number; maxLat: number; minLon: number; maxLon: number } | undefined
+	if (stateNode?.value) {
+		const regions = await lookup.findPlace({ text: String(stateNode.value), placetype: "region", limit: 1 })
+		regionBbox = regions[0]?.bbox
+	}
+
 	if (postcodeNode?.value) {
 		const cs = usable(
-			await lookup.findPlace({
-				text: String(postcodeNode.value),
-				placetype: "postalcode",
-				country: "US",
-				limit: 5,
-			})
+			await lookup.findPlace({ text: String(postcodeNode.value), placetype: "postalcode", bbox: regionBbox, limit: 5 })
 		)
 		if (cs.length > 0) return cs
 	}
 	if (localityNode?.value) {
 		const cs = usable(
-			await lookup.findPlace({
-				text: String(localityNode.value),
-				placetype: "locality",
-				country: "US",
-				limit: 5,
-			})
+			await lookup.findPlace({ text: String(localityNode.value), placetype: "locality", bbox: regionBbox, limit: 5 })
 		)
 		if (cs.length > 0) return cs
 	}
 
-	return usable(await lookup.findPlace({ text: rawText, country: "US", limit: 5 }))
+	return usable(await lookup.findPlace({ text: rawText, bbox: regionBbox, limit: 5 }))
 }
 
 type TreeNode = {

--- a/docs/src/shared/resources.tsx
+++ b/docs/src/shared/resources.tsx
@@ -29,8 +29,10 @@ export interface MailwomanClassifierLike {
 export interface MailwomanLookupLike {
 	findPlace: (q: {
 		text: string
-		placetype?: "locality" | "postalcode" | undefined
+		placetype?: "locality" | "postalcode" | "region" | undefined
 		country?: string
+		/** Point-in-bbox filter — constrains candidates to a parsed region/state's bounds. */
+		bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
 		limit?: number
 	}) => Promise<
 		Array<{

--- a/resolver-wof-wasm/lookup.test.ts
+++ b/resolver-wof-wasm/lookup.test.ts
@@ -140,6 +140,24 @@ describe("WofWasmPlaceLookup", () => {
 		}
 	})
 
+	test("bbox filter constrains same-name localities to a region's bounds", async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			// Both Greenvilles match by name, but only id 210 (34.85,-82.39) sits in this box — the
+			// 'Roseville, Michigan' disambiguation path (constrain a locality to a parsed region's bbox).
+			const matches = await lookup.findPlace({
+				text: "Greenville",
+				placetype: "locality",
+				bbox: { minLat: 34, maxLat: 35, minLon: -83, maxLon: -82 },
+				limit: 5,
+			})
+			expect(matches.map((m) => m.id)).toEqual([210])
+		} finally {
+			lookup.close()
+		}
+	})
+
 	test("country filter rejects out-of-scope matches", async () => {
 		const { db } = await loadSlimWofDatabase({ source: slimBytes })
 		const lookup = new WofWasmPlaceLookup({ db })

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -84,6 +84,13 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 			conditions.push("spr.country = ?")
 			params.push(query.country.toUpperCase())
 		}
+		// Point-in-bbox filter. Used to constrain a locality lookup to a parsed region/state's bounds
+		// (e.g. "Roseville, Michigan" → only the Roseville whose centroid sits in Michigan's bbox),
+		// which the broken-in-the-slim-DB parent_id chain can't do via descendant filtering.
+		if (query.bbox) {
+			conditions.push("spr.latitude BETWEEN ? AND ?", "spr.longitude BETWEEN ? AND ?")
+			params.push(query.bbox.minLat, query.bbox.maxLat, query.bbox.minLon, query.bbox.maxLon)
+		}
 
 		// Over-fetch a pool ordered by raw BM25, then re-rank in JS (exact-name tier, then
 		// population-weighted bm25). The over-fetch is load-bearing: a famous place can sit a few rows


### PR DESCRIPTION
## Two reports, one root cause

The demo cascade threw away the geography the parser found — it **hardcoded `country: "US"`** and **never passed the parsed region/state**:

- **"Berlin"** resolved to Berlin, **NH** (9k) instead of Berlin, **DE** (3.7M) — German Berlin was filtered out by `country: "US"`. (The "parallelogram" was Berlin NH's small-town polygon.)
- **"Roseville, Michigan"** always returned Roseville, **CA** — the larger namesake the population boost (#353) picks when nothing disambiguates, because the parsed "Michigan" was dropped.

## Fix: the cascade uses what the parser found

- **Country is no longer hardcoded.** A global search + the population ranking surfaces the famous same-name place (Berlin → Berlin, DE). The DB is US+DE, so this *is* the multi-locale behavior the demo exists to show.
- **A parsed region/state is resolved to its bbox** and used to constrain the postcode + locality lookups. "Roseville, Michigan" → the Roseville inside Michigan's bounds; cross-country ZIP collisions get pinned to the parsed state too.

The slim DB's `parent_id` chain is too sparse to filter by descendant (a locality's immediate parent is often an uncopied intermediate), so the region **bbox** — every region carries one — is the robust constraint.

- `resolver-wof-wasm`: implement the `FindPlaceQuery.bbox` point-in-bbox filter (declared in the interface, ignored by the WASM impl until now).

## Verification (vs the deployed US+DE DB)

- `"Straußstraße 27, 12623 Berlin"` → the **12623 postcode point in eastern Berlin (52.50, 13.62)** — correct for that ZIP, more precise than the whole-city polygon, and its 0.0 bbox span means a clean `flyTo` (no box).
- `"Roseville, Michigan"` → **Roseville, MI (42.51, -82.94)**.
- 7/7 resolver tests pass (added region-disambiguation + bbox tests).

Both `resolver-wof-wasm/**` and `docs/**` are in the docs-build path filter (#354), so merging auto-deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)