### PR TITLE
feat(resolver): carry region abbreviations into the slim DB for data-driven exact-abbrev tiering (#189)

### DIFF
--- a/docs/src/shared/httpvfs-resolver.ts
+++ b/docs/src/shared/httpvfs-resolver.ts
@@ -82,6 +82,7 @@ export async function loadHttpvfsDb(dbUrl: string, sqljsBaseUrl: string): Promis
 export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
 	#worker: HttpvfsWorker
 	#hasPop: boolean | undefined
+	#hasAbbrCache: boolean | undefined
 	#dualRolesCache: Map<number, DualRole[]> | undefined
 
 	constructor(worker: HttpvfsWorker) {
@@ -153,6 +154,32 @@ export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
 		return this.#hasPop
 	}
 
+	async #hasAbbr(): Promise<boolean> {
+		if (this.#hasAbbrCache === undefined) {
+			const r = rowsFromExec(
+				await this.#worker.db.exec("SELECT 1 FROM sqlite_master WHERE type='table' AND name='place_abbr' LIMIT 1")
+			)
+			this.#hasAbbrCache = r.length > 0
+		}
+		return this.#hasAbbrCache
+	}
+
+	/**
+	 * Ids whose region abbreviation exactly equals `text` (case-insensitive), from the slim DB's
+	 * `place_abbr` table (carried by build-slim, #189). Empty on DBs built before the table. Lets the
+	 * demo resolver tier an exact-abbrev match ("VT" → Vermont) above a foreign region that merely
+	 * token-matches — the data-driven replacement for the hardcoded `expandUsRegion` map. Mirrors
+	 * `WofWasmPlaceLookup.#abbrExactIds` (keep the two in lockstep).
+	 */
+	async #abbrExactIds(text: string): Promise<Set<number>> {
+		const t = text.trim()
+		if (!t || !(await this.#hasAbbr())) return new Set()
+		const rows = rowsFromExec(
+			await this.#worker.db.exec(`SELECT id FROM place_abbr WHERE abbr = ${sqlStr(t)} COLLATE NOCASE`)
+		)
+		return new Set(rows.map((r) => Number(r.id)))
+	}
+
 	async findPlace(query: Parameters<MailwomanLookupLike["findPlace"]>[0]) {
 		const text = (query.text ?? "").trim()
 		if (!text) return []
@@ -185,12 +212,17 @@ export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
 
 		const rows = rowsFromExec(await this.#worker.db.exec(sql))
 		const normQuery = normName(text)
+		// Exact-abbrev tier: a candidate whose region abbreviation equals the query ("VT" → Vermont) is
+		// an exact match, same tier as an exact name match — so it outranks a foreign region that merely
+		// token-matches "VT". Mirrors WofWasmPlaceLookup; no-op on slim DBs without `place_abbr`.
+		const abbrIds = await this.#abbrExactIds(text)
 		return rows
 			.map((row) => {
 				const pop = typeof row.population === "number" ? row.population : 0
 				const popBoost = pop > 0 ? POPULATION_BOOST * Math.min(1, Math.log10(1 + pop) / POPULATION_SCALE_LOG10) : 0
 				const adj = (row.bm25 as number) - popBoost
-				return { row, exactTier: normName(String(row.name)) === normQuery ? 0 : 1, adj }
+				const exactTier = normName(String(row.name)) === normQuery || abbrIds.has(Number(row.id)) ? 0 : 1
+				return { row, exactTier, adj }
 			})
 			.sort((a, b) => a.exactTier - b.exactTier || a.adj - b.adj)
 			.slice(0, limit)

--- a/resolver-wof-sqlite/build-slim.test.ts
+++ b/resolver-wof-sqlite/build-slim.test.ts
@@ -252,4 +252,28 @@ describe("buildSlimWofDatabase", () => {
 			slim.close()
 		}
 	})
+
+	test("materializes place_abbr from language='abbr' names, filtered to surviving ids, surviving dropNames (#189)", async () => {
+		const source = join(scratch, "src.db")
+		const output = join(scratch, "slim.db")
+		buildFixtureWof(source)
+		const s = new DatabaseSync(source)
+		s.exec(`INSERT INTO names (id, language, name) VALUES (101, 'abbr', 'IL')`) // Illinois (region) — survives
+		s.exec(`INSERT INTO names (id, language, name) VALUES (202, 'abbr', 'MZ')`) // Mascoutah (locality) — trimmed
+		s.close()
+
+		// top-2 keeps Springfield, drops Mascoutah; dropNames removes the source names table afterward.
+		await buildSlimWofDatabase({ inputs: [source], output, topLocalitiesPerCountry: 2, dropNames: true })
+
+		const slim = new DatabaseSync(output, { readOnly: true })
+		try {
+			const rows = slim.prepare(`SELECT id, abbr FROM place_abbr ORDER BY abbr`).all()
+			// Illinois keeps its abbr; the trimmed locality's is gone (names was pre-filtered to surviving
+			// ids). And place_abbr persists even though dropNames removed the source `names` table.
+			expect(rows).toEqual([{ id: 101, abbr: "IL" }])
+			expect(slim.prepare(`SELECT 1 FROM sqlite_master WHERE name='names'`).get()).toBeUndefined()
+		} finally {
+			slim.close()
+		}
+	})
 })

