### PR TITLE
feat(anchor): channel choreography (train+inference) — v0.9.13 postcode fix for consolidation

### DIFF
--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -44,6 +44,11 @@ class DataConfig:
     # AND model.use_gazetteer_anchor is on, the loader paints per-piece multi-hot membership clues
     # from the RAW SURFACE (never gold labels — same computation at train + inference). None → off.
     gazetteer_lexicon_path: str | None = None
+    # Gazetteer channel choreography (#464, v0.9.13 postcode fix). When True (with anchor + gazetteer
+    # channels on), zero the gazetteer clue on tokens adjacent to a postcode-anchor hit, so the model
+    # never learns the biased region->postcode CRF transition that cost v0.9.12 ~3pp US postcode.
+    # Inference MUST mirror it (classifier suppressGazetteerNearPostcode). For the consolidation run.
+    gazetteer_choreography: bool = False
 
 
 @dataclass

--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -491,6 +491,7 @@ def iter_encoded(
             max_length=cfg_data.max_length,
             anchor_lookup=anchor_lookup,
             gazetteer_lexicon=gazetteer_lexicon,
+            gazetteer_choreography=getattr(cfg_data, "gazetteer_choreography", False),
         )
         # Drop rows whose non-padding length exceeds max_length (length filter §2).
         non_pad = sum(enc["attention_mask"])

