### PR TITLE
perf(resolver): drop build-time names table — wof-hot.db 144 MB → 53 MB

### DIFF
--- a/scripts/build-wof-points.mjs
+++ b/scripts/build-wof-points.mjs
@@ -147,6 +147,14 @@ for (const pc of POSTCODE_SOURCES) copyFrom(pc, { postcodes: true })
 
 console.error(`spr=${out.prepare("SELECT count(*) n FROM spr").get().n}, building FTS + bbox...`)
 buildPlaceSearchFts(out, { drop: true })
+
+// `names` (every alt-name, ~1.5M rows) is the SOURCE the FTS index is built from — place_search is a
+// self-contained FTS5 (no external `content=`), so once it's built the names table + its index are
+// dead weight at query time (the resolver hits place_search + spr + place_population, never names).
+// Dropping it is the single biggest size win: ~90 MB off, taking US+DE+FR from 144 MB → ~53 MB, under
+// GitHub Pages' 100 MB/file ceiling. If a future consumer needs raw alt-names at runtime, keep them in
+// a separate shard rather than re-bloating the hot DB.
+out.exec(`DROP TABLE IF EXISTS names;`)
 out.exec(`VACUUM;`)
 const counts = {
 	spr: out.prepare("SELECT count(*) n FROM spr").get().n,


### PR DESCRIPTION
## Why

The US+DE+FR resolver DB was 144 MB, over GitHub Pages' 100 MB/file ceiling. Per-table breakdown (`dbstat`) showed the culprit:

| table | size |
|---|---:|
| **names** | **71 MB** |
| place_search (FTS5) | 36 MB |
| **names_id_idx** | **19.5 MB** |
| spr | 11 MB |
| place_bbox (R*Tree) | 5.6 MB |

`names` (~1.5M alt-name rows) + its index = **90 MB, nearly two-thirds of the file**.

## The fix

`place_search` is a **self-contained FTS5** (no external `content=`), so `names` is only the *source* the FTS index was built from — the resolver queries `place_search` + `spr` + `place_population` and **never touches `names` at runtime**. Drop it after `buildPlaceSearchFts`, before `VACUUM`.

**144 MB → 53 MB.** Every demo asset is now under 100 MB/file (no sharding needed). Paris/Berlin/postcode resolution verified intact. The 52 MB DB is already re-pushed to HF, so the live demo loads ~3× less today.

This unblocks serving the whole demo from **GitHub Pages** (same-origin, redirect-free, range-capable) — which also sidesteps the HF per-request-redirect latency that made HTTP-VFS slow (see PR #358).

🤖 Generated with [Claude Code](https://claude.com/claude-code)