### PR TITLE
fix(eval): hierarchy-aware credit for German regional-suffix localities (#386)

### DIFF
--- a/scripts/diag-saxony-namematch.ts
+++ b/scripts/diag-saxony-namematch.ts
@@ -1,0 +1,90 @@
+/**
+ * Validates the #386 hierarchy-aware regional-qualifier credit in oa-resolver-eval's
+ * localityMatches, standalone against the real admin gazetteer. Replicates normName + the
+ * ancestor-token matcher and asserts: (1) the four Saxony artifacts credit (gold `X <Kreis>` →
+ * resolved `X`), and (2) negative controls do NOT credit (a wrong qualifier, or a qualifier matched
+ * against an unrelated place's id).
+ *
+ * Node --experimental-strip-types scripts/diag-saxony-namematch.ts
+ */
+import { DatabaseSync } from "node:sqlite"
+
+const DB = process.argv[2] ?? "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+const db = new DatabaseSync(DB, { readOnly: true })
+
+const normName = (s: string | undefined): string => {
+	if (!s) return ""
+	const x = s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+	return x.replace(/\s+/g, " ").trim()
+}
+
+const ancStmt = db.prepare(
+	"SELECT nm.name FROM ancestors a JOIN names nm ON nm.id = a.ancestor_id " +
+		"WHERE a.id = ? AND a.ancestor_placetype IN ('county', 'region', 'macrocounty', 'macroregion')"
+)
+const ancestorTokensFor = (id: number): Set<string> => {
+	const set = new Set<string>()
+	for (const r of ancStmt.all(id) as { name: string }[])
+		for (const t of normName(r.name).split(" ")) if (t.length >= 4) set.add(t)
+	return set
+}
+
+// gold `<base> <qual…>` credits resolved place `id` (whose canonical name is `resolvedName`)
+const credits = (gold: string, resolvedName: string, id: number): boolean => {
+	const e = normName(gold)
+	const base = normName(resolvedName)
+	if (!base || !e.startsWith(base + " ")) return false
+	const quals = e
+		.slice(base.length + 1)
+		.split(" ")
+		.filter(Boolean)
+	const anc = ancestorTokensFor(id)
+	return quals.length > 0 && quals.every((q) => q.length >= 3 && [...anc].some((a) => a.startsWith(q)))
+}
+
+const idOf = (name: string): number =>
+	(
+		db.prepare("SELECT id FROM names WHERE name = ? AND placetype = 'locality' LIMIT 1").get(name) as
+			| { id: number }
+			| undefined
+	)?.id ?? -1
+
+const plauen = idOf("Plauen")
+const chemnitz = idOf("Chemnitz")
+// Pin the SAXON Marienberg (Erzgebirgskreis); idOf-by-name would grab the Rhineland-Palatinate one
+// (county Westerwald), which the matcher correctly rejects for "Erzgeb" — the resolver, by contrast,
+// picks the right Marienberg by coordinate, so in the real eval this is the place under test.
+const marienberg = 101820701
+const treuen = idOf("Treuen")
+const munich = idOf("München") >= 0 ? idOf("München") : idOf("Munich")
+
+type Case = { gold: string; resolved: string; id: number; want: boolean }
+const cases: Case[] = [
+	// Positives — the four artifacts from #386
+	{ gold: "Plauen Vogtl", resolved: "Plauen", id: plauen, want: true },
+	{ gold: "Chemnitz Sachs", resolved: "Chemnitz", id: chemnitz, want: true },
+	{ gold: "Marienberg Erzgeb", resolved: "Marienberg", id: marienberg, want: true },
+	{ gold: "Treuen Vogtl", resolved: "Treuen", id: treuen, want: true },
+	// Negatives — must NOT over-credit
+	{ gold: "Plauen Bayern", resolved: "Plauen", id: plauen, want: false }, // wrong region (Plauen is in Saxony, not Bavaria)
+	{ gold: "Plauen Vogtl", resolved: "Munich", id: munich, want: false }, // right qualifier, wrong place's ancestry
+	{ gold: "Plauen xy", resolved: "Plauen", id: plauen, want: false }, // too-short / nonsense qualifier
+]
+
+let pass = 0
+for (const c of cases) {
+	const got = c.id >= 0 ? credits(c.gold, c.resolved, c.id) : false
+	const ok = got === c.want
+	pass += ok ? 1 : 0
+	console.log(
+		`${ok ? "PASS" : "FAIL"}  ${c.want ? "credit  " : "reject  "} gold="${c.gold}" → "${c.resolved}" (id=${c.id})  got=${got}`
+	)
+}
+console.log(`\n${pass}/${cases.length} cases passed`)
+db.close()
+process.exit(pass === cases.length ? 0 : 1)

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -40,10 +40,10 @@
  *   --tokenizer /mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model\
  *   --model-card /tmp/v072-eval/model-card.json
  *
- *   `--wof` defaults to `admin-global-priority.db,postcode-locality-intl.db` — coordinate-first locality
- *   resolution is ON by default (no-op where the candidate table has no rows, e.g. US). Pass `--wof
- *   <admin.db>` alone for the admin-only baseline, or append a postcode shard (postalcode-*.db) to also
- *   resolve the postcode node.
+ *   `--wof` defaults to `admin-global-priority.db,postcode-locality-intl.db` — coordinate-first
+ *   locality resolution is ON by default (no-op where the candidate table has no rows, e.g. US).
+ *   Pass `--wof <admin.db>` alone for the admin-only baseline, or append a postcode shard
+ *   (postalcode-*.db) to also resolve the postcode node.
  */
 
 import { lookupGermanState } from "@mailwoman/codex/de"
@@ -283,7 +283,8 @@ async function main(): Promise<void> {
 	const postcodeAnchorLookup = modelAnchorPath
 		? (await import("@mailwoman/neural")).parseAnchorLookup(JSON.parse(readFileSync(modelAnchorPath, "utf8")))
 		: undefined
-	if (modelAnchorPath) console.error(`[model-anchor] feeding anchor from ${modelAnchorPath} (${postcodeAnchorLookup!.size} codes)`)
+	if (modelAnchorPath)
+		console.error(`[model-anchor] feeding anchor from ${modelAnchorPath} (${postcodeAnchorLookup!.size} codes)`)
 	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels, postcodeAnchorLookup })
 
 	// v0 = our TypeScript port of the Pelias parser. Scoring it through the same resolver makes this a
