### PR TITLE
feat(resolver): extend postcode-anchor country posterior to region lookups, tier-safe (#369)

### DIFF
--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -445,6 +445,50 @@ describe("resolveTree — alternatives (candidate-list API)", () => {
 		expect(on.roots[0]!.placeId).toBe("wof:1") // US already top, boost keeps it there
 	})
 
+	test("anchor posterior re-ranks REGION candidates by country (#369), off by default", async () => {
+		// The region analogue of the locality re-rank — the collision class #447's over-fetch fix
+		// couldn't reach. A bare region abbreviation is genuinely shared across countries ("VT" is both
+		// Vermont and Viterbo; "ME" both Maine and Messina); modeled here as two same-named regions so
+		// the fake backend's name-substring match returns both. The non-US region scores higher on
+		// name/BM25, so without a signal the wrong country wins — and because resolveTree resolves region
+		// FIRST and inherits its country down, that poisons the locality too. The postcode posterior
+		// breaks the tie at the region.
+		const regions: ResolvedPlace[] = [
+			{ id: 1, name: "Vermontia", placetype: "region", country: "IT", lat: 42.4, lon: 12.1, score: 8 },
+			{ id: 2, name: "Vermontia", placetype: "region", country: "US", lat: 44.0, lon: -72.7, score: 7 },
+		]
+		const input = tree("Vermontia", [node("region", "Vermontia", 0, 9)])
+
+		// Default (no posterior): the higher-scored IT region wins — byte-stable.
+		const off = await createWofResolver(new FakeResolverBackend(regions)).resolveTree(input)
+		expect(off.roots[0]!.placeId).toBe("wof:1")
+
+		// With a US country posterior, the +weight*posterior boost pulls the US region to the top.
+		const on = await createWofResolver(new FakeResolverBackend(regions)).resolveTree(input, {
+			anchorPosterior: { US: 1.0 },
+		})
+		expect(on.roots[0]!.placeId).toBe("wof:2")
+		expect((on.roots[0]!.alternatives as ResolvedPlace[])[0]!.id).toBe(1) // displaced IT survives
+	})
+
+	test("anchor posterior keeps the EXACT match within the pinned country (#369) — tier-safe", async () => {
+		// The "ME → Maine, not the more-populous Missouri" guard. Three regions all match the query.
+		// With a confident US posterior the US EXACT match (Maineland) must win over (a) a higher-SCORE
+		// US PARTIAL match (Missouriland — a plain additive boost would promote it, dropping the tier)
+		// and (b) a foreign EXACT match (Messinaland — the posterior breaks that tie WITHIN the exact
+		// tier). `exactMatch` is the backend-supplied tier flag (see ResolvedPlace.exactMatch).
+		const regions: ResolvedPlace[] = [
+			{ id: 1, name: "Maineland", placetype: "region", country: "US", lat: 45, lon: -69, score: 5, exactMatch: true },
+			{ id: 2, name: "Missouriland", placetype: "region", country: "US", lat: 38, lon: -92, score: 7, exactMatch: false },
+			{ id: 3, name: "Messinaland", placetype: "region", country: "IT", lat: 38, lon: 15, score: 6, exactMatch: true },
+		]
+		const input = tree("land", [node("region", "land", 0, 4)])
+		const on = await createWofResolver(new FakeResolverBackend(regions)).resolveTree(input, {
+			anchorPosterior: { US: 1.0 },
+		})
+		expect(on.roots[0]!.placeId).toBe("wof:1") // US exact wins: tier primary, then US posterior
+	})
+
 	// Dual-role hierarchy completion (#405/#415). In `…, Berlin, Berlin <PC>` the parser drops the
 	// locality (city == region), leaving a region but no locality. Completion records the dropped
 	// locality as a `locality` INTERPRETATION on the resolved region node (one node, one span, two

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -253,14 +253,33 @@ class WofResolver implements Resolver {
 		// postcode), boost candidates by `anchorWeight * posterior[candidate.country]` and re-sort, so a
 		// postcode that pins the country pulls the right-country place over a higher-BM25 foreign namesake
 		// (the "Berlin DE vs Berlin US" class the #59 harness measured). No-op when `anchorPosterior` is
-		// undefined (the default) → byte-identical resolution. Locality-scoped: the posterior is a country
-		// signal, and admin parents already carry country via `parentId`.
+		// undefined (the default) → byte-identical resolution.
+		//
+		// Applied to BOTH region and locality — the two placetypes that suffer cross-country namesake/
+		// abbreviation collisions a country posterior can break. The region case is the one #447's window
+		// fix couldn't reach: a bare 2-letter abbreviation is genuinely shared across countries ("VT" is
+		// both Vermont and Viterbo; "ME" both Maine and Messina), so with no country signal the score
+		// picks the wrong one — and because resolveTree resolves region FIRST and inherits its country
+		// down, a wrong region poisons the locality too. The postcode posterior breaks the tie at the
+		// region, and the right country then flows to the locality. (Country/macroregion/county are
+		// excluded: they don't exhibit this collision class and carry country via `parentId` when nested.)
+		//
+		// Tier-SAFE ordering: the candidate's exact-match flag is the PRIMARY key, so the country pin
+		// never crosses the exact/partial boundary. WITHIN a tier, `score + anchorWeight * posterior`
+		// applies the (soft) country boost. So a confident US postcode keeps the US EXACT region
+		// ("ME" → Maine) ahead of a more-populous US PARTIAL match (Missouri) AND, within the exact
+		// tier, ahead of a foreign exact match (Messina IT); a soft posterior still blends with score.
+		// (A plain additive re-rank loses the tier — it isn't encoded in `score` — and flips
+		// "ME" → Missouri / "PA" → Alabama. Backends that don't set `exactMatch` degrade to additive.)
+		const anchorEligible = placetype === "region" || placetype === "locality"
 		let ranked = candidates
-		if (state.anchorPosterior && placetype === "locality" && candidates.length > 1) {
+		if (state.anchorPosterior && anchorEligible && candidates.length > 1) {
 			const post = state.anchorPosterior
 			const w = state.anchorWeight
 			ranked = [...candidates].sort(
-				(a, b) => b.score + w * (post[b.country] ?? 0) - (a.score + w * (post[a.country] ?? 0))
+				(a, b) =>
+					Number(b.exactMatch ?? false) - Number(a.exactMatch ?? false) ||
+					b.score + w * (post[b.country] ?? 0) - (a.score + w * (post[a.country] ?? 0))
 			)
 		}
 		const top = ranked[0]!

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -41,6 +41,15 @@ export interface ResolvedPlace {
 	 */
 	score: number
 	/**
+	 * Set by the backend when this candidate is an EXACT name/alias match for the query (vs a partial
+	 * token match). The postcode-anchor re-rank (#369) uses it as the PRIMARY key so a country
+	 * posterior can pin the country WITHOUT crossing the exact-match tier: "ME" under a confident US
+	 * posterior stays Maine (US exact) rather than promoting the more-populous Missouri (US partial),
+	 * and still beats Messina (IT exact) on the posterior WITHIN the exact tier. Absent → treated as
+	 * non-exact (backends that don't tier omit it; the re-rank degrades to a plain score+posterior).
+	 */
+	exactMatch?: boolean
+	/**
 	 * Set when the resolver detected that the address's postcode and its parsed locality name point
 	 * to geographically different places (a transposed / wrong-for-the-city postcode). Surfaced onto
 	 * the resolved node's metadata as `postcode_city_mismatch` so callers can lower confidence or

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -712,6 +712,10 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 				candidates.map((c) => c.id as number),
 				query.text
 			)
+			// Stamp the tier onto every candidate (not just when the tiering sort fires) so a downstream
+			// re-rank — #369's postcode-anchor country pin in `resolveTree` — can keep the country pin from
+			// crossing the exact/partial boundary ("ME" → Maine, not the more-populous Missouri).
+			for (const c of candidates) c.exactMatch = exactIds.has(c.id as number)
 			if (exactIds.size > 0 && exactIds.size < candidates.length) {
 				candidates.sort((a, b) => {
 					const ax = exactIds.has(a.id as number) ? 1 : 0

--- a/resolver-wof-sqlite/types.ts
+++ b/resolver-wof-sqlite/types.ts
@@ -58,6 +58,13 @@ export interface PlaceCandidate {
 	score: number
 	distanceKm?: number
 	/**
+	 * True when this candidate's name OR an alias EXACTLY equals the query (the exact-match tier from
+	 * {@link RankingWeights.exactMatchTiering}). Surfaced so a downstream country re-rank (#369's
+	 * postcode anchor in `resolveTree`) can pin the country without crossing the tier — see the
+	 * `exactMatch` field on `@mailwoman/core`'s `ResolvedPlace`.
+	 */
+	exactMatch?: boolean
+	/**
 	 * Population from WOF's `wof:population` property. Only present when the candidate has it on
 	 * record — WOF carries population for ~15% of localities (mostly larger ones). Absent does NOT
 	 * mean zero, just unknown.


### PR DESCRIPTION
## What

The postcode-anchor re-rank (#369) only re-ranked **locality** candidates by the country posterior. Region abbreviations are the collision class **#447**'s over-fetch fix couldn't reach: a bare 2-letter abbreviation is genuinely shared across countries (`VT` = Vermont *and* Viterbo; `ME` = Maine *and* Messina), so with no country signal the score picks the wrong one — and since `resolveTree` resolves region **first** and inherits its country downward, a wrong region poisons the locality too.

This extends the re-rank to region — but tier-safely.

## The subtlety (why a naive extension is wrong)

The naive additive `score + w·posterior` discards the backend's exact-match **tier** (it isn't encoded in `score`). With a confident US posterior it lifts every US candidate equally, so a higher-population US **partial** match beats the US **exact** one:

```
anchor ON (additive):  ME → Missouri,  PA → Alabama   ✗  (tier lost)
```

**Fix:** surface the exact-match tier as `exactMatch` on the candidate and re-rank **tier-primary**, `score + anchorWeight·posterior` **secondary**. The country pin never crosses the exact/partial boundary, still beats a foreign *exact* match within the exact tier, and blends gracefully on soft posteriors. `anchorWeight` stays meaningful. (Design independently confirmed by a DeepSeek consult.)

## Measured (canonical 12-country gazetteer, bare region abbrev, no country arg)

| | ME | PA | VA | VT | CA | total |
|---|---|---|---|---|---|---|
| anchor **OFF** | Messina IT | Palermo IT | Valladolid ES | Viterbo IT | Cagliari IT | **0/5** |
| anchor **ON** (US posterior) | Maine | Pennsylvania | Virginia | Vermont | California | **5/5** |

Default (no `anchorPosterior`) is **byte-identical** — the posterior is opt-in.

## Changes
- `core`: `ResolvedPlace.exactMatch`; re-rank applies to region + locality, tier-primary.
- `resolver-wof-sqlite`: `PlaceCandidate.exactMatch`, stamped from the exact-match-id set.
- tests: region re-rank + a tier-safety guard (`ME` → Maine, not the more-populous Missouri).

## Tests
Full `core/resolver` + `resolver-wof-sqlite` suites green (186 passed, 33 integration skipped).

Closes the resolver half of the cross-country collision residual from #447. The slim/WASM demo path is unaffected (it doesn't use `resolveTree`'s anchor); demo-side abbrev tiering is tracked on #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)