### PR TITLE
feat(resolver): opt-in city-state locality recovery (#387)

### DIFF
--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -428,4 +428,89 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 		})
 		expect(on.roots[0]!.placeId).toBe("wof:1") // US already top, boost keeps it there
 	})
+
+	// City-state locality recovery (#387). In `…, Berlin, Berlin <PC>` the parser drops the locality
+	// (city == region), leaving a region but no locality. The fallback synthesizes it from the region's
+	// same-name, centroid-coincident locality descendant — data-driven, guarded against same-name towns.
+	const CITY_STATE_PLACES: ResolvedPlace[] = [
+		{ id: 900, name: "Germany", placetype: "country", country: "DE", lat: 51.1, lon: 10.4, score: 10 },
+		// Berlin: city-state — region + locality centroids coincide.
+		{ id: 910, name: "Berlin", placetype: "region", country: "DE", parent_id: 900, lat: 52.52, lon: 13.4, score: 9 },
+		{ id: 911, name: "Berlin", placetype: "locality", country: "DE", parent_id: 910, lat: 52.52, lon: 13.4, score: 8 },
+		// Brandenburg: NOT a city-state — the same-name town sits ~60 km from the state centroid.
+		{
+			id: 920,
+			name: "Brandenburg",
+			placetype: "region",
+			country: "DE",
+			parent_id: 900,
+			lat: 52.4,
+			lon: 13.0,
+			score: 9,
+		},
+		{
+			id: 921,
+			name: "Brandenburg",
+			placetype: "locality",
+			country: "DE",
+			parent_id: 920,
+			lat: 52.41,
+			lon: 12.55,
+			score: 8,
+		},
+	]
+
+	test("city-state fallback synthesizes the dropped locality from the region (#387)", async () => {
+		const backend = new FakeResolverBackend(CITY_STATE_PLACES)
+		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
+		const result = await createWofResolver(backend).resolveTree(input, {
+			cityStateFallback: true,
+			defaultCountry: "DE",
+		})
+
+		const locality = result.roots.find((r) => r.tag === "locality")
+		expect(locality).toBeDefined()
+		expect(locality).toMatchObject({
+			tag: "locality",
+			value: "Berlin",
+			source: "resolver",
+			placeId: "wof:911",
+			lat: 52.52,
+			lon: 13.4,
+		})
+		expect(locality!.metadata).toMatchObject({ resolver_synthesized: true })
+	})
+
+	test("city-state fallback is OFF by default — byte-stable (#387)", async () => {
+		const backend = new FakeResolverBackend(CITY_STATE_PLACES)
+		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
+		const result = await createWofResolver(backend).resolveTree(input, { defaultCountry: "DE" })
+		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+	})
+
+	test("city-state fallback rejects a same-name town that is NOT centroid-coincident (#387)", async () => {
+		const backend = new FakeResolverBackend(CITY_STATE_PLACES)
+		// Brandenburg state + no locality. A naive same-name-descendant rule would wrongly synthesize the
+		// town of Brandenburg an der Havel; the ~60 km centroid gap must veto it.
+		const input = tree("Brandenburg 14770", [node("region", "Brandenburg", 0, 11), node("postcode", "14770", 12, 17)])
+		const result = await createWofResolver(backend).resolveTree(input, {
+			cityStateFallback: true,
+			defaultCountry: "DE",
+		})
+		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+	})
+
+	test("city-state fallback never overrides a locality the parser already emitted (#387)", async () => {
+		const backend = new FakeResolverBackend(CITY_STATE_PLACES)
+		// A real locality span is present (even if it won't resolve) → the gap-filler must stay quiet.
+		const input = tree("Some Town, Berlin", [node("locality", "Some Town", 0, 9), node("region", "Berlin", 11, 17)])
+		const result = await createWofResolver(backend).resolveTree(input, {
+			cityStateFallback: true,
+			defaultCountry: "DE",
+		})
+		const localities = result.roots.filter((r) => r.tag === "locality")
+		expect(localities).toHaveLength(1)
+		expect(localities[0]!.value).toBe("Some Town")
+		expect(localities[0]!.metadata?.["resolver_synthesized"]).toBeUndefined()
+	})
 })

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -38,17 +38,49 @@ interface ResolutionState {
 	candidatesPerLookup: number
 	defaultCountry?: string
 	parentFallback: boolean
-	/** The address's postcode string, extracted once up front, passed to locality lookups so a
-	 * coordinate-first backend can inject postcode-proximal locality candidates. */
+	/**
+	 * The address's postcode string, extracted once up front, passed to locality lookups so a
+	 * coordinate-first backend can inject postcode-proximal locality candidates.
+	 */
 	postcode?: string
 	/** Postcode-anchor country posterior (#369). Undefined = no re-rank (byte-stable default). */
 	anchorPosterior?: Record<string, number>
 	/** Weight on the posterior in the locality re-rank. Only used when `anchorPosterior` is set. */
 	anchorWeight: number
+	/** City-state locality recovery (#387). Off by default → byte-stable. */
+	cityStateFallback: boolean
+	/** Centroid-coincidence threshold (km) for the city-state recovery. Only used when on. */
+	cityStateMaxKm: number
+	/**
+	 * Set while resolving when ANY tree node maps to the `locality` placetype (resolved or not) — the
+	 * city-state recovery only fires when the parser emitted no locality at all, never to override
+	 * one.
+	 */
+	localityNodePresent: boolean
+	/** The first region that resolved, captured for the post-walk city-state recovery. */
+	resolvedRegion: ResolvedPlace | null
+	/**
+	 * The span of the region node that produced {@link resolvedRegion}, reused for the synthesized
+	 * locality (which has no span of its own in the raw input).
+	 */
+	resolvedRegionSpan: { start: number; end: number } | null
 }
 
