### PR TITLE
feat(corpus): unit-designator synthesis augmentation, reusing a USPS Pub-28 C2 codex (#451)

### DIFF
--- a/codex/us/index.ts
+++ b/codex/us/index.ts
@@ -3,10 +3,11 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   The United States address system (USPS): street suffixes, ZIP codes, and the state abbreviations
- *   they hang off of.
+ *   The United States address system (USPS): street suffixes, secondary unit designators, ZIP codes,
+ *   and the state abbreviations they hang off of.
  */
 
 export * from "./state.js"
 export * from "./street-suffix.js"
+export * from "./unit-designator.js"
 export * from "./zipcode.js"

--- a/codex/us/unit-designator.test.ts
+++ b/codex/us/unit-designator.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+	isUnitDesignatorToken,
+	lookupUnitDesignator,
+	matchLeadingDesignator,
+	US_UNIT_DESIGNATOR_LOOKUP,
+	US_UNIT_DESIGNATOR_PREFERRED_ABBR,
+} from "./unit-designator.js"
+
+describe("US_UNIT_DESIGNATOR_LOOKUP", () => {
+	it("maps canonical, full-word, and abbreviated variants to the canonical key", () => {
+		expect(US_UNIT_DESIGNATOR_LOOKUP.get("apartment")).toBe("APARTMENT")
+		expect(US_UNIT_DESIGNATOR_LOOKUP.get("apt")).toBe("APARTMENT")
+		expect(US_UNIT_DESIGNATOR_LOOKUP.get("ste")).toBe("SUITE")
+		expect(US_UNIT_DESIGNATOR_LOOKUP.get("suite")).toBe("SUITE")
+		expect(US_UNIT_DESIGNATOR_LOOKUP.get("fl")).toBe("FLOOR")
+		expect(US_UNIT_DESIGNATOR_LOOKUP.get("rm")).toBe("ROOM")
+	})
+
+	it("does not know unrelated words", () => {
+		expect(US_UNIT_DESIGNATOR_LOOKUP.has("4b")).toBe(false)
+		expect(US_UNIT_DESIGNATOR_LOOKUP.has("oakland")).toBe(false)
+	})
+})
+
+describe("US_UNIT_DESIGNATOR_PREFERRED_ABBR", () => {
+	it("gives the approved USPS abbreviation per canonical", () => {
+		expect(US_UNIT_DESIGNATOR_PREFERRED_ABBR.APARTMENT).toBe("APT")
+		expect(US_UNIT_DESIGNATOR_PREFERRED_ABBR.SUITE).toBe("STE")
+		expect(US_UNIT_DESIGNATOR_PREFERRED_ABBR.FLOOR).toBe("FL")
+	})
+})
+
+describe("matchLeadingDesignator", () => {
+	it("matches the LEADING designator word and reports the matched surface form", () => {
+		expect(matchLeadingDesignator("Apt 4B")).toEqual({ canonical: "APARTMENT", matched: "Apt" })
+		expect(matchLeadingDesignator("SUITE 200")).toEqual({ canonical: "SUITE", matched: "SUITE" })
+		expect(matchLeadingDesignator("Basement")).toEqual({ canonical: "BASEMENT", matched: "Basement" })
+	})
+
+	it("returns null on a bare identifier or empty input", () => {
+		expect(matchLeadingDesignator("4B")).toBeNull()
+		expect(matchLeadingDesignator("#210")).toBeNull()
+		expect(matchLeadingDesignator("")).toBeNull()
+	})
+
+	it("only matches the LEADING word (a trailing designator-shaped token is ignored)", () => {
+		// "Building" is a designator, but here it's not the leading token.
+		expect(matchLeadingDesignator("4B Building")).toBeNull()
+	})
+})
+
+describe("lookupUnitDesignator + isUnitDesignatorToken", () => {
+	it("looks up by canonical, abbreviation, or variant", () => {
+		expect(lookupUnitDesignator("Suite")).toEqual({ designator: "SUITE", abbreviation: "STE" })
+		expect(lookupUnitDesignator("apt")).toEqual({ designator: "APARTMENT", abbreviation: "APT" })
+		expect(lookupUnitDesignator("nope")).toBeNull()
+		expect(lookupUnitDesignator(null)).toBeNull()
+	})
+
+	it("isUnitDesignatorToken is case-insensitive", () => {
+		expect(isUnitDesignatorToken("Apt")).toBe(true)
+		expect(isUnitDesignatorToken("STE")).toBe(true)
+		expect(isUnitDesignatorToken("floor")).toBe(true)
+		expect(isUnitDesignatorToken("4B")).toBe(false)
+	})
+})

