### PR TITLE
feat(corpus): multi-locale affix shard — proves the FR-postcode fix (#466 step 1)

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v0.9.14-affix-ml.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v0.9.14-affix-ml.yaml
@@ -1,0 +1,158 @@
+# === v0.9.14-affix-ml (#466 step 1) — the AFFIX MULTI-LOCALE REROLL ==============================
+# ONE conceptual variable vs v0.9.8-affix (the gated affix lever): the affix shard is now MULTI-LOCALE.
+# Corpus v0.4.11-affix-ml = v0.4.6-affix with the US-only synth-affix shard SWAPPED for a multi-locale
+# one (50K US affix splits — identical dose to v0.9.8 — PLUS 40K native-order FR/DE/IT/NL balance rows,
+# no affix split, no annotation). Everything else is held EXACTLY at v0.9.8: same recipe (postcode
+# anchor ON, self-cond ON, phrase priors ON), same source_weights (synth-affix 2.0), seed 42, 20k steps.
+# NO gazetteer anchor here — that + its choreography fold in at CONSOLIDATION (#466). This is a clean
+# SOLO A/B: does multi-locale balance clear the FR-postcode dilution WITHOUT losing the affix win?
+#
+# WHY. v0.9.8 cleared the affix gate (street_prefix 0→78, street_suffix 0→67, P100; US street +2.1
+# negative-space) but its ONE blemish was FR postcode −3.9 — a US-ONLY shard (every row "City, ST ZIP")
+# strengthened the US postcode-after-region pattern and diluted FR's postcode-BEFORE-locality order.
+# The night-9 cumulative country run PROVED the recovery: its multi-locale rows lifted FR postcode
+# 95.6→99.5. This reroll folds that exact fix into the affix shard itself (see the postmortem
+# 2026-06-09, and docs/articles/plan/2026-06-09-parity-endgame.mdx move 2). The US affix EXPOSURE is
+# unchanged (50K US rows at weight 2.0 = same weighted mass as v0.9.8); the balance rows are additive.
+#
+# PRE-REGISTERED GATE (stop at 20k), fp32-to-fp32 vs v4.1.0 / v0.9.8:
+#   - RECOVER FR postcode: FR postcode F1 >= v4.1.0 (undo the −3.9; back within ~1pp).
+#   - RETAIN the affix win: street_suffix F1 >= 65% AND street_prefix F1 >= 70% on the real-affix eval
+#     (data/eval/external/street-affix-real.jsonl) — at or above v0.9.8 (78/67).
+#   - `street` F1 >= v4.1.0 (no loss; negative space) on golden US + the real-affix eval.
+#   - RETAIN the unit win: `unit` >= 88% on data/eval/external/unit-real-designators.jsonl.
+#   - NO-REGRESSION (within ~1pp, fp32): US house_number / postcode / locality / region; DE native-order
+#     locality (de-order-eval.sh). The balance rows ADD FR/DE order signal — DE should hold or improve.
+#   DECISION: FR postcode recovered + affix retained + no tripwire → PROMOTE candidate (v4.2.0) and the
+#     affix lever is BANKED for consolidation. If affix slips below v0.9.8: too much balance crowded the
+#     US dose — raise synth-affix to 2.5 or lower --multilocale-count and rerun. If FR still dilutes:
+#     raise --multilocale-count (more FR balance).
+# Measure: per-locale-f1.ts (US/FR golden, fp32 — needs --tokenizer + --model-card) + score-affix.ts
+#   (the UNFOLDED affix scorer — per-locale-f1's foldToComponents joins affixes into `street` and can't
+#   measure the split) + the street-affix-real + unit-real-designators evals + de-order-eval.sh.
+#
+# CORPUS: v0.4.11-affix-ml (shard swap, no base rebuild). Reproduce:
+#   node scripts/build-street-affix-shard.mjs --output /tmp/affix-ml-train.jsonl --count 50000 --multilocale-count 40000 --seed 42
+#   python3 scripts/jsonl-to-parquet.py --input /tmp/affix-ml-train.jsonl --output <NEW>/train/part-affix-ml-train.parquet
+#   python3 scripts/assemble-affix-ml-overlay-manifest.py --base <v0.4.6-affix MANIFEST.json> \
+#       --new-dir <NEW> --modal-root /data/.../corpus-v0.4.11-affix-ml --version v0.4.11-affix-ml
+#   # then `modal volume put` the parquet + the manifest onto the mailwoman-training volume.
+#
+# Launch:
+#   modal run -d scripts/modal/train_remote.py \
+#     --config v0.9.14-affix-ml.yaml --resume none \
+#     --trackio --trackio-space sister-software/mailwoman-trackio
+
+data:
+  corpus_dir: /data/corpus/versioned/v0.4.11-affix-ml/corpus-v0.4.11-affix-ml
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-po-box: 1.5
+    synth-intersection: 0.2
+    synth-german: 6.0
+    # retained from v4.1.0 (v0.9.7-unit-v3) — keep the secondary-unit win.
+    synth-unit: 1.5
+    # the multi-locale affix shard. 2.0 keeps the US affix EXPOSURE identical to v0.9.8 (50K US rows at
+    # 2.0); the 40K FR/DE/IT/NL balance rows ride the same weight (additive, postcode-order signal).
+    synth-affix: 2.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  class_weights:
+    O: 0.5
+    B-country: 2.0
+    I-country: 2.0
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v0914-affix-ml-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 20000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  trackio_project: mailwoman
+  trackio_run_name: v0.9.14-affix-ml-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/scripts/assemble-affix-ml-overlay-manifest.py
+++ b/scripts/assemble-affix-ml-overlay-manifest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Assemble the MULTI-LOCALE affix-overlay MANIFEST (#466 step 1 — the affix reroll).
+
+v0.9.8's only blemish was FR-postcode dilution from a US-ONLY affix shard (FR postcode −3.9). The
+multi-locale country shard demonstrated the recovery (95.6→99.5); this reroll folds the same fix into
+the affix shard itself: native-order FR/DE/IT/NL BALANCE rows (no affix split, no annotation) restore
+the postcode-ORDER distribution so the US affix coverage doesn't pull the model US-ward.
+
+This is a pure SHARD SWAP, not a rebuild: it reads the v0.4.6-affix manifest (= v0.4.5-unit-v2 base +
+the US-only affix shard), DROPS the old `synth-affix` shard, and ADDS the new multi-locale affix
+parquet. The base shards (and synth-unit / synth-german / deepseek overlays) are referenced VERBATIM —
+the US affix dose is identical to v0.9.8 (same 50K `--count`), so the only conceptual change vs v0.9.8
+is the appended multi-locale balance rows.
+
+Pipeline:
+  node scripts/build-street-affix-shard.mjs --output /tmp/affix-ml-train.jsonl \
+      --count 50000 --multilocale-count 40000 --seed 42
+  python3 scripts/jsonl-to-parquet.py --input /tmp/affix-ml-train.jsonl \
+      --output <NEW>/train/part-affix-ml-train.parquet
+  python3 scripts/assemble-affix-ml-overlay-manifest.py \
+      --base /mnt/playpen/mailwoman-data/corpus/versioned/v0.4.6-affix/corpus-v0.4.6-affix/MANIFEST.json \
+      --new-dir /mnt/playpen/mailwoman-data/corpus/versioned/v0.4.11-affix-ml/corpus-v0.4.11-affix-ml \
+      --modal-root /data/corpus/versioned/v0.4.11-affix-ml/corpus-v0.4.11-affix-ml \
+      --version v0.4.11-affix-ml
+  # then `modal volume put` the parquet + the manifest onto the mailwoman-training volume.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+
+def _descriptor(local_path: Path, modal_path: str, split: str, source: str) -> dict:
+    sids = pq.read_table(local_path, columns=["source_id"])["source_id"].to_pylist()
+    return {
+        "split": split,
+        "path": modal_path,
+        "format": "parquet",
+        "compression": "SNAPPY",
+        "rows": len(sids),
+        "bytes": os.path.getsize(local_path),
+        "sha256": hashlib.sha256(local_path.read_bytes()).hexdigest(),
+        "first_source_id": sids[0],
+        "last_source_id": sids[-1],
+        "source": source,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", type=Path, required=True, help="base MANIFEST.json to swap (v0.4.6-affix)")
+    ap.add_argument("--new-dir", type=Path, required=True, help="local overlay corpus dir (holds the affix-ml parquet + the written manifest)")
+    ap.add_argument("--modal-root", required=True, help="the overlay corpus root as the trainer sees it on the Modal volume")
+    ap.add_argument("--version", default="v0.4.11-affix-ml")
+    args = ap.parse_args()
+
+    base = json.loads(args.base.read_text())
+
+    # Drop the OLD US-only affix shard(s); keep everything else (base + unit + german + deepseek) verbatim.
+    kept = [s for s in base["shards"] if s.get("source") != "synth-affix"]
+    dropped = len(base["shards"]) - len(kept)
+    if dropped == 0:
+        print("WARN: no synth-affix shard found in base — is this the v0.4.6-affix manifest?")
+    dropped_rows = sum(s["rows"] for s in base["shards"] if s.get("source") == "synth-affix" and s["split"] == "train")
+
+    a_train = _descriptor(
+        args.new_dir / "train" / "part-affix-ml-train.parquet",
+        f"{args.modal_root}/train/part-affix-ml-train.parquet",
+        "train",
+        "synth-affix",
+    )
+
+    manifest = {
+        "corpus_version": args.version,
+        "overlay_base": base.get("corpus_version"),
+        "note": (
+            f"{base.get('corpus_version')} shards minus the US-only synth-affix shard + a MULTI-LOCALE "
+            "affix shard (#466 step 1): 50K US affix splits (USPS Pub-28 C1/C2, identical dose to "
+            "v0.9.8) + native-order FR/DE/IT/NL balance rows to undo the FR-postcode dilution."
+        ),
+        "schema": base["schema"],
+        "rows_per_shard": base["rows_per_shard"],
+        "row_group_size": base["row_group_size"],
+        "shards": kept + [a_train],
+        "counts": {
+            "train": base["counts"]["train"] - dropped_rows + a_train["rows"],
+            "val": base["counts"]["val"],
+            "test": base["counts"]["test"],
+        },
+        "total_rows": base["total_rows"] - dropped_rows + a_train["rows"],
+    }
+    out = args.new_dir / "MANIFEST.json"
+    out.write_text(json.dumps(manifest, indent=1) + "\n")
+    print(f"wrote {out}")
+    print(f"  shards: {len(manifest['shards'])} ({len(kept)} kept, dropped {dropped} old affix, +1 affix-ml)")
+    print(f"  counts: {manifest['counts']}  total: {manifest['total_rows']}")
+    print(f"  affix-ml train: {a_train['rows']} rows ({a_train['bytes']} bytes)  (old affix train was {dropped_rows})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-street-affix-shard.mjs
+++ b/scripts/build-street-affix-shard.mjs
@@ -55,12 +55,27 @@ const TRAIN_SOURCES = [
 ]
 const EVAL_SOURCE = { zip: "/tmp/oa-cache/us__vt__statewide.zip", csv: "us/vt/statewide.csv", region: "VT" }
 
+// Multi-locale BALANCE sources (--multilocale-count > 0). These rows carry NO affix split — they exist
+// only to keep the postcode-ORDER distribution multi-locale so a US-heavy affix shard doesn't dilute
+// FR/DE postcode (the v0.9.8 blemish: a US-only shard drove FR postcode −3.9; the multi-locale country
+// shard recovered it 95.6→99.5). Native-order rendering mirrors build-country-shard-balanced.mjs:
+// FR = number-street, postcode-city; DE/IT/NL = street-number, postcode-city. `order` drives the body.
+const MULTILOCALE_SOURCES = [
+	{ zip: "/tmp/oa-cache/de__sn__statewide.zip", csv: "de/sn/statewide.csv", iso2: "DE", region: "", order: "eu" },
+	{ zip: "/tmp/oa-cache/fr__countrywide.zip", csv: "fr/countrywide.csv", iso2: "FR", region: "", order: "fr" },
+	{ zip: "/tmp/oa-cache/it__countrywide.zip", csv: "it/countrywide.csv", iso2: "IT", region: "", order: "eu" },
+	{ zip: "/tmp/oa-cache/nl__countrywide.zip", csv: "nl/countrywide.csv", iso2: "NL", region: "", order: "eu" },
+]
+const MULTILOCALE_EVAL_SOURCES = [
+	{ zip: "/tmp/oa-cache/de__berlin.zip", csv: "de/berlin.csv", iso2: "DE", region: "", order: "eu" },
+]
+
 const DIRECTIONAL_ABBRS = Object.values(DirectionalAbbreviation) // ["N","E","S","W","NE","NW","SE","SW"]
 const INJECT_PREFIX_PROB = 0.3 // fraction of prefix-less streets that get a synthetic directional
 
 function parseArgs() {
 	const args = process.argv.slice(2)
-	const out = { count: 50000, seed: 42, source: "synth-affix", golden: false }
+	const out = { count: 50000, seed: 42, source: "synth-affix", golden: false, multilocaleCount: 0 }
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i]
 		if (a === "--output") out.output = args[++i]
@@ -68,9 +83,12 @@ function parseArgs() {
 		else if (a === "--seed") out.seed = parseInt(args[++i], 10)
 		else if (a === "--source-name") out.source = args[++i]
 		else if (a === "--golden") out.golden = true
+		else if (a === "--multilocale-count") out.multilocaleCount = parseInt(args[++i], 10)
 	}
 	if (!out.output) {
-		console.error("Usage: build-street-affix-shard.mjs --output <labeled.jsonl> [--count N] [--seed N] [--golden]")
+		console.error(
+			"Usage: build-street-affix-shard.mjs --output <labeled.jsonl> [--count N] [--seed N] [--golden] [--multilocale-count N]"
+		)
 		process.exit(1)
 	}
 	return out
@@ -240,6 +258,76 @@ function renderRow(random, base, street, streetComponents) {
 	}
 }
 
+/**
+ * Capped reader for the multi-locale BALANCE sources. The FR/IT/NL countrywide extracts are GB-scale;
+ * reading the whole CSV blows V8's string limit, so cap the bytes with `head` (mirrors
+ * build-country-shard-balanced.mjs). Only keeps tuples that carry a POSTCODE — the whole point of the
+ * balance rows is native-order postcode signal, so a postcode-less row contributes nothing.
+ */
+function readBalanceTuples(source, limit) {
+	const maxLines = Math.max(limit * 8, 20000) + 1
+	const r = spawnSync("bash", ["-c", `unzip -p "${source.zip}" "${source.csv}" | head -n ${maxLines}`], {
+		maxBuffer: 1024 * 1024 * 1024,
+		encoding: "buffer",
+	})
+	if (r.status !== 0) {
+		console.error(`  WARN: unzip failed for ${source.zip} (status ${r.status})`)
+		return []
+	}
+	const lines = r.stdout.toString("utf8").split(/\r?\n/)
+	if (lines.length < 2) return []
+	const header = splitCsv(lines[0]).map((h) => h.trim().toLowerCase())
+	const idx = (n) => header.indexOf(n)
+	const iNum = idx("number"),
+		iStreet = idx("street"),
+		iCity = idx("city"),
+		iRegion = idx("region"),
+		iPost = idx("postcode")
+	const get = (cells, i) => (i >= 0 && i < cells.length ? (cells[i] ?? "").trim() : "")
+	const tuples = []
+	const seen = new Set()
+	for (let li = 1; li < lines.length && tuples.length < limit; li++) {
+		if (!lines[li]) continue
+		const cells = splitCsv(lines[li])
+		const street = get(cells, iStreet),
+			locality = get(cells, iCity),
+			house_number = get(cells, iNum),
+			postcode = get(cells, iPost)
+		if (!street || !locality || !house_number || !postcode) continue // postcode is required for balance
+		const key = `${house_number}|${street}|${locality}`.toLowerCase()
+		if (seen.has(key)) continue
+		seen.add(key)
+		tuples.push({
+			house_number,
+			street,
+			locality,
+			region: get(cells, iRegion) || source.region,
+			postcode,
+			iso2: source.iso2,
+			order: source.order,
+		})
+	}
+	return tuples
+}
+
+/**
+ * Render a non-US BALANCE row in native order — NO affix split, NO country token. `street` is the OA
+ * value verbatim (so the model learns affixes are US-conditional: "Rue de la Paix" stays whole). The
+ * sole job is to put a postcode in its native position (FR: before city, after a number-street body;
+ * DE/IT/NL: before city, after a street-number body) so the shard doesn't pull the model US-ward.
+ */
+function renderBalanceRow(t) {
+	const { house_number: hn, street, locality: loc, postcode: pc, order } = t
+	// region is intentionally omitted — it isn't rendered in `raw`, so labeling it would fail alignment,
+	// and it adds nothing to the postcode-ORDER signal these rows exist for.
+	const components = { house_number: hn, street, locality: loc, postcode: pc }
+	const raw =
+		order === "fr"
+			? `${hn} ${street}, ${pc} ${loc}` // French: number-street, postcode-city
+			: `${street} ${hn}, ${pc} ${loc}` // DE/IT/NL: street-number, postcode-city
+	return { raw, components }
+}
+
 async function main() {
 	const opts = parseArgs()
 	const random = mulberry32(opts.seed)
@@ -311,12 +399,68 @@ async function main() {
 		emitted++
 	}
 
+	// ── Multi-locale balance rows (--multilocale-count) ─────────────────────────────────────────────
+	// Appended AFTER the US affix rows so the US affix signal is unchanged vs v0.9.8 (same `--count`),
+	// and the non-US rows ride the SAME `synth-affix` source weight. These carry native-order postcodes
+	// to undo the US-only shard's FR-postcode dilution — no affix labels, no annotation.
+	let balanceEmitted = 0,
+		balanceSkipped = 0
+	const balanceIso = {}
+	if (opts.multilocaleCount > 0) {
+		const mlSources = opts.golden ? MULTILOCALE_EVAL_SOURCES : MULTILOCALE_SOURCES
+		const perSource = Math.ceil((opts.multilocaleCount * 3) / mlSources.length) // over-read; balance locales
+		const mlPool = []
+		for (const s of mlSources) {
+			const t = readBalanceTuples(s, perSource)
+			console.error(`  balance ${s.csv} (${s.iso2}): ${t.length} tuples`)
+			for (const x of t) mlPool.push(x)
+		}
+		const M = mlPool.length
+		let mlGuard = 0
+		while (M > 0 && balanceEmitted < opts.multilocaleCount && mlGuard++ < opts.multilocaleCount * 10) {
+			const t = mlPool[Math.floor(random() * M)]
+			const { raw, components } = renderBalanceRow(t)
+			// Every component surface must survive in raw, else alignment can't label it.
+			if (![components.street, components.locality, components.postcode].every((s) => raw.includes(s))) {
+				balanceSkipped++
+				continue
+			}
+			balanceIso[t.iso2] = (balanceIso[t.iso2] ?? 0) + 1
+			const locale = `${t.iso2.toLowerCase()}-${t.iso2}`
+			if (opts.golden) {
+				outStream.write(JSON.stringify({ raw, components, country: t.iso2 }) + "\n")
+				balanceEmitted++
+				continue
+			}
+			const canonical = {
+				raw,
+				components,
+				country: t.iso2,
+				locale,
+				source: opts.source,
+				source_id: stableSourceId(opts.source, components),
+				corpus_version: "0.4.0",
+				license: "OpenAddresses non-US skeletons (native-order postcode balance for the affix shard)",
+			}
+			const aligned = alignRow(canonical)
+			if (aligned.kind !== "labeled" || !aligned.row) {
+				balanceSkipped++
+				continue
+			}
+			outStream.write(JSON.stringify({ ...aligned.row, synth_method: "affix-balance", synth_base_id: null }) + "\n")
+			balanceEmitted++
+		}
+	}
+
 	outStream.end()
 	await new Promise((resolve) => outStream.on("finish", resolve))
 	console.error(
 		`Done: emitted ${emitted} affix rows, skipped ${skipped}, no-affix ${noAffix} (pool ${pool.length}). → ${opts.output}\n` +
 			`  formats: ${JSON.stringify(formatCounts)}\n` +
-			`  affix mix: ${JSON.stringify(affixCounts)}`
+			`  affix mix: ${JSON.stringify(affixCounts)}` +
+			(opts.multilocaleCount > 0
+				? `\n  balance: emitted ${balanceEmitted}, skipped ${balanceSkipped}, iso ${JSON.stringify(balanceIso)}`
+				: "")
 	)
 }
 

--- a/scripts/eval/score-affix.ts
+++ b/scripts/eval/score-affix.ts
@@ -16,7 +16,7 @@ const arg = (k: string, d?: string) => {
 const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
 const LK = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
 const file = arg("--file", "data/eval/external/street-affix-real.jsonl")!
-const TAGS = ["street_prefix", "street", "street_suffix", "house_number", "locality", "region", "postcode"] as const
+const TAGS = ["street_prefix", "street", "street_suffix", "house_number", "locality", "region", "postcode", "unit"] as const
 
 const card = JSON.parse(readFileSync("neural-weights-en-us/model-card.json", "utf8"))
 const [tokenizer, runner] = await Promise.all([MailwomanTokenizer.loadFromFile(TOK), OnnxRunner.create(arg("--model")!)])


### PR DESCRIPTION
## What

The affix multi-locale **reroll** (#466 step 1). v0.9.8 cleared the affix gate (street_prefix 0→78, street_suffix 0→67, P100) but a US-only shard diluted **FR postcode −3.9** (the #462 blocker). This folds the night-9 recovery (multi-locale rows lifted FR postcode 95.6→99.5 in the cumulative country run) into the affix shard itself.

- `build-street-affix-shard.mjs --multilocale-count`: appends native-order FR/DE/IT/NL **balance rows** (`street` verbatim, **no affix split, no annotation**). US affix dose unchanged (50K). Default-off → v0.9.8 reproduction byte-identical.
- `assemble-affix-ml-overlay-manifest.py`: pure shard-swap of `v0.4.6-affix` (base/unit/german/deepseek verbatim).
- `v0.9.14-affix-ml.yaml`: clean SOLO A/B vs v0.9.8 (recipe held, NO gazetteer).
- `score-affix.ts`: +`unit` tag (so it can measure unit retention).

## Gate result (fp32, v0.9.8 is int8 ≈ ±1pp)

**Primary goal — FR postcode RECOVERED ✅:** v4.1.0 99.5 · v0.9.8 95.6 · **v0.9.14 99.7**. Affix retained (suffix 67→69.6, prefix 75 ≥ floor), unit flat (92.1), DE native-order locality **+7 → 91.0** (balance rows helped).

**But as a solo 20k run it's a lateral move on FR, not a clean win** — classic fixed-budget cumulative-dilution:

| tag | v4.1.0 | v0.9.8 | v0.9.14 | Δ vs v0.9.8 |
|---|--:|--:|--:|--:|
| FR postcode | 99.5 | 95.6 | 99.7 | **+4.1** |
| FR house_number | 91.0 | 92.0 | 87.2 | **−4.8** |
| US street | 78.5 | 80.4 | 79.0 | −1.4 |
| US micro | 80.2 | 81.6 | 81.1 | −0.5 |

## Decision (operator, 2026-06-10): carry into consolidation

The reroll **proved the mechanism** (multi-locale balance recovers FR postcode → #462's "promote despite dilution?" is moot). It is **NOT promoted standalone** — the 40K balance rows competing for a fixed 20k budget is exactly the dilution the consolidation rule addresses with a larger budget. The multi-locale affix shard rides into the **consolidation run (#466)** alongside the gazetteer choreography (#468). Tracking there.

Merge value: the builder/assembler/config are the reproducible inputs the consolidation run consumes.

Closes #462.