--- a/corpus-python/src/mailwoman_train/gazetteer_anchor.py
+++ b/corpus-python/src/mailwoman_train/gazetteer_anchor.py
@@ -128,6 +128,34 @@ def gazetteer_char_paint(raw: str, lexicon: GazetteerLexicon) -> tuple[list[int]
     return char_bits, n_matches
 
 
+def suppress_gazetteer_near_postcode(
+    feats: list[list[float]],
+    confs: list[float],
+    anchor_confidence: Sequence[float],
+    feature_dim: int,
+    window: int = 1,
+) -> tuple[list[list[float]], list[float]]:
+    """TRAIN-TIME channel choreography (#464, v0.9.13 postcode fix; DeepSeek 2026-06-10) — the mirror
+    of TS ``suppressGazetteerNearPostcode``. Zero the gazetteer clue on pieces within ``window`` of a
+    postcode-anchor hit (``anchor_confidence[i] > 0``) so the model never LEARNS the biased
+    region->postcode CRF transition (the inference-only fix can't undo a weight-baked transition; the
+    cure is applying this at TRAIN time, keyed off the SAME anchor signal inference uses, so the two
+    stay consistent). Returns new (feats, confs); does not mutate.
+    """
+    n = len(confs)
+    suppress = [False] * n
+    for i in range(n):
+        if i < len(anchor_confidence) and anchor_confidence[i] > 0:
+            for d in range(-window, window + 1):
+                j = i + d
+                if d != 0 and 0 <= j < n:
+                    suppress[j] = True
+    zero = [0.0] * feature_dim
+    out_feats = [zero if suppress[i] else feats[i] for i in range(n)]
+    out_confs = [0.0 if suppress[i] else confs[i] for i in range(n)]
+    return out_feats, out_confs
+
+
 def realign_gazetteer_to_pieces(
     raw: str,
     pieces: Sequence[PieceSpan],

--- a/corpus-python/src/mailwoman_train/test_gazetteer_anchor.py
+++ b/corpus-python/src/mailwoman_train/test_gazetteer_anchor.py
@@ -12,6 +12,7 @@ from .gazetteer_anchor import (
     GazetteerLexicon,
     gazetteer_char_paint,
     realign_gazetteer_to_pieces,
+    suppress_gazetteer_near_postcode,
 )
 from .tokenizer import PieceSpan
 
@@ -102,6 +103,23 @@ def test_po_box_and_cedex_clues():
     # marks lexicon membership (model-first: a hint, never a verdict).
     assert painted_words("12 Box Canyon Rd")["Box"] == BITS["po_box"]
     assert painted_words("75008 PARIS CEDEX 02")["CEDEX"] == BITS["cedex"]
+
+
+def test_choreography_zeros_clue_adjacent_to_postcode_anchor():
+    # "Los Angeles, CA 90012": pieces [LA, CA(region clue, bits=19), 90012(postcode anchor conf=1)].
+    feats = [[0, 0, 0, 0, 0], [1, 1, 0, 0, 1], [0, 0, 0, 0, 0]]
+    confs = [0.0, 1.0, 0.0]
+    anchor_conf = [0.0, 0.0, 1.0]  # postcode anchor fires on the ZIP piece
+    out_f, out_c = suppress_gazetteer_near_postcode(feats, confs, anchor_conf, feature_dim=5, window=1)
+    # The CA clue (index 1) is adjacent to the postcode anchor (index 2) → zeroed.
+    assert out_f[1] == [0, 0, 0, 0, 0]
+    assert out_c[1] == 0.0
+    # A clue NOT adjacent to a postcode anchor is untouched.
+    feats2 = [[1, 1, 0, 0, 1], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]
+    confs2 = [1.0, 0.0, 0.0]
+    anchor2 = [0.0, 0.0, 1.0]  # postcode 2 pieces away from the clue
+    of2, oc2 = suppress_gazetteer_near_postcode(feats2, confs2, anchor2, feature_dim=5, window=1)
+    assert of2[0] == [1, 1, 0, 0, 1] and oc2[0] == 1.0
 
 
 def test_realign_projects_first_nonws_char_and_pads_zero():

--- a/corpus-python/src/mailwoman_train/tokenizer.py
+++ b/corpus-python/src/mailwoman_train/tokenizer.py
@@ -271,6 +271,7 @@ def encode_row(
     max_length: int,
     anchor_lookup: "dict[str, tuple[dict[str, float], float, float]] | None" = None,
     gazetteer_lexicon=None,
+    gazetteer_choreography: bool = False,
 ) -> dict[str, list]:
     """Encode a single row into ``input_ids`` + ``attention_mask`` + ``label_ids``.
 
@@ -317,6 +318,15 @@ def encode_row(
         gfeats, gconfs = realign_gazetteer_to_pieces(raw, list(spans), gazetteer_lexicon)
         gfeats = gfeats[:max_length]
         gconfs = gconfs[:max_length]
+        # Train-time channel choreography (#464): zero the clue adjacent to postcode-anchor hits so
+        # the model never learns the biased region->postcode CRF transition. Keyed off the SAME anchor
+        # confidence inference uses (consistent train/inference). No-op without the anchor channel.
+        if gazetteer_choreography and "anchor_confidence" in out:
+            from .gazetteer_anchor import suppress_gazetteer_near_postcode
+
+            gfeats, gconfs = suppress_gazetteer_near_postcode(
+                gfeats, gconfs, out["anchor_confidence"][: len(gconfs)], gazetteer_lexicon.feature_dim
+            )
         gzero = [0.0] * gazetteer_lexicon.feature_dim
         if pad_needed > 0:
             gfeats = gfeats + [gzero] * pad_needed

--- a/docs/articles/plan/2026-06-09-parity-endgame.mdx
+++ b/docs/articles/plan/2026-06-09-parity-endgame.mdx
@@ -13,6 +13,23 @@ review (the model-first reversal, the synonymy/homonymy framing, and the gazette
 anchor discussion). Three principles now govern the endgame, and a concrete move
 order follows from them.
 
+## Status (2026-06-10): country banked
+
+Move 1 is **done**. The general gazetteer anchor took `country` from 0 (starved in
+v4.1.0) to **83.3 F1** on the hard homograph gate (recall 74.1, precision 95.2,
+**over-fire 0**), and lifted the spine with it (region US +11.7, locality +14.9).
+Progression: v0.9.10 balanced shard 57.9 → v0.9.11 +class-weight 65.0 → v0.9.12
++gazetteer anchor 83.3. The one cost was US postcode −3.7 — the region clue ("CA",
+"GA") sitting next to the US ZIP strengthens `B-region` and weakens the
+`B-region → B-postcode` CRF transition (US-only; FR's postcode precedes the
+locality, so it never sees this). The fix is **train-time channel choreography**:
+zero the gazetteer clue on tokens adjacent to a postcode-anchor hit, at *both* train
+and inference (the pairing is load-bearing — the harm is weight-baked, so an
+inference-only patch can't undo it). Operator decision: **accept v0.9.12/13 as the
+country lever and carry the choreography into the consolidation retrain** (move 4),
+where the dip washes out — no standalone fix-retrain. Choreography ships
+default-off/byte-stable in PR #468.
+
 ## The three governing principles
 
 **1. Model-first, lexicon-as-evidence.** The day's central correction: no deterministic
@@ -40,13 +57,14 @@ the bendable version of the crutch rules systems can't drop.
 
 ## The move order
 
-1. **Finish country (step 2b): the gazetteer anchor, built general.** A per-token
-   **candidate-tag-set** feature channel (multi-hot over `country, region, po_box,
-   cedex, …`), sourced from codex, riding the same input-layer mechanics as the
-   postcode anchor and phrase priors. Country is the first consumer (its long-tail
-   recall — Eswatini, Timor-Leste, multi-word names — is the measured gap);
-   region/locality/street membership come nearly free later. Gate unchanged: country
-   recall up on the homograph eval, precision/over-fire intact, spine flat.
+1. ~~**Finish country (step 2b): the gazetteer anchor, built general.**~~ **DONE
+   (2026-06-10).** A per-token **candidate-tag-set** feature channel (multi-hot over
+   `country, region, po_box, cedex, …`), sourced from codex, riding the same
+   input-layer mechanics as the postcode anchor and phrase priors. Country was the
+   first consumer (its long-tail recall — Eswatini, Timor-Leste, multi-word names —
+   was the measured gap); region/locality/street membership come nearly free later.
+   Gate cleared: country 0 → 83.3 F1, precision/over-fire intact, spine lifted. See
+   the status section above; po_box/cedex ride the same channel for free.
 2. **Promote the affix lever via the multi-locale reroll (#466 step 1).** v0.9.8's
    only blemish is FR-postcode dilution from a US-only shard; the multi-locale country
    shard already demonstrated the recovery. Reroll affix multi-locale, clear its own
@@ -56,8 +74,9 @@ the bendable version of the crutch rules systems can't drop.
    already proven at 100% as feature-sources/eval material). Prove each solo.
 4. **Consolidate (#466): one model carrying all banked levers.** Weight-merge or a
    single multi-tag run at a larger step budget (the cumulative-dilution lesson:
-   never stack shards into a fixed 20k budget). Full per-tag regression gate; this
-   is the v0-parity flag-plant.
+   never stack shards into a fixed 20k budget). This run also **carries the gazetteer
+   choreography** (PR #468), where the v0.9.12 US-postcode dip is expected to wash
+   out for free. Full per-tag regression gate; this is the v0-parity flag-plant.
 5. **Then the pivot: from parity to the things v0 cannot do.** The lossless
    decomposition (typed `unknown` spans surviving projection — the small decoder
    change), canonical values on every span, and record-linkage as a named

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -21,7 +21,7 @@ import {
 	type DecoderToken,
 } from "@mailwoman/core/decoder"
 import { buildAnchorFeatures, type AnchorLookup } from "./anchor-inference.js"
-import { buildGazetteerFeatures, type GazetteerLexicon } from "./gazetteer-inference.js"
+import { buildGazetteerFeatures, suppressGazetteerNearPostcode, type GazetteerLexicon } from "./gazetteer-inference.js"
 import { buildFstEmissionPriors, type FstMatcherLike } from "./fst-prior.js"
 import { STAGE2_BIO_LABELS } from "./labels.js"
 import type { InferResult } from "./onnx-runner.js"
@@ -89,6 +89,18 @@ export interface NeuralAddressClassifierConfig {
 	 * models. Load via `parseGazetteerLexicon` from `./gazetteer-inference.js`.
 	 */
 	gazetteerLexicon?: GazetteerLexicon
+	/**
+	 * Channel choreography (#464, v0.9.13 postcode fix): when true, zero the gazetteer clue on pieces
+	 * adjacent to a postcode-anchor hit (needs both `gazetteerLexicon` and `postcodeAnchorLookup`).
+	 * Targets the region-clue→postcode CRF interference (~3pp US postcode).
+	 *
+	 * PAIRING IS LOAD-BEARING: set this IFF the model was TRAINED with the matching train-time
+	 * choreography (`data.gazetteer_choreography`). The 2026-06-10 diagnostic showed the harm is
+	 * WEIGHT-BAKED — applying this at inference on a model trained *without* train-choreography does
+	 * NOT recover postcode and adds train/inference skew. Only enable for a consolidation-era model
+	 * trained with the train-time half.
+	 */
+	suppressGazetteerNearPostcode?: boolean
 }
 
 export class NeuralAddressClassifier {
@@ -166,7 +178,11 @@ export class NeuralAddressClassifier {
 		const gazetteer = this.cfg.gazetteerLexicon
 			? buildGazetteerFeatures(text, pieces, this.cfg.gazetteerLexicon)
 			: undefined
-		const { logits } = await this.cfg.runner.infer(ids, anchor, gazetteer)
+		const gazFed =
+			gazetteer && anchor && this.cfg.suppressGazetteerNearPostcode
+				? suppressGazetteerNearPostcode(gazetteer, anchor.confidence)
+				: gazetteer
+		const { logits } = await this.cfg.runner.infer(ids, anchor, gazFed)
 
 		this.assertEmissionWidth(logits)
 
@@ -250,7 +266,11 @@ export class NeuralAddressClassifier {
 		const gazetteer = this.cfg.gazetteerLexicon
 			? buildGazetteerFeatures(text, pieces, this.cfg.gazetteerLexicon)
 			: undefined
-		const { logits } = await this.cfg.runner.infer(ids, anchor, gazetteer)
+		const gazFed =
+			gazetteer && anchor && this.cfg.suppressGazetteerNearPostcode
+				? suppressGazetteerNearPostcode(gazetteer, anchor.confidence)
+				: gazetteer
+		const { logits } = await this.cfg.runner.infer(ids, anchor, gazFed)
 
 		this.assertEmissionWidth(logits)
 

--- a/neural/gazetteer-inference.ts
+++ b/neural/gazetteer-inference.ts
@@ -137,6 +137,38 @@ export function gazetteerCharPaint(text: string, lexicon: GazetteerLexicon): num
 }
 
 /**
+ * Channel choreography (#464, v0.9.13 postcode fix; DeepSeek 2026-06-10): zero the gazetteer clue on
+ * pieces within `window` of a postcode-anchor hit. The clue fires on the region token (`CA`/`GA`)
+ * immediately before a US postcode; its additive vector strengthens `B-region`, which makes the
+ * `B-region → B-postcode` CRF transition less competitive and drops the postcode (~3pp, US-only — FR
+ * postcode precedes the locality, no region neighbor). Suppressing the clue adjacent to the postcode
+ * removes the interference while leaving every other clue intact. Returns a NEW features/confidence
+ * pair (does not mutate). `anchorConfidence[i] > 0` marks postcode-span pieces. PAIRS WITH the
+ * train-time half (`gazetteer_anchor.suppress_gazetteer_near_postcode`) — enable both or neither.
+ */
+export function suppressGazetteerNearPostcode(
+	gazetteer: { features: number[][]; confidence: number[] },
+	anchorConfidence: ReadonlyArray<number>,
+	window = 1
+): { features: number[][]; confidence: number[] } {
+	const n = gazetteer.confidence.length
+	const suppress = new Array<boolean>(n).fill(false)
+	for (let i = 0; i < n; i++) {
+		if ((anchorConfidence[i] ?? 0) > 0) {
+			for (let d = -window; d <= window; d++) {
+				const j = i + d
+				if (j >= 0 && j < n && d !== 0) suppress[j] = true
+			}
+		}
+	}
+	const dim = gazetteer.features[0]?.length ?? 0
+	return {
+		features: gazetteer.features.map((row, i) => (suppress[i] ? new Array<number>(dim).fill(0) : row)),
+		confidence: gazetteer.confidence.map((c, i) => (suppress[i] ? 0 : c)),
+	}
+}
+
+/**
  * Per-piece gazetteer features + confidence for `text`, projected onto its SP `pieces` by the SAME
  * char→piece rule the labels use (a piece takes the bits of the first non-whitespace char it covers).
  * Returns `(pieces × featureDim)` features + `(pieces,)` confidence (1.0 wherever any bit fires).

--- a/scripts/eval/per-locale-f1.ts
+++ b/scripts/eval/per-locale-f1.ts
@@ -50,6 +50,7 @@ interface Args {
 	modelCardPath?: string
 	modelAnchorLookupPath?: string
 	gazetteerLexiconPath?: string
+	suppressGazNearPostcode?: boolean
 	outJson?: string
 }
 
@@ -73,6 +74,7 @@ function parseArgs(): Args {
 		// missing anchor inputs). Mirrors oa-resolver-eval's --model-anchor-lookup.
 		else if (a === "--model-anchor-lookup" && argv[i + 1]) out.modelAnchorLookupPath = argv[++i]
 		else if (a === "--gazetteer-lexicon" && argv[i + 1]) out.gazetteerLexiconPath = argv[++i]
+		else if (a === "--suppress-gaz-near-postcode") out.suppressGazNearPostcode = true
 		else if (a === "--out-json" && argv[i + 1]) out.outJson = argv[++i]
 	}
 	return out as Args
@@ -237,6 +239,7 @@ async function main(): Promise<void> {
 			labels: card.labels,
 			postcodeAnchorLookup,
 			gazetteerLexicon,
+			suppressGazetteerNearPostcode: !!args.suppressGazNearPostcode,
 		})
 	} else {
 		neural = await NeuralAddressClassifier.loadFromWeights()

--- a/scripts/eval/score-country-homograph.ts
+++ b/scripts/eval/score-country-homograph.ts
@@ -30,6 +30,7 @@ const neural = new NeuralAddressClassifier({
 	labels: card.labels,
 	postcodeAnchorLookup: parseAnchorLookup(JSON.parse(readFileSync(LK, "utf8"))),
 	...(existsSync(GAZ) ? { gazetteerLexicon: parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))) } : {}),
+	suppressGazetteerNearPostcode: argv.includes("--suppress-gaz-near-postcode"),
 })
 
 const rows = readFileSync(file, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l))


### PR DESCRIPTION
The country lever's last loose end, resolved per the DeepSeek consult + operator decision.

## The finding
v0.9.12 (gazetteer anchor) lifted **country 0→83, region +12, locality +15, over-fire 0** but cost **US postcode −3.7** (FR untouched — its postcode precedes the locality). v0.9.13 (confidence curriculum) held the gains but recovered postcode only +0.6.

DeepSeek's mechanism: the clue on the region token (`CA`/`GA`) right before the US postcode strengthens `B-region`, making `B-region→B-postcode` less competitive in Viterbi. **The cheap inference-only diagnostic falsified the live-interference theory** — zeroing the clue at inference did *not* recover postcode and added train/inference skew → the harm is **weight-baked**. So the fix must be **train-time**.

## This PR (the fix, ready for consolidation)
- **Train half** (`gazetteer_anchor.suppress_gazetteer_near_postcode` + `encode_row`, gated on `data.gazetteer_choreography`): zero the clue adjacent to postcode-anchor hits at train time so the model never learns the biased transition. Keyed off the same anchor signal inference uses.
- **Inference half** (`neural.suppressGazetteerNearPostcode`): the matching runtime suppression. **Pairing is load-bearing** — enable IFF trained with the train half (docstring + a falsified-diagnostic note warn against solo use).
- Harness flags (`--suppress-gaz-near-postcode`), Python + TS parity tests.

## Decision (operator)
**Accept v0.9.13 as the country lever** (the −3.1 postcode is a small, documented cost on a still-95% tag vs the huge gains) and **carry the train-time choreography into the consolidation retrain** (#466), where DeepSeek expects the dip to wash out anyway. No standalone fix-retrain.

Verified: neural tsc + 6 TS parity + 7 Python tests green. Default-off / byte-stable.