--- a/codex/us/unit-designator.ts
+++ b/codex/us/unit-designator.ts
@@ -1,0 +1,123 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   USPS Publication 28, Appendix C2 — Secondary Unit Designators.
+ *
+ *   The sibling of {@link ./street-suffix.ts}: where that table standardizes the trailing street
+ *   *type* (AVENUE → AVE), this one standardizes the *secondary unit* designator that introduces an
+ *   apartment / suite / floor / room (APARTMENT → APT, SUITE → STE). For each canonical designator
+ *   the value lists recognized variants in USPS order; the first is the approved USPS abbreviation
+ *   (what the post office prints).
+ *
+ *   Used by `@mailwoman/corpus`'s synthesis layer (the `unit-{expand,abbreviate}` augmentations) to
+ *   vary the designator in a `unit` component while preserving the identifier — the data-generation
+ *   counterpart to the runtime `UnitDesignatorClassifier` (which matches the broader libpostal
+ *   `unit_types` lexicon). Designators are LEADING ("Apt 4B"), unlike street suffixes which trail.
+ *
+ *   Data is verbatim USPS Pub-28 C2.
+ * @see {@link https://pe.usps.com/text/pub28/28apc_003.htm USPS Secondary Unit Designators}
+ */
+
+/**
+ * Canonical USPS secondary unit designator → recognized variants. The first variant is the approved
+ * USPS abbreviation. Keys + values uppercase per the publication. The designators marked by USPS as
+ * "requires a secondary number" (APT, BLDG, FL, …) and the standalone ones (BSMT, LBBY, PH, …) are
+ * both included — synthesis treats them uniformly.
+ */
+export const US_UNIT_DESIGNATOR_VARIANTS = {
+	APARTMENT: ["APT", "APRT", "APMT"],
+	BASEMENT: ["BSMT"],
+	BUILDING: ["BLDG", "BLD"],
+	DEPARTMENT: ["DEPT"],
+	FLOOR: ["FL", "FLR"],
+	FRONT: ["FRNT"],
+	HANGAR: ["HNGR"],
+	KEY: ["KEY"],
+	LOBBY: ["LBBY"],
+	LOT: ["LOT"],
+	LOWER: ["LOWR"],
+	OFFICE: ["OFC"],
+	PENTHOUSE: ["PH"],
+	PIER: ["PIER"],
+	REAR: ["REAR"],
+	ROOM: ["RM"],
+	SIDE: ["SIDE"],
+	SLIP: ["SLIP"],
+	SPACE: ["SPC"],
+	STOP: ["STOP"],
+	SUITE: ["STE", "SUIT"],
+	TRAILER: ["TRLR"],
+	UNIT: ["UNIT"],
+	UPPER: ["UPPR"],
+} as const satisfies Record<string, readonly string[]>
+
+/** Canonical USPS secondary unit designator (full word, uppercase per the publication). */
+export type UsUnitDesignator = keyof typeof US_UNIT_DESIGNATOR_VARIANTS
+
+/**
+ * Inverse lookup: every variant abbreviation OR full canonical word → its canonical key, built once
+ * at module load, lowercase-keyed for case-insensitive matching (`apt` → `"APARTMENT"`, `ste` →
+ * `"SUITE"`, `suite` → `"SUITE"`).
+ */
+export const US_UNIT_DESIGNATOR_LOOKUP: ReadonlyMap<string, UsUnitDesignator> = (() => {
+	const out = new Map<string, UsUnitDesignator>()
+	for (const canonical of Object.keys(US_UNIT_DESIGNATOR_VARIANTS) as UsUnitDesignator[]) {
+		out.set(canonical.toLowerCase(), canonical)
+		for (const variant of US_UNIT_DESIGNATOR_VARIANTS[canonical]) {
+			// First canonical that claims a variant wins (matches the publication's ordering).
+			if (!out.has(variant.toLowerCase())) out.set(variant.toLowerCase(), canonical)
+		}
+	}
+	return out
+})()
+
+/** Approved USPS abbreviation per canonical (`APARTMENT → "APT"`, `SUITE → "STE"`). */
+export const US_UNIT_DESIGNATOR_PREFERRED_ABBR: Readonly<Record<UsUnitDesignator, string>> = Object.fromEntries(
+	(Object.keys(US_UNIT_DESIGNATOR_VARIANTS) as UsUnitDesignator[]).map((k) => [k, US_UNIT_DESIGNATOR_VARIANTS[k][0]])
+) as Readonly<Record<UsUnitDesignator, string>>
+
+/**
+ * If the FIRST whitespace-separated word of `unit` is a known USPS designator variant, return the
+ * canonical key and the matched word. Returns null if the leading word isn't a known designator
+ * (e.g. a bare `"4B"` or `"#210"`). Leading-word-only — designators introduce the unit, unlike
+ * street suffixes which trail.
+ */
+export function matchLeadingDesignator(unit: string): { canonical: UsUnitDesignator; matched: string } | null {
+	const trimmed = unit.trim()
+	if (!trimmed) return null
+	const first = trimmed.split(/\s+/)[0]!
+	const canonical = US_UNIT_DESIGNATOR_LOOKUP.get(first.toLowerCase())
+	if (!canonical) return null
+	return { canonical, matched: first }
+}
+
+/** Result of a successful USPS secondary-unit designator lookup. */
+export interface UnitDesignatorMatch<D extends UsUnitDesignator = UsUnitDesignator> {
+	/** The matched canonical designator, i.e. "APARTMENT", "SUITE". */
+	designator: D
+	/** The approved USPS abbreviation, i.e. "APT", "STE". */
+	abbreviation: (typeof US_UNIT_DESIGNATOR_VARIANTS)[D][0]
+}
+
+/**
+ * Look up a USPS secondary unit designator (by canonical word, abbreviation, or any variant) and its
+ * approved abbreviation.
+ */
+export function lookupUnitDesignator<D extends UsUnitDesignator>(designator: D): UnitDesignatorMatch<D>
+export function lookupUnitDesignator(input: string | null | undefined): UnitDesignatorMatch | null
+export function lookupUnitDesignator(input: string | null | undefined): UnitDesignatorMatch | null {
+	if (!input || typeof input !== "string") return null
+	const designator = US_UNIT_DESIGNATOR_LOOKUP.get(input.trim().toLowerCase())
+	if (!designator) return null
+	return { designator, abbreviation: US_UNIT_DESIGNATOR_VARIANTS[designator][0] }
+}
+
+/**
+ * True when a token is any USPS secondary unit designator or abbreviation (case-insensitive) —
+ * `"Apt"`, `"STE"`, `"floor"`.
+ */
+export function isUnitDesignatorToken(input: unknown): boolean {
+	return typeof input === "string" && US_UNIT_DESIGNATOR_LOOKUP.has(input.trim().toLowerCase())
+}

--- a/corpus/src/synthesize.test.ts
+++ b/corpus/src/synthesize.test.ts
@@ -23,6 +23,8 @@ import {
 	streetSuffixAbbreviate,
 	streetSuffixExpand,
 	synthesizeRow,
+	unitDesignatorAbbreviate,
+	unitDesignatorExpand,
 	zipPlus4DashDrop,
 } from "./synthesize.js"
 import type { CanonicalRow } from "./types.js"
@@ -316,6 +318,77 @@ describe("US street-suffix codex augmentations (Pub-28 Appendix C)", () => {
 		const us = defaultAugmentationsForCountry("US")
 		expect(us).toContain(streetSuffixAbbreviate)
 		expect(us).toContain(streetSuffixExpand)
+	})
+})
+
+describe("US unit-designator codex augmentations (Pub-28 Appendix C2)", () => {
+	const unitRow = (over: Partial<CanonicalRow>): CanonicalRow =>
+		baseRow({
+			raw: "123 Main St Apt 4B, Oakland, CA 94601",
+			components: {
+				house_number: "123",
+				street: "Main St",
+				unit: "Apt 4B",
+				locality: "Oakland",
+				region: "CA",
+				postcode: "94601",
+			},
+			...over,
+		})
+
+	it("unitDesignatorExpand Apt → Apartment (title case + identifier preserved)", () => {
+		const out = unitDesignatorExpand(unitRow({}))!
+		expect(out.components.unit).toBe("Apartment 4B")
+		expect(out.raw).toBe("123 Main St Apartment 4B, Oakland, CA 94601")
+		expect(out.synth?.method).toBe("us-unit-designator-expand")
+	})
+
+	it("unitDesignatorAbbreviate Apartment → Apt", () => {
+		const out = unitDesignatorAbbreviate(
+			unitRow({
+				raw: "123 Main St Apartment 4B, Oakland, CA 94601",
+				components: { house_number: "123", street: "Main St", unit: "Apartment 4B", locality: "Oakland", region: "CA", postcode: "94601" },
+			})
+		)!
+		expect(out.components.unit).toBe("Apt 4B")
+		expect(out.raw).toContain("Main St Apt 4B,")
+	})
+
+	it("unitDesignatorAbbreviate SUITE → STE (uppercase preserved)", () => {
+		const out = unitDesignatorAbbreviate(
+			unitRow({ raw: "1 OCEAN DR SUITE 200", components: { house_number: "1", street: "OCEAN DR", unit: "SUITE 200" } })
+		)!
+		expect(out.components.unit).toBe("STE 200")
+		expect(out.raw).toContain("STE 200")
+	})
+
+	it("unitDesignatorExpand handles a designator-only unit (Basement → Bsmt inverse)", () => {
+		const out = unitDesignatorExpand(unitRow({ raw: "12 Elm St Bsmt", components: { house_number: "12", street: "Elm St", unit: "Bsmt" } }))!
+		expect(out.components.unit).toBe("Basement")
+		expect(out.raw).toContain("Elm St Basement")
+	})
+
+	it("unitDesignatorAbbreviate returns null when the designator is already the approved abbreviation", () => {
+		expect(unitDesignatorAbbreviate(unitRow({}))).toBeNull() // "Apt 4B" already abbreviated
+	})
+
+	it("returns null when the unit has no recognized leading designator (bare identifier)", () => {
+		const row = unitRow({ raw: "123 Main St 4B, Oakland, CA 94601", components: { house_number: "123", street: "Main St", unit: "4B", locality: "Oakland", region: "CA", postcode: "94601" } })
+		expect(unitDesignatorExpand(row)).toBeNull()
+		expect(unitDesignatorAbbreviate(row)).toBeNull()
+	})
+
+	it("returns null on a non-US row + when there's no unit component", () => {
+		expect(unitDesignatorExpand(unitRow({ country: "FR" }))).toBeNull()
+		expect(unitDesignatorExpand(baseRow({ raw: "123 Main St", components: { house_number: "123", street: "Main St" } }))).toBeNull()
+	})
+
+	it("AUGMENTATIONS + defaultAugmentationsForCountry('US') include both unit augmentations", () => {
+		expect(AUGMENTATIONS["us-unit-designator-abbreviate"]).toBe(unitDesignatorAbbreviate)
+		expect(AUGMENTATIONS["us-unit-designator-expand"]).toBe(unitDesignatorExpand)
+		const us = defaultAugmentationsForCountry("US")
+		expect(us).toContain(unitDesignatorAbbreviate)
+		expect(us).toContain(unitDesignatorExpand)
 	})
 })
 

