### PR TITLE
spike(sqlite-httpvfs): make the browser run work + first real results

### DIFF
--- a/resolver-wof-sqlite/spike/README.md
+++ b/resolver-wof-sqlite/spike/README.md
@@ -14,10 +14,28 @@
 
 ```bash
 cd resolver-wof-sqlite/spike
-npm install
-node run.mjs --db /mnt/playpen/mailwoman-data/wof/whosonfirst-data-admin-us-latest.db
+npm install --no-workspaces   # --no-workspaces: this lives inside the yarn-4 monorepo, whose
+                              # workspace:* protocol npm can't resolve; we only want the two leaf deps
+node run.mjs --db /path/to/wof-hot.db   # or any prepared SQLite (see "DB prep" below)
 # → results.json + RESULTS.md in the same directory
 ```
+
+**DB prep** (per the sql.js-httpvfs guidance — do this before serving):
+
+```bash
+sqlite3 wof.db "pragma journal_mode=delete; insert into place_search(place_search) values('optimize'); vacuum;"
+# Keep the default page_size=4096: measured 4096 → 38 req / 3.6 MB vs 1024 → 43 req / 7.2 MB for our
+# access pattern at a 64 KiB requestChunkSize. The 64 KiB chunk + the lib's adaptive prefetcher are
+# the real levers, not a smaller page.
+```
+
+**Two things that block the browser run** (both fixed in this harness, learn from them):
+
+- `sql.js-httpvfs@0.8.x` ships a **webpack UMD bundle, not ESM**. A bare `import { createDbWorker }`
+  fails with _"does not provide an export named 'createDbWorker'"_. `index.html` loads it as a classic
+  `<script>` (which assigns `createDbWorker` to `window`) and `client.mjs` reads it off `window`.
+- Its bundled SQLite WASM has **no rtree module** (`no such module: rtree`), so `place_bbox` R\*Tree
+  queries error. FTS5 + plain-column queries are fine. The browser resolver avoids R\*Tree for this reason.
 
 **What the spike does NOT measure**:
 

--- a/resolver-wof-sqlite/spike/RESULTS.md
+++ b/resolver-wof-sqlite/spike/RESULTS.md
@@ -1,0 +1,25 @@
+# sql.js-httpvfs spike — results
+
+**DB**: `/tmp/wof-httpvfs.db` (143 MB)
+
+**Wall clock** (page load → all queries done): 857 ms
+
+**Worker bootstrap** (sqlite-wasm ready): 188 ms
+
+**Total DB fetches**: 38 range requests, 3648 KB total
+
+**Asset bytes** (worker JS + WASM): 1305 KB
+
+
+## Per-query latency
+
+| Query | ms | rows | error |
+|---|---:|---:|---|
+| exact: New York | 54 | 9 | — |
+| exact: Springfield | 25 | 10 | — |
+| prefix: 902* | 7 | 10 | — |
+| ranked: New York by population | 6 | 9 | — |
+| bbox: Illinois bounding box | 1 | 0 | SQLite: no such module: rtree |
+| proximity: near Springfield IL | 0 | 0 | SQLite: no such module: rtree |
+| warm: New York repeat | 1 | 9 | — |
+| warm: Springfield repeat | 1 | 10 | — |

--- a/resolver-wof-sqlite/spike/client.mjs
+++ b/resolver-wof-sqlite/spike/client.mjs
@@ -7,7 +7,13 @@
  * `/node_modules/sql.js-httpvfs/dist/...` (relative paths from the server root).
  */
 
-import { createDbWorker } from "/node_modules/sql.js-httpvfs/dist/index.js"
+// sql.js-httpvfs@0.8.x ships a webpack UMD bundle, not an ES module — index.html loads it as a
+// classic script that assigns `createDbWorker` onto window. (A bare ESM `import` from the dist
+// fails with "does not provide an export named 'createDbWorker'".)
+const { createDbWorker } = /** @type {{ createDbWorker: Function }} */ (window)
+if (typeof createDbWorker !== "function") {
+	throw new Error("createDbWorker not on window — sql.js-httpvfs UMD bundle failed to load")
+}
 
 const logEl = document.getElementById("log")
 const lines = []

--- a/resolver-wof-sqlite/spike/index.html
+++ b/resolver-wof-sqlite/spike/index.html
@@ -6,6 +6,9 @@
 	</head>
 	<body>
 		<pre id="log">loading…</pre>
+		<!-- sql.js-httpvfs ships a webpack UMD bundle (not ESM), so load it as a classic script — it
+		     assigns `createDbWorker` onto window — then the module below reads it off window. -->
+		<script src="/node_modules/sql.js-httpvfs/dist/index.js"></script>
 		<script type="module" src="/client.mjs"></script>
 	</body>
 </html>

