### PR TITLE
feat(resolver): relation-driven dual-role hierarchy completion (#405)

### DIFF
--- a/core/resolver/index.ts
+++ b/core/resolver/index.ts
@@ -6,4 +6,11 @@
 
 export { createWofResolver } from "./resolve.js"
 export { DEFAULT_PLACETYPE_MAP } from "./types.js"
-export type { PlacetypeMap, ResolveOpts, ResolvedPlace, Resolver, ResolverBackend } from "./types.js"
+export type {
+	CoincidentLocality,
+	PlacetypeMap,
+	ResolveOpts,
+	ResolvedPlace,
+	Resolver,
+	ResolverBackend,
+} from "./types.js"

--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, test, vi } from "vitest"
 import { decodeAsXml } from "../decoder/serialize-xml.js"
 import type { AddressNode, AddressTree, ComponentTag } from "../decoder/types.js"
 import { createWofResolver } from "./resolve.js"
-import type { ResolvedPlace, ResolverBackend } from "./types.js"
+import type { CoincidentLocality, ResolvedPlace, ResolverBackend } from "./types.js"
 
 function node(
 	tag: ComponentTag,
@@ -36,9 +36,11 @@ function tree(raw: string, roots: AddressNode[]): AddressTree {
 class FakeResolverBackend implements ResolverBackend {
 	readonly calls: Array<Parameters<ResolverBackend["findPlace"]>[0]> = []
 	readonly #places: ResolvedPlace[]
+	readonly #coincident: Map<number, CoincidentLocality[]>
 
-	constructor(places: ResolvedPlace[]) {
+	constructor(places: ResolvedPlace[], coincident?: Map<number, CoincidentLocality[]>) {
 		this.#places = places
+		this.#coincident = coincident ?? new Map()
 	}
 
 	async findPlace(query: Parameters<ResolverBackend["findPlace"]>[0]): Promise<ResolvedPlace[]> {
@@ -51,6 +53,10 @@ class FakeResolverBackend implements ResolverBackend {
 			.filter((p) => !query.country || p.country === query.country)
 			.filter((p) => query.parentId === undefined || p.parent_id === query.parentId)
 			.slice(0, query.limit ?? 5)
+	}
+
+	coincidentLocalitiesFor(adminId: number | string): CoincidentLocality[] {
+		return this.#coincident.get(Number(adminId)) ?? []
 	}
 }
 
@@ -429,15 +435,15 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 		expect(on.roots[0]!.placeId).toBe("wof:1") // US already top, boost keeps it there
 	})
 
-	// City-state locality recovery (#387). In `…, Berlin, Berlin <PC>` the parser drops the locality
-	// (city == region), leaving a region but no locality. The fallback synthesizes it from the region's
-	// same-name, centroid-coincident locality descendant — data-driven, guarded against same-name towns.
-	const CITY_STATE_PLACES: ResolvedPlace[] = [
+	// Dual-role hierarchy completion (#405, generalizes #387). In `…, Berlin, Berlin <PC>` the parser
+	// drops the locality (city == region), leaving a region but no locality. Completion synthesizes it
+	// from the backend's precomputed coincident-roles relation (#403) — a membership lookup, not a
+	// runtime distance check. The places fixture only needs the region (so it resolves); the relation
+	// supplies the completion candidate.
+	const DUAL_ROLE_PLACES: ResolvedPlace[] = [
 		{ id: 900, name: "Germany", placetype: "country", country: "DE", lat: 51.1, lon: 10.4, score: 10 },
-		// Berlin: city-state — region + locality centroids coincide.
 		{ id: 910, name: "Berlin", placetype: "region", country: "DE", parent_id: 900, lat: 52.52, lon: 13.4, score: 9 },
-		{ id: 911, name: "Berlin", placetype: "locality", country: "DE", parent_id: 910, lat: 52.52, lon: 13.4, score: 8 },
-		// Brandenburg: NOT a city-state — the same-name town sits ~60 km from the state centroid.
+		// Brandenburg resolves as a region but is NOT in the relation (not a dual-role place).
 		{
 			id: 920,
 			name: "Brandenburg",
@@ -448,23 +454,27 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 			lon: 13.0,
 			score: 9,
 		},
-		{
-			id: 921,
-			name: "Brandenburg",
-			placetype: "locality",
-			country: "DE",
-			parent_id: 920,
-			lat: 52.41,
-			lon: 12.55,
-			score: 8,
-		},
 	]
+	const berlinLocality: CoincidentLocality = {
+		id: 911,
+		name: "Berlin",
+		placetype: "locality",
+		country: "DE",
+		lat: 52.52,
+		lon: 13.4,
+		score: 0,
+		relationshipType: "city-state",
+		population: 3_600_000,
+		distanceKm: 0,
+	}
+	// admin_id → coincident localities. Berlin (910) is dual-role; Brandenburg (920) is absent.
+	const RELATION = new Map<number, CoincidentLocality[]>([[910, [berlinLocality]]])
 
-	test("city-state fallback synthesizes the dropped locality from the region (#387)", async () => {
-		const backend = new FakeResolverBackend(CITY_STATE_PLACES)
+	test("hierarchy completion synthesizes the dropped locality from the relation (#405)", async () => {
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
 		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
 		const result = await createWofResolver(backend).resolveTree(input, {
-			cityStateFallback: true,
+			hierarchyCompletion: true,
 			defaultCountry: "DE",
 		})
 
@@ -478,34 +488,101 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 			lat: 52.52,
 			lon: 13.4,
 		})
-		expect(locality!.metadata).toMatchObject({ resolver_synthesized: true })
+		expect(locality!.metadata).toMatchObject({ resolver_synthesized: true, relationship_type: "city-state" })
 	})
 
-	test("city-state fallback is OFF by default — byte-stable (#387)", async () => {
-		const backend = new FakeResolverBackend(CITY_STATE_PLACES)
+	test("the deprecated cityStateFallback alias still drives completion (#405)", async () => {
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
+		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
+		const result = await createWofResolver(backend).resolveTree(input, {
+			cityStateFallback: true,
+			defaultCountry: "DE",
+		})
+		expect(result.roots.find((r) => r.tag === "locality")?.placeId).toBe("wof:911")
+	})
+
+	test("hierarchy completion is OFF by default — byte-stable (#405)", async () => {
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
 		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
 		const result = await createWofResolver(backend).resolveTree(input, { defaultCountry: "DE" })
 		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
 	})
 
-	test("city-state fallback rejects a same-name town that is NOT centroid-coincident (#387)", async () => {
-		const backend = new FakeResolverBackend(CITY_STATE_PLACES)
-		// Brandenburg state + no locality. A naive same-name-descendant rule would wrongly synthesize the
-		// town of Brandenburg an der Havel; the ~60 km centroid gap must veto it.
+	test("hierarchy completion does nothing for a region absent from the relation (#405)", async () => {
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
+		// Brandenburg resolves as a region but isn't a dual-role place → the relation has no entry → no completion.
 		const input = tree("Brandenburg 14770", [node("region", "Brandenburg", 0, 11), node("postcode", "14770", 12, 17)])
 		const result = await createWofResolver(backend).resolveTree(input, {
-			cityStateFallback: true,
+			hierarchyCompletion: true,
 			defaultCountry: "DE",
 		})
 		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
 	})
 
-	test("city-state fallback never overrides a locality the parser already emitted (#387)", async () => {
-		const backend = new FakeResolverBackend(CITY_STATE_PLACES)
+	test("hierarchy completion abstains when candidates tie on population AND distance (#405)", async () => {
+		// Two same-name localities, identical population + distance → genuinely indistinguishable → abstain.
+		const twin = (id: number): CoincidentLocality => ({
+			id,
+			name: "Berlin",
+			placetype: "locality",
+			country: "DE",
+			lat: 52.52,
+			lon: 13.4,
+			score: 0,
+			relationshipType: "city-state",
+			population: 1000,
+			distanceKm: 5,
+		})
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, new Map([[910, [twin(911), twin(912)]]]))
+		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
+		const result = await createWofResolver(backend).resolveTree(input, {
+			hierarchyCompletion: true,
+			defaultCountry: "DE",
+		})
+		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+	})
+
+	test("hierarchy completion picks the most populous when an admin has several (#405)", async () => {
+		// The principal city (high population) wins even if it sits farther from the region centroid (Niigata).
+		const small: CoincidentLocality = {
+			id: 912,
+			name: "Berlin",
+			placetype: "locality",
+			country: "DE",
+			lat: 52.5,
+			lon: 13.4,
+			score: 0,
+			relationshipType: "capital-seat",
+			population: 0,
+			distanceKm: 1,
+		}
+		const big: CoincidentLocality = {
+			id: 911,
+			name: "Berlin",
+			placetype: "locality",
+			country: "DE",
+			lat: 52.52,
+			lon: 13.4,
+			score: 0,
+			relationshipType: "capital-seat",
+			population: 3_600_000,
+			distanceKm: 40,
+		}
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, new Map([[910, [small, big]]]))
+		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
+		const result = await createWofResolver(backend).resolveTree(input, {
+			hierarchyCompletion: true,
+			defaultCountry: "DE",
+		})
+		expect(result.roots.find((r) => r.tag === "locality")?.placeId).toBe("wof:911")
+	})
+
+	test("hierarchy completion never overrides a locality the parser already emitted (#405)", async () => {
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
 		// A real locality span is present (even if it won't resolve) → the gap-filler must stay quiet.
 		const input = tree("Some Town, Berlin", [node("locality", "Some Town", 0, 9), node("region", "Berlin", 11, 17)])
 		const result = await createWofResolver(backend).resolveTree(input, {
-			cityStateFallback: true,
+			hierarchyCompletion: true,
 			defaultCountry: "DE",
 		})
 		const localities = result.roots.filter((r) => r.tag === "locality")

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -14,6 +14,7 @@
 
 import type { AddressNode, AddressTree, ComponentTag } from "../decoder/types.js"
 import {
+	type CoincidentLocality,
 	DEFAULT_PLACETYPE_MAP,
 	type PlacetypeMap,
 	type ResolvedPlace,
@@ -47,14 +48,11 @@ interface ResolutionState {
 	anchorPosterior?: Record<string, number>
 	/** Weight on the posterior in the locality re-rank. Only used when `anchorPosterior` is set. */
 	anchorWeight: number
-	/** City-state locality recovery (#387). Off by default → byte-stable. */
-	cityStateFallback: boolean
-	/** Centroid-coincidence threshold (km) for the city-state recovery. Only used when on. */
-	cityStateMaxKm: number
+	/** Dual-role hierarchy completion (#405). Off by default → byte-stable. */
+	hierarchyCompletion: boolean
 	/**
 	 * Set while resolving when ANY tree node maps to the `locality` placetype (resolved or not) — the
-	 * city-state recovery only fires when the parser emitted no locality at all, never to override
-	 * one.
+	 * completion only fires when the parser emitted no locality at all, never to override one.
 	 */
 	localityNodePresent: boolean
 	/** The first region that resolved, captured for the post-walk city-state recovery. */
@@ -66,15 +64,20 @@ interface ResolutionState {
 	resolvedRegionSpan: { start: number; end: number } | null
 }
 
-/** Great-circle distance in km between two centroids (WGS-84). */
-function haversineKm(a: { lat: number; lon: number }, b: { lat: number; lon: number }): number {
-	const R = 6371
-	const dLat = ((b.lat - a.lat) * Math.PI) / 180
-	const dLon = ((b.lon - a.lon) * Math.PI) / 180
-	const s =
-		Math.sin(dLat / 2) ** 2 +
-		Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLon / 2) ** 2
-	return 2 * R * Math.asin(Math.sqrt(s))
+/**
+ * Pick the completion locality when an admin maps to several coincident same-name candidates
+ * (#405). Population is the PRIMARY signal — the principal city is the populous one, and it can sit
+ * FARTHER from the admin centroid than a tiny same-name hamlet (the Niigata case from #403).
+ * Nearest centroid breaks a population tie; a genuine tie (same population AND distance) ABSTAINS
+ * rather than guess.
+ */
+function pickCompletion(candidates: readonly CoincidentLocality[]): CoincidentLocality | null {
+	if (candidates.length === 0) return null
+	if (candidates.length === 1) return candidates[0]!
+	const ranked = [...candidates].sort((a, b) => b.population - a.population || a.distanceKm - b.distanceKm)
+	const [first, second] = ranked
+	if (first!.population === second!.population && first!.distanceKm === second!.distanceKm) return null
+	return first!
 }
 
 /**
@@ -111,8 +114,8 @@ class WofResolver implements Resolver {
 			postcode: firstPostcodeValue(tree.roots),
 			anchorPosterior: opts.anchorPosterior,
 			anchorWeight: opts.anchorWeight ?? 2.0,
-			cityStateFallback: opts.cityStateFallback ?? false,
-			cityStateMaxKm: opts.cityStateMaxKm ?? 15,
+			// `cityStateFallback` is the #387 alias that #405 generalized — still honored.
+			hierarchyCompletion: opts.hierarchyCompletion ?? opts.cityStateFallback ?? false,
 			localityNodePresent: false,
 			resolvedRegion: null,
 			resolvedRegionSpan: null,
@@ -123,41 +126,29 @@ class WofResolver implements Resolver {
 			newRoots.push(await this.#walk(root, /* parentResolved */ null, state))
 		}
 
-		// City-state locality recovery (#387). Only when enabled, a region resolved, and the parser
-		// emitted NO locality node — then ask the backend for a same-name locality descendant of the
-		// region and synthesize it iff its centroid coincides with the region's (the city-state
-		// signature). See ResolveOpts.cityStateFallback for the full rationale + false-positive guard.
-		if (state.cityStateFallback && state.resolvedRegion && !state.localityNodePresent && state.lookupsRemaining > 0) {
-			const synthesized = await this.#recoverCityStateLocality(state)
+		// Dual-role hierarchy completion (#405). Only when enabled, a region resolved, and the parser
+		// emitted NO locality — synthesize the locality from the backend's precomputed coincident-roles
+		// relation (#403). See ResolveOpts.hierarchyCompletion for the rationale + disambiguation rule.
+		if (state.hierarchyCompletion && state.resolvedRegion && !state.localityNodePresent) {
+			const synthesized = this.#completeFromRelation(state)
 			if (synthesized) newRoots.push(synthesized)
 		}
 		return { raw: tree.raw, roots: newRoots }
 	}
 
 	/**
-	 * Query the backend for the region's same-name locality descendant and, when its centroid
-	 * coincides with the region's (≤ `cityStateMaxKm`), build a synthesized locality node. Returns
-	 * null otherwise. Marked `metadata.resolver_synthesized` — the node has no span in the raw
-	 * input.
+	 * Complete a dropped dual-role locality from the backend's coincident-roles relation (#403/#405).
+	 * Consults `coincidentLocalitiesFor(regionId)` (O(1) map lookup — no distance math, no backend
+	 * query), picks the principal city ({@link pickCompletion}: population-primary, distance tiebreak,
+	 * abstain on a genuine tie), and builds a synthesized locality node borrowing the region's span.
+	 * Returns null when the backend has no relation, the region isn't a dual-role place, or it
+	 * abstains. Marked `metadata.resolver_synthesized` + `metadata.relationship_type`.
 	 */
-	async #recoverCityStateLocality(state: ResolutionState): Promise<AddressNode | null> {
+	#completeFromRelation(state: ResolutionState): AddressNode | null {
 		const region = state.resolvedRegion!
-		if (typeof region.id !== "number") return null
-		state.lookupsRemaining--
-		let candidates: ResolvedPlace[]
-		try {
-			candidates = await this.#backend.findPlace({
-				text: region.name,
-				placetype: "locality",
-				country: region.country || undefined,
-				parentId: region.id,
-				limit: 1,
-			})
-		} catch {
-			return null
-		}
-		const loc = candidates[0]
-		if (!loc || haversineKm(loc, region) > state.cityStateMaxKm) return null
+		if (typeof region.id !== "number" || !this.#backend.coincidentLocalitiesFor) return null
+		const loc = pickCompletion(this.#backend.coincidentLocalitiesFor(region.id))
+		if (!loc) return null
 		const span = state.resolvedRegionSpan ?? { start: 0, end: 0 }
 		const synthesized: AddressNode = {
 			tag: "locality",
@@ -168,7 +159,11 @@ class WofResolver implements Resolver {
 			children: [],
 		}
 		decorateNode(synthesized, loc, [])
-		synthesized.metadata = { ...(synthesized.metadata ?? {}), resolver_synthesized: true }
+		synthesized.metadata = {
+			...(synthesized.metadata ?? {}),
+			resolver_synthesized: true,
+			relationship_type: loc.relationshipType,
+		}
 		return synthesized
 	}
 
@@ -177,9 +172,9 @@ class WofResolver implements Resolver {
 		const decorated: AddressNode = { ...node, children: [] }
 
 		const placetype = state.placetypeMap[node.tag as ComponentTag]
-		// Track locality presence for the city-state recovery (#387): the recovery must NOT fire if the
-		// parser already emitted a locality node (even one that failed to resolve) — it only fills a
-		// genuine gap. Cheap and always-on; only consulted when cityStateFallback is set.
+		// Track locality presence for hierarchy completion (#405): completion must NOT fire if the parser
+		// already emitted a locality node (even one that failed to resolve) — it only fills a genuine
+		// gap. Cheap and always-on; only consulted when hierarchyCompletion is set.
 		if (placetype === "locality") state.localityNodePresent = true
 		let resolved: ResolvedPlace | null = null
 		if (placetype && state.lookupsRemaining > 0 && node.value.trim().length > 0) {

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -71,6 +71,29 @@ export interface ResolverBackend {
 		postcode?: string
 		limit?: number
 	}): Promise<ResolvedPlace[]>
+	/**
+	 * The dual-role locality (or localities) coincident with an admin place id, from the precomputed
+	 * coincident-roles relation (#403). Drives {@link ResolveOpts.hierarchyCompletion}: when the parse
+	 * drops the locality of a city-state / capital-seat region, the resolver completes it from here
+	 * instead of re-querying. OPTIONAL — backends without the relation omit it, and completion
+	 * no-ops. Synchronous: it's an in-memory map lookup once the relation is loaded.
+	 */
+	coincidentLocalitiesFor?(adminId: number | string): CoincidentLocality[]
+}
+
+/**
+ * A dual-role locality returned by {@link ResolverBackend.coincidentLocalitiesFor} — a resolved
+ * place (so it can decorate a node directly) plus the relation metadata the completion step
+ * disambiguates on.
+ */
+export interface CoincidentLocality extends ResolvedPlace {
+	/** `city-state` / `capital-seat` / `consolidated-county` — surfaced as
+`metadata.relationship_type`. */
+	relationshipType: string
+	/** Locality population (0 when unknown) — the PRIMARY disambiguator when an admin has several. */
+	population: number
+	/** Centroid distance (km) admin↔locality from the relation — the population tiebreak. */
+	distanceKm: number
 }
 
 /**
@@ -140,28 +163,27 @@ export interface ResolveOpts {
 	 */
 	anchorWeight?: number
 	/**
-	 * Recover the dropped locality in a CITY-STATE address (#387). In the international-order layout
-	 * `…, Berlin, Berlin <PC>` the city and the region are the same word; the parser labels one as
-	 * the region and drops the locality entirely, so the resolved tree carries a region but no
-	 * locality (Berlin/Hamburg/Bremen — 955/1500 Berlin rows resolved to nothing in the v0.9.4 DE PIP
-	 * eval).
+	 * Recover the dropped locality in a DUAL-ROLE-place address (#405, epic #402). Many places occupy
+	 * multiple admin tiers under one name — city-states (Berlin/Hamburg/Bremen = city == state),
+	 * capital-seat provinces (Milano, Madrid), UK unitary authorities — and in the
+	 * international-order layout `…, Berlin, Berlin <PC>` the parser labels one token the region and
+	 * drops the locality entirely, leaving a region but no locality (955/1500 Berlin rows resolved to
+	 * nothing on v0.9.4).
 	 *
-	 * When this is on AND a region resolved AND the tree has NO locality node, the resolver asks the
-	 * backend for a same-name locality DESCENDANT of that region and — only if its centroid is within
-	 * {@link cityStateMaxKm} of the region centroid — synthesizes a locality node from it. That triple
-	 * (same name + descendant + coincident centroid) is what distinguishes a genuine city-state from
-	 * a normal same-name town inside a state (Brandenburg an der Havel sits 60 km from Brandenburg's
-	 * centroid; Berlin's coincide at 0 km), so the recovery is data-driven, not a hardcoded
-	 * city-state list. The synthesized node carries `metadata.resolver_synthesized = true` — it has
-	 * no span in the raw input. OFF by default: omit it and resolution is byte-identical.
+	 * When this is on AND a region resolved AND the tree has NO locality node, the resolver consults
+	 * the backend's precomputed coincident-roles relation
+	 * ({@link ResolverBackend.coincidentLocalitiesFor}, #403) for a same-name coincident locality and
+	 * synthesizes a node from it. The relation is the gazetteer's own structure (same name +
+	 * descendant + centroid-coincidence, derived at build time), so the runtime is an O(1) membership
+	 * lookup — no magic distance constant. When an admin maps to several same-name localities, the
+	 * most populous wins (the principal city), nearest-centroid breaks a population tie, and a
+	 * genuine tie ABSTAINS (no completion) rather than guess. The synthesized node carries
+	 * `metadata.resolver_synthesized = true` (+ `relationship_type`) — it has no span in the raw
+	 * input. OFF by default: omit it and resolution is byte-identical.
 	 */
+	hierarchyCompletion?: boolean
+	/** @deprecated Renamed to {@link hierarchyCompletion} (#405 generalized #387). Still honored. */
 	cityStateFallback?: boolean
-	/**
-	 * Max km between a region centroid and its same-name locality descendant for the
-	 * {@link cityStateFallback} recovery to fire. Default 15 (city-states cluster at 0–9.3 km; the
-	 * nearest false positive, Brandenburg, is 60 km). Only consulted when `cityStateFallback` is on.
-	 */
-	cityStateMaxKm?: number
 }
 
 /**

--- a/resolver-wof-sqlite/coincident-localities-lookup.test.ts
+++ b/resolver-wof-sqlite/coincident-localities-lookup.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   End-to-end test for WofSqlitePlaceLookup.coincidentLocalitiesFor (#405): builds a fixture
+ *   gazetteer, derives the coincident_roles relation (#403), then verifies the backend method joins
+ *   the relation with `spr` and returns the dual-role completion candidates the resolver consumes.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { buildCoincidentRoles } from "./coincident-roles.js"
+import { WofSqlitePlaceLookup } from "./lookup.js"
+
+let db: DatabaseSync
+let lookup: WofSqlitePlaceLookup
+
+beforeEach(() => {
+	db = new DatabaseSync(":memory:")
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, min_longitude REAL, max_latitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);
+		CREATE TABLE ancestors (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT);
+		CREATE TABLE place_population (id INTEGER PRIMARY KEY, population INTEGER NOT NULL);
+	`)
+	const spr = db.prepare(
+		`INSERT INTO spr (id, parent_id, name, placetype, country, latitude, longitude,
+			min_latitude, min_longitude, max_latitude, max_longitude, is_current, is_deprecated)
+			VALUES (?, NULL, ?, ?, 'DE', ?, ?, ?, ?, ?, ?, 1, 0)`
+	)
+	// Berlin: region 910 + coincident locality 911 (city-state). Brandenburg: region 920 + far town 921.
+	spr.run(910, "Berlin", "region", 52.52, 13.4, 52.22, 13.1, 52.82, 13.7)
+	spr.run(911, "Berlin", "locality", 52.52, 13.4, 52.42, 13.3, 52.62, 13.5)
+	spr.run(920, "Brandenburg", "region", 52.4, 13.0, 51.2, 11.8, 53.6, 14.2)
+	spr.run(921, "Brandenburg", "locality", 52.41, 11.9, 52.36, 11.85, 52.46, 11.95)
+	db.prepare(`INSERT INTO place_population (id, population) VALUES (?, ?)`).run(911, 3_600_000)
+	const anc = db.prepare(`INSERT INTO ancestors (id, ancestor_id, ancestor_placetype) VALUES (?, ?, 'region')`)
+	anc.run(911, 910)
+	anc.run(921, 920)
+
+	buildCoincidentRoles(db)
+	lookup = new WofSqlitePlaceLookup({ database: db, buildFts: true })
+})
+
+afterEach(() => db.close())
+
+describe("WofSqlitePlaceLookup.coincidentLocalitiesFor", () => {
+	test("returns the dual-role locality joined with spr", () => {
+		const berlin = lookup.coincidentLocalitiesFor(910)
+		expect(berlin).toHaveLength(1)
+		expect(berlin[0]).toMatchObject({
+			id: 911,
+			name: "Berlin",
+			placetype: "locality",
+			country: "DE",
+			lat: 52.52,
+			lon: 13.4,
+			relationshipType: "city-state",
+			population: 3_600_000,
+		})
+	})
+
+	test("returns [] for a region not in the relation (Brandenburg's town is too far)", () => {
+		expect(lookup.coincidentLocalitiesFor(920)).toHaveLength(0)
+	})
+
+	test("returns [] for an unknown admin id", () => {
+		expect(lookup.coincidentLocalitiesFor(99999)).toHaveLength(0)
+	})
+
+	test("returns [] gracefully when the relation table is absent", () => {
+		const bare = new DatabaseSync(":memory:")
+		bare.exec(`CREATE TABLE spr (id INTEGER PRIMARY KEY, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL, min_latitude REAL, min_longitude REAL, max_latitude REAL,
+			max_longitude REAL, is_current INTEGER, is_deprecated INTEGER, parent_id INTEGER);
+			CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT);`)
+		const bareLookup = new WofSqlitePlaceLookup({ database: bare, buildFts: true })
+		expect(bareLookup.coincidentLocalitiesFor(910)).toHaveLength(0)
+		bare.close()
+	})
+})

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -15,6 +15,7 @@ import { DatabaseSync, type SQLInputValue } from "node:sqlite"
 
 import { SqliteDialect } from "@mailwoman/core/kysley/dialect"
 
+import type { CoincidentLocality } from "@mailwoman/core/resolver"
 import {
 	ADDRESS_CONVENTION_TABLE,
 	resolveConvention,
@@ -24,6 +25,8 @@ import {
 	type ResolvedConvention,
 	type Strategy,
 } from "./convention.js"
+
+import { COINCIDENT_ROLES_TABLE, coincidentRolesExists } from "./coincident-roles.js"
 import {
 	buildPlaceSearchFts,
 	PLACE_BBOX_TABLE,
@@ -295,6 +298,9 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	readonly #countryWofIdCache = new Map<string, number | null>()
 	/** Strategy names already warned about — so an unknown name surfaces once, not once per query. */
 	readonly #warnedUnknownStrategies = new Set<string>()
+	/** Lazily-built `admin_id → coincident localities` map from the #403 relation (null until first
+use). */
+	#coincidentRolesCache: Map<number, CoincidentLocality[]> | null = null
 
 	constructor(opts: WofSqlitePlaceLookupOpts, weights?: Partial<RankingWeights>) {
 		if (opts.database && opts.databasePath) {
@@ -399,6 +405,61 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			if (result !== null) return result
 		}
 		return []
+	}
+
+	/**
+	 * Dual-role localities coincident with an admin id, from the precomputed `coincident_roles`
+	 * relation (#403). Backs {@link ResolveOpts.hierarchyCompletion} (#405): O(1) once the relation is
+	 * loaded. Returns `[]` when the relation table is absent (older DB) or the admin isn't a
+	 * dual-role place, so completion degrades gracefully. The relation + `spr` join is loaded once
+	 * and memoized.
+	 */
+	coincidentLocalitiesFor(adminId: number | string): CoincidentLocality[] {
+		const id = typeof adminId === "number" ? adminId : Number(adminId)
+		if (!Number.isFinite(id)) return []
+		if (!this.#coincidentRolesCache) {
+			const map = new Map<number, CoincidentLocality[]>()
+			if (coincidentRolesExists(this.#db)) {
+				const rows = this.#db
+					.prepare(
+						`SELECT cr.admin_id AS adminId, s.id AS id, s.name AS name, s.country AS country,
+							s.latitude AS lat, s.longitude AS lon,
+							cr.relationship_type AS relationshipType, cr.locality_population AS population,
+							cr.distance_km AS distanceKm
+						FROM ${COINCIDENT_ROLES_TABLE} cr JOIN spr s ON s.id = cr.locality_id`
+					)
+					.all() as unknown as Array<{
+					adminId: number
+					id: number
+					name: string
+					country: string
+					lat: number
+					lon: number
+					relationshipType: string
+					population: number
+					distanceKm: number
+				}>
+				for (const r of rows) {
+					const candidate: CoincidentLocality = {
+						id: r.id,
+						name: r.name,
+						placetype: "locality",
+						country: r.country,
+						lat: r.lat,
+						lon: r.lon,
+						score: 0,
+						relationshipType: r.relationshipType,
+						population: r.population,
+						distanceKm: r.distanceKm,
+					}
+					const list = map.get(r.adminId)
+					if (list) list.push(candidate)
+					else map.set(r.adminId, [candidate])
+				}
+			}
+			this.#coincidentRolesCache = map
+		}
+		return this.#coincidentRolesCache.get(id) ?? []
 	}
 
 	/**


### PR DESCRIPTION
Second child of epic **#402**. Generalizes #387's Berlin-only city-state fallback to the full dual-role class, driven by #403's coincident-roles relation instead of a hardcoded 15 km constant.

## What
- **`ResolveOpts.hierarchyCompletion`** (default **OFF** → byte-stable; `cityStateFallback` kept as a deprecated alias). When a region resolves and the parse has **no** locality node, the resolver completes it from the backend's precomputed relation.
- **`ResolverBackend.coincidentLocalitiesFor(adminId)`** (new optional method) + the **`CoincidentLocality`** type. `WofSqlitePlaceLookup` implements it by joining `coincident_roles` (#403) with `spr`, loaded once + memoized — **O(1) map lookup at runtime, no distance math, no magic number**. Backends without the relation omit the method → completion no-ops gracefully (correct dependency direction: core defines the interface, resolver-wof-sqlite implements it).
- **Disambiguation:** the principal city wins by **population (primary)**, nearest centroid breaks a tie, a genuine tie (same population AND distance) **abstains**. Population-primary rather than distance-primary (DeepSeek's first sketch) because the real city can sit farther from the admin centroid than a 0-pop point — the **Niigata** case surfaced in #403.
- Removed the runtime haversine from `resolve.ts` (the relation is precomputed).

## Tests
- **core/resolver: 28** (7 new dual-role — synthesize-from-relation, deprecated-alias still works, default-off byte-stable, region-absent-from-relation no-op, **abstain-on-tie**, **most-populous-wins**, never-override-the-parser).
- **resolver-wof-sqlite:** an end-to-end backend test (build the relation in a fixture db → load it through the lookup → assert candidates, exclusion, empty-on-missing-table).
- Full suites green: **142 resolver-wof-sqlite + 28 core/resolver, 0 regressions.**

Next: **#406** wires `--hierarchy-completion` into `oa-resolver-eval` and runs the IT/ES/GB cross-locale regression before any default flip. Depends on this + #403 (#408, merged).