### PR TITLE
docs: entry-point fixes — AGENTS.md links, status refresh, releases matrix, model-work runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,10 +22,12 @@ Source files live at each workspace's root (no `src/` nesting). The repo root ho
 
 ## Where to read next
 
-- **[`docs/plan/README.md`](./docs/plan/README.md)** — the implementation plan that drove the neural classifier work. Phases 0–3 are substantially shipped; Phases 4–6 are the forward roadmap. Read this first if you're working on anything model-related.
-- **[`docs/plan/reference/`](./docs/plan/reference/)** — design rationale, schema source of truth, TS contracts, operations playbook, address-data-sources catalog. `SCHEMA.md` is the single source of truth for the `ComponentTag` union.
+- **[`docs/articles/concepts/what-mailwoman-is.mdx`](./docs/articles/concepts/what-mailwoman-is.mdx)** — what the system *is* (a calibrated, retrieval-augmented sequence labeler), the grammar/atlas division of labor, and the disciplines that keep the architecture honest. Read this first if you're new to the project entirely.
+- **[`docs/articles/plan/README.mdx`](./docs/articles/plan/README.mdx)** — the implementation plan that drove the neural classifier work. Phases 0–3 are substantially shipped; Phases 4–6 are the forward roadmap. Read this first if you're working on anything model-related.
+- **[`docs/articles/plan/reference/`](./docs/articles/plan/reference/)** — design rationale, schema source of truth, TS contracts, operations playbook, address-data-sources catalog. `SCHEMA.mdx` is the single source of truth for the `ComponentTag` union.
+- **[`docs/articles/plan/CONTRIBUTING_MODEL_WORK.mdx`](./docs/articles/plan/CONTRIBUTING_MODEL_WORK.mdx)** — the model-work runbook: which evals gate a change, the lever-shape taxonomy, how to add a shard. Read before touching the model, a shard recipe, or an eval.
 - **[`RELEASING.md`](./RELEASING.md)** — local and CI release flows. Read before cutting a release.
-- **[`docs/evals/`](./docs/evals/)** — eval reports per training step, plus the train-log CSV. Format documented in `docs/plan/reference/eval-ledger.schema.json`.
+- **[`docs/articles/evals/`](./docs/articles/evals/)** — eval reports per training step. The per-model score ledger lives at `evals/scores-by-version.json` (repo root), schema in `docs/articles/plan/reference/eval-ledger.schema.json`. The authoritative per-tag parity table is the latest `parity-scorecard-*.md`.
 
 ## Release pipeline pitfalls
 

