### PR TITLE
demo: add the int'l-order Berlin city-state example (#387 repro)

### DIFF
--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -51,6 +51,7 @@ const EXAMPLE_ADDRESSES: Array<{ label: string; address: string }> = [
 	{ label: "Space Needle", address: "400 Broad St, Seattle, WA 98109" },
 	{ label: "ZIP only", address: "90210" },
 	{ label: "Berlin (native order)", address: "Straußstraße 27, 12623 Berlin" },
+	{ label: "Berlin city-state (int'l order)", address: "5 Hauptstraße, Berlin, Berlin 10115" },
 	{ label: "Paris (street fall-through)", address: "181 Rue du Chevaleret, Paris" },
 ]
 


### PR DESCRIPTION
Adds `5 Hauptstraße, Berlin, Berlin 10115` to the demo's example set — the international-order city-state layout (locality == region) that the dual-role badge + `hierarchyCompletion` address (#402 / shipped live in #434). A clickable repro for #387.

Follow-up to #434 (operator-requested). One-line change; triggers a docs-build redeploy so the new example chip shows on the live demo.

Related: #387 (the parser-side city-state collapse this exercises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)