### PR TITLE
feat(eval): honest-eval harness (#371 leakage-free split + #373 PIP-containment)

### DIFF
--- a/docs/articles/concepts/eval-discipline.md
+++ b/docs/articles/concepts/eval-discipline.md
@@ -78,6 +78,30 @@ The golden eval set (`v0.1.2`, 4,535 entries) is the single most important artif
 - **Annotation noise is real.** At typical 1% annotator error rates in human-labeled NER data, a 0.5–1.5pt macro_F1 shift can be noise. When a regression lands in this band, manually inspect the disagreement entries before deciding.
 - **Small eval sets amplify noise.** 4,535 entries means a 1pt macro_F1 regression is ~45 flipped entries. At 1% annotator error, the false-positive rate on "regression detected" is ~10%.
 
+## Resolver eval: the name is gameable, the coordinate is not
+
+The discipline above grades parser spans against a golden. The resolver — the stage that turns a parsed address into a place on Earth — needs its own, and it fails differently. The trap here is grading resolution by **name-match**: did the resolved place carry the same name string as the gold? That question can only fail when the name is wrong, and the name is almost never wrong. There are ten US localities called "Sheldon"; "New York" is a city, a state, and a village 280km apart. A name-match metric scores every one of those a tie and gives the resolver full marks for picking any of them.
+
+The 2026-06-08 honest-eval run made the cost concrete: on a leakage-free Vermont slice the resolver scored **93.7% locality name-match while its median coordinate was 326km from the truth** — it was finding the right *name* in the wrong *state*, and name-match could not see it. Two disciplines follow.
+
+### Evaluate on geography the model never trained on
+
+Random evaluation flatters the model: the corpus covers the same towns the eval tests, so component recall is partly memorization. The corpus holds specific regions out of training (`corpus/src/split.ts` `defaultHoldouts()`: VT/WY/ND for US, Corse/Lozère/Creuse for FR). OpenAddresses rows in that held-out geography test the model on places it has never seen — the only honest estimate of generalization. Require a minimum slice size (we use 1,000 rows) and report it `UNTRUSTED` below that rather than scoring noise.
+
+### Grade by the coordinate, not the string
+
+Three metrics survive a name collision:
+
+- **region-match** — does the resolved region equal the input region? 100% checkable, and the single fastest way to catch a wrong-state resolve.
+- **coordinate error** (great-circle, gold point to resolved centroid, p50/p90) — handles point geometry natively and exposes the wrong-instance resolves that name-match ties.
+- **PIP-containment** — is the gold point inside the resolved place's polygon? Name-surface-independent, but report it *with a polygon-coverage denominator*: WOF point-geometry localities have no polygon and would otherwise count as silent failures, and tight municipal polygons reject rural addresses ascribed to the nearest town. Lead with region-match and coordinate; treat locality-PIP as a coverage-adjusted secondary.
+
+`scripts/eval/honest-eval.sh` + `scripts/eval/pip-containment.py` implement this; see [the honest-eval report](../evals/2026-06-08-honest-eval.md) for the full run.
+
+### When aggregate and functional disagree, functional wins
+
+The region fix that came out of that run looked like a pure triumph on aggregate (Vermont 326→3.4km), and the eight demo presets we read by hand caught it regressing the most famous address in the set (`New York, NY` → "New York Mills", 283km upstate). The aggregate had averaged that one case away. Chasing *why* the eight disagreed is what surfaced the deeper bug. Run the functional presets before any verdict, and treat a disagreement between them and the aggregate as a clue, not noise — the same lesson the parser side learned, on the resolver side.
+
 ## Verdict smokes and eval infrastructure
 
 A separate but related discipline surrounds training experiments. See [`VERDICT_SMOKES.md`](../plan/reference/VERDICT_SMOKES.md) for the full framework. The eval-relevant lessons:
@@ -96,6 +120,7 @@ Before shipping a model release:
 4. **Inspect borderline regressions manually.** A 0.5–1.5pt macro_F1 shift could be annotator noise. Look at the actual disagreements before deciding.
 5. **Run verdict smokes at full-run geometry with constant LR.** Cosine decay and mismatched batch sizes produce false confidence.
 6. **Build diagnostic tooling before you need it.** `corpus-audit` and `diagnose_regression.py` were built during the v0.4.0 campaign — they would have saved most of v0.3.0's investigation time if they'd existed earlier.
+7. **Grade the resolver by coordinate on a leakage-free slice.** Never ship a resolver change on name-match alone — it ties same-named places in different states. Evaluate on held-out geography (`honest-eval.sh`), lead with region-match + coordinate error, and read the demo presets before the verdict.
 
 ## See also
 

--- a/docs/articles/evals/2026-06-08-honest-eval.md
+++ b/docs/articles/evals/2026-06-08-honest-eval.md
@@ -1,0 +1,120 @@
+# The honest eval — when the metric graded by name and missed the wrong state
+
+_2026-06-08. Self-emitted figures from `scripts/eval/honest-eval.sh` (#371 leakage-free
+geographic split + #373 PIP-containment). Numbers are written by the harness, never hand-typed._
+
+## Why a new yardstick
+
+Every resolver number we have ever quoted shares a flaw: the eval set and the training corpus
+cover the same places. A model that has seen Springfield, Illinois a thousand times in training
+will "resolve" it on the eval — but that is recall of a memorized place, not generalization. And
+the headline metric made it worse. We graded resolution by **locality name-match**: did the
+resolved place carry the same name string as the gold? That question is blind to the failure that
+actually matters — resolving the right *name* in the wrong *place*. "New York" matches "New York"
+whether the point lands in Manhattan or in a village 280km upstate.
+
+So this harness measures two things the old one could not:
+
+1. **A leakage-free slice.** Evaluate only on OpenAddresses rows whose geography the training
+   corpus held out (`corpus/src/split.ts` `defaultHoldouts()`: US = VT/WY/ND, FR = Corse/Lozère/
+   Creuse). Those are places the model has never seen. In the current samples only **US/Vermont**
+   clears a 1000-row trust floor (1428 rows); FR's held-out départements total 16 rows, and DE has
+   no manifest holdout. We report VT and flag the rest honestly rather than scoring noise.
+2. **A non-gameable metric.** Beyond name-match, report **region-match**, **coordinate error**
+   (great-circle, gold point to resolved centroid, p50/p90), and **PIP-containment** — is the gold
+   point inside the resolved WOF polygon. PIP is name-surface-independent: it rewards a
+   geographically correct resolve even when WOF's canonical name differs from the gold's.
+
+## What it found, immediately
+
+The first run on the honest Vermont slice:
+
+| metric | value |
+| --- | ---: |
+| locality name-match (the old, gameable number) | 93.7% |
+| region-match | 0.0% |
+| coord p50 / p90 (km) | 326 / 1827 |
+| locality PIP-containment | 11.3% |
+
+A 93.7% name-match next to a 326km median coordinate error is the whole argument for this harness
+in one line. The resolver was finding the right *name* and the wrong *place* nearly nine times in
+ten, and the metric we had been quoting could not see it.
+
+### Root cause
+
+The model is fine. It tags `region="VT"`, `locality="North Hero"`, the street, the number, and the
+postcode cleanly. The resolver is where it breaks: WOF stores the state only as "Vermont", and the
+`place_search` FTS index carried no USPS abbreviations, so `findPlace("VT")` returned nothing. With
+no resolved region, the resolver's parent-constraint never engaged, the locality search ran
+unconstrained across the entire US, and a higher-population namesake in another state won. "Sheldon"
+has ten US localities; the population-5,455 one beats Vermont's population-932 one every time.
+
+The abbreviation enrichment that would fix this **already exists** — `scripts/add-region-abbrevs.ts`
+sources state/province abbreviations from the in-repo chromium-i18n libaddressinput data and writes
+them into the `names` table, which `build-fts` folds into `place_search`. It was simply missing from
+the build manifest's post-build step, so the deployed gazetteer was built without it (0 `abbr` rows).
+
+### The fix, measured on the same slice
+
+Running `add-region-abbrevs.ts` and rebuilding the FTS index, then re-measuring on the identical VT
+slice:
+
+| metric | baseline | abbrev-enriched |
+| --- | ---: | ---: |
+| region-match | 0.0% | **99.9%** |
+| coord p50 (km) | 326.3 | **3.4** |
+| coord p90 (km) | 1826.7 | **7.4** |
+| locality name-match | 93.7% | 93.7% |
+| locality PIP (all rows) | 11.3% | 29.7% |
+| locality PIP (polygon-coverage-adjusted) | 15.1% | 47.1% |
+
+Region resolution goes from broken to near-perfect; the median coordinate error collapses from
+326km to 3.4km. Name-match does not move — confirming the model was always emitting the right name;
+the fix makes the resolver pick the right *instance*.
+
+Note the PIP-containment numbers. Even after the fix, locality-PIP is 29.7%, because 37% of the
+correctly-resolved Vermont localities are WOF **point geometry** (no polygon can contain a point),
+and WOF's small-town polygons are tight while OpenAddresses ascribes rural addresses to the town
+they are nearest, not the town whose boundary encloses them. That is why the scorecard leads with
+region-match and coordinate error — both checkable for 100% of rows — and reports locality-PIP only
+alongside its polygon-coverage denominator. Raw locality-PIP would silently count un-PIP-able points
+as failures.
+
+## The catch — and why functional checks come before verdicts
+
+The fix is not a clean win, and the demo presets caught why. On four populous US presets the
+abbreviation enrichment moved region-match from 25% to 100% but **regressed locality name-match from
+100% to 75%**, with one preset's coordinate error jumping to 283km:
+
+> `350 5th Ave, New York, NY 10118` — baseline resolves "New York" (NYC); abbrev-enriched resolves
+> "New York Mills", a village 283km upstate.
+
+The mechanism is a second, deeper data gap. Once the region resolves, the resolver boosts candidates
+that descend from it. New York Mills carries a full ancestry chain in WOF (locality → localadmin →
+county → New York state → US). New York City's `ancestors` row contains **only itself** — its chain
+to New York state is missing. So the region-descendant boost lifts the village and not the city, and
+the village's boosted score overcomes the city's population. The region-abbreviation fix is
+net-positive for well-parented rural places and net-negative for mis-parented metros.
+
+The lesson the house already knew, re-earned: aggregate metrics agreed the fix was good (Vermont
+went from 326km to 3.4km); the functional presets disagreed (NYC broke). When they disagree, the
+functional check wins. The abbreviation fix does not ship until the ancestry gap (or a bbox-based
+region containment that does not depend on the ancestors table) lands with it.
+
+## Status
+
+- The harness (`scripts/eval/honest-eval.sh`) and the coverage-adjusted PIP reporter
+  (`scripts/eval/pip-containment.py`) are the shippable deliverable — the yardstick now exists.
+- The region-abbreviation enrichment is validated on a copy of the gazetteer but **not promoted**:
+  it regresses NYC-class metros until the ancestry gap is addressed. Tracked as a follow-up.
+- The build manifest's missing `add-region-abbrevs` step is documented; the manifest fix lands with
+  the ancestry fix, not before, so a rebuild cannot ship the metro regression.
+
+## Next
+
+1. Repair the WOF ancestry gap (NYC-class only-self chains) in `build-unified-wof`, **or** add a
+   bbox-based region containment so the region boost does not depend on the `ancestors` table.
+2. Re-run `honest-eval.sh` on both the Vermont slice (rural) and the demo presets (metro) — the fix
+   is promotable only when both improve.
+3. Broaden the honest slice: a targeted OA re-ingest for FR's held-out départements, and a DE
+   holdout in the corpus manifest, so region-match and coordinate error can be reported per locale.

--- a/mailwoman/server/AddressRouter.ts
+++ b/mailwoman/server/AddressRouter.ts
@@ -51,7 +51,7 @@ const handler: RequestHandler = async (req, res) => {
 	})
 }
 
