### PR TITLE
docs(eval): v0.9.4 + the PIP pivot — German collapse was two problems (#327)

### DIFF
--- a/docs/articles/evals/2026-06-07-v0.9.4-pip-pivot.md
+++ b/docs/articles/evals/2026-06-07-v0.9.4-pip-pivot.md
@@ -1,0 +1,83 @@
+# v0.9.4 dual-injection + the PIP pivot — the German "collapse" was two different problems
+
+**Verdict: v0.9.4 not promoted, and we stop retraining German.** Three retrains (v0.9.2 both-order,
+v0.9.3 region-tail, v0.9.4 dual-injection) chased a single international-order locality-match number that
+turns out to conflate two unrelated problems — one of which is a measurement artifact, the other of which
+no anchor change can touch. A non-gameable metric (PIP-containment) pulled them apart. Tracking: #327.
+
+## v0.9.4 result
+
+The dual-injection retrain (`model.inject_first_token=true`, same corpus, one variable vs v0.9.3) gave the
+2×2 (DE locality-MATCH by name):
+
+|           | anchor OFF | anchor ON |
+| --------- | ---------: | --------: |
+| US order  |      47.3% |     43.7% |
+| native DE |      48.3% | **83.5%** |
+
+US 96.4%, FR 84.9% (no-regression OK). International anchor-ON locality is **43.7%**, _below_ v0.9.3's
+44.7% and far under the 70% promote bar. Adding the position-0 country cue moved region-match (38→58%)
+and resolved-rate (72→88%) but not locality-match. Across all three retrains the anchor consistently
+_lowers_ international locality-match (off ~47 > on ~44) while coordinate p50 holds ~6 km. That pattern —
+the geography stays right while the string-match metric drops — is the tell.
+
+## PIP-containment splits the problem in half
+
+So we measured the thing that can't be gamed: is the gold OpenAddresses point _inside the polygon_ of the
+locality we resolved? (`scripts/eval/pip-containment.py`, point-in-polygon over the WOF GeoJSON.)
+
+```
+intl DE (v0.9.4, 3000 rows)   name-match   PIP-containment   delta
+OVERALL                          43.7%          56.1%        +12.4pp
+Berlin   (n=1500)                36.3%          36.3%         -0.1pp
+Sachsen  (n=1500)                51.1%          75.9%        +24.8pp
+```
+
+Two completely different stories under one average.
+
+**Saxony is a name-match artifact.** The model and resolver place Saxon addresses correctly 76% of the
+time, but the name-match metric only credits 51% — a 24.8-point gap. The reason is visible in every
+miss: OpenAddresses gold carries a regional suffix that WOF's canonical name drops.
+
+```
+gold "Plauen Vogtl"   resolved "Plauen"       (point inside Plauen ✓)
+gold "Chemnitz Sachs" resolved "Chemnitz"     (point inside Chemnitz ✓)
+gold "Marienberg Erzgeb" resolved "Marienberg" (point inside Marienberg ✓)
+gold "Treuen Vogtl"   resolved "Treuen"       (point inside Treuen ✓)
+```
+
+These are not errors. The resolver found the right place; the metric demands an exact string the
+gazetteer doesn't use. Retraining cannot fix a measurement bug.
+
+**Berlin is a genuine failure — but not the one we were retraining for.** Berlin's PIP equals its
+name-match (36.3%), so there's no hidden artifact. Looking closer: of 1,500 Berlin rows, **955 resolve to
+nothing at all**, and the 545 that resolve all resolve correctly to Berlin. Berlin's problem is not a
+wrong pick or a too-small polygon — it's that the model drops the locality span entirely in the
+city-state layout `…, Berlin, Berlin 14199`, where locality and region are the same word. One "Berlin"
+gets labeled region, the other is lost, and there's nothing left for the resolver to place. This is a
+real segmentation bug, but it's specific to city-states (Berlin/Hamburg/Bremen) and has nothing to do
+with the postcode anchor or word order in general — which is exactly why three anchor/order retrains
+never touched it.
+
+## Why three retrains "failed"
+
+They optimized an aggregate that was half artifact, half a bug the lever couldn't reach. The anchor was
+never the problem (coord p50 ~6 km throughout); the metric was conflating a gazetteer-name mismatch in
+Saxony with a city-state parse failure in Berlin. With those separated, neither calls for another
+anchor retrain.
+
+## What's next (no A100)
+
+DeepSeek signed off this pivot across four turns. The two real fixes, both off the GPU:
+
+1. **Resolver name-match: alias the regional suffixes** (`Vogtl`→Vogtland, `Sachs`→Sachsen, `Erzgeb`→
+   Erzgebirge, `OL`→Oberlausitz, …) so `Plauen Vogtl` credits `Plauen`. This recovers the 24.8pp Saxon
+   gap in the eval metric without any model change. Filed as a follow-up.
+2. **Berlin city-state segmentation** — the model needs to learn the `City, City Postcode` layout where
+   locality == region. A focused data-augmentation pass (city-state addresses in both orders) is the fix,
+   but it's a gated retrain for a future shift, not tonight. Filed as a follow-up.
+
+v0.9.5 (the `[COUNTRY_DE]` start-token that was queued if PIP fell below 90%) is **cancelled**: the
+country signal helps neither half — Saxony is already correct, and Berlin's country is never in doubt.
+The corpus and anchor levers are spent; the German story moves to the resolver and a narrow city-state
+data fix.

--- a/scripts/eval/de-duplicate-locality-diag.ts
+++ b/scripts/eval/de-duplicate-locality-diag.ts
@@ -1,0 +1,118 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   DeepSeek diagnostic (2026-06-07): is the international-order German locality collapse driven by
+ *   the adjacent same-token "City, Region" pairs (Berlin's locality == its region) confusing the
+ *   PARSE, vs a purely positional anchor problem? Splits the international-order de-sample by
+ *   whether expected locality == expected region (the city-states: Berlin/Hamburg/Bremen) vs
+ *   distinct (München/Bayern), and reports the model's locality-span correctness in each bucket.
+ *
+ *   If duplicates are much worse than distinct → token-level confusion (dual-injection won't fix it).
+ *   If both are equally poor → the positional-anchor hypothesis holds (v0.9.4 is the right fix).
+ *
+ *   Parse-level (no resolver): we check whether the model's locality span matches the expected
+ *   locality.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/de-duplicate-locality-diag.ts\
+ *   --eval data/eval/external/openaddresses-de-sample.jsonl\
+ *   --model /tmp/v093-eval/model.onnx --model-card neural-weights-en-us/model-card.json\
+ *   [--anchor-lookup /mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json]
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { readFileSync } from "node:fs"
+
+function arg(name: string, fallback = ""): string {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+}
+
+interface OaRow {
+	input: string
+	expected: { locality?: string; region?: string }
+}
+
+function norm(s: string): string {
+	return s
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}]+/gu, " ")
+		.trim()
+		.replace(/\s+/g, " ")
+}
+function valueMatch(pred: string, gold: string): boolean {
+	const a = norm(pred)
+	const b = norm(gold)
+	if (!a || !b) return false
+	if (a === b) return true
+	const aset = new Set(a.split(" "))
+	const bset = new Set(b.split(" "))
+	const subset = (xs: Set<string>, ys: Set<string>): boolean => [...xs].every((t) => ys.has(t))
+	return subset(aset, bset) || subset(bset, aset)
+}
+function firstByTag(tree: AddressTree, tag: string): AddressNode | undefined {
+	let found: AddressNode | undefined
+	const walk = (n: AddressNode): void => {
+		if (found) return
+		if (n.tag === tag) found = n
+		else for (const c of n.children) walk(c)
+	}
+	for (const r of tree.roots) walk(r)
+	return found
+}
+
+async function main(): Promise<void> {
+	const evalPath = arg("eval", "data/eval/external/openaddresses-de-sample.jsonl")
+	const rows: OaRow[] = readFileSync(evalPath, "utf8")
+		.split("\n")
+		.filter((l) => l.trim())
+		.map((l) => JSON.parse(l))
+
+	const { NeuralAddressClassifier, parseAnchorLookup } = await import("@mailwoman/neural")
+	const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+	const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+	const modelCard = JSON.parse(readFileSync(arg("model-card", "neural-weights-en-us/model-card.json"), "utf8"))
+	const anchorPath = arg("anchor-lookup", "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json")
+	const postcodeAnchorLookup = anchorPath ? parseAnchorLookup(JSON.parse(readFileSync(anchorPath, "utf8"))) : undefined
+	const [tokenizer, runner] = await Promise.all([
+		MailwomanTokenizer.loadFromFile(
+			arg("tokenizer", "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model")
+		),
+		OnnxRunner.create(arg("model", "/tmp/v093-eval/model.onnx")),
+	])
+	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels, postcodeAnchorLookup })
+	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
+
+	const acc = { dup: { ok: 0, n: 0 }, distinct: { ok: 0, n: 0 } }
+	let i = 0
+	for (const row of rows) {
+		i++
+		if (i % 1000 === 0) console.error(`  ${i}/${rows.length}`)
+		const loc = row.expected.locality
+		const reg = row.expected.region
+		if (!loc) continue
+		const isDup = !!reg && norm(loc) === norm(reg)
+		const bucket = isDup ? acc.dup : acc.distinct
+		bucket.n++
+		let tree: AddressTree
+		try {
+			tree = await neural.parse(row.input, parseOpts)
+		} catch {
+			continue
+		}
+		const pred = firstByTag(tree, "locality")
+		if (pred && valueMatch(pred.value, loc)) bucket.ok++
+	}
+
+	const pct = (b: { ok: number; n: number }): string => (b.n ? ((100 * b.ok) / b.n).toFixed(1) : "0.0") + "%"
+	console.log(`# DE intl locality-parse — duplicate (locality==region) vs distinct`)
+	console.log(``)
+	console.log(`| bucket | n | locality-parse correct |`)
+	console.log(`| --- | ---: | ---: |`)
+	console.log(`| duplicate (Berlin/Berlin) | ${acc.dup.n} | ${pct(acc.dup)} |`)
+	console.log(`| distinct (München/Bayern) | ${acc.distinct.n} | ${pct(acc.distinct)} |`)
+	console.error(`\nduplicate ${pct(acc.dup)} (n=${acc.dup.n}) vs distinct ${pct(acc.distinct)} (n=${acc.distinct.n})`)
+}
+
+void main()


### PR DESCRIPTION
v0.9.4 dual-injection not promoted (intl-ON 43.7%). But PIP-containment (the non-gameable metric) reframes the whole German saga: **Saxony's 'collapse' is a name-match artifact** (PIP 75.9% vs name 51.1%, +24.8pp — `Plauen Vogtl`→`Plauen` etc. are geographically correct), **Berlin is a genuine city-state segmentation bug** (955/1500 unresolved — locality dropped in `City, City Postcode` order). Three retrains chased the conflated aggregate; the anchor was never the problem (coord p50 ~6 km throughout). **v0.9.5 cancelled.** Real fixes are off-GPU: resolver suffix-alias (Saxony) + a future Berlin city-state data-aug (filed as follow-ups). DeepSeek-signed across 4 turns. Self-emitted figures.