### PR TITLE
Route A Phase I: A/B harness + decision report — verdict STAY (#421)

### DIFF
--- a/docs/articles/evals/2026-06-07-route-a-phase-i-baseline.md
+++ b/docs/articles/evals/2026-06-07-route-a-phase-i-baseline.md
@@ -1,0 +1,45 @@
+# Route A Phase I — joint-decode vs argmax baseline (2026-06-07)
+
+The decision document for [epic #421](https://github.com/sister-software/mailwoman/issues/421). Before committing to making the joint-decode / concordance stage the default, we measured the *existing* opt-in path (`forceJointReconcile`) head-to-head against the argmax default. The result is decisive, and it points the opposite way from what you'd hope.
+
+## Verdict: **STAY** — do not flip the default. Phase II (phrase grouper) is a hard gate, not an option.
+
+Joint-decode wins enormously on the case it was built for and **catastrophically regresses everything else**, for one diagnosable reason. The "just flip the default" option is dead; the full programme is the only viable path, and it's blocked on a prerequisite.
+
+## What we measured
+
+`scripts/eval/joint-vs-argmax.ts` runs the same runtime pipeline twice per address — default vs `forceJointReconcile` — over the OpenAddresses samples (v0.9.4 model). Latency is warmed and the run-order is alternated per row so neither path eats the ONNX cold-start.
+
+| locale | argmax loc | joint loc | Δ loc | regressed | improved | latency p99 × |
+|---|--:|--:|--:|--:|--:|--:|
+| **DE international** (city-state collision — the target) | 72.2% | **97.2%** | **+25.0pp** | 2.4% | 26.8% | 1.45 |
+| US (native) | 98.8% | 97.4% | −1.4pp | 2.2% | 0.8% | 1.75 |
+| FR (native) | 97.5% | 97.8% | +0.3pp | 2.0% | 2.3% | 2.07 |
+| NL (native) | 99.5% | **84.0%** | **−15.5pp** | **16.0%** | 0.3% | 1.63 |
+| IT (native) | 84.8% | **68.5%** | **−16.3pp** | **26.0%** | 9.8% | 1.73 |
+| ES (native) | 83.8% | **58.5%** | **−25.3pp** | **34.0%** | 8.8% | 1.62 |
+
+The gate (from #421) wants a regression rate **≤ 0.5%** to even consider flipping the default. The multi-word locales come in at **16–34%** — fifty to seventy times the bar.
+
+## Why — the phrase grouper, exactly as predicted
+
+The win and the loss have the same root. The reconciler decodes over the spans the phrase grouper proposes; when those proposals don't cover a multi-word component, it falls back to single-token spans. That's a *feature* for the city-state collision (`…, Berlin, Berlin 10115` — the second `Berlin` is a single token the reconciler can re-tag as a locality, which argmax drops — hence +25pp). It's a *disaster* for native-order locales whose place names are multi-word:
+
+```
+"Reggio nell'Emilia"          argmax → "Reggio nell'Emilia" ✓     joint → "Reggio"        (fragmented)
+"Las Palmas de Gran Canaria"  argmax → "de Gran Canaria"          joint → "CALLE MAYOR"   (grabbed the street)
+```
+
+Italian, Spanish, and Dutch are dense with multi-word localities, so they take the full brunt; US and French, mostly single-word, barely move. The improvement column confirms the upside is real (DE 26.8%, IT 9.8%, ES 8.8% of rows get *better*) — joint decoding genuinely recovers cases argmax can't — but it's swamped by the fragmentation it introduces.
+
+Latency is a non-issue: p50 is unchanged across the board and p99 sits at 1.5–2.1×, comfortably under the 3.0× ceiling. The blocker is purely quality.
+
+## What this means for the plan
+
+- **JUST-FLIP is dead.** Flipping `forceJointReconcile` to default today would tank locality accuracy on three of six locales by 15–25 points. No telemetry gate survives that.
+- **The dual-role / multi-role work was the right call.** The city-state recovery it ships (Berlin → 80.9% PIP) is exactly the +25pp that joint-decode also delivers — but the Resolve-stage relation completion delivers it *without* the multi-word collateral. That mechanism stays.
+- **FULL Route A hinges entirely on Phase II ([#425](https://github.com/sister-software/mailwoman/issues/425)) — maturing the phrase grouper to propose multi-word spans reliably.** Until the phrase grouper covers `Reggio nell'Emilia` as one span, joint decoding cannot be the default. This A/B is the re-gate: after #425, re-run it; flip only if the native-order regression drops under the bar.
+
+So Phase I did its job — it cost a day and a benchmark, and it turned "should we spend weeks making concordance the default?" into "not until the phrase grouper can cover multi-word spans, and here's the test that proves when it can." Phases III–IV (concordance dual-role signal, flip) stay closed behind that.
+
+_Harness: `scripts/eval/joint-vs-argmax.ts`. Numbers generated; per-locale JSON under the run's `--out-json`._

--- a/scripts/eval/joint-vs-argmax.ts
+++ b/scripts/eval/joint-vs-argmax.ts
@@ -1,0 +1,214 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Route A Phase I (#423) — joint-decode vs argmax A/B harness.
+ *
+ *   The joint-decode path (Stage-5 reconcile/concordance beam) is already BUILT but opt-in
+ *   (`forceJointReconcile`). This runs the SAME runtime pipeline twice per address — default
+ *   (argmax sort) vs `forceJointReconcile: true` — and records, per case: locality/region match vs
+ *   gold, wall-clock latency, and whether the joint path regressed or improved the structured
+ *   output. The aggregate (regression rate, accuracy delta, latency p99 multiplier) feeds the #424
+ *   decision gate.
+ *
+ *   Run (compile core first — the pipeline loads compiled out/): node --experimental-strip-types
+ *   scripts/eval/joint-vs-argmax.ts\
+ *   --eval data/eval/external/openaddresses-de-sample.jsonl --limit 500\
+ *   --model /tmp/v094-eval/model.onnx --model-card neural-weights-en-us/model-card.json\
+ *   --tokenizer /mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model\
+ *   --default-country DE --out-json /tmp/joint-de.json
+ */
+import { decodeAsJson } from "@mailwoman/core/decoder"
+import { createWofResolver } from "@mailwoman/core/resolver"
+import { NeuralAddressClassifier, parseAnchorLookup } from "@mailwoman/neural"
+import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
+import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+import { createRuntimePipeline } from "mailwoman"
+import { readFileSync, writeFileSync } from "node:fs"
+
+function arg(name: string, fallback = ""): string {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+}
+
+interface GoldRow {
+	input: string
+	expected: { locality?: string | null; region?: string | null; postcode?: string | null }
+	state?: string
+}
+
+const norm = (s: string | undefined | null): string =>
+	(s ?? "")
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+
+/** Did the projected output match gold on a field (subset-tolerant: gold token-subset of resolved or
+vice-versa)? */
+function fieldMatch(resolved: string | undefined, gold: string | undefined | null): boolean {
+	const r = norm(resolved)
+	const g = norm(gold)
+	if (!g) return true // nothing to match → not a miss
+	if (!r) return false
+	if (r === g) return true
+	const rt = new Set(r.split(" "))
+	const gt = g.split(" ")
+	return gt.every((t) => rt.has(t)) || r.split(" ").every((t) => new Set(gt).has(t))
+}
+
+function pct(n: number, d: number): string {
+	return d === 0 ? "—" : `${((100 * n) / d).toFixed(1)}%`
+}
+
+function percentile(xs: number[], p: number): number {
+	if (xs.length === 0) return 0
+	const sorted = [...xs].sort((a, b) => a - b)
+	return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))]!
+}
+
+async function main(): Promise<void> {
+	const evalPath = arg("eval")
+	const limit = Number(arg("limit", "0")) || Infinity
+	const dc = arg("default-country", "")
+	const modelPath = arg("model")
+	const cardPath = arg("model-card")
+	const tokPath = arg("tokenizer", "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model")
+	const anchorPath = arg("model-anchor-lookup")
+	const wof = arg(
+		"wof",
+		"/mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postcode-locality-intl.db"
+	)
+	if (!evalPath || !modelPath || !cardPath) throw new Error("need --eval, --model, --model-card")
+
+	const card = JSON.parse(readFileSync(cardPath, "utf8"))
+	const [tokenizer, runner] = await Promise.all([
+		MailwomanTokenizer.loadFromFile(tokPath),
+		OnnxRunner.create(modelPath),
+	])
+	const postcodeAnchorLookup = anchorPath ? parseAnchorLookup(JSON.parse(readFileSync(anchorPath, "utf8"))) : undefined
+	const classifier = new NeuralAddressClassifier({ tokenizer, runner, labels: card.labels, postcodeAnchorLookup })
+
+	const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
+	const wofPaths = wof.split(",").map((s) => s.trim())
+	const backend = new WofSqlitePlaceLookup({ databasePath: wofPaths.length === 1 ? wofPaths[0]! : wofPaths })
+	const resolver = createWofResolver(backend as never)
+
+	const pipeline = createRuntimePipeline({ classifier, resolver })
+	const resolveOpts = dc && dc.toLowerCase() !== "none" ? { defaultCountry: dc } : {}
+
+	const rows = readFileSync(evalPath, "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.slice(0, limit === Infinity ? undefined : limit)
+		.map((l) => JSON.parse(l) as GoldRow)
+
+	// Warm the model + JIT before timing so the first rows don't eat ONNX cold-start (which would
+	// unfairly penalize whichever path runs first). Alternate first-path per row too (below).
+	for (let w = 0; w < 3 && rows[w]; w++) {
+		await pipeline(rows[w]!.input, { forceJointReconcile: false, resolveOpts })
+		await pipeline(rows[w]!.input, { forceJointReconcile: true, resolveOpts })
+	}
+
+	let argmaxLocOk = 0
+	let jointLocOk = 0
+	let argmaxRegOk = 0
+	let jointRegOk = 0
+	let regressed = 0
+	let improved = 0
+	let changed = 0
+	const argmaxLat: number[] = []
+	const jointLat: number[] = []
+
+	for (const row of rows) {
+		const score = async (forceJointReconcile: boolean): Promise<{ loc: boolean; reg: boolean; ms: number }> => {
+			const t0 = performance.now()
+			let json: Partial<Record<string, string>> = {}
+			try {
+				const result = await pipeline(row.input, { forceJointReconcile, resolveOpts })
+				json = decodeAsJson(result.tree)
+			} catch {
+				/* leave json empty → miss */
+			}
+			const ms = performance.now() - t0
+			return {
+				loc: fieldMatch(json.locality, row.expected.locality),
+				reg: fieldMatch(json.region, row.expected.region),
+				ms,
+			}
+		}
+		// Alternate which path runs first so any per-input cache warmth doesn't favor one path.
+		const argmaxFirst = argmaxLat.length % 2 === 0
+		let a: { loc: boolean; reg: boolean; ms: number }
+		let j: { loc: boolean; reg: boolean; ms: number }
+		if (argmaxFirst) {
+			a = await score(false)
+			j = await score(true)
+		} else {
+			j = await score(true)
+			a = await score(false)
+		}
+		argmaxLat.push(a.ms)
+		jointLat.push(j.ms)
+		if (a.loc) argmaxLocOk++
+		if (j.loc) jointLocOk++
+		if (a.reg) argmaxRegOk++
+		if (j.reg) jointRegOk++
+		// Per-FIELD regression/improvement: did joint make a field WORSE (or better) than argmax had it?
+		// Per-field (not combined loc&&reg) so a low overall region-match doesn't mask a locality change.
+		const locRegressed = a.loc && !j.loc
+		const regRegressed = a.reg && !j.reg
+		const locImproved = !a.loc && j.loc
+		const regImproved = !a.reg && j.reg
+		if (locRegressed || regRegressed || locImproved || regImproved) changed++
+		if (locRegressed || regRegressed) regressed++
+		if (locImproved || regImproved) improved++
+	}
+
+	const n = rows.length
+	const report = {
+		eval: evalPath,
+		n,
+		argmax: {
+			localityMatch: argmaxLocOk / n,
+			regionMatch: argmaxRegOk / n,
+			latP50: percentile(argmaxLat, 50),
+			latP99: percentile(argmaxLat, 99),
+		},
+		joint: {
+			localityMatch: jointLocOk / n,
+			regionMatch: jointRegOk / n,
+			latP50: percentile(jointLat, 50),
+			latP99: percentile(jointLat, 99),
+		},
+		regressionRate: regressed / n,
+		improvementRate: improved / n,
+		accuracyDeltaPp: (100 * (jointLocOk + jointRegOk - argmaxLocOk - argmaxRegOk)) / (2 * n),
+		latencyP99Multiplier: percentile(argmaxLat, 99) > 0 ? percentile(jointLat, 99) / percentile(argmaxLat, 99) : 0,
+	}
+
+	console.log(`\n=== joint-decode vs argmax — ${evalPath} (n=${n}) ===`)
+	console.log(
+		`  argmax: loc ${pct(argmaxLocOk, n)}  reg ${pct(argmaxRegOk, n)}  p50 ${report.argmax.latP50.toFixed(1)}ms  p99 ${report.argmax.latP99.toFixed(1)}ms`
+	)
+	console.log(
+		`  joint : loc ${pct(jointLocOk, n)}  reg ${pct(jointRegOk, n)}  p50 ${report.joint.latP50.toFixed(1)}ms  p99 ${report.joint.latP99.toFixed(1)}ms`
+	)
+	console.log(
+		`  changed=${changed}  regressed=${regressed} (${pct(regressed, n)})  improved=${improved} (${pct(improved, n)})`
+	)
+	console.log(
+		`  accuracy delta = ${report.accuracyDeltaPp >= 0 ? "+" : ""}${report.accuracyDeltaPp.toFixed(2)}pp  ·  latency p99 ×${report.latencyP99Multiplier.toFixed(2)}`
+	)
+
+	const outJson = arg("out-json")
+	if (outJson) {
+		writeFileSync(outJson, JSON.stringify(report, null, 2))
+		console.error(`wrote ${outJson}`)
+	}
+	;(backend as { close?: () => void }).close?.()
+}
+
+main()


### PR DESCRIPTION
Phase I of epic #421 — the cheap, decisive measurement before committing to making concordance the default. Closes #423 (harness) + #424 (decision report); informs #422.

## Verdict: **STAY** — don't flip the default; Phase II (phrase grouper) is a hard gate

A/B of the **existing opt-in** joint-decode (`forceJointReconcile`) vs argmax, 6 locales, v0.9.4 model:

| locale | argmax loc | joint loc | regressed | latency p99 × |
|---|--:|--:|--:|--:|
| **DE intl** (collision — target) | 72% | **97%** (+25pp) | 2.4% | 1.45 |
| US | 99% | 97% | 2.2% | 1.75 |
| FR | 98% | 98% | 2.0% | 2.07 |
| **NL** | 99% | **84%** (−15pp) | **16%** | 1.63 |
| **IT** | 85% | **69%** (−16pp) | **26%** | 1.73 |
| **ES** | 84% | **59%** (−25pp) | **34%** | 1.62 |

Joint-decode wins enormously on the city-state collision (+25pp) but **catastrophically fragments native-order multi-word localities** — `Reggio nell'Emilia`→`Reggio`, `Las Palmas de Gran Canaria`→`CALLE MAYOR` — at 16–34% regression, 50–70× the 0.5% bar. The cause is exactly DeepSeek's predicted phrase-grouper gap: the reconciler falls back to single-token spans when proposals don't cover the multi-word component. Latency is fine (p50 flat, p99 1.5–2.1×).

## So
- **JUST-FLIP is dead** — would tank 3/6 locales by 15–25pp.
- **The dual-role / multi-role work was the right call** — its Resolve-stage completion delivers the same +25pp city-state win *without* the multi-word collateral.
- **FULL Route A hinges on Phase II (#425)** — mature the phrase grouper to cover multi-word spans, then re-run this A/B as the re-gate. Phases III–IV stay closed behind it.

Harness: `scripts/eval/joint-vs-argmax.ts`. Report: `docs/articles/evals/2026-06-07-route-a-phase-i-baseline.md`.