### PR TITLE
fix(#397): make link-dev-weights self-verify against the deployed default

### DIFF
--- a/mailwoman/server/AddressRouter.ts
+++ b/mailwoman/server/AddressRouter.ts
@@ -51,7 +51,7 @@ const handler: RequestHandler = async (req, res) => {
 	})
 }
 
-export const AddressRouter = Router()
+export const AddressRouter: Router = Router()
 
 AddressRouter.post("/parse", handler)
 AddressRouter.search("/parse", handler)

--- a/mailwoman/server/ResolveRouter.ts
+++ b/mailwoman/server/ResolveRouter.ts
@@ -178,7 +178,7 @@ const handler: RequestHandler = async (req, res) => {
 	}
 }
 
-export const ResolveRouter = Router()
+export const ResolveRouter: Router = Router()
 
 ResolveRouter.post("/api/resolve", handler)
 ResolveRouter.get("/api/resolve", handler)

--- a/neural-weights-en-us/scripts/link-dev-weights.sh
+++ b/neural-weights-en-us/scripts/link-dev-weights.sh
@@ -4,17 +4,55 @@
 # The published @mailwoman/neural-weights-en-us bundle contains the real model.onnx
 # + tokenizer.model files (declared in package.json `files`). In the monorepo only
 # the metadata files (package.json, model-card.json, README.md) are committed; the
-# binaries live in /mnt/playpen/mailwoman-data/models/ from Phase 2 training and
-# get copied in at publish time.
+# binaries live in /mnt/playpen/mailwoman-data/models/ from training and get copied
+# in at publish time.
 #
 # This script symlinks the dev artifacts so `@mailwoman/neural`'s loadFromWeights
 # can find them during local testing. Run from anywhere; resolves paths from the
 # package dir.
+#
+# ---------------------------------------------------------------------------
+# #397 GUARD — why this script verifies a hash (read before editing the paths)
+# ---------------------------------------------------------------------------
+# `neural/test/weights.test.ts` invokes this script, so EVERY `yarn test` run
+# re-creates these symlinks. If the defaults below point at a stale model, the
+# whole repo silently starts grading evals against the wrong weights — which is
+# exactly the trap that wasted an eval shift (the symlink had drifted to
+# v0.5.3 / tokenizer v0.5.0-a1 while the deployed default was v4.0.0).
+#
+# To make drift impossible to ignore, when the DEFAULT artifacts are used (no
+# MAILWOMAN_DEV_MODEL / MAILWOMAN_DEV_TOKENIZER override) this script asserts the
+# linked bytes match EXPECTED_*_MD5 — the md5 of what the demo actually serves at
+#   https://public.sister.software/mailwoman/en-us/<defaultVersion>/{model,tokenizer}
+# A mismatch FAILS LOUD instead of grading the wrong model.
+#
+# ON DEFAULT PROMOTION (releases.json `defaultVersion` bump): update the four
+# DEFAULT_* values below to the new artifact + its md5 in ONE place. Recompute via:
+#   curl -s https://public.sister.software/mailwoman/en-us/<ver>/model.onnx | md5sum
+#   curl -s https://public.sister.software/mailwoman/en-us/<ver>/tokenizer.model | md5sum
+# ---------------------------------------------------------------------------
 set -euo pipefail
 
+# --- current default (releases.json defaultVersion = v4.0.0) ---------------
+# v4.0.0 en-us ships the v0.9.3 multi-locale model (step 20000) + the 0.6.0-a0
+# tokenizer. NB: model-card.json's lineage text ("formerly v0.6.0 step 100000")
+# is stale prose; these md5s are the authoritative bytes the demo serves.
+DEFAULT_MODEL="/mnt/playpen/mailwoman-data/models/quantized/model-v093-step-20000-int8.onnx"
+DEFAULT_MODEL_MD5="0ec9af2ade916b26682f2b9898f1e673"
+DEFAULT_TOKENIZER="/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+DEFAULT_TOKENIZER_MD5="b6137e8c52914c9715374268ecaa4bc6"
+
 PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SRC_MODEL="${MAILWOMAN_DEV_MODEL:-/mnt/playpen/mailwoman-data/models/quantized/model-v053-step-028000-int8.onnx}"
