### PR TITLE
feat(eval): promotion-gate.sh — enforced gate runner, validated against the v4.2.0 ship

### DIFF
--- a/scripts/eval/gates/v4.2.0-ship.json
+++ b/scripts/eval/gates/v4.2.0-ship.json
@@ -1,0 +1,21 @@
+{
+	"$comment": "Gate spec for the v4.2.0 ship (night-10, 2026-06-10). Bars are the STATED re-baselines from the fork decision + the always-on floors. A gate spec is a CONTRACT (feedback-no-silent-gate-drift): edits require a stated reason in the PR that changes this file.",
+	"label": "v4.2.0-ship",
+	"requires_gazetteer_lexicon": true,
+	"floors": {
+		"us.postcode": 97.0,
+		"us.country_homograph_f1": 83.3,
+		"us.micro": 81.6,
+		"us.locality": 62.2,
+		"us.region": 80.1,
+		"us.street": 74.0,
+		"us.street_prefix": 60.0,
+		"us.street_suffix": 45.0,
+		"us.unit_real": 88.0,
+		"fr.postcode": 99.5,
+		"fr.house_number": 91.0,
+		"de.native_locality": 83.8
+	},
+	"int8_vs_fp32_max_delta_pp": 1.5,
+	"ledger_path": "evals/scores-by-version.json"
+}

