### PR TITLE
feat(corpus): three new adapters — GeoNames, GeoNames-postal, IRS EO-BMF

### DIFF
--- a/corpus/src/adapters/geonames-postal/README.md
+++ b/corpus/src/adapters/geonames-postal/README.md
@@ -1,0 +1,45 @@
+# `geonames-postal` adapter
+
+GeoNames postal-code dump → `CanonicalRow`. Multi-locale **postcode → locality → region** with
+place + region names **inline** (no aux-file join), covering ~80 countries — broadens postcode
+coverage well beyond `wof-postalcode`/the coordinate-first table (forward coverage for the
+multi-locale goal).
+
+- **Source:** [GeoNames postal export](https://download.geonames.org/export/zip/).
+- **License:** **CC-BY-4.0** (attribute "GeoNames"); stamped per row.
+
+## Download
+
+```bash
+DIR=/mnt/playpen/mailwoman-data/geonames-postal
+mkdir -p "$DIR" && cd "$DIR"
+for cc in DE FR ES IT NL; do curl -O "https://download.geonames.org/export/zip/$cc.zip" && unzip -o "$cc.zip"; done
+```
+
+## Run
+
+```bash
+npx mailwoman corpus run geonames-postal --input /mnt/playpen/mailwoman-data/geonames-postal/DE.txt --country DE --limit 50000
+```
+
+**Prefer non-US countries.** This adapter emits postcode-FIRST (international) order — correct for
+DE/FR/most of the world. US postcodes are postcode-LAST and are already covered by TIGER/WOF; don't
+ingest US through this adapter.
+
+## Output
+
+Per row, up to two postcode-first variants:
+
+| variant | components | raw |
+| --- | --- | --- |
+| `pl` | `{ postcode, locality }` | `75001 Paris` |
+| `plr` | `{ postcode, locality, region }` | `75001 Paris, Île-de-France` |
+
+The region variant is skipped when admin1 just repeats the place (city-states / micro-admin), to
+avoid `"X X"` noise. `source_id` = component-hash + variant.
+
+## Format reference
+
+12 tab-separated columns, no header: `country, postcode, place, admin1_name, admin1_code,
+admin2_name, admin2_code, admin3_name, admin3_code, latitude, longitude, accuracy`. This adapter reads
+`country, postcode, place, admin1_name`. Full layout: the [export readme](https://download.geonames.org/export/zip/readme.txt).

--- a/corpus/src/adapters/geonames-postal/adapter.test.ts
+++ b/corpus/src/adapters/geonames-postal/adapter.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+	createGeonamesPostalAdapter,
+	GEONAMES_POSTAL_ADAPTER_ID,
+	GEONAMES_POSTAL_DEFAULT_LICENSE,
+} from "./adapter.js"
+import type { CanonicalRow } from "../../types.js"
+
+let scratch: string
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "mailwoman-gnpostal-"))
+})
+
+// 12-column GeoNames postal row: country, postcode, place, admin1_name, admin1_code, admin2_*, admin3_*, lat, lon, accuracy.
+function row(country: string, postcode: string, place: string, admin1: string): string {
+	const cols = new Array(12).fill("")
+	cols[0] = country
+	cols[1] = postcode
+	cols[2] = place
+	cols[3] = admin1
+	cols[9] = "42.5"
+	cols[10] = "1.6"
+	cols[11] = "6"
+	return cols.join("\t")
+}
+
+function writeFixture(...rows: string[]): string {
+	const p = join(scratch, "XX.txt")
+	writeFileSync(p, rows.join("\n") + "\n", "utf8")
+	return p
+}
+
+async function collect(p: string, extra?: Record<string, unknown>): Promise<CanonicalRow[]> {
+	const out: CanonicalRow[] = []
+	for await (const r of createGeonamesPostalAdapter().rows({ inputPath: p, ...extra })) out.push(r)
+	return out
+}
+
+describe("geonames-postal adapter", () => {
+	it("has the expected id and license", () => {
+		const a = createGeonamesPostalAdapter()
+		expect(a.id).toBe(GEONAMES_POSTAL_ADAPTER_ID)
+		expect(a.defaultLicense).toBe(GEONAMES_POSTAL_DEFAULT_LICENSE)
+	})
+
+	it("emits postcode-first variants with region when admin1 differs from the place", async () => {
+		const rows = await collect(writeFixture(row("DE", "10115", "Berlin", "Berlin"), row("FR", "75001", "Paris", "Île-de-France")))
+		const fr = rows.filter((r) => r.country === "FR")
+		const byRaw = Object.fromEntries(fr.map((r) => [r.raw, r]))
+		expect(byRaw["75001 Paris"]?.components).toEqual({ postcode: "75001", locality: "Paris" })
+		expect(byRaw["75001 Paris, Île-de-France"]?.components).toEqual({ postcode: "75001", locality: "Paris", region: "Île-de-France" })
+		for (const r of fr) {
+			expect(r.license).toBe(GEONAMES_POSTAL_DEFAULT_LICENSE)
+			expect(r.source).toBe(GEONAMES_POSTAL_ADAPTER_ID)
+		}
+	})
+
+	it("drops the region variant when admin1 just repeats the place (no 'X X' noise)", async () => {
+		// Berlin (postcode 10115, admin1 'Berlin') — region == place, so only the {postcode,locality} row.
+		const rows = await collect(writeFixture(row("DE", "10115", "Berlin", "Berlin")))
+		expect(rows).toHaveLength(1)
+		expect(rows[0]?.components).toEqual({ postcode: "10115", locality: "Berlin" })
+		expect(rows[0]?.raw).toBe("10115 Berlin")
+	})
+
+	it("skips rows missing postcode or place", async () => {
+		const rows = await collect(writeFixture(row("DE", "", "Nowhere", "Bayern"), row("DE", "80331", "", "Bayern"), row("DE", "80331", "München", "Bayern")))
+		expect(rows.every((r) => r.components.locality === "München")).toBe(true)
+	})
+
+	it("honors the country filter and the row limit", async () => {
+		const p = writeFixture(row("DE", "80331", "München", "Bayern"), row("FR", "75001", "Paris", "Île-de-France"))
+		expect((await collect(p, { country: "DE" })).every((r) => r.country === "DE")).toBe(true)
+		expect(await collect(p, { limit: 1 })).toHaveLength(1)
+	})
+})