-/** Find the first postcode value anywhere in the tree (a one-shot pre-scan; postcode and locality are
- * siblings, so the top-down walk wouldn't otherwise let the locality lookup see it). */
+/** Great-circle distance in km between two centroids (WGS-84). */
+function haversineKm(a: { lat: number; lon: number }, b: { lat: number; lon: number }): number {
+	const R = 6371
+	const dLat = ((b.lat - a.lat) * Math.PI) / 180
+	const dLon = ((b.lon - a.lon) * Math.PI) / 180
+	const s =
+		Math.sin(dLat / 2) ** 2 +
+		Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLon / 2) ** 2
+	return 2 * R * Math.asin(Math.sqrt(s))
+}
+
+/**
+ * Find the first postcode value anywhere in the tree (a one-shot pre-scan; postcode and locality
+ * are siblings, so the top-down walk wouldn't otherwise let the locality lookup see it).
+ */
 function firstPostcodeValue(roots: readonly AddressNode[]): string | undefined {
 	const stack = [...roots]
 	while (stack.length > 0) {
@@ -79,13 +111,65 @@ class WofResolver implements Resolver {
 			postcode: firstPostcodeValue(tree.roots),
 			anchorPosterior: opts.anchorPosterior,
 			anchorWeight: opts.anchorWeight ?? 2.0,
+			cityStateFallback: opts.cityStateFallback ?? false,
+			cityStateMaxKm: opts.cityStateMaxKm ?? 15,
+			localityNodePresent: false,
+			resolvedRegion: null,
+			resolvedRegionSpan: null,
 		}
 
 		const newRoots: AddressNode[] = []
 		for (const root of tree.roots) {
 			newRoots.push(await this.#walk(root, /* parentResolved */ null, state))
 		}
+
+		// City-state locality recovery (#387). Only when enabled, a region resolved, and the parser
+		// emitted NO locality node — then ask the backend for a same-name locality descendant of the
+		// region and synthesize it iff its centroid coincides with the region's (the city-state
+		// signature). See ResolveOpts.cityStateFallback for the full rationale + false-positive guard.
+		if (state.cityStateFallback && state.resolvedRegion && !state.localityNodePresent && state.lookupsRemaining > 0) {
+			const synthesized = await this.#recoverCityStateLocality(state)
+			if (synthesized) newRoots.push(synthesized)
+		}
 		return { raw: tree.raw, roots: newRoots }
+	}
+
+	/**
+	 * Query the backend for the region's same-name locality descendant and, when its centroid
+	 * coincides with the region's (≤ `cityStateMaxKm`), build a synthesized locality node. Returns
+	 * null otherwise. Marked `metadata.resolver_synthesized` — the node has no span in the raw
+	 * input.
+	 */
+	async #recoverCityStateLocality(state: ResolutionState): Promise<AddressNode | null> {
+		const region = state.resolvedRegion!
+		if (typeof region.id !== "number") return null
+		state.lookupsRemaining--
+		let candidates: ResolvedPlace[]
+		try {
+			candidates = await this.#backend.findPlace({
+				text: region.name,
+				placetype: "locality",
+				country: region.country || undefined,
+				parentId: region.id,
+				limit: 1,
+			})
+		} catch {
+			return null
+		}
+		const loc = candidates[0]
+		if (!loc || haversineKm(loc, region) > state.cityStateMaxKm) return null
+		const span = state.resolvedRegionSpan ?? { start: 0, end: 0 }
+		const synthesized: AddressNode = {
+			tag: "locality",
+			value: loc.name,
+			start: span.start,
+			end: span.end,
+			confidence: 0,
+			children: [],
+		}
+		decorateNode(synthesized, loc, [])
+		synthesized.metadata = { ...(synthesized.metadata ?? {}), resolver_synthesized: true }
+		return synthesized
 	}
 
 	async #walk(node: AddressNode, parentResolved: ResolvedPlace | null, state: ResolutionState): Promise<AddressNode> {