@@ -316,11 +317,48 @@ async function main(): Promise<void> {
 		}
 		return set
 	}
+	// Hierarchy-aware regional-qualifier credit (#386). OpenAddresses tags many German localities with
+	// a disambiguating district suffix WOF's canonical name drops — gold `Plauen Vogtl`/`Chemnitz Sachs`
+	// resolve to `Plauen`/`Chemnitz` (the point lands inside; PIP confirms it), but a bare string compare
+	// reads a miss. Rather than a hardcoded suffix blacklist (the no-load-bearing-trivia smell), credit
+	// the qualifier ONLY when it matches the resolved place's OWN WOF ancestry: `Vogtl`→county `Vogtland`,
+	// `Sachs`→region `Sachsen`. List-free and non-gameable — a genuinely wrong place won't carry the
+	// gold's qualifier among its ancestors. `und`/non-latin ancestor names normalize to empty under
+	// normName (Cyrillic/CJK are stripped), so the token set is latin-only without a language filter.
+	const ancestorNamesStmt = adminDb.prepare(
+		"SELECT nm.name FROM ancestors a JOIN names nm ON nm.id = a.ancestor_id " +
+			"WHERE a.id = ? AND a.ancestor_placetype IN ('county', 'region', 'macrocounty', 'macroregion')"
+	)
+	const ancestorTokCache = new Map<number, Set<string>>()
+	const ancestorTokensFor = (id: number): Set<string> => {
+		let set = ancestorTokCache.get(id)
+		if (!set) {
+			set = new Set<string>()
+			for (const r of ancestorNamesStmt.all(id) as { name: string }[]) {
+				for (const t of normName(r.name).split(" ")) if (t.length >= 4) set.add(t)
+			}
+			ancestorTokCache.set(id, set)
+		}
+		return set
+	}
 	const localityMatches = (expected: string | undefined, locNode: Resolved | undefined): boolean => {
 		if (!expected || !locNode) return false
 		const e = normName(expected)
 		if (!e) return false
-		return normName(locNode.name) === e || altNamesFor(locNode.id).has(e)
+		if (normName(locNode.name) === e || altNamesFor(locNode.id).has(e)) return true
+		// Near-miss: gold `<resolved name> <qualifier…>`. Credit only when EVERY trailing qualifier is an
+		// abbreviation-prefix (≥3 chars) of one of the resolved place's ancestor-name tokens. The base
+		// must equal the resolved name exactly, so this can only ADD credit to an already-correct place.
+		const base = normName(locNode.name)
+		if (base && e.startsWith(base + " ")) {
+			const quals = e
+				.slice(base.length + 1)
+				.split(" ")
+				.filter(Boolean)
+			const anc = ancestorTokensFor(locNode.id)
+			if (quals.length > 0 && quals.every((q) => q.length >= 3 && [...anc].some((a) => a.startsWith(q)))) return true
+		}
+		return false
 	}
 
 	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