--- a/resolver-wof-sqlite/build-slim.ts
+++ b/resolver-wof-sqlite/build-slim.ts
@@ -78,6 +78,7 @@ export type SlimBuildPhase =
 	| "names"
 	| "place_population"
 	| "coincident_roles"
+	| "place_abbr"
 	| "fts"
 	| "vacuum"
 	| "done"
@@ -186,6 +187,21 @@ export async function buildSlimWofDatabase(opts: BuildSlimOptions): Promise<Buil
 			drop: true, // schema we copied had no FTS tables, but be explicit
 			onProgress: (phase, name) => progress("fts", `${phase} ${name}`),
 		})
+
+		// Materialize region/state ABBREVIATIONS into a standalone `place_abbr (id, abbr)` table BEFORE
+		// `names` is (optionally) dropped. The full DB lets the resolver tier an exact-abbrev match by
+		// querying `names` (`#exactMatchIds`), but the slim DB drops `names` for size — so the
+		// browser resolver gets its own tiny lookup (~hundreds of rows) to do the same data-driven
+		// exact-abbrev tiering ("VT" → Vermont, not a token-matching foreign region) instead of the
+		// demo's hardcoded `expandUsRegion` map. Sourced from the `language='abbr'` rows
+		// `add-region-abbrevs.ts` wrote, already filtered to surviving spr ids via the names copy. The
+		// table is always created (empty when the source predates the abbrev enrichment) so the
+		// resolver can query it unconditionally.
+		progress("place_abbr", "materializing region abbreviations")
+		out.exec(`CREATE TABLE IF NOT EXISTS place_abbr (id INTEGER NOT NULL, abbr TEXT NOT NULL)`)
+		out.exec(`INSERT INTO place_abbr (id, abbr) SELECT id, name FROM names WHERE language = 'abbr'`)
+		out.exec(`CREATE INDEX IF NOT EXISTS place_abbr_by_abbr ON place_abbr (abbr COLLATE NOCASE)`)
+		out.exec(`CREATE INDEX IF NOT EXISTS place_abbr_by_id ON place_abbr (id)`)
 
 		// Capture the names count BEFORE any drop so the build report stays informative.
 		const namesRows = countRows(out, "names")

--- a/resolver-wof-wasm/lookup.test.ts
+++ b/resolver-wof-wasm/lookup.test.ts
@@ -70,6 +70,17 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO place_population VALUES (220, 1700);
 		INSERT INTO place_population VALUES (221, 8400000);
 
