### PR TITLE
eval: leakage-split F1 — no geographic memorization on locality/region/postcode (#371)

### DIFF
--- a/docs/articles/evals/2026-06-07-leakage-split-us.md
+++ b/docs/articles/evals/2026-06-07-leakage-split-us.md
@@ -1,0 +1,34 @@
+# Leakage-split F1 — openaddresses-us-sample.jsonl
+
+Per-tag F1 split by corpus-held-out geography (VT/WY/ND) vs in-training geography. A large in-training − held-out gap = the headline F1 is partly memorization (#371).
+
+- held-out rows: 1428 · in-training rows: 8572 · model: `neural-weights-en-us/model.onnx` (v4.0.0)
+
+| tag       | held-out F1 | in-training F1 | gap (in − held) |
+| --------- | ----------: | -------------: | --------------: |
+| locality  |       1.000 |          0.987 |          -0.012 |
+| region    |       1.000 |          0.999 |          -0.001 |
+| postcode  |       1.000 |          0.996 |          -0.004 |
+| **macro** |   **1.000** |      **0.994** |      **-0.006** |
+
+## Per-state macro-F1 (difficulty confound check)
+
+| state |    n | macro-F1 | held-out?   |
+| ----- | ---: | -------: | ----------- |
+| MT    | 4284 |    0.979 |             |
+| DC    | 4287 |    0.992 |             |
+| IA    | 4287 |    0.996 |             |
+| SD    | 4284 |    0.998 |             |
+| CA    | 4287 |    1.000 |             |
+| VT    | 4284 |    1.000 | ✅ held-out |
+| IL    | 4287 |    1.000 |             |
+
+## Read
+
+DeepSeek (2026-06-07) flagged geographic train/test leakage as the top risk to our headline F1: the model trains on the corpus (tiger/BAN/WOF), which covers the same streets and localities OA tests, so component recall could be partly memorization. The corpus holds out specific US geography (VT/WY/ND) from training, so OA rows there test places the model never saw.
+
+The result refutes that hypothesis on the tags OA can grade. Held-out Vermont scores 1.000 macro-F1 against 0.994 in-training, so held-out is if anything marginally easier. The per-state spread tells the same story from another angle: Montana (in-training) is the worst at 0.979 while Vermont (held-out) ties California and Illinois at the top. The ordering tracks intrinsic state difficulty, not training exposure. The shipped en-US model's locality/region/postcode recognition generalizes to unseen geography, and the near-perfect numbers also confirm that these three tags on clean, canonical US addresses are essentially a solved problem.
+
+One caveat carries the whole result, so it's worth stating plainly. This only tests `locality`, `region`, and `postcode`, because that's all OpenAddresses gold carries. Leakage would bite hardest on STREET recognition, where memorizing a street name is the obvious shortcut, and OA can't grade street at all. A complete leakage check needs full-BIO corpus gold restricted to held-out geography, which is tracked as a follow-up on #371. And only Vermont survives in this US sample (Wyoming and North Dakota contribute zero rows), so the held-out signal is one state wide.
+
+Reproduce: `node --experimental-strip-types scripts/eval/leakage-split-f1.ts --eval data/eval/external/openaddresses-us-sample.jsonl --held VT,WY,ND --out-md <path>`.

--- a/scripts/eval/leakage-split-f1.ts
+++ b/scripts/eval/leakage-split-f1.ts
@@ -1,0 +1,212 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Leakage-split F1 (#371, DeepSeek 2026-06-07 S39 — "may change everything"). Random OA evaluation
+ *   can flatter us: the model trains on the corpus (tiger/BAN/WOF), which COVERS the same
+ *   streets/localities that OA tests, so component recall is partly memorization rather than
+ *   generalization. The corpus holds out specific geography (`v0.1.0` `splits/SPLIT_MANIFEST.json`:
+ *   VT/WY/ND for US, Corse/Lozère/ Creuse for FR). So OA rows in the held-out geography test the
+ *   model on places it NEVER trained on, and the gap between in-training F1 and held-out F1 is an
+ *   honest estimate of the leakage inflation.
+ *
+ *   This computes per-tag precision/recall/F1 over OA, split by held-out vs in-training geography,
+ *   for the tags OA gold carries ({locality, region, postcode}). A large in-training − held-out gap
+ *   means the headline F1 is partly memorization.
+ *
+ *   Caveat: held-out geography can differ in intrinsic difficulty (rural VT vs urban CA), so a gap is
+ *   an upper bound on leakage, not a clean isolation. Reported per-state so the confound is
+ *   visible.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/leakage-split-f1.ts\
+ *   --eval data/eval/external/openaddresses-us-sample.jsonl --held VT,WY,ND\
+ *   [--model neural-weights-en-us/model.onnx --tokenizer ... --model-card ... --out-md <path>]
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { readFileSync, writeFileSync } from "node:fs"
+
+function arg(name: string, fallback = ""): string {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+}
+
+interface OaRow {
+	input: string
+	expected: { locality?: string; region?: string; postcode?: string }
+	state: string
+}
+
+const GRADED = ["locality", "region", "postcode"] as const
+
+function norm(s: string): string {
+	return s
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}]+/gu, " ")
+		.trim()
+		.replace(/\s+/g, " ")
+}
+
+function valueMatch(pred: string, gold: string): boolean {
+	const a = norm(pred)
+	const b = norm(gold)
+	if (!a || !b) return false
+	if (a === b) return true
+	const aset = new Set(a.split(" "))
+	const bset = new Set(b.split(" "))
+	const subset = (xs: Set<string>, ys: Set<string>): boolean => [...xs].every((t) => ys.has(t))
+	return subset(aset, bset) || subset(bset, aset)
+}
+
+function firstByTag(tree: AddressTree, tag: string): AddressNode | undefined {
+	let found: AddressNode | undefined
+	const walk = (n: AddressNode): void => {
+		if (found) return
+		if (n.tag === tag) found = n
+		else for (const c of n.children) walk(c)
+	}
+	for (const r of tree.roots) walk(r)
+	return found
+}
+
+interface Counts {
+	tp: number
+	fp: number
+	fn: number
+}
+const newCounts = (): Record<string, Counts> => ({
+	locality: { tp: 0, fp: 0, fn: 0 },
+	region: { tp: 0, fp: 0, fn: 0 },
+	postcode: { tp: 0, fp: 0, fn: 0 },
+})
+
+/** Grade one parse against OA's partial gold; accumulate TP/FP/FN per graded tag. */
+function grade(tree: AddressTree, expected: OaRow["expected"], acc: Record<string, Counts>): void {
+	for (const tag of GRADED) {
+		const gold = expected[tag]
+		const pred = firstByTag(tree, tag)
+		if (gold && pred) {
+			if (valueMatch(pred.value, gold)) acc[tag]!.tp++
+			else {
+				acc[tag]!.fp++
+				acc[tag]!.fn++
+			}
+		} else if (gold && !pred) {
+			acc[tag]!.fn++ // missed a component that's there
+		} else if (!gold && pred) {
+			acc[tag]!.fp++ // emitted a component OA says isn't there (rare for these tags)
+		}
+	}
+}
+
+function f1(c: Counts): { p: number; r: number; f1: number } {
+	const p = c.tp + c.fp ? c.tp / (c.tp + c.fp) : 0
+	const r = c.tp + c.fn ? c.tp / (c.tp + c.fn) : 0
+	return { p, r, f1: p + r ? (2 * p * r) / (p + r) : 0 }
+}
+
+async function main(): Promise<void> {
+	const evalPath = arg("eval", "data/eval/external/openaddresses-us-sample.jsonl")
+	const held = new Set(
+		arg("held", "VT,WY,ND")
+			.split(",")
+			.map((s) => s.trim().toUpperCase())
+	)
+	const limit = Number(arg("limit", "0")) || Infinity
+
+	const rows: OaRow[] = readFileSync(evalPath, "utf8")
+		.split("\n")
+		.filter((l) => l.trim())
+		.map((l) => JSON.parse(l))
+		.slice(0, limit === Infinity ? undefined : limit)
+
+	const { NeuralAddressClassifier } = await import("@mailwoman/neural")
+	const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+	const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+	const modelCard = JSON.parse(readFileSync(arg("model-card", "neural-weights-en-us/model-card.json"), "utf8"))
+	const [tokenizer, runner] = await Promise.all([
+		MailwomanTokenizer.loadFromFile(arg("tokenizer", "neural-weights-en-us/tokenizer.model")),
+		OnnxRunner.create(arg("model", "neural-weights-en-us/model.onnx")),
+	])
+	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels })
+	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
+
+	const heldAcc = newCounts()
+	const inAcc = newCounts()
+	const perState: Record<string, Record<string, Counts>> = {}
+	let heldN = 0
+	let inN = 0
+	let i = 0
+	for (const row of rows) {
+		i++
+		if (i % 1000 === 0) console.error(`  ${i}/${rows.length}`)
+		let tree: AddressTree
+		try {
+			tree = await neural.parse(row.input, parseOpts)
+		} catch {
+			continue
+		}
+		const st = (row.state || "??").toUpperCase()
+		const isHeld = held.has(st)
+		grade(tree, row.expected, isHeld ? heldAcc : inAcc)
+		if (!perState[st]) perState[st] = newCounts()
+		grade(tree, row.expected, perState[st]!)
+		if (isHeld) heldN++
+		else inN++
+	}
+
+	const macro = (acc: Record<string, Counts>): number => GRADED.reduce((s, t) => s + f1(acc[t]!).f1, 0) / GRADED.length
+
+	const lines: string[] = []
+	lines.push(`# Leakage-split F1 — ${evalPath.split("/").pop()}`)
+	lines.push("")
+	lines.push(
+		`Per-tag F1 split by corpus-held-out geography (${[...held].join("/")}) vs in-training geography. ` +
+			`A large in-training − held-out gap = the headline F1 is partly memorization (#371).`
+	)
+	lines.push("")
+	lines.push(
+		`- held-out rows: ${heldN} · in-training rows: ${inN} · model: ${arg("model", "neural-weights-en-us/model.onnx")}`
+	)
+	lines.push("")
+	lines.push("| tag | held-out F1 | in-training F1 | gap (in − held) |")
+	lines.push("| --- | ---: | ---: | ---: |")
+	for (const t of GRADED) {
+		const h = f1(heldAcc[t]!).f1
+		const inF = f1(inAcc[t]!).f1
+		lines.push(`| ${t} | ${h.toFixed(3)} | ${inF.toFixed(3)} | ${(inF - h >= 0 ? "+" : "") + (inF - h).toFixed(3)} |`)
+	}
+	lines.push(
+		`| **macro** | **${macro(heldAcc).toFixed(3)}** | **${macro(inAcc).toFixed(3)}** | **${(macro(inAcc) - macro(heldAcc) >= 0 ? "+" : "") + (macro(inAcc) - macro(heldAcc)).toFixed(3)}** |`
+	)
+	lines.push("")
+	lines.push("## Per-state macro-F1 (difficulty confound check)")
+	lines.push("")
+	lines.push("| state | n | macro-F1 | held-out? |")
+	lines.push("| --- | ---: | ---: | --- |")
+	const stateRows = Object.entries(perState)
+		.map(([st, acc]) => {
+			const n = GRADED.reduce((s, t) => s + acc[t]!.tp + acc[t]!.fn, 0)
+			return { st, n, m: macro(acc), held: held.has(st) }
+		})
+		.sort((a, b) => a.m - b.m)
+	for (const s of stateRows) {
+		lines.push(`| ${s.st} | ${s.n} | ${s.m.toFixed(3)} | ${s.held ? "✅ held-out" : ""} |`)
+	}
+	lines.push("")
+
+	const out = lines.join("\n") + "\n"
+	const outMd = arg("out-md")
+	if (outMd) {
+		writeFileSync(outMd, out)
+		console.error(`wrote → ${outMd}`)
+	} else {
+		console.log(out)
+	}
+	console.error(
+		`\nmacro-F1 held-out ${macro(heldAcc).toFixed(3)} vs in-training ${macro(inAcc).toFixed(3)} (gap ${(macro(inAcc) - macro(heldAcc)).toFixed(3)})`
+	)
+}
+
+void main()


### PR DESCRIPTION
Addresses #371 (DeepSeek's #1, "may change everything"). New additive eval `scripts/eval/leakage-split-f1.ts` + committed report.

**Question:** is our headline OA F1 inflated by memorization? The model trains on the corpus (tiger/BAN/WOF), which covers the same streets/localities OA tests. The corpus holds out VT/WY/ND from training, so OA rows there test never-seen geography.

**Result (shipped en-us v4.0.0):** held-out VT macro-F1 **1.000** vs in-training **0.994** — held-out is if anything marginally *easier*. Per-state spread (MT 0.979 worst/in-training, VT 1.000 top/held-out) tracks intrinsic difficulty, not training exposure. **No memorization inflation** on locality/region/postcode.

**Caveat (load-bearing):** OA gold only carries {locality, region, postcode}; leakage bites hardest on STREET, which OA can't grade. A complete check needs full-BIO corpus gold restricted to held-out geography — left as a follow-up checkbox on #371. Only VT survives in the US sample (WY/ND have zero rows), so the held-out signal is one state wide.

Report: `docs/articles/evals/2026-06-07-leakage-split-us.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)