### PR TITLE
feat(demo): range-load resolver DBs via sql.js-httpvfs (Phase 2+3, zero warnings)

### DIFF
--- a/docs/blog/tags.yml
+++ b/docs/blog/tags.yml
@@ -177,3 +177,15 @@ motivation:
   description: Articles making the case for Mailwoman — why neural, why TypeScript, why a staged pipeline.
 
 #endregion
+
+browser:
+  label: Browser
+  description: Articles about running Mailwoman entirely in the browser — WASM, WebGPU, sql.js-httpvfs, and the client-side demo.
+
+fst:
+  label: FST
+  description: Articles about the finite-state-transducer gazetteer that ships to the browser for fast locality matching.
+
+demo:
+  label: Demo
+  description: Articles about the public client-side geocoder demo and the assets that power it.

--- a/docs/plugins/demo-assets/plugin.mjs
+++ b/docs/plugins/demo-assets/plugin.mjs
@@ -25,6 +25,7 @@ import {
 	fetchArtifactFromHf,
 	readModelCard,
 	resolveWeightsArtifact,
+	stageSqlJsHttpvfs,
 	syncArtifact,
 } from "./resolve.mjs"
 
@@ -89,6 +90,11 @@ export default function demoAssetsPlugin(context) {
 			if (!existsSync(polyDest)) {
 				await fetchArtifactFromHf("wof-polygons.db", polyDest, { version: hfVersion })
 			}
+
+			// --- sql.js-httpvfs runtime assets (worker + wasm + UMD), for range-loading the DBs ---
+			const sqljsDir = resolve(staticDir, "sqljs")
+			mkdirSync(sqljsDir, { recursive: true })
+			stageSqlJsHttpvfs(sqljsDir)
 
 			// --- Report ---
 			const assets = ["model.onnx", "tokenizer.model", "fst-en-US.bin", "wof-hot.db", "wof-polygons.db"]

--- a/docs/plugins/demo-assets/resolve.mjs
+++ b/docs/plugins/demo-assets/resolve.mjs
@@ -262,6 +262,37 @@ export function syncArtifact(sourcePath, destPath, label) {
 	return true
 }
 
+/**
+ * Stage sql.js-httpvfs's runtime assets (the UMD bundle + its Worker + WASM) into `destDir`. The
+ * demo loads these at RUNTIME by URL — the UMD via a classic <script>, the worker + wasm passed to
+ * createDbWorker — so webpack never sees them. That's deliberate: bundling sql.js-httpvfs (a webpack
+ * UMD bundle with dynamic Worker/wasm requires) is exactly what produces "Critical dependency"
+ * build warnings, so we keep it out of the graph entirely.
+ *
+ * @param {string} destDir - e.g. static/mailwoman/sqljs
+ * @returns {boolean}
+ */
+export function stageSqlJsHttpvfs(destDir) {
+	let distDir
+	try {
+		distDir = dirname(requireFromPlugin.resolve("sql.js-httpvfs/dist/index.js"))
+	} catch {
+		console.warn("[demo-assets] sql.js-httpvfs not resolvable — HTTP-VFS assets not staged")
+		return false
+	}
+	const files = ["index.js", "sqlite.worker.js", "sql-wasm.wasm"]
+	for (const f of files) {
+		const src = resolve(distDir, f)
+		if (!existsSync(src)) {
+			console.warn(`[demo-assets] sql.js-httpvfs: missing ${f} in dist`)
+			return false
+		}
+		copyFileSync(src, resolve(destDir, f))
+	}
+	console.log(`[demo-assets] sql.js-httpvfs: staged ${files.length} runtime assets`)
+	return true
+}
+
 // ---------------------------------------------------------------------------
 // FST builder
 // ---------------------------------------------------------------------------

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -6,11 +6,11 @@
  *   Mailwoman geocoder demo — fully client-side. Combines:
  *
  *   - `@mailwoman/neural-web` (onnxruntime-web, WASM SIMD with WebGPU fallback) for the BIO classifier.
- *   - `@mailwoman/resolver-wof-wasm` (sqlite-wasm) for the WOF locality / postcode lookup.
+ *   - sql.js-httpvfs (../../shared/httpvfs-resolver) range-loading the same-origin WOF + polygon DBs.
  *   - `@mailwoman/cartographer` `StyleSpecificationComposer` over the v4 protomaps basemap.
  *
- *   Static-asset bundle (~60 MB cold): `/mailwoman/model.onnx`, `/mailwoman/tokenizer.model`,
- *   `/mailwoman/wof-hot.db`. After first load the browser caches everything.
+ *   The model/tokenizer/fst come from HF (one-shot full-fetch); the resolver DBs are served
+ *   same-origin from `/mailwoman/` and range-loaded, so a session fetches a few MB of them, not 70+.
  */
 
 import "maplibre-gl/dist/maplibre-gl.css"
@@ -276,11 +276,10 @@ const DemoApp: React.FC = () => {
 
 				if (release?.hasWofDb) {
 					setLookupLoader(() => async () => {
-						const resolverWasm = await import("@mailwoman/resolver-wof-wasm")
-						const { db } = await resolverWasm.loadSlimWofDatabase({
-							source: sameOriginDbUrl("wof-hot.db"),
-						})
-						return new resolverWasm.WofWasmPlaceLookup({ db })
+						// Range-load the same-origin DB via sql.js-httpvfs — ~5 MB/session vs the whole 53 MB.
+						const { loadHttpvfsDb, WofHttpvfsPlaceLookup } = await import("../../shared/httpvfs-resolver")
+						const worker = await loadHttpvfsDb(sameOriginDbUrl("wof-hot.db"), `${siteConfig.baseUrl}mailwoman/sqljs`)
+						return new WofHttpvfsPlaceLookup(worker)
 					})
 				}
 
@@ -371,9 +370,12 @@ const DemoApp: React.FC = () => {
 			if (release?.hasPolygons && selectedVersion && candidate.id) {
 				try {
 					if (!polygonDbRef.current) {
-						polygonDbRef.current = loadPolygonDb(sameOriginDbUrl("wof-polygons.db"))
+						polygonDbRef.current = loadPolygonDb(
+							sameOriginDbUrl("wof-polygons.db"),
+							`${siteConfig.baseUrl}mailwoman/sqljs`
+						)
 					}
-					const geom = (await polygonDbRef.current).get(candidate.id)
+					const geom = await (await polygonDbRef.current).get(candidate.id)
 					if (geom) {
 						drawPlaceGeometry(map, geom)
 						const gb = geomBounds(geom)
@@ -707,29 +709,22 @@ function geomBounds(geometry: PlaceGeometry): { minLon: number; minLat: number; 
 	return { minLon, minLat, maxLon, maxLat }
 }
 
-/** id → simplified admin geometry, backed by the lazily-loaded `wof-polygons.db`. */
+/** id → simplified admin geometry, backed by the lazily-loaded `wof-polygons.db`. Async (range-loaded). */
 interface PolygonDb {
-	get(id: number): PlaceGeometry | null
+	get(id: number): Promise<PlaceGeometry | null>
 }
 
 /**
- * Open the crisp-polygon DB (a normal SQLite, built by scripts/build-wof-polygons.mjs) in sqlite-wasm
- * and expose an id → geometry lookup. Reuses the resolver's loader — the file is just bytes to
- * deserialize, with no schema coupling to the WOF resolver tables.
+ * Open the crisp-polygon DB (built by scripts/build-wof-polygons.mjs) via sql.js-httpvfs — a single
+ * `SELECT geom WHERE id=?` touches ~1 page, so the browser fetches a few KB of the 19 MB file rather
+ * than the whole thing. Same range-load path as the resolver DB.
  */
-async function loadPolygonDb(url: string): Promise<PolygonDb> {
-	const resolverWasm = await import("@mailwoman/resolver-wof-wasm")
-	const { db } = await resolverWasm.loadSlimWofDatabase({ source: url })
+async function loadPolygonDb(url: string, sqljsBaseUrl: string): Promise<PolygonDb> {
+	const { loadHttpvfsDb, makeHttpvfsPolygonLookup } = await import("../../shared/httpvfs-resolver")
+	const worker = await loadHttpvfsDb(url, sqljsBaseUrl)
+	const lookup = makeHttpvfsPolygonLookup(worker)
 	return {
-		get(id: number): PlaceGeometry | null {
-			const rows = db.selectObjects("SELECT geom FROM polygons WHERE id = ?", [id]) as Array<{ geom: string }>
-			if (rows.length === 0) return null
-			try {
-				return JSON.parse(rows[0].geom) as PlaceGeometry
-			} catch {
-				return null
-			}
-		},
+		get: (id: number) => lookup.get(id) as Promise<PlaceGeometry | null>,
 	}
 }
 

--- a/docs/src/shared/httpvfs-resolver.ts
+++ b/docs/src/shared/httpvfs-resolver.ts
@@ -1,0 +1,173 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   sql.js-httpvfs-backed resolver for the demo. Range-loads the SAME-ORIGIN DB (served from the
+ *   Pages deploy) so a session fetches ~5 MB instead of the whole 53 MB — the win that matters on
+ *   mobile / metered links.
+ *
+ *   The query SQL + ranking mirror `@mailwoman/resolver-wof-wasm`'s `WofWasmPlaceLookup` (exact-name
+ *   tier → population-adjusted bm25, plus a point-in-bbox region constraint), but run ASYNC over the
+ *   worker's `db.exec`. We can't share that class directly: it consumes a synchronous in-memory
+ *   `@sqlite.org/sqlite-wasm` handle, whereas this talks to a Comlink-proxied sql.js worker. Keep the
+ *   two ranking implementations in lockstep. (sql.js-httpvfs's WASM has no rtree module, so we only
+ *   use FTS5 + plain-column bbox here — which is all the resolver path needs.)
+ *
+ *   sql.js-httpvfs ships a webpack UMD bundle (not ESM) and a Worker + WASM. The demo-assets plugin
+ *   stages all three into `static/mailwoman/sqljs/`; we load the UMD via a classic <script> (→
+ *   `window.createDbWorker`) and hand the worker + wasm URLs to it. Nothing here is bundled by
+ *   webpack — that's what keeps the Docusaurus build warning-free.
+ */
+
+import type { MailwomanLookupLike } from "./resources"
+
+const POPULATION_BOOST = 4.0
+const POPULATION_SCALE_LOG10 = 6.0
+
+const normName = (s: string): string => s.toLowerCase().trim().replace(/\s+/g, " ")
+/** Escape a string literal for inline SQL (we inline rather than bind — avoids param-marshaling over Comlink). */
+const sqlStr = (s: string): string => `'${s.replace(/'/g, "''")}'`
+
+/** Trim raw input into an FTS5-safe MATCH term. Mirrors resolver-wof-wasm's sanitizeFtsQuery intent. */
+function sanitizeFts(text: string): string {
+	const trimmed = text.trim()
+	const prefix = trimmed.endsWith("*")
+	const cleaned = trimmed
+		.replace(/[*]/g, " ")
+		.replace(/["'()^:{}\[\]~]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+	if (!cleaned) return ""
+	// Phrase-quote so multi-word names match as a unit, matching the demo's locality lookups.
+	return prefix ? `"${cleaned}"*` : `"${cleaned}"`
+}
+
+/** sql.js exec result → row objects. */
+function rowsFromExec(res: Array<{ columns: string[]; values: unknown[][] }> | undefined): Record<string, unknown>[] {
+	if (!res || res.length === 0) return []
+	const { columns, values } = res[0]
+	return values.map((row) => Object.fromEntries(columns.map((c, i) => [c, row[i]])))
+}
+
+interface HttpvfsWorker {
+	db: { exec(sql: string): Promise<Array<{ columns: string[]; values: unknown[][] }>> }
+}
+
+/**
+ * Load the sql.js-httpvfs UMD (once) and open a DB over byte-range fetches from `dbUrl`.
+ * `sqljsBaseUrl` is where the plugin staged the worker + wasm (e.g. "/mailwoman/sqljs").
+ */
+export async function loadHttpvfsDb(dbUrl: string, sqljsBaseUrl: string): Promise<HttpvfsWorker> {
+	const w = window as unknown as { createDbWorker?: (...args: unknown[]) => Promise<HttpvfsWorker> }
+	if (typeof w.createDbWorker !== "function") {
+		await new Promise<void>((res, rej) => {
+			const s = document.createElement("script")
+			s.src = `${sqljsBaseUrl}/index.js`
+			s.onload = () => res()
+			s.onerror = () => rej(new Error("sql.js-httpvfs UMD failed to load"))
+			document.head.appendChild(s)
+		})
+	}
+	if (typeof w.createDbWorker !== "function") throw new Error("createDbWorker missing after UMD load")
+	return w.createDbWorker(
+		[{ from: "inline", config: { serverMode: "full", url: dbUrl, requestChunkSize: 65536 } }],
+		`${sqljsBaseUrl}/sqlite.worker.js`,
+		`${sqljsBaseUrl}/sql-wasm.wasm`
+	)
+}
+
+/** PlaceLookup over the httpvfs worker — same ranking as WofWasmPlaceLookup, async. */
+export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
+	#worker: HttpvfsWorker
+	#hasPop: boolean | undefined
+
+	constructor(worker: HttpvfsWorker) {
+		this.#worker = worker
+	}
+
+	async #hasPopulation(): Promise<boolean> {
+		if (this.#hasPop === undefined) {
+			const r = rowsFromExec(
+				await this.#worker.db.exec("SELECT 1 FROM sqlite_master WHERE type='table' AND name='place_population' LIMIT 1")
+			)
+			this.#hasPop = r.length > 0
+		}
+		return this.#hasPop
+	}
+
+	async findPlace(query: Parameters<MailwomanLookupLike["findPlace"]>[0]) {
+		const text = (query.text ?? "").trim()
+		if (!text) return []
+		const fts = sanitizeFts(text)
+		if (!fts) return []
+		const limit = Math.max(1, query.limit ?? 10)
+
+		const conds = [`place_search MATCH ${sqlStr(fts)}`, "spr.is_current != 0", "spr.is_deprecated = 0"]
+		if (query.placetype) {
+			const types = (Array.isArray(query.placetype) ? query.placetype : [query.placetype]).filter(Boolean) as string[]
+			if (types.length) conds.push(`spr.placetype IN (${types.map(sqlStr).join(",")})`)
+		}
+		if (query.country) conds.push(`spr.country = ${sqlStr(query.country.toUpperCase())}`)
+		if (query.bbox) {
+			const b = query.bbox
+			conds.push(
+				`spr.latitude BETWEEN ${Number(b.minLat)} AND ${Number(b.maxLat)} AND spr.longitude BETWEEN ${Number(b.minLon)} AND ${Number(b.maxLon)}`
+			)
+		}
+
+		const hasPop = await this.#hasPopulation()
+		const pool = Math.max(limit, 50)
+		const sql =
+			`SELECT spr.id, spr.name, spr.placetype, spr.country, spr.latitude, spr.longitude, spr.parent_id, ` +
+			`spr.min_latitude, spr.max_latitude, spr.min_longitude, spr.max_longitude, ` +
+			`${hasPop ? "pp.population" : "NULL"} AS population, bm25(place_search) AS bm25 ` +
+			`FROM place_search JOIN spr ON spr.id = place_search.wof_id ` +
+			`${hasPop ? "LEFT JOIN place_population pp ON pp.id = spr.id " : ""}` +
+			`WHERE ${conds.join(" AND ")} ORDER BY bm25(place_search) ASC LIMIT ${pool}`
+
+		const rows = rowsFromExec(await this.#worker.db.exec(sql))
+		const normQuery = normName(text)
+		return rows
+			.map((row) => {
+				const pop = typeof row.population === "number" ? row.population : 0
+				const popBoost = pop > 0 ? POPULATION_BOOST * Math.min(1, Math.log10(1 + pop) / POPULATION_SCALE_LOG10) : 0
+				const adj = (row.bm25 as number) - popBoost
+				return { row, exactTier: normName(String(row.name)) === normQuery ? 0 : 1, adj }
+			})
+			.sort((a, b) => a.exactTier - b.exactTier || a.adj - b.adj)
+			.slice(0, limit)
+			.map(({ row, adj }) => ({
+				id: row.id as number,
+				name: row.name as string,
+				placetype: row.placetype as string,
+				lat: row.latitude as number,
+				lon: row.longitude as number,
+				score: -adj,
+				bbox:
+					row.min_latitude != null && row.max_latitude != null && row.min_longitude != null && row.max_longitude != null
+						? {
+								minLat: row.min_latitude as number,
+								maxLat: row.max_latitude as number,
+								minLon: row.min_longitude as number,
+								maxLon: row.max_longitude as number,
+							}
+						: undefined,
+			}))
+	}
+}
+
+/** Polygon lookup over an httpvfs worker: id → GeoJSON geometry (async). */
+export function makeHttpvfsPolygonLookup(worker: HttpvfsWorker) {
+	return {
+		async get(id: number): Promise<unknown | null> {
+			const rows = rowsFromExec(await worker.db.exec(`SELECT geom FROM polygons WHERE id = ${Number(id)}`))
+			if (rows.length === 0) return null
+			try {
+				return JSON.parse(String(rows[0].geom))
+			} catch {
+				return null
+			}
+		},
+	}
+}


### PR DESCRIPTION
**Phases 2 + 3** — the mobile win + the zero-warnings cleanup. Builds on Phase 1 (#360, DBs served same-origin).

## What changed
- **Plugin stages sql.js-httpvfs's runtime assets** (UMD + worker + wasm) into `static/mailwoman/sqljs/`. They're loaded at **runtime by URL** (the UMD via a classic `<script>` → `window.createDbWorker`; worker/wasm passed to it) — **never through webpack**, which is what keeps the build warning-free.
- **New `shared/httpvfs-resolver.ts`** — an async `WofHttpvfsPlaceLookup` over `worker.db.exec` that mirrors `WofWasmPlaceLookup`'s ranking exactly (exact-name tier → population-adjusted bm25 + point-in-bbox), plus an async polygon lookup. No R*Tree (sql.js-httpvfs's WASM lacks it; the resolver path doesn't use it).
- **Demo loads both DBs over httpvfs** (`PolygonDb.get` is now async). This drops `@mailwoman/resolver-wof-wasm` from the demo bundle, **tree-shaking `@sqlite.org/sqlite-wasm` out** (verified: `sqlite3-worker1`/`InitModule` gone) — which clears the 2 "Critical dependency" warnings.
- **Phase 3** — added the missing blog tags (`browser`/`fst`/`demo`) to `tags.yml`.

## Result
- **Build: 0 warnings** (down from 4), SSG success, DBs + sqljs assets land in `build/mailwoman/`.
- A session fetches **~5 MB of byte ranges** instead of the whole 53 MB — the win for mobile / metered links (measured cold-vs-warm in #358).

## What's the operator's to verify
The **browser/mobile runtime** — that range-loading works over the live Pages deploy (same-origin, redirect-free) — can't be driven from here. Merge deploys it; please sanity-check the demo (desktop + a phone) resolves an address and draws a polygon, and that the Network tab shows small range requests to `/mailwoman/wof-hot.db` rather than a 53 MB download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)