### PR TITLE
fix(resolver): widen over-fetch for short queries so exact-abbrev regions aren't window-dropped

### DIFF
--- a/resolver-wof-sqlite/exact-match-tiering.test.ts
+++ b/resolver-wof-sqlite/exact-match-tiering.test.ts
@@ -122,6 +122,37 @@ describe("findPlace — exact-match tiering", () => {
 		expect(results[0]!.id).toBe(11) // higher population wins within the exact tier
 	})
 
+	test("short-query over-fetch rescues an exact-abbrev region below the normal window (NY → New York)", async () => {
+		// The window-drop class (distinct from the population-override above). An exact-abbrev holder
+		// ("NY" → New York) whose BM25 for the bare 2-letter token is poor — its long multilingual
+		// alt-name document dilutes the score — sinks BELOW the normal `limit * 4` over-fetch window,
+		// behind a crowd of regions that merely TOKEN-match "ny". Without widening the window for short
+		// queries it never enters the candidate pool, so exact-match tiering can't promote it and a
+		// token-matching decoy wins (the real-DB "NY → Highland, GB" bug). With the widening, New York
+		// is in the pool and tiering lifts it. No `country` hint — this is the bare, no-context path.
+		const decoys: SeedRegion[] = Array.from({ length: 60 }, (_, i) => ({
+			id: 1000 + i,
+			name: `Ny Province ${i}`, // tokenizes to include "ny" → matches MATCH 'ny'; short doc → good BM25
+			country: "GB",
+			lat: 50 + i * 0.01,
+			lon: -1 + i * 0.01,
+		}))
+		const newYork: SeedRegion = {
+			id: 1,
+			name: "New York",
+			country: "US",
+			lat: 43,
+			lon: -75,
+			// Exact alias "NY" + a long alt-name doc → poor BM25 for "ny" → sorts below all 60 decoys
+			// (rank ~61: outside the default `limit * 4` window, inside the 200 short-query floor).
+			aliases: ["NY", ...Array.from({ length: 40 }, (_, i) => `New York alternate label ${i}`)],
+		}
+		lookup = new WofSqlitePlaceLookup({ database: buildDb([newYork, ...decoys]), buildFts: true })
+		const results = await lookup.findPlace({ text: "NY", placetype: "region", limit: 2 })
+		expect(results[0]!.id).toBe(1)
+		expect(results[0]!.name).toBe("New York")
+	})
+
 	test("a single candidate is unaffected (no tier to split)", async () => {
 		lookup = new WofSqlitePlaceLookup({
 			database: buildDb([

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -174,6 +174,15 @@ const DEFAULT_WEIGHTS: RankingWeights = {
 	exactMatchTiering: true,
 }
 
+/**
+ * Over-fetch floor for SHORT (≤3-char) queries — region abbreviations like "NY"/"VT". An exact-abbrev
+ * holder's BM25 is poor (long multilingual alt-name document), so the normal `limit * 4` window can
+ * drop it before `exactMatchTiering` promotes it. 200 comfortably covers every same-abbrev region
+ * across the 12-country gazetteer (a 2-letter token matches a few dozen regions at most) while staying
+ * a cheap region-placetype fetch. See the `#fuzzyNameMatch` over-fetch comment.
+ */
+const SHORT_QUERY_OVERFETCH = 200
+
 interface RawSearchRow {
 	id: number
 	name: string
@@ -530,7 +539,16 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 */
 	async #fuzzyNameMatch(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
 		const limit = query.limit ?? 10
-		const ftsLimit = limit * 4 // over-fetch so post-scoring has room to re-rank
+		// Over-fetch so post-scoring + exact-match tiering have room to re-rank. SHORT queries (a 2–3-char
+		// region abbreviation like "NY"/"VT") are the danger case the `exactMatchTiering` docstring flags:
+		// the exact-abbrev holder's BM25 is poor (its long multilingual alt-name document tanks the score),
+		// so under the normal `limit * 4` window it drops OUT of the candidate pool BEFORE tiering can
+		// promote it — "NY" then resolves to a token-matching foreign region (Highland, GB) instead of New
+		// York. Widen the window for short queries so the exact match is always present to be tiered.
+		// (Cross-country abbrev collisions — "VT" is BOTH Vermont and Viterbo — still need a country/
+		// postcode signal to disambiguate; this only rescues the window-drop class, not genuine ambiguity.
+		// With a `country` hint every abbrev resolves; bare + no-context lifts 7→10/15 US states.)
+		const ftsLimit = query.text.trim().length <= 3 ? Math.max(limit * 4, SHORT_QUERY_OVERFETCH) : limit * 4
 
 		const placetypes = normalizePlacetypes(query.placetype)
 		const ftsQuery = sanitizeFtsQuery(query.text)


### PR DESCRIPTION
## What

`findPlace` over-fetches `limit * 4` FTS candidates, then exact-match tiering promotes an exact name/alias match above token matches. But a 2-letter region abbreviation (`NY`/`VT`) is the danger case the `exactMatchTiering` docstring already flagged: the exact-abbrev holder's BM25 for the bare token is poor (its long multilingual alt-name document dilutes the score), so it sinks **below** the `limit * 4` window and never reaches tiering — `NY` then resolves to a token-matching foreign region (Highland, GB) instead of New York.

**Fix:** floor the over-fetch at 200 for short (≤3-char) queries so the exact match is always present to be tiered. One-line behavior change in `#fuzzyNameMatch`; no schema/data change.

## Measured (real canonical 12-country gazetteer, bare region abbrev, **no** country context)

| | correct |
|---|---|
| before | 7/15 |
| after | **10/15** |

`NY`, `WA`, `LA` rescued (were window-drops). The remaining 5 — `ME`/`PA`/`VA`/`VT`/`CA` — are genuine **cross-country abbrev collisions** (Messina, Palermo, Valladolid, Viterbo, Cagliari each *also* hold the exact abbrev), which need a country/postcode signal to disambiguate. With a `country` hint every abbrev already resolves (**15/15**) — which is why the honest-eval (`--default-country US`) was unaffected by this bug.

## Scope

`resolver-wof-sqlite` only. The slim/WASM demo path resolves abbreviations client-side via `expandUsRegion` (#365) and the slim DB drops the `names` table (no abbr signal to tier), so it's unaffected. Carrying abbreviations into the slim DB for data-driven tiering there is the **#189 follow-up**; extending the postcode-anchor country posterior to region lookups (#369-adjacent) would close the remaining cross-country collisions for the bare path.

## Tests

- New regression test in `exact-match-tiering.test.ts`: a fixture where the exact-abbrev holder sits below the normal window behind 60 token-matchers; asserts it's still resolved. Verified the test **fails** when the widening is reverted.
- Full `resolver-wof-sqlite` suite green (152 passed, 33 integration skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)