### PR TITLE
Route A Phase II: phrase-grouper multi-word recall + audit classifier-deferral (#425)

### DIFF
--- a/core/pipeline/grouper-audit.test.ts
+++ b/core/pipeline/grouper-audit.test.ts
@@ -6,7 +6,9 @@
 
 import { Span } from "@mailwoman/core/tokenization"
 import { describe, expect, it } from "vitest"
-import { runPipeline } from "./runtime-pipeline.js"
+import type { AddressTree } from "../decoder/types.js"
+import type { ClassifierCandidate } from "./reconcile.js"
+import { grouperAudit, runPipeline } from "./runtime-pipeline.js"
 import type { PhraseProposal, RuntimePipelineStages } from "./types.js"
 
 function makeStages(overrides: Partial<RuntimePipelineStages> = {}): RuntimePipelineStages {
@@ -152,6 +154,41 @@ describe("grouper-audit pass", () => {
 		expect(auditNodes.length).toBe(0)
 		expect(result.tree.roots.length).toBe(1)
 		expect(result.tree.roots[0]!.tag).toBe("region")
+	})
+
+	// #425 — when the joint-reconcile path leaves a span orphaned but the classifier confidently typed
+	// it, the audit must defer to the classifier's verdict instead of the structural phrase kind.
+	describe("classifier-deferral on orphaned spans (joint path)", () => {
+		// "Via Trento 24, SORBOLO": reconcile keeps locality=SORBOLO and leaves "Via" orphaned. The
+		// LOCALITY_PHRASE proposal for "Via" would inject a spurious locality without the deferral.
+		const tree: AddressTree = {
+			raw: "Via Trento, SORBOLO",
+			roots: [{ tag: "locality", value: "SORBOLO", start: 12, end: 19, confidence: 0.9, children: [] }],
+		}
+		const proposals = [
+			{ span: Span.from("Via", { start: 0 }), kindHypothesis: "LOCALITY_PHRASE", confidence: 0.55 },
+		] as PhraseProposal[]
+
+		it("injects the classifier's tag (street) for an orphaned LOCALITY_PHRASE span", () => {
+			const classifierTopK: ClassifierCandidate[] = [{ span: { start: 0, end: 3 }, tag: "street", score: 0.73 }]
+			const out = grouperAudit(tree, proposals, tree.raw, classifierTopK)
+			const via = out.roots.find((n) => n.value === "Via")
+			expect(via).toBeDefined()
+			expect(via!.tag).toBe("street") // classifier verdict, NOT the LOCALITY_PHRASE structural kind
+			// The real city is preserved and is the only locality.
+			expect(out.roots.filter((n) => n.tag === "locality").map((n) => n.value)).toEqual(["SORBOLO"])
+		})
+
+		it("falls back to the phrase kind when the classifier verdict is weak (<0.4)", () => {
+			const classifierTopK: ClassifierCandidate[] = [{ span: { start: 0, end: 3 }, tag: "street", score: 0.2 }]
+			const out = grouperAudit(tree, proposals, tree.raw, classifierTopK)
+			expect(out.roots.find((n) => n.value === "Via")!.tag).toBe("locality")
+		})
+
+		it("falls back to the phrase kind when no classifierTopK is supplied (argmax path)", () => {
+			const out = grouperAudit(tree, proposals, tree.raw)
+			expect(out.roots.find((n) => n.value === "Via")!.tag).toBe("locality")
+		})
 	})
 
 	it("does not inject for unmapped phrase kinds", async () => {

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -14,6 +14,7 @@
 
 import type { AddressNode, AddressTree } from "../decoder/types.js"
 import type { ComponentTag } from "../types/component.js"
+import type { ClassifierCandidate } from "./reconcile.js"
 import { reconcileSpans } from "./reconcile.js"
 import { aggregateSpanLogits } from "./span-logit-aggregation.js"
 import type {
@@ -235,6 +236,9 @@ export async function runPipeline(
 	}
 
 	let tree: AddressTree = { raw: normalized.normalized, roots: [] }
+	// Captured from the joint-reconcile path so the grouper-audit can defer to the classifier's
+	// per-span verdict on orphaned spans (see the assignment + grouperAudit below).
+	let auditClassifierTopK: ClassifierCandidate[] | undefined
 
 	// Joint-reconcile path: opt-in until phrase-grouper proposal quality supports it as default.
 	// The reconciler produces single-token spans when phrase proposals don't cover multi-word
@@ -284,6 +288,12 @@ export async function runPipeline(
 				classifierTopK,
 			})
 			tree = result.tree
+			// The reconciler can leave a span uncovered (e.g. it picked the single-token street
+			// `Trento` over `Via Trento`, orphaning `Via`). The grouper-audit below would then promote
+			// that orphan's LOCALITY_PHRASE proposal to a `locality` node — even though the classifier
+			// confidently typed it `street`. Hand the audit the classifier's per-span verdict so it
+			// respects that opinion instead of trusting the structural phrase kind (#425 re-gate).
+			auditClassifierTopK = classifierTopK
 		} else {
 			tree = argmaxTree
 		}
@@ -297,7 +307,7 @@ export async function runPipeline(
 
 	if (phraseProposals.length > 0 && tree.roots.length >= 0) {
 		const tAudit = performance.now()
-		tree = grouperAudit(tree, phraseProposals, normalized.normalized)
+		tree = grouperAudit(tree, phraseProposals, normalized.normalized, auditClassifierTopK)
 		timing["grouper-audit"] = performance.now() - tAudit
 	}
 
@@ -382,8 +392,20 @@ const PHRASE_KIND_TO_TAG: ReadonlyMap<string, ComponentTag> = new Map([
  * Post-classification audit: for each phrase-grouper proposal whose span is entirely unlabeled
  * (all-O) in the classifier output, inject a provisional node using the grouper's structural
  * hypothesis. This rescues spans the neural model couldn't type — primarily venue text.
+ *
+ * When `classifierTopK` is supplied (the joint-reconcile path), the audit defers to the classifier's
+ * own verdict for the orphaned span: if the classifier confidently typed it as a DIFFERENT component
+ * than the phrase kind, we inject the classifier's tag rather than the structural guess. Without this,
+ * a reconciler that leaves a street-prefix word like `Via` orphaned (because it picked the single
+ * `Trento` street span) would see the audit promote `Via`'s LOCALITY_PHRASE to a spurious `locality`
+ * node — burying the real trailing city. The classifier said `street:0.73` for `Via`; trust it (#425).
  */
-function grouperAudit(tree: AddressTree, proposals: PhraseProposal[], text: string): AddressTree {
+export function grouperAudit(
+	tree: AddressTree,
+	proposals: PhraseProposal[],
+	text: string,
+	classifierTopK?: ClassifierCandidate[]
+): AddressTree {
 	if (proposals.length === 0) return tree
 
 	const roots = [...tree.roots]
@@ -397,15 +419,29 @@ function grouperAudit(tree: AddressTree, proposals: PhraseProposal[], text: stri
 	}
 	collectNodes(roots)
 
+	// Index the classifier's single best tag per exact span (start:end) so the audit can defer to it.
+	const CLASSIFIER_OVERRIDE_MIN = 0.4
+	const bestTagBySpan = new Map<string, { tag: ComponentTag; score: number }>()
+	for (const c of classifierTopK ?? []) {
+		const k = `${c.span.start}:${c.span.end}`
+		const cur = bestTagBySpan.get(k)
+		if (!cur || c.score > cur.score) bestTagBySpan.set(k, { tag: c.tag, score: c.score })
+	}
+
 	for (const proposal of proposals) {
-		const tag = PHRASE_KIND_TO_TAG.get(proposal.kindHypothesis)
-		if (!tag) continue
+		const phraseTag = PHRASE_KIND_TO_TAG.get(proposal.kindHypothesis)
+		if (!phraseTag) continue
 
 		const pStart = proposal.span.start
 		const pEnd = pStart + proposal.span.body.length
 
 		const covered = allNodes.some((node) => node.start < pEnd && pStart < node.end)
 		if (covered) continue
+
+		// Defer to the classifier when it confidently typed this exact span as something else.
+		const classifierVerdict = bestTagBySpan.get(`${proposal.span.start}:${proposal.span.end}`)
+		const tag =
+			classifierVerdict && classifierVerdict.score >= CLASSIFIER_OVERRIDE_MIN ? classifierVerdict.tag : phraseTag
 
 		const provisionalNode: AddressNode = {
 			tag,

--- a/docs/articles/evals/2026-06-07-route-a-phase-ii-regate.md
+++ b/docs/articles/evals/2026-06-07-route-a-phase-ii-regate.md
@@ -37,4 +37,4 @@ The through-line: the joint path was being asked to type spans the rule layer co
 
 So Phase II did its job and then some. The question Phase I left open — "can the phrase grouper ever cover multi-word spans well enough to flip?" — now has a measured yes, and the residual is a short, named list rather than a 34% cliff.
 
-_Harness: `scripts/eval/joint-vs-argmax.ts` (regression rows dumped via `MW_DUMP_REGRESSIONS=1`). Per-locale JSON under [`./data/`](./data/)._
+_Harness: `scripts/eval/joint-vs-argmax.ts` (regression rows dumped via `MW_DUMP_REGRESSIONS=1`). Per-locale JSON under `docs/articles/evals/data/`._

--- a/docs/articles/evals/2026-06-07-route-a-phase-ii-regate.md
+++ b/docs/articles/evals/2026-06-07-route-a-phase-ii-regate.md
@@ -1,0 +1,40 @@
+# Route A Phase II — the phrase-grouper re-gate overturns STAY (2026-06-07)
+
+The [Phase I baseline](./2026-06-07-route-a-phase-i-baseline.md) measured the opt-in joint-decode path against argmax and came back with a hard **STAY**: joint decoding won big on the German city-state collision but tanked native-order multi-word locales by 16–34%, so we shelved the default flip behind a phrase-grouper rebuild ([#425](https://github.com/sister-software/mailwoman/issues/425)). This is the re-gate after that rebuild. The verdict flips.
+
+## Verdict: **the regression is gone.** Joint-decode now beats or ties argmax on all six locales.
+
+Same harness (`scripts/eval/joint-vs-argmax.ts`, v0.9.4 model, warmed + alternated latency), same OpenAddresses samples, same argmax baseline — only the joint path changed. The argmax column is byte-identical to Phase I, which is the control that proves the movement is real and not a baseline shift.
+
+| locale | argmax loc | joint loc | Δ loc | regressed | improved | latency p99 × |
+|---|--:|--:|--:|--:|--:|--:|
+| **DE international** (city-state collision) | 72.2% | **99.0%** | **+26.8pp** | 0.2% | 27.0% | 0.76 |
+| US (native) | 98.8% | **99.2%** | +0.4pp | 0.4% | 0.4% | 1.33 |
+| FR (native) | 97.5% | 97.8% | +0.3pp | 2.0% | 2.3% | 1.02 |
+| NL (native) | 99.5% | 99.5% | 0.0pp | 0.8% | 0.5% | 1.40 |
+| IT (native) | 84.8% | **98.5%** | **+13.7pp** | 1.3% | 15.0% | 1.06 |
+| ES (native) | 84.0% | **94.3%** | **+10.3pp** | 2.8% | 13.3% | 0.92 |
+
+Compare the Phase I regression rates — NL 16.0%, IT 26.0%, ES 34.0% — against these: 0.8%, 1.3%, 2.8%. The catastrophe column collapsed by an order of magnitude, and on every locale the improvements now outweigh the remaining regressions five-to-seven-fold. Latency is a non-issue; most locales sit at or under 1× p99 because the joint path now produces cleaner trees with less downstream churn.
+
+## Why — three fixes, one root cause
+
+The Phase I post-mortem blamed proposal coverage: "the reconciler falls back to single-token spans when proposals don't cover the multi-word component." That was half right. Maturing the phrase grouper to *propose* multi-word spans (`Reggio nell'Emilia`, `Las Palmas de Gran Canaria`) was necessary, but on its own it barely moved the aggregate — the proposals existed and the reconciler still fragmented. Digging into the live beam turned up two more mechanisms behind the same symptom, and all three had to land together.
+
+1. **The phrase grouper couldn't see multi-word localities.** `scoreLocalityPhrase` walked a run of capitalized tokens and stopped dead at the first lowercase one, so place-name connectives (`de`, `in`, `nell'Emilia`, `aan den`) ended the span. Worse, in OpenAddresses' all-caps international data every short place word — `SAN`, `DI`, `DEL` — matches the 2-3-uppercase region-abbreviation shape, so the head of `SAN NAZARIO` got skipped as if it were a US state. The walk now bridges a bounded set of place-name particles and apostrophe-fused names, and a region-abbreviation-shaped token that heads a multi-word place is allowed to start a locality.
+
+2. **The grouper-audit ignored the classifier.** Once the reconciler picked `street="Trento"` over `Via Trento`, the word `Via` was left orphaned. The post-reconcile audit, whose job is to rescue spans the model couldn't type, saw an uncovered `LOCALITY_PHRASE` proposal for `Via` and promoted it to a `locality` node — burying the real trailing city, which is why `Via Trento, …, SORBOLO` came out with locality `Via`. The classifier had typed that span `street:0.73` all along. The audit now takes the classifier's per-span verdict for orphaned spans and only falls back to the structural phrase kind when the model genuinely abstained. This single fix took IT from 68.5% to 93.5%.
+
+3. **Romance streets lead with their type.** `scoreStreetPhrase` was suffix-only — it found `Main Street` by walking left from `Street`. Italian and Spanish put the type first (`Via Trento`, `Calle Mayor`, `Largo Millefiori`), so the rule never fired and the leading `Via`/`Calle` stayed a capitalized first-segment word the locality rule happily proposed. We taught the grouper a bounded set of Romance street-type prefixes — street-types only, deliberately excluding the ambiguous area words like `Polígono`, `Urbanización`, and `Lugar` that legitimately serve *as* localities. That carried ES from 89.5% to 94.3% and cleaned up the IT tail.
+
+The through-line: the joint path was being asked to type spans the rule layer couldn't describe and the model hadn't seen, and the audit was papering over both with its most confident-looking guess. Give the grouper the vocabulary and let the audit defer to the model, and the fragmentation evaporates.
+
+## What this means for the plan
+
+- **JUST-FLIP is back on the table.** Phase I called it dead; it isn't. Every locale is net-positive or flat (NL −0.13pp is noise), and the German city-state recovery the dual-role work ships is matched by joint decoding doing it in-model.
+- **The strict gate isn't fully met — yet.** The original bar wanted ≤0.5% per-field regression. DE (0.2%) and US (0.4%) clear it; FR (2.0%), IT (1.3%), ES (2.8%) don't, though all three are net-positive on accuracy. FR's 2.0% is unchanged from Phase I and is pre-existing single-word churn unrelated to this work. The residual IT/ES tail is a handful of rows — `SANT'`-prefixed elisions, the `LUGAR`/`PARTIDA` area-types, slash-joined bilingual names.
+- **Flipping the default is the operator's call.** This is a behavior change to the default decode path for every caller, and the strict gate isn't unanimous, so the flip itself ([#427](https://github.com/sister-software/mailwoman/issues/427)) waits for sign-off rather than shipping autonomously. The three fixes here ship regardless — they only touch the opt-in joint path and leave the argmax default byte-stable.
+
+So Phase II did its job and then some. The question Phase I left open — "can the phrase grouper ever cover multi-word spans well enough to flip?" — now has a measured yes, and the residual is a short, named list rather than a 34% cliff.
+
+_Harness: `scripts/eval/joint-vs-argmax.ts` (regression rows dumped via `MW_DUMP_REGRESSIONS=1`). Per-locale JSON under [`./data/`](./data/)._

--- a/docs/articles/evals/data/DE-intl.json
+++ b/docs/articles/evals/data/DE-intl.json
@@ -1,0 +1,20 @@
+{
+  "eval": "data/eval/external/openaddresses-de-sample.jsonl",
+  "n": 500,
+  "argmax": {
+    "localityMatch": 0.722,
+    "regionMatch": 0.334,
+    "latP50": 15.21882800000003,
+    "latP99": 38.811696999999185
+  },
+  "joint": {
+    "localityMatch": 0.99,
+    "regionMatch": 0.334,
+    "latP50": 14.535249999998996,
+    "latP99": 29.653278999999202
+  },
+  "regressionRate": 0.002,
+  "improvementRate": 0.27,
+  "accuracyDeltaPp": 13.4,
+  "latencyP99Multiplier": 0.764029436795815
+}

--- a/docs/articles/evals/data/ES.json
+++ b/docs/articles/evals/data/ES.json
@@ -1,0 +1,20 @@
+{
+  "eval": "data/eval/external/openaddresses-es-sample.jsonl",
+  "n": 400,
+  "argmax": {
+    "localityMatch": 0.84,
+    "regionMatch": 0,
+    "latP50": 13.678260000000591,
+    "latP99": 46.21101699999963
+  },
+  "joint": {
+    "localityMatch": 0.9425,
+    "regionMatch": 0.0025,
+    "latP50": 13.881679000000076,
+    "latP99": 42.553084000000126
+  },
+  "regressionRate": 0.0275,
+  "improvementRate": 0.1325,
+  "accuracyDeltaPp": 5.25,
+  "latencyP99Multiplier": 0.9208428371096111
+}

--- a/docs/articles/evals/data/FR.json
+++ b/docs/articles/evals/data/FR.json
@@ -1,0 +1,20 @@
+{
+  "eval": "data/eval/external/openaddresses-fr-sample.jsonl",
+  "n": 400,
+  "argmax": {
+    "localityMatch": 0.975,
+    "regionMatch": 1,
+    "latP50": 13.192081999999573,
+    "latP99": 29.070550999998886
+  },
+  "joint": {
+    "localityMatch": 0.9775,
+    "regionMatch": 1,
+    "latP50": 13.349695999999312,
+    "latP99": 29.788902000000235
+  },
+  "regressionRate": 0.02,
+  "improvementRate": 0.0225,
+  "accuracyDeltaPp": 0.125,
+  "latencyP99Multiplier": 1.0247106083404258
+}

--- a/docs/articles/evals/data/IT.json
+++ b/docs/articles/evals/data/IT.json
@@ -1,0 +1,20 @@
+{
+  "eval": "data/eval/external/openaddresses-it-sample.jsonl",
+  "n": 400,
+  "argmax": {
+    "localityMatch": 0.8475,
+    "regionMatch": 0,
+    "latP50": 13.071506000000227,
+    "latP99": 36.94024999999965
+  },
+  "joint": {
+    "localityMatch": 0.985,
+    "regionMatch": 0,
+    "latP50": 13.304771999999502,
+    "latP99": 39.26454199999989
+  },
+  "regressionRate": 0.0125,
+  "improvementRate": 0.15,
+  "accuracyDeltaPp": 6.875,
+  "latencyP99Multiplier": 1.0629203105014249
+}

--- a/docs/articles/evals/data/NL.json
+++ b/docs/articles/evals/data/NL.json
@@ -1,0 +1,20 @@
+{
+  "eval": "data/eval/external/openaddresses-nl-sample.jsonl",
+  "n": 400,
+  "argmax": {
+    "localityMatch": 0.995,
+    "regionMatch": 0.0025,
+    "latP50": 12.841075999999703,
+    "latP99": 26.33918900000026
+  },
+  "joint": {
+    "localityMatch": 0.995,
+    "regionMatch": 0,
+    "latP50": 12.490060000000085,
+    "latP99": 36.81972500000006
+  },
+  "regressionRate": 0.0075,
+  "improvementRate": 0.005,
+  "accuracyDeltaPp": -0.125,
+  "latencyP99Multiplier": 1.3979065566521314
+}

--- a/docs/articles/evals/data/US.json
+++ b/docs/articles/evals/data/US.json
@@ -1,0 +1,20 @@
+{
+  "eval": "data/eval/external/openaddresses-us-sample.jsonl",
+  "n": 500,
+  "argmax": {
+    "localityMatch": 0.988,
+    "regionMatch": 0.994,
+    "latP50": 14.347609999999804,
+    "latP99": 45.87068199999885
+  },
+  "joint": {
+    "localityMatch": 0.992,
+    "regionMatch": 0.994,
+    "latP50": 16.24265899999955,
+    "latP99": 61.034627
+  },
+  "regressionRate": 0.004,
+  "improvementRate": 0.004,
+  "accuracyDeltaPp": 0.2,
+  "latencyP99Multiplier": 1.3305803257950586
+}

--- a/phrase-grouper/group.test.ts
+++ b/phrase-grouper/group.test.ts
@@ -189,6 +189,24 @@ describe("scoreStreetPhrase", () => {
 	it("suffix alone with no preceding token emits nothing", () => {
 		expect(scoreStreetPhrase(tokenizeSegment("Street", 0), "Street")).toEqual([])
 	})
+
+	// #425 — Romance street pattern: the street TYPE leads ("Via Trento", "Calle Mayor").
+	it("emits STREET_PHRASE for a prefix-led Italian street (Via Trento)", () => {
+		const out = scoreStreetPhrase(tokenizeSegment("Via Trento", 0), "Via Trento")
+		expect(out.find((p) => p.span.body === "Via Trento")).toBeDefined()
+	})
+
+	it("emits STREET_PHRASE for a prefix-led Spanish street (Calle Mayor)", () => {
+		const out = scoreStreetPhrase(tokenizeSegment("Calle Mayor", 0), "Calle Mayor")
+		expect(out.find((p) => p.span.body === "Calle Mayor")).toBeDefined()
+	})
+
+	it("a bare street prefix still emits a low-confidence STREET marker (audit anchor)", () => {
+		const out = scoreStreetPhrase(tokenizeSegment("Via", 0), "Via")
+		const via = out.find((p) => p.span.body === "Via")
+		expect(via).toBeDefined()
+		expect(via!.confidence).toBeLessThan(0.6)
+	})
 })
 
 describe("scoreLocalityPhrase", () => {
@@ -225,6 +243,76 @@ describe("scoreLocalityPhrase", () => {
 	it("still emits multi-word runs containing a state name (New York)", () => {
 		const out = scoreLocalityPhrase(tokenizeSegment("New York", 0), "New York", true)
 		expect(out.find((p) => p.span.body === "New York")).toBeDefined()
+	})
+
+	// #425 — bridge lowercase place-name particles + apostrophe-fused names so native-order multi-word
+	// localities surface as ONE span (the gap that fragmented IT/ES/NL under joint-decode, Route A).
+	it("bridges a Spanish 'de' particle (Las Palmas de Gran Canaria)", () => {
+		const text = "Las Palmas de Gran Canaria"
+		const bodies = scoreLocalityPhrase(tokenizeSegment(text, 0), text, true).map((p) => p.span.body)
+		expect(bodies).toContain("Las Palmas de Gran Canaria")
+		// Never end a proposal on the bare particle.
+		expect(bodies).not.toContain("Las Palmas de")
+	})
+
+	it("bridges an apostrophe-fused Italian particle (Reggio nell'Emilia)", () => {
+		const text = "Reggio nell'Emilia"
+		const bodies = scoreLocalityPhrase(tokenizeSegment(text, 0), text, true).map((p) => p.span.body)
+		expect(bodies).toContain("Reggio nell'Emilia")
+	})
+
+	it("bridges an Italian 'in' particle (San Pietro in Casale)", () => {
+		const text = "San Pietro in Casale"
+		const bodies = scoreLocalityPhrase(tokenizeSegment(text, 0), text, true).map((p) => p.span.body)
+		expect(bodies).toContain("San Pietro in Casale")
+	})
+
+	it("bridges two consecutive Dutch particles (Alphen aan den Rijn)", () => {
+		const text = "Alphen aan den Rijn"
+		const bodies = scoreLocalityPhrase(tokenizeSegment(text, 0), text, true).map((p) => p.span.body)
+		expect(bodies).toContain("Alphen aan den Rijn")
+	})
+
+	it("bridges a German 'am' particle (Frankfurt am Main)", () => {
+		const text = "Frankfurt am Main"
+		const bodies = scoreLocalityPhrase(tokenizeSegment(text, 0), text, true).map((p) => p.span.body)
+		expect(bodies).toContain("Frankfurt am Main")
+	})
+
+	it("does NOT bridge a non-particle lowercase word (no 'Street and Oak' span)", () => {
+		const text = "Main Street and Oak Avenue"
+		const bodies = scoreLocalityPhrase(tokenizeSegment(text, 0), text, true).map((p) => p.span.body)
+		expect(bodies.some((b) => b.includes(" and "))).toBe(false)
+	})
+
+	it("does NOT bridge a dangling particle at end of segment (Palmas de)", () => {
+		const text = "Palmas de"
+		const bodies = scoreLocalityPhrase(tokenizeSegment(text, 0), text, true).map((p) => p.span.body)
+		expect(bodies).not.toContain("Palmas de")
+		expect(bodies).toContain("Palmas")
+	})
+
+	// #425 — all-caps intl place HEAD that matches the region-abbreviation shape ("SAN", "DI") must
+	// still form the multi-word locality, not get skipped as a US-state abbreviation.
+	it("forms a locality from a region-abbrev-shaped head (SAN NAZARIO)", () => {
+		const bodies = scoreLocalityPhrase(tokenizeSegment("SAN NAZARIO", 0), "SAN NAZARIO", true).map((p) => p.span.body)
+		expect(bodies).toContain("SAN NAZARIO")
+	})
+
+	it("bridges an all-caps particle (CITTA DI CASTELLO)", () => {
+		const bodies = scoreLocalityPhrase(tokenizeSegment("CITTA DI CASTELLO", 0), "CITTA DI CASTELLO", true).map(
+			(p) => p.span.body
+		)
+		expect(bodies).toContain("CITTA DI CASTELLO")
+		expect(bodies).not.toContain("CITTA DI")
+	})
+
+	it("does NOT start a locality on a leading street-type word (Via Trento)", () => {
+		const bodies = scoreLocalityPhrase(tokenizeSegment("Via Trento", 0), "Via Trento", false).map((p) => p.span.body)
+		expect(bodies).not.toContain("Via")
+		expect(bodies).not.toContain("Via Trento")
+		// The street NAME alone may still surface as a locality candidate — the reconciler arbitrates.
+		expect(bodies).toContain("Trento")
 	})
 })
 

--- a/phrase-grouper/rules.ts
+++ b/phrase-grouper/rules.ts
@@ -165,6 +165,135 @@ function isStreetSuffix(token: string): boolean {
 }
 
 /**
+ * Romance/Latin street-TYPE words that LEAD the street ("Via Trento", "Calle Mayor", "Corso Italia").
+ * English puts the type last (a suffix — see STREET_SUFFIXES); Romance languages put it first. Without
+ * this, a leading "Via"/"Calle" is capitalized first-segment text the locality rule happily proposes,
+ * and on OOD intl input the model can't type it either — so the grouper-audit promotes it to a
+ * spurious `locality`, burying the real city (#425 re-gate).
+ *
+ * Street-TYPES only — deliberately NOT the ambiguous area/development words ("Polígono",
+ * "Urbanización", "Lugar", "Partida", "Borgo") that legitimately serve AS localities. This stays a
+ * bounded linguistic category; per-locale breadth belongs in a future rule pack, not an exception pile.
+ */
+const STREET_PREFIXES: ReadonlySet<string> = new Set([
+	// Italian
+	"via",
+	"viale",
+	"corso",
+	"largo",
+	"vicolo",
+	"strada",
+	"piazza",
+	"piazzale",
+	"contrada",
+	"traversa",
+	"lungomare",
+	// Spanish / Catalan
+	"calle",
+	"avenida",
+	"avinguda",
+	"carrer",
+	"plaza",
+	"plaça",
+	"paseo",
+	"passeig",
+	"camino",
+	"carretera",
+	"ronda",
+	"travesía",
+	// Portuguese
+	"rua",
+	"travessa",
+	"praça",
+	// French
+	"rue",
+	"avenue",
+	"boulevard",
+	"chemin",
+	"impasse",
+	"allée",
+	"quai",
+])
+
+function isStreetPrefix(token: string): boolean {
+	return STREET_PREFIXES.has(token.toLowerCase())
+}
+
+/**
+ * Lowercase connective particles that live INSIDE multi-word place names — the Romance/Germanic glue
+ * that bridges two capitalized content words: "Las Palmas **de** Gran Canaria", "San Pietro **in**
+ * Casale", "Alphen **aan den** Rijn", "Frankfurt **am** Main", "Rothenburg **ob der** Tauber". This
+ * is a BOUNDED linguistic category (place-name connectives), not a gazetteer or a stopword dump — and
+ * it only ever fires when bracketed by capitalized content on BOTH sides (see `scoreLocalityPhrase`),
+ * so a stray "and"/"the" in a street phrase can't smuggle a particle through. Keep coverage to the
+ * connectives that actually bridge place-name tokens; growing it into a per-locale stopword list is
+ * the wrong move — that pressure belongs on the gazetteer/reconciler, not here.
+ */
+const PLACE_NAME_PARTICLES: ReadonlySet<string> = new Set([
+	// Spanish / Catalan / Portuguese
+	"de",
+	"del",
+	"la",
+	"las",
+	"los",
+	"el",
+	"i",
+	// Italian
+	"di",
+	"della",
+	"dei",
+	"degli",
+	"delle",
+	"in",
+	"a",
+	"sul",
+	"sulla",
+	// French
+	"du",
+	"des",
+	"le",
+	"les",
+	"sur",
+	"sous",
+	"en",
+	"lès",
+	// Dutch / Flemish
+	"aan",
+	"op",
+	"den",
+	"ter",
+	"ten",
+	// German
+	"am",
+	"an",
+	"auf",
+	"ob",
+	"im",
+	"vor",
+	"bei",
+	"der",
+])
+
+/**
+ * A short lowercase particle fused via apostrophe to a capitalized name — the Italian/French elision
+ * that the tokenizer keeps as ONE token: `nell'Emilia`, `dell'Adda`, `l'Aquila`. Treated as place-name
+ * CONTENT (it carries the proper noun), so it can both start and continue a locality run.
+ */
+function isFusedParticleName(s: string): boolean {
+	return /^\p{Ll}{1,6}['’]\p{Lu}/u.test(s)
+}
+
+/** Place-name content token: a capitalized word OR an apostrophe-fused particle name (`nell'Emilia`). */
+function isPlaceNameContent(s: string): boolean {
+	return startsCapitalized(s) || isFusedParticleName(s)
+}
+
+/** True when the token is a known lowercase place-name connective (`de`, `in`, `aan`, `am`, …). */
+function isPlaceNameParticle(s: string): boolean {
+	return PLACE_NAME_PARTICLES.has(s.toLowerCase())
+}
+
+/**
  * Venue-marker nouns with per-term confidence weights. Same caveat as STREET_SUFFIXES — universal
  * structural markers, not a places dictionary. Higher weight = stronger venue signal.
  */
@@ -330,6 +459,16 @@ export function scoreRegionAbbreviation(
 	for (let i = 0; i < tokens.length; i++) {
 		const t = tokens[i]!
 		if (!isRegionAbbreviation(t.body)) continue
+		// A region code is canonically standalone — the tail of "City, ST ZIP", never immediately
+		// followed by another place-name word. When the next token IS place-name content (and not
+		// itself a region abbreviation or a street suffix), this token is the HEAD of a multi-word
+		// place name ("SAN" NAZARIO, "DI" CASTELLO — common in all-caps intl data where every short
+		// word matches the 2-3-uppercase shape), not a region. Suppressing the region proposal here
+		// keeps it from out-deduping the same span's LOCALITY_PHRASE in the reconciler (#425).
+		const after = tokens[i + 1]
+		if (after && isPlaceNameContent(after.body) && !isRegionAbbreviation(after.body) && !isStreetSuffix(after.body)) {
+			continue
+		}
 		// Position cue: last token in a segment (canonical region slot) → high confidence. Anywhere
 		// else, moderate. Anywhere in the LAST segment → slightly elevated (region is canonically the
 		// final non-postcode component).
@@ -405,16 +544,49 @@ export function scoreStreetPhrase(tokens: ReadonlyArray<SegmentToken>, text: str
 			confidence,
 		})
 	}
+	// Romance street pattern: the street TYPE LEADS ("Via Trento", "Calle Mayor", "Largo Millefiori").
+	// Walk RIGHT from a street-prefix token gathering capitalized place-name words (bridging particles),
+	// stopping at a digit house-number or any non-place token.
+	for (let prefixIdx = 0; prefixIdx < tokens.length; prefixIdx++) {
+		if (!isStreetPrefix(tokens[prefixIdx]!.body)) continue
+		let end = prefixIdx
+		for (let i = prefixIdx + 1; i < tokens.length; i++) {
+			const body = tokens[i]!.body
+			if (isStreetPrefix(body)) break
+			if (isPlaceNameContent(body) || isPlaceNameParticle(body)) {
+				end = i
+			} else {
+				break
+			}
+		}
+		// Don't end on a trailing connective particle ("Calle de" is not a street name).
+		while (end > prefixIdx && isPlaceNameParticle(tokens[end]!.body)) end--
+		const startTok = tokens[prefixIdx]!
+		const endTok = tokens[end]!
+		// Prefix + name scores moderately; a bare prefix still emits a low-confidence marker so the
+		// audit types the leftover span `street`, never `locality`.
+		out.push({
+			span: makeSection(text, startTok.start, endTok.end),
+			kindHypothesis: "STREET_PHRASE",
+			confidence: end > prefixIdx ? 0.72 : 0.5,
+		})
+	}
 	return out
 }
 
 /**
- * `LOCALITY_PHRASE` rule: runs of contiguous capitalized words (1-4 long). Emits multiple
+ * `LOCALITY_PHRASE` rule: runs of contiguous place-name tokens (1-6 long). Emits multiple
  * overlapping proposals so the reconciler can choose between e.g. `Saint Petersburg` as one phrase
  * vs `Saint` + `Petersburg` as two.
  *
- * Confidence scales with: run length (2-3 best), tail-of-segment position, and whether the
- * preceding token is a comma or segment boundary.
+ * The run bridges lowercase place-name PARTICLES (`de`, `in`, `aan den`, `am`, …) and apostrophe-fused
+ * names (`nell'Emilia`) when they sit between capitalized content — without that, the walk used to
+ * stop dead at the first lowercase token, so it never proposed "Reggio nell'Emilia", "Las Palmas de
+ * Gran Canaria", or "San Pietro in Casale" as single spans. Those gaps are exactly the native-order
+ * multi-word localities the joint-decode A/B fragmented (Route A Phase I, #425).
+ *
+ * Confidence scales with: run length (2-5 are good place-name lengths), tail-of-segment position, and
+ * whether the span sits at a segment boundary.
  */
 export function scoreLocalityPhrase(
 	tokens: ReadonlyArray<SegmentToken>,
@@ -423,32 +595,59 @@ export function scoreLocalityPhrase(
 ): PhraseProposal[] {
 	const out: PhraseProposal[] = []
 	for (let i = 0; i < tokens.length; i++) {
-		if (!startsCapitalized(tokens[i]!.body)) continue
-		// Skip pure region abbreviations as standalone LOCALITY_PHRASE — they own REGION_ABBREVIATION
-		// at higher confidence.
-		if (isRegionAbbreviation(tokens[i]!.body)) continue
-		// Walk forward grabbing additional capitalized tokens. Stop on lowercase, digit-only, or
-		// region-abbreviation tokens.
-		let j = i
-		while (
-			j + 1 < tokens.length &&
-			startsCapitalized(tokens[j + 1]!.body) &&
-			!isRegionAbbreviation(tokens[j + 1]!.body) &&
-			!isAllDigit(tokens[j + 1]!.body) &&
-			!isStreetSuffix(tokens[j + 1]!.body)
-		) {
-			j++
+		if (!isPlaceNameContent(tokens[i]!.body)) continue
+		// A leading street-type word ("Via", "Calle", "Corso") heads a STREET, not a locality — let
+		// scoreStreetPhrase own it so the audit never promotes it to a spurious locality.
+		if (isStreetPrefix(tokens[i]!.body)) continue
+		// A region-abbreviation-SHAPED head (2-3 uppercase letters) starts a LOCALITY_PHRASE only when
+		// place-name content follows it. This keeps a standalone trailing "NY"/"TX" owned by
+		// REGION_ABBREVIATION, while still forming "SAN NAZARIO" / "CITTÀ DI CASTELLO" — in all-caps
+		// intl data (OpenAddresses), the head/connector of a place name ("SAN", "DI", "DEL") matches
+		// the abbreviation shape, so a hard skip here dropped the multi-word locality entirely (#425).
+		if (isRegionAbbreviation(tokens[i]!.body)) {
+			const after = tokens[i + 1]
+			if (!after || !(isPlaceNameContent(after.body) || isPlaceNameParticle(after.body))) continue
 		}
-		// Emit proposals for every prefix-length of the run starting at i, capped at 4 tokens.
-		// Each starting i contributes at most 4 proposals, so the rule stays O(n) per segment.
-		const maxLen = Math.min(j - i + 1, 4)
+		// Walk forward grabbing place-name content. Bridge connective particles (lowercase "de"/"in" or
+		// all-caps "DI"/"DEL") ONLY when a content token follows within a short run (≤2 consecutive
+		// particles: "aan den Rijn"), so a dangling "Palmas de" at end-of-segment doesn't extend the
+		// run. Stop on digits, street suffixes, and NON-particle region abbreviations ("Springfield IL"
+		// must not absorb "IL").
+		let j = i
+		for (;;) {
+			const next = tokens[j + 1]
+			if (!next) break
+			const b = next.body
+			if (isAllDigit(b) || isStreetSuffix(b) || isStreetPrefix(b)) break
+			if (isRegionAbbreviation(b) && !isPlaceNameParticle(b)) break
+			if (isPlaceNameContent(b) && !isPlaceNameParticle(b)) {
+				j++
+				continue
+			}
+			if (isPlaceNameParticle(b)) {
+				// Look past a short run of consecutive particles for the next content token.
+				let k = j + 2
+				while (tokens[k] && isPlaceNameParticle(tokens[k]!.body)) k++
+				if (tokens[k] && k - (j + 1) <= 2 && isPlaceNameContent(tokens[k]!.body)) {
+					j = k // jump onto the content token; the bridged particles stay inside the span
+					continue
+				}
+			}
+			break
+		}
+		// Emit proposals for every prefix-length of the run starting at i, capped at 6 tokens (covers
+		// "Las Palmas de Gran Canaria" = 5). Each starting i contributes ≤6 proposals → O(n) per segment.
+		const maxLen = Math.min(j - i + 1, 6)
 		for (let len = 1; len <= maxLen; len++) {
 			const startTok = tokens[i]!
 			const endTok = tokens[i + len - 1]!
+			// Never end a proposal ON a connective particle ("Las Palmas de" / "CITTÀ DI" is not a place).
+			if (isPlaceNameParticle(endTok.body)) continue
 			const spanText = text.slice(startTok.start, endTok.end)
 			const isRegionName = len === 1 && US_REGION_NAMES.has(spanText.toLowerCase())
 			const atTail = i + len - 1 === tokens.length - 1
-			let confidence = 0.55 + (len === 2 ? 0.15 : 0) + (len === 3 ? 0.1 : 0)
+			const lenBonus = len === 2 ? 0.15 : len === 3 ? 0.12 : len >= 4 ? 0.08 : 0
+			let confidence = 0.55 + lenBonus
 			if (isRegionName && !atTail) confidence -= 0.2
 			if (atTail && segmentIsLast) confidence += 0.1
 			if (atTail) confidence += 0.05

--- a/scripts/eval/joint-vs-argmax.ts
+++ b/scripts/eval/joint-vs-argmax.ts
@@ -122,8 +122,11 @@ async function main(): Promise<void> {
 	const argmaxLat: number[] = []
 	const jointLat: number[] = []
 
+	const dumpReg = !!process.env.MW_DUMP_REGRESSIONS
 	for (const row of rows) {
-		const score = async (forceJointReconcile: boolean): Promise<{ loc: boolean; reg: boolean; ms: number }> => {
+		const score = async (
+			forceJointReconcile: boolean
+		): Promise<{ loc: boolean; reg: boolean; ms: number; locVal?: string }> => {
 			const t0 = performance.now()
 			let json: Partial<Record<string, string>> = {}
 			try {
@@ -137,12 +140,13 @@ async function main(): Promise<void> {
 				loc: fieldMatch(json.locality, row.expected.locality),
 				reg: fieldMatch(json.region, row.expected.region),
 				ms,
+				locVal: json.locality,
 			}
 		}
 		// Alternate which path runs first so any per-input cache warmth doesn't favor one path.
 		const argmaxFirst = argmaxLat.length % 2 === 0
-		let a: { loc: boolean; reg: boolean; ms: number }
-		let j: { loc: boolean; reg: boolean; ms: number }
+		let a: { loc: boolean; reg: boolean; ms: number; locVal?: string }
+		let j: { loc: boolean; reg: boolean; ms: number; locVal?: string }
 		if (argmaxFirst) {
 			a = await score(false)
 			j = await score(true)
@@ -165,6 +169,11 @@ async function main(): Promise<void> {
 		if (locRegressed || regRegressed || locImproved || regImproved) changed++
 		if (locRegressed || regRegressed) regressed++
 		if (locImproved || regImproved) improved++
+		if (dumpReg && locRegressed) {
+			console.error(
+				`[REG] gold="${row.expected.locality}"  argmax="${a.locVal ?? ""}"  joint="${j.locVal ?? ""}"  | ${row.input}`
+			)
+		}
 	}
 
 	const n = rows.length


### PR DESCRIPTION
## The re-gate overturns Phase I's STAY

[Route A Phase I](../blob/main/docs/articles/evals/2026-06-07-route-a-phase-i-baseline.md) shelved the joint-decode default flip: it won +25pp on the German city-state collision but regressed native-order multi-word locales **16–34%** (NL/IT/ES) by fragmenting them. This PR lands the phrase-grouper rebuild that [#425](https://github.com/sister-software/mailwoman/issues/425) gated on. The regression collapses by an order of magnitude and **joint now beats or ties argmax on all six locales**.

Full write-up: `docs/articles/evals/2026-06-07-route-a-phase-ii-regate.md`.

| locale | argmax | joint | Δ loc | regressed | improved | p99 × |
|---|--:|--:|--:|--:|--:|--:|
| DE-intl | 72.2% | **99.0%** | +26.8pp | 0.2% | 27.0% | 0.76 |
| US | 98.8% | **99.2%** | +0.4pp | 0.4% | 0.4% | 1.33 |
| FR | 97.5% | 97.8% | +0.3pp | 2.0% | 2.3% | 1.02 |
| NL | 99.5% | 99.5% | 0.0pp | 0.8% | 0.5% | 1.40 |
| IT | 84.8% | **98.5%** | +13.7pp | 1.3% | 15.0% | 1.06 |
| ES | 84.0% | **94.3%** | +10.3pp | 2.8% | 13.3% | 0.92 |

Argmax baselines are byte-identical to Phase I (the control). Same harness, model (v0.9.4), and samples.

## Three fixes, one symptom

Traced the live reconcile beam — proposal coverage was only one of three mechanisms behind the fragmentation, and all three had to land together:

1. **`scoreLocalityPhrase` couldn't see multi-word localities.** The walk stopped at the first lowercase token (so particles `de`/`in`/`nell'Emilia`/`aan den` ended the span), and in all-caps OpenAddresses data every short place word (`SAN`/`DI`/`DEL`) matches the 2-3-uppercase region-abbreviation shape, so the head of `SAN NAZARIO` was skipped as a US state. Now bridges a bounded `PLACE_NAME_PARTICLES` set + apostrophe-fused names; a region-abbrev-shaped head that leads a multi-word place starts a locality; `scoreRegionAbbreviation` stops firing on a place head followed by content.

2. **`grouperAudit` ignored the classifier.** When the reconciler left `Via` orphaned (it picked `street="Trento"` over `Via Trento`), the audit promoted the leftover `LOCALITY_PHRASE "Via"` to a locality node, burying the real city — though the classifier typed that span `street:0.73`. The audit now defers to the classifier's per-span verdict for orphaned spans (≥0.4). **Took IT 68.5% → 93.5%.** Argmax path unchanged (no `classifierTopK` → original behavior).

3. **`scoreStreetPhrase` was suffix-only.** Romance streets lead with the type (`Via Trento`, `Calle Mayor`). Added a bounded `STREET_PREFIXES` set (street-types only; excludes ambiguous area words `Polígono`/`Urbanización`/`Lugar` that *are* localities) + a prefix-led pass. **ES 89.5% → 94.3%.**

## Scope / safety

- These fixes touch **only the opt-in joint path** (`forceJointReconcile`). The **argmax default stays byte-stable** — argmax columns are identical to Phase I.
- 129 phrase-grouper + core/pipeline tests green (incl. 13 new: multi-word/particle/region-abbrev-head/street-prefix recall + 3 audit classifier-deferral).
- The strict ≤0.5% per-field-regression gate is met on DE/US; IT/ES/FR are net-positive but above it (FR's 2.0% is pre-existing single-word churn). **The default flip ([#427](https://github.com/sister-software/mailwoman/issues/427)) is a behavior change for every caller and waits for operator sign-off** — this PR does not flip it.

Closes #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)