--- a/corpus/src/synthesize.ts
+++ b/corpus/src/synthesize.ts
@@ -24,7 +24,13 @@
  *   most useful at training time, not corpus build time.
  */
 
-import { US_STREET_SUFFIX_PREFERRED_ABBR, matchCase, matchTrailingSuffix } from "@mailwoman/codex/us"
+import {
+	US_STREET_SUFFIX_PREFERRED_ABBR,
+	US_UNIT_DESIGNATOR_PREFERRED_ABBR,
+	matchCase,
+	matchLeadingDesignator,
+	matchTrailingSuffix,
+} from "@mailwoman/codex/us"
 import type { BioLabel, ComponentTag } from "@mailwoman/core/types"
 import { alignRow } from "./align.js"
 import { whitespaceTokenizer, type Tokenizer } from "./tokenize.js"
@@ -332,6 +338,62 @@ export const streetSuffixExpand: Augmentation = (row) => {
 	return withAugmentation(row, "us-street-suffix-expand", newRaw, newComponents)
 }
 
+/**
+ * US: swap the LEADING secondary-unit designator in `components.unit` to its approved USPS
+ * abbreviation, preserving case + the identifier. `"Apartment 4B"` → `"Apt 4B"`; `"SUITE 200"` →
+ * `"STE 200"`; `"floor 3"` → `"fl 3"`. Returns null when the unit has no recognized leading
+ * designator (a bare `"4B"` / `"#210"`), the designator is already the approved abbreviation, or the
+ * swap would leave `raw` untouched.
+ *
+ * Mirrors `streetSuffixAbbreviate`, but designators LEAD the unit (vs suffixes that trail the
+ * street). Sourced from the USPS Pub-28 C2 codex — the data-generation counterpart to the runtime
+ * `UnitDesignatorClassifier`.
+ */
+export const unitDesignatorAbbreviate: Augmentation = (row) => {
+	if (row.country !== "US") return null
+	const unit = row.components.unit
+	if (!unit) return null
+	const match = matchLeadingDesignator(unit)
+	if (!match) return null
+
+	const preferred = US_UNIT_DESIGNATOR_PREFERRED_ABBR[match.canonical]
+	const target = matchCase(preferred, match.matched)
+	if (target === match.matched) return null
+
+	const newUnit = `${target}${unit.slice(match.matched.length)}`
+	if (newUnit === unit) return null
+
+	const newComponents: ComponentDict = { ...row.components, unit: newUnit }
+	const newRaw = row.raw.replace(new RegExp(`\\b${escapeRegex(unit)}\\b`, "g"), newUnit)
+	if (newRaw === row.raw) return null
+	return withAugmentation(row, "us-unit-designator-abbreviate", newRaw, newComponents)
+}
+
+/**
+ * US: swap the LEADING secondary-unit designator in `components.unit` to its full canonical form,
+ * preserving case + the identifier. `"Apt 4B"` → `"Apartment 4B"`; `"STE 200"` → `"SUITE 200"`.
+ * Returns null when there's no recognized leading designator, it's already the canonical word, or
+ * the swap would leave `raw` untouched. Same leading-word-only rule as `unitDesignatorAbbreviate`.
+ */
+export const unitDesignatorExpand: Augmentation = (row) => {
+	if (row.country !== "US") return null
+	const unit = row.components.unit
+	if (!unit) return null
+	const match = matchLeadingDesignator(unit)
+	if (!match) return null
+
+	const target = matchCase(match.canonical, match.matched)
+	if (target === match.matched) return null
+
+	const newUnit = `${target}${unit.slice(match.matched.length)}`
+	if (newUnit === unit) return null
+
+	const newComponents: ComponentDict = { ...row.components, unit: newUnit }
+	const newRaw = row.raw.replace(new RegExp(`\\b${escapeRegex(unit)}\\b`, "g"), newUnit)
+	if (newRaw === row.raw) return null
+	return withAugmentation(row, "us-unit-designator-expand", newRaw, newComponents)
+}
+
 /** US: ZIP+4 form `12345-6789` → `123456789` (dash dropped). */
 export const zipPlus4DashDrop: Augmentation = (row) => {
 	if (row.country !== "US") return null
@@ -378,6 +440,8 @@ export const AUGMENTATIONS: Record<string, Augmentation> = {
 	"directional-abbreviate": directionalAbbreviate,
 	"us-street-suffix-abbreviate": streetSuffixAbbreviate,
 	"us-street-suffix-expand": streetSuffixExpand,
+	"us-unit-designator-abbreviate": unitDesignatorAbbreviate,
+	"us-unit-designator-expand": unitDesignatorExpand,
 	"zip-plus4-dash-drop": zipPlus4DashDrop,
 	"particle-strip": particleStrip,
 }
@@ -395,6 +459,8 @@ export function defaultAugmentationsForCountry(country: string): readonly Augmen
 				directionalAbbreviate,
 				streetSuffixAbbreviate,
 				streetSuffixExpand,
+				unitDesignatorAbbreviate,
+				unitDesignatorExpand,
 				zipPlus4DashDrop,
 			]
 		case "FR":