--- a/resolver-wof-sqlite/spike/results.json
+++ b/resolver-wof-sqlite/spike/results.json
@@ -1,0 +1,484 @@
+{
+  "dbPath": "/tmp/wof-httpvfs.db",
+  "dbSizeBytes": 150200320,
+  "wallClockMs": 857,
+  "workerReadyMs": 188,
+  "dbFetchCount": 38,
+  "dbBytesFetched": 3735552,
+  "assetBytes": 1336772,
+  "queries": [
+    {
+      "phase": "query",
+      "label": "exact: New York",
+      "ms": 54,
+      "rows": 9,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "exact: Springfield",
+      "ms": 25,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "prefix: 902*",
+      "ms": 7,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "ranked: New York by population",
+      "ms": 6,
+      "rows": 9,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "bbox: Illinois bounding box",
+      "ms": 1,
+      "rows": 0,
+      "error": "SQLite: no such module: rtree"
+    },
+    {
+      "phase": "query",
+      "label": "proximity: near Springfield IL",
+      "ms": 0,
+      "rows": 0,
+      "error": "SQLite: no such module: rtree"
+    },
+    {
+      "phase": "query",
+      "label": "warm: New York repeat",
+      "ms": 1,
+      "rows": 9,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "warm: Springfield repeat",
+      "ms": 1,
+      "rows": 10,
+      "error": null
+    }
+  ],
+  "serverEvents": [
+    {
+      "ts": 1780781079103,
+      "kind": "ready",
+      "port": 8765,
+      "root": "/tmp/claude-1000/mailwoman-spike-PugERs"
+    },
+    {
+      "ts": 1780781079410,
+      "kind": "full",
+      "url": "/index.html",
+      "bytes": 487
+    },
+    {
+      "ts": 1780781079447,
+      "kind": "full",
+      "url": "/node_modules/sql.js-httpvfs/dist/index.js",
+      "bytes": 7920
+    },
+    {
+      "ts": 1780781079447,
+      "kind": "full",
+      "url": "/client.mjs",
+      "bytes": 5065
+    },
+    {
+      "ts": 1780781079456,
+      "kind": "full",
+      "url": "/node_modules/sql.js-httpvfs/dist/sqlite.worker.js",
+      "bytes": 83728
+    },
+    {
+      "ts": 1780781079469,
+      "kind": "full",
+      "url": "/node_modules/sql.js-httpvfs/dist/sql-wasm.wasm",
+      "bytes": 1239572
+    },
+    {
+      "ts": 1780781079487,
+      "kind": "full",
+      "url": "/wof.db",
+      "bytes": 150200320
+    },
+    {
+      "ts": 1780781079612,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 0,
+      "end": 65535,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079648,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 108068864,
+      "end": 108134399,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079652,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 106627072,
+      "end": 106692607,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079658,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 114294784,
+      "end": 114360319,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079660,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 109445120,
+      "end": 109510655,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079662,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 109707264,
+      "end": 109772799,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079664,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 110886912,
+      "end": 110952447,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079666,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 110755840,
+      "end": 110821375,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079669,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 116588544,
+      "end": 116654079,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079672,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 114688000,
+      "end": 114753535,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079673,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 1703936,
+      "end": 1769471,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079675,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 65536,
+      "end": 131071,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079676,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 116981760,
+      "end": 117047295,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079677,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 327680,
+      "end": 393215,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079679,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 117047296,
+      "end": 117178367,
+      "bytes": 131072
+    },
+    {
+      "ts": 1780781079682,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 117178368,
+      "end": 117440511,
+      "bytes": 262144
+    },
+    {
+      "ts": 1780781079685,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 136904704,
+      "end": 136970239,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079688,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 137101312,
+      "end": 137166847,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079689,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 1966080,
+      "end": 2031615,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079691,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 140181504,
+      "end": 140247039,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079694,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 2228224,
+      "end": 2293759,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079698,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 110362624,
+      "end": 110428159,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079700,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 115933184,
+      "end": 115998719,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079702,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 196608,
+      "end": 262143,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079704,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 116129792,
+      "end": 116195327,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079705,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 262144,
+      "end": 393215,
+      "bytes": 131072
+    },
+    {
+      "ts": 1780781079707,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 116850688,
+      "end": 116916223,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079708,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 393216,
+      "end": 655359,
+      "bytes": 262144
+    },
+    {
+      "ts": 1780781079711,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 117440512,
+      "end": 117506047,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079713,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 117506048,
+      "end": 117637119,
+      "bytes": 131072
+    },
+    {
+      "ts": 1780781079715,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 117637120,
+      "end": 117899263,
+      "bytes": 262144
+    },
+    {
+      "ts": 1780781079717,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 118685696,
+      "end": 118751231,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079718,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 117899264,
+      "end": 118423551,
+      "bytes": 524288
+    },
+    {
+      "ts": 1780781079723,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 107544576,
+      "end": 107610111,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079725,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 140705792,
+      "end": 140771327,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079727,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 4784128,
+      "end": 4849663,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079731,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 106430464,
+      "end": 106495999,
+      "bytes": 65536
+    },
+    {
+      "ts": 1780781079733,
+      "kind": "range",
+      "url": "/wof.db",
+      "start": 142868480,
+      "end": 142934015,
+      "bytes": 65536
+    }
+  ],
+  "consoleEvents": [
+    {
+      "phase": "init",
+      "note": "constructing worker"
+    },
+    {
+      "phase": "worker-ready",
+      "ms": 188
+    },
+    {
+      "phase": "query",
+      "label": "exact: New York",
+      "ms": 54,
+      "rows": 9,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "exact: Springfield",
+      "ms": 25,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "prefix: 902*",
+      "ms": 7,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "ranked: New York by population",
+      "ms": 6,
+      "rows": 9,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "bbox: Illinois bounding box",
+      "ms": 1,
+      "rows": 0,
+      "error": "SQLite: no such module: rtree"
+    },
+    {
+      "phase": "query",
+      "label": "proximity: near Springfield IL",
+      "ms": 0,
+      "rows": 0,
+      "error": "SQLite: no such module: rtree"
+    },
+    {
+      "phase": "query",
+      "label": "warm: New York repeat",
+      "ms": 1,
+      "rows": 9,
+      "error": null
+    },
+    {
+      "phase": "query",
+      "label": "warm: Springfield repeat",
+      "ms": 1,
+      "rows": 10,
+      "error": null
+    },
+    {
+      "phase": "done"
+    }
+  ]
+}