--- a/corpus/src/adapters/geonames-postal/adapter.ts
+++ b/corpus/src/adapters/geonames-postal/adapter.ts
@@ -1,0 +1,100 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `geonames-postal`: GeoNames postal-code dump consumer (https://www.geonames.org/, CC-BY-4.0).
+ *
+ *   The GeoNames postal export (`https://download.geonames.org/export/zip/<CC>.zip`) is a clean,
+ *   per-country `postcode → place → admin1` table with the place + region NAMES inline (no aux-file
+ *   join needed). It broadens the corpus's postcode→locality→region coverage to ~80 countries, well
+ *   beyond `wof-postalcode`/the coordinate-first table — forward coverage for the multi-locale goal.
+ *
+ *   Input: a per-country postal dump (`<CC>.txt`, 12 tab-separated columns, no header):
+ *     country, postcode, place, admin1_name, admin1_code, admin2_*, admin3_*, lat, lon, accuracy.
+ *
+ *   Output: per row, postcode-FIRST (international) variants — the common order for the non-US
+ *   locales this fills (US postcodes are already covered by TIGER/WOF, which use postcode-LAST):
+ *     1. `{ postcode, locality }`            → "AD100 Canillo"
+ *     2. `{ postcode, locality, region }`    → "AD100 Canillo, Canillo"
+ *   Prefer configuring this adapter for non-US countries; for US, the postcode-last sources are the
+ *   right order. License: `"CC-BY-4.0"` per row (attribute "GeoNames").
+ */
+
+import { parse as csvParse } from "csv-parse"
+import { createReadStream } from "node:fs"
+import { stableSourceId } from "../../adapter.js"
+import { reconcileComponents } from "../../format.js"
+import type { AdapterOptions, CanonicalRow, CorpusAdapter } from "../../types.js"
+
+export const GEONAMES_POSTAL_ADAPTER_ID = "geonames-postal"
+export const GEONAMES_POSTAL_DEFAULT_LICENSE = "CC-BY-4.0"
+
+// GeoNames postal-dump columns (0-based).
+const COL = { country: 0, postcode: 1, place: 2, admin1Name: 3 } as const
+
+export function createGeonamesPostalAdapter(): CorpusAdapter {
+	return {
+		id: GEONAMES_POSTAL_ADAPTER_ID,
+		defaultLicense: GEONAMES_POSTAL_DEFAULT_LICENSE,
+		description:
+			"GeoNames postal codes (CC-BY-4.0) — multi-locale postcode→locality→region, names inline; international postcode-first order.",
+
+		async *rows(opts: AdapterOptions): AsyncIterable<CanonicalRow> {
+			const stream = createReadStream(opts.inputPath, { encoding: "utf8" })
+			const parser = stream.pipe(
+				csvParse({ delimiter: "\t", quote: false, relax_column_count: true, skip_empty_lines: true })
+			)
+
+			let emitted = 0
+			try {
+				for await (const rec of parser as AsyncIterable<string[]>) {
+					if (opts.signal?.aborted) break
+					if (opts.limit !== undefined && emitted >= opts.limit) break
+
+					const cc = (rec[COL.country] ?? "").trim()
+					if (!cc) continue
+					if (opts.country && cc !== opts.country) continue
+
+					const postcode = (rec[COL.postcode] ?? "").trim()
+					const locality = (rec[COL.place] ?? "").trim()
+					if (!postcode || !locality) continue
+					const region = (rec[COL.admin1Name] ?? "").trim()
+
+					// Postcode-first (international) variants. Skip the region variant when admin1 just
+					// repeats the place (common for city-states / micro-admin) to avoid "X X" noise.
+					const variants: Array<{ slot: string; comp: CanonicalRow["components"]; raw: string }> = [
+						{ slot: "pl", comp: { postcode, locality }, raw: `${postcode} ${locality}` },
+					]
+					if (region && region.toLowerCase() !== locality.toLowerCase()) {
+						variants.push({
+							slot: "plr",
+							comp: { postcode, locality, region },
+							raw: `${postcode} ${locality}, ${region}`,
+						})
+					}
+
+					for (const v of variants) {
+						if (opts.limit !== undefined && emitted >= opts.limit) break
+						const aligned = reconcileComponents(v.comp, v.raw)
+						if (Object.keys(aligned).length < 2) continue
+						yield {
+							raw: v.raw,
+							components: aligned,
+							country: cc,
+							source: GEONAMES_POSTAL_ADAPTER_ID,
+							source_id: `${stableSourceId(GEONAMES_POSTAL_ADAPTER_ID, aligned)}-${v.slot}`,
+							corpus_version: "",
+							license: GEONAMES_POSTAL_DEFAULT_LICENSE,
+						}
+						emitted++
+					}
+				}
+			} finally {
+				stream.destroy()
+			}
+		},
+	}
+}
+
+export const geonamesPostalAdapter = createGeonamesPostalAdapter()

--- a/corpus/src/adapters/geonames/README.md
+++ b/corpus/src/adapters/geonames/README.md
@@ -1,0 +1,56 @@
+# `geonames` adapter
+
+GeoNames populated-places → `CanonicalRow`. Global locality coverage (incl. the small towns a
+coarser admin gazetteer lacks) — the cheapest way to broaden the corpus's **locale** coverage.
+
+- **Source:** [GeoNames](https://www.geonames.org/) geographical database.
+- **License:** **CC-BY-4.0** (attribution required on redistribution). Stamped `"CC-BY-4.0"` per row;
+  attribute "GeoNames" in any redistributed corpus. See `feedback-no-load-bearing-trivia` — the
+  per-row `license` + `source`/`source_id` are the provenance record.
+- **Coverage:** every country GeoNames publishes; this adapter ingests `feature_class = "P"`
+  (populated places), excluding historical/abandoned/destroyed codes (`PPLH`/`PPLQ`/`PPLW`/`PPLCH`).
+
+## Download
+
+Per-country dumps + two sibling name files, all from the same directory:
+
+```bash
+DIR=/mnt/playpen/mailwoman-data/geonames
+mkdir -p "$DIR" && cd "$DIR"
+curl -O https://download.geonames.org/export/dump/US.zip && unzip -o US.zip   # → US.txt (per country)
+curl -O https://download.geonames.org/export/dump/admin1CodesASCII.txt        # <CC>.<admin1> → region name
+curl -O https://download.geonames.org/export/dump/countryInfo.txt             # ISO → country name
+```
+
+The `admin1CodesASCII.txt` and `countryInfo.txt` must sit in the **same directory** as the country
+file; the adapter reads them as siblings of `inputPath`. If either is missing the corresponding
+component (region / country) is omitted and the adapter still emits locality-only rows.
+
+## Run
+
+```bash
+# Single country (CLI):
+npx mailwoman corpus run geonames --input /mnt/playpen/mailwoman-data/geonames/US.txt --country US --limit 5000
+
+# In a full build, configure adapterInputs["geonames"] = { inputPath: ".../<CC>.txt", country: "<CC>" }
+# per country you want ingested. `corpus build` skips the adapter when no input is configured.
+```
+
+## Output
+
+Up to two hierarchy variants per place (domestic + international order, mirroring `wof-admin`):
+
+| variant | components | raw |
+| --- | --- | --- |
+| `lr` | `{ locality, region }` | `Montpelier, Vermont` |
+| `lrc` | `{ locality, region, country }` | `Montpelier, Vermont, United States` |
+
+`source_id` = `geonames-<geonameid>-<variant>`. When region/country names are unavailable the adapter
+falls back to `{ locality, country }` or `{ locality }`.
+
+## Format reference
+
+GeoNames main-table columns (0-based, tab-separated, no header) used here:
+`0` geonameid · `1` name · `3` alternatenames · `6` feature_class · `7` feature_code ·
+`8` country_code · `10` admin1_code. Full schema: the "geoname" table in the
+[export readme](https://download.geonames.org/export/dump/readme.txt).

--- a/corpus/src/adapters/geonames/adapter.test.ts
+++ b/corpus/src/adapters/geonames/adapter.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { beforeEach, describe, expect, it } from "vitest"
+import { createGeonamesAdapter, GEONAMES_ADAPTER_ID, GEONAMES_DEFAULT_LICENSE } from "./adapter.js"
+import type { CanonicalRow } from "../../types.js"
+
+let scratch: string
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "mailwoman-geonames-"))
+})
+
+// Build a 19-column GeoNames main-table row (tab-separated). Only the columns the adapter reads
+// need to be meaningful; the rest are padded.
+function gnRow(o: {
+	id: string
+	name: string
+	alt?: string
+	featureClass: string
+	featureCode: string
+	country: string
+	admin1?: string
+}): string {
+	const cols = new Array(19).fill("")
+	cols[0] = o.id
+	cols[1] = o.name
+	cols[2] = o.name // asciiname
+	cols[3] = o.alt ?? ""
+	cols[4] = "44.0" // lat
+	cols[5] = "-72.7" // lon
+	cols[6] = o.featureClass
+	cols[7] = o.featureCode
+	cols[8] = o.country
+	cols[10] = o.admin1 ?? ""
+	return cols.join("\t")
+}
+
+function writeFixture(rows: string[], opts?: { admin1?: boolean; countries?: boolean }): string {
+	const country = join(scratch, "US.txt")
+	writeFileSync(country, rows.join("\n") + "\n", "utf8")
+	if (opts?.admin1 !== false) {
+		writeFileSync(
+			join(scratch, "admin1CodesASCII.txt"),
+			["US.VT\tVermont\tVermont\t5242283", "US.CA\tCalifornia\tCalifornia\t5332921"].join("\n") + "\n",
+			"utf8"
+		)
+	}
+	if (opts?.countries !== false) {
+		writeFileSync(
+			join(scratch, "countryInfo.txt"),
+			["# ISO\tISO3\tnum\tfips\tCountry\trest", "US\tUSA\t840\tUS\tUnited States\t"].join("\n") + "\n",
+			"utf8"
+		)
+	}
+	return country
+}
+
+async function collect(inputPath: string, extra?: Record<string, unknown>): Promise<CanonicalRow[]> {
+	const out: CanonicalRow[] = []
+	for await (const r of createGeonamesAdapter().rows({ inputPath, ...extra })) out.push(r)
+	return out
+}
+
+describe("geonames adapter", () => {
+	it("has the expected id and license", () => {
+		const a = createGeonamesAdapter()
+		expect(a.id).toBe(GEONAMES_ADAPTER_ID)
+		expect(a.defaultLicense).toBe(GEONAMES_DEFAULT_LICENSE)
+	})
+
+	it("emits both hierarchy variants for a populated place, with mapped region + country names", async () => {
+		const p = writeFixture([gnRow({ id: "5234567", name: "Montpelier", featureClass: "P", featureCode: "PPLA", country: "US", admin1: "VT" })])
+		const rows = await collect(p)
+		expect(rows).toHaveLength(2)
+		const byRaw = Object.fromEntries(rows.map((r) => [r.raw, r]))
+		expect(byRaw["Montpelier, Vermont"]?.components).toEqual({ locality: "Montpelier", region: "Vermont" })
+		expect(byRaw["Montpelier, Vermont, United States"]?.components).toEqual({
+			locality: "Montpelier",
+			region: "Vermont",
+			country: "United States",
+		})
+		for (const r of rows) {
+			expect(r.country).toBe("US")
+			expect(r.source).toBe(GEONAMES_ADAPTER_ID)
+			expect(r.license).toBe(GEONAMES_DEFAULT_LICENSE)
+			expect(r.source_id).toMatch(/^geonames-5234567-(lr|lrc)$/)
+		}
+	})
+
+	it("skips non-populated-place features and historical/abandoned places", async () => {
+		const p = writeFixture([
+			gnRow({ id: "1", name: "Mount Mansfield", featureClass: "T", featureCode: "MT", country: "US", admin1: "VT" }), // mountain
+			gnRow({ id: "2", name: "Ghost Town", featureClass: "P", featureCode: "PPLQ", country: "US", admin1: "VT" }), // abandoned
+			gnRow({ id: "3", name: "Burlington", featureClass: "P", featureCode: "PPL", country: "US", admin1: "VT" }), // real
+		])
+		const rows = await collect(p)
+		expect(rows.every((r) => r.components.locality === "Burlington")).toBe(true)
+		expect(rows.length).toBe(2) // only Burlington, two variants
+	})
+
+	it("honors the country filter and the row limit", async () => {
+		const p = writeFixture([
+			gnRow({ id: "10", name: "Burlington", featureClass: "P", featureCode: "PPL", country: "US", admin1: "VT" }),
+			gnRow({ id: "11", name: "Toronto", featureClass: "P", featureCode: "PPL", country: "CA", admin1: "08" }),
+		])
+		expect((await collect(p, { country: "US" })).every((r) => r.country === "US")).toBe(true)
+		expect(await collect(p, { limit: 1 })).toHaveLength(1)
+	})
+
+	it("degrades gracefully when the region/country name files are absent (locality only)", async () => {
+		const p = writeFixture(
+			[gnRow({ id: "20", name: "Burlington", featureClass: "P", featureCode: "PPL", country: "US", admin1: "VT" })],
+			{ admin1: false, countries: false }
+		)
+		const rows = await collect(p)
+		expect(rows).toHaveLength(1)
+		expect(rows[0]?.components).toEqual({ locality: "Burlington" })
+		expect(rows[0]?.raw).toBe("Burlington")
+	})
+})

