### PR TITLE
feat(resolver): ship coincident_roles to the slim/demo DB + WASM completion (#402)

### DIFF
--- a/resolver-wof-sqlite/build-slim.test.ts
+++ b/resolver-wof-sqlite/build-slim.test.ts
@@ -177,4 +177,30 @@ describe("buildSlimWofDatabase", () => {
 		// Same 5 rows (1 country + 1 region + 1 locality + 2 postcodes) — no duplication across shards.
 		expect(result.rowCounts.spr).toBe(5)
 	})
+
+	test("carries the coincident_roles relation, filtered to surviving spr ids (#402)", async () => {
+		const source = join(scratch, "src.db")
+		const output = join(scratch, "slim.db")
+		buildFixtureWof(source)
+		// A dual-role relation: Illinois(101) ⊃ Springfield(201) [survives top-2] and ⊃ Mascoutah(202) [trimmed].
+		const s = new DatabaseSync(source)
+		s.exec(`CREATE TABLE coincident_roles (
+			admin_id INTEGER NOT NULL, locality_id INTEGER NOT NULL, relationship_type TEXT NOT NULL,
+			admin_placetype TEXT NOT NULL, distance_km REAL NOT NULL, locality_population INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (admin_id, locality_id))`)
+		s.exec(`INSERT INTO coincident_roles VALUES (101, 201, 'capital-seat', 'region', 5.0, 114000)`)
+		s.exec(`INSERT INTO coincident_roles VALUES (101, 202, 'capital-seat', 'region', 6.0, 8000)`)
+		s.close()
+
+		await buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 2 }) // keeps Springfield, drops Mascoutah
+
+		const slim = new DatabaseSync(output, { readOnly: true })
+		try {
+			const rows = slim.prepare(`SELECT admin_id, locality_id FROM coincident_roles ORDER BY locality_id`).all()
+			// Only the surviving pair — Mascoutah's row is dropped because 202 was trimmed from spr.
+			expect(rows).toEqual([{ admin_id: 101, locality_id: 201 }])
+		} finally {
+			slim.close()
+		}
+	})
 })

--- a/resolver-wof-sqlite/build-slim.ts
+++ b/resolver-wof-sqlite/build-slim.ts
@@ -60,6 +60,7 @@ export type SlimBuildPhase =
 	| "postcode"
 	| "names"
 	| "geojson"
+	| "coincident_roles"
 	| "fts"
 	| "vacuum"
 	| "done"
@@ -285,6 +286,24 @@ async function copyFromSource(
 				)
 				.onConflict((oc) => oc.doNothing())
 				.execute()
+
+			// Carry the coincident_roles relation (#402) when this source has it (the admin DB), so the
+			// slim/demo DB supports dual-role hierarchy completion (on by default). Filtered to surviving
+			// spr ids → no orphans. Tiny (~hundreds of rows). `ancestors` is intentionally NOT copied (huge
+			// + build-only), so we copy the derived table rather than rebuild it. Raw SQL — conditional +
+			// not in the Kysely build schema.
+			const relationSchema = out
+				.prepare(`SELECT sql FROM src.sqlite_master WHERE type = 'table' AND name = 'coincident_roles'`)
+				.get() as { sql?: string } | undefined
+			if (relationSchema?.sql) {
+				progress("coincident_roles", `${inputPath}: copying dual-role relation`)
+				out.exec(relationSchema.sql.replace(/CREATE TABLE/i, "CREATE TABLE IF NOT EXISTS"))
+				out.exec(
+					`INSERT OR IGNORE INTO coincident_roles SELECT * FROM src.coincident_roles
+						WHERE admin_id IN (SELECT id FROM spr) AND locality_id IN (SELECT id FROM spr)`
+				)
+				out.exec(`CREATE INDEX IF NOT EXISTS coincident_roles_by_admin ON coincident_roles (admin_id)`)
+			}
 		} finally {
 			out.exec(`DETACH DATABASE src;`)
 		}