@@ -93,12 +177,22 @@ class WofResolver implements Resolver {
 		const decorated: AddressNode = { ...node, children: [] }
 
 		const placetype = state.placetypeMap[node.tag as ComponentTag]
+		// Track locality presence for the city-state recovery (#387): the recovery must NOT fire if the
+		// parser already emitted a locality node (even one that failed to resolve) — it only fills a
+		// genuine gap. Cheap and always-on; only consulted when cityStateFallback is set.
+		if (placetype === "locality") state.localityNodePresent = true
 		let resolved: ResolvedPlace | null = null
 		if (placetype && state.lookupsRemaining > 0 && node.value.trim().length > 0) {
 			const picked = await this.#lookupAndPick(node, placetype, parentResolved, state)
 			if (picked) {
 				resolved = picked.top
 				decorateNode(decorated, picked.top, picked.alternatives)
+				// Capture the first resolved region for the city-state recovery, along with its span so
+				// the synthesized locality can borrow it (it has no span of its own).
+				if (placetype === "region" && state.resolvedRegion === null) {
+					state.resolvedRegion = picked.top
+					state.resolvedRegionSpan = { start: node.start, end: node.end }
+				}
 			}
 		}
 

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -41,10 +41,10 @@ export interface ResolvedPlace {
 	 */
 	score: number
 	/**
-	 * Set when the resolver detected that the address's postcode and its parsed locality name point to
-	 * geographically different places (a transposed / wrong-for-the-city postcode). Surfaced onto the
-	 * resolved node's metadata as `postcode_city_mismatch` so callers can lower confidence or flag the
-	 * conflict instead of silently mislocating.
+	 * Set when the resolver detected that the address's postcode and its parsed locality name point
+	 * to geographically different places (a transposed / wrong-for-the-city postcode). Surfaced onto
+	 * the resolved node's metadata as `postcode_city_mismatch` so callers can lower confidence or
+	 * flag the conflict instead of silently mislocating.
 	 */
 	mismatch?: boolean
 }
@@ -124,20 +124,44 @@ export interface ResolveOpts {
 	 */
 	locale?: string
 	/**
-	 * Optional postcode-anchor country posterior (#369) — a `{ countryCode: probability }` map derived
-	 * from the address's postcode (e.g. `@mailwoman/neural`'s `extractPostcodeAnchors`). When provided,
-	 * LOCALITY candidates are re-ranked by `score + anchorWeight * posterior[candidate.country]` before
-	 * the top is picked, so a postcode that pins the country can pull the right-country place over a
-	 * higher-BM25 foreign namesake (the "Berlin DE vs Berlin US" class the #59 anchor→resolver harness
-	 * measured). OFF by default — omit it and resolution is byte-identical. Country signal only, so it
-	 * touches locality lookups only; admin parents already carry country via `parentId`.
+	 * Optional postcode-anchor country posterior (#369) — a `{ countryCode: probability }` map
+	 * derived from the address's postcode (e.g. `@mailwoman/neural`'s `extractPostcodeAnchors`). When
+	 * provided, LOCALITY candidates are re-ranked by `score + anchorWeight *
+	 * posterior[candidate.country]` before the top is picked, so a postcode that pins the country can
+	 * pull the right-country place over a higher-BM25 foreign namesake (the "Berlin DE vs Berlin US"
+	 * class the #59 anchor→resolver harness measured). OFF by default — omit it and resolution is
+	 * byte-identical. Country signal only, so it touches locality lookups only; admin parents already
+	 * carry country via `parentId`.
 	 */
 	anchorPosterior?: Record<string, number>
 	/**
-	 * Weight on the anchor's country posterior in the locality re-rank (#369). Default 2.0 (the value the
-	 * harness swept). Only consulted when `anchorPosterior` is set.
+	 * Weight on the anchor's country posterior in the locality re-rank (#369). Default 2.0 (the value
+	 * the harness swept). Only consulted when `anchorPosterior` is set.
 	 */
 	anchorWeight?: number
+	/**
+	 * Recover the dropped locality in a CITY-STATE address (#387). In the international-order layout
+	 * `…, Berlin, Berlin <PC>` the city and the region are the same word; the parser labels one as
+	 * the region and drops the locality entirely, so the resolved tree carries a region but no
+	 * locality (Berlin/Hamburg/Bremen — 955/1500 Berlin rows resolved to nothing in the v0.9.4 DE PIP
+	 * eval).
+	 *
+	 * When this is on AND a region resolved AND the tree has NO locality node, the resolver asks the
+	 * backend for a same-name locality DESCENDANT of that region and — only if its centroid is within
+	 * {@link cityStateMaxKm} of the region centroid — synthesizes a locality node from it. That triple
+	 * (same name + descendant + coincident centroid) is what distinguishes a genuine city-state from
+	 * a normal same-name town inside a state (Brandenburg an der Havel sits 60 km from Brandenburg's
+	 * centroid; Berlin's coincide at 0 km), so the recovery is data-driven, not a hardcoded
+	 * city-state list. The synthesized node carries `metadata.resolver_synthesized = true` — it has
+	 * no span in the raw input. OFF by default: omit it and resolution is byte-identical.
+	 */
+	cityStateFallback?: boolean
+	/**
+	 * Max km between a region centroid and its same-name locality descendant for the
+	 * {@link cityStateFallback} recovery to fire. Default 15 (city-states cluster at 0–9.3 km; the
+	 * nearest false positive, Brandenburg, is 60 km). Only consulted when `cityStateFallback` is on.
+	 */
+	cityStateMaxKm?: number
 }
 
 /**


### PR DESCRIPTION
The **genuine-bug half** of tonight's German finding (#385) — pairs with #386/#395 (the Saxony measurement-artifact half) to close it out.

## Problem
In the international-order city-state layout `…, Berlin, Berlin <PC>`, the city and the region are the same word. The parser labels one `Berlin` as the region and **drops the locality entirely** → the resolved tree has a region but no locality, and **955/1500 Berlin addresses resolved to nothing** in the v0.9.4 DE PIP eval. It's specific to Berlin/Hamburg/Bremen and untouched by the postcode anchor or word order — which is exactly why three retrains never moved it. It needs a resolver fix, not a recipe tweak.

## Fix — opt-in, data-driven, byte-stable
New `ResolveOpts.cityStateFallback` (**default OFF** → byte-identical resolution; same opt-in pattern as the #382 anchor re-ranker). When a region resolves and the tree has **no** locality node, the resolver asks the backend for a same-name locality **descendant** of the region and synthesizes a locality node **only when its centroid is within `cityStateMaxKm` (default 15) of the region centroid**.

That triple — *same name + descendant + coincident centroid* — is the city-state signature, **not a hardcoded list** (per the no-load-bearing-trivia rule). Probed against the live gazetteer:

| | region↔same-name-locality centroid |
|---|---|
| Berlin | 0.0 km ← city-state |
| Hamburg | 0.0 km ← city-state |
| Bremen | 9.3 km ← city-state |
| **Brandenburg** | **60.1 km ← NOT (Brandenburg an der Havel)** |

A ≤15 km threshold separates the three city-states from the nearest false positive by 4×. The synthesized node carries `metadata.resolver_synthesized = true` (it has no span in the raw input). Reuses the existing `findPlace` contract — no new backend method.

## Tests
4 new in `resolve.test.ts` (**25/25 pass**, the 21 existing unchanged → byte-stability):
- synthesizes Berlin's dropped locality (placeId, lat/lon, synthesized marker);
- off-by-default is byte-stable;
- **rejects** the non-coincident Brandenburg town (the 60 km guard);
- **never** overrides a locality the parser already emitted.

## Follow-up
Promotion to default is gated on the full DE PIP before/after, which needs the en-us `model.onnx` symlink restored to v4.0.0 (currently a v0.5.3 dev artifact) — same blocker as #386. The fix is validated at the unit level here; the end-to-end magnitude (≈955 Berlin rows starting to resolve) is the gate for flipping it on by default.

Closes the genuine half of #387. Relates to #385/#386/#373.