### PR TITLE
feat(demo): load the French postcode anchor (postcode-fr.bin)

### DIFF
--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -239,12 +239,13 @@ const DemoApp: React.FC = () => {
 					modelCardUrl: assetUrl(DEFAULT_LOCALE, selectedVersion, "model-card.json"),
 					runner: { useWebGpu: !forceWasm },
 					// Anchor-trained bundles (v4.0.0+) ship postcode binaries so the demo feeds the postcode
-					// anchor — US + DE cover the demo's example set (incl. the native-order Berlin case).
+					// anchor — US + DE + FR cover the demo's example set (native-order Berlin, French ZIPs).
 					...(release?.hasAnchor
 						? {
 								postcodeBinaryUrls: [
 									assetUrl(DEFAULT_LOCALE, selectedVersion, "postcode-us.bin"),
 									assetUrl(DEFAULT_LOCALE, selectedVersion, "postcode-de.bin"),
+									assetUrl(DEFAULT_LOCALE, selectedVersion, "postcode-fr.bin"),
 								],
 							}
 						: {}),


### PR DESCRIPTION
The demo fed the model US + DE postcode anchors; French addresses with a ZIP (e.g. "75008 Paris") had no anchor channel. Now that the resolver covers France, ship the FR anchor too.

- Built **`postcode-fr.bin`** (27,119 codes, 24,575 placed; from `postalcode-intl.db`) — uploaded to HF `en-us/v4.0.0/` (HTTP 200).
- Added it to the demo's `postcodeBinaryUrls` alongside US + DE.

The local `docs/static/mailwoman/postcode-fr.bin` is a gitignored build artifact; the deployed demo fetches the HF copy at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)