--- a/docs/articles/api.mdx
+++ b/docs/articles/api.mdx
@@ -70,6 +70,13 @@ const resolvedTree: AddressTree = await resolver.resolveTree(tree)
 const enriched = await resolver.resolveTree(tree, { hierarchyCompletion: true, includeAncestors: true })
 ```
 
+The resolver is the second half of a deliberate division of labor: gazetteer knowledge also flows
+*into* the parse itself as soft anchor features (postcode anchor, gazetteer candidate-tag clues) —
+the lexicon informs the model, it never overrides it. See
+[What Mailwoman is](./concepts/what-mailwoman-is.mdx) for the architecture and
+[Closed-vocab fields: model-first](./plan/reference/closed-vocab-fields-model-first.mdx) for why
+"informs, never overrides" is load-bearing.
+
 ## Output types
 
 ### `AddressTree`

--- a/docs/articles/concepts/what-mailwoman-is.mdx
+++ b/docs/articles/concepts/what-mailwoman-is.mdx
@@ -1,0 +1,152 @@
+---
+sidebar_position: 1
+title: What Mailwoman is — a name for the thing we're building
+tags:
+  - concepts
+  - architecture
+  - philosophy
+---
+
+# What Mailwoman is — a name for the thing we're building
+
+If you've tried to describe Mailwoman to someone and reached for "it's like
+libpostal but neural" or "it's a geocoder without Elasticsearch," you've felt
+the problem: both are true and neither is the thing. This page gives the
+project its name, its lineage, and the two disciplines that keep it honest.
+It's the page to read when the component count starts to feel like complexity
+instead of architecture — because the system is layered, not tangled, and the
+layers have a logic.
+
+## The name
+
+Mailwoman is a **calibrated, retrieval-augmented sequence labeler over a
+microlanguage** — coupled to a gazetteer that resolves its output to
+coordinates.
+
+Every word is load-bearing:
+
+- **Sequence labeler.** The model is a small transformer encoder doing BIO
+  token classification — the named-entity-recognition lineage
+  (BiLSTM-CRF → BERT token classification → this). It is not an LLM and
+  nothing about it is generative. For a closed label set over short strings,
+  this is the most boring, battle-proven architecture in NLP. Boring is a
+  feature.
+- **Microlanguage.** Addresses are a real language in the strict sense: a
+  grammar (regional, conventional, frequently violated) over a vocabulary
+  that's partly open (street names, venue names) and partly a finite atlas
+  (places that exist). That split — open grammar, closed world — is the entire
+  design.
+- **Retrieval-augmented.** The model never memorizes the atlas. Postcode and
+  gazetteer knowledge arrive as soft input features — anchors — retrieved at
+  inference time from provenance-tracked databases that grow without
+  retraining. If you know RAG from the LLM world, this is RAG for token
+  classification. If you know speech recognition, it's *contextual biasing
+  with shallow fusion*: the model owns structure, external knowledge tips
+  ambiguous decisions, and nothing overrides the learner. (We re-derived this
+  independently, then found the prior art. See
+  [FST priors as shallow fusion](./fst-priors-as-shallow-fusion.mdx) and
+  [Closed-vocab fields: model-first](../plan/reference/closed-vocab-fields-model-first.mdx)
+  for the night we learned the override version is wrong.)
+- **Calibrated.** The confidences are isotonic-calibrated against held-out
+  data, so "0.6" means right-about-60%-of-the-time, not "my rule was fairly
+  specific." See [Confidence calibration](./confidence-calibration.mdx).
+
+## The division of labor
+
+> **The model learns the grammar. The gazetteer knows the atlas.**
+
+This one sentence is the architecture. Everything in the pipeline is the
+model (grammar), a knowledge base (world), or evidence routing between the
+two. The two halves scale independently — corpus and compute grow the
+grammar; data builds grow the atlas — and neither requires the other to
+retrain. Asking a model to memorize the world's place names is where capacity
+goes to die; asking a database to understand "Friedrichstraße 43-45, 10117
+Berlin-Mitte" written four different ways is where rule systems went to die.
+Each side does the job the other is structurally bad at.
+
+## The sieve and the posterior
+
+The systems Mailwoman replaces — elaborate regexes, cascading pattern
+matchers, libpostal's averaged perceptron, Pelias's rules — are **sieves**.
+Input either fits a slot or falls through to the next pattern, and what those
+systems call confidence is really *rule specificity*: certainty about the
+template, silence about the world. A sieve cannot say "I'm not sure." Novel
+input doesn't get a hedged answer; it gets a hole.
+
+A calibrated model inverts this. Mailwoman doesn't ask *"which of my patterns
+does this string match?"* — it asks *"what is the most probable reading of
+this string as an address, given what the atlas says exists?"* Parsing as
+inference instead of template matching. The practical consequence is that
+uncertainty becomes an honest, actionable measurement: the resolver can
+abstain on it, soft-score with it, or fall back to rules because of it. The
+capability difference shows up exactly where the
+[arena evals](../evals/parity-scorecard-2026-06-09.md) say it does: on noisy,
+degraded, real-user input — the queries a geocoder actually receives — the
+model wins decisively, because degraded input is where sieves leak and
+posteriors bend.
+
+## The bitter lesson, read carefully
+
+The bitter lesson is routinely misread as "no knowledge engineering." It
+actually says: no knowledge engineering *inside the learner*. The pre-model
+machines encoded the world's structure into the rules themselves, which is
+why every novel input was a hole. Mailwoman puts the grammar in weights and
+the atlas in a database — knowledge engineering on the *outside*, where it
+belongs, as data with provenance rather than as code with exceptions. The
+anchor channels are the interface between the two, and they are deliberately
+soft: features, never overrides.
+
+## The pocket budget
+
+A standing constraint shapes everything: the parser must run in a browser tab
+or a React Native app. This started as a distribution decision — nothing to
+install, the demo recruits its own users — and turned out to be the project's
+best architectural decision twice over:
+
+1. **It's why the iteration loop exists.** Small model → ~1-hour single-GPU
+   retrains → single-variable lever experiments with same-day gates. The
+   parity campaign's methodology is only affordable at this size.
+2. **It forced the correct architecture.** A model too small to memorize the
+   atlas *had* to get world knowledge from retrieval. The capacity budget did
+   design work. And when capacity got tight, the small model surfaced root
+   causes — corpus artifacts, boundary bugs, rendering-order confounds —
+   instead of absorbing them into parameters. A bigger model would have
+   masked those bugs, not fixed them.
+
+The honest cost: the *data* doesn't fit the pocket even though the model
+does. So the constraint resolves into **two tiers, same code, different
+payloads** — Tier A ("pocket"): parser + anchors + the slim hot gazetteer;
+full parse quality, coarse resolution, offline, address data never leaves the
+device. Tier B ("library"): the identical pipeline with full SQLite payloads
+on a server or desktop, where street-level data lives. The pocket claim stays
+true because it's scoped, not because we stopped checking. There is also
+real headroom: the model could grow severalfold before challenging a
+conservative mobile budget — the constraint that actually binds is iteration
+cost, and that's the one worth defending.
+
+## The discipline that keeps it honest
+
+Two failure modes can quietly un-make this architecture, and both have names
+in our history:
+
+- **The override.** Letting a lookup table seize the wheel from the model
+  because it scored well on a friendly eval. We did this once, for `country`,
+  and reversed it within a day when the homograph eval caught the sieve
+  sneaking back in. Knowledge informs; it never overrides.
+- **The accreting patch.** Post-model repairs — regex fixups, span merges,
+  audit passes — are individually defensible and collectively the sieve
+  regrowing around the model's edges. The rule: every patch is either
+  *scaffolding* (a confession of something learnable, absorbed into the next
+  consolidation retrain) or *data* (provenance-tracked, feeding the model as
+  soft evidence). Never a growing exception list. The health metric is
+  simple: the patch count goes **down** at each consolidation.
+
+## Why you can't find the comparable project
+
+The neural-parsing literature validates the parser half — multiple
+independent efforts reached the same conclusion about transformers beating
+CRFs on degraded input. But the published systems are parser-only. Nobody
+couples calibrated neural parsing, gazetteer fusion at inference time, and
+coordinate-first resolution into one system. If you've been struggling to
+explain Mailwoman by analogy, that's why: it isn't failing to match the
+reference implementation. It is the reference implementation.

--- a/docs/articles/getting-started.mdx
+++ b/docs/articles/getting-started.mdx
@@ -41,6 +41,11 @@ region: "NY" (confidence: 0.88)
 postcode: "10118" (confidence: 0.91)
 ```
 
