### PR TITLE
fix(server): annotate Router exports to fix TS2883 on main

### DIFF
--- a/mailwoman/server/AddressRouter.ts
+++ b/mailwoman/server/AddressRouter.ts
@@ -51,7 +51,7 @@ const handler: RequestHandler = async (req, res) => {
 	})
 }
 
-export const AddressRouter = Router()
+export const AddressRouter: Router = Router()
 
 AddressRouter.post("/parse", handler)
 AddressRouter.search("/parse", handler)

--- a/mailwoman/server/ResolveRouter.ts
+++ b/mailwoman/server/ResolveRouter.ts
@@ -178,7 +178,7 @@ const handler: RequestHandler = async (req, res) => {
 	}
 }
 
-export const ResolveRouter = Router()
+export const ResolveRouter: Router = Router()
 
 ResolveRouter.post("/api/resolve", handler)
 ResolveRouter.get("/api/resolve", handler)


### PR DESCRIPTION
## Problem

`Bump packages.` (49e85b5) updated `express` / `@types/express`. After the bump, `tsc` can no longer name the inferred type of the exported `AddressRouter` / `ResolveRouter` without referencing the non-portable `Router` type from `express/node_modules/@types/express-serve-static-core`:

```
mailwoman/server/AddressRouter.ts(54,14): error TS2883: The inferred type of 'AddressRouter' cannot be named without a reference to 'Router' from 'express/node_modules/@types/express-serve-static-core'. This is likely not portable. A type annotation is necessary.
mailwoman/server/ResolveRouter.ts(181,14): error TS2883: ...
```

This broke `yarn compile` in the **docs-build** workflow on `main` ([run 27112890623](https://github.com/sister-software/mailwoman/actions/runs/27112890623)), which blocks the demo redeploy.

## Fix

Add explicit `: Router` annotations to both exports. `Router` is already imported as a value in each file and doubles as the interface type, so no new import is needed.

## Verification

- `yarn compile` → exit 0, zero TS errors locally (was exit 2 on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)