### PR DESCRIPTION
## What

The `unit` tag trains at **~0%** (the v0-parity gap, #451) because the corpus synth layer never *generated* it — the lexicon and the runtime classifier already existed (libpostal `unit_types` → `UnitDesignatorClassifier`), but nothing turned that into training signal. This adds the data-generation half, mirroring the existing `us-street-suffix-{expand,abbreviate}` precedent exactly.

## Reuse, not reinvent
The street-suffix work standardized on a **codex** (USPS Pub-28) for synthesis while libpostal backs the runtime classifier. This follows that pattern:
- **`codex/us/unit-designator.ts`** — USPS Pub-28 **Appendix C2** secondary unit designators (`APARTMENT→APT`, `SUITE→STE`, `FLOOR→FL`, …), the sibling of the Pub-28 street-suffix codex with the same shape (variants map, inverse lookup, preferred-abbrev, branded `lookup`/`is*` helpers). Designators **lead** the unit (`"Apt 4B"`), so `matchLeadingDesignator` vs the suffix's trailing match; `matchCase` is shared.
- **`corpus/src/synthesize.ts`** — `unit-designator-{expand,abbreviate}` augmentations that swap the leading designator on `components.unit` while preserving the identifier + case, rebuilding `raw` in lockstep. Registered in `AUGMENTATIONS` + wired into `defaultAugmentationsForCountry("US")`.

Provenance-tracked (USPS Pub-28 C2), not a hand-rolled list — the no-load-bearing-trivia principle.

## How this fits the plan
This is **(c)** of the v0-parity coverage work. The held-out **eval** coverage for `unit` **(b)** comes from the *same* corpus build's `labeled-val` — the adapters (NAD) emit `unit` natively in held-out geography, so one build delivers both the training signal and the measurement. Negative space gets tested for real once that build runs.

## Tests
16 new (8 codex + 8 synthesis: expand/abbreviate, case preservation, designator-only units, bare-identifier null, non-US null, registry/default wiring). Full `codex` + `synthesize` suites green (242 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)