### PR TITLE
feat(resolver): precompute the coincident-roles relation (#403)

### DIFF
--- a/resolver-wof-sqlite/build-coincident-roles-cli.ts
+++ b/resolver-wof-sqlite/build-coincident-roles-cli.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `mailwoman-wof-build-coincident-roles <path-to-admin.db>... [--drop]`
+ *
+ *   Operator-side one-shot CLI (#403, epic #402): derives the `coincident_roles` relation into an
+ *   existing admin gazetteer — the dual-role places (city-states, capital-seat provinces,
+ *   consolidated city-counties) the hierarchy-completion step (#405) consults. Additive +
+ *   idempotent; re-run after refreshing `spr`/`ancestors`. Mirrors `build-fts-cli.ts`. Should also
+ *   be invoked as a post-step of the main `scripts/build-unified-wof.ts`.
+ */
+
+import { existsSync } from "node:fs"
+import { exit, stderr } from "node:process"
+import { DatabaseSync } from "node:sqlite"
+
+import { buildCoincidentRoles } from "./coincident-roles.js"
+
+function printUsageAndExit(code: number): never {
+	stderr.write(
+		[
+			"usage: mailwoman-wof-build-coincident-roles <path-to-admin.db>... [--drop]",
+			"",
+			"Derives the coincident_roles relation (dual-role places — city-states, capital-seat",
+			"provinces, consolidated city-counties) into one or more admin gazetteers. The",
+			"hierarchy-completion resolver step (#405) consults it. Additive + idempotent.",
+			"",
+			"  --drop   Drop and rebuild coincident_roles if it already exists (default: rebuild).",
+			"",
+			"Example:",
+			"  mailwoman-wof-build-coincident-roles /data/wof/admin-global-priority.db",
+			"",
+		].join("\n")
+	)
+	exit(code)
+}
+
+function buildOne(path: string, drop: boolean): number {
+	if (!existsSync(path)) {
+		stderr.write(`mailwoman-wof-build-coincident-roles: file not found: ${path}\n`)
+		return 1
+	}
+	stderr.write(`Opening ${path}…\n`)
+	const db = new DatabaseSync(path)
+	try {
+		const result = buildCoincidentRoles(db, {
+			drop,
+			onProgress: (phase, detail) => stderr.write(`  [${phase}]${detail ? ` — ${detail}` : ""}\n`),
+		})
+		const top = Object.entries(result.byCountry)
+			.sort((a, b) => b[1] - a[1])
+			.map(([cc, n]) => `${cc} ${n}`)
+			.join(", ")
+		stderr.write(
+			`Built: ${result.rowCount} coincident-role rows (${(result.durationMs / 1000).toFixed(2)}s)\n  by country: ${top}\n`
+		)
+		return 0
+	} catch (err) {
+		stderr.write(`mailwoman-wof-build-coincident-roles: ${err instanceof Error ? err.message : String(err)}\n`)
+		return 1
+	} finally {
+		db.close()
+	}
+}
+
+export function main(argv: readonly string[]): number {
+	const paths: string[] = []
+	// The relation is a cheap (~2 s) derived table that must reflect the current spr/ancestors, so it
+	// rebuilds by default (idempotent). `--no-drop` appends instead — only useful for incremental tests.
+	let drop = true
+	for (const a of argv) {
+		if (a === "--drop") drop = true
+		else if (a === "--no-drop") drop = false
+		else if (a === "--help" || a === "-h") printUsageAndExit(0)
+		else if (a.startsWith("-")) {
+			stderr.write(`mailwoman-wof-build-coincident-roles: unknown flag ${JSON.stringify(a)}\n`)
+			printUsageAndExit(2)
+		} else paths.push(a)
+	}
+	if (paths.length === 0) printUsageAndExit(2)
+	let worst = 0
+	for (const path of paths) {
+		const rc = buildOne(path, drop)
+		if (rc > worst) worst = rc
+	}
+	return worst
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	exit(main(process.argv.slice(2)))
+}

--- a/resolver-wof-sqlite/coincident-roles.test.ts
+++ b/resolver-wof-sqlite/coincident-roles.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the coincident-roles relation builder (#403, epic #402). Builds an in-memory fixture
+ *   gazetteer (spr + ancestors + place_population) covering the city-state, capital-seat, and
+ *   too-far (excluded) cases, then asserts the derived relation + the in-memory loader.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import {
+	buildCoincidentRoles,
+	coincidentRolesExists,
+	loadCoincidentRoles,
+	type CoincidentRole,
+} from "./coincident-roles.js"
+
+interface FixtureRow {
+	id: number
+	name: string
+	placetype: string
+	country: string
+	lat: number
+	lon: number
+	/** Half-extent in degrees → bbox = [lat±d, lon±d]. Bigger d ⇒ bigger bbox ⇒ looser relative
+tolerance. */
+	d: number
+	population?: number
+}
+
+// Region/locality pairs. A locality is made a DESCENDANT of a region via the `ancestors` table below.
+const FIXTURE: FixtureRow[] = [
+	// Berlin — city-state: region + locality centroids coincide (dist 0), small bbox.
+	{ id: 10, name: "Berlin", placetype: "region", country: "DE", lat: 52.52, lon: 13.4, d: 0.3 },
+	{
+		id: 11,
+		name: "Berlin",
+		placetype: "locality",
+		country: "DE",
+		lat: 52.52,
+		lon: 13.4,
+		d: 0.2,
+		population: 3_600_000,
+	},
+	// Milano — capital-seat: large province bbox, comune ~5 km from the province centroid.
+	{ id: 20, name: "Milano", placetype: "region", country: "IT", lat: 45.5, lon: 9.2, d: 0.6 },
+	{
+		id: 21,
+		name: "Milano",
+		placetype: "locality",
+		country: "IT",
+		lat: 45.46,
+		lon: 9.19,
+		d: 0.2,
+		population: 1_350_000,
+	},
+	// Brandenburg — NOT dual-role: same-name town ~75 km W of the region centroid → beyond the relative
+	// tolerance (region bbox ⌀ ~313 km → 15 % ≈ 47 km). Mirrors the real gazetteer, where Brandenburg
+	// is correctly absent from the 128.
+	{ id: 30, name: "Brandenburg", placetype: "region", country: "DE", lat: 52.4, lon: 13.0, d: 1.2 },
+	{
+		id: 31,
+		name: "Brandenburg",
+		placetype: "locality",
+		country: "DE",
+		lat: 52.41,
+		lon: 11.9,
+		d: 0.1,
+		population: 72_000,
+	},
+	// Bayern region + München locality (different name) → never matched.
+	{ id: 40, name: "Bayern", placetype: "region", country: "DE", lat: 48.9, lon: 11.4, d: 1.5 },
+	{
+		id: 41,
+		name: "München",
+		placetype: "locality",
+		country: "DE",
+		lat: 48.14,
+		lon: 11.58,
+		d: 0.2,
+		population: 1_500_000,
+	},
+	// County-tier same-name pair (a French-canton analogue) → excluded (v1 is region-tier only).
+	{ id: 50, name: "Casteljaloux", placetype: "county", country: "FR", lat: 44.3, lon: 0.09, d: 0.4 },
+	{
+		id: 51,
+		name: "Casteljaloux",
+		placetype: "locality",
+		country: "FR",
+		lat: 44.3,
+		lon: 0.1,
+		d: 0.05,
+		population: 5000,
+	},
+	// Ambiguous region: two same-name coincident localities → relation records BOTH (resolver disambiguates).
+	{ id: 60, name: "Padova", placetype: "region", country: "IT", lat: 45.4, lon: 11.87, d: 0.5 },
+	{ id: 61, name: "Padova", placetype: "locality", country: "IT", lat: 45.41, lon: 11.88, d: 0.1, population: 200_000 },
+	{ id: 62, name: "Padova", placetype: "locality", country: "IT", lat: 45.45, lon: 11.95, d: 0.1, population: 20 },
+]
+
+// (locality id → its region ancestor id)
+const ANCESTRY: Array<[number, number]> = [
+	[11, 10],
+	[21, 20],
+	[31, 30],
+	[51, 50],
+	[61, 60],
+	[62, 60],
+]
+
+let db: DatabaseSync
+
+beforeEach(() => {
+	db = new DatabaseSync(":memory:")
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, min_longitude REAL, max_latitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE ancestors (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT);
+		CREATE TABLE place_population (id INTEGER PRIMARY KEY, population INTEGER NOT NULL);
+	`)
+	const insSpr = db.prepare(
+		`INSERT INTO spr (id, parent_id, name, placetype, country, latitude, longitude,
+			min_latitude, min_longitude, max_latitude, max_longitude, is_current, is_deprecated)
+			VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0)`
+	)
+	const insPop = db.prepare(`INSERT INTO place_population (id, population) VALUES (?, ?)`)
+	for (const r of FIXTURE) {
+		insSpr.run(r.id, r.name, r.placetype, r.country, r.lat, r.lon, r.lat - r.d, r.lon - r.d, r.lat + r.d, r.lon + r.d)
+		if (r.population !== undefined) insPop.run(r.id, r.population)
+	}
+	const insAnc = db.prepare(`INSERT INTO ancestors (id, ancestor_id, ancestor_placetype) VALUES (?, ?, 'region')`)
+	for (const [id, anc] of ANCESTRY) insAnc.run(id, anc)
+})
+
+afterEach(() => db.close())
+
+function rolesFor(adminId: number): CoincidentRole[] {
+	return loadCoincidentRoles(db).get(adminId) ?? []
+}
+
+describe("buildCoincidentRoles", () => {
+	test("records city-state and capital-seat region pairs", () => {
+		const result = buildCoincidentRoles(db)
+		expect(coincidentRolesExists(db)).toBe(true)
+
+		const berlin = rolesFor(10)
+		expect(berlin).toHaveLength(1)
+		expect(berlin[0]).toMatchObject({ localityId: 11, relationshipType: "city-state", population: 3_600_000 })
+
+		const milano = rolesFor(20)
+		expect(milano).toHaveLength(1)
+		expect(milano[0]).toMatchObject({ localityId: 21, relationshipType: "capital-seat" })
+
+		expect(result.byCountry).toMatchObject({ DE: expect.any(Number), IT: expect.any(Number) })
+	})
+
+	test("excludes a same-name town beyond the relative tolerance (Brandenburg ~75 km)", () => {
+		buildCoincidentRoles(db)
+		expect(rolesFor(30)).toHaveLength(0)
+	})
+
+	test("excludes county-tier pairs (v1 is region-tier only)", () => {
+		buildCoincidentRoles(db)
+		expect(rolesFor(50)).toHaveLength(0)
+	})
+
+	test("never matches a region to a differently-named locality", () => {
+		buildCoincidentRoles(db)
+		expect(rolesFor(40)).toHaveLength(0)
+	})
+
+	test("records BOTH localities for an ambiguous admin (resolver disambiguates)", () => {
+		buildCoincidentRoles(db)
+		const padova = rolesFor(60)
+		expect(padova).toHaveLength(2)
+		expect(padova.map((r) => r.localityId).sort()).toEqual([61, 62])
+	})
+
+	test("is idempotent — a rebuild yields the same row count", () => {
+		const a = buildCoincidentRoles(db)
+		const b = buildCoincidentRoles(db)
+		expect(b.rowCount).toBe(a.rowCount)
+	})
+
+	test("loadCoincidentRoles returns an empty map when the table is absent", () => {
+		const fresh = new DatabaseSync(":memory:")
+		expect(loadCoincidentRoles(fresh).size).toBe(0)
+		expect(coincidentRolesExists(fresh)).toBe(false)
+		fresh.close()
+	})
+})

--- a/resolver-wof-sqlite/coincident-roles.ts
+++ b/resolver-wof-sqlite/coincident-roles.ts
@@ -1,0 +1,233 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `buildCoincidentRoles` — derives the **coincident-roles relation** (#403, epic #402) into the
+ *   unified gazetteer.
+ *
+ *   Many places occupy MULTIPLE admin tiers under one name: German city-states (Berlin/Hamburg/Bremen
+ *   = city == state), Italian provinces named after their capital (Milano, Varese…), Spanish
+ *   provinces-after-capitals, UK unitary authorities, JP prefectures, NL province-capitals
+ *   (Utrecht/Groningen), Shanghai. When an address surfaces only the admin role (the parser drops
+ *   the locality span), the resolver has no locality to place. The hierarchy-completion step (#405)
+ *   repairs that by consulting THIS relation; the table replaces #387's hardcoded 15 km constant
+ *   with the gazetteer's own structure, so the runtime is an O(1) membership lookup with no
+ *   distance math.
+ *
+ *   V1 is REGION-tier only (admin.placetype = `region`): the ~124 places matching the census across 9
+ *   countries (IT/ES/GB/JP/KR/FR/DE/NL/CN). County-tier same-name coincidences are deliberately
+ *   excluded — they're dominated by French cantons and JP counties (admin subdivisions named after
+ *   a seat town, not dual-role cities) that don't hit the parser-drops-locality failure; genuine
+ *   consolidated city-counties (US SF/Denver) are a separate follow-up needing a relative-size
+ *   filter.
+ *
+ *   A pair `(admin, locality)` is recorded when all hold: same `name` (case-insensitive), the
+ *   locality is a `descendant` of the admin (via the `ancestors` table), and their centroids are
+ *   within a RELATIVE tolerance — `toleranceFraction × admin-bbox-diagonal`, floored at
+ *   `minToleranceKm`. The relative term lets a large Italian province admit a city ~tens of km from
+ *   its centroid while a tiny city-state stays tight; the floor catches city-states whose bbox is
+ *   small (Bremen's centroids sit 9.3 km apart). The tolerance lives ONLY here at build time — it
+ *   never enters the resolver hot path.
+ *
+ *   `relationship_type` is recorded for debuggability / deferred per-type behavior; v1 completion is
+ *   uniform (see #405). It's a coarse classification, not load-bearing.
+ *
+ *   Mirrors the derived-table builder pattern in `fts.ts` (`buildPlaceSearchFts`). Run incrementally
+ *   against an existing `admin-global-priority.db` via `build-coincident-roles-cli.ts`; should also
+ *   be wired as a post-step of the main `scripts/build-unified-wof.ts`.
+ */
+
+import type { DatabaseSync } from "node:sqlite"
+
+export const COINCIDENT_ROLES_TABLE = "coincident_roles"
+
+/** A place that plays multiple admin roles — one row of the relation, keyed by `admin_id`. */
+export interface CoincidentRole {
+	localityId: number
+	relationshipType: "city-state" | "capital-seat" | "consolidated-county"
+	adminPlacetype: string
+	distanceKm: number
+	population: number
+}
+
+export interface BuildCoincidentRolesOpts {
+	/** Drop + rebuild the table if it already exists. Default true (the build is cheap + idempotent). */
+	drop?: boolean
+	/** Relative tolerance: a pair is kept when centroid distance ≤ `toleranceFraction ×
+bbox-diagonal`. Default 0.15. */
+	toleranceFraction?: number
+	/** Floor (km) under the relative tolerance, so small-bbox city-states still qualify. Default 12. */
+	minToleranceKm?: number
+	/** Centroid distance (km) below which a region-tier pair is classed `city-state` (metadata only).
+Default 2. */
+	cityStateMaxKm?: number
+	onProgress?: (phase: string, detail?: string) => void
+}
+
+export interface BuildCoincidentRolesResult {
+	created: boolean
+	rowCount: number
+	byCountry: Record<string, number>
+	durationMs: number
+}
+
+/** Great-circle distance in km between two WGS-84 points. */
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+	const R = 6371
+	const dLat = ((lat2 - lat1) * Math.PI) / 180
+	const dLon = ((lon2 - lon1) * Math.PI) / 180
+	const s =
+		Math.sin(dLat / 2) ** 2 +
+		Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLon / 2) ** 2
+	return 2 * R * Math.asin(Math.sqrt(s))
+}
+
+interface CandidateRow {
+	admin_id: number
+	admin_placetype: string
+	country: string
+	locality_id: number
+	rlat: number
+	rlon: number
+	llat: number
+	llon: number
+	min_latitude: number
+	min_longitude: number
+	max_latitude: number
+	max_longitude: number
+	pop: number
+}
+
+function tableExists(db: DatabaseSync, name: string): boolean {
+	return !!db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?").get(name)
+}
+
+/**
+ * Derive the coincident-roles relation into `db`. Additive — only creates/replaces the
+ * `coincident_roles` table; never touches `spr`/`names`/`ancestors`. Idempotent.
+ */
+export function buildCoincidentRoles(
+	db: DatabaseSync,
+	opts: BuildCoincidentRolesOpts = {}
+): BuildCoincidentRolesResult {
+	const start = Date.now()
+	const drop = opts.drop ?? true
+	const toleranceFraction = opts.toleranceFraction ?? 0.15
+	const minToleranceKm = opts.minToleranceKm ?? 12
+	const cityStateMaxKm = opts.cityStateMaxKm ?? 2
+	const onProgress = opts.onProgress ?? (() => {})
+
+	if (tableExists(db, COINCIDENT_ROLES_TABLE) && drop) {
+		onProgress("dropping", COINCIDENT_ROLES_TABLE)
+		db.exec(`DROP TABLE ${COINCIDENT_ROLES_TABLE}`)
+	}
+	onProgress("creating", COINCIDENT_ROLES_TABLE)
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS ${COINCIDENT_ROLES_TABLE} (
+			admin_id INTEGER NOT NULL,
+			locality_id INTEGER NOT NULL,
+			relationship_type TEXT NOT NULL,
+			admin_placetype TEXT NOT NULL,
+			distance_km REAL NOT NULL,
+			locality_population INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (admin_id, locality_id)
+		)
+	`)
+
+	onProgress("scanning")
+	// Admin (region/county tier) ⋈ same-name DESCENDANT locality. `place_population` is optional (LEFT
+	// JOIN → 0 when absent). The relative-tolerance filter + relationship classification happen in JS so
+	// the SQL stays a plain join. `spr` exposes the bbox columns we need for the diagonal.
+	const candidates = db
+		.prepare(
+			`SELECT r.id AS admin_id, r.placetype AS admin_placetype, r.country AS country, l.id AS locality_id,
+				r.latitude AS rlat, r.longitude AS rlon, l.latitude AS llat, l.longitude AS llon,
+				r.min_latitude, r.min_longitude, r.max_latitude, r.max_longitude,
+				COALESCE(p.population, 0) AS pop
+			FROM spr r
+			JOIN spr l ON lower(l.name) = lower(r.name) AND l.placetype = 'locality'
+				AND l.is_current != 0 AND l.is_deprecated = 0
+			JOIN ${"ancestors"} a ON a.id = l.id AND a.ancestor_id = r.id
+			LEFT JOIN place_population p ON p.id = l.id
+			WHERE r.placetype = 'region'
+				AND r.is_current != 0 AND r.is_deprecated = 0`
+		)
+		.all() as unknown as CandidateRow[]
+
+	onProgress("filtering", `${candidates.length} candidates`)
+	const insert = db.prepare(
+		`INSERT OR REPLACE INTO ${COINCIDENT_ROLES_TABLE}
+			(admin_id, locality_id, relationship_type, admin_placetype, distance_km, locality_population)
+			VALUES (?, ?, ?, ?, ?, ?)`
+	)
+	const byCountry: Record<string, number> = {}
+	let rowCount = 0
+	db.exec("BEGIN")
+	try {
+		for (const c of candidates) {
+			const dist = haversineKm(c.rlat, c.rlon, c.llat, c.llon)
+			const diag = haversineKm(c.min_latitude, c.min_longitude, c.max_latitude, c.max_longitude)
+			const tolerance = Math.max(toleranceFraction * diag, minToleranceKm)
+			if (dist > tolerance) continue
+			// v1 is region-tier only: a place is a `city-state` when its centroid coincides with the
+			// region's (Berlin/Hamburg), else `capital-seat` (a region named after its principal city, e.g.
+			// Milano province → Milano comune). `consolidated-county` is reserved for a future county-tier
+			// pass (US SF/Denver) — excluded from v1 because county-tier same-name coincidences are
+			// dominated by French cantons / JP counties that don't hit the parser-drops-locality failure.
+			const relationshipType = dist <= cityStateMaxKm ? "city-state" : "capital-seat"
+			insert.run(c.admin_id, c.locality_id, relationshipType, c.admin_placetype, dist, c.pop)
+			rowCount++
+			byCountry[c.country] = (byCountry[c.country] ?? 0) + 1
+		}
+		db.exec("COMMIT")
+	} catch (err) {
+		db.exec("ROLLBACK")
+		throw err
+	}
+	db.exec(`CREATE INDEX IF NOT EXISTS coincident_roles_by_admin ON ${COINCIDENT_ROLES_TABLE} (admin_id)`)
+
+	onProgress("done", `${rowCount} coincident-role rows`)
+	return { created: true, rowCount, byCountry, durationMs: Date.now() - start }
+}
+
+/** True iff the relation table exists. Used by the resolver to decide whether completion can run. */
+export function coincidentRolesExists(db: DatabaseSync): boolean {
+	return tableExists(db, COINCIDENT_ROLES_TABLE)
+}
+
+/**
+ * Load the relation into an in-memory map keyed by `admin_id` for O(1) runtime lookup (#405). Each
+ * admin may map to MULTIPLE same-name descendants; the consumer disambiguates (min distance →
+ * population → abstain). Returns an empty map when the table is absent.
+ */
+export function loadCoincidentRoles(db: DatabaseSync): Map<number, CoincidentRole[]> {
+	const map = new Map<number, CoincidentRole[]>()
+	if (!coincidentRolesExists(db)) return map
+	const rows = db
+		.prepare(
+			`SELECT admin_id, locality_id, relationship_type, admin_placetype, distance_km, locality_population
+			FROM ${COINCIDENT_ROLES_TABLE}`
+		)
+		.all() as unknown as Array<{
+		admin_id: number
+		locality_id: number
+		relationship_type: CoincidentRole["relationshipType"]
+		admin_placetype: string
+		distance_km: number
+		locality_population: number
+	}>
+	for (const r of rows) {
+		const entry: CoincidentRole = {
+			localityId: r.locality_id,
+			relationshipType: r.relationship_type,
+			adminPlacetype: r.admin_placetype,
+			distanceKm: r.distance_km,
+			population: r.locality_population,
+		}
+		const list = map.get(r.admin_id)
+		if (list) list.push(entry)
+		else map.set(r.admin_id, [entry])
+	}
+	return map
+}

--- a/resolver-wof-sqlite/package.json
+++ b/resolver-wof-sqlite/package.json
@@ -21,7 +21,8 @@
 		"./fst-autocomplete": "./out/fst-autocomplete.js",
 		"./fst-types": "./out/fst-types.js",
 		"./fst-deserialize-web": "./out/fst-deserialize-web.js",
-		"./unified-schema": "./out/unified-schema.js"
+		"./unified-schema": "./out/unified-schema.js",
+		"./coincident-roles": "./out/coincident-roles.js"
 	},
 	"dependencies": {
 		"@mailwoman/core": "workspace:*",
@@ -35,6 +36,7 @@
 		"README.md"
 	],
 	"bin": {
+		"mailwoman-wof-build-coincident-roles": "./out/build-coincident-roles-cli.js",
 		"mailwoman-wof-build-fts": "./out/build-fts-cli.js",
 		"mailwoman-wof-build-slim": "./out/build-slim-cli.js"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -4640,6 +4640,7 @@ __metadata:
     "@mailwoman/core": "workspace:*"
     kysely: "npm:^0.29.2"
   bin:
+    mailwoman-wof-build-coincident-roles: ./out/build-coincident-roles-cli.js
     mailwoman-wof-build-fts: ./out/build-fts-cli.js
     mailwoman-wof-build-slim: ./out/build-slim-cli.js
   languageName: unknown


### PR DESCRIPTION
First child of the dual-role epic **#402**. Derives the gazetteer relation that replaces #387's hardcoded 15 km city-state constant.

## What
`buildCoincidentRoles(db)` scans for **region-tier** admins that have a **same-name, descendant, ~centroid-coincident locality** and writes a `coincident_roles` table (`admin_id, locality_id, relationship_type, distance_km, locality_population`). The hierarchy-completion step (#405) consults it as an **O(1) membership lookup** — no distance math in the hot path. Loader (`loadCoincidentRoles`) returns an in-memory `Map<admin_id, CoincidentRole[]>`.

## Key decisions (DeepSeek-signed, see #402)
- **Relative, build-time-only tolerance:** `max(0.15 × admin-bbox-diagonal, 12 km)`. A large Italian province admits a city tens of km from its centroid; a city-state stays tight; Bremen's 9.3 km exclave-skewed centroid still qualifies. No magic km at runtime.
- **Region-tier only for v1.** A region-only scan reproduces the census exactly — **128 rows / 124 admins** across 9 countries (IT 56 / ES 19 / JP 18 / GB 12 / KR 8 / CN 6 / DE 3 / FR 3 / NL 2 / US 1). County-tier same-name coincidences (5k+ French *cantons*, JP counties) are deliberately excluded — wrong class, and they don't hit the parser-drops-locality failure. Genuine consolidated city-counties (US SF/Denver) are a documented follow-up.
- **`relationship_type`** (`city-state` / `capital-seat`) recorded for debuggability; v1 behavior is uniform.
- **Ambiguous admins record ALL candidates** (Niigata, Padova have two same-name localities); #405 disambiguates. ⚠️ **Note for #405:** Niigata shows the *populous* real city can sit farther from the prefecture centroid than a 0-pop point — population should likely be the **primary** disambiguator, not distance.

## Validation
Run on the live `admin-global-priority.db`: 128 clean rows, canonical cases correct (Berlin/Hamburg/Paris/Bristol → city-state @ 0 km; Milano/Madrid/Tokyo → capital-seat; populations captured), **Brandenburg-an-der-Havel correctly excluded**. **7/7 unit tests** (`coincident-roles.test.ts` — city-state, capital-seat, too-far exclusion, county exclusion, wrong-name, ambiguous-records-both, idempotent, empty-map).

CLI: `mailwoman-wof-build-coincident-roles <admin.db>` (idempotent rebuild). Should also be wired as a post-step of `scripts/build-unified-wof.ts`.

Next: #404 (lineage) and #405 (completion consuming this relation).