### PR TITLE
Demo: route the browser parser through the joint pipeline (#427 follow-up)

### DIFF
--- a/core/tokenization/Graph.ts
+++ b/core/tokenization/Graph.ts
@@ -4,7 +4,11 @@
  * @author Teffen Ellis, et al.
  */
 
-import { Sequence } from "@mailwoman/core/resources"
+// Import `Sequence` from its leaf module, NOT the `@mailwoman/core/resources` barrel: the barrel
+// re-exports the libpostal/WOF dictionaries (top-level `readdir` + fast-glob, Node-only), which would
+// drag the entire resource-loading layer into any browser bundle that touches tokenization — and
+// `@mailwoman/phrase-grouper` touches it via `Span`. `Sequence` itself is a pure `extends Set`.
+import { Sequence } from "../resources/set.js"
 
 export type GraphNodeCallback<G> = (node: G) => boolean
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,6 +34,7 @@
 		"@mailwoman/core": "workspace:*",
 		"@mailwoman/kind-classifier": "workspace:*",
 		"@mailwoman/neural-web": "workspace:*",
+		"@mailwoman/phrase-grouper": "workspace:*",
 		"@mailwoman/query-shape": "workspace:*",
 		"@mailwoman/resolver-wof-wasm": "workspace:*",
 		"@mdx-js/react": "^3.1.1",

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -444,16 +444,29 @@ const DemoApp: React.FC = () => {
 			try {
 				// Stage 2.4 + 2.5: compute QueryShape + kind classification. Pure functions, ~µs.
 				// Surfaced in the UI so users see the staged pipeline working.
-				const [{ computeQueryShape }, { classifyKindSync }] = await Promise.all([
+				const [{ computeQueryShape }, { classifyKindSync }, { runPipeline }, { groupPhrases }] = await Promise.all([
 					import("@mailwoman/query-shape"),
 					import("@mailwoman/kind-classifier"),
+					import("@mailwoman/core/pipeline"),
+					import("@mailwoman/phrase-grouper"),
 				])
 				const tStart = performance.now()
 				const queryShape = computeQueryShape(text)
 				const kindResult = classifyKindSync({ raw: text, normalized: text }, queryShape)
 				const tShape = performance.now()
 
-				const tree = await classifier.parse(text, { queryShape, fst: fstMatcher ?? undefined })
+				// Run the full runtime pipeline — phrase grouper (Stage 2.7) + joint-reconcile decode
+				// (Stage 5), the default since #427 — instead of the raw argmax `classifier.parse`. This
+				// is what surfaces multi-word localities, Romance street prefixes, and the correct
+				// house-number boundary in the browser, matching the library + CLI. Normalize / locale /
+				// kind default inside runPipeline; the demo's own WOF httpvfs lookup runs below on the
+				// resulting tree (no resolver stage is passed).
+				const { tree } = await runPipeline(text, {
+					computeQueryShape,
+					groupPhrases,
+					classifier: classifier as unknown as Parameters<typeof runPipeline>[1]["classifier"],
+					fst: (fstMatcher ?? undefined) as Parameters<typeof runPipeline>[1]["fst"],
+				})
 				const tClassify = performance.now()
 				const nodes = flattenTree(tree)
 				const localityNodes = nodes.filter((n) => n.tag === "locality" || n.tag === "city")

--- a/yarn.lock
+++ b/yarn.lock
@@ -4544,6 +4544,7 @@ __metadata:
     "@mailwoman/core": "workspace:*"
     "@mailwoman/kind-classifier": "workspace:*"
     "@mailwoman/neural-web": "workspace:*"
+    "@mailwoman/phrase-grouper": "workspace:*"
     "@mailwoman/query-shape": "workspace:*"
     "@mailwoman/resolver-wof-wasm": "workspace:*"
     "@mdx-js/react": "npm:^3.1.1"


### PR DESCRIPTION
The demo called `classifier.parse()` directly — raw argmax, bypassing the runtime pipeline. So **none of Route A showed up in the browser**: joint-decode, the phrase-grouper multi-word recall, the house-number boundary fix were all invisible, and the live demo rendered the nested argmax tree with the split house number (`Friedrichstraße 1` + `23`). Redeploying could never change that — found while verifying the demo after #431.

## The rewire

Route the demo's parse step through `runPipeline` (phrase grouper + joint reconcile, default-on since #427), keeping the demo's own httpvfs WOF lookup for resolution. The web `NeuralAddressClassifier` already exposes `parseWithLogits` (`web-onnx-runner` returns logits) and threads the model card's `labels`, so the joint path runs in WASM.

## Why a library change was needed (the bundling fix)

`@mailwoman/phrase-grouper` pulls `Span` from `@mailwoman/core/tokenization`, and `core/tokenization/Graph.ts` imported `Sequence` from the **`@mailwoman/core/resources` barrel** — which re-exports the libpostal/WOF dictionaries (top-level `readdir` + fast-glob, Node-only). That dragged the entire resource-loading layer into the client bundle and broke `docusaurus build` (`can't resolve os` / `node:fs` / `fast-glob`). `Sequence` is a pure `extends Set`; importing it from its leaf module (`../resources/set.js`) decouples tokenization from the Node-heavy barrel. Same class, no runtime change — and it unblocks any browser consumer of tokenization.

## Verification

- `docusaurus build` compiles clean (client + server).
- docs `typecheck` passes.
- **342** core + phrase-grouper tests green (the `Graph` decoupling is load-bearing across tokenization).
- Local node trace of the same `runPipeline` path → correct `Friedrichstraße` + `123`.
- In-browser WASM-classifier runtime is the operator's browser-verify after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)