### PR TITLE
chore(toolchain): pin export/quant deps to the v4.1.0 set (Safari graph stability)

### DIFF
--- a/corpus-python/pyproject.toml
+++ b/corpus-python/pyproject.toml
@@ -25,11 +25,16 @@ dev = [
     "pytest>=7.0",
 ]
 train = [
-    "torch>=2.2",
-    "transformers>=4.41",
+    # Pinned to the exact export/quant toolchain that produced the v4.1.0 ONNX artifact
+    # (2026-06-09). Unpinned `>=` drifted (transformers→5.x, onnx→1.21) and broke int8
+    # quant; these match scripts/modal/train_remote.py's image so a local export/quant
+    # produces the same browser-shipped graph. See that file's pin comment for the
+    # mobile-Safari (onnxruntime-web native WebGPU EP) invariant before bumping.
+    "torch==2.12.0",
+    "transformers==5.9.0",
     "datasets>=2.19",
-    "onnx>=1.16",
-    "onnxruntime>=1.18",
+    "onnx==1.21.0",
+    "onnxruntime==1.26.0",
     "tqdm>=4.66",
     # Optional experiment tracking. Logging is best-effort and guarded at runtime
     # (see mailwoman_train/trackio_logging.py) so its absence never breaks a train run.

--- a/scripts/modal/train_remote.py
+++ b/scripts/modal/train_remote.py
@@ -37,16 +37,30 @@ training_image = (
         "curl -sSL https://rclone.org/install.sh | bash",
     )
     .pip_install(
-        "torch",
+        # --- PINNED export/quant toolchain (2026-06-09) ---------------------------------
+        # These five drive the ONNX graph that ships to browsers. They were UNPINNED (`>=`)
+        # and drifted between v0.9.3 (Jun-6) and v0.9.7 (Jun-8): transformers→5.x and
+        # onnx→1.21 started rejecting a dynamo-emitted value_info during int8 quant (see
+        # mailwoman_train/quantize.py's value_info strip). Pinned to the exact set that
+        # produced the v4.1.0 int8 artifact, VERIFIED graph-identical (opset 17, same
+        # 28×DynamicQuantizeLinear/MatMulInteger, 0 reverse-slices) to the Safari-proven
+        # v0.9.3 graph. INVARIANT: the int8 graph (opset + quant op scheme) must stay
+        # within what the pinned `onnxruntime-web` native WebGPU EP runs on Metal (the
+        # JSEP int8-dequant slice bug — neural-web uses onnxruntime-web/webgpu). A bump
+        # here that raises the opset or changes the quant scheme is a Safari decision, not
+        # a free upgrade — re-verify on a real iOS device (CI cannot exercise WebGPU).
+        # Query the live image set with `modal run scripts/modal/train_remote.py::versions`.
+        "torch==2.12.0",
+        "transformers==5.9.0",
+        "onnx==1.21.0",
+        "onnxruntime==1.26.0",
+        "onnxscript==0.7.0",
+        # --- non-graph deps (unpinned floors are fine) ---------------------------------
         "sentencepiece>=0.2.0",
         "pyarrow>=15",
         "pyyaml>=6",
         "numpy>=1.26,<3",
-        "transformers>=4.41",
         "datasets>=2.19",
-        "onnx>=1.16",
-        "onnxruntime>=1.18",
-        "onnxscript>=0.1",
         "tqdm>=4.66",
         # Optional experiment tracking — streamed to a Hugging Face Space dashboard when
         # the run config sets train.trackio_enabled (best-effort, see trackio_logging.py).
@@ -280,6 +294,23 @@ def main(
     train.remote(config_name=config, resume=resume, trackio=trackio, trackio_space=trackio_space)
     print("\nTraining complete!")
     print(f"\nDownload results with:\n  modal volume get mailwoman-training /output/ ./output/")
+
+
+@app.function(image=training_image, timeout=120)
+def versions():
+    """Print the export/quant toolchain versions baked into ``training_image``.
+
+    Used to capture the exact versions for pinning (the unpinned ``>=`` deps drifted
+    between v0.9.3 and v0.9.7 and broke int8 quant — see scripts/modal pins + quantize.py).
+    Run: ``modal run scripts/modal/train_remote.py::versions``
+    """
+    import torch, transformers, onnx, onnxruntime, onnxscript, sys
+    print(f"python      {sys.version.split()[0]}")
+    print(f"torch       {torch.__version__}")
+    print(f"transformers {transformers.__version__}")
+    print(f"onnx        {onnx.__version__}")
+    print(f"onnxruntime {onnxruntime.__version__}")
+    print(f"onnxscript  {onnxscript.__version__}")
 
 
 @app.function(


### PR DESCRIPTION
Pins the five graph-shaping deps (torch 2.12.0, transformers 5.9.0, onnx 1.21.0, onnxruntime 1.26.0, onnxscript 0.7.0) in both `scripts/modal/train_remote.py` (export image) and `corpus-python/pyproject.toml` (local quant) to the exact set that produced the v4.1.0 ONNX artifact.

**Why:** unpinned `>=` deps drifted between v0.9.3 (Jun-6) and v0.9.7 (Jun-8) — transformers→5.9, onnx→1.21 — and broke int8 quant (the dynamo `value_info` onnx now rejects; fixed by the `value_info` strip in quantize.py).

**Safari check (the motivation behind this PR):** the v4.1.0 int8 graph from the *new* toolchain is **op-identical** to the Safari-proven v0.9.3 graph — opset 17, same 28×DynamicQuantizeLinear/MatMulInteger, **0 reverse-slices** (the JSEP int8-dequant trigger). So pinning loses nothing on mobile Safari; it *protects* it by freezing the browser-shipped graph against a future drift that could outpace what the pinned `onnxruntime-web` native WebGPU EP runs on Metal. The pin comments document that invariant (a bump = a conscious iOS-reverify decision; CI can't exercise WebGPU).

Adds a `versions` Modal entrypoint to capture the live image set for future pins. No graph/behavior change vs the shipped v4.1.0 (pins == currently-installed versions).