+Those confidence numbers are calibrated probabilities, not vibes — pass the bundled per-locale
+calibrator and "0.88" means right-about-88%-of-the-time. See
+[Confidence calibration](./concepts/confidence-calibration.mdx) for how to load it and what the
+numbers mean.
+
 ### CLI
 
 ```bash

--- a/docs/articles/plan/CONTRIBUTING_MODEL_WORK.mdx
+++ b/docs/articles/plan/CONTRIBUTING_MODEL_WORK.mdx
@@ -1,0 +1,82 @@
+---
+sidebar_position: 2
+title: Contributing model work — the runbook
+description: Which evals gate a change, the lever-shape taxonomy, and how to ship a shard without breaking four locales.
+---
+
+# Contributing model work — the runbook
+
+You want to improve a tag, add a locale, or change anything that touches the model. This page is
+the procedure. The concepts behind it live elsewhere
+([What Mailwoman is](../concepts/what-mailwoman-is.mdx),
+[Eval discipline](../concepts/eval-discipline.mdx),
+[Negative space](../concepts/negative-space-coverage.mdx)); this is the part you follow with your
+hands.
+
+## The iron rules
+
+1. **Real-OOD eval before training.** Build (or find) the held-out real-world eval for your tag
+   *first*, and pre-register the gate — target numbers, no-regression bounds — in the training
+   config as a comment before step 1 runs. If you can't define the gate, you aren't ready to train.
+2. **Never compare F1 across tokenizer versions.** Same tokenizer or the comparison is void
+   (`per-locale-f1.ts --tokenizer` enforces this; the model card records the version).
+3. **Compare fp32-to-fp32.** Int8 is a release artifact, not an experiment lens.
+4. **One variable per run.** Prove a lever solo, then consolidate. Stacking shards in one 20k run
+   dilutes every tag (measured, twice — see the cumulative-dilution note in the
+   [parity scorecard](../evals/parity-scorecard-2026-06-09.md)).
+5. **Recompile before eval.** Eval harnesses load compiled `core/out` — a stale build makes your
+   core change a silent no-op.
+
+## Which tool for which tag (the lever-shape taxonomy)
+
+- **Open-vocab / distributional tags** (street, affixes, unit, locality): the model must learn the
+  boundary from context → **format-diverse synth shard + retrain** is the tool.
+- **Closed-vocab tags** (country, po_box, cedex): a finite surface set in a predictable slot →
+  **gazetteer/codex lexicon as a soft anchor feature** — the matcher informs the model, it never
+  overrides it. We measured the override version and reversed it; read
+  [Closed-vocab fields: model-first](./reference/closed-vocab-fields-model-first.mdx) before
+  proposing a deterministic tagger.
+- **Format quirks both systems miss** (rare edge shapes): consider a query-shape route before a
+  shard — some formats are structurally different enough that routing beats tagging.
+
+## The standard gate set
+
+Run for *every* candidate, regardless of what you changed (this is what
+[`promotion-gate.sh`, #479](https://github.com/sister-software/mailwoman/issues/479) automates):
+
+| Check | Command | Bar |
+| --- | --- | --- |
+| Per-locale floors | `scripts/eval/per-locale-f1.ts` (US/FR, `--tokenizer`) + `per-locale-f1-floors.py` | within 1pp, fp32-to-fp32 |
+| German native order | `scripts/eval/de-order-eval.sh` | NO-REGRESSION |
+| Unit retention | unit-real designators eval | ≥ 88 |
+| Affix split | `scripts/eval/score-affix.ts` (NOT `per-locale-f1` — its fold can't see the split) | hold gated numbers |
+| Demo smoke | `eval-model` skill / `demo-preset-compare.ts` | presets stable |
+| Honest geography | `scripts/eval/honest-eval.sh` | region-match + coord p50/p90 + PIP hold |
+
+Plus your tag's pre-registered real-OOD gate. Pass → append the run to
+`evals/scores-by-version.json` and write the dated report in `docs/articles/evals/`.
+
+## Adding a shard
+
+1. Generator lives in `corpus/` (`synthesize-*.ts`) or `scripts/build-*-shard.mjs`; every row
+   carries `synth: {method, base_source_id}` ancestry.
+2. Audit format diversity against the real eval's observed forms *before* generating — thin
+   diversity teaches lexical pattern-matching, not the boundary.
+3. Overlay manifests declare lineage against a base corpus version
+   (`scripts/assemble-*-overlay-manifest.py` is the pattern); never hand-edit a manifest.
+4. Train via `modal run -d scripts/modal/train_remote.py --config <yaml> --resume auto`
+   (~1h A100). Config lives in `corpus-python/src/mailwoman_train/configs/` — copy the latest,
+   change one variable, write the gate comment.
+
+## Reading the scorecard
+
+Two lenses that disagree on purpose: **arena head-to-head** is whole-parse-strict (the honest
+"usable parse" lens; understates per-tag wins) and **per-tag F1** is what the campaign moves.
+Golden-dev per-tag numbers lie for tags the golden set barely contains (unit reads 6.3 there and
+92.3 on real-OOD) — for campaign tags, the real-OOD column is the truth.
+
+## When your lever doesn't gate
+
+Tune-and-retry once, then stop and write the postmortem instead of a third run — the v0.6.x cycle
+is the cautionary retrospective. A negative result recorded in the ledger is a contribution; a
+recipe-tweak treadmill is not.

--- a/docs/articles/releases.mdx
+++ b/docs/articles/releases.mdx
@@ -1,0 +1,52 @@
+---
+sidebar_position: 2
+title: Releases & capabilities
+description: Which npm version shipped which model and which capabilities.
+---
+
+# Releases & capabilities
+
+Two version series exist and used to be easy to confuse:
+
+- **npm version** — what `npm install` gives you. All workspaces release in lockstep
+  (e.g. `mailwoman@4.1.0` pairs with `@mailwoman/neural-weights-en-us@4.1.0`).
+- **Training series** (`v0.x.y`) — internal model lineage used by configs, the eval ledger, and
+  the docs. A training run only becomes an npm release if it passes its pre-registered gates.
+
+Since 4.0.0 the npm version is the one that matters to consumers; the shipped weights'
+`model-card.json` records the exact training lineage, corpus, and tokenizer. The full per-model
+score record is `evals/scores-by-version.json` (schema:
+[`eval-ledger.schema.json`](./plan/reference/eval-ledger.schema.json)).
+
+## The matrix
+
+| npm | Date | Model lineage | What it added | Per-tag truth |
+| --- | --- | --- | --- | --- |
+| **4.1.0** (current) | 2026-06-09 | `v0.9.7-unit-v3` @ 20k (off `v0.9.3`, off `v0.7.2`) | **Secondary-unit coverage** (`unit` 0 → 92.3 real-OOD) — the first negative-space parity win. Int8 quant toolchain pinned + fixed (Safari WebGPU graph stability). Two-backend artifact release (npm + demo pointer). | [Parity scorecard 2026-06-09](./evals/parity-scorecard-2026-06-09.md) |
+| **4.0.0** | 2026-06-06 | `v0.9.3-de-regiontail` | First fully-synced release across all workspaces (`mailwoman` installable again, end to end). Multi-locale model (both-order German synth, region-tail), **live postcode-anchor inference**, self-conditioning. New scoped packages published (codex, locale-gate, resolvers, neural-web). | ledger `v0.9.3` rows |
+| 2.x / 3.0.0 (weights) | 2026-05 | `v0.4.0` (8.87M params, 21 labels) | The Phase-3 integration era: 6-stage runtime pipeline, CRF decode, hybrid policy registry. Weights versioned independently of the runtime packages (3.0.0 weights + 2.1.0 runtime) — the misalignment this page exists to prevent. | ledger `0.1.0`–`3.0.0` rows |
+
+Earlier training-series numbering (`v0.1.0`, `v0.2.0`, the realigned `3.0.0`) predates the
+lockstep policy; treat the eval ledger as the record there.
+
+## In flight
+
+| Series | Target | Status |
+| --- | --- | --- |
+| `v0.9.8` affix → `v0.9.14` affix-ml → **v1.0 consolidation** | next npm minor | [#466](https://github.com/sister-software/mailwoman/issues/466): bake the gated levers — street affixes (0 → 78/67), country gazetteer soft anchor (83.3 F1), multi-locale affix balance, postcode-anchor choreography — into one model with the full regression gate. |
+
+## Capability quick-reference
+
+| Capability | Since |
+| --- | --- |
+| 6-stage runtime pipeline (normalize → … → resolve) | 2.x era |
+| Hybrid rule/neural policy registry | 2.x era |
+| WOF SQLite resolver (exact-match tiering, coordinate-first postcode disambiguation) | 4.0.0 |
+| Postcode anchor at inference (PCB1) | 4.0.0 |
+| Japanese postcode-route resolution (Geographic Rule Engine) | 4.0.0 |
+| Isotonic confidence calibration (per-locale `calibration.json` in the weights bundle) | 4.0.0 |
+| Secondary-unit (`unit`) recognition | 4.1.0 |
+| Street affixes, country soft anchor, multi-locale balance | v1.0 consolidation (in flight) |
+
+When a release ships, this page gains a row and the [status page](./status.mdx) gets re-verified —
+they change together or not at all.

--- a/docs/articles/reviews/2026-06-10-deep-dive-review.md
+++ b/docs/articles/reviews/2026-06-10-deep-dive-review.md
@@ -1,0 +1,103 @@
+# Mailwoman deep dive: docs, implementation, and the road to a geocoder
+
+**Date:** 2026-06-10 · **Scope:** full-repo technical review (docs site, parser implementation, resolver/data layer, training+eval pipeline) plus external geocoder-landscape research. Produced from five parallel review passes; this document is the synthesis.
+
+---
+
+## Verdict
+
+The model refactor has earned the word "mature" — and the external research backs it harder than expected: **no open-source geocoder ships a neural parser in production**. Every published neural-vs-libpostal comparison (Huppert's SOTA survey, Continuity's transformer parser, the arXiv fraud-detection work) reaches the same conclusion mailwoman bet on: transformers beat CRFs exactly where real geocoder queries live (typos, prefixes, degraded input), at under 80 MB instead of libpostal's 2.2 GiB. The ONNX-in-browser parser is ahead of the field, not behind it.
+
+The Elasticsearch-free architecture is also no longer a contrarian bet. Pelias's Placeholder/PIP sidecars exist *because* ES can't do admin hierarchy; Photon just finished a multi-year forced OpenSearch port; Nominatim 5.0 (Feb 2025) shipped as a pip-installable library; addok serves all of France from Redis+SQLite in 6 GB. The field is drifting toward "geocoder as a library" — which is what the ancestors-table-in-SQLite design already is.
+
+The weaknesses are not in the model or the architecture. They are operational: **stale doc entry points, a reproducibility crater in training, scattered promotion gates, and three missing geocoder table stakes** (interpolation, reverse, autocomplete integration). All fixable; none require rethinking the design.
+
+One calibration note from the research: the incumbent moved. Senzing retrained libpostal's CRF in 2024–2025 (~1.2B records, +4% avg accuracy, up to +87% per-country, Apache 2). Parity claims should benchmark against *that* model, not the 2017 weights the current arenas use.
+
+---
+
+## 1. Documentation
+
+**Strong:** the concept layer is genuinely rich — 34 concept articles, the "Understanding" section (falsehoods, why-neural, alternatives-rejected), and the decision-record spine from #467 (`closed-vocab-fields-model-first.mdx` + parity-endgame + knowledge-ladder) form a coherent, current narrative around model-first + soft anchors. Architecture documentation scores ~8/10.
+
+**Weak:** the *entry points* and *operational* layers.
+
+| Issue | Detail |
+| --- | --- |
+| AGENTS.md dead links | `docs/plan/README.md`, `docs/plan/reference/`, `docs/evals/` all moved to `docs/articles/...` (and `SCHEMA.md` → `SCHEMA.mdx`). The canonical onboarding file 404s on its three "read this first" pointers. |
+| `status.mdx` ~6 weeks stale | Claims shipped model is v0.4.0 / npm 3.0.0; reality is v4.1.0 npm with the v0.9.x line at v0.9.13. Training-state section frozen in May. |
+| No version↔capability matrix | Nothing maps npm versions → model lineage → features (anchors, unit coverage, calibration). The model-version vs npm-version split confuses every reader. |
+| No operational runbooks | 92 eval reports but no "to evaluate your change, run X"; corpus/training docs scattered across 4 files with no retrain runbook; the gazetteer-anchor implementation isn't cross-linked from its design doc. |
+
+**Top doc fixes by ROI:** (1) fix AGENTS.md paths (30 min), (2) versions/capabilities matrix page, (3) refresh `status.mdx` + link the parity scorecard as the live truth, (4) a CONTRIBUTING_MODEL_WORK runbook (eval harness + lever taxonomy + shard recipe), (5) cross-link gazetteer-anchor design ↔ implementation.
+
+---
+
+## 2. Parser implementation
+
+**Strong.** The 6-stage runtime pipeline (`mailwoman/runtime-pipeline.ts` → `core/pipeline/runtime-pipeline.ts`) composes via injection — every stage optional with graceful defaults, workspace boundaries respected. Anchor and gazetteer features are *additive* model inputs with zero-filled fallbacks (the architectural intent of "soft anchor, never override" is visible in the code, not just the docs). `build-tree.ts` is robust: boundary trimming, same-tag whitespace merge (the Saint-Paul fix), distance-based parent attachment. Three lossless serializers. ~755 tests.
+
+**Ranked weaknesses:**
+
+1. **`parse()` vs `parseWithLogits()` duplication** (`neural/classifier.ts:157` vs `:240`) — ~78 identical lines (anchor/gazetteer build, prior stacking, viterbi). Worse: only `parse()` runs postcode/unit repair, so reconcile consumes *unrepaired* labels — design intent undocumented, latent divergence bug. Extract a shared `buildTokens()` helper.
+2. **TLA in `core/resources/libpostal.ts`** — the known fragility surface; `Graph.ts` already dodges the barrel import to avoid it. Lazy-load `availableLanguages` behind an async getter and the whole class of vitest/bundler cycle bugs disappears.
+3. **`__isCompiledTree` path-sniffing** (`core/utils/repo.ts:42`) — breaks on output-dir or symlink changes; discovered only at runtime.
+4. **Policy registry**: `applyPreferenceFilters` (~30 lines, the rule/neural dedup core) has no tests, and per-component neural rollout requires code changes — no config surface for A/B-ing `neural_preferred` per tag.
+5. **Reconcile's classifier contract is still a mock** — `ClassifierCandidate` top-k is hand-built in tests; no production path emits it yet. Flag before the real wiring lands.
+6. Smaller: `ParseOpts` not exported (typo-silent options), gazetteer lexicon parsed without schema validation, grouper penalty hardcoded at 0.55.
+
+---
+
+## 3. Training + eval pipeline
+
+**Operationally mature, structurally fragile.** The corpus build is deterministic with full lineage (manifests + SHAs, locality-holdout splits, synth ancestry tags); training deps are pinned (the v4.1.0 Safari-opset set); the eval ledger (`evals/scores-by-version.json`) is current through v0.9.13 with corpus/eval-set SHAs per run. The eval inventory is huge: 40+ harnesses spanning name-match, coordinate error, PIP containment, calibration, per-locale tripwires.
+
+**The five risks, ranked:**
+
+1. **No clone-and-train path.** Corpus shards, tokenizer, anchor/gazetteer lookups all live on R2/Modal/`/mnt/playpen` with hardcoded paths. A fresh agent cannot reproduce v0.9.12 from the repo. → `REPRODUCIBILITY.md` + publish corpus snapshots beside model releases.
+2. **Gate scatter.** Each config carries its own pre-registered gate comment; execution is manual night-shift discipline, not CI. One `promotion-gate.sh` that parses the config's gate block and runs the listed scripts would turn lore into enforcement — and auto-append to the ledger on pass.
+3. **Curriculum state unlogged.** Anchor/gazetteer confidence ramps are step-aware; a resume mid-ramp silently changes training dynamics and nothing records which curriculum a checkpoint saw. Stamp curriculum state into the model card; assert on resume.
+4. **Overlay shard resolution fails silently.** Overlay manifests cross-reference base corpora by absolute path; the loader's glob fallback means a moved base corpus trains on the wrong data without erroring (the v0.7.1 trap, still open). Add strict mode + explicit `base_corpus_version` lineage.
+5. **Int8 toolchain pinning is undocumented.** The value_info-strip fix and the Safari-WebGPU opset≤17 invariant live in code comments; a well-meaning dep bump re-breaks iOS undetected. Add a version-verification script + a toy export/quant CI check.
+
+Eval-hygiene lore (tokenizer-F1 incomparability, name-match vs coordinate truth, German native-order rendering) is *partially* encoded in tooling (`--tokenizer` flag, `de-order-eval.sh`, honest-eval) — better than memory-only, but the promotion-gate consolidation is what makes it survivable.
+
+---
+
+## 4. Distance to a full geocoder
+
+Capability checklist (evidence-based, from the resolver/data-layer pass):
+
+| Capability | Status |
+| --- | --- |
+| Freeform forward geocoding (admin-level) | **Shipped** — parser → WOF resolver → coords/IDs/confidence, 7 priority countries, HTTP `/api/resolve` |
+| Structured forward | Partial — admin components only; no street/house-number resolution |
+| Fuzzy/typo tolerance | Shipped (FTS5 BM25 + trigram soft-match + the neural parser itself) |
+| Postcode resolution | Shipped (anchor posterior, postcode→locality, mismatch detection) |
+| Confidence | Partial — per-component calibrated + resolver score; no end-to-end composition (commercial norm: Mapbox-style per-component match codes — the isotonic work maps directly onto this) |
+| **Autocomplete** | **Missing as a product** — `fst-autocomplete.ts` exists (prefix walk, importance-ranked) but is unwired. This is the highest-traffic endpoint of every production geocoder. BIO tagging is awkward on 3-char prefixes: serve prefixes from the FST tier, engage the parser past a token threshold. |
+| **House-number interpolation** | **Missing** — the single biggest coverage gap vs v0/Pelias. TIGER data already ships; Karlsruhe-schema ranges cover OSM. Scoped at ~2–3 weeks for a prototype. |
+| **Reverse geocoding** | **Missing** — but `wof-polygons.db` + the PIP machinery already exist; this is assembly, not research. |
+| Batch API | Missing (cheap, universally expected) |
+| Service abstraction / multi-instance | Missing — in-process sync SQLite; `RemoteResolver` adapter pattern declared in `core/resolver/types.ts` but unimplemented |
+| Data update pipeline | Operator-driven builds; no delta sync |
+
+**Data strategy (new input from research):** Overture's address theme is nearing GA — 455M pre-conflated address points (OpenAddresses + agencies) under permissive terms, with stable GERS UUIDs, plus a divisions theme. Adopting Overture as the conflation layer for the *address/street* tier (keeping WOF for hierarchy) would sidestep both bespoke OA ingestion and the ODbL share-alike question, and make results joinable to the ecosystem (Esri/Precisely already link via GERS). Design the gazetteer schema so a place row can carry a GERS ID alongside the WOF ID. Licensing note: per the OSMF guideline, serving geocode results from OSM-derived data does *not* infect customer databases (insubstantial extracts) — only systematic bulk extraction re-triggers ODbL.
+
+---
+
+## 5. Recommended roadmap
+
+**Phase A — Consolidate the parser win (now → ~2 weeks).** Land #466/#468 (affix-ml shard + gazetteer choreography) into the consolidation retrain; re-benchmark the arenas against Senzing's retrained libpostal; cut the v1.0-parity model. This finishes the campaign already in flight — don't start geocoder work mid-retrain.
+
+**Phase B — Hygiene sprint (~1 week, parallelizable).** AGENTS.md links + status.mdx + version matrix; `promotion-gate.sh` + ledger auto-append; REPRODUCIBILITY.md; strict shard resolution; `buildTokens()` dedup + libpostal TLA removal. Cheap, and everything after gets safer.
+
+**Phase C — Geocoder table stakes (~6–8 weeks).** In order of leverage: (1) house-number interpolation off TIGER (biggest coverage win, gate on honest-eval coord p50 dropping from ~10 km admin-centroid toward street-level), (2) reverse geocoding off wof-polygons.db (symmetric tree output), (3) autocomplete endpoint wiring the existing FST tier with parser engagement past a token threshold. Add batch as a thin layer over all three.
+
+**Phase D — Data + service maturity (~quarter).** Overture/GERS conflation layer for addresses; RemoteResolver + multi-instance deployment; delta-sync builds; observability (latency SLOs, per-country coverage metrics, periodic honest-eval on production traffic). addok (full France, 6 GB RAM, minutes to deploy) is the ops-simplicity benchmark to cite and beat.
+
+**Positioning:** "the geocoder that's a library" — pip/npm-installable, embedded SQLite, runs in the browser, no ES cluster. Nominatim 5 legitimated the frame; nobody owns it with a neural parser.
+
+---
+
+*Review passes: docs editorial+accuracy, parser implementation, resolver/geocoder gap, training+eval pipeline, external landscape (Pelias/Nominatim/Photon/addok/Airmail/Overture, with sources). Agent transcripts available in session history.*

--- a/docs/articles/status.mdx
+++ b/docs/articles/status.mdx
@@ -6,94 +6,105 @@ description: What ships today, what's behind a flag, and what's still experiment
 
 # Status
 
-This page is the single source of truth for what works in Mailwoman right now. It is updated on every release.
+This page is the single source of truth for what works in Mailwoman right now.
+
+:::info[Verified as of 2026-06-10 — release 4.1.0]
+Numbers below are sourced from the shipped `model-card.json` and the
+[parity scorecard (2026-06-09)](./evals/parity-scorecard-2026-06-09.md), which is the
+authoritative per-tag table. For which release added which capability, see
+[Releases & capabilities](./releases.mdx).
+:::
 
 ## Packages
 
-| Package                           | npm version | Description                                                         |
-| --------------------------------- | ----------- | ------------------------------------------------------------------- |
-| `mailwoman`                       | 2.1.0       | CLI + high-level `AddressParser` entry point                        |
-| `@mailwoman/core`                 | 2.1.0       | Tokenization, classification, solver, decoder, policy registry      |
-| `@mailwoman/classifiers`          | 2.1.0       | Rule-based classifiers (postcode, street, venue, WOF dictionaries)  |
-| `@mailwoman/neural`               | 2.1.0       | ONNX runtime + SentencePiece tokenizer + neural classifier wrapper  |
-| `@mailwoman/neural-weights-en-us` | 3.0.0       | Trained model bundle (US English)                                   |
-| `@mailwoman/neural-weights-fr-fr` | 3.0.0       | Trained model bundle (FR French)                                    |
-| `@mailwoman/phrase-grouper`       | 2.1.0       | Rule-based span boundary proposal (Stage 2.7)                       |
-| `@mailwoman/normalize`            | 2.1.0       | Unicode normalization + whitespace collapsing (Stage 1)             |
-| `@mailwoman/query-shape`          | 2.1.0       | Structural input priors (script class, postcode format detection)   |
-| `@mailwoman/kind-classifier`      | 2.1.0       | Query category classifier (postcode_only, structured_address, etc.) |
-| `@mailwoman/resolver-wof-wasm`    | 0.1.0       | Browser-side WOF resolver (SQLite via WASM)                         |
-| `@mailwoman/neural-web`           | 0.1.0       | Browser-side neural classifier (onnxruntime-web)                    |
+All publishable workspaces release in lockstep; the current npm version is **4.1.0**.
 
-## Model weights
+| Package                                          | Description                                                        |
+| ------------------------------------------------ | ------------------------------------------------------------------ |
+| `mailwoman`                                      | CLI + high-level `AddressParser` + runtime pipeline factory        |
+| `@mailwoman/core`                                 | Tokenization, classification, solver, decoder, policy registry     |
+| `@mailwoman/codex`                                | Per-address-system postal reference data (USPS suffixes, ZIP types) |
+| `@mailwoman/classifiers`                          | Rule-based classifiers                                             |
+| `@mailwoman/neural`                               | ONNX runtime + SentencePiece tokenizer + anchor inference          |
+| `@mailwoman/neural-weights-en-us` / `-fr-fr`      | Trained model bundles                                              |
+| `@mailwoman/normalize` / `query-shape` / `locale-gate` / `kind-classifier` / `phrase-grouper` | Pipeline stages 1–2.7 |
+| `@mailwoman/resolver-wof-sqlite` / `-wasm`        | WOF gazetteer resolver (Node SQLite / browser WASM)                |
+| `@mailwoman/neural-web`                           | Browser-side neural classifier (onnxruntime-web)                   |
 
-| Property             | Value                                                                                                                 |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Shipped version**  | v0.4.0 (npm `@mailwoman/neural-weights-en-us@3.0.0`)                                                                  |
-| **Architecture**     | 8.87M params — 6-layer transformer encoder, 256 hidden dim, 4 attention heads                                         |
-| **Label vocabulary** | 21 BIO labels: country, region, locality, dependent_locality, postcode, subregion, cedex, venue, street, house_number |
-| **Training corpus**  | corpus-v0.3.0 (677M aligned rows)                                                                                     |
-| **Tokenizer**        | SentencePiece unigram, 16K vocab, byte_fallback=true                                                                  |
-| **CRF**              | Linear-chain CRF with frozen BIO structural mask — Viterbi decode at inference                                        |
-| **Size**             | ~25 MB (int8-quantized ONNX + tokenizer)                                                                              |
+## Model weights (4.1.0)
 
-### Per-component F1 on golden v0.1.2 (4,535 entries)
+| Property             | Value                                                                                                          |
+| -------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **Lineage**          | `v0.9.7-unit-v3` @ step 20k — unit-coverage retrain off `v0.9.3-de-regiontail`, itself off `v0.7.2`            |
+| **Architecture**     | 29.3M params — 6-layer encoder, 384 hidden, 6 heads, 48K-vocab SentencePiece embedding                          |
+| **Label vocabulary** | 33 BIO labels over 16 component tags (incl. `unit`, `po_box`, `street_prefix`/`_suffix`, `intersection_a/b`)    |
+| **Training corpus**  | `corpus-v0.4.5-unit-v2` · tokenizer `v0.6.0-a0`                                                                 |
+| **Anchors**          | Postcode anchor (PCB1) live at inference; gazetteer anchor lands with the v1.0 consolidation                    |
+| **Decode**           | Viterbi with frozen BIO structural mask (CRF at inference; CE-only training)                                    |
+| **Size**             | 28.4 MB int8 ONNX (112.9 MB fp32) · opset 17 · max sequence 128                                                 |
 
-| Component    | F1   | Notes                                                |
-| ------------ | ---- | ---------------------------------------------------- |
-| house_number | 0.79 | Usable                                               |
-| postcode     | 0.69 | Regressed from v0.3.0's 0.76 (NAD downweight effect) |
-| venue        | 0.39 | Low                                                  |
-| street       | 0.30 | Low                                                  |
-| locality     | 0.27 | Rule classifiers carry this in practice              |
-| country      | 0.21 | Mostly adversarial transliteration eval noise        |
-| region       | 0.19 | Rule classifiers carry this in practice              |
+### Per-tag health (summary)
 
-Full-parse exact match: ~0.08 (model gets every component right on 8% of addresses). In practice, the hybrid system — rule classifiers carrying coarse components, neural on house_number and street — performs better than per-tag neural numbers alone suggest.
+The full per-tag table — two lenses, golden-dev and real-OOD — lives in the
+[parity scorecard](./evals/parity-scorecard-2026-06-09.md). The shape of it:
 
-### Known regressions
+- **Healthy:** postcode (98/99 US/FR), house_number (96/91), venue-US (90), street (79 US).
+- **Fixed by the parity campaign:** `unit` 0 → 92.3 on real-OOD designators (the 4.1.0 headline).
+- **In flight (consolidation #466):** street affixes (0 → 78/67 gated), `country` (gazetteer
+  soft anchor, 83.3 F1 proven), multi-locale affix balance.
+- **Open gaps:** FR venue/region ([#330](https://github.com/sister-software/mailwoman/issues/330)),
+  intersections ([#487](https://github.com/sister-software/mailwoman/issues/487)).
 
-- **Postcode F1 0.69** (v0.3.0: 0.76). Caused by NAD source downweight removing "postcode-first" positional patterns from training. v0.5.0 targets recovery.
-- **Coarse labels (country, region, locality) are rule-carried.** The neural model's per-tag F1 on these is low. The rule-based WOF dictionary classifiers handle them in practice.
-- **Non-Latin scripts.** The v0.1.0 tokenizer falls back to raw bytes on CJK, Cyrillic, and other non-Latin scripts. The A1 tokenizer (48K vocab, trained on corpus-v0.4.0) halves byte-fallback but is not yet used in a stable classifier.
+Capability-arena truth (whole-parse, vs the v0 rules system): rules still win on
+clean/canonical input, the neural parser wins decisively on noisy/degraded input (+21pp),
+both are weak on rare edge formats. The
+[arbitration layer (#478)](https://github.com/sister-software/mailwoman/issues/478) exists to
+make the pipeline take the better of both per component.
 
 ## Runtime pipeline — stage status
 
-| Stage | Name             | Status     | Notes                                                                                                                                                                           |
-| ----- | ---------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | Normalize        | ✅ default | NFC, whitespace collapse, locale-aware case folding                                                                                                                             |
-| 2     | Locale gate      | 🚩 opt-in  | Workspace ships (`@mailwoman/locale-gate`); not wired as factory default. Falls back to caller-provided locale hint.                                                            |
-| 2.5   | Kind classifier  | ✅ default | Rule-based. Fast-paths bare postcodes and single localities.                                                                                                                    |
-| 2.7   | Phrase grouper   | ✅ default | Rule-based (`@mailwoman/phrase-grouper`). Proposes coherent spans before classification.                                                                                        |
-| 3     | Token classify   | ✅ default | Neural (9M-param encoder) + rule classifiers. Hybrid via policy registry.                                                                                                       |
-| 4     | Sequence correct | ✅ default | CRF with frozen BIO structural mask + Viterbi decode. Prevents orphan I-tags.                                                                                                   |
-| 5     | Reconcile        | 🚩 opt-in  | Joint decoding with WOF concordance scoring. Implemented but requires `forceJointReconcile` flag and classifier with `parseWithLogits` support. Argmax fallback is the default. |
-| 6     | Resolve          | 🚩 opt-in  | WOF SQLite gazetteer lookup. Returns administrative/postcode-level place candidates, not rooftop/address-point coordinates.                                                     |
+| Stage | Name             | Status     | Notes                                                                                                           |
+| ----- | ---------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| 1     | Normalize        | ✅ default | NFC, whitespace collapse, locale-aware case folding                                                             |
+| 2     | Locale gate      | 🚩 opt-in  | Ships (`@mailwoman/locale-gate`); not wired as factory default                                                  |
+| 2.5   | Kind classifier  | ✅ default | Rule-based; fast-paths bare postcodes and single localities                                                     |
+| 2.7   | Phrase grouper   | ✅ default | Rule-based span proposals before classification                                                                 |
+| 3     | Token classify   | ✅ default | Neural encoder + rule classifiers, hybrid via policy registry (per-component modes)                             |
+| 4     | Sequence correct | ✅ default | Viterbi over the frozen BIO mask; postcode/unit label repairs                                                   |
+| 5     | Reconcile        | 🚩 opt-in  | Joint decoding with WOF concordance scoring (`forceJointReconcile` + `parseWithLogits`); argmax is the default  |
+| 6     | Resolve          | 🚩 opt-in  | WOF SQLite gazetteer: admin/postcode-level candidates with coordinates, exact-match tiering, coordinate-first postcode disambiguation, opt-in `hierarchyCompletion`/`cityStateFallback`/`includeAncestors` |
+
+## Confidence
+
+Every node carries a confidence score; pass a calibrator (isotonic, shipped per-locale in the
+weights bundle as `calibration.json`) to make those scores honest probabilities — see
+[Confidence calibration](./concepts/confidence-calibration.mdx) for what the numbers mean.
 
 ## Browser demo
 
-The live demo at [mailwoman.sister.software/demo](https://mailwoman.sister.software/demo) runs:
+The live demo at [mailwoman.sister.software/demo](https://mailwoman.sister.software/demo) runs the
+int8 model (28.4 MB) via `@mailwoman/neural-web` plus a slim WOF "hot" database via
+`@mailwoman/resolver-wof-wasm`, with artifacts served from a versioned `releases.json` pointer.
+It calls the classifier's argmax path directly; joint reconcile is not active in the demo.
 
-- Neural classifier (~25 MB ONNX) via `@mailwoman/neural-web` + `onnxruntime-web`
-- WOF locality database (~35 MB SQLite) via `@mailwoman/resolver-wof-wasm` + `sqlite-wasm`
-- Total cold load: ~60 MB, cached after first visit
+## Model line (June 2026)
 
-The demo does **not** use the full runtime pipeline coordinator. It loads the neural classifier directly and calls `classifier.parse(text)` — the argmax path. Joint reconcile is not active in the demo.
-
-## Training state (May 2026)
-
-| Item                 | State                                                                                                                      |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| CE-only smoke        | **Passed.** `crf_loss_weight=0.0` trained past step 2000 without divergence. val_macro_f1=0.444 — best in project history. |
-| CE-only full 50K run | **In progress.** If stable: first v0.5.0 weights.                                                                          |
-| A1 tokenizer         | Trained (48K vocab, byte-fallback 36.7% → 18.2%). Not yet used in a stable classifier.                                     |
-| corpus-v0.4.0        | Built (v0.3.0 + 4,771 kryptonite + ~73K transliteration pairs). No stable classifier trained on it yet.                    |
+The shipped weights are 4.1.0; the training series continues as `v0.9.x` toward a **v1.0
+consolidation** ([#466](https://github.com/sister-software/mailwoman/issues/466)) that bakes the
+gated parity levers (affixes, country anchor, multi-locale balance) into one model. The ordered
+work queue to the full geocoder is
+[epic #488](https://github.com/sister-software/mailwoman/issues/488).
 
 ## What is not supported today
 
-- Rooftop or address-point geocoding. The resolver returns place-level candidates (locality/region/postcode), not delivery-point coordinates.
-- Multi-locale ensemble (en-US + fr-FR in the same runtime).
-- Japanese addresses. Phase 6 validation stress test, deferred.
-- PO boxes, unit/apartment numbers, attention lines. Tier 3 label expansion, deferred.
-- Fine-tuning from a pretrained model. Weights train from scratch on Mailwoman's corpus.
-- Server-side API. The runtime is a library, not a service.
+- Rooftop / address-point geocoding — the resolver returns place-level candidates. The
+  address-point tier ([#476](https://github.com/sister-software/mailwoman/issues/476)) and
+  interpolation ([#483](https://github.com/sister-software/mailwoman/issues/483)) are queued.
+- Reverse geocoding ([#484](https://github.com/sister-software/mailwoman/issues/484)) and
+  autocomplete-as-a-product ([#190](https://github.com/sister-software/mailwoman/issues/190)).
+- Multi-locale ensemble (en-US + fr-FR weights in the same runtime).
+- Korean addresses (no open data path). Japanese addresses **are** supported via the
+  postcode-route resolver (Geographic Rule Engine).
+- A supported server API — `mailwoman/server` ships an experimental Express server
+  (`/api/parse`, `/api/resolve`); production service hardening is
+  [#485](https://github.com/sister-software/mailwoman/issues/485).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -8,7 +8,7 @@ const sidebars: SidebarsConfig = {
 			type: "category",
 			label: "Start here",
 			collapsed: false,
-			items: ["status", "getting-started", "api"],
+			items: ["status", "releases", "getting-started", "api"],
 		},
 		{
 			type: "category",


### PR DESCRIPTION
Closes #482 — the top item of the Geocoder v1 daily queue (#488).

## What

- **AGENTS.md**: the three "read this first" links 404'd (`docs/plan/` → `docs/articles/plan/`, `SCHEMA.md` → `SCHEMA.mdx`, `docs/evals/` → `docs/articles/evals/`). Fixed, plus pointers to the two new pages below.
- **`status.mdx`**: was ~6 weeks stale (claimed v0.4.0/npm 3.0.0; reality is 4.1.0). Re-verified end to end against the committed `model-card.json` (lineage `v0.9.7-unit-v3`, 29.3M params, 33 labels, 28.4 MB int8) and the parity scorecard, with a verified-as-of banner so staleness is visible next time.
- **`releases.mdx`** (new, "Start here" sidebar): the npm ↔ training-series ↔ capability matrix — ends the model-version-vs-npm-version confusion.
- **`plan/CONTRIBUTING_MODEL_WORK.mdx`** (new): the model-work runbook — iron rules (tokenizer comparability, fp32-to-fp32, one variable per run, recompile-before-eval), the lever-shape taxonomy, the standard gate set, shard procedure, scorecard lenses. The "92 eval reports but no 'run this'" fix.
- **`concepts/what-mailwoman-is.mdx`** (new, concepts position 1): the framing doc — calibrated retrieval-augmented sequence labeler, the grammar/atlas division of labor, sieve→posterior, the pocket budget as a two-tier contract, and the patch-retirement discipline.
- **`reviews/2026-06-10-deep-dive-review.md`** (new): the full-repo deep dive that produced the daily queue.
- Cross-links: `api.mdx` resolver section → anchors/model-first; `getting-started.mdx` → confidence calibration.

## Verification

Full `yarn compile` + `@mailwoman/docs` build passes (broken-link check green; the only warnings are pre-existing undefined blog tags). Every number in `status.mdx`/`releases.mdx` is sourced from `model-card.json`, `package.json`, the eval ledger, or the 2026-06-09 parity scorecard — nothing hand-recalled.

## Note for the merger

A stray copy of the deep-dive review sits untracked at the main checkout's repo root (`2026-06-10-DEEP-DIVE-REVIEW.md`); it's superseded by the copy this PR lands under `docs/articles/reviews/` and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)