### PR TITLE
feat(resolver): completion records a locality interpretation, not a synthesized node (#415)

### DIFF
--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -445,11 +445,10 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 		expect(on.roots[0]!.placeId).toBe("wof:1") // US already top, boost keeps it there
 	})
 
-	// Dual-role hierarchy completion (#405, generalizes #387). In `…, Berlin, Berlin <PC>` the parser
-	// drops the locality (city == region), leaving a region but no locality. Completion synthesizes it
-	// from the backend's precomputed coincident-roles relation (#403) — a membership lookup, not a
-	// runtime distance check. The places fixture only needs the region (so it resolves); the relation
-	// supplies the completion candidate.
+	// Dual-role hierarchy completion (#405/#415). In `…, Berlin, Berlin <PC>` the parser drops the
+	// locality (city == region), leaving a region but no locality. Completion records the dropped
+	// locality as a `locality` INTERPRETATION on the resolved region node (one node, one span, two
+	// roles — no synthesized sibling), from the backend's precomputed coincident-roles relation (#403).
 	const DUAL_ROLE_PLACES: ResolvedPlace[] = [
 		{ id: 900, name: "Germany", placetype: "country", country: "DE", lat: 51.1, lon: 10.4, score: 10 },
 		{ id: 910, name: "Berlin", placetype: "region", country: "DE", parent_id: 900, lat: 52.52, lon: 13.4, score: 9 },
@@ -477,10 +476,15 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 		population: 3_600_000,
 		distanceKm: 0,
 	}
-	// admin_id → coincident localities. Berlin (910) is dual-role; Brandenburg (920) is absent.
 	const RELATION = new Map<number, CoincidentLocality[]>([[910, [berlinLocality]]])
 
