### PR TITLE
fix(demo): self-heal Safari torn-range-cache DB + revalidatable releases.json

### DIFF
--- a/docs/src/shared/httpvfs-resolver.ts
+++ b/docs/src/shared/httpvfs-resolver.ts
@@ -73,11 +73,30 @@ export async function loadHttpvfsDb(dbUrl: string, sqljsBaseUrl: string): Promis
 		})
 	}
 	if (typeof w.createDbWorker !== "function") throw new Error("createDbWorker missing after UMD load")
-	return w.createDbWorker(
-		[{ from: "inline", config: { serverMode: "full", url: dbUrl, requestChunkSize: 65536 } }],
-		`${sqljsBaseUrl}/sqlite.worker.js`,
-		`${sqljsBaseUrl}/sql-wasm.wasm`
-	)
+
+	// Open over byte-range fetches, then force the header + schema pages through SQLite with a
+	// cheap read. On mobile Safari the HTTP cache can hand sql.js-httpvfs a torn 64 KB range chunk,
+	// which surfaces as "database disk image is malformed"; the assets' immutable Cache-Control means
+	// a once-poisoned cache entry is trusted indefinitely, so the only escape is a fresh URL. Try the
+	// cacheable URL first (fast — Cloudflare edge-caches the ranges); if it opens corrupt, retry ONCE
+	// with a cache-busting query param to force fresh chunks. Self-heals a poisoned cache without
+	// permanently defeating caching for the happy path. See the 2026-06 mobile-Safari demo report.
+	const open = async (url: string): Promise<HttpvfsWorker> => {
+		const worker = await w.createDbWorker!(
+			[{ from: "inline", config: { serverMode: "full", url, requestChunkSize: 65536 } }],
+			`${sqljsBaseUrl}/sqlite.worker.js`,
+			`${sqljsBaseUrl}/sql-wasm.wasm`
+		)
+		await worker.db.exec("SELECT count(*) FROM sqlite_master") // throws here if the schema chunk is torn
+		return worker
+	}
+	try {
+		return await open(dbUrl)
+	} catch (err) {
+		if (!/malformed|not a database|disk image/i.test(String(err))) throw err
+		const sep = dbUrl.includes("?") ? "&" : "?"
+		return open(`${dbUrl}${sep}cb=${Date.now()}`)
+	}
 }
 
 /** PlaceLookup over the httpvfs worker — same ranking as WofWasmPlaceLookup, async. */

--- a/scripts/publish-demo-assets-to-r2.py
+++ b/scripts/publish-demo-assets-to-r2.py
@@ -46,7 +46,17 @@ try:
 except ImportError:
     sys.exit("boto3 is required: pip install boto3")
 
+# Versioned assets live under en-us/<version>/ and never change → immutable, long-lived
+# (Cloudflare edge-caches the byte ranges sql.js-httpvfs reads).
 CACHE_CONTROL = "public, max-age=604800, immutable"
+# EXCEPTION: releases.json is the MUTABLE version pointer the demo reads to pick
+# defaultVersion. It must NOT be immutable — otherwise a `defaultVersion` flip never
+# reaches returning visitors (they stay pinned to the old version's assets for up to a
+# week, which on mobile Safari surfaces as a stale/torn cached DB → "database disk image
+# is malformed"). Short max-age + must-revalidate so flips propagate within ~a minute.
+MUTABLE_CACHE_CONTROL = "public, max-age=60, must-revalidate"
+# Basenames served with MUTABLE_CACHE_CONTROL instead of the immutable default.
+MUTABLE_FILES = {"releases.json"}
 # Content-Type by extension. The DBs/model/binaries MUST be octet-stream so Cloudflare
 # doesn't gzip them (gzipped ranges break sql.js-httpvfs).
 CONTENT_TYPE = {
@@ -97,18 +107,19 @@ def main() -> None:
         rel = p.relative_to(src).as_posix()
         key = f"{args.prefix}/{rel}"
         ct = CONTENT_TYPE.get(p.suffix.lower(), "application/octet-stream")
+        cc = MUTABLE_CACHE_CONTROL if p.name in MUTABLE_FILES else CACHE_CONTROL
         size_mb = p.stat().st_size / 1024 / 1024
         total += p.stat().st_size
         if args.dry_run:
-            print(f"  [dry-run] {key}  ({ct}, {size_mb:.1f} MB)")
+            print(f"  [dry-run] {key}  ({ct}, {cc}, {size_mb:.1f} MB)")
             continue
         s3.upload_file(
             str(p),
             args.bucket,
             key,
-            ExtraArgs={"ContentType": ct, "CacheControl": CACHE_CONTROL},
+            ExtraArgs={"ContentType": ct, "CacheControl": cc},
         )
-        print(f"  ✓ {key}  ({ct}, {size_mb:.1f} MB)")
+        print(f"  ✓ {key}  ({ct}, {cc}, {size_mb:.1f} MB)")
 
     print(f"\n{'(dry-run) ' if args.dry_run else ''}{len(files)} objects, {total / 1024 / 1024:.1f} MB → {args.bucket}/{args.prefix}/")
     print("Served at https://public.sister.software/{}/...".format(args.prefix))


### PR DESCRIPTION
Mobile Safari returns SQLite `database disk image is malformed` on **cached** demo loads (a private tab works). Root cause: Safari's HTTP cache hands sql.js-httpvfs a torn 64 KB range chunk for the WOF DB; `immutable` Cache-Control means a poisoned entry is trusted indefinitely. DBs verified byte-identical to v4.0.0 + valid SQLite — not corruption.

- **httpvfs-resolver.ts**: open → force header+schema pages through a cheap read → on `malformed`, retry once with a cache-busting query param (fresh chunks). Self-heals without defeating edge-caching on the happy path.
- **publish-demo-assets-to-r2.py**: serve `releases.json` (the mutable version pointer) with a short revalidatable Cache-Control instead of the immutable default the script applied to *every* file — that pinned returning visitors to old-version assets for a week. (Live object already re-PUT with the fix.)

Relates to #378 (browser SLO/robustness).

NOTE: docs-build is currently red on main from a *pre-existing* breakage (PipelineExplorer + concept MDX import 4 components that don't exist) — unrelated to this change, but it blocks the demo redeploy. Flagged separately.