### PR TITLE
feat(decoder): interpretations[] — multi-role node schema (#414)

### DIFF
--- a/core/decoder/serialize-json.ts
+++ b/core/decoder/serialize-json.ts
@@ -7,6 +7,10 @@
  *
  *   Flattens the tree to `{ tag: value }`. First-occurrence wins for repeated tags — matches
  *   libpostal's behavior. Use `decodeAsTuples` if order or repetition matters.
+ *
+ *   A multi-role node (#413 — a city-state span tagged `region` that also plays `locality`) emits one
+ *   entry per role from its `interpretations`, so `out.locality` still surfaces for a completed
+ *   city-state. The shared span means every role gets the same `value`.
  */
 
 import type { ComponentTag } from "../types/component.js"
@@ -14,6 +18,11 @@ import type { AddressNode, AddressTree } from "./types.js"
 
 function visit(node: AddressNode, out: Partial<Record<ComponentTag, string>>): void {
 	if (!(node.tag in out)) out[node.tag] = node.value
+	if (node.interpretations) {
+		for (const interp of node.interpretations) {
+			if (!(interp.tag in out)) out[interp.tag] = node.value
+		}
+	}
 	for (const child of node.children) visit(child, out)
 }
 

--- a/core/decoder/serialize-xml.ts
+++ b/core/decoder/serialize-xml.ts
@@ -88,6 +88,12 @@ function attrs(node: AddressNode, opts: Required<SerializeXmlOpts>): string {
 	if (opts.includePlace && node.placeId !== undefined) {
 		parts.push(`place="${escapeXml(node.placeId)}"`)
 	}
+	// Multi-role node (#413): a city-state span tagged `region` that also plays `locality` lists every
+	// role it holds, primary first — `roles="region locality"`. Emitted only when extra roles exist.
+	if (node.interpretations && node.interpretations.length > 0) {
+		const roles = [node.tag, ...node.interpretations.map((i) => i.tag)]
+		parts.push(`roles="${escapeXml(roles.join(" "))}"`)
+	}
 	return parts.length === 0 ? "" : " " + parts.join(" ")
 }
 

--- a/core/decoder/serialize.test.ts
+++ b/core/decoder/serialize.test.ts
@@ -193,3 +193,34 @@ describe("decodeAsXml (nested mixed-content)", () => {
 		expect(xml).toContain("<address raw=")
 	})
 })
+
+describe("interpretations (multi-role nodes, #413)", () => {
+	// A city-state: the `region` span "Berlin" also plays `locality` via an interpretation.
+	const cityStateTree = () => {
+		const tree = buildAddressTree("Berlin 10115", [tok("Berlin", 0, 6, "B-region"), tok("10115", 7, 12, "B-postcode")])
+		const region = tree.roots.find((r) => r.tag === "region")!
+		;(region as { interpretations?: unknown }).interpretations = [
+			{ tag: "locality", placeId: "wof:101909779", lat: 52.52, lon: 13.4 },
+		]
+		return tree
+	}
+
+	test("decodeAsJson emits one entry per role — region AND locality both surface", () => {
+		expect(decodeAsJson(cityStateTree())).toMatchObject({ region: "Berlin", locality: "Berlin", postcode: "10115" })
+	})
+
+	test("decodeAsJson is byte-stable when no interpretations are present", () => {
+		const tree = buildAddressTree("Berlin 10115", [tok("Berlin", 0, 6, "B-region"), tok("10115", 7, 12, "B-postcode")])
+		expect(decodeAsJson(tree)).toEqual({ region: "Berlin", postcode: "10115" })
+	})
+
+	test("decodeAsXml lists the roles, primary first", () => {
+		const xml = decodeAsXml(cityStateTree())
+		expect(xml).toContain('roles="region locality"')
+	})
+
+	test("decodeAsXml emits no roles attribute on a single-role node", () => {
+		const tree = buildAddressTree("Berlin 10115", [tok("Berlin", 0, 6, "B-region"), tok("10115", 7, 12, "B-postcode")])
+		expect(decodeAsXml(tree)).not.toContain("roles=")
+	})
+})

