### PR TITLE
feat(eval): collectResolved reads interpretations (#416)

### DIFF
--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -98,6 +98,24 @@ function collectResolved(tree: AddressTree): Resolved[] {
 			const name = String(meta?.["resolver_name"] ?? n.value ?? "")
 			out.push({ id: Number(n.placeId.slice(4)), name, placetype, lat: n.lat, lon: n.lon })
 		}
+		// Multi-role completion (#415/#416): a dual-role region carries extra roles (e.g. `locality`) as
+		// INTERPRETATIONS on the same node, not separate children. Surface each resolved interpretation as
+		// its own Resolved so the eval finds the completed locality (placetype/coord/name come from the
+		// interpretation).
+		for (const interp of (n.interpretations ?? []) as ReadonlyArray<{
+			tag: string
+			placeId?: string
+			sourceId?: string
+			lat?: number
+			lon?: number
+			metadata?: Record<string, unknown>
+		}>) {
+			if (interp.placeId?.startsWith("wof:") && interp.lat !== undefined && interp.lon !== undefined) {
+				const placetype = String(interp.sourceId ?? interp.tag).split(":")[0] ?? ""
+				const name = String(interp.metadata?.["resolver_name"] ?? n.value ?? "")
+				out.push({ id: Number(interp.placeId.slice(4)), name, placetype, lat: interp.lat, lon: interp.lon })
+			}
+		}
 		for (const c of n.children) visit(c)
 	}
 	for (const r of tree.roots) visit(r)


### PR DESCRIPTION
Final child of epic **#413**. Migrates the eval to the multi-role representation.

## What
A dual-role region now carries its completed locality as an **interpretation on the same node** (not a child). `collectResolved` surfaces each resolved interpretation as its own `Resolved` — placetype from `interp.sourceId`, name from `interp.metadata.resolver_name`, coord from the interpretation — so the eval finds the completed locality exactly as it did the synthesized node.

## Metric-neutral (real v0.9.4 model)
- **DE Berlin PIP 80.9%** (name 80.9%, overall 78.4%) — **identical** to the synthesized-node baseline.
- **IT resolved 99.5% / name 90.7%** — **identical** (completion inert on native order).

The whole multi-role refactor (#414 schema + #415 completion + #416 eval) **preserves the measured result** while retiring the synthesized-node + overlapping-span hack. Closes epic #413.