### PR TITLE
Demo: surface the dual-role city-state relation (#402)

### DIFF
--- a/docs/scripts/build-demo-assets.sh
+++ b/docs/scripts/build-demo-assets.sh
@@ -45,7 +45,12 @@ cp -L "${WEIGHTS_PKG}/model.onnx" "${STATIC_DIR}/model.onnx"
 echo "==> tokenizer.model (from ${WEIGHTS_PKG}/tokenizer.model)"
 cp -L "${WEIGHTS_PKG}/tokenizer.model" "${STATIC_DIR}/tokenizer.model"
 
-echo "==> wof-hot.db (slim WOF, top-1000 US localities + all postcodes)"
+# `--countries` MUST include every country the demo resolves, AND it gates which `coincident_roles`
+# survive the slim filter (the relation is dropped for any place whose spr row is trimmed). DE/FR carry
+# the city-states the dual-role badge surfaces (Berlin/Hamburg/Bremen, Paris) — a US-only slim has zero
+# coincident roles, so the badge would never appear. Override via SLIM_COUNTRIES.
+SLIM_COUNTRIES="${SLIM_COUNTRIES:-US,DE,FR}"
+echo "==> wof-hot.db (slim WOF, top-${SLIM_TOP_LOCALITIES:-1000} localities/country in ${SLIM_COUNTRIES} + all postcodes + coincident_roles)"
 if [[ ! -e "${SLIM_CLI}" ]]; then
     echo "build-slim-cli not compiled — running yarn compile first."
     (cd "${REPO_ROOT}" && yarn compile)
@@ -54,7 +59,8 @@ node "${SLIM_CLI}" \
     --in "${WOF_ADMIN_DB}" \
     --in "${WOF_POSTCODE_DB}" \
     --out "${STATIC_DIR}/wof-hot.db" \
-    --top "${SLIM_TOP_LOCALITIES:-1000}"
+    --top "${SLIM_TOP_LOCALITIES:-1000}" \
+    --countries "${SLIM_COUNTRIES}"
 
 echo
 echo "Done. Static assets:"

--- a/docs/src/components/ResultPanel/ResultPanel.tsx
+++ b/docs/src/components/ResultPanel/ResultPanel.tsx
@@ -1,5 +1,5 @@
 import CodeBlock from "@theme/CodeBlock"
-import { useCallback, useState } from "react"
+import { Fragment, useCallback, useState } from "react"
 import { DemoResult } from "../../shared/resources.tsx"
 import { CandidatePicker } from "../CandidatePicker/CandidatePicker.tsx"
 import { FailureDiagnostic } from "../FailureDiagnostic/FailureDiagnostic.tsx"
@@ -175,6 +175,25 @@ export const ResultPanel: React.FC<ResultPanelProps> = ({ result, selectedCandid
 							<dt>score</dt>
 							<dd>{selected.score.toFixed(3)}</dd>
 						</dl>
+						{result.dualRoles && result.dualRoles.length > 0 ? (
+							<p
+								style={{
+									margin: "0.5rem 0 0",
+									padding: "0.4rem 0.6rem",
+									borderRadius: "6px",
+									background: "var(--ifm-color-info-contrast-background, rgba(54, 122, 246, 0.1))",
+									fontSize: "0.9rem",
+								}}
+							>
+								🏛️ <strong>Dual-role place.</strong> {selected.name} also resolves as{" "}
+								{result.dualRoles.map((r, i) => (
+									<Fragment key={`${r.role}-${r.id}`}>
+										{i > 0 ? ", " : ""}a <strong>{r.role}</strong> ({r.relationshipType.replace(/-/g, " ")})
+									</Fragment>
+								))}
+								.
+							</p>
+						) : null}
 					</div>
 					{result.candidates.length > 1 ? (
 						<CandidatePicker

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -28,6 +28,7 @@ import { ResultPanel } from "../../components/ResultPanel/ResultPanel.tsx"
 import {
 	assetUrl,
 	DemoResult,
+	DualRole,
 	FstMatcherLike,
 	FstProvenanceLike,
 	loadFstGazetteer,
@@ -514,7 +515,21 @@ const DemoApp: React.FC = () => {
 				// Marker draw is centralised in the useEffect below — it reacts to result +
 				// selectedCandidateIndex changes. Just stash the candidates; the effect handles
 				// clearing stale marker/bbox AND rendering the new selection.
-				setSelectedCandidateIndex(0)
+				// Dual-role (#402): surface whether the resolved place doubles as another admin tier — a
+					// city-state (Berlin = locality AND region) or a capital-seat. Best-effort + optional: the
+					// lookup returns [] when the slim DB predates the coincident_roles relation.
+					let dualRoles: DualRole[] | undefined
+					const primaryHit = candidates[0]
+					if (primaryHit && wofLookup.coincidentRolesFor) {
+						try {
+							const roles = await wofLookup.coincidentRolesFor(primaryHit.id)
+							if (roles.length > 0) dualRoles = roles
+						} catch {
+							/* relation absent / query failed → no dual-role badge */
+						}
+					}
+
+					setSelectedCandidateIndex(0)
 				setResult({
 					input: text,
 					tree,
@@ -526,6 +541,7 @@ const DemoApp: React.FC = () => {
 					fstActive: fstMatcher !== null,
 					fstProvenance,
 					timing: { shape: tShape - tStart, classify: tClassify - tShape, resolve: tResolve - tBeforeResolve },
+						dualRoles,
 				})
 			} catch (parsingError) {
 				console.error("Error parsing input", parsingError)

--- a/docs/src/shared/httpvfs-resolver.ts
+++ b/docs/src/shared/httpvfs-resolver.ts
@@ -20,7 +20,7 @@
  *   webpack — that's what keeps the Docusaurus build warning-free.
  */
 
-import type { MailwomanLookupLike } from "./resources"
+import type { DualRole, MailwomanLookupLike } from "./resources"
 
 const POPULATION_BOOST = 4.0
 const POPULATION_SCALE_LOG10 = 6.0
@@ -81,9 +81,65 @@ export async function loadHttpvfsDb(dbUrl: string, sqljsBaseUrl: string): Promis
 export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
 	#worker: HttpvfsWorker
 	#hasPop: boolean | undefined
+	#dualRolesCache: Map<number, DualRole[]> | undefined
 
 	constructor(worker: HttpvfsWorker) {
 		this.#worker = worker
+	}
+
+	/**
+	 * Dual-role lookup (#402): a city-state / capital-seat place holds two admin tiers under one name
+	 * (Berlin is both a region and a locality). The `coincident_roles` relation pairs an `admin_id`
+	 * with the `locality_id` it doubles as; this returns the PARTNER role for a resolved place in
+	 * EITHER direction, so the demo can badge "Berlin → also a region (city-state)" whether the parse
+	 * resolved the city or the state. Loaded once + memoized (the relation is ~hundreds of rows).
+	 * Returns `[]` when the slim DB predates the relation (existence-guarded) — degrades silently.
+	 */
+	async coincidentRolesFor(placeId: number): Promise<DualRole[]> {
+		if (!Number.isFinite(placeId)) return []
+		if (!this.#dualRolesCache) {
+			const map = new Map<number, DualRole[]>()
+			const exists = rowsFromExec(
+				await this.#worker.db.exec("SELECT 1 FROM sqlite_master WHERE type='table' AND name='coincident_roles' LIMIT 1")
+			)
+			if (exists.length > 0) {
+				const rows = rowsFromExec(
+					await this.#worker.db.exec(
+						`SELECT cr.admin_id AS adminId, cr.locality_id AS localityId, cr.relationship_type AS rel,
+							a.name AS adminName, a.placetype AS adminType, l.name AS locName, l.placetype AS locType
+						FROM coincident_roles cr JOIN spr a ON a.id = cr.admin_id JOIN spr l ON l.id = cr.locality_id`
+					)
+				)
+				const push = (key: number, role: DualRole): void => {
+					const arr = map.get(key) ?? []
+					arr.push(role)
+					map.set(key, arr)
+				}
+				for (const r of rows) {
+					const adminId = Number(r.adminId)
+					const localityId = Number(r.localityId)
+					const rel = String(r.rel)
+					// Resolved place is the locality → it ALSO acts as the region (the admin partner).
+					push(localityId, {
+						id: adminId,
+						name: String(r.adminName),
+						placetype: String(r.adminType),
+						relationshipType: rel,
+						role: "region",
+					})
+					// Resolved place is the admin → it ALSO acts as the locality.
+					push(adminId, {
+						id: localityId,
+						name: String(r.locName),
+						placetype: String(r.locType),
+						relationshipType: rel,
+						role: "locality",
+					})
+				}
+			}
+			this.#dualRolesCache = map
+		}
+		return this.#dualRolesCache.get(placeId) ?? []
 	}
 
 	async #hasPopulation(): Promise<boolean> {

--- a/docs/src/shared/resources.tsx
+++ b/docs/src/shared/resources.tsx
@@ -45,6 +45,9 @@ export interface MailwomanLookupLike {
 			bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
 		}>
 	>
+	/** Dual-role partner roles for a resolved place id (#402). Optional — absent on lookups built from a
+	 * slim DB that predates the `coincident_roles` relation. */
+	coincidentRolesFor?: (placeId: number) => Promise<DualRole[]>
 }
 
 export interface KindResult {
@@ -86,6 +89,21 @@ export interface DemoResult {
 	timing?: StageTiming
 	fstActive: boolean
 	fstProvenance?: FstProvenanceLike | null
+	/** Dual-role (#402): the additional admin tier(s) the resolved place also fulfils (city-state etc.). */
+	dualRoles?: DualRole[]
+}
+
+/**
+ * One additional admin role a resolved place ALSO fulfils — the dual-role / city-state relation
+ * (#402). Berlin resolves as a locality but `role: "region"` here surfaces that it is also a federal
+ * state. `relationshipType` is the gazetteer-derived class (`city-state`, `capital-seat`, …).
+ */
+export interface DualRole {
+	id: number
+	name: string
+	placetype: string
+	relationshipType: string
+	role: "region" | "locality"
 }
 
 export interface ResolvedHit {


### PR DESCRIPTION
The demo resolves through its **own** httpvfs WOF lookup, so the core resolver's `hierarchyCompletion` (dual-role) never ran — a city-state like Berlin showed only as a locality, never "also a region". This wires the `coincident_roles` relation into the demo directly.

## Changes

- **`WofHttpvfsPlaceLookup.coincidentRolesFor(placeId)`** — mirrors `WofWasmPlaceLookup` but resolves the partner role in **either direction** (a resolved locality → its region partner; a resolved region → its locality), so the badge works whether the parse landed on the city or the state. Loaded once + memoized; existence-guarded → `[]` when the slim DB predates the relation (degrades silently).
- **Demo `onSubmit`** queries it for the primary resolved hit, attaches `dualRoles` to `DemoResult`; **`ResultPanel`** renders a "🏛️ Dual-role place" badge (*"Berlin also resolves as a region (city state)"*).
- **`build-demo-assets.sh`** now passes `--countries US,DE,FR` (override via `SLIM_COUNTRIES`). `build-slim` filters `coincident_roles` to surviving spr ids, and a **US-only slim has zero city-states** — DE/FR carry Berlin/Hamburg/Bremen/Paris. Without this the badge could never appear no matter how the demo is wired.

## Verification

- `docusaurus build` clean (client + server); docs `typecheck` passes.
- Relation query + map logic verified against a synthetic Berlin DB: resolved-locality → region partner, resolved-region → locality partner, unknown → `[]`.
- The full source DB carries **128** `coincident_roles` rows (Berlin/Hamburg/Bremen confirmed).

## Operator note

The badge appears **live** once the deployed `wof-hot.db` is rebuilt with DE-inclusive countries + the post-#420 `build-slim` and re-uploaded (the R2 pipeline). The code degrades silently until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)