### PR TITLE
feat(resolver): ancestor-lineage attachment (#404) + dual-role docs (#407)

### DIFF
--- a/core/resolver/index.ts
+++ b/core/resolver/index.ts
@@ -7,6 +7,7 @@
 export { createWofResolver } from "./resolve.js"
 export { DEFAULT_PLACETYPE_MAP } from "./types.js"
 export type {
+	Ancestor,
 	CoincidentLocality,
 	PlacetypeMap,
 	ResolveOpts,

--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, test, vi } from "vitest"
 import { decodeAsXml } from "../decoder/serialize-xml.js"
 import type { AddressNode, AddressTree, ComponentTag } from "../decoder/types.js"
 import { createWofResolver } from "./resolve.js"
-import type { CoincidentLocality, ResolvedPlace, ResolverBackend } from "./types.js"
+import type { Ancestor, CoincidentLocality, ResolvedPlace, ResolverBackend } from "./types.js"
 
 function node(
 	tag: ComponentTag,
@@ -37,10 +37,16 @@ class FakeResolverBackend implements ResolverBackend {
 	readonly calls: Array<Parameters<ResolverBackend["findPlace"]>[0]> = []
 	readonly #places: ResolvedPlace[]
 	readonly #coincident: Map<number, CoincidentLocality[]>
+	readonly #ancestors: Map<number, Ancestor[]>
 
-	constructor(places: ResolvedPlace[], coincident?: Map<number, CoincidentLocality[]>) {
+	constructor(
+		places: ResolvedPlace[],
+		coincident?: Map<number, CoincidentLocality[]>,
+		ancestors?: Map<number, Ancestor[]>
+	) {
 		this.#places = places
 		this.#coincident = coincident ?? new Map()
+		this.#ancestors = ancestors ?? new Map()
 	}
 
 	async findPlace(query: Parameters<ResolverBackend["findPlace"]>[0]): Promise<ResolvedPlace[]> {
@@ -57,6 +63,10 @@ class FakeResolverBackend implements ResolverBackend {
 
 	coincidentLocalitiesFor(adminId: number | string): CoincidentLocality[] {
 		return this.#coincident.get(Number(adminId)) ?? []
+	}
+
+	ancestors(id: number | string): Ancestor[] {
+		return this.#ancestors.get(Number(id)) ?? []
 	}
 }
 
@@ -589,5 +599,40 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 		expect(localities).toHaveLength(1)
 		expect(localities[0]!.value).toBe("Some Town")
 		expect(localities[0]!.metadata?.["resolver_synthesized"]).toBeUndefined()
+	})
+
+	// Ancestor-lineage attachment (#404). Opt-in enrichment: stamp each resolved node's containment
+	// chain onto metadata.ancestors. Off by default → byte-stable.
+	const LINEAGE = new Map<number, Ancestor[]>([
+		[
+			101727113,
+			[
+				{ id: 85688541, placetype: "region", name: "Illinois" },
+				{ id: 85633147, placetype: "country", name: "United States" },
+			],
+		],
+	])
+
+	test("includeAncestors stamps the lineage onto a resolved node (#404)", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES, undefined, LINEAGE)
+		const input = tree("Illinois, Springfield", [
+			node("region", "Illinois", 0, 8, [node("locality", "Springfield", 10, 21)]),
+		])
+		const result = await createWofResolver(backend).resolveTree(input, { includeAncestors: true })
+		const locality = result.roots[0]?.children[0]
+		expect(locality?.placeId).toBe("wof:101727113")
+		expect(locality?.metadata?.["ancestors"]).toEqual([
+			{ id: 85688541, placetype: "region", name: "Illinois" },
+			{ id: 85633147, placetype: "country", name: "United States" },
+		])
+	})
+
+	test("includeAncestors is OFF by default — no ancestors metadata (#404)", async () => {
+		const backend = new FakeResolverBackend(FIXTURE_PLACES, undefined, LINEAGE)
+		const input = tree("Illinois, Springfield", [
+			node("region", "Illinois", 0, 8, [node("locality", "Springfield", 10, 21)]),
+		])
+		const result = await createWofResolver(backend).resolveTree(input)
+		expect(result.roots[0]?.children[0]?.metadata?.["ancestors"]).toBeUndefined()
 	})
 })

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -50,6 +50,8 @@ interface ResolutionState {
 	anchorWeight: number
 	/** Dual-role hierarchy completion (#405). Off by default → byte-stable. */
 	hierarchyCompletion: boolean
+	/** Attach ancestor lineage to each resolved node (#404). Off by default → byte-stable. */
+	includeAncestors: boolean
 	/**
 	 * Set while resolving when ANY tree node maps to the `locality` placetype (resolved or not) — the
 	 * completion only fires when the parser emitted no locality at all, never to override one.
@@ -116,6 +118,7 @@ class WofResolver implements Resolver {
 			anchorWeight: opts.anchorWeight ?? 2.0,
 			// `cityStateFallback` is the #387 alias that #405 generalized — still honored.
 			hierarchyCompletion: opts.hierarchyCompletion ?? opts.cityStateFallback ?? false,
+			includeAncestors: opts.includeAncestors ?? false,
 			localityNodePresent: false,
 			resolvedRegion: null,
 			resolvedRegionSpan: null,
@@ -182,6 +185,11 @@ class WofResolver implements Resolver {
 			if (picked) {
 				resolved = picked.top
 				decorateNode(decorated, picked.top, picked.alternatives)
+				// Lineage attachment (#404): stamp the resolved place's ancestor chain onto metadata. Opt-in
+				// + only when the backend supplies it, so the default stays byte-identical (no extra query).
+				if (state.includeAncestors && this.#backend.ancestors) {
+					decorated.metadata = { ...(decorated.metadata ?? {}), ancestors: this.#backend.ancestors(picked.top.id) }
+				}
 				// Capture the first resolved region for the city-state recovery, along with its span so
 				// the synthesized locality can borrow it (it has no span of its own).
 				if (placetype === "region" && state.resolvedRegion === null) {

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -79,6 +79,20 @@ export interface ResolverBackend {
 	 * no-ops. Synchronous: it's an in-memory map lookup once the relation is loaded.
 	 */
 	coincidentLocalitiesFor?(adminId: number | string): CoincidentLocality[]
+	/**
+	 * The ancestor lineage of a resolved place — its containment chain (county → region → country),
+	 * nearest-first. Backs {@link ResolveOpts.includeAncestors} (#404): the Pelias/Nominatim
+	 * "always-attach-the-hierarchy" enrichment. OPTIONAL — backends without it omit it, and the
+	 * attachment is skipped. Synchronous: a memoized read of the gazetteer's `ancestors` table.
+	 */
+	ancestors?(id: number | string): Ancestor[]
+}
+
+/** One link in a resolved place's containment lineage ({@link ResolverBackend.ancestors}, #404). */
+export interface Ancestor {
+	id: number | string
+	placetype: string
+	name: string
 }
 
 /**
@@ -87,8 +101,10 @@ export interface ResolverBackend {
  * disambiguates on.
  */
 export interface CoincidentLocality extends ResolvedPlace {
-	/** `city-state` / `capital-seat` / `consolidated-county` — surfaced as
-`metadata.relationship_type`. */
+	/**
+	 * `city-state` / `capital-seat` / `consolidated-county` — surfaced as
+	 * `metadata.relationship_type`.
+	 */
 	relationshipType: string
 	/** Locality population (0 when unknown) — the PRIMARY disambiguator when an admin has several. */
 	population: number
@@ -184,6 +200,15 @@ export interface ResolveOpts {
 	hierarchyCompletion?: boolean
 	/** @deprecated Renamed to {@link hierarchyCompletion} (#405 generalized #387). Still honored. */
 	cityStateFallback?: boolean
+	/**
+	 * Attach each resolved node's ancestor lineage (#404) — the containment chain (county → region →
+	 * country) the backend's {@link ResolverBackend.ancestors} returns — onto `metadata.ancestors`.
+	 * The Pelias/Nominatim "always-attach-the-hierarchy" enrichment, so a consumer gets the full
+	 * admin ladder from a single resolved place. OFF by default: omit it and resolution is
+	 * byte-identical (and there's no extra query). Only attaches to nodes the resolver actually
+	 * resolved.
+	 */
+	includeAncestors?: boolean
 }
 
 /**

--- a/docs/articles/api.md
+++ b/docs/articles/api.md
@@ -62,6 +62,12 @@ const resolver = await createWofResolver({
 
 // Resolve a parsed tree
 const resolvedTree: AddressTree = await resolver.resolveTree(tree)
+
+// Opt-in resolver enrichments (both off by default → byte-stable):
+//   hierarchyCompletion — recover the dropped locality of a dual-role place (Berlin, Milano)
+//   includeAncestors    — stamp each resolved node's containment chain onto metadata.ancestors
+// See concepts/dual-role-places.md.
+const enriched = await resolver.resolveTree(tree, { hierarchyCompletion: true, includeAncestors: true })
 ```
 
 ## Output types

--- a/docs/articles/concepts/README.md
+++ b/docs/articles/concepts/README.md
@@ -25,6 +25,7 @@ Additional articles:
 
 - [Joint decoding walkthrough](./joint-decoding-walkthrough.md) — how the reconciler picks coherent interpretations
 - [Reconcile empty-parse bonus](./reconcile-empty-parse-bonus.md) — handling the "model gives up" failure mode
+- [Dual-role places](./dual-role-places.md) — completing the dropped locality of a city-state or capital-seat province
 - [Synthetic corpus validation](./synthetic-corpus-validation.md) — how we validate LLM-generated training data
 - [DeepSeek reasoning budget](./deepseek-reasoning-budget.md) — the adversarial corpus generation pipeline
 - [Staged pipeline contract](./staged-pipeline-contract.md) — implementer-facing TypeScript contracts

--- a/docs/articles/concepts/dual-role-places.md
+++ b/docs/articles/concepts/dual-role-places.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 12
+title: Dual-role places and hierarchy completion
+tags:
+  - concepts
+  - resolver
+  - locality
+  - region
+---
+
+# Dual-role places and hierarchy completion
+
+Some places are two things at once. Berlin is a city and a federal state. Milano is a comune and the province named after it. Bristol is a city and a unitary authority. Utrecht is a city and a province. A census of our gazetteer found about **122 of these across nine countries** — Italy alone has 70 (its provinces are nearly all named after their capital), then Spain (14), the UK (12), Japan (10), Korea (7), and a handful each for France, Germany, the Netherlands, and China.
+
+These cause a specific failure. In international order — `5 Hauptstraße, Berlin, Berlin 10115` — the city and the state are the same word, and the parser often labels one `Berlin` as the region and drops the other entirely. The resolved tree then carries a region but no locality, and the resolver has nothing to place: on a 1,500-row Berlin eval, 955 rows resolved to nothing.
+
+## Completing the hierarchy
+
+When the parser drops the locality of a dual-role place, the gazetteer still knows what it was — the region and the locality are two linked records with the same name and a coincident centroid. So the resolver can finish the job. With `hierarchyCompletion` enabled, after the walk, if a region resolved and the tree has no locality node, the resolver looks the region up in a precomputed **coincident-roles relation** and synthesizes the missing locality from it.
+
+The relation is the important part. Rather than a hardcoded list of city-states or a magic distance threshold, it's derived from the gazetteer's own structure at build time: a region and a locality are recorded as a pair when they share a name, the locality descends from the region in the `ancestors` table, and their centroids fall within a relative tolerance (a fraction of the region's bounding-box diagonal, so a large Italian province admits a city tens of kilometres from its centroid while a tiny city-state stays tight). At runtime the resolver does an O(1) membership lookup — no distance maths, no constant to tune. Build the table once with `mailwoman-wof-build-coincident-roles`; it ships in the admin gazetteer.
+
+Each completion carries a `relationship_type` (`city-state`, `capital-seat`, or `consolidated-county`) on `metadata.relationship_type`, and the synthesized node is marked `metadata.resolver_synthesized = true` — it has no span in the raw input, so a consumer can tell it apart from a parsed component.
+
+## Picking the right city
+
+A few admins map to more than one same-name locality, so completion has to choose. The rule is population first: the principal city is the populous one, and it can sit farther from the admin centroid than a tiny same-name hamlet — Niigata prefecture's centroid is dragged out to sea, so the real Niigata city is 41 km away while a 0-population point is closer. Nearest centroid breaks a population tie. When two candidates tie on both, completion abstains rather than guess, because a wrong locality is worse than a missing one.
+
+The whole thing is off by default. Turn it on and a Berlin address that used to resolve to nothing comes back with its locality; leave it off and resolution is byte-for-byte what it was.
+
+## Attaching the lineage
+
+A related option, `includeAncestors`, stamps each resolved node's full containment chain — county, region, country, nearest-first — onto `metadata.ancestors`. This is the move Pelias and Nominatim make as a matter of course: a single resolved place comes back carrying its whole admin ladder. It's the same gazetteer `ancestors` data the coincident-roles relation is built from, and it's also off by default.
+
+## Where this sits
+
+Hierarchy completion lives in the resolve stage as a post-walk pass. The cleaner long-term home is the [reconcile stage](./joint-decoding-walkthrough.md), whose concordance scoring already ranks parses by how well their resolved places agree in the admin hierarchy — exactly the signal that says "the region Berlin and the locality Berlin are the same place." Until joint decoding is the default decode path, the relation-driven completion bridges the gap: it recovers the dropped locality from the gazetteer without needing the classifier to have surfaced it. The coincident-roles relation and the lineage attachment are both substrates that a future concordance default would score against.

--- a/resolver-wof-sqlite/coincident-localities-lookup.test.ts
+++ b/resolver-wof-sqlite/coincident-localities-lookup.test.ts
@@ -35,15 +35,19 @@ beforeEach(() => {
 			min_latitude, min_longitude, max_latitude, max_longitude, is_current, is_deprecated)
 			VALUES (?, NULL, ?, ?, 'DE', ?, ?, ?, ?, ?, ?, 1, 0)`
 	)
-	// Berlin: region 910 + coincident locality 911 (city-state). Brandenburg: region 920 + far town 921.
+	// Germany 900 ⊃ Berlin region 910 ⊃ coincident locality 911 (city-state). Brandenburg: 920 + far town 921.
+	spr.run(900, "Germany", "country", 51.1, 10.4, 47.3, 5.9, 55.1, 15.0)
 	spr.run(910, "Berlin", "region", 52.52, 13.4, 52.22, 13.1, 52.82, 13.7)
 	spr.run(911, "Berlin", "locality", 52.52, 13.4, 52.42, 13.3, 52.62, 13.5)
 	spr.run(920, "Brandenburg", "region", 52.4, 13.0, 51.2, 11.8, 53.6, 14.2)
 	spr.run(921, "Brandenburg", "locality", 52.41, 11.9, 52.36, 11.85, 52.46, 11.95)
 	db.prepare(`INSERT INTO place_population (id, population) VALUES (?, ?)`).run(911, 3_600_000)
-	const anc = db.prepare(`INSERT INTO ancestors (id, ancestor_id, ancestor_placetype) VALUES (?, ?, 'region')`)
-	anc.run(911, 910)
-	anc.run(921, 920)
+	const anc = db.prepare(`INSERT INTO ancestors (id, ancestor_id, ancestor_placetype) VALUES (?, ?, ?)`)
+	// Berlin locality 911's lineage: region 910 then country 900 (nearest-first expected).
+	anc.run(911, 910, "region")
+	anc.run(911, 900, "country")
+	anc.run(910, 900, "country")
+	anc.run(921, 920, "region")
 
 	buildCoincidentRoles(db)
 	lookup = new WofSqlitePlaceLookup({ database: db, buildFts: true })
@@ -73,6 +77,14 @@ describe("WofSqlitePlaceLookup.coincidentLocalitiesFor", () => {
 
 	test("returns [] for an unknown admin id", () => {
 		expect(lookup.coincidentLocalitiesFor(99999)).toHaveLength(0)
+	})
+
+	test("ancestors() returns the lineage nearest-first, joined with spr (#404)", () => {
+		expect(lookup.ancestors(911)).toEqual([
+			{ id: 910, placetype: "region", name: "Berlin" },
+			{ id: 900, placetype: "country", name: "Germany" },
+		])
+		expect(lookup.ancestors(99999)).toHaveLength(0)
 	})
 
 	test("returns [] gracefully when the relation table is absent", () => {

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -15,7 +15,7 @@ import { DatabaseSync, type SQLInputValue } from "node:sqlite"
 
 import { SqliteDialect } from "@mailwoman/core/kysley/dialect"
 
-import type { CoincidentLocality } from "@mailwoman/core/resolver"
+import type { Ancestor, CoincidentLocality } from "@mailwoman/core/resolver"
 import {
 	ADDRESS_CONVENTION_TABLE,
 	resolveConvention,
@@ -298,9 +298,13 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	readonly #countryWofIdCache = new Map<string, number | null>()
 	/** Strategy names already warned about — so an unknown name surfaces once, not once per query. */
 	readonly #warnedUnknownStrategies = new Set<string>()
-	/** Lazily-built `admin_id → coincident localities` map from the #403 relation (null until first
-use). */
+	/**
+	 * Lazily-built `admin_id → coincident localities` map from the #403 relation (null until first
+	 * use).
+	 */
 	#coincidentRolesCache: Map<number, CoincidentLocality[]> | null = null
+	/** Per-id memoized ancestor lineages (#404) — a hot chain is queried once. */
+	readonly #ancestorsCache = new Map<number, Ancestor[]>()
 
 	constructor(opts: WofSqlitePlaceLookupOpts, weights?: Partial<RankingWeights>) {
 		if (opts.database && opts.databasePath) {
@@ -460,6 +464,34 @@ use). */
 			this.#coincidentRolesCache = map
 		}
 		return this.#coincidentRolesCache.get(id) ?? []
+	}
+
+	/**
+	 * The ancestor lineage of a place — its containment chain joined with `spr` for canonical names,
+	 * ordered NEAREST-FIRST (localadmin → county → region → … → country). Backs
+	 * {@link ResolveOpts.includeAncestors} (#404). Self is excluded; memoized per id. Returns `[]`
+	 * when the place has no recorded ancestry.
+	 */
+	ancestors(id: number | string): Ancestor[] {
+		const pid = typeof id === "number" ? id : Number(id)
+		if (!Number.isFinite(pid)) return []
+		const cached = this.#ancestorsCache.get(pid)
+		if (cached) return cached
+		// Nearest-first: rank by placetype specificity (descending). Unknown placetypes sort last.
+		const rows = this.#db
+			.prepare(
+				`SELECT a.ancestor_id AS id, a.ancestor_placetype AS placetype, s.name AS name
+				FROM ancestors a JOIN spr s ON s.id = a.ancestor_id
+				WHERE a.id = ? AND a.ancestor_id != a.id
+				ORDER BY CASE a.ancestor_placetype
+					WHEN 'localadmin' THEN 6 WHEN 'borough' THEN 6 WHEN 'county' THEN 5
+					WHEN 'macrocounty' THEN 4 WHEN 'region' THEN 3 WHEN 'macroregion' THEN 2
+					WHEN 'country' THEN 1 ELSE 0 END DESC`
+			)
+			.all(pid) as unknown as Array<{ id: number; placetype: string; name: string }>
+		const lineage: Ancestor[] = rows.map((r) => ({ id: r.id, placetype: r.placetype, name: r.name }))
+		this.#ancestorsCache.set(pid, lineage)
+		return lineage
 	}
 
 	/**


### PR DESCRIPTION
Fifth child of epic **#402** — the Pelias/Nominatim 'always-attach-the-hierarchy' enrichment (the substrate from the architecture discussion), and what the latent concordance layer would later score against.

## What
- **`ResolverBackend.ancestors(id)`** (new optional method) + the **`Ancestor`** type (`id`/`placetype`/`name`). `WofSqlitePlaceLookup` implements it by joining the gazetteer `ancestors` table with `spr` for canonical names, **nearest-first** (localadmin→county→region→country), memoized per id.
- **`ResolveOpts.includeAncestors`** (default **OFF** → byte-stable, no extra query). When on, each resolved node gets its containment chain stamped onto `metadata.ancestors`.

Kept deliberately minimal + metadata-based: byte-stable, doesn't touch the `AddressNode` schema or the serializers. Surfacing the lineage directly in `decodeAsJson`/`decodeAsXml` is a noted follow-up.

## Tests
- core/resolver: `includeAncestors` stamps the lineage; default-off → no `ancestors` metadata.
- resolver-wof-sqlite: `ancestors()` returns the nearest-first chain joined with `spr`; empty for unknown ids.
- Full suites green: **173 passed, 0 regressions.**

This is the last code child of #402; #407 (docs) remains.