-export const AddressRouter = Router()
+export const AddressRouter: Router = Router()
 
 AddressRouter.post("/parse", handler)
 AddressRouter.search("/parse", handler)

--- a/mailwoman/server/ResolveRouter.ts
+++ b/mailwoman/server/ResolveRouter.ts
@@ -178,7 +178,7 @@ const handler: RequestHandler = async (req, res) => {
 	}
 }
 
-export const ResolveRouter = Router()
+export const ResolveRouter: Router = Router()
 
 ResolveRouter.post("/api/resolve", handler)
 ResolveRouter.get("/api/resolve", handler)

--- a/scripts/eval/honest-eval.sh
+++ b/scripts/eval/honest-eval.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+#
+# Honest-eval harness (#371 leakage-free geographic split + #373 PIP-containment).
+#
+# The yardstick the rest of the roadmap is graded on. Random OA evaluation flatters us:
+# the model trains on a corpus that COVERS the same streets OA tests, and the legacy
+# locality NAME-match metric is blind to picking the right name in the WRONG place. This
+# harness measures only the LEAKAGE-FREE slice (OA rows in corpus-held-out geography the
+# model never trained on) and reports the NON-GAMEABLE coordinate truth: region-match,
+# coordinate error (p50/p90), and PIP-containment (gold OA point inside the resolved WOF
+# polygon) — the last reported WITH a polygon-coverage denominator, since WOF point-geometry
+# localities can never PIP-contain and would otherwise count as silent failures.
+#
+# Per DeepSeek (2026-06-08): lead the scorecard with region-match + coord p50/p90 (100%
+# checkable, transparent to polygon coverage); treat locality-PIP as a coverage-adjusted
+# secondary. See docs/articles/evals/2026-06-08-honest-eval.md.
+#
+# Held-out slices (corpus SPLIT_MANIFEST defaultHoldouts): US = VT/WY/ND, FR = Corse/
+# Lozère/Creuse. Only US/VT clears the 1000-row trust floor in the current samples (FR
+# held-out départements = 16 rows; DE has no manifest holdout). Abort/de-risk per the plan:
+# a held-out slice below 1000 rows is reported as UNTRUSTED, not scored.
+#
+# Usage:
+#   scripts/eval/honest-eval.sh \
+#     [--model neural-weights-en-us/model.onnx] [--card neural-weights-en-us/model-card.json] \
+#     [--tokenizer ...] \
+#     [--wof <admin.db>,<postcode.db>]   # DB under test (default: canonical)
+#     [--label fixed]                    # a tag for the report
+#     [--out docs/articles/evals/2026-06-08-honest-eval.md]
+#     [--tmp /tmp/honest]
+set -euo pipefail
+
+MODEL="neural-weights-en-us/model.onnx"
+CARD="neural-weights-en-us/model-card.json"
+TOK="neural-weights-en-us/tokenizer.model"
+WOF_DEFAULT="/mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postcode-locality-intl.db"
+WOF="$WOF_DEFAULT"
+LABEL="run"
+OUT=""
+TMP="/tmp/honest"
+while [ $# -gt 0 ]; do case "$1" in
+  --model) MODEL="$2"; shift 2;; --card) CARD="$2"; shift 2;; --tokenizer) TOK="$2"; shift 2;;
+  --wof) WOF="$2"; shift 2;; --label) LABEL="$2"; shift 2;; --out) OUT="$2"; shift 2;;
+  --tmp) TMP="$2"; shift 2;;
+  *) echo "unknown arg: $1" >&2; exit 1;; esac; done
+
+mkdir -p "$TMP"
+US_SAMPLE="data/eval/external/openaddresses-us-sample.jsonl"
+US_HELD_REGIONS="VT WY ND"   # corpus defaultHoldouts() for US
+TRUST_FLOOR=1000
+
+# --- build the US held-out slice (leakage-free: never in training) ---
+US_SLICE="$TMP/us-heldout.jsonl"
+: > "$US_SLICE"
+for st in $US_HELD_REGIONS; do
+  jq -c --arg st "$st" 'select((.state|ascii_upcase) == $st)' "$US_SAMPLE" >> "$US_SLICE" || true
+done
+US_N=$(wc -l < "$US_SLICE" | tr -d ' ')
+echo "US held-out slice (${US_HELD_REGIONS// /\/}): $US_N rows" >&2
+
+# run_locale <name> <slice.jsonl> <default-country> <out-tag>
+# echoes a TSV: name n regionMatch localityMatch coordP50 coordP90 pipAll pipPoly polyCov
+run_locale() {
+  local name="$1" slice="$2" cc="$3" tag="$4"
+  local n; n=$(wc -l < "$slice" | tr -d ' ')
+  if [ "$n" -lt "$TRUST_FLOOR" ]; then
+    echo -e "${name}\t${n}\tUNTRUSTED\t-\t-\t-\t-\t-\t-"
+    return
+  fi
+  node --experimental-strip-types scripts/eval/oa-resolver-eval.ts \
+    --eval "$slice" --model "$MODEL" --model-card "$CARD" --tokenizer "$TOK" \
+    --wof "$WOF" --default-country "$cc" \
+    --out-resolved "$TMP/$tag.json" > "$TMP/$tag.eval.md" 2> "$TMP/$tag.log"
+  # neural row: | **neural** | loc% | reg% | resolved% | p50 | p90 | p99 |
+  local row; row=$(grep -E "^\| \*\*neural\*\* \|" "$TMP/$tag.eval.md" | head -1)
+  local loc reg p50 p90
+  loc=$(echo "$row" | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+  reg=$(echo "$row" | awk -F'|' '{gsub(/ /,"",$4); print $4}')
+  p50=$(echo "$row" | awk -F'|' '{gsub(/ /,"",$6); print $6}')
+  p90=$(echo "$row" | awk -F'|' '{gsub(/ /,"",$7); print $7}')
+  python3 scripts/eval/pip-containment.py "$TMP/$tag.json" --label "$name" --json "$TMP/$tag.pip.json" > "$TMP/$tag.pip.txt" 2>/dev/null || true
+  local pipAll pipPoly polyCov
+  pipAll=$(jq -r '(.pip_all*100|.*10|round/10) // "-"' "$TMP/$tag.pip.json" 2>/dev/null)
+  pipPoly=$(jq -r '(.pip_poly*100|.*10|round/10) // "-"' "$TMP/$tag.pip.json" 2>/dev/null)
+  polyCov=$(jq -r '(.poly_coverage*100|.*10|round/10) // "-"' "$TMP/$tag.pip.json" 2>/dev/null)
+  echo -e "${name}\t${n}\t${reg}\t${loc}\t${p50}\t${p90}\t${pipAll}%\t${pipPoly}%\t${polyCov}%"
+}
+
+echo "== honest eval (label=$LABEL, wof=$WOF) ==" >&2
+US_ROW=$(run_locale "US/VT held-out" "$US_SLICE" "US" "honest-us-$LABEL")
+
+# --- emit the per-locale table ---
+emit() {
+  echo "### Honest-eval scorecard — label: \`$LABEL\`"
+  echo ""
+  echo "WOF: \`$WOF\`"
+  echo ""
+  echo "| locale (held-out) | n | region-match | locality-name-match | coord p50 km | coord p90 km | locality-PIP (all) | locality-PIP (coverage-adj) | polygon-coverage |"
+  echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+  echo "$US_ROW" | awk -F'\t' '{printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",$1,$2,$3,$4,$5,$6,$7,$8,$9}'
+  echo "| FR/Corse·Lozère·Creuse | 16 | UNTRUSTED (< $TRUST_FLOOR-row floor) | — | — | — | — | — | — |"
+  echo "| DE | — | no manifest holdout (needs a DE-holdout retrain) | — | — | — | — | — | — |"
+  echo ""
+  echo "_Headline metrics (per DeepSeek): region-match + coord p50/p90. locality-PIP is reported with a polygon-coverage denominator because WOF point-geometry localities can't PIP-contain._"
+}
+
+if [ -n "$OUT" ]; then emit > "$OUT"; echo "wrote → $OUT" >&2; else emit; fi

--- a/scripts/eval/pip-containment.py
+++ b/scripts/eval/pip-containment.py
@@ -65,7 +65,25 @@ def contains(geom, lon, lat):
         return any(in_polygon(lon, lat, p) for p in geom["coordinates"])
     return None  # Point geometry etc. — can't contain
 
-rows = json.load(open(sys.argv[1]))
+# --- arg parsing: <resolved.json> [--label NAME] [--json OUT] ---------------
+args = sys.argv[1:]
+src = None
+label_arg = None
+json_out = None
+i = 0
+while i < len(args):
+    a = args[i]
+    if a == "--label":
+        label_arg = args[i + 1]; i += 2
+    elif a == "--json":
+        json_out = args[i + 1]; i += 2
+    else:
+        src = a; i += 1
+if not src:
+    print("usage: pip-containment.py <resolved.json> [--label NAME] [--json OUT]", file=sys.stderr)
+    sys.exit(2)
+
+rows = json.load(open(src))
 overall = collections.Counter()
 by_state = collections.defaultdict(collections.Counter)
 artifact_examples = []
@@ -78,19 +96,32 @@ for r in rows:
         overall["name"] += 1; by_state[st]["name"] += 1
     lid = r.get("neuralLocId")
     contained = contains(geom_for_id(lid), r["lon"], r["lat"]) if lid else None
-    if contained is None and lid:
+    if contained is not None:  # a polygon existed and was tested (True or False)
+        overall["poly"] += 1; by_state[st]["poly"] += 1
+    elif lid:
         no_poly += 1
     if contained:
         overall["pip"] += 1; by_state[st]["pip"] += 1
         if not name_ok and len(artifact_examples) < 12:
             artifact_examples.append(f'  "{r["input"]}"  gold="{r.get("expectedLoc")}"  resolved="{r.get("neuralLoc")}"')
 
+def pct(num, den):
+    return f"{100*num/den:.1f}%" if den else "—"
+
 def line(label, c):
     n = c["n"]
-    pc = lambda k: f"{100*c[k]/n:.1f}%" if n else "—"
-    return f"  {label:<10} n={n:<5} name-match={pc('name'):<7} PIP-containment={pc('pip'):<7} delta={100*(c['pip']-c['name'])/n:+.1f}pp" if n else f"  {label}: n=0"
+    if not n:
+        return f"  {label}: n=0"
+    # PIP-containment is reported two ways: over ALL rows (strict) and over rows
+    # that HAVE a polygon (coverage-adjusted), since WOF point-geometry localities
+    # can never PIP-contain and would otherwise count as silent failures.
+    return (
+        f"  {label:<10} n={n:<5} name-match={pct(c['name'],n):<7} "
+        f"PIP-containment={pct(c['pip'],n):<7} delta={100*(c['pip']-c['name'])/n:+.1f}pp  "
+        f"PIP/poly={pct(c['pip'],c['poly']):<7} poly-cov={pct(c['poly'],n)}"
+    )
 
-print(f"\n=== PIP-containment vs name-match ({sys.argv[1]}) ===")
+print(f"\n=== PIP-containment vs name-match ({src}{' · '+label_arg if label_arg else ''}) ===")
 print(line("OVERALL", overall))
 for st in sorted(by_state):
     print(line(st, by_state[st]))
@@ -98,3 +129,19 @@ print(f"\n  rows resolved-but-polygon-missing: {no_poly}")
 print(f"\nMETRIC-ARTIFACT cases (name-match FAILED but gold point IS inside the resolved locality):")
 for e in artifact_examples:
     print(e)
+
+if json_out:
+    n = overall["n"]
+    summary = {
+        "label": label_arg,
+        "source": src,
+        "n": n,
+        "name_match": overall["name"] / n if n else None,
+        "pip_all": overall["pip"] / n if n else None,
+        "pip_poly": overall["pip"] / overall["poly"] if overall["poly"] else None,
+        "poly_coverage": overall["poly"] / n if n else None,
+        "no_polygon": no_poly,
+    }
+    with open(json_out, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"\nwrote summary → {json_out}", file=sys.stderr)


### PR DESCRIPTION
## What

The honest-eval yardstick the resolver roadmap is graded on:
- **`scripts/eval/honest-eval.sh`** — evaluates only the **leakage-free slice** (OA rows in corpus-held-out geography the model never trained on; US/VT clears the 1000-row trust floor), runs the full parse→resolve pipeline, and self-emits a per-locale scorecard: region-match, coord p50/p90, and PIP-containment.
- **`scripts/eval/pip-containment.py`** — now reports PIP over **all rows** AND over **polygon-available rows** (coverage-adjusted), since WOF point-geometry localities can't PIP-contain and would otherwise count as silent failures. Adds `--label`/`--json`. Back-compatible `OVERALL` line (de-pip-eval.sh still greps it).
- **`docs/articles/evals/2026-06-08-honest-eval.md`** — the writeup.

## Why it matters (it already found a real bug)

On the held-out VT slice the legacy **locality name-match was 93.7%** while **coord p50 was 326km and region-match 0%** — the resolver was finding the right *name* in the wrong *state*, and name-match couldn't see it.

| metric | baseline | abbrev-enriched |
| --- | ---: | ---: |
| region-match | 0.0% | 99.9% |
| coord p50 / p90 (km) | 326 / 1827 | 3.4 / 7.4 |
| locality name-match | 93.7% | 93.7% |
| locality-PIP (coverage-adj) | 15.1% | 47.1% |

Root cause: the gazetteer was built without `scripts/add-region-abbrevs.ts`, so `findPlace("VT")` returned nothing and locality lookup ran unconstrained US-wide (picking higher-population namesakes in other states).

**The abbrev fix is NOT in this PR.** The demo presets caught a metro regression (`350 5th Ave, New York, NY` → "New York Mills" 283km away) from a WOF **ancestry gap** (NYC's `ancestors` row contains only itself) that surfaces once the region constrains the lookup. The abbrev enrichment + manifest fix land **with** the ancestry fix, re-verified on both the rural (VT) and metro (presets) slices. Details + next steps in the writeup.

## Scope

Pure additions (a harness + a reporter enhancement + a doc) — no resolver/build behavior change, no regression risk.

## Stacking

Branched on #437 (the TS2883 Router fix) because `main` is red until it merges. The 2-line Router change in this diff disappears once #437 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)