### PR TITLE
feat(resolver): hierarchyCompletion on by default (#402)

### DIFF
--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -511,8 +511,26 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 		expect(result.roots.find((r) => r.tag === "locality")?.placeId).toBe("wof:911")
 	})
 
-	test("hierarchy completion is OFF by default — byte-stable (#405)", async () => {
+	test("hierarchy completion is ON by default (#402)", async () => {
 		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
+		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
+		const result = await createWofResolver(backend).resolveTree(input, { defaultCountry: "DE" })
+		expect(result.roots.find((r) => r.tag === "locality")?.placeId).toBe("wof:911")
+	})
+
+	test("hierarchyCompletion: false opts out of the default (#402)", async () => {
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
+		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
+		const result = await createWofResolver(backend).resolveTree(input, {
+			hierarchyCompletion: false,
+			defaultCountry: "DE",
+		})
+		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+	})
+
+	test("a backend without the relation no-ops (default-on is safe) (#402)", async () => {
+		// No relation map → coincidentLocalitiesFor returns [] → completion can't fire even when on.
+		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES)
 		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
 		const result = await createWofResolver(backend).resolveTree(input, { defaultCountry: "DE" })
 		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -116,8 +116,11 @@ class WofResolver implements Resolver {
 			postcode: firstPostcodeValue(tree.roots),
 			anchorPosterior: opts.anchorPosterior,
 			anchorWeight: opts.anchorWeight ?? 2.0,
+			// Default-ON (#402): completion only fires for a dual-role region whose locality the parser
+			// dropped, and no-ops entirely when the backend has no relation (the browser WASM resolver, or
+			// a gazetteer without `coincident_roles`). Pass `hierarchyCompletion: false` to opt out.
 			// `cityStateFallback` is the #387 alias that #405 generalized — still honored.
-			hierarchyCompletion: opts.hierarchyCompletion ?? opts.cityStateFallback ?? false,
+			hierarchyCompletion: opts.hierarchyCompletion ?? opts.cityStateFallback ?? true,
 			includeAncestors: opts.includeAncestors ?? false,
 			localityNodePresent: false,
 			resolvedRegion: null,

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -195,7 +195,9 @@ export interface ResolveOpts {
 	 * most populous wins (the principal city), nearest-centroid breaks a population tie, and a
 	 * genuine tie ABSTAINS (no completion) rather than guess. The synthesized node carries
 	 * `metadata.resolver_synthesized = true` (+ `relationship_type`) — it has no span in the raw
-	 * input. OFF by default: omit it and resolution is byte-identical.
+	 * input. ON by default (#402): it only fires for a dual-role region whose locality the parser
+	 * dropped, and no-ops entirely when the backend has no relation (the browser WASM resolver, or a
+	 * gazetteer without the `coincident_roles` table). Pass `false` to opt out.
 	 */
 	hierarchyCompletion?: boolean
 	/** @deprecated Renamed to {@link hierarchyCompletion} (#405 generalized #387). Still honored. */

--- a/scripts/build-unified-wof.ts
+++ b/scripts/build-unified-wof.ts
@@ -19,7 +19,12 @@
  *   single repo directory.
  */
 
-import { createUnifiedIndexes, createUnifiedSchema, populateAncestors } from "@mailwoman/resolver-wof-sqlite/unified-schema"
+import { buildCoincidentRoles } from "@mailwoman/resolver-wof-sqlite/coincident-roles"
+import {
+	createUnifiedIndexes,
+	createUnifiedSchema,
+	populateAncestors,
+} from "@mailwoman/resolver-wof-sqlite/unified-schema"
 import FastGlob from "fast-glob"
 import { existsSync, statSync, unlinkSync } from "node:fs"
 import { readFile } from "node:fs/promises"
@@ -31,8 +36,11 @@ interface Args {
 	outputPath: string
 	concurrency: number
 	batchCommitSize: number
-	/** Override the ingested placetype set (comma-separated). Defaults to ADMIN_PLACETYPES; pass
-	 *  `--placetypes postalcode` to build the postcode shard from whosonfirst-data-postalcode-* repos. */
+	/**
+	 * Override the ingested placetype set (comma-separated). Defaults to ADMIN_PLACETYPES; pass
+	 * `--placetypes postalcode` to build the postcode shard from whosonfirst-data-postalcode-*
+	 * repos.
+	 */
 	placetypes?: string[]
 }
 
@@ -49,7 +57,10 @@ function parseArgs(): Args {
 		else if (args[i] === "--output" && args[i + 1]) outputPath = args[++i]
 		else if (args[i] === "--concurrency" && args[i + 1]) concurrency = parseInt(args[++i]!, 10)
 		else if (args[i] === "--batch" && args[i + 1]) batchCommitSize = parseInt(args[++i]!, 10)
-		else if (args[i] === "--placetypes" && args[i + 1]) placetypes = args[++i]!.split(",").map((s) => s.trim()).filter(Boolean)
+		else if (args[i] === "--placetypes" && args[i + 1])
+			placetypes = args[++i]!.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean)
 	}
 
 	if (!dataDir || !outputPath) {
@@ -312,6 +323,13 @@ async function main() {
 	console.error("  Building ancestors (parent_id closure)...")
 	const ancestorRows = populateAncestors(db)
 	console.error(`  ancestors: ${ancestorRows} rows`)
+
+	// Dual-role-place relation (#403, epic #402) — needs `ancestors` + `spr` bbox + `place_population`,
+	// all present by now. Drives the resolver's hierarchy completion (on by default). Tiny (~hundreds of
+	// rows); `build-slim` carries it through to the shipped DB.
+	console.error("  Building coincident_roles (dual-role places)...")
+	const roles = buildCoincidentRoles(db)
+	console.error(`  coincident_roles: ${roles.rowCount} rows`)
 
 	console.error("  Creating indexes...")
 	createUnifiedIndexes(db)


### PR DESCRIPTION
Flips `hierarchyCompletion` to **default-on** (operator-approved after the clean #406 regression: DE Berlin 36.3→80.9% PIP; IT/ES 0 false completions / 6k rows).

- Default is now on in `resolve.ts`; `hierarchyCompletion: false` opts out (the deprecated `cityStateFallback` alias still works).
- **Safe by construction:** completion only fires for a dual-role region whose locality the parser dropped, and **no-ops entirely** when the backend has no relation — the browser WASM resolver (no `coincidentLocalitiesFor`) or any gazetteer without the `coincident_roles` table. So this is a no-op until the relation is shipped into the loaded gazetteer.
- Tests: default-on completes; `false` opts out; a relation-less backend no-ops. **675 tests pass, 0 regressions.**

⚠️ This flip alone has no production effect yet — the `coincident_roles` table must be built into the shipped/demo gazetteer (tracked as the next step). The server (`ResolveRouter`, resolver-wof-sqlite) will complete once its DB has the table; the browser demo needs the table in its R2 DB **and** `coincidentLocalitiesFor` in the WASM resolver.