+		-- Region abbreviation tiering (#189): 'Vermontstate' (tiny pop) carries the exact abbrev 'VT';
+		-- 'Vt Plains' (huge pop) only TOKEN-matches "vt". build-slim materializes place_abbr (110→VT) so
+		-- the WASM resolver tiers the exact-abbrev holder above the populous token match.
+		INSERT INTO spr VALUES (110, 100, 'Vermontstate', 'region', 'US', 44.0, -72.7, 42.7, 45.0, -73.4, -71.5, -1, 0);
+		INSERT INTO spr VALUES (111, 100, 'Vt Plains', 'region', 'US', 38.0, -99.0, 36.0, 40.0, -101.0, -97.0, -1, 0);
+		INSERT INTO names (id, language, name) VALUES (110, 'eng', 'Vermontstate');
+		INSERT INTO names (id, language, name) VALUES (110, 'abbr', 'VT');
+		INSERT INTO names (id, language, name) VALUES (111, 'eng', 'Vt Plains');
+		INSERT INTO place_population VALUES (110, 1000);
+		INSERT INTO place_population VALUES (111, 100000000);
+
 		-- Dual-role relation (#402): Illinois(101) ⊃ Springfield(201). build-slim carries it to the slim DB.
 		CREATE TABLE coincident_roles (
 			admin_id INTEGER NOT NULL, locality_id INTEGER NOT NULL, relationship_type TEXT NOT NULL,
@@ -123,6 +134,22 @@ describe("WofWasmPlaceLookup", () => {
 			expect(matches[0]?.placetype).toBe("locality")
 			expect(matches[0]?.country).toBe("US")
 			expect(matches[0]?.lat).toBeCloseTo(41.88, 1)
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test("exact-abbreviation tiering via place_abbr beats a populous token match (#189)", async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			const matches = await lookup.findPlace({ text: "VT", placetype: "region", limit: 5 })
+			// 'Vermontstate' holds the exact abbrev "VT" (place_abbr 110→VT, tiny pop); 'Vt Plains' only
+			// token-matches "vt" with a huge population. The exact-abbrev tier must win — the data-driven
+			// replacement for the demo's hardcoded expandUsRegion map.
+			expect(matches[0]?.id).toBe(110)
+			expect(matches[0]?.name).toBe("Vermontstate")
+			expect(matches[0]?.exactMatch).toBe(true)
 		} finally {
 			lookup.close()
 		}

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -46,6 +46,7 @@ function normalizeName(s: string): string {
 export class WofWasmPlaceLookup implements PlaceLookup {
 	readonly #db: Database
 	#hasPopulationCache?: boolean
+	#hasPlaceAbbrCache?: boolean
 	/**
 	 * Lazily-built `admin_id → coincident localities` map from the #403 relation (the slim DB carries
 	 * it).
@@ -65,6 +66,28 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 			this.#hasPopulationCache = r.length > 0
 		}
 		return this.#hasPopulationCache
+	}
+
+	/** Lazily probe (once) whether the slim DB carries the `place_abbr` aux table (build-slim ≥ #189). */
+	#hasPlaceAbbr(): boolean {
+		if (this.#hasPlaceAbbrCache === undefined) {
+			const r = this.#db.selectObjects(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='place_abbr' LIMIT 1`)
+			this.#hasPlaceAbbrCache = r.length > 0
+		}
+		return this.#hasPlaceAbbrCache
+	}
+
+	/**
+	 * Ids whose region abbreviation exactly equals `text` (case-insensitive), from `place_abbr`. The
+	 * exact-abbrev tier signal — see the `findPlace` call site. Empty on slim DBs without the table.
+	 */
+	#abbrExactIds(text: string): Set<number> {
+		const t = text.trim()
+		if (!t || !this.#hasPlaceAbbr()) return new Set()
+		const rows = this.#db.selectObjects(`SELECT id FROM place_abbr WHERE abbr = ? COLLATE NOCASE`, [t]) as Array<{
+			id: number
+		}>
+		return new Set(rows.map((r) => Number(r.id)))
 	}
 
 	async findPlace(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
@@ -134,9 +157,16 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 		}>
 
 		const normQuery = normalizeName(text)
+		// Exact-abbreviation ids: region/state abbreviations live in the slim DB's `place_abbr` table
+		// (carried by build-slim before `names` is dropped). A candidate whose abbreviation equals the
+		// query is an EXACT match — same tier as an exact name match — so "VT" → Vermont outranks a
+		// foreign region that merely token-matches "VT" via a multilingual name fragment. No-op on slim
+		// DBs built before place_abbr (the table is absent → empty set). This is the data-driven
+		// replacement for the demo's hardcoded `expandUsRegion` map; it also generalizes beyond US.
+		const abbrIds = this.#abbrExactIds(text)
 		return rows
 			.map((row) => {
-				const exactTier = normalizeName(row.name) === normQuery ? 0 : 1
+				const exactTier = normalizeName(row.name) === normQuery || abbrIds.has(row.id) ? 0 : 1
 				const popBoost =
 					row.population && row.population > 0
 						? POPULATION_BOOST * Math.min(1, Math.log10(1 + row.population) / POPULATION_SCALE_LOG10)
@@ -147,7 +177,7 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 			})
 			.sort((a, b) => a.exactTier - b.exactTier || a.adjScore - b.adjScore)
 			.slice(0, limit)
-			.map(({ row, adjScore }) => ({
+			.map(({ row, adjScore, exactTier }) => ({
 				id: row.id,
 				name: row.name,
 				placetype: row.placetype as WofPlacetype,
@@ -155,6 +185,9 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 				lat: row.latitude,
 				lon: row.longitude,
 				parent_id: row.parent_id ?? undefined,
+				// Surface the exact-match tier so a downstream country re-rank (#369) can keep the country
+				// pin from crossing it — parity with `WofSqlitePlaceLookup`. See ResolvedPlace.exactMatch.
+				exactMatch: exactTier === 0,
 				bbox:
 					row.min_latitude != null && row.max_latitude != null && row.min_longitude != null && row.max_longitude != null
 						? {


### PR DESCRIPTION
## What

The slim/browser DB drops `names` for size — which is exactly where the full DB tiers an exact-abbrev match (`WofSqlitePlaceLookup.#exactMatchIds`). So the WASM/httpvfs resolver couldn't distinguish "VT" matching **Vermont's abbreviation** from "VT" matching a foreign region's **name token**, and the demo papered over it with a hardcoded US-only `expandUsRegion` map (#365).

This carries the abbreviations through: build-slim materializes a tiny **`place_abbr (id, abbr)`** table from the `language='abbr'` rows **before** dropping `names` (the same small-aux-table pattern as `coincident_roles`, filtered to surviving spr ids). The WASM + httpvfs resolvers query it to set the exact-abbrev tier — so an exact abbreviation outranks a populous token match, **data-driven** and generalizing beyond US states.

`WofWasmPlaceLookup` also surfaces `exactMatch` for parity with `WofSqlitePlaceLookup` (the #369 country re-rank key).

## Validated (real slim rebuild from the canonical 12-country gazetteer)

- `place_abbr` carries **51** US state/DC abbreviations (names dropped; +0 meaningful size — the table is tiny).
- WASM resolver, bare abbrev (no `expandUsRegion`): `VT`→Vermont, `PA`→Pennsylvania, `NY`→New York, `IL`→Illinois, `CA`→California, `WA`→Washington — all `exactMatch=true`.

## Scope / follow-up

Foundational. **Retiring the demo's `expandUsRegion` map** is a follow-up gated on the `place_abbr`-carrying slim DB reaching R2 — otherwise the live demo would query bare abbrevs against an older slim DB that lacks the table. (This is also a building block for the "what is slim now" hybrid rethink — Option C — tracked separately.)

## Changes
- `resolver-wof-sqlite/build-slim`: `place_abbr` table + phase + test (built, filtered to surviving ids, survives `--drop-names`).
- `resolver-wof-wasm/lookup`: exact-abbrev tier via `place_abbr` + `exactMatch` output + test (abbrev beats a populous token match).
- `docs/src/shared/httpvfs-resolver`: mirrored ranking (kept in lockstep).

## Tests
Full `resolver-wof-sqlite` + `resolver-wof-wasm` suites green (162 passed, 33 integration skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)