### PR TITLE
feat(eval): --city-state-fallback flag on oa-resolver-eval (#387)

### DIFF
--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -367,7 +367,15 @@ async function main(): Promise<void> {
 	// non-US eval to US places (a German "Berlin" then loses to a tiny US Berlin). Settable via
 	// `--default-country <ISO|none>`; `none` disables the filter so ranking alone decides.
 	const dc = arg("default-country", "US")
-	const resolveOpts = dc && dc.toLowerCase() !== "none" ? { defaultCountry: dc } : {}
+	// `--city-state-fallback` (#387): recover the locality the parser drops in a city-state layout
+	// (`…, Berlin, Berlin <PC>` — city == region). Opt-in, default-off, so by default this eval's
+	// numbers are byte-identical; pass it to measure the Berlin/Hamburg/Bremen before/after. Applied to
+	// BOTH the neural and rules resolve paths (they share `resolveOpts`), so the comparison stays fair.
+	const cityStateFallback = process.argv.includes("--city-state-fallback")
+	const resolveOpts = {
+		...(dc && dc.toLowerCase() !== "none" ? { defaultCountry: dc } : {}),
+		...(cityStateFallback ? { cityStateFallback: true } : {}),
+	}
 
 	// Postcode-anchor fusion (opt-in via `--postcode-anchor`). The resolver supplies the admin/place
 	// identity, but its coordinate is the place CENTROID — legitimately tens of km from edge addresses.


### PR DESCRIPTION
Small follow-through to #396: a `--city-state-fallback` flag on `oa-resolver-eval` that threads `ResolveOpts.cityStateFallback` into both resolve paths (neural + rules). Opt-in/default-off → byte-identical without it; mirrors the existing `--anchor-rerank`. This is the measurement handle for the #387 promotion gate — once the DE model path is sorted (#397), running it with vs without the flag yields the Berlin-recovery magnitude (~955 rows). Relates to #387/#397.