### PR TITLE
fix(demo): always refetch releases.json (bypass stale immutable pointer cache)

### DIFF
--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -137,9 +137,15 @@ const DemoApp: React.FC = () => {
 		void (async () => {
 			try {
 				const [manifestRes, maplibre, basemapSource] = await Promise.all([
-					fetch(assetUrl(DEFAULT_LOCALE, "", "releases.json").replace(/\/\/releases/, "/releases")).then((r) =>
-						r.ok ? (r.json() as Promise<ReleasesManifest>) : null
-					),
+					// `cache: "reload"` bypasses the HTTP cache for the version pointer. releases.json was
+					// historically served with an immutable Cache-Control (the publish script applied it to
+					// every file), so a returning visitor's browser keeps a stale copy for up to a week and
+					// never sees a defaultVersion bump — the symptom being "the new version only shows in a
+					// private tab". Always refetch the pointer (it's ~4 KB); the versioned assets it points
+					// to stay immutably cached.
+					fetch(assetUrl(DEFAULT_LOCALE, "", "releases.json").replace(/\/\/releases/, "/releases"), {
+						cache: "reload",
+					}).then((r) => (r.ok ? (r.json() as Promise<ReleasesManifest>) : null)),
 					import("maplibre-gl"),
 					fetchBasemapSource(),
 				])


### PR DESCRIPTION
Follow-up to #459. iOS Safari (and any returning visitor) only sees v4.1.0 in a private tab because their browser cached the old `releases.json` while it was still served `immutable` — it won't revalidate for ~a week, so it keeps reading `defaultVersion: v4.0.0`.

Server-side the pointer is now `max-age=60` (helps *new* visitors), but an already-cached immutable copy ignores that. `fetch(releases.json, { cache: "reload" })` bypasses the HTTP cache for the pointer on every load, so returning visitors pick up the current default. The versioned assets it points to stay immutably cached. Deploys via docs-build.