### PR TITLE
feat(resolver): opt-in postcode-anchor country re-ranker (#369)

### DIFF
--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -395,4 +395,37 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 		const alts = root.alternatives as ResolvedPlace[]
 		expect(alts).toHaveLength(1) // limit 2 → top + 1 alternative
 	})
+
+	test("anchor posterior re-ranks locality candidates by country (#369), off by default", async () => {
+		// Two same-named localities; US scores higher on name/BM25, DE is the runner-up.
+		const berlins: ResolvedPlace[] = [
+			{ id: 1, name: "Berlin", placetype: "locality", country: "US", lat: 44.46, lon: -71.18, score: 8 },
+			{ id: 2, name: "Berlin", placetype: "locality", country: "DE", lat: 52.52, lon: 13.4, score: 7 },
+		]
+		const input = tree("Berlin", [node("locality", "Berlin", 0, 6)])
+
+		// Default (no posterior): the higher-scored US Berlin wins — byte-stable.
+		const off = await createWofResolver(new FakeResolverBackend(berlins)).resolveTree(input)
+		expect(off.roots[0]!.placeId).toBe("wof:1")
+
+		// With a DE country posterior, the +weight*posterior boost pulls the German Berlin to the top.
+		const on = await createWofResolver(new FakeResolverBackend(berlins)).resolveTree(input, {
+			anchorPosterior: { DE: 1.0 },
+		})
+		expect(on.roots[0]!.placeId).toBe("wof:2")
+		// The displaced US Berlin survives as the top alternative.
+		expect((on.roots[0]!.alternatives as ResolvedPlace[])[0]!.id).toBe(1)
+	})
+
+	test("anchor posterior leaves the pick unchanged when it already agrees (#369)", async () => {
+		const berlins: ResolvedPlace[] = [
+			{ id: 1, name: "Berlin", placetype: "locality", country: "US", lat: 44.46, lon: -71.18, score: 8 },
+			{ id: 2, name: "Berlin", placetype: "locality", country: "DE", lat: 52.52, lon: 13.4, score: 7 },
+		]
+		const input = tree("Berlin", [node("locality", "Berlin", 0, 6)])
+		const on = await createWofResolver(new FakeResolverBackend(berlins)).resolveTree(input, {
+			anchorPosterior: { US: 1.0 },
+		})
+		expect(on.roots[0]!.placeId).toBe("wof:1") // US already top, boost keeps it there
+	})
 })

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -41,6 +41,10 @@ interface ResolutionState {
 	/** The address's postcode string, extracted once up front, passed to locality lookups so a
 	 * coordinate-first backend can inject postcode-proximal locality candidates. */
 	postcode?: string
+	/** Postcode-anchor country posterior (#369). Undefined = no re-rank (byte-stable default). */
+	anchorPosterior?: Record<string, number>
+	/** Weight on the posterior in the locality re-rank. Only used when `anchorPosterior` is set. */
+	anchorWeight: number
 }
 
 /** Find the first postcode value anywhere in the tree (a one-shot pre-scan; postcode and locality are
@@ -73,6 +77,8 @@ class WofResolver implements Resolver {
 			defaultCountry: opts.defaultCountry,
 			parentFallback: opts.parentFallback ?? true,
 			postcode: firstPostcodeValue(tree.roots),
+			anchorPosterior: opts.anchorPosterior,
+			anchorWeight: opts.anchorWeight ?? 2.0,
 		}
 
 		const newRoots: AddressNode[] = []
@@ -149,9 +155,23 @@ class WofResolver implements Resolver {
 		}
 
 		if (candidates.length === 0) return null
-		const top = candidates[0]!
+		// Postcode-anchor re-rank (#369): when a country posterior is supplied (from the address's
+		// postcode), boost candidates by `anchorWeight * posterior[candidate.country]` and re-sort, so a
+		// postcode that pins the country pulls the right-country place over a higher-BM25 foreign namesake
+		// (the "Berlin DE vs Berlin US" class the #59 harness measured). No-op when `anchorPosterior` is
+		// undefined (the default) → byte-identical resolution. Locality-scoped: the posterior is a country
+		// signal, and admin parents already carry country via `parentId`.
+		let ranked = candidates
+		if (state.anchorPosterior && placetype === "locality" && candidates.length > 1) {
+			const post = state.anchorPosterior
+			const w = state.anchorWeight
+			ranked = [...candidates].sort(
+				(a, b) => b.score + w * (post[b.country] ?? 0) - (a.score + w * (post[a.country] ?? 0))
+			)
+		}
+		const top = ranked[0]!
 		if (top.score < state.minWinningScore) return null
-		return { top, alternatives: candidates.slice(1) }
+		return { top, alternatives: ranked.slice(1) }
 	}
 }
 

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -123,6 +123,21 @@ export interface ResolveOpts {
 	 * break when locale-aware resolvers land in 4.4+.
 	 */
 	locale?: string
