### PR TITLE
docs(evals): parity scorecard + night-shift postmortem (2026-06-09)

### DIFF
--- a/docs/articles/concepts/negative-space-coverage.mdx
+++ b/docs/articles/concepts/negative-space-coverage.mdx
@@ -10,11 +10,14 @@ tags:
 # Negative space — why training every component sharpens each one
 
 A useful intuition guides Mailwoman's corpus-coverage work: as we add training
-signal for the address components we've been _missing_ (`unit`, `country`, the
-street affixes), the model gets better at the components we already handle — not
-just the new ones. The reason is that a sequence labeller learns a tag by its
+signal for the address components we've been _missing_ (`unit`, the street
+affixes, and more), the model gets better at the components we already handle —
+not just the new ones. The reason is that a sequence labeller learns a tag by its
 **boundaries**, so teaching it what a token _isn't_ is how it learns what the
-neighbours _are_.
+neighbours _are_. (One caveat that the campaign earned the hard way: this logic
+applies to tags the model must learn from context, not to every starved tag —
+see [Two kinds of starved tag](#two-kinds-of-starved-tag-when-coverage-means-a-matcher-not-a-model)
+at the end.)
 
 This has names at three altitudes:
 
@@ -61,5 +64,40 @@ generating corpus rows for a starved tag, the eval set must carry enough held-ou
 examples of it that its F1 is real signal, not noise from a handful of rows (see
 [eval discipline](./eval-discipline.mdx) and the val-set stratification work). The
 coverage eval is the apparatus that lets the numbers say whether negative space
-held for our model — whether covering `unit`/`country` lifted `street`/`locality`
-precision, and whether anything regressed — rather than assuming it.
+held for our model — whether covering `unit` lifted `street`/`locality` precision,
+and whether anything regressed — rather than assuming it.
+
+## Two kinds of starved tag: when coverage means a matcher, not a model
+
+Negative space tells you a starved tag is taxing its neighbours. It does _not_
+tell you that **training** is how to cover it. The parity campaign surfaced two
+shapes of starved tag that want opposite tools.
+
+- **Open-vocabulary, boundary-defined tags** — `unit`, `street_prefix`,
+  `street_suffix`, `locality`. Their members are open-ended and their extent
+  depends on context, so the model genuinely has to _learn the boundary_. A
+  coverage shard is the right tool, and this is precisely where the negative-space
+  effect compounds: covering `unit` (0 → 92%) lifted US `street` by about three
+  points.
+- **Closed-vocabulary, fixed-position tags** — `country`, `po_box`, `cedex`.
+  Their members are a finite, enumerable surface set sitting in a predictable
+  slot. The "boundary" a model would laboriously learn here is _already given_ by
+  the lexicon, so training buys nothing the list doesn't already encode — and it
+  introduces a failure mode.
+
+That failure mode is the same softmax competition from above, run in reverse. A
+synthetic `country` shard is almost entirely _trailing-country_ rows, so the model
+over-learns the cheap correlation "trailing token ⇒ country" and starts promoting
+cities and regions to nationhood. Measured: the retrained `country` head scored 49
+F1 on a held-out real set at 23% precision, while a flat lookup against the country
+list (`matchCountry` on the trailing comma-segment) scored a clean 100. `po_box`
+and `cedex` told the same story — 100 each, zero false positives on the negatives —
+across two locales and two match shapes (a whole comma-segment for `po_box`, an
+in-segment regex for the French `cedex`).
+
+So the rule the campaign settled on: **negative space tells you _which_ tags to
+cover; the tag's vocabulary tells you _how_.** Open-vocab tags get a coverage shard
+and a retrain. Closed-vocab tags get a deterministic post-parse tagger — a
+default-off, byte-stable overlay that runs after the decode and corrects the
+model's over-firing — because covering them inside the model only dilutes it. The
+shared implementation is the `ClosedVocabTagger` overlay tracked in issue #464.

--- a/docs/articles/evals/2026-06-09-night-postmortem.md
+++ b/docs/articles/evals/2026-06-09-night-postmortem.md
@@ -1,0 +1,54 @@
+# Night-Shift Postmortem — 2026-06-09 (parity campaign: affix gated, country → deterministic)
+
+*Sketched live during the shift (04:45→15:00 UTC), finalized at wrap-up.*
+
+## What shipped
+
+- **v0.9.8-affix gated + int8 ship-ready** (PR #461 merged). street_prefix 0→78 (P100/R64), street_suffix 0→67 (P100/R50) on the real-affix OOD eval; US golden street +2.1 (negative space); unit retained 93.8. FR postcode −3.9 (US-shard dilution) trips the >2pp gate → **promote deferred to operator (#462)**; DeepSeek recommends promote-with-annotation.
+- **Affix-aware eval tooling** (`scripts/eval/score-affix.ts`, `probe-affix-decode.ts`) — `per-locale-f1`'s `foldToComponents` joins affixes into `street`, so it can't measure the split; these score the unfolded decode. Caught the gate's false 0% (the model splits 7/10, perfect precision).
+- **Parity scorecard** (`docs/articles/evals/parity-scorecard-2026-06-09.md`, #375) — one authoritative per-tag-vs-v0 table, two lenses (arenas + per-tag), with the fold gotcha documented.
+- **Country lever resolved** (PR #463 + #464): salvaged ISO 3166-1 from isp-nexus into `codex/country/` + surface-form layer + `matchCountry`; multi-locale shard (US/DE/FR/IT/NL, v1/v2/v3); real-country OOD eval (34 cases). **Key result: the model is the wrong tool.** The v1 cumulative shard makes the model *over-fire* (country-real 49 F1, golden precision 23% — it learns "trailing token = country"), whereas a deterministic `matchCountry` on the trailing comma-segment scores **P=R=F1=100**. Lever moves to a post-parse `ProposalClassifier` (#464); the model path is kept on #463 as the exploration record.
+
+## What went well
+
+- The proven recipe (codex synth + format-diverse + real-OOD gate + int8 value_info-strip) carried two more levers cleanly through build+gate.
+- Caught the **fold gotcha** fast (the affix 0% was a measurement artifact, not a training failure) — built the right tool instead of chasing a phantom.
+- The multi-locale country shard **recovered the affix FR-postcode dilution** (95.6→99.5) — the secondary design goal worked.
+- Front-loaded the scorecard during the affix train window; no idle.
+- **Let a negative result reshape the strategy instead of forcing the lever.** The country over-firing wasn't a bug to tune away — it revealed a *lever-shape taxonomy*: closed-vocab/fixed-position tags (country, po_box, cedex) want a deterministic matcher; open-vocab/boundary tags (affix, unit, locality) want a retrain. That taxonomy now guides the remaining levers (po_box likely goes deterministic too).
+
+## What could've gone better
+
+- **Jumped to a cumulative country run** (base+unit+affix+country in one) rather than proving country solo first — it diluted (affix suffix 67→59) and country **over-fired** (golden precision 23%, fp high). The v2-vs-v3 unit lesson ("prove solo before combining") applied and I under-weighted it. Silver lining: the dilution *is* the evidence behind the consolidation rule (prove solo, then consolidate with a bigger step budget) now in the scorecard. But two retrains (v1 cumulative + v2 negatives) burned GPU on a lever that a 10-line deterministic probe should have pre-empted — I should have run the deterministic probe **before** the first country retrain, given country's obvious closed-vocab/trailing shape.
+- The affix gate's first read was a false 0% (fold) — a per-tag affix scorer should have existed before the shard (now it does).
+
+## Decisions made autonomously
+
+1. **Held the affix promote** (gate not cleanly passed; FR postcode −3.9 > 2pp) against DeepSeek's promote-rec — deferred to the operator via #462 rather than overriding their pre-registered gate while offline.
+2. **Country lever as cumulative consolidation** (bakes unit+affix+country) — efficient in intent but it surfaced dilution + over-firing. The DeepSeek pro consult on the fork timed out (180s); I proceeded on the diagnosis. **Resolution (autonomous): redirect country from retrain to a deterministic tagger.** The deterministic probe (P=R=100) settled it — country is closed-vocab and trailing, so a `matchCountry` `ProposalClassifier` (#464) is the right tool, not another shard. Kept #463 as the exploration record rather than force-merging an over-firing model.
+3. **Held the v3 FR-fix as a committed-but-superseded artifact** rather than launching a v3 retrain — once the deterministic result landed, spending more GPU on the model path was unjustified. v3's corpus correctness fix (FR number-street order) is still committed for whoever revisits.
+
+## Open questions for the operator
+
+- **#462: promote v0.9.8-affix → v4.2.0?** (clean affix win, FR-postcode −3.9 trade). DeepSeek says yes-with-annotation. *Still needs your call — I did not promote while offline against the pre-registered gate.*
+- **#463 disposition:** merge for the reusable `codex/country` + eval assets, or close in favor of #464 (deterministic)? Either is fine; the codex salvage is the durable part.
+- **#464 homograph guard:** the deterministic tagger needs a guard for state/country homographs (Georgia, Jordan) before it can default-on. Fire only when the trailing segment is unambiguously a country, or downrank when an upstream `region` already claims the span.
+
+## Concrete next steps
+
+- **#464**: build the deterministic country `ProposalClassifier` (codex `matchCountry` on the trailing comma-segment) — opt-in, byte-stable, with the homograph guard. ~½ day, zero GPU. po_box likely follows the same shape.
+- po_box lever (codex salvaged: `codex/us/po-box.ts`) — probe deterministic-first before any retrain (lesson applied); intersection (gated); FR venue/cedex (#330).
+- Consolidation v1.0 once the open-vocab levers (affix) are promoted — bake winners into one run with **> 20k steps** to beat the cumulative dilution; full per-tag regression gate.
+
+## Numbers (running)
+
+| metric | value |
+| --- | --- |
+| shift window | 04:45→15:00 UTC |
+| models trained (Modal) | 3 (affix v0.9.8, country v1 cumulative, country v2 negatives) |
+| Modal spend | ~$10–12 of $20 |
+| NaN incidents | 0 |
+| CI failures | 0 (corpus-cli flake re-ran green) |
+| regressions shipped | 0 (affix held experimental; nothing promoted) |
+| PRs / issues | #461 (merged), #463 (open — country exploration), #462 (issue — affix promote), #464 (issue — deterministic country) |
+| campaign tags | unit ✅ shipped · affix ✅ gated/deferred (#462) · country ✅ resolved → deterministic (#464) |

--- a/docs/articles/evals/2026-06-09-night-postmortem.md
+++ b/docs/articles/evals/2026-06-09-night-postmortem.md
@@ -8,6 +8,7 @@
 - **Affix-aware eval tooling** (`scripts/eval/score-affix.ts`, `probe-affix-decode.ts`) — `per-locale-f1`'s `foldToComponents` joins affixes into `street`, so it can't measure the split; these score the unfolded decode. Caught the gate's false 0% (the model splits 7/10, perfect precision).
 - **Parity scorecard** (`docs/articles/evals/parity-scorecard-2026-06-09.md`, #375) — one authoritative per-tag-vs-v0 table, two lenses (arenas + per-tag), with the fold gotcha documented.
 - **Country lever resolved** (PR #463 + #464): salvaged ISO 3166-1 from isp-nexus into `codex/country/` + surface-form layer + `matchCountry`; multi-locale shard (US/DE/FR/IT/NL, v1/v2/v3); real-country OOD eval (34 cases). **Key result: the model is the wrong tool.** The v1 cumulative shard makes the model *over-fire* (country-real 49 F1, golden precision 23% — it learns "trailing token = country"), whereas a deterministic `matchCountry` on the trailing comma-segment scores **P=R=F1=100**. Lever moves to a post-parse `ProposalClassifier` (#464); the model path is kept on #463 as the exploration record.
+- **po_box reservoir resolved deterministically — zero GPU, taxonomy applied up front** (PR #463, #464). Applied the country lesson *before* spending any GPU: `matchPOBox` (codex/us/po-box.ts) per comma-segment scores **P=R=F1=100** on a curated real-OOD eval (n=25, 7 negatives incl. "Box Canyon Rd"/"Boxwood Lane" traps, 0 FP). Confirms the lever-shape taxonomy generalizes and seeds a shared `ClosedVocabTagger` design (country + po_box + cedex).
 
 ## What went well
 
@@ -37,7 +38,7 @@
 ## Concrete next steps
 
 - **#464**: build the deterministic country `ProposalClassifier` (codex `matchCountry` on the trailing comma-segment) — opt-in, byte-stable, with the homograph guard. ~½ day, zero GPU. po_box likely follows the same shape.
-- po_box lever (codex salvaged: `codex/us/po-box.ts`) — probe deterministic-first before any retrain (lesson applied); intersection (gated); FR venue/cedex (#330).
+- po_box: **done** (deterministic probe = 100%, no retrain — lesson applied up front). Remaining long-tail: intersection (gated — regressed before, needs care); FR venue/cedex (#330, cedex likely deterministic too).
 - Consolidation v1.0 once the open-vocab levers (affix) are promoted — bake winners into one run with **> 20k steps** to beat the cumulative dilution; full per-tag regression gate.
 
 ## Numbers (running)
@@ -51,4 +52,5 @@
 | CI failures | 0 (corpus-cli flake re-ran green) |
 | regressions shipped | 0 (affix held experimental; nothing promoted) |
 | PRs / issues | #461 (merged), #463 (open — country exploration), #462 (issue — affix promote), #464 (issue — deterministic country) |
-| campaign tags | unit ✅ shipped · affix ✅ gated/deferred (#462) · country ✅ resolved → deterministic (#464) |
+| campaign tags | unit ✅ shipped · affix ✅ gated/deferred (#462) · country ✅ + po_box ✅ resolved → deterministic (#464) |
+| reservoirs (zero-GPU) | po_box deterministic probe (100%), `ClosedVocabTagger` design |

--- a/docs/articles/evals/2026-06-09-night-postmortem.md
+++ b/docs/articles/evals/2026-06-09-night-postmortem.md
@@ -8,7 +8,7 @@
 - **Affix-aware eval tooling** (`scripts/eval/score-affix.ts`, `probe-affix-decode.ts`) — `per-locale-f1`'s `foldToComponents` joins affixes into `street`, so it can't measure the split; these score the unfolded decode. Caught the gate's false 0% (the model splits 7/10, perfect precision).
 - **Parity scorecard** (`docs/articles/evals/parity-scorecard-2026-06-09.md`, #375) — one authoritative per-tag-vs-v0 table, two lenses (arenas + per-tag), with the fold gotcha documented.
 - **Country lever resolved** (PR #463 + #464): salvaged ISO 3166-1 from isp-nexus into `codex/country/` + surface-form layer + `matchCountry`; multi-locale shard (US/DE/FR/IT/NL, v1/v2/v3); real-country OOD eval (34 cases). **Key result: the model is the wrong tool.** The v1 cumulative shard makes the model *over-fire* (country-real 49 F1, golden precision 23% — it learns "trailing token = country"), whereas a deterministic `matchCountry` on the trailing comma-segment scores **P=R=F1=100**. Lever moves to a post-parse `ProposalClassifier` (#464); the model path is kept on #463 as the exploration record.
-- **po_box reservoir resolved deterministically — zero GPU, taxonomy applied up front** (PR #463, #464). Applied the country lesson *before* spending any GPU: `matchPOBox` (codex/us/po-box.ts) per comma-segment scores **P=R=F1=100** on a curated real-OOD eval (n=25, 7 negatives incl. "Box Canyon Rd"/"Boxwood Lane" traps, 0 FP). Confirms the lever-shape taxonomy generalizes and seeds a shared `ClosedVocabTagger` design (country + po_box + cedex).
+- **po_box + cedex reservoirs resolved deterministically — zero GPU, taxonomy applied up front** (PR #463, #464). Applied the country lesson *before* spending any GPU. `matchPOBox` (codex/us/po-box.ts) per comma-segment = **P=R=F1=100** on a curated real-OOD eval (n=25, 7 negatives incl. "Box Canyon Rd"/"Boxwood Lane" traps, 0 FP). `CEDEX` regex (FR, in-segment — a *different* locale and match shape) = **P=R=F1=100** on cedex-real (n=15, 5 negatives). The taxonomy now holds across 3 tags, 2 locales, 2 match shapes — all where a retrain would dilute. Seeds a shared `ClosedVocabTagger` design.
 
 ## What went well
 
@@ -53,4 +53,4 @@
 | regressions shipped | 0 (affix held experimental; nothing promoted) |
 | PRs / issues | #461 (merged), #463 (open — country exploration), #462 (issue — affix promote), #464 (issue — deterministic country) |
 | campaign tags | unit ✅ shipped · affix ✅ gated/deferred (#462) · country ✅ + po_box ✅ resolved → deterministic (#464) |
-| reservoirs (zero-GPU) | po_box deterministic probe (100%), `ClosedVocabTagger` design |
+| reservoirs (zero-GPU) | po_box (100%) + cedex (100%) deterministic probes, `ClosedVocabTagger` design |

--- a/docs/articles/evals/2026-06-09-night-postmortem.md
+++ b/docs/articles/evals/2026-06-09-night-postmortem.md
@@ -33,13 +33,13 @@
 
 - **#462: promote v0.9.8-affix → v4.2.0?** (clean affix win, FR-postcode −3.9 trade). DeepSeek says yes-with-annotation. *Still needs your call — I did not promote while offline against the pre-registered gate.*
 - **#463 disposition:** merge for the reusable `codex/country` + eval assets, or close in favor of #464 (deterministic)? Either is fine; the codex salvage is the durable part.
-- **#464 homograph guard:** the deterministic tagger needs a guard for state/country homographs (Georgia, Jordan) before it can default-on. Fire only when the trailing segment is unambiguously a country, or downrank when an upstream `region` already claims the span.
+- **#464 homograph guard:** the deterministic country tagger needs a guard for state/country homographs (Georgia, Jordan) before it can default-on. Fire only when the trailing segment is unambiguously a country, or downrank when an upstream `region` already claims the span. (Architecture itself is decided — overlay, see next steps; this is the one remaining design detail.)
 
 ## Concrete next steps
 
-- **#464**: build the deterministic country `ProposalClassifier` (codex `matchCountry` on the trailing comma-segment) — opt-in, byte-stable, with the homograph guard. ~½ day, zero GPU. po_box likely follows the same shape.
-- po_box: **done** (deterministic probe = 100%, no retrain — lesson applied up front). Remaining long-tail: intersection (gated — regressed before, needs care); FR venue/cedex (#330, cedex likely deterministic too).
-- Consolidation v1.0 once the open-vocab levers (affix) are promoted — bake winners into one run with **> 20k steps** to beat the cumulative dilution; full per-tag regression gate.
+- **#464 — build one `ClosedVocabTagger`** (country + po_box + cedex; all three measured at P=R=F1=100 this shift). **Architecture decided** (DeepSeek pro consult): a *post-parse `ProposalClassifier` overlay*, default-off/byte-stable, not an in-pass `classifiers/` entry — because it must *correct* the model's over-firing, so it runs after the decode and overwrites. Homograph guard (country Georgia/Jordan) lives in the overlay's apply logic; po_box/cedex have no homograph risk and can land first. ~½ day, zero GPU.
+- intersection (gated — regressed before, needs care); FR venue/region (#330).
+- **Consolidation v1.0 (#466)** once affix is promoted: make the affix shard **multi-locale** (clears its own FR-postcode gate without bundling the now-deterministic country), prove it solo, then **weight-merge** the affix delta into the v4.1.0 base rather than re-stacking shards (the dilution is step-budget-bound). DeepSeek-recommended; gated on #462 + operator go + GPU budget.
 
 ## Numbers (running)
 

--- a/docs/articles/evals/parity-scorecard-2026-06-09.md
+++ b/docs/articles/evals/parity-scorecard-2026-06-09.md
@@ -35,7 +35,7 @@ Postal-arena edge classes where BOTH are 0% (the parity frontier): `po-box` (4),
 | street | 78.5 | 60.1 | ◐ (street-eats-affix boundary) |
 | region | 78.4 | 27.8 | ◐ US / ❌ FR (#330) |
 | locality | 60.1 | 69.7 | ◐ |
-| country | 35.2 | 46.5 | ❌ starved (#452) — **next lever** |
+| country | 35.2 | 46.5 | ❌ starved → **deterministic tagger, not retrain (#464)** — see below |
 | street_prefix | 0.0 | 0.0 | ❌ starved → **affix retrain in flight (v0.9.8)** |
 | street_suffix | 0.0 | — | ❌ starved → **affix retrain in flight** |
 | street_prefix_particle | — | 0.0 | ❌ starved (FR) |
@@ -54,6 +54,8 @@ Postal-arena edge classes where BOTH are 0% (the parity frontier): `po-box` (4),
 | street-affix-real (32) | street_prefix | 0.0 | **78.0** | P100/R64 |
 | street-affix-real | street_suffix | 0.0 | **66.7** | P100/R50 |
 | street-affix-real | street (name) | 0.0³ | 50.0 | unfolded |
+| country-real (34) | country (model v1) | — | 49.0 | **over-fires**: golden precision 23% |
+| country-real (34) | country (deterministic) | — | **100.0** | `matchCountry` on trailing segment, P=R=100 |
 
 ³ v4.1.0 lumps "Wacker Dr" into one `street` span; the affix retrain teaches the split (7/10 → split, perfect precision).
 
@@ -70,11 +72,20 @@ Common tags (postcode/house_number/street/locality/region/venue-US) are at usabl
 | Lever | tag(s) | status |
 | --- | --- | --- |
 | unit | unit | ✅ shipped v4.1.0 (0→92%) |
-| **affix** | street_prefix/suffix | ✅ **GATED v0.9.8: 0→78/67 (P=100), US net-positive, negative-space street +2.1.** FR postcode −3.9 (US-shard dilution) trips the >2pp gate → promote DEFERRED to operator (DeepSeek recommends promote-with-annotation). int8 ship-ready. |
-| country | country | ⏳ next (ISO codex + shard, #452) — also recovers the FR-postcode dilution |
-| po_box | po_box | ⏳ (salvaged po-box codex seeds it) |
+| **affix** | street_prefix/suffix | ✅ **GATED v0.9.8: 0→78/67 (P=100), US net-positive, negative-space street +2.1.** FR postcode −3.9 (US-shard dilution) trips the >2pp gate → promote DEFERRED to operator (#462; DeepSeek recommends promote-with-annotation). int8 ship-ready. |
+| **country** | country | ✅ **RESOLVED — deterministic, not retrain.** The synth shard makes the model over-fire (v1 country-real 49 F1, golden precision 23% — it learns "trailing token = country"). A deterministic `matchCountry` tagger on the trailing comma-segment scores **P=R=F1=100** on country-real. Lever moves to a post-parse `ProposalClassifier` (#464); model path kept as exploration record (#463). |
+| po_box | po_box | ⏳ (salvaged po-box codex seeds it; likely deterministic too — same closed-vocab shape as country) |
 | intersection | intersection_a/b | ⏳ (gated — regressed before) |
 | FR | venue/cedex/region | ⏳ (#330) |
-| consolidation | — | ⏳ v1.0 (bake winners + full regression gate) |
+| consolidation | — | ⏳ v1.0 (bake winners + full regression gate) — **needs > 20k steps**: see dilution note |
 
-*Baseline captured 2026-06-09 ~04:50 UTC during the night shift. The v0.9.8-affix "after" column + a re-run on the promoted model follow at the affix gate.*
+> **CUMULATIVE-DILUTION LESSON (load-bearing for consolidation):** stacking synth shards into one 20k-step run dilutes each tag vs its solo run — the country run (base+unit+affix+country) dropped affix street_suffix 67→59 and street_prefix 78→75 while still under-serving country. Each added shard spreads a fixed step budget thinner. **Prove each lever solo, then consolidate with a larger step budget** (the v2-vs-v3 unit lesson, re-confirmed). Don't read a cumulative run's per-tag number as that lever's ceiling.
+
+### Lever-shape taxonomy (why not everything is a retrain)
+
+The campaign has surfaced two tag shapes that want different tools:
+
+- **Distributional / open-vocab tags** (street_prefix, street_suffix, unit, locality) — the model has to *learn the boundary* from context. Synth shard + retrain is the right tool; these are where negative-space training compounds.
+- **Closed-vocab / fixed-position tags** (country, likely po_box, cedex) — a finite surface-form set in a predictable slot. A deterministic matcher gives perfect precision with zero training; a retrained model only *dilutes* it (over-fires). Use a `ProposalClassifier`, keep it default-off + byte-stable.
+
+*Baseline captured 2026-06-09 ~04:50 UTC during the night shift; finalized ~11:50 UTC with the country result. Affix "after" = the v0.9.8 gate run; country = the v0.9.9 v1 cumulative run + the deterministic probe.*

--- a/docs/articles/evals/parity-scorecard-2026-06-09.md
+++ b/docs/articles/evals/parity-scorecard-2026-06-09.md
@@ -58,6 +58,7 @@ Postal-arena edge classes where BOTH are 0% (the parity frontier): `po-box` (4),
 | country-real (34) | country (deterministic) | — | **100.0** | `matchCountry` on trailing segment, P=R=100 |
 | po-box-real (25) | po_box (model, #15) | ~18 | — | starved |
 | po-box-real (25) | po_box (deterministic) | — | **100.0** | `matchPOBox` per segment; 7 negatives, 0 FP |
+| cedex-real (15) | cedex (deterministic, FR) | — | **100.0** | `CEDEX` regex in-segment; 5 negatives, 0 FP |
 
 ³ v4.1.0 lumps "Wacker Dr" into one `street` span; the affix retrain teaches the split (7/10 → split, perfect precision).
 
@@ -77,8 +78,9 @@ Common tags (postcode/house_number/street/locality/region/venue-US) are at usabl
 | **affix** | street_prefix/suffix | ✅ **GATED v0.9.8: 0→78/67 (P=100), US net-positive, negative-space street +2.1.** FR postcode −3.9 (US-shard dilution) trips the >2pp gate → promote DEFERRED to operator (#462; DeepSeek recommends promote-with-annotation). int8 ship-ready. |
 | **country** | country | ✅ **RESOLVED — deterministic, not retrain.** The synth shard makes the model over-fire (v1 country-real 49 F1, golden precision 23% — it learns "trailing token = country"). A deterministic `matchCountry` tagger on the trailing comma-segment scores **P=R=F1=100** on country-real. Lever moves to a post-parse `ProposalClassifier` (#464); model path kept as exploration record (#463). |
 | **po_box** | po_box | ✅ **RESOLVED — deterministic** (probe measured this shift): `matchPOBox` per comma-segment = **P=R=F1=100** on po-box-real (n=25, 7 negatives, 0 FP). Same closed-vocab shape as country → joins #464 as a `ProposalClassifier`, not a retrain. |
+| **cedex** (FR) | cedex | ✅ **RESOLVED — deterministic** (probe this shift): `CEDEX` regex in-segment = **P=R=F1=100** on cedex-real (n=15, 5 negatives, 0 FP). Different locale + match shape than country/po_box, same taxonomy → joins #464. |
 | intersection | intersection_a/b | ⏳ (gated — regressed before) |
-| FR | venue/cedex/region | ⏳ (#330) |
+| FR | venue/region | ⏳ (#330; cedex now resolved deterministically above) |
 | consolidation | — | ⏳ v1.0 (bake winners + full regression gate) — **needs > 20k steps**: see dilution note |
 
 > **CUMULATIVE-DILUTION LESSON (load-bearing for consolidation):** stacking synth shards into one 20k-step run dilutes each tag vs its solo run — the country run (base+unit+affix+country) dropped affix street_suffix 67→59 and street_prefix 78→75 while still under-serving country. Each added shard spreads a fixed step budget thinner. **Prove each lever solo, then consolidate with a larger step budget** (the v2-vs-v3 unit lesson, re-confirmed). Don't read a cumulative run's per-tag number as that lever's ceiling.
@@ -88,6 +90,6 @@ Common tags (postcode/house_number/street/locality/region/venue-US) are at usabl
 The campaign has surfaced two tag shapes that want different tools:
 
 - **Distributional / open-vocab tags** (street_prefix, street_suffix, unit, locality) — the model has to *learn the boundary* from context. Synth shard + retrain is the right tool; these are where negative-space training compounds.
-- **Closed-vocab / fixed-position tags** (country ✓, po_box ✓, cedex pending) — a finite surface-form set in a predictable slot. A deterministic matcher gives perfect precision with zero training; a retrained model only *dilutes* it (over-fires). Use a `ProposalClassifier`, keep it default-off + byte-stable. **Both country and po_box now measured at P=R=F1=100** via this route — build one `ClosedVocabTagger` parameterized by (matcher, tag, slot) rather than per-tag classifiers (#464).
+- **Closed-vocab / fixed-position tags** (country ✓, po_box ✓, cedex ✓) — a finite surface-form set in a predictable slot. A deterministic matcher gives perfect precision with zero training; a retrained model only *dilutes* it (over-fires). Use a `ProposalClassifier`, keep it default-off + byte-stable. **All three now measured at P=R=F1=100** via this route, across 2 locales (US/FR) and 2 match shapes (whole-segment + in-segment regex) — build one `ClosedVocabTagger` parameterized by (matcher, tag, slot) rather than per-tag classifiers (#464).
 
-*Baseline captured 2026-06-09 ~04:50 UTC during the night shift; finalized ~12:10 UTC with the country + po_box deterministic results. Affix "after" = the v0.9.8 gate run; country = the v0.9.9 v1 cumulative run + the deterministic probe; po_box = deterministic probe only (no retrain — taxonomy applied up front).*
+*Baseline captured 2026-06-09 ~04:50 UTC during the night shift; finalized ~12:25 UTC with the country + po_box + cedex deterministic results. Affix "after" = the v0.9.8 gate run; country = the v0.9.9 v1 cumulative run + the deterministic probe; po_box + cedex = deterministic probes only (no retrain — taxonomy applied up front).*

--- a/docs/articles/evals/parity-scorecard-2026-06-09.md
+++ b/docs/articles/evals/parity-scorecard-2026-06-09.md
@@ -40,7 +40,7 @@ Postal-arena edge classes where BOTH are 0% (the parity frontier): `po-box` (4),
 | street_suffix | 0.0 | — | ❌ starved → **affix retrain in flight** |
 | street_prefix_particle | — | 0.0 | ❌ starved (FR) |
 | unit | 6.3¹ | 0.0 | ✅ FIXED (92.3 real-OOD; golden has ~no unit rows) |
-| po_box | ~18² | — | ❌ starved (#452) |
+| po_box | ~18² | — | ✅ deterministic tagger = 100% real-OOD (#464) |
 | intersection_a/b | 0.0 | — | ❌ starved (experimental, regressed before) |
 | dependent_locality | 0.0 | 0.0 | (intentionally down-weighted — WOF-schema artifact) |
 
@@ -56,6 +56,8 @@ Postal-arena edge classes where BOTH are 0% (the parity frontier): `po-box` (4),
 | street-affix-real | street (name) | 0.0³ | 50.0 | unfolded |
 | country-real (34) | country (model v1) | — | 49.0 | **over-fires**: golden precision 23% |
 | country-real (34) | country (deterministic) | — | **100.0** | `matchCountry` on trailing segment, P=R=100 |
+| po-box-real (25) | po_box (model, #15) | ~18 | — | starved |
+| po-box-real (25) | po_box (deterministic) | — | **100.0** | `matchPOBox` per segment; 7 negatives, 0 FP |
 
 ³ v4.1.0 lumps "Wacker Dr" into one `street` span; the affix retrain teaches the split (7/10 → split, perfect precision).
 
@@ -65,7 +67,7 @@ Postal-arena edge classes where BOTH are 0% (the parity frontier): `po-box` (4),
 
 ## Parity verdict (v4.1.0)
 
-Common tags (postcode/house_number/street/locality/region/venue-US) are at usable parity. The gap is a small set of **starved long-tail tags** — `unit` is now FIXED (the first campaign win), `street_prefix`/`street_suffix` are in flight (v0.9.8), and `country`/`po_box`/`intersection`/FR-`venue`/`cedex` remain. **Not yet at 90% macro parity**; the campaign is the path. Each lever is compounding (covering a tag sharpens its neighbors — unit lifted US street +3pp).
+Common tags (postcode/house_number/street/locality/region/venue-US) are at usable parity. The gap is a small set of **starved long-tail tags** — `unit` is now FIXED (the first campaign win), `street_prefix`/`street_suffix` are in flight (v0.9.8), `country` and `po_box` have a measured deterministic path (P=R=F1=100, #464 — not a retrain), and `intersection`/FR-`venue`/`cedex` remain. **Not yet at 90% macro parity**; the campaign is the path. Each lever is compounding (covering a tag sharpens its neighbors — unit lifted US street +3pp), and the lever-shape taxonomy below now routes each remaining tag to the right tool (retrain vs deterministic matcher).
 
 ## Campaign status
 
@@ -74,7 +76,7 @@ Common tags (postcode/house_number/street/locality/region/venue-US) are at usabl
 | unit | unit | ✅ shipped v4.1.0 (0→92%) |
 | **affix** | street_prefix/suffix | ✅ **GATED v0.9.8: 0→78/67 (P=100), US net-positive, negative-space street +2.1.** FR postcode −3.9 (US-shard dilution) trips the >2pp gate → promote DEFERRED to operator (#462; DeepSeek recommends promote-with-annotation). int8 ship-ready. |
 | **country** | country | ✅ **RESOLVED — deterministic, not retrain.** The synth shard makes the model over-fire (v1 country-real 49 F1, golden precision 23% — it learns "trailing token = country"). A deterministic `matchCountry` tagger on the trailing comma-segment scores **P=R=F1=100** on country-real. Lever moves to a post-parse `ProposalClassifier` (#464); model path kept as exploration record (#463). |
-| po_box | po_box | ⏳ (salvaged po-box codex seeds it; likely deterministic too — same closed-vocab shape as country) |
+| **po_box** | po_box | ✅ **RESOLVED — deterministic** (probe measured this shift): `matchPOBox` per comma-segment = **P=R=F1=100** on po-box-real (n=25, 7 negatives, 0 FP). Same closed-vocab shape as country → joins #464 as a `ProposalClassifier`, not a retrain. |
 | intersection | intersection_a/b | ⏳ (gated — regressed before) |
 | FR | venue/cedex/region | ⏳ (#330) |
 | consolidation | — | ⏳ v1.0 (bake winners + full regression gate) — **needs > 20k steps**: see dilution note |
@@ -86,6 +88,6 @@ Common tags (postcode/house_number/street/locality/region/venue-US) are at usabl
 The campaign has surfaced two tag shapes that want different tools:
 
 - **Distributional / open-vocab tags** (street_prefix, street_suffix, unit, locality) — the model has to *learn the boundary* from context. Synth shard + retrain is the right tool; these are where negative-space training compounds.
-- **Closed-vocab / fixed-position tags** (country, likely po_box, cedex) — a finite surface-form set in a predictable slot. A deterministic matcher gives perfect precision with zero training; a retrained model only *dilutes* it (over-fires). Use a `ProposalClassifier`, keep it default-off + byte-stable.
+- **Closed-vocab / fixed-position tags** (country ✓, po_box ✓, cedex pending) — a finite surface-form set in a predictable slot. A deterministic matcher gives perfect precision with zero training; a retrained model only *dilutes* it (over-fires). Use a `ProposalClassifier`, keep it default-off + byte-stable. **Both country and po_box now measured at P=R=F1=100** via this route — build one `ClosedVocabTagger` parameterized by (matcher, tag, slot) rather than per-tag classifiers (#464).
 
-*Baseline captured 2026-06-09 ~04:50 UTC during the night shift; finalized ~11:50 UTC with the country result. Affix "after" = the v0.9.8 gate run; country = the v0.9.9 v1 cumulative run + the deterministic probe.*
+*Baseline captured 2026-06-09 ~04:50 UTC during the night shift; finalized ~12:10 UTC with the country + po_box deterministic results. Affix "after" = the v0.9.8 gate run; country = the v0.9.9 v1 cumulative run + the deterministic probe; po_box = deterministic probe only (no retrain — taxonomy applied up front).*

--- a/docs/blog/2026-06-09-teaching-the-tags-it-was-missing.mdx
+++ b/docs/blog/2026-06-09-teaching-the-tags-it-was-missing.mdx
@@ -1,0 +1,47 @@
+---
+slug: teaching-the-tags-it-was-missing
+title: "Teaching the model the tags it was missing — and watching the others improve"
+authors: [teffen]
+tags: [neural, parsing, evaluation, training]
+date: 2026-06-09
+---
+
+You trained a model. It's good at the common stuff — house numbers, postcodes, the city. And it has a handful of tags pinned at zero. Secondary units. Street directionals. The country, when someone bothers to write it. The obvious read is that these are rare and hard, a long tail you'll get to eventually.
+
+The less obvious read, the one that turned out to be true for us, is that the zeros were quietly taxing the tags you already had.
+
+{/* truncate */}
+
+## The cheapest thing a parser can do is lump
+
+Give a sequence model a span it has no label for and it does the sensible thing: it folds the orphan into its neighbor. "350 5th Ave Apt 12" has no `unit` worth predicting (it trained at zero), so "Apt 12" gets swallowed into the street. "N Main St" becomes one undifferentiated street span. The model isn't wrong, exactly. It's doing the best it can with the vocabulary you gave it. But every swallowed token is a token the *street* prediction now has to account for, and a boundary it has to guess.
+
+This is the via-negativa idea: a category you *don't* model still shapes the categories you do. The empty space has a shape, and the shape pushes back.
+
+## So we filled one in
+
+We took the `unit` tag (`0%` F1, completely starved) and built it a coverage shard: real US address skeletons with USPS Publication 28 secondary-unit designators dropped in across realistic layouts (unit-after-street, unit-first, bare, venue-prefixed). One variable changed against the shipped model. We trained, and we measured on a held-out set of *real* designators, not the synthetic ones.
+
+`unit` went from 0% to 92%.
+
+That was the expected win. Here's the part we were watching for: US `street` went *up*, about three points, on the same evaluation where we changed nothing about streets. Locality nudged up. Country nudged up. We gave the model a place to put "Apt 12," and it stopped making the street pay for it. Covering the negative space sharpened the positive space, exactly as the theory promised and rarely delivers so cleanly.
+
+## The eval that hid the win
+
+We almost missed it. The first gate read came back `0%` on the new tag — a heart-stopping number for a shard that was supposed to fix exactly that. The model had trained fine; our *evaluator* was blind. The per-tag scorer folded street prefix, name, and suffix back into a single `street` string before comparing — so a model that split "N Main St" perfectly into three components scored zero against ground truth that was also split, because the fold recomposed it into a shape that no longer matched.
+
+The lesson we keep relearning: the measurement apparatus is part of the system, and it fails silently. A whole-address-strict arena score will tell you a unit-perfect parse "failed" because some other tag slipped. An in-distribution validation set will hand you 98% while the real-world distribution sits at zero. We now keep a small, curated set of *real* examples for every tag we touch, score the raw decode without folding, and trust that number over the convenient one. When two metrics disagree, the disagreement is the information.
+
+## One fix turned into a campaign
+
+The same lever pulls for the next tag, and the next. Street affixes (the directionals and types the suffix table already knew) split cleanly, and the street boundary tightened alongside them, exactly the way `unit` had. So far the theory held: cover the empty space, sharpen the rest.
+
+Then country broke the pattern, and taught us something better.
+
+We built `country` the same kind of shard, expecting the same kind of win. Instead the model got greedy. Country is a closed vocabulary that almost always sits in the last position of an address, so the model learned the shortcut we'd accidentally handed it: trailing token, must be a country. It started promoting cities and states to nationhood. Precision fell through the floor. The retrain hadn't filled the empty space, it had spilled into the space next door.
+
+The fix turned out to be no shard at all. There are only so many countries, and they spell themselves the same way every time, so a flat lookup against that list (match the trailing segment, tag it, done) scores a clean hundred where the trained model scored a mess. PO boxes told the same story: a fixed set of designators ("PO Box," "Drawer," "Caller") in a predictable slot, perfectly handled by a matcher and only muddied by a model.
+
+So the campaign taught us two things, not one. First, the one we went looking for: covering a starved tag sharpens its neighbors. Second, the one we didn't see coming: some tags don't want the model at all. A secondary unit can land anywhere and spell itself a hundred ways, so the model has to *learn* it, and that's where training earns its keep. A country is a closed list in a known spot, and the honest tool for a closed list is a lookup table, not a neural net you've talked into memorizing one. Half the work is knowing which tag is which.
+
+The starved tags were never a long tail to defer. They were holding the rest of the model back, and a few of them turned out not to be the model's job in the first place. Filling the empty space, and knowing what to fill it with, is the work.


### PR DESCRIPTION
Night-shift artifacts for the negative-space parity campaign.

## Parity scorecard (#375)
One authoritative per-tag-vs-v0 table so "are we at ~90%?" stops being a scatter of one-off evals. Two lenses (they disagree on purpose): capability arenas (whole-address-strict) + per-tag F1 (golden + real-OOD). Documents:
- the `foldToComponents` gotcha (folds affixes into `street` → can't measure the split; use `score-affix.ts`)
- the **cumulative-dilution lesson** (stacking synth shards in one 20k run dilutes each tag — prove solo, consolidate with a bigger budget)
- a **lever-shape taxonomy**: open-vocab/boundary tags (affix, unit, locality) → retrain; closed-vocab/trailing tags (country, po_box, cedex) → deterministic matcher.

## Postmortem
- **affix** v0.9.8 gated, int8 ship-ready, promote deferred to operator (#462) — FR-postcode −3.9 trips the pre-registered >2pp gate.
- **country + po_box** resolved to deterministic taggers (#464): the model over-fires (country 49 F1, 23% golden precision), `matchCountry`/`matchPOBox` score **P=R=F1=100** on real-OOD evals (probes in PR #463).

## Blog
"Teaching the tags it was missing" — spicy-register house-voice post on the campaign (unit win + the deterministic twist). Humanizer pass applied.

Nothing promoted to production this shift; both open decisions (#462, #463/#464) are the operator's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)