--- a/core/decoder/types.ts
+++ b/core/decoder/types.ts
@@ -104,6 +104,32 @@ export interface AddressNode {
 	 * `@mailwoman/core/resolver`.
 	 */
 	alternatives?: ReadonlyArray<unknown>
+	/**
+	 * ADDITIONAL roles this single span plays, beyond `tag` (#413). A place can hold multiple admin
+	 * tiers under one name — a city-state (Berlin is region AND locality) or a capital-seat province
+	 * (Milano province ~ Milano comune). Rather than synthesize a second node with a borrowed span,
+	 * the resolver records the extra role(s) here, so one node = one span = many roles (the model
+	 * Google's `address_components[].types` uses). `tag`/`placeId`/`lat`/`lon` remain the PRIMARY
+	 * role; each interpretation is a distinct secondary role with its own resolved place. Serializers
+	 * surface every role (a city-state emits both `region` and `locality`). Distinct from
+	 * `alternatives` — those are same-role runner-up places (Springfield IL vs MA); interpretations
+	 * are DIFFERENT tags, same span. Empty / absent for the common single-role node. Both completion
+	 * (#415) and a future concordance decode write into this one slot.
+	 */
+	interpretations?: ReadonlyArray<Interpretation>
+}
+
+/** One additional role a span plays (#413) — see {@link AddressNode.interpretations}. */
+export interface Interpretation {
+	tag: ComponentTag
+	/** Resolver-supplied normalized place URI for this role (e.g. `wof:101909779`). */
+	placeId?: string
+	sourceId?: string
+	/** Centroid for this role's place (a capital-seat comune differs from its province). */
+	lat?: number
+	lon?: number
+	confidence?: number
+	metadata?: Record<string, unknown>
 }
 
 /**

--- a/docs/articles/api.md
+++ b/docs/articles/api.md
@@ -96,8 +96,11 @@ interface AddressNode {
 	source: "rule" | "neural" // Which classifier produced this node
 	children: AddressNode[] // Nested components (e.g. street contains street_prefix)
 	alternatives?: AddressAlternative[] // Resolver candidates when --candidates is set
+	interpretations?: Interpretation[] // Extra roles this one span plays — a city-state is region AND locality (#413)
 }
 ```
+
+A node usually plays one role (its `tag`). A **dual-role place** plays several on one span: `Berlin` is both a region and a locality. The extra roles ride in `interpretations` (each a `{ tag, placeId, lat, lon, … }`), and the flat projections surface every role — `decodeAsJson` emits both `region` and `locality`, `decodeAsXml` lists `roles="region locality"`. See [concepts/dual-role-places.md](./concepts/dual-role-places.md).
 
 ### `AddressAlternative`
 


### PR DESCRIPTION
First child of epic **#413**. The additive, byte-stable foundation that retires the synthesized-node hack from #402.

## What
- New **`AddressNode.interpretations?: Interpretation[]`** + the `Interpretation` type — the *additional* roles one span plays beyond `tag`. A city-state span tagged `region` carries a `locality` interpretation (same span, its own `{tag, placeId, lat, lon}`). The node's own `tag`/`placeId` stay the **primary** role, so existing consumers are untouched. Distinct from `alternatives` (same-role runners-up, e.g. Springfield IL vs MA).
- **`decodeAsJson`** emits one keyed entry per role — a city-state surfaces both `region:"Berlin"` and `locality:"Berlin"`, so `tree.locality` keeps resolving (the whole point of completing the locality). **`decodeAsXml`** lists `roles="region locality"`.

## Byte-stable
Nothing emits `interpretations` yet (#415 wires the completion into it), so all output is byte-identical. **68 decoder tests pass**, incl. 4 new: JSON emits both roles, JSON unchanged when empty, XML roles attribute, XML omits it for single-role nodes.

Next: #415 rewrites `#completeFromRelation` to push a `locality` interpretation onto the region node (deleting the synthesized-node path); #416 migrates the eval/consumers. Then Route A writes into this same slot.