+	/**
+	 * Optional postcode-anchor country posterior (#369) — a `{ countryCode: probability }` map derived
+	 * from the address's postcode (e.g. `@mailwoman/neural`'s `extractPostcodeAnchors`). When provided,
+	 * LOCALITY candidates are re-ranked by `score + anchorWeight * posterior[candidate.country]` before
+	 * the top is picked, so a postcode that pins the country can pull the right-country place over a
+	 * higher-BM25 foreign namesake (the "Berlin DE vs Berlin US" class the #59 anchor→resolver harness
+	 * measured). OFF by default — omit it and resolution is byte-identical. Country signal only, so it
+	 * touches locality lookups only; admin parents already carry country via `parentId`.
+	 */
+	anchorPosterior?: Record<string, number>
+	/**
+	 * Weight on the anchor's country posterior in the locality re-rank (#369). Default 2.0 (the value the
+	 * harness swept). Only consulted when `anchorPosterior` is set.
+	 */
+	anchorWeight?: number
 }
 
 /**

--- a/docs/articles/evals/2026-06-07-leakage-split-us.md
+++ b/docs/articles/evals/2026-06-07-leakage-split-us.md
@@ -1,0 +1,34 @@
+# Leakage-split F1 — openaddresses-us-sample.jsonl
+
+Per-tag F1 split by corpus-held-out geography (VT/WY/ND) vs in-training geography. A large in-training − held-out gap = the headline F1 is partly memorization (#371).
+
+- held-out rows: 1428 · in-training rows: 8572 · model: `neural-weights-en-us/model.onnx` (v4.0.0)
+
+| tag       | held-out F1 | in-training F1 | gap (in − held) |
+| --------- | ----------: | -------------: | --------------: |
+| locality  |       1.000 |          0.987 |          -0.012 |
+| region    |       1.000 |          0.999 |          -0.001 |
+| postcode  |       1.000 |          0.996 |          -0.004 |
+| **macro** |   **1.000** |      **0.994** |      **-0.006** |
+
+## Per-state macro-F1 (difficulty confound check)
+
+| state |    n | macro-F1 | held-out?   |
+| ----- | ---: | -------: | ----------- |
+| MT    | 4284 |    0.979 |             |
+| DC    | 4287 |    0.992 |             |
+| IA    | 4287 |    0.996 |             |
+| SD    | 4284 |    0.998 |             |
+| CA    | 4287 |    1.000 |             |
+| VT    | 4284 |    1.000 | ✅ held-out |
+| IL    | 4287 |    1.000 |             |
+
+## Read
+
+DeepSeek (2026-06-07) flagged geographic train/test leakage as the top risk to our headline F1: the model trains on the corpus (tiger/BAN/WOF), which covers the same streets and localities OA tests, so component recall could be partly memorization. The corpus holds out specific US geography (VT/WY/ND) from training, so OA rows there test places the model never saw.
+
+The result refutes that hypothesis on the tags OA can grade. Held-out Vermont scores 1.000 macro-F1 against 0.994 in-training, so held-out is if anything marginally easier. The per-state spread tells the same story from another angle: Montana (in-training) is the worst at 0.979 while Vermont (held-out) ties California and Illinois at the top. The ordering tracks intrinsic state difficulty, not training exposure. The shipped en-US model's locality/region/postcode recognition generalizes to unseen geography, and the near-perfect numbers also confirm that these three tags on clean, canonical US addresses are essentially a solved problem.
+
+One caveat carries the whole result, so it's worth stating plainly. This only tests `locality`, `region`, and `postcode`, because that's all OpenAddresses gold carries. Leakage would bite hardest on STREET recognition, where memorizing a street name is the obvious shortcut, and OA can't grade street at all. A complete leakage check needs full-BIO corpus gold restricted to held-out geography, which is tracked as a follow-up on #371. And only Vermont survives in this US sample (Wyoming and North Dakota contribute zero rows), so the held-out signal is one state wide.
+
+Reproduce: `node --experimental-strip-types scripts/eval/leakage-split-f1.ts --eval data/eval/external/openaddresses-us-sample.jsonl --held VT,WY,ND --out-md <path>`.

--- a/scripts/eval/leakage-split-f1.ts
+++ b/scripts/eval/leakage-split-f1.ts
@@ -1,0 +1,212 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Leakage-split F1 (#371, DeepSeek 2026-06-07 S39 — "may change everything"). Random OA evaluation
+ *   can flatter us: the model trains on the corpus (tiger/BAN/WOF), which COVERS the same
+ *   streets/localities that OA tests, so component recall is partly memorization rather than
+ *   generalization. The corpus holds out specific geography (`v0.1.0` `splits/SPLIT_MANIFEST.json`:
+ *   VT/WY/ND for US, Corse/Lozère/ Creuse for FR). So OA rows in the held-out geography test the
+ *   model on places it NEVER trained on, and the gap between in-training F1 and held-out F1 is an
+ *   honest estimate of the leakage inflation.
+ *
+ *   This computes per-tag precision/recall/F1 over OA, split by held-out vs in-training geography,
+ *   for the tags OA gold carries ({locality, region, postcode}). A large in-training − held-out gap
+ *   means the headline F1 is partly memorization.
+ *
+ *   Caveat: held-out geography can differ in intrinsic difficulty (rural VT vs urban CA), so a gap is
+ *   an upper bound on leakage, not a clean isolation. Reported per-state so the confound is
+ *   visible.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/leakage-split-f1.ts\
+ *   --eval data/eval/external/openaddresses-us-sample.jsonl --held VT,WY,ND\
+ *   [--model neural-weights-en-us/model.onnx --tokenizer ... --model-card ... --out-md <path>]
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { readFileSync, writeFileSync } from "node:fs"
+
+function arg(name: string, fallback = ""): string {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+}
+
+interface OaRow {
+	input: string
+	expected: { locality?: string; region?: string; postcode?: string }
+	state: string
+}
+
+const GRADED = ["locality", "region", "postcode"] as const
+
+function norm(s: string): string {
+	return s
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}]+/gu, " ")
+		.trim()
+		.replace(/\s+/g, " ")
+}
+
+function valueMatch(pred: string, gold: string): boolean {
+	const a = norm(pred)
+	const b = norm(gold)
+	if (!a || !b) return false
+	if (a === b) return true
+	const aset = new Set(a.split(" "))
+	const bset = new Set(b.split(" "))
+	const subset = (xs: Set<string>, ys: Set<string>): boolean => [...xs].every((t) => ys.has(t))
+	return subset(aset, bset) || subset(bset, aset)
+}
+
+function firstByTag(tree: AddressTree, tag: string): AddressNode | undefined {
+	let found: AddressNode | undefined
+	const walk = (n: AddressNode): void => {
+		if (found) return
+		if (n.tag === tag) found = n
+		else for (const c of n.children) walk(c)
+	}
+	for (const r of tree.roots) walk(r)
+	return found
+}
+
+interface Counts {
+	tp: number
+	fp: number
+	fn: number
+}
+const newCounts = (): Record<string, Counts> => ({
+	locality: { tp: 0, fp: 0, fn: 0 },
+	region: { tp: 0, fp: 0, fn: 0 },
+	postcode: { tp: 0, fp: 0, fn: 0 },
+})
+
+/** Grade one parse against OA's partial gold; accumulate TP/FP/FN per graded tag. */
+function grade(tree: AddressTree, expected: OaRow["expected"], acc: Record<string, Counts>): void {
+	for (const tag of GRADED) {
+		const gold = expected[tag]
+		const pred = firstByTag(tree, tag)
+		if (gold && pred) {
+			if (valueMatch(pred.value, gold)) acc[tag]!.tp++
+			else {
+				acc[tag]!.fp++
+				acc[tag]!.fn++
+			}
+		} else if (gold && !pred) {
+			acc[tag]!.fn++ // missed a component that's there
+		} else if (!gold && pred) {
+			acc[tag]!.fp++ // emitted a component OA says isn't there (rare for these tags)
+		}
+	}
+}
+
+function f1(c: Counts): { p: number; r: number; f1: number } {
+	const p = c.tp + c.fp ? c.tp / (c.tp + c.fp) : 0
+	const r = c.tp + c.fn ? c.tp / (c.tp + c.fn) : 0
+	return { p, r, f1: p + r ? (2 * p * r) / (p + r) : 0 }
+}
+
+async function main(): Promise<void> {
+	const evalPath = arg("eval", "data/eval/external/openaddresses-us-sample.jsonl")
+	const held = new Set(
+		arg("held", "VT,WY,ND")
+			.split(",")
+			.map((s) => s.trim().toUpperCase())
+	)
+	const limit = Number(arg("limit", "0")) || Infinity
+
+	const rows: OaRow[] = readFileSync(evalPath, "utf8")
+		.split("\n")
+		.filter((l) => l.trim())
+		.map((l) => JSON.parse(l))
+		.slice(0, limit === Infinity ? undefined : limit)
+
+	const { NeuralAddressClassifier } = await import("@mailwoman/neural")
+	const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+	const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+	const modelCard = JSON.parse(readFileSync(arg("model-card", "neural-weights-en-us/model-card.json"), "utf8"))
+	const [tokenizer, runner] = await Promise.all([
+		MailwomanTokenizer.loadFromFile(arg("tokenizer", "neural-weights-en-us/tokenizer.model")),
+		OnnxRunner.create(arg("model", "neural-weights-en-us/model.onnx")),
+	])
+	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels })
+	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
+
+	const heldAcc = newCounts()
+	const inAcc = newCounts()
+	const perState: Record<string, Record<string, Counts>> = {}
+	let heldN = 0
+	let inN = 0
+	let i = 0
+	for (const row of rows) {
+		i++
+		if (i % 1000 === 0) console.error(`  ${i}/${rows.length}`)
+		let tree: AddressTree
+		try {
+			tree = await neural.parse(row.input, parseOpts)
+		} catch {
+			continue
+		}
+		const st = (row.state || "??").toUpperCase()
+		const isHeld = held.has(st)
+		grade(tree, row.expected, isHeld ? heldAcc : inAcc)
+		if (!perState[st]) perState[st] = newCounts()
+		grade(tree, row.expected, perState[st]!)
+		if (isHeld) heldN++
+		else inN++
+	}
+
+	const macro = (acc: Record<string, Counts>): number => GRADED.reduce((s, t) => s + f1(acc[t]!).f1, 0) / GRADED.length
+
+	const lines: string[] = []
+	lines.push(`# Leakage-split F1 — ${evalPath.split("/").pop()}`)
+	lines.push("")
+	lines.push(
+		`Per-tag F1 split by corpus-held-out geography (${[...held].join("/")}) vs in-training geography. ` +
+			`A large in-training − held-out gap = the headline F1 is partly memorization (#371).`
+	)
+	lines.push("")
+	lines.push(
+		`- held-out rows: ${heldN} · in-training rows: ${inN} · model: ${arg("model", "neural-weights-en-us/model.onnx")}`
+	)
+	lines.push("")
+	lines.push("| tag | held-out F1 | in-training F1 | gap (in − held) |")
+	lines.push("| --- | ---: | ---: | ---: |")
+	for (const t of GRADED) {
+		const h = f1(heldAcc[t]!).f1
+		const inF = f1(inAcc[t]!).f1
+		lines.push(`| ${t} | ${h.toFixed(3)} | ${inF.toFixed(3)} | ${(inF - h >= 0 ? "+" : "") + (inF - h).toFixed(3)} |`)
+	}
+	lines.push(
+		`| **macro** | **${macro(heldAcc).toFixed(3)}** | **${macro(inAcc).toFixed(3)}** | **${(macro(inAcc) - macro(heldAcc) >= 0 ? "+" : "") + (macro(inAcc) - macro(heldAcc)).toFixed(3)}** |`
+	)
+	lines.push("")
+	lines.push("## Per-state macro-F1 (difficulty confound check)")
+	lines.push("")
+	lines.push("| state | n | macro-F1 | held-out? |")
+	lines.push("| --- | ---: | ---: | --- |")
+	const stateRows = Object.entries(perState)
+		.map(([st, acc]) => {
+			const n = GRADED.reduce((s, t) => s + acc[t]!.tp + acc[t]!.fn, 0)
+			return { st, n, m: macro(acc), held: held.has(st) }
+		})
+		.sort((a, b) => a.m - b.m)
+	for (const s of stateRows) {
+		lines.push(`| ${s.st} | ${s.n} | ${s.m.toFixed(3)} | ${s.held ? "✅ held-out" : ""} |`)
+	}
+	lines.push("")
+
+	const out = lines.join("\n") + "\n"
+	const outMd = arg("out-md")
+	if (outMd) {
+		writeFileSync(outMd, out)
+		console.error(`wrote → ${outMd}`)
+	} else {
+		console.log(out)
+	}
+	console.error(
+		`\nmacro-F1 held-out ${macro(heldAcc).toFixed(3)} vs in-training ${macro(inAcc).toFixed(3)} (gap ${(macro(inAcc) - macro(heldAcc)).toFixed(3)})`
+	)
+}
+
+void main()


### PR DESCRIPTION
Lands the resolver re-ranker the #59 anchor→resolver harness greenlit (S7 of #369), behind a flag.

**What:** `ResolveOpts.anchorPosterior` (a `{countryCode: prob}` map from the address's postcode) + `anchorWeight` (default 2.0). When set, locality candidates are re-ranked by `score + anchorWeight*posterior[candidate.country]` before the top is picked — so a postcode that pins the country pulls the right-country place over a higher-BM25 foreign namesake (Berlin DE vs Berlin US). Locality-scoped (admin parents already carry country via `parentId`).

**Why:** the harness showed this is worth a continent on resolution (33 DE picks corrected / 117k km; 333 US rows pulled >100 km closer vs 7 worse) and is invisible to name-match.

**Byte-stable:** OFF by default — omit `anchorPosterior` and resolution is byte-identical. Tests cover the DE flip, the no-op-when-already-agreeing case, and the default. `core/resolver` only; `yarn compile` clean.

Follow-ups on #369: S8 (measure admin-match on a held set, flag on vs off) · S9 (weight + gate on the anchor's own confidence) · S11/#61 (region-level posterior) · S46 (spatial-falloff pruning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)