@@ -390,8 +428,10 @@ async function main(): Promise<void> {
 		return best ? { lat: best.lat, lon: best.lon } : null
 	}
 
-	/** The postcode anchor's country posterior for a raw address (highest-confidence placed anchor),
-	 * fed into the resolver's locality re-rank via `ResolveOpts.anchorPosterior` (#369 S8). */
+	/**
+	 * The postcode anchor's country posterior for a raw address (highest-confidence placed anchor),
+	 * fed into the resolver's locality re-rank via `ResolveOpts.anchorPosterior` (#369 S8).
+	 */
 	const anchorPosteriorFor = (input: string): Record<string, number> | undefined => {
 		if (!postcodeLookup || !extractAnchors) return undefined
 		let best: { posterior: Record<string, number>; conf: number } | null = null


### PR DESCRIPTION
Closes the name-match half of the v0.9.4 intl-DE locality "collapse" surfaced by tonight's PIP-containment finding (#385): Saxony name-match 51.1% vs PIP-containment **75.9%** — a +24.8pp gap that was the metric refusing to call Plauen Plauen.

## What
OpenAddresses tags German localities with a disambiguating district suffix WOF's canonical name drops:

| gold (OA) | resolved (WOF) | point |
|---|---|---|
| `Plauen Vogtl` | `Plauen` | inside Plauen ✓ |
| `Chemnitz Sachs` | `Chemnitz` | inside Chemnitz ✓ |
| `Marienberg Erzgeb` | `Marienberg` | inside Marienberg ✓ |
| `Treuen Vogtl` | `Treuen` | inside Treuen ✓ |

`oa-resolver-eval`'s `localityMatches` read each as a miss.

## How — principled, not a blacklist
Per #386's explicit requirement (and the no-load-bearing-trivia rule), this is **hierarchy-aware**, list-free: gold `X Y` credits resolved `X` only when every trailing qualifier `Y` is an abbreviation-prefix (≥3 chars) of one of the resolved place's **own WOF ancestor names** — `Vogtl`→county `Vogtland`, `Sachs`→region `Sachsen`, `Erzgeb`→`Erzgebirgskreis`. Non-gameable: a genuinely wrong place won't carry the gold's qualifier among its ancestors. The base must equal the resolved name exactly, so the branch can only **add** credit to an already-correct place — it can never loosen a real wrong-place miss.

## Validation
`scripts/diag-saxony-namematch.ts` replicates the matcher against the real admin gazetteer — **7/7**: four artifacts credit; three negative controls reject (wrong region `Plauen Bayern`; right qualifier against the wrong place's ancestry; too-short qualifier). Notably a Rhineland-Palatinate `Marienberg` (county Westerwald) is correctly rejected for `Erzgeb` — only the Saxon Marienberg (Erzgebirgskreis) credits.

## Follow-up
Live before/after on the full DE `oa-resolver-eval` (expected ≈+12pp overall locality-match, Saxony's half) is gated on restoring the en-us `model.onnx` symlink to v4.0.0 (currently a v0.5.3 dev artifact) so the model-running number is consistent. The fix itself is model-independent — it's a grading correction validated by unit test above.

Relates to coordinate-first resolver direction + #385/#373.