-	test("hierarchy completion synthesizes the dropped locality from the relation (#405)", async () => {
+	// The completed `locality` role, read off the region node's interpretations (where #415 puts it).
+	const localityRole = (roots: AddressNode[]): Interpretation | undefined =>
+		(roots.find((r) => r.tag === "region")?.interpretations as Interpretation[] | undefined)?.find(
+			(i) => i.tag === "locality"
+		)
+
+	test("completion records the dropped locality as an interpretation on the region node (#415)", async () => {
 		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
 		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
 		const result = await createWofResolver(backend).resolveTree(input, {
@@ -488,34 +492,32 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 			defaultCountry: "DE",
 		})
 
-		const locality = result.roots.find((r) => r.tag === "locality")
-		expect(locality).toBeDefined()
-		expect(locality).toMatchObject({
+		// No synthesized locality NODE — the role rides on the region node.
+		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+		expect(localityRole(result.roots)).toMatchObject({
 			tag: "locality",
-			value: "Berlin",
-			source: "resolver",
 			placeId: "wof:911",
 			lat: 52.52,
 			lon: 13.4,
+			metadata: { relationship_type: "city-state", resolver_completed: true },
 		})
-		expect(locality!.metadata).toMatchObject({ resolver_synthesized: true, relationship_type: "city-state" })
 	})
 
-	test("the deprecated cityStateFallback alias still drives completion (#405)", async () => {
+	test("the deprecated cityStateFallback alias still drives completion (#415)", async () => {
 		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
 		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
 		const result = await createWofResolver(backend).resolveTree(input, {
 			cityStateFallback: true,
 			defaultCountry: "DE",
 		})
-		expect(result.roots.find((r) => r.tag === "locality")?.placeId).toBe("wof:911")
+		expect(localityRole(result.roots)?.placeId).toBe("wof:911")
 	})
 
 	test("hierarchy completion is ON by default (#402)", async () => {
 		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
 		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
 		const result = await createWofResolver(backend).resolveTree(input, { defaultCountry: "DE" })
-		expect(result.roots.find((r) => r.tag === "locality")?.placeId).toBe("wof:911")
+		expect(localityRole(result.roots)?.placeId).toBe("wof:911")
 	})
 
 	test("hierarchyCompletion: false opts out of the default (#402)", async () => {
@@ -525,30 +527,27 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 			hierarchyCompletion: false,
 			defaultCountry: "DE",
 		})
-		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+		expect(localityRole(result.roots)).toBeUndefined()
 	})
 
 	test("a backend without the relation no-ops (default-on is safe) (#402)", async () => {
-		// No relation map → coincidentLocalitiesFor returns [] → completion can't fire even when on.
 		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES)
 		const input = tree("Berlin 10115", [node("region", "Berlin", 0, 6), node("postcode", "10115", 7, 12)])
 		const result = await createWofResolver(backend).resolveTree(input, { defaultCountry: "DE" })
-		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+		expect(localityRole(result.roots)).toBeUndefined()
 	})
 
 	test("hierarchy completion does nothing for a region absent from the relation (#405)", async () => {
 		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
-		// Brandenburg resolves as a region but isn't a dual-role place → the relation has no entry → no completion.
 		const input = tree("Brandenburg 14770", [node("region", "Brandenburg", 0, 11), node("postcode", "14770", 12, 17)])
 		const result = await createWofResolver(backend).resolveTree(input, {
 			hierarchyCompletion: true,
 			defaultCountry: "DE",
 		})
-		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+		expect(localityRole(result.roots)).toBeUndefined()
 	})
 
 	test("hierarchy completion abstains when candidates tie on population AND distance (#405)", async () => {
-		// Two same-name localities, identical population + distance → genuinely indistinguishable → abstain.
 		const twin = (id: number): CoincidentLocality => ({
 			id,
 			name: "Berlin",
@@ -567,11 +566,10 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 			hierarchyCompletion: true,
 			defaultCountry: "DE",
 		})
-		expect(result.roots.find((r) => r.tag === "locality")).toBeUndefined()
+		expect(localityRole(result.roots)).toBeUndefined()
 	})
 
 	test("hierarchy completion picks the most populous when an admin has several (#405)", async () => {
-		// The principal city (high population) wins even if it sits farther from the region centroid (Niigata).
 		const small: CoincidentLocality = {
 			id: 912,
 			name: "Berlin",
@@ -602,21 +600,18 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 			hierarchyCompletion: true,
 			defaultCountry: "DE",
 		})
-		expect(result.roots.find((r) => r.tag === "locality")?.placeId).toBe("wof:911")
+		expect(localityRole(result.roots)?.placeId).toBe("wof:911")
 	})
 
-	test("hierarchy completion never overrides a locality the parser already emitted (#405)", async () => {
+	test("hierarchy completion never adds a role when the parser already emitted a locality (#405)", async () => {
 		const backend = new FakeResolverBackend(DUAL_ROLE_PLACES, RELATION)
-		// A real locality span is present (even if it won't resolve) → the gap-filler must stay quiet.
 		const input = tree("Some Town, Berlin", [node("locality", "Some Town", 0, 9), node("region", "Berlin", 11, 17)])
 		const result = await createWofResolver(backend).resolveTree(input, {
 			hierarchyCompletion: true,
 			defaultCountry: "DE",
 		})
-		const localities = result.roots.filter((r) => r.tag === "locality")
-		expect(localities).toHaveLength(1)
-		expect(localities[0]!.value).toBe("Some Town")
-		expect(localities[0]!.metadata?.["resolver_synthesized"]).toBeUndefined()
+		expect(result.roots.filter((r) => r.tag === "locality")).toHaveLength(1)
+		expect(localityRole(result.roots)).toBeUndefined()
 	})
 
 	// Ancestor-lineage attachment (#404). Opt-in enrichment: stamp each resolved node's containment

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -162,7 +162,7 @@ class WofResolver implements Resolver {
 			lat: loc.lat,
 			lon: loc.lon,
 			confidence: 0,
-			metadata: { relationship_type: loc.relationshipType, resolver_completed: true },
+			metadata: { relationship_type: loc.relationshipType, resolver_completed: true, resolver_name: loc.name },
 		}
 		regionNode.interpretations = [...(regionNode.interpretations ?? []), interpretation]
 	}

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -12,7 +12,7 @@
  *   not the MA one.
  */
 
-import type { AddressNode, AddressTree, ComponentTag } from "../decoder/types.js"
+import type { AddressNode, AddressTree, ComponentTag, Interpretation } from "../decoder/types.js"
 import {
 	type CoincidentLocality,
 	DEFAULT_PLACETYPE_MAP,
@@ -57,13 +57,13 @@ interface ResolutionState {
 	 * completion only fires when the parser emitted no locality at all, never to override one.
 	 */
 	localityNodePresent: boolean
-	/** The first region that resolved, captured for the post-walk city-state recovery. */
+	/** The first region that resolved (its place — for the coincident-roles lookup). */
 	resolvedRegion: ResolvedPlace | null
 	/**
-	 * The span of the region node that produced {@link resolvedRegion}, reused for the synthesized
-	 * locality (which has no span of its own in the raw input).
+	 * The decorated region NODE that produced {@link resolvedRegion} — completion pushes the locality
+	 * interpretation onto it in place (no synthesized sibling).
 	 */
-	resolvedRegionSpan: { start: number; end: number } | null
+	resolvedRegionNode: AddressNode | null
 }
 
 /**
@@ -124,7 +124,7 @@ class WofResolver implements Resolver {
 			includeAncestors: opts.includeAncestors ?? false,
 			localityNodePresent: false,
 			resolvedRegion: null,
-			resolvedRegionSpan: null,
+			resolvedRegionNode: null,
 		}
 
 		const newRoots: AddressNode[] = []
@@ -132,45 +132,39 @@ class WofResolver implements Resolver {
 			newRoots.push(await this.#walk(root, /* parentResolved */ null, state))
 		}
 
-		// Dual-role hierarchy completion (#405). Only when enabled, a region resolved, and the parser
-		// emitted NO locality — synthesize the locality from the backend's precomputed coincident-roles
-		// relation (#403). See ResolveOpts.hierarchyCompletion for the rationale + disambiguation rule.
-		if (state.hierarchyCompletion && state.resolvedRegion && !state.localityNodePresent) {
-			const synthesized = this.#completeFromRelation(state)
-			if (synthesized) newRoots.push(synthesized)
+		// Dual-role hierarchy completion (#405/#415). Only when enabled, a region resolved, and the parser
+		// emitted NO locality — record the dropped locality as a SECONDARY ROLE (an interpretation) on the
+		// resolved region node, from the backend's precomputed coincident-roles relation (#403). One node,
+		// one span, two roles — no synthesized sibling. See ResolveOpts.hierarchyCompletion.
+		if (state.hierarchyCompletion && state.resolvedRegion && state.resolvedRegionNode && !state.localityNodePresent) {
+			this.#completeRegionRole(state.resolvedRegion, state.resolvedRegionNode)
 		}
 		return { raw: tree.raw, roots: newRoots }
 	}
 
 	/**
-	 * Complete a dropped dual-role locality from the backend's coincident-roles relation (#403/#405).
-	 * Consults `coincidentLocalitiesFor(regionId)` (O(1) map lookup — no distance math, no backend
-	 * query), picks the principal city ({@link pickCompletion}: population-primary, distance tiebreak,
-	 * abstain on a genuine tie), and builds a synthesized locality node borrowing the region's span.
-	 * Returns null when the backend has no relation, the region isn't a dual-role place, or it
-	 * abstains. Marked `metadata.resolver_synthesized` + `metadata.relationship_type`.
+	 * Record a dropped dual-role locality as a `locality` INTERPRETATION on the resolved region node
+	 * (#415, generalizes #405's synthesized node). Consults `coincidentLocalitiesFor(regionId)` (O(1)
+	 * map lookup — no distance math, no backend query), picks the principal city
+	 * ({@link pickCompletion}: population-primary, distance tiebreak, abstain on a genuine tie), and
+	 * appends an interpretation to `regionNode.interpretations`. No-op when the backend has no
+	 * relation, the region isn't a dual-role place, or it abstains. The region node's primary role
+	 * stays `region`; the locality rides alongside.
 	 */
-	#completeFromRelation(state: ResolutionState): AddressNode | null {
-		const region = state.resolvedRegion!
-		if (typeof region.id !== "number" || !this.#backend.coincidentLocalitiesFor) return null
+	#completeRegionRole(region: ResolvedPlace, regionNode: AddressNode): void {
+		if (typeof region.id !== "number" || !this.#backend.coincidentLocalitiesFor) return
 		const loc = pickCompletion(this.#backend.coincidentLocalitiesFor(region.id))
-		if (!loc) return null
-		const span = state.resolvedRegionSpan ?? { start: 0, end: 0 }
-		const synthesized: AddressNode = {
+		if (!loc) return
+		const interpretation: Interpretation = {
 			tag: "locality",
-			value: loc.name,
-			start: span.start,
-			end: span.end,
+			placeId: `wof:${loc.id}`,
+			sourceId: `${loc.placetype}:${loc.id}`,
+			lat: loc.lat,
+			lon: loc.lon,
 			confidence: 0,
-			children: [],
+			metadata: { relationship_type: loc.relationshipType, resolver_completed: true },
 		}
-		decorateNode(synthesized, loc, [])
-		synthesized.metadata = {
-			...(synthesized.metadata ?? {}),
-			resolver_synthesized: true,
-			relationship_type: loc.relationshipType,
-		}
-		return synthesized
+		regionNode.interpretations = [...(regionNode.interpretations ?? []), interpretation]
 	}
 
 	async #walk(node: AddressNode, parentResolved: ResolvedPlace | null, state: ResolutionState): Promise<AddressNode> {
@@ -193,11 +187,11 @@ class WofResolver implements Resolver {
 				if (state.includeAncestors && this.#backend.ancestors) {
 					decorated.metadata = { ...(decorated.metadata ?? {}), ancestors: this.#backend.ancestors(picked.top.id) }
 				}
-				// Capture the first resolved region for the city-state recovery, along with its span so
-				// the synthesized locality can borrow it (it has no span of its own).
+				// Capture the first resolved region (place + node) for hierarchy completion — the locality
+				// interpretation is pushed onto this node in the post-walk pass.
 				if (placetype === "region" && state.resolvedRegion === null) {
 					state.resolvedRegion = picked.top
-					state.resolvedRegionSpan = { start: node.start, end: node.end }
+					state.resolvedRegionNode = decorated
 				}
 			}
 		}


### PR DESCRIPTION
Second child of epic **#413**. Retires the synthesized-node hack from #405/#387.

## What
`#completeRegionRole` (was `#completeFromRelation`) now **pushes a `locality` Interpretation onto the resolved region node** instead of inventing a locality node that borrows the region's span. One node, one span, two roles. The region's primary role stays `region`; the locality rides in `node.interpretations` with its own placeId/lat/lon + `metadata.relationship_type`. **No overlapping spans, no invented node, no `resolver_synthesized` marker.**

The `coincident_roles` relation + `coincidentLocalitiesFor` are unchanged (still the data source for *which* locality); only the output shape changed. Disambiguation (population-primary, abstain-on-tie) unchanged.

## End-to-end (real DB, default-on)
```
region.interpretations = [{ tag:locality, placeId:wof:101909779, lat,lon, relationship_type:city-state, resolver_completed:true }]
decodeAsJson           = { region:'Berlin', locality:'Berlin', postcode:'10115' }   ← locality still surfaces
locality NODE present  = false                                                       ← no synthesized sibling
```

## Tests
32 resolver tests, rewritten to assert the interpretation on the region node (records-the-role, alias, default-on, opt-out, no-relation-no-op, absent-from-relation, abstain-on-tie, most-populous-wins, never-when-parser-emitted-a-locality). **Full suites green (600 passed, 0 regressions).**

Next: #416 migrates the eval's `collectResolved` to read interpretations + re-runs the DE/IT/ES regression to confirm Berlin PIP stays ~80.9%.