--- a/scripts/eval/promotion-gate-verdict.ts
+++ b/scripts/eval/promotion-gate-verdict.ts
@@ -1,0 +1,117 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Verdict assembler for promotion-gate.sh (#479). Parses the battery outputs the runner
+ *   teed into --out-dir, checks every number against the gate spec's floors, enforces the
+ *   fp32↔int8 delta cap, and writes verdict.json. Exit 0 = all floors met; exit 1 = any miss.
+ *
+ *   Parsing contract: the scorers emit pipe-tables (`| tag | P | R | F1 |` from the affix
+ *   scorers, `| tag | golden | … |` from per-locale-f1, the de-order summary line). If a
+ *   harness output format changes, THIS file is the single place the gate's parsing breaks —
+ *   loudly (a floor whose number can't be found is a FAIL, never a skip).
+ */
+
+import { readFileSync, writeFileSync } from "node:fs"
+import * as path from "node:path"
+import { parseArgs } from "node:util"
+
+const { values: args } = parseArgs({
+	options: {
+		gate: { type: "string" },
+		"out-dir": { type: "string" },
+		"with-int8": { type: "boolean", default: false },
+	},
+})
+if (!args.gate || !args["out-dir"]) throw new Error("--gate and --out-dir required")
+
+const gate = JSON.parse(readFileSync(args.gate, "utf8")) as {
+	label: string
+	floors: Record<string, number>
+	int8_vs_fp32_max_delta_pp?: number
+}
+const dir = args["out-dir"]
+const read = (f: string) => readFileSync(path.join(dir, f), "utf8")
+
+/** Pull `| <tag> | … | <F1> |`-style F1 from an affix/country scorer table (P, R, F1 columns). */
+function scorerF1(md: string, tag: string): number | undefined {
+	const m = md.match(new RegExp(`\\|\\s*${tag}\\s*\\|\\s*[\\d.]+\\s*\\|\\s*[\\d.]+\\s*\\|\\s*([\\d.]+)`))
+	return m ? Number(m[1]) : undefined
+}
+
+/** Pull the per-locale table's per-tag percentage for a locale column (US first, FR second). */
+function perLocale(md: string, tag: string, locale: "us" | "fr"): number | undefined {
+	const m = md.match(new RegExp(`\\|\\s*${tag}\\s*\\|\\s*([\\d.]+)%\\s*\\|\\s*([\\d.—-]+)%?`))
+	if (!m) return undefined
+	return Number(locale === "us" ? m[1] : m[2]) || undefined
+}
+
+function collect(tag: "fp32" | "int8"): Record<string, number | undefined> {
+	const pl = read(`${tag}-per-locale.md`)
+	const affix = read(`${tag}-affix.md`)
+	const unit = read(`${tag}-unit.md`)
+	const country = read(`${tag}-country.md`)
+	const deorder = read(`${tag}-deorder.md`)
+	const deNative = deorder.match(/native DE\s*\|\s*[\d.]+%\s*\|\s*([\d.]+)%/)
+	// Locale summary row: `| us | <n> | <macro>% | <micro>% | <exact>% |`
+	const micro = pl.match(/\|\s*us\s*\|\s*\d+\s*\|\s*[\d.]+%\s*\|\s*([\d.]+)%/)
+	return {
+		"us.postcode": perLocale(pl, "postcode", "us"),
+		"us.locality": perLocale(pl, "locality", "us"),
+		"us.region": perLocale(pl, "region", "us"),
+		"us.street": perLocale(pl, "street", "us"),
+		"us.micro": micro ? Number(micro[1]) : undefined,
+		"us.street_prefix": scorerF1(affix, "street_prefix"),
+		"us.street_suffix": scorerF1(affix, "street_suffix"),
+		"us.unit_real": scorerF1(unit, "unit"),
+		"us.country_homograph_f1": scorerF1(country, "country"),
+		"fr.postcode": perLocale(pl, "postcode", "fr"),
+		"fr.house_number": perLocale(pl, "house_number", "fr"),
+		"de.native_locality": deNative ? Number(deNative[1]) : undefined,
+	}
+}
+
+const fp32 = collect("fp32")
+const int8 = args["with-int8"] ? collect("int8") : undefined
+const graded = int8 ?? fp32 // floors are graded on the ship artifact when present
+
+const results: Record<string, { floor: number; actual: number | undefined; pass: boolean }> = {}
+let failed = false
+for (const [key, floor] of Object.entries(gate.floors)) {
+	const actual = graded[key]
+	const pass = actual !== undefined && actual >= floor
+	if (!pass) failed = true
+	results[key] = { floor, actual, pass }
+}
+
+const deltas: Record<string, number> = {}
+if (int8 && gate.int8_vs_fp32_max_delta_pp !== undefined) {
+	for (const key of Object.keys(gate.floors)) {
+		const a = fp32[key]
+		const b = int8[key]
+		if (a === undefined || b === undefined) continue
+		const d = Math.abs(a - b)
+		deltas[key] = Number(d.toFixed(2))
+		if (d > gate.int8_vs_fp32_max_delta_pp) {
+			failed = true
+			results[`int8_delta.${key}`] = { floor: gate.int8_vs_fp32_max_delta_pp, actual: d, pass: false }
+		}
+	}
+}
+
+const verdict = {
+	label: gate.label,
+	graded_artifact: int8 ? "int8" : "fp32",
+	verdict: failed ? "FAIL" : "PASS",
+	results,
+	int8_vs_fp32_deltas: deltas,
+	generated_at_dir: dir,
+}
+writeFileSync(path.join(dir, "verdict.json"), JSON.stringify(verdict, null, "\t"))
+
+console.log(`\n== promotion gate [${gate.label}] — ${verdict.verdict} ==`)
+for (const [k, r] of Object.entries(results)) {
+	console.log(`  ${r.pass ? "✓" : "✗"} ${k}: ${r.actual ?? "NOT FOUND"} (floor ${r.floor})`)
+}
+process.exit(failed ? 1 : 0)

--- a/scripts/eval/promotion-gate.sh
+++ b/scripts/eval/promotion-gate.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+#
+# Promotion gate runner (#479) — ONE command that runs the standard eval battery against a
+# candidate model, checks every number against a gate-spec CONTRACT, and emits a single
+# machine-readable verdict. Exists so promotion gates are ENFORCED, not night-shift
+# discipline, and so "why did this model ship?" has a one-file answer.
+#
+# Usage:
+#   scripts/eval/promotion-gate.sh \
+#     --model <fp32.onnx> [--int8 <int8.onnx>] \
+#     --gate scripts/eval/gates/<spec>.json \
+#     [--tokenizer <tokenizer.model>] [--card <model-card.json>] \
+#     [--gazetteer-lexicon <lexicon.json>] [--out-dir /tmp/gate-<label>]
+#
+# Behavior:
+#   - Runs: per-locale-f1 (US/FR, tokenizer-enforced), score-affix (+ unit-real),
+#     score-country-homograph, de-order-eval, demo-preset-compare. When --int8 is given,
+#     re-runs the per-tag battery on the int8 artifact and enforces the fp32↔int8 delta cap.
+#   - Collects headline numbers into <out-dir>/verdict.json with per-floor PASS/FAIL.
+#   - Exit 0 = every floor met; exit 1 = any miss (CI-able, agent-guardrail-able).
+#
+# Lore encoded (the traps that bit before — see CONTRIBUTING_MODEL_WORK.mdx):
+#   - Tokenizer comparability: the tokenizer path must contain the card's tokenizer_version;
+#     refuses to grade otherwise (F1 across tokenizers is meaningless).
+#   - Gaz-fed flags: when the gate spec sets requires_gazetteer_lexicon, every scorer gets
+#     --gazetteer-lexicon + --suppress-gaz-near-postcode (zero-filled clues fake an affix
+#     crash and depress country recall).
+#   - Recompile-before-eval: warns when core/ sources are newer than core/out.
+#   - foldToComponents: affix floors are graded from score-affix (unfolded), never from
+#     per-locale-f1 (whose fold reports 0 even on a perfect split).
+set -euo pipefail
+
+MODEL="" INT8="" GATE="" OUT_DIR=""
+TOK="/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+CARD="neural-weights-en-us/model-card.json"
+GAZ="data/gazetteer/anchor-lexicon-v1.json"
+LK="/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
+
+while [[ $# -gt 0 ]]; do case "$1" in
+	--model) MODEL="$2"; shift 2;; --int8) INT8="$2"; shift 2;;
+	--gate) GATE="$2"; shift 2;; --tokenizer) TOK="$2"; shift 2;;
+	--card) CARD="$2"; shift 2;; --gazetteer-lexicon) GAZ="$2"; shift 2;;
+	--out-dir) OUT_DIR="$2"; shift 2;;
+	*) echo "unknown arg: $1" >&2; exit 2;;
+esac; done
+
+[[ -n "$MODEL" && -n "$GATE" ]] || { echo "✗ --model and --gate required" >&2; exit 2; }
+LABEL=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$GATE','utf8')).label)")
+OUT_DIR="${OUT_DIR:-/tmp/gate-$LABEL-$(date -u +%H%M)}"
+mkdir -p "$OUT_DIR"
+
+# --- lore guard: tokenizer comparability -----------------------------------
+CARD_TOK=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$CARD','utf8')).training.tokenizer_version)")
+[[ "$TOK" == *"$CARD_TOK"* ]] || { echo "✗ tokenizer path '$TOK' does not contain card tokenizer_version '$CARD_TOK' — F1 would be incomparable" >&2; exit 2; }
+
+# --- lore guard: recompile-before-eval --------------------------------------
+if [[ -d core/out ]] && [[ -n "$(find core -maxdepth 2 -name '*.ts' -newer core/out -print -quit 2>/dev/null)" ]]; then
+	echo "⚠ core/ sources newer than core/out — run 'yarn compile' or the harness grades stale code" >&2
+fi
+
+GAZ_ARGS=()
+if [[ "$(node -e "console.log(JSON.parse(require('fs').readFileSync('$GATE','utf8')).requires_gazetteer_lexicon === true)")" == "true" ]]; then
+	GAZ_ARGS=(--gazetteer-lexicon "$GAZ" --suppress-gaz-near-postcode)
+fi
+
+run_battery() { # $1 = model path, $2 = tag (fp32|int8)
+	local m="$1" tag="$2"
+	echo "== battery [$tag] $m =="
+	node --experimental-strip-types scripts/eval/per-locale-f1.ts --model "$m" --tokenizer "$TOK" \
+		--model-card "$CARD" --model-anchor-lookup "$LK" "${GAZ_ARGS[@]}" > "$OUT_DIR/$tag-per-locale.md"
+	node --experimental-strip-types scripts/eval/score-affix.ts --model "$m" "${GAZ_ARGS[@]}" > "$OUT_DIR/$tag-affix.md"
+	node --experimental-strip-types scripts/eval/score-affix.ts --model "$m" \
+		--file data/eval/external/unit-real-designators.jsonl "${GAZ_ARGS[@]}" > "$OUT_DIR/$tag-unit.md"
+	node --experimental-strip-types scripts/eval/score-country-homograph.ts --model "$m" \
+		--suppress-gaz-near-postcode > "$OUT_DIR/$tag-country.md"
+	scripts/eval/de-order-eval.sh --model "$m" --card "$CARD" --tokenizer "$TOK" \
+		--anchor-lookup "$LK" --out "$OUT_DIR/$tag-deorder" > "$OUT_DIR/$tag-deorder.md" 2>&1 || true
+}
+
+run_battery "$MODEL" fp32
+[[ -n "$INT8" ]] && run_battery "$INT8" int8
+node --experimental-strip-types scripts/eval/demo-preset-compare.ts --model-path="${INT8:-$MODEL}" > "$OUT_DIR/presets.md"
+
+# --- collect + verify (node does the parsing; bash stays an orchestrator) ---
+node --experimental-strip-types scripts/eval/promotion-gate-verdict.ts \
+	--gate "$GATE" --out-dir "$OUT_DIR" $( [[ -n "$INT8" ]] && echo --with-int8 )


### PR DESCRIPTION
Closes #479. Gate specs as contract JSON, one command runs the battery + grades floors + enforces the int8 delta cap + exits nonzero. Lore guards: tokenizer comparability refusal, gaz-fed flags, recompile warning, unfolded-affix grading. Acceptance: reproduced tonight's v4.2.0 ship verdict bit-for-bit (12/12 floors, max int8 delta 0.1pp). Ledger auto-append deliberately deferred to a follow-up commit on this file once the append shape is agreed — the verdict JSON carries everything needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)