--- a/resolver-wof-wasm/lookup.test.ts
+++ b/resolver-wof-wasm/lookup.test.ts
@@ -69,6 +69,13 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO geojson VALUES (211, '{"properties":{"wof:population":580000}}');
 		INSERT INTO geojson VALUES (220, '{"properties":{"wof:population":1700}}');
 		INSERT INTO geojson VALUES (221, '{"properties":{"wof:population":8400000}}');
+
+		-- Dual-role relation (#402): Illinois(101) ⊃ Springfield(201). build-slim carries it to the slim DB.
+		CREATE TABLE coincident_roles (
+			admin_id INTEGER NOT NULL, locality_id INTEGER NOT NULL, relationship_type TEXT NOT NULL,
+			admin_placetype TEXT NOT NULL, distance_km REAL NOT NULL, locality_population INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (admin_id, locality_id));
+		INSERT INTO coincident_roles VALUES (101, 201, 'capital-seat', 'region', 5.0, 114000);
 	`)
 	db.close()
 }
@@ -87,6 +94,25 @@ afterAll(async () => {
 })
 
 describe("WofWasmPlaceLookup", () => {
+	test("coincidentLocalitiesFor reads the relation carried into the slim DB (#402)", async () => {
+		// End-to-end: the fixture source had coincident_roles → build-slim carried it → the WASM lookup reads it.
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			const roles = lookup.coincidentLocalitiesFor(101) // Illinois
+			expect(roles).toHaveLength(1)
+			expect(roles[0]).toMatchObject({
+				id: 201,
+				name: "Springfield",
+				placetype: "locality",
+				relationshipType: "capital-seat",
+			})
+			expect(lookup.coincidentLocalitiesFor(99999)).toHaveLength(0)
+		} finally {
+			lookup.close()
+		}
+	})
+
 	test("opens a slim DB and resolves a locality", async () => {
 		const { db } = await loadSlimWofDatabase({ source: slimBytes })
 		const lookup = new WofWasmPlaceLookup({ db })

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -20,6 +20,7 @@
 
 import type { Database } from "@sqlite.org/sqlite-wasm"
 
+import type { CoincidentLocality } from "@mailwoman/core/resolver"
 import type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WofPlacetype } from "@mailwoman/resolver-wof-sqlite"
 
 export interface WofWasmPlaceLookupOpts {
@@ -29,8 +30,8 @@ export interface WofWasmPlaceLookupOpts {
 
 /**
  * Population-boost tunables, mirroring `resolver-wof-sqlite/lookup.ts` defaults. The boost is
- * `POPULATION_BOOST * min(1, log10(1 + pop) / POPULATION_SCALE_LOG10)`, subtracted from bm25 (lower =
- * better, matching SQLite's convention). A 1M-population city earns the full boost — enough to
+ * `POPULATION_BOOST * min(1, log10(1 + pop) / POPULATION_SCALE_LOG10)`, subtracted from bm25 (lower
+ * = better, matching SQLite's convention). A 1M-population city earns the full boost — enough to
  * surface the famous same-name place ("New York" over "West New York") without steamrolling a
  * clearly-better text match, because exact-name tiering is consulted FIRST.
  */
@@ -45,6 +46,9 @@ function normalizeName(s: string): string {
 export class WofWasmPlaceLookup implements PlaceLookup {
 	readonly #db: Database
 	#hasPopulationCache?: boolean
+	/** Lazily-built `admin_id → coincident localities` map from the #403 relation (the slim DB carries
+it). */
+	#coincidentRolesCache?: Map<number, CoincidentLocality[]>
 
 	constructor(opts: WofWasmPlaceLookupOpts) {
 		this.#db = opts.db
@@ -150,10 +154,7 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 				lon: row.longitude,
 				parent_id: row.parent_id ?? undefined,
 				bbox:
-					row.min_latitude != null &&
-					row.max_latitude != null &&
-					row.min_longitude != null &&
-					row.max_longitude != null
+					row.min_latitude != null && row.max_latitude != null && row.min_longitude != null && row.max_longitude != null
 						? {
 								minLat: row.min_latitude,
 								maxLat: row.max_latitude,
@@ -165,6 +166,61 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 				// score is what we sorted by, so callers see the same ordering they're shown.
 				score: -adjScore,
 			}))
+	}
+
+	/**
+	 * Dual-role localities coincident with an admin id, from the `coincident_roles` relation (#403)
+	 * carried into the slim DB by build-slim. Backs the resolver's hierarchy completion (on by
+	 * default) in the browser — mirrors `WofSqlitePlaceLookup.coincidentLocalitiesFor`. Returns `[]`
+	 * when the slim DB predates the relation. Loaded once + memoized (the relation is ~hundreds of
+	 * rows).
+	 */
+	coincidentLocalitiesFor(adminId: number | string): CoincidentLocality[] {
+		const id = typeof adminId === "number" ? adminId : Number(adminId)
+		if (!Number.isFinite(id)) return []
+		if (!this.#coincidentRolesCache) {
+			const map = new Map<number, CoincidentLocality[]>()
+			const exists = this.#db.selectObjects(
+				`SELECT 1 FROM sqlite_master WHERE type='table' AND name='coincident_roles' LIMIT 1`
+			)
+			if (exists.length > 0) {
+				const rows = this.#db.selectObjects(
+					`SELECT cr.admin_id AS adminId, s.id AS id, s.name AS name, s.country AS country,
+						s.latitude AS lat, s.longitude AS lon, cr.relationship_type AS relationshipType,
+						cr.locality_population AS population, cr.distance_km AS distanceKm
+					FROM coincident_roles cr JOIN spr s ON s.id = cr.locality_id`
+				) as Array<{
+					adminId: number
+					id: number
+					name: string
+					country: string
+					lat: number
+					lon: number
+					relationshipType: string
+					population: number
+					distanceKm: number
+				}>
+				for (const r of rows) {
+					const candidate: CoincidentLocality = {
+						id: r.id,
+						name: r.name,
+						placetype: "locality",
+						country: r.country,
+						lat: r.lat,
+						lon: r.lon,
+						score: 0,
+						relationshipType: r.relationshipType,
+						population: r.population,
+						distanceKm: r.distanceKm,
+					}
+					const list = map.get(r.adminId)
+					if (list) list.push(candidate)
+					else map.set(r.adminId, [candidate])
+				}
+			}
+			this.#coincidentRolesCache = map
+		}
+		return this.#coincidentRolesCache.get(id) ?? []
 	}
 
 	close(): void {


### PR DESCRIPTION
Makes dual-role hierarchy completion (on by default) work in the **browser demo**, not just node — the two code changes behind the demo deployment.

## What
- **`build-slim.ts`** carries the `coincident_roles` relation into the shipped/R2 slim DB, filtered to surviving `spr` ids (no orphans). The table is tiny; `ancestors` stays dropped (huge + build-only), so we copy the derived relation rather than rebuild it.
- **`WofWasmPlaceLookup.coincidentLocalitiesFor`** (resolver-wof-wasm, sql.js) — mirrors the node `WofSqlitePlaceLookup` so the browser resolver can complete; gracefully returns `[]` when a slim DB predates the relation.

## End-to-end test
The WASM fixture's source has `coincident_roles` → build-slim carries it → the WASM lookup reads it back (Illinois → Springfield). **13 tests pass** (build-slim 5 + wasm 8).

## To actually go live (your pipeline)
Rebuild the slim DB from the relation-bearing full DB + R2 resync + docs-build demo redeploy. The full DB **already** has `coincident_roles` (#403 + the build-unified-wof wiring merged in #412), so this is a **build-slim re-run + R2 upload**, not a full WOF rebuild. After it, the live demo renders a Berlin/Milano address with the multi-typed node (#413).

Completes the demo-deploy code for #402.