-SRC_TOKENIZER="${MAILWOMAN_DEV_TOKENIZER:-/mnt/playpen/mailwoman-data/models/tokenizer/v0.5.0-a1/tokenizer.model}"
+
+# An explicit override means the caller is deliberately experimenting with a
+# non-default model — skip the hash assertion in that case (but warn loudly).
+MODEL_OVERRIDDEN=0
+TOKENIZER_OVERRIDDEN=0
+[ -n "${MAILWOMAN_DEV_MODEL:-}" ] && MODEL_OVERRIDDEN=1
+[ -n "${MAILWOMAN_DEV_TOKENIZER:-}" ] && TOKENIZER_OVERRIDDEN=1
+
+SRC_MODEL="${MAILWOMAN_DEV_MODEL:-$DEFAULT_MODEL}"
+SRC_TOKENIZER="${MAILWOMAN_DEV_TOKENIZER:-$DEFAULT_TOKENIZER}"
 
 if [ ! -f "$SRC_MODEL" ]; then
 	echo "missing source model: $SRC_MODEL" >&2
@@ -33,3 +71,32 @@ ln -sf "$SRC_TOKENIZER" "$PKG_DIR/tokenizer.model"
 echo "linked:"
 echo "  $PKG_DIR/model.onnx → $SRC_MODEL"
 echo "  $PKG_DIR/tokenizer.model → $SRC_TOKENIZER"
+
+# --- #397 drift guard: assert default bytes match what the demo serves ------
+assert_md5() {
+	local label="$1" path="$2" expected="$3"
+	local actual
+	actual="$(md5sum "$path" | cut -d' ' -f1)"
+	if [ "$actual" != "$expected" ]; then
+		echo "" >&2
+		echo "ERROR (#397 guard): linked default $label md5 mismatch." >&2
+		echo "  linked:   $path" >&2
+		echo "  got:      $actual" >&2
+		echo "  expected: $expected (deployed en-us defaultVersion)" >&2
+		echo "  The dev symlink has drifted from the deployed default. Either the" >&2
+		echo "  artifact moved, or releases.json defaultVersion changed without a" >&2
+		echo "  matching bump to DEFAULT_${label^^}_MD5 in this script." >&2
+		exit 1
+	fi
+}
+
+if [ "$MODEL_OVERRIDDEN" -eq 0 ]; then
+	assert_md5 "model" "$PKG_DIR/model.onnx" "$DEFAULT_MODEL_MD5"
+else
+	echo "  (model override active — skipping #397 default-hash check)" >&2
+fi
+if [ "$TOKENIZER_OVERRIDDEN" -eq 0 ]; then
+	assert_md5 "tokenizer" "$PKG_DIR/tokenizer.model" "$DEFAULT_TOKENIZER_MD5"
+else
+	echo "  (tokenizer override active — skipping #397 default-hash check)" >&2
+fi


### PR DESCRIPTION
## Problem (#397)

`neural/test/weights.test.ts` invokes `link-dev-weights.sh`, so **every `yarn test` re-creates the en-us symlinks**. The script's hardcoded defaults had drifted to a stale **v0.5.3 model + v0.5.0-a1 tokenizer**, while the deployed default is **v4.0.0** (the v0.9.3 multi-locale model, step 20000, + 0.6.0-a0 tokenizer). Net effect: any eval run after a `yarn test` silently graded the wrong model on the wrong tokenizer — exactly the trap that can invalidate a whole eval shift.

Verified the deployed bytes directly:

| artifact | deployed v4.0.0 md5 | local file |
|---|---|---|
| model.onnx | `0ec9af2ade916b26682f2b9898f1e673` | `model-v093-step-20000-int8.onnx` |
| tokenizer.model | `b6137e8c52914c9715374268ecaa4bc6` | `tokenizer/v0.6.0-a0/tokenizer.model` |

## Fix

- Point the script defaults at the correct current artifacts.
- **Drift guard:** when defaults are used (no `MAILWOMAN_DEV_*` override), assert the linked bytes match the expected md5 and **fail loud** on mismatch. A future `defaultVersion` promotion that forgets to bump this script is now caught immediately instead of silently grading stale weights.
- Document the single-place update step for the next default bump.

## Note

`neural-weights-en-us/model-card.json`'s lineage prose ("formerly v0.6.0 step 100000") is **stale** — the md5s above are the authoritative bytes the demo serves. Correcting the model-card is a separate follow-up (does the npm bundle match R2?).

## Stacking

Branched on top of #437 (the TS2883 Router fix) because `main` is currently red — `yarn compile` fails there, so CI can't go green without #437. **Merge #437 first**; the 2-line Router change in this diff disappears once #437 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)