### PR TITLE
docs: confidence-calibration concept doc + the "which Berlin" resolver-metric blog (#368)

### DIFF
--- a/docs/articles/concepts/confidence-calibration.md
+++ b/docs/articles/concepts/confidence-calibration.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 31
+title: Confidence calibration
+tags:
+  - concepts
+  - neural
+  - calibration
+  - eval
+---
+
+# Confidence calibration
+
+Every span the parser emits carries a number: `conf="0.94"` on the locality, `conf="0.81"` on the street. You're going to want to do something with that number. Auto-accept the parses you're sure of, route the shaky ones to a human, lower a resolver's trust when the parser is hedging. Before you can lean on it, there's one question worth answering honestly: when the model says it's 94% sure, is it actually right 94% of the time?
+
+For a long while, ours wasn't.
+
+## The forecaster's promise
+
+Think about a weather forecaster. A good one who says "70% chance of rain" should be right on about seven of every ten days they say it. That's the whole contract: the number means what it says. If it rains on nineteen of every twenty "70%" days, the forecaster is sandbagging; if it rains on half, they're overselling. Either way you stop trusting the percentage, and the percentage was the useful part.
+
+A neural classifier makes the same promise implicitly, every time it hands you a softmax probability. And like a lot of cross-entropy-trained models, ours quietly broke it: confident in some bands, timid in others, with no single knob that lined the number up with reality.
+
+We measured the gap with Expected Calibration Error. Bucket the predictions by stated confidence, and in each bucket compare the average confidence to how often those predictions were actually right. Average the gaps, weighted by how many predictions land in each bucket. Zero is a forecaster you can trust. Ours sat around 0.067, about seven points of slack between what the model claimed and what it delivered.
+
+## A correction sticker, not a new model
+
+The fix doesn't touch the model. It's the same move you'd make with a cheap kitchen thermometer that reads ten degrees low. You don't crack it open and re-machine the probe; you tape a little card to the handle that says "reads 340, it's really 350."
+
+We build that card by running the shipped model over a pile of addresses where we already know the answer, watching where its stated confidence drifts from how often it turns out correct, and fitting a lookup table that translates raw confidence into an honest one. The fit is _isotonic_, which is a fancy word for a simple promise: the translation never runs backwards, so a raw 0.9 always maps to at least as much corrected confidence as a raw 0.8. Twenty bins, monotone, nothing exotic. And we calibrate the number you actually read, the per-span `conf=` aggregated across a span's tokens, rather than some internal per-token probability you'd never see.
+
+The result, measured on addresses the fit never saw: ECE 0.067 → 0.0035. The Brier score, another honesty measure, drops from 0.034 to 0.027. The `conf=` now means roughly what it says.
+
+## Where the honesty lives
+
+Two details keep this from being a number that flatters itself.
+
+First, we fit on one slice of data and report on another. Grading a calibrator on the same examples you tuned it on is like a forecaster grading last week's forecasts after he's already seen the weather; the score comes out better than the future will. So every number above is measured on a held-out 20% the fit never touched.
+
+Second, the calibration set is half OpenAddresses (real, government-sourced addresses the model never trained on) and half training-corpus rows. The corpus half is in-domain, so the model runs a touch optimistic there; the OpenAddresses half is the genuinely held-out, real-world signal. We report the OpenAddresses-only number next to the combined one (0.071 → 0.0067) precisely so that optimism stays visible instead of getting averaged away. Trust the OpenAddresses number more. We'd rather hand it to you than bury it.
+
+## It's off by default
+
+Calibration is opt-in. The default parse output is byte-for-byte what it was before, because silently rewriting the `conf=` values would break anything downstream that pinned to them. So the lookup table ships as a small JSON, and a caller who wants calibrated confidence builds a calibrator and passes it in:
+
+```ts
+import { createCalibrator } from "@mailwoman/core/decoder"
+import table from "../data/eval/calibration/isotonic-en-us-v4.0.0.json"
+
+const calibrate = createCalibrator(table)
+const tree = await classifier.parse(input, { calibrate })
+```
+
+Leave it out and you get today's numbers, unchanged.
+
+## Why bother
+
+A calibrated `conf=` is the difference between "the model felt good about this" and "this is right about 94% of the time." The first is a vibe. The second is something you can build a threshold on, accept-above-0.95 and review-the-rest, and have the threshold mean what you set it to. That's the entire reason to put a number on the output: so you can act on it without re-deriving the model's mood every time.
+
+The pipeline that produced the table (build the set, score the model, fit the curve) lives in `scripts/eval/`, and re-running it for a new model is three commands. The full reliability tables and methodology are in the [calibration eval report](../evals/2026-06-07-isotonic-calibration.md).

--- a/docs/blog/2026-06-07-which-berlin.mdx
+++ b/docs/blog/2026-06-07-which-berlin.mdx
@@ -2,7 +2,7 @@
 title: "Which Berlin? When your metric grades the wrong thing"
 description: "Our resolver kept dropping German addresses in New Hampshire, and our scorecard handed it a gold star every time. Here's how a name-match metric lied to us for months, and what a postcode hint was quietly worth once we measured by distance instead."
 authors: [teffen]
-tags: [neural, resolver, eval, calibration]
+tags: [neural, resolver, hubris]
 ---
 
 Ask a geocoder for "Berlin" and it has to make a choice. There's the one in Germany, obviously. There's also Berlin, New Hampshire (population nine thousand and change), Berlin, Wisconsin, Berlin, Connecticut, and a dozen more scattered across the United States like the name was on sale. The parser hands you the word `Berlin` tagged as a locality; something downstream has to decide _which_ dot on the map that is. How would you even know if it picked right?
@@ -37,7 +37,7 @@ A metric you can satisfy without being right will let you be wrong forever, chee
 
 ## The same week, the same lesson
 
-This landed the same week we did something that sounds unrelated and turns out to be the identical problem: we calibrated the parser's confidence. Every span comes out stamped with a `conf=` number, and we'd never checked whether a 0.9 actually meant right-nine-times-in-ten. It didn't, until we fit a correction that made it honest (the [calibration writeup](/articles/concepts/confidence-calibration) has the details, including the weather-forecaster version of the story).
+This landed the same week we did something that sounds unrelated and turns out to be the identical problem: we calibrated the parser's confidence. Every span comes out stamped with a `conf=` number, and we'd never checked whether a 0.9 actually meant right-nine-times-in-ten. It didn't, until we fit a correction that made it honest (the [calibration writeup](/docs/concepts/confidence-calibration) has the details, including the weather-forecaster version of the story).
 
 Both are the same realization wearing different hats. A geocoder reports numbers about itself constantly: how confident it is in a tag, how well it scored on a benchmark. Those numbers are worthless decoration until you've checked that they mean what they say. A confidence that isn't calibrated is a vibe with a decimal point. A benchmark you can game is a way to feel good while shipping the wrong Berlin.
 

--- a/docs/blog/2026-06-07-which-berlin.mdx
+++ b/docs/blog/2026-06-07-which-berlin.mdx
@@ -1,0 +1,46 @@
+---
+title: "Which Berlin? When your metric grades the wrong thing"
+description: "Our resolver kept dropping German addresses in New Hampshire, and our scorecard handed it a gold star every time. Here's how a name-match metric lied to us for months, and what a postcode hint was quietly worth once we measured by distance instead."
+authors: [teffen]
+tags: [neural, resolver, eval, calibration]
+---
+
+Ask a geocoder for "Berlin" and it has to make a choice. There's the one in Germany, obviously. There's also Berlin, New Hampshire (population nine thousand and change), Berlin, Wisconsin, Berlin, Connecticut, and a dozen more scattered across the United States like the name was on sale. The parser hands you the word `Berlin` tagged as a locality; something downstream has to decide _which_ dot on the map that is. How would you even know if it picked right?
+
+For a long time our answer was a scorecard that checked the name. Did the resolved place's name equal the expected name? Tick. Move on. It is a completely reasonable thing to measure, and it was lying to us for months.
+
+{/* truncate */}
+
+## The gold star for New Hampshire
+
+Here's the failure the name check can't see. Feed it a German address, let the resolver land on Berlin, New Hampshire, and ask the scorecard how it did. The resolved name is "Berlin." The expected name is "Berlin." Tick. Gold star. We just put a Berlin address an ocean away from Berlin and the metric congratulated us for it.
+
+This isn't a contrived edge case. Bare locality names collide constantly across borders, and a name-only check is structurally blind to the collision. Whenever the model dropped a German locality on its American namesake, our headline number stayed perfectly, serenely flat. The bug and the scorecard were made for each other.
+
+We only tripped over it by accident, chasing something else entirely.
+
+## The hint that did nothing, loudly
+
+Every address carries a postcode, and a postcode mostly pins down a country. So we built a small extractor that turns the postcode into a guess about which country you're in, and we ran a simulation: feed that country guess into the resolver's ranking, give candidates from the right country a nudge, and see how much the name-match score improves.
+
+It improved by nothing. Zero. Flat line.
+
+Which, briefly, looked like a dead end. The hint was supposed to help and the number said it didn't. Then it clicked: the number _couldn't_ say it helped, because the number grades by name, and fixing a wrong-country pick doesn't change the name. We'd handed our metric exactly the kind of improvement it was built to ignore.
+
+## Measure the distance and the floor falls out
+
+So we threw out the name check and graded by distance instead. We have the real government coordinates for every test address, so we can ask the only question that actually matters: how far is the resolver's pick from where the address really is?
+
+The picture inverted immediately. On German addresses, the postcode hint dragged 33 picks back across the Atlantic to where they belonged, erasing about 117,000 kilometers of total error. On American addresses it pulled 333 of them more than 100 km closer to the truth and pushed only 7 the wrong way, a roughly fifty-to-one trade. The hint was quietly worth a continent, and the name scorecard had been sitting there the whole time reporting that absolutely nothing was happening.
+
+A metric you can satisfy without being right will let you be wrong forever, cheerfully, in production. "Berlin" matches "Berlin" no matter which one you meant. The distance to the real point does not care what you call the place; it just measures whether you found it. We switched the yardstick, and we're building the country hint into the resolver for real now that we can finally see what it does.
+
+## The same week, the same lesson
+
+This landed the same week we did something that sounds unrelated and turns out to be the identical problem: we calibrated the parser's confidence. Every span comes out stamped with a `conf=` number, and we'd never checked whether a 0.9 actually meant right-nine-times-in-ten. It didn't, until we fit a correction that made it honest (the [calibration writeup](/articles/concepts/confidence-calibration) has the details, including the weather-forecaster version of the story).
+
+Both are the same realization wearing different hats. A geocoder reports numbers about itself constantly: how confident it is in a tag, how well it scored on a benchmark. Those numbers are worthless decoration until you've checked that they mean what they say. A confidence that isn't calibrated is a vibe with a decimal point. A benchmark you can game is a way to feel good while shipping the wrong Berlin.
+
+So the next time a metric tells you everything is fine, ask it the one thing it isn't measuring. Ours was measuring the spelling. It should have been measuring the distance.
+
+_The harness, the per-row deltas, and the reproducible reports live in `scripts/eval/anchor-resolver-delta.ts` and `docs/articles/evals/`. Numbers in this post are generated, not hand-typed._


### PR DESCRIPTION
The operator-requested write-up of #59 (PR #367), two pieces, addressing the calibration epic #368.

**`docs/articles/concepts/confidence-calibration.md`** (polished) — what confidence calibration is, in plain terms: the weather-forecaster contract ("when it says 90%, is it right 90%?"), the kitchen-thermometer correction-sticker for the method (isotonic, 20-bin, per-span), the held-out-vs-in-domain honesty (OA-only is the trustworthy number), and the opt-in/byte-stable wiring. All figures pulled from the committed eval report (ECE 0.067 → 0.0035; OA-only 0.071 → 0.0067; Brier 0.034 → 0.027).

**`docs/blog/2026-06-07-which-berlin.mdx`** (spicy) — the anchor→resolver harness finding as a story: a name-match metric is structurally blind to country confusion (Berlin DE vs Berlin NH both "match"), so feeding the postcode's country hint showed **+0.0%** on name-match while the coordinate yardstick revealed 33 DE picks corrected (117k km) and 333 US rows pulled >100 km closer vs 7 worse. Tied to calibration under one theme: a geocoder's self-reported numbers are decoration until you check they mean what they say.

House voice (polished doc / spicy blog), figures generated not hand-typed, MDX-`<` checked, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)