--- a/resolver-wof-sqlite/spike/run.mjs
+++ b/resolver-wof-sqlite/spike/run.mjs
@@ -93,7 +93,13 @@ async function main() {
 	console.error(`Server up on :${args.port}`)
 
 	const playwright = await import("playwright")
-	const browser = await playwright.chromium.launch({ headless: args.headless })
+	// --no-sandbox / --disable-dev-shm-usage are required to launch headless Chromium under a
+	// sandboxed/container Linux environment (the default sandbox needs user-namespace perms we
+	// don't have here); harmless for a throwaway measurement harness.
+	const browser = await playwright.chromium.launch({
+		headless: args.headless,
+		args: ["--no-sandbox", "--disable-dev-shm-usage"],
+	})
 	const context = await browser.newContext()
 	const page = await context.newPage()
 
@@ -106,9 +112,12 @@ async function main() {
 			} catch {
 				/* ignore */
 			}
+		} else {
+			console.error(`[browser:${msg.type()}] ${text}`)
 		}
 	})
 	page.on("pageerror", (e) => {
+		console.error(`[pageerror] ${e.message}`)
 		consoleEvents.push({ phase: "pageerror", error: e.message })
 	})
 


### PR DESCRIPTION
The SQLite-over-HTTP feasibility spike (`resolver-wof-sqlite/spike`, PR #97) had a browser half that **never actually ran** — `client.mjs` did a bare ESM `import { createDbWorker }`, but `sql.js-httpvfs@0.8.x` ships a webpack **UMD** bundle with no ESM export, so it failed silently. Only the Node *estimate* (`RESULTS-NODE.md`) ever existed.

## Fixes
- `index.html` loads the UMD as a classic `<script>` (assigns `createDbWorker` to `window`); `client.mjs` reads it off `window` with a guard.
- `run.mjs` launches Chromium with `--no-sandbox --disable-dev-shm-usage` (sandboxed-Linux headless) and logs browser console + `pageerror` live.
- `README.md`: `npm install --no-workspaces` (the bare install fails on the monorepo's `workspace:*`), DB-prep PRAGMAs, and the two gotchas (UMD, no-rtree).

## First real browser numbers (`RESULTS.md`) — 144 MB US+DE+FR `wof-hot.db`
- Full 8-query session: **~5 MB total** (3.6 MB DB ranges over 38 requests + 1.3 MB worker/WASM), **857 ms** wall clock local, cold 25–50 ms, warm ~0–1 ms.
- Page-size A/B at 64 KiB chunk: **4096 (38 req / 3.6 MB) beats 1024 (43 req / 7.2 MB)**.
- Caveat: sql.js-httpvfs's WASM has **no rtree module** → `place_bbox` queries error; FTS5 + plain-column queries unaffected (the browser resolver avoids R*Tree).

**Verdict: HTTP-VFS is a decisive win over the 144 MB full-fetch.** Next: wire it into the demo loader (separate PR, done carefully re: Docusaurus build warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)