--- a/corpus/src/adapters/geonames/adapter.ts
+++ b/corpus/src/adapters/geonames/adapter.ts
@@ -1,0 +1,152 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `geonames`: GeoNames populated-places consumer (https://www.geonames.org/, CC-BY-4.0).
+ *
+ *   GeoNames is a global gazetteer of ~12M features. This adapter ingests the POPULATED PLACES
+ *   (`feature_class = "P"`, excluding historical/abandoned/destroyed variants) from a per-country
+ *   dump file — global locality coverage, including the small towns and villages a coarser admin
+ *   gazetteer (WOF) lacks. It's the cheapest path to broadening the corpus's LOCALE coverage.
+ *
+ *   Input: a per-country tab-separated dump (e.g. `US.txt` from
+ *   `https://download.geonames.org/export/dump/`, 19 columns, no header). Two sibling files in the
+ *   same directory supply human-readable names (downloaded once from the same place):
+ *     - `admin1CodesASCII.txt` — `<CC>.<admin1_code>` → region name (e.g. `US.VT` → "Vermont").
+ *     - `countryInfo.txt`       — ISO alpha-2 → country name (e.g. `US` → "United States"); `#`-commented.
+ *   If a sibling is missing, the corresponding component is simply omitted (graceful degradation).
+ *
+ *   Output: per place, up to two hierarchy variants (mirroring `wof-admin`'s with/without-country
+ *   balance so the model sees both domestic and international order) —
+ *     1. `{ locality, region }`              → "City, Region"
+ *     2. `{ locality, region, country }`     → "City, Region, Country"
+ *   `reconcileComponents` drops any component that didn't survive into the rendered `raw`.
+ *
+ *   License: stamped `"CC-BY-4.0"` per row (GeoNames' terms); provenance is the `geonames-<id>` key.
+ */
+
+import { parse as csvParse } from "csv-parse"
+import { createReadStream, existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { stableSourceId } from "../../adapter.js"
+import { reconcileComponents } from "../../format.js"
+import type { AdapterOptions, CanonicalRow, CorpusAdapter } from "../../types.js"
+
+export const GEONAMES_ADAPTER_ID = "geonames"
+export const GEONAMES_DEFAULT_LICENSE = "CC-BY-4.0"
+
+// GeoNames main-table column indices (0-based; see the export README).
+const COL = { geonameid: 0, name: 1, alternatenames: 3, featureClass: 6, featureCode: 7, country: 8, admin1: 10 } as const
+
+// Populated-place feature codes that are NOT current real places — skip them.
+const NON_CURRENT_PPL = new Set(["PPLH", "PPLQ", "PPLW", "PPLCH"])
+
+/** Load `admin1CodesASCII.txt` → Map("<CC>.<admin1>" → region name). Empty map if absent. */
+function loadAdmin1(dir: string): Map<string, string> {
+	const map = new Map<string, string>()
+	const fp = join(dir, "admin1CodesASCII.txt")
+	if (!existsSync(fp)) return map
+	for (const line of readFileSync(fp, "utf8").split("\n")) {
+		if (!line) continue
+		const cols = line.split("\t")
+		if (cols[0] && cols[1]) map.set(cols[0], cols[1])
+	}
+	return map
+}
+
+/** Load `countryInfo.txt` → Map(ISO → country name). Empty map if absent. The file is `#`-commented. */
+function loadCountries(dir: string): Map<string, string> {
+	const map = new Map<string, string>()
+	const fp = join(dir, "countryInfo.txt")
+	if (!existsSync(fp)) return map
+	for (const line of readFileSync(fp, "utf8").split("\n")) {
+		if (!line || line.startsWith("#")) continue
+		const cols = line.split("\t")
+		// ISO(0), ISO3(1), iso-numeric(2), fips(3), Country(4), ...
+		if (cols[0] && cols[4]) map.set(cols[0], cols[4])
+	}
+	return map
+}
+
+export function createGeonamesAdapter(): CorpusAdapter {
+	return {
+		id: GEONAMES_ADAPTER_ID,
+		defaultLicense: GEONAMES_DEFAULT_LICENSE,
+		description:
+			"GeoNames populated places (CC-BY-4.0) — global locality coverage incl. small towns, with region/country names from the sibling admin1/countryInfo files.",
+
+		async *rows(opts: AdapterOptions): AsyncIterable<CanonicalRow> {
+			const dir = dirname(opts.inputPath)
+			const admin1 = loadAdmin1(dir)
+			const countries = loadCountries(dir)
+
+			const stream = createReadStream(opts.inputPath, { encoding: "utf8" })
+			const parser = stream.pipe(
+				csvParse({ delimiter: "\t", quote: false, relax_column_count: true, skip_empty_lines: true })
+			)
+
+			let emitted = 0
+			try {
+				for await (const rec of parser as AsyncIterable<string[]>) {
+					if (opts.signal?.aborted) break
+					if (opts.limit !== undefined && emitted >= opts.limit) break
+
+					if (rec[COL.featureClass] !== "P") continue
+					if (NON_CURRENT_PPL.has(rec[COL.featureCode] ?? "")) continue
+
+					const cc = (rec[COL.country] ?? "").trim()
+					if (!cc) continue
+					if (opts.country && cc !== opts.country) continue
+
+					const locality = (rec[COL.name] ?? "").trim()
+					if (!locality) continue
+					const geonameid = (rec[COL.geonameid] ?? "").trim()
+					const region = admin1.get(`${cc}.${(rec[COL.admin1] ?? "").trim()}`)
+					const country = countries.get(cc)
+
+					// Two hierarchy variants (domestic + international order) — but only emit the
+					// distinct ones the available names support.
+					const variants: Array<{ slot: string; comp: CanonicalRow["components"]; raw: string }> = []
+					if (region) {
+						variants.push({ slot: "lr", comp: { locality, region }, raw: `${locality}, ${region}` })
+						if (country) {
+							variants.push({
+								slot: "lrc",
+								comp: { locality, region, country },
+								raw: `${locality}, ${region}, ${country}`,
+							})
+						}
+					} else if (country) {
+						variants.push({ slot: "lc", comp: { locality, country }, raw: `${locality}, ${country}` })
+					} else {
+						variants.push({ slot: "l", comp: { locality }, raw: locality })
+					}
+
+					for (const v of variants) {
+						if (opts.limit !== undefined && emitted >= opts.limit) break
+						const aligned = reconcileComponents(v.comp, v.raw)
+						if (Object.keys(aligned).length === 0) continue
+						const sourceId = geonameid
+							? `${GEONAMES_ADAPTER_ID}-${geonameid}-${v.slot}`
+							: stableSourceId(GEONAMES_ADAPTER_ID, aligned)
+						yield {
+							raw: v.raw,
+							components: aligned,
+							country: cc,
+							source: GEONAMES_ADAPTER_ID,
+							source_id: sourceId,
+							corpus_version: "",
+							license: GEONAMES_DEFAULT_LICENSE,
+						}
+						emitted++
+					}
+				}
+			} finally {
+				stream.destroy()
+			}
+		},
+	}
+}
+
+export const geonamesAdapter = createGeonamesAdapter()

--- a/corpus/src/adapters/index.ts
+++ b/corpus/src/adapters/index.ts
@@ -24,6 +24,7 @@ import type { CorpusAdapter } from "../types.js"
 import { banAdapter } from "./ban/adapter.js"
 import { fccBdcAdapter } from "./fcc-bdc/adapter.js"
 import { geonamesAdapter } from "./geonames/adapter.js"
+import { geonamesPostalAdapter } from "./geonames-postal/adapter.js"
 import { openaddressesAdapter } from "./openaddresses/adapter.js"
 import { stateHiSchoolsAdapter } from "./state-hi-schools/adapter.js"
 import { stateIaContractorsAdapter } from "./state-ia-contractors/adapter.js"
@@ -53,6 +54,7 @@ export const BUILTIN_ADAPTERS: readonly CorpusAdapter[] = [
 	wofAdminAdapter,
 	wofPostalcodeAdapter,
 	geonamesAdapter,
+	geonamesPostalAdapter,
 	banAdapter,
 	tigerAdapter,
 	openaddressesAdapter,
@@ -77,6 +79,11 @@ for (const adapter of BUILTIN_ADAPTERS) {
 export { BAN_ADAPTER_ID, banAdapter } from "./ban/adapter.js"
 export { FCC_BDC_ADAPTER_ID, FCC_BDC_DEFAULT_LICENSE, fccBdcAdapter } from "./fcc-bdc/adapter.js"
 export { GEONAMES_ADAPTER_ID, GEONAMES_DEFAULT_LICENSE, geonamesAdapter } from "./geonames/adapter.js"
+export {
+	GEONAMES_POSTAL_ADAPTER_ID,
+	GEONAMES_POSTAL_DEFAULT_LICENSE,
+	geonamesPostalAdapter,
+} from "./geonames-postal/adapter.js"
 export {
 	OPENADDRESSES_ADAPTER_ID,
 	OPENADDRESSES_DEFAULT_LICENSE,

--- a/corpus/src/adapters/index.ts
+++ b/corpus/src/adapters/index.ts
@@ -23,6 +23,7 @@ import { defaultAdapterRegistry } from "../adapter.js"
 import type { CorpusAdapter } from "../types.js"
 import { banAdapter } from "./ban/adapter.js"
 import { fccBdcAdapter } from "./fcc-bdc/adapter.js"
+import { geonamesAdapter } from "./geonames/adapter.js"
 import { openaddressesAdapter } from "./openaddresses/adapter.js"
 import { stateHiSchoolsAdapter } from "./state-hi-schools/adapter.js"
 import { stateIaContractorsAdapter } from "./state-ia-contractors/adapter.js"
@@ -50,6 +51,7 @@ import { wofPostalcodeAdapter } from "./wof-postalcode-json/adapter.js"
 export const BUILTIN_ADAPTERS: readonly CorpusAdapter[] = [
 	wofAdminAdapter,
 	wofPostalcodeAdapter,
+	geonamesAdapter,
 	banAdapter,
 	tigerAdapter,
 	openaddressesAdapter,
@@ -72,6 +74,7 @@ for (const adapter of BUILTIN_ADAPTERS) {
 
 export { BAN_ADAPTER_ID, banAdapter } from "./ban/adapter.js"
 export { FCC_BDC_ADAPTER_ID, FCC_BDC_DEFAULT_LICENSE, fccBdcAdapter } from "./fcc-bdc/adapter.js"
+export { GEONAMES_ADAPTER_ID, GEONAMES_DEFAULT_LICENSE, geonamesAdapter } from "./geonames/adapter.js"
 export {
 	OPENADDRESSES_ADAPTER_ID,
 	OPENADDRESSES_DEFAULT_LICENSE,

--- a/corpus/src/adapters/index.ts
+++ b/corpus/src/adapters/index.ts
@@ -32,6 +32,7 @@ import { stateTxNotariesAdapter } from "./state-tx-notaries/adapter.js"
 import { tigerAdapter } from "./tiger/adapter.js"
 import { usgovHrsaFqhcAdapter } from "./usgov-hrsa-fqhc/adapter.js"
 import { usgovImlsPlsAdapter } from "./usgov-imls-pls/adapter.js"
+import { usgovIrsBmfAdapter } from "./usgov-irs-bmf/adapter.js"
 import { usgovNadAdapter } from "./usgov-nad/adapter.js"
 import { usgovNppesAdapter } from "./usgov-nppes/adapter.js"
 import { wofAdminAdapter } from "./wof-admin-json/adapter.js"
@@ -60,6 +61,7 @@ export const BUILTIN_ADAPTERS: readonly CorpusAdapter[] = [
 	usgovNppesAdapter,
 	usgovNadAdapter,
 	usgovImlsPlsAdapter,
+	usgovIrsBmfAdapter,
 	stateIaContractorsAdapter,
 	stateTxNotariesAdapter,
 	stateNyNotariesAdapter,
@@ -111,6 +113,11 @@ export {
 	USGOV_IMLS_PLS_DEFAULT_LICENSE,
 	usgovImlsPlsAdapter,
 } from "./usgov-imls-pls/adapter.js"
+export {
+	USGOV_IRS_BMF_ADAPTER_ID,
+	USGOV_IRS_BMF_DEFAULT_LICENSE,
+	usgovIrsBmfAdapter,
+} from "./usgov-irs-bmf/adapter.js"
 export { USGOV_NAD_ADAPTER_ID, USGOV_NAD_DEFAULT_LICENSE, usgovNadAdapter } from "./usgov-nad/adapter.js"
 export { USGOV_NPPES_ADAPTER_ID, USGOV_NPPES_DEFAULT_LICENSE, usgovNppesAdapter } from "./usgov-nppes/adapter.js"
 export {

--- a/corpus/src/adapters/usgov-irs-bmf/README.md
+++ b/corpus/src/adapters/usgov-irs-bmf/README.md
@@ -1,0 +1,41 @@
+# `usgov-irs-bmf` adapter
+
+IRS Exempt Organizations Business Master File (EO BMF) → `CanonicalRow`. US non-profit
+**venue + address** signal (a different organization population than `usgov-nppes`), with strong
+**PO-box** coverage — useful `po_box`-tag training data (a tag with historically low recall).
+
+- **Source:** [IRS EO BMF extract](https://www.irs.gov/charities-non-profits/exempt-organizations-business-master-file-extract-eo-bmf).
+- **License:** **Public Domain** (US federal). Stamped `"Public Domain"` per row.
+- **Coverage:** all US states + territories (per-region CSVs).
+
+## Download
+
+Direct, stable CSV URLs (no auth):
+
+```bash
+DIR=/mnt/playpen/mailwoman-data/irs-bmf
+mkdir -p "$DIR" && cd "$DIR"
+for f in eo1 eo2 eo3 eo4 eo_pr eo_xx; do curl -O "https://www.irs.gov/pub/irs-soi/$f.csv"; done
+```
+
+`eo1`..`eo4` are the four US regions; `eo_pr` = Puerto Rico; `eo_xx` = international.
+
+## Run
+
+```bash
+npx mailwoman corpus run usgov-irs-bmf --input /mnt/playpen/mailwoman-data/irs-bmf/eo1.csv --country US --limit 50000
+# In a full build: adapterInputs["usgov-irs-bmf"] = { inputPath: ".../eoN.csv", country: "US" } per file.
+```
+
+## Output
+
+One row per record with a usable city + ZIP. `NAME` → `venue`; the street line is classified as
+`po_box` (PO BOX / P.O. BOX / POB / BOX …) or split into `house_number` + `street`; `CITY`/`STATE`/`ZIP`
+fill the locality line (`STATE` is already a USPS abbreviation; ZIP+4 is reduced to the 5-digit code).
+`source_id` = `usgov-irs-bmf-<EIN>`.
+
+## Format reference
+
+Header: `EIN,NAME,ICO,STREET,CITY,STATE,ZIP,GROUP,SUBSECTION,…` (28 columns, comma-separated, no
+quoting). This adapter reads `NAME, STREET, CITY, STATE, ZIP` (+ `EIN` for the id). Full layout: the
+[EO BMF data dictionary](https://www.irs.gov/pub/irs-soi/eo_info.pdf).

--- a/corpus/src/adapters/usgov-irs-bmf/adapter.test.ts
+++ b/corpus/src/adapters/usgov-irs-bmf/adapter.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { beforeEach, describe, expect, it } from "vitest"
+import { createUsgovIrsBmfAdapter, USGOV_IRS_BMF_ADAPTER_ID, USGOV_IRS_BMF_DEFAULT_LICENSE } from "./adapter.js"
+import type { CanonicalRow } from "../../types.js"
+
+const HEADER = "EIN,NAME,STREET,CITY,STATE,ZIP"
+
+let scratch: string
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "mailwoman-irsbmf-"))
+})
+
+function writeCsv(...lines: string[]): string {
+	const p = join(scratch, "eo.csv")
+	writeFileSync(p, HEADER + "\n" + lines.join("\n") + "\n", "utf8")
+	return p
+}
+
+async function collect(p: string, extra?: Record<string, unknown>): Promise<CanonicalRow[]> {
+	const out: CanonicalRow[] = []
+	for await (const r of createUsgovIrsBmfAdapter().rows({ inputPath: p, ...extra })) out.push(r)
+	return out
+}
+
+describe("usgov-irs-bmf adapter", () => {
+	it("has the expected id and license", () => {
+		const a = createUsgovIrsBmfAdapter()
+		expect(a.id).toBe(USGOV_IRS_BMF_ADAPTER_ID)
+		expect(a.defaultLicense).toBe(USGOV_IRS_BMF_DEFAULT_LICENSE)
+	})
+
+	it("tags a PO-box street line as po_box (not street)", async () => {
+		const rows = await collect(writeCsv('010674605,IGLESIA FUENTE DE AGUA VIVA,PO BOX 3869,CAROLINA,PR,00984-3869'))
+		expect(rows).toHaveLength(1)
+		const r = rows[0]!
+		expect(r.components.po_box).toBe("PO BOX 3869")
+		expect(r.components.street).toBeUndefined()
+		expect(r.components).toMatchObject({ venue: "IGLESIA FUENTE DE AGUA VIVA", locality: "CAROLINA", region: "PR", postcode: "00984" })
+		expect(r.country).toBe("US")
+		expect(r.source).toBe(USGOV_IRS_BMF_ADAPTER_ID)
+		expect(r.source_id).toBe("usgov-irs-bmf-010674605")
+	})
+
+	it("splits a numbered street into house_number + street", async () => {
+		const rows = await collect(writeCsv("123456789,COMMUNITY FOUNDATION INC,1234 MAIN ST,SAN JUAN,PR,00901"))
+		const r = rows[0]!
+		expect(r.components).toMatchObject({ house_number: "1234", street: "MAIN ST", locality: "SAN JUAN", region: "PR", postcode: "00901" })
+		expect(r.components.po_box).toBeUndefined()
+	})
+
+	it("drops the +4 from a ZIP+4 postcode", async () => {
+		const rows = await collect(writeCsv("111,ORG A,PO BOX 1,PONCE,PR,00731-1234"))
+		expect(rows[0]?.components.postcode).toBe("00731")
+	})
+
+	it("skips rows missing city or zip", async () => {
+		const rows = await collect(writeCsv("1,NO CITY,PO BOX 1,,PR,00901", "2,NO ZIP,PO BOX 2,SAN JUAN,PR,", "3,OK ORG,PO BOX 3,SAN JUAN,PR,00901"))
+		expect(rows).toHaveLength(1)
+		expect(rows[0]?.components.locality).toBe("SAN JUAN")
+	})
+
+	it("honors the row limit", async () => {
+		const rows = await collect(writeCsv("1,A,PO BOX 1,SAN JUAN,PR,00901", "2,B,PO BOX 2,SAN JUAN,PR,00901"), { limit: 1 })
+		expect(rows).toHaveLength(1)
+	})
+
+	it("rejects a non-US country filter", async () => {
+		const p = writeCsv("1,A,PO BOX 1,SAN JUAN,PR,00901")
+		await expect(async () => {
+			for await (const _ of createUsgovIrsBmfAdapter().rows({ inputPath: p, country: "FR" })) void _
+		}).rejects.toThrow(/only US/)
+	})
+})

--- a/corpus/src/adapters/usgov-irs-bmf/adapter.ts
+++ b/corpus/src/adapters/usgov-irs-bmf/adapter.ts
@@ -1,0 +1,138 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `usgov-irs-bmf`: IRS Exempt Organizations Business Master File (EO BMF) CSV consumer.
+ *
+ *   The EO BMF is the IRS's authoritative registry of US tax-exempt organizations (charities,
+ *   churches, foundations, ...), published as per-region CSVs at
+ *   `https://www.irs.gov/charities-non-profits/exempt-organizations-business-master-file-extract-eo-bmf`
+ *   (`eo1.csv`..`eo4.csv`, `eo_pr.csv`, `eo_xx.csv`). Each row carries an organization NAME plus its
+ *   mailing address. It complements `usgov-nppes` with a DIFFERENT venue population (non-profits vs
+ *   healthcare providers) and, notably, a high share of PO-box addresses — useful `po_box`-tag signal
+ *   (a tag with historically low recall).
+ *
+ *   Output: one row per record with a usable city + postcode. NAME → `venue`; the street line becomes
+ *   `po_box` when it's a PO-box, else `house_number` + `street`; CITY/STATE/ZIP fill the locality line.
+ *   STATE is already a USPS abbreviation in the source. License: `"Public Domain"` (US federal).
+ */
+
+import { parse as csvParse } from "csv-parse"
+import { createReadStream } from "node:fs"
+import { stableSourceId } from "../../adapter.js"
+import { reconcileComponents } from "../../format.js"
+import type { AdapterOptions, CanonicalRow, CorpusAdapter } from "../../types.js"
+
+export const USGOV_IRS_BMF_ADAPTER_ID = "usgov-irs-bmf"
+export const USGOV_IRS_BMF_DEFAULT_LICENSE = "Public Domain"
+
+const HOUSE_NUMBER_PREFIX = /^(\d+(?:-\d+)?[A-Za-z]?)\s+(.+)$/
+// PO box in its many written forms: "PO BOX 12", "P.O. BOX 12", "P O BOX 12", "POB 12", "BOX 12".
+const PO_BOX = /^\s*(?:P\.?\s?O\.?\s*BOX|POB|BOX)\s+\w/i
+
+interface IrsBmfRow {
+	EIN: string
+	NAME: string
+	STREET: string
+	CITY: string
+	STATE: string
+	ZIP: string
+}
+
+/** Classify the street line into a `po_box` or a `{house_number?, street}` split. */
+function splitStreetLine(street: string): { po_box: string } | { house_number?: string; street: string } | null {
+	const trimmed = street.trim()
+	if (!trimmed) return null
+	if (PO_BOX.test(trimmed)) return { po_box: trimmed }
+	const m = HOUSE_NUMBER_PREFIX.exec(trimmed)
+	if (m) return { house_number: m[1], street: m[2]!.trim() }
+	return { street: trimmed }
+}
+
+function composeRaw(
+	venue: string | undefined,
+	streetPart: string,
+	city: string,
+	state: string,
+	postcode: string
+): string {
+	const cityPart = [city.trim(), [state, postcode].filter(Boolean).join(" ").trim()].filter(Boolean).join(", ")
+	return [venue, streetPart, cityPart].filter(Boolean).join(", ")
+}
+
+export function createUsgovIrsBmfAdapter(): CorpusAdapter {
+	return {
+		id: USGOV_IRS_BMF_ADAPTER_ID,
+		defaultLicense: USGOV_IRS_BMF_DEFAULT_LICENSE,
+		description:
+			"IRS Exempt Organizations Business Master File — US non-profit venue+address (public-domain), with strong PO-box coverage.",
+
+		async *rows(opts: AdapterOptions): AsyncIterable<CanonicalRow> {
+			if (opts.country && opts.country !== "US") {
+				throw new Error(`usgov-irs-bmf adapter: only US supported, got country=${opts.country}`)
+			}
+
+			const stream = createReadStream(opts.inputPath, { encoding: "utf8" })
+			const parser = stream.pipe(
+				csvParse({ columns: true, skip_empty_lines: true, relax_quotes: true, relax_column_count: true, trim: true })
+			)
+
+			let emitted = 0
+			try {
+				for await (const record of parser as AsyncIterable<IrsBmfRow>) {
+					if (opts.signal?.aborted) break
+					if (opts.limit !== undefined && emitted >= opts.limit) break
+
+					const ein = (record.EIN ?? "").trim()
+					const venue = (record.NAME ?? "").trim() || undefined
+					const street = (record.STREET ?? "").trim()
+					const city = (record.CITY ?? "").trim()
+					const state = (record.STATE ?? "").trim()
+					const zipRaw = (record.ZIP ?? "").trim()
+					if (!city || !zipRaw) continue
+					const postcode = zipRaw.split("-")[0]!.trim() // 5-digit; drop the optional +4
+
+					const split = splitStreetLine(street)
+					if (!split) continue
+
+					const streetPart = "po_box" in split ? split.po_box : [split.house_number, split.street].filter(Boolean).join(" ")
+
+					const components: CanonicalRow["components"] = {
+						...(venue ? { venue } : {}),
+						...("po_box" in split
+							? { po_box: split.po_box }
+							: { ...(split.house_number ? { house_number: split.house_number } : {}), street: split.street }),
+						locality: city,
+						...(state ? { region: state } : {}),
+						postcode,
+					}
+
+					const raw = composeRaw(venue, streetPart, city, state, postcode)
+					if (!raw) continue
+
+					const aligned = reconcileComponents(components, raw)
+					if (Object.keys(aligned).length <= 2) continue
+
+					const sourceId = ein ? `${USGOV_IRS_BMF_ADAPTER_ID}-${ein}` : stableSourceId(USGOV_IRS_BMF_ADAPTER_ID, aligned)
+
+					yield {
+						raw,
+						components: aligned,
+						country: "US",
+						locale: "en-US",
+						source: USGOV_IRS_BMF_ADAPTER_ID,
+						source_id: sourceId,
+						corpus_version: "",
+						license: USGOV_IRS_BMF_DEFAULT_LICENSE,
+					}
+					emitted++
+				}
+			} finally {
+				stream.destroy()
+			}
+		},
+	}
+}
+
+export const usgovIrsBmfAdapter = createUsgovIrsBmfAdapter()

--- a/mailwoman/server/AddressRouter.ts
+++ b/mailwoman/server/AddressRouter.ts
@@ -51,7 +51,7 @@ const handler: RequestHandler = async (req, res) => {
 	})
 }
 
-export const AddressRouter = Router()
+export const AddressRouter: Router = Router()
 
 AddressRouter.post("/parse", handler)
 AddressRouter.search("/parse", handler)

--- a/mailwoman/server/ResolveRouter.ts
+++ b/mailwoman/server/ResolveRouter.ts
@@ -178,7 +178,7 @@ const handler: RequestHandler = async (req, res) => {
 	}
 }
 
-export const ResolveRouter = Router()
+export const ResolveRouter: Router = Router()
 
 ResolveRouter.post("/api/resolve", handler)
 ResolveRouter.get("/api/resolve", handler)


### PR DESCRIPTION
Three new `CorpusAdapter`s this shift — explicitly-authorized corpus growth. All **additive** (`corpus build` skips adapters with no configured input → inert for existing builds), tested, documented, registered. `yarn compile` clean; **17 adapter tests green**.

## 1. `geonames` (CC-BY-4.0) — multi-locale gazetteer
Global populated places → locality(+region+country) with domestic + intl hierarchy variants. Names mapped from sibling `admin1CodesASCII.txt`/`countryInfo.txt`. Broadens **locale** coverage (small towns WOF lacks). 5 tests; format verified vs a real dump.

## 2. `geonames-postal` (CC-BY-4.0) — multi-locale postcode→locality→region
GeoNames postal export — clean per-country `postcode → place → admin1` with names **inline** (no aux-join), ~80 countries. Postcode-FIRST (international) variants; drops the region variant when admin1 repeats the place. Broadens postcode coverage beyond `wof-postalcode`/coordinate-first. **Prefer non-US** (US is postcode-last, covered by TIGER/WOF). 5 tests; format verified.

## 3. `usgov-irs-bmf` (Public Domain) — venue + address + PO boxes
IRS EO-BMF (stable direct CSV URLs). US non-profit `NAME` + address — a different venue population than `usgov-nppes`, **PO-box-heavy** → `po_box`-tag signal (low-recall tag). 7 tests; validated vs real `eo_pr.csv`.

## Safety
- All three skipped by `corpus build` until configured — **no effect on the model/resolver/runtime/existing builds**.
- Per-row provenance (`source`/`source_id`/`license`); CC-BY attribution tracked (`feedback-no-load-bearing-trivia`).

Stacked on #437 for green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)