### PR TITLE
feat(data): postal_city alias table builder + NAD-note correction (measured refutation)

### DIFF
--- a/docs/articles/evals/2026-06-10-nad-source-independent-holdout.md
+++ b/docs/articles/evals/2026-06-10-nad-source-independent-holdout.md
@@ -22,19 +22,27 @@ within-noise story as the lineage-shared evals. The consolidation's gains are no
 memorized OpenAddresses rows. This was the question this holdout exists to answer, and the
 answer is clean.
 
-## Finding 2 — the vanity-city gap, quantified at last
+## Finding 2 — the census-designation gap (CORRECTED same night)
 
-v0 beats neural on locality-NAME-match here (86.7 vs ~78) while neural crushes region
-(100.0 vs 91.7). NAD's locality field is the *postal* city — exactly the
-postal-city/geographic-city divergence #475 targets. The pattern (name miss + region
-perfect + p90 blowups on the margin) is the resolver returning the geographically-correct
-locality whose WOF name differs from the postal city on the gold row, plus genuine
-wrong-locality picks on vanity-city rows. Two consumers of this finding:
+> **CORRECTION (night-10, hours after first publication):** the first version of this
+> section attributed the locality gap to the postal-city/vanity-city divergence (#475).
+> The alias-table join MEASURED that attribution and refuted it: only 1 of 461 named
+> misses is alias-explained — NAD's locality field carries *census/municipal* names, not
+> postal names, so this eval cannot exhibit the vanity-city failure mode at all.
 
-1. **#475 (postal_city alias table)** now has its motivating number: closing the alias gap
-   is worth up to ~9pp of US locality-name-match on source-independent data.
-2. **#478 (arbitration)**: v0's 86.7 locality vs neural's 100.0 region is the per-component
-   complementarity argument in one row of a table.
+What the misses actually are (classified, n=461 with a resolved-but-wrong name):
+
+- **54.0% are the SAME PLACE under a different name surface** — census designations:
+  `College CDP` ↔ WOF `Fox Farm-College`, `City and Borough of Juneau`, `X Township` ↔
+  `X` (NJ alone is 148 of 461 — townships). This is the Plauen-Vogtl name-match-artifact
+  class, US edition; the fix lane is the #386-style hierarchy-aware designation credit
+  generalized to US census surfaces — filed as its own issue with these numbers.
+- The remainder are genuine ranking/disambiguation misses (e.g. Juneau → Wrangell).
+
+Consumers: the designation-credit issue (primary); **#478** still gets its
+complementarity row (v0 locality 86.7 vs neural region 100.0). **#475's alias table is
+NOT validated by this eval** — it needs an eval whose *inputs* carry postal surfaces
+(real-traffic shaped); noted on the issue.
 
 Caveats: admin-centroid coord errors are expected to be tens of km (the harness's own
 note); v0's 24.6 p90 reflects its conservative no-resolve behavior on hard rows (99.4%

--- a/scripts/build-postal-city-alias.ts
+++ b/scripts/build-postal-city-alias.ts
@@ -1,0 +1,96 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build the POSTAL-CITY ALIAS table (#475) from the pinned-release Overture US Parquet:
+ *   per-address ground truth for the postal-city/geographic-city split that the resolver's
+ *   coordinate-first soft-scorer currently approximates geometrically.
+ *
+ *   The signal: 45.9M US rows carry BOTH `postal_city` (what the postal system calls the
+ *   place — USPS "acceptable city names", vanity cities) AND a geographic locality
+ *   (`address_levels[2]`); 16.0M of them (34.9%) DIVERGE. Aggregated per
+ *   `(postcode, postal_city, geo_locality)` with observed counts, that divergence is the
+ *   alias evidence: "postcode 10954's mail says Nanuet; the polygon says Clarkstown".
+ *
+ *   SIBLING table by design (`postal_city_alias`, its own sqlite) — never mixed into the
+ *   PIP-derived `postcode_locality` rows: one table = one provenance class
+ *   (feedback-no-load-bearing-trivia). A count floor drops typo noise; everything kept is
+ *   observed-in-the-wild N times, with N recorded.
+ *
+ *   Usage:
+ *     node --experimental-strip-types scripts/build-postal-city-alias.ts \
+ *       [--release 2026-05-20.0] [--min-count 25] \
+ *       [--out /mnt/playpen/mailwoman-data/wof/postal-city-alias-us.db]
+ */
+
+import { mkdirSync, rmSync } from "node:fs"
+import * as path from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { DuckDBInstance } from "@duckdb/node-api"
+
+const { values: args } = parseArgs({
+	options: {
+		release: { type: "string", default: "2026-05-20.0" },
+		"min-count": { type: "string", default: "25" },
+		out: { type: "string", default: "/mnt/playpen/mailwoman-data/wof/postal-city-alias-us.db" },
+	},
+})
+const PARQUET = `/mnt/playpen/mailwoman-data/overture/${args.release}/addresses-us.parquet`
+const MIN_COUNT = Number(args["min-count"])
+
+mkdirSync(path.dirname(args.out!), { recursive: true })
+rmSync(args.out!, { force: true })
+
+const instance = await DuckDBInstance.create()
+const duck = await instance.connect()
+const result = await duck.runAndReadAll(`
+	SELECT
+		trim(postcode) AS postcode,
+		lower(trim(postal_city)) AS postal_city,
+		lower(trim(address_levels[2].value)) AS geo_locality,
+		count(*)::BIGINT AS n
+	FROM read_parquet('${PARQUET}')
+	WHERE nullif(trim(postcode), '') IS NOT NULL
+		AND nullif(trim(postal_city), '') IS NOT NULL
+		AND nullif(trim(address_levels[2].value), '') IS NOT NULL
+	GROUP BY 1, 2, 3
+	HAVING count(*) >= ${MIN_COUNT}
+`)
+const rows = result.getRowObjects() as { postcode: string; postal_city: string; geo_locality: string; n: bigint }[]
+
+const db = new DatabaseSync(args.out!)
+db.exec(`
+	PRAGMA journal_mode = WAL;
+	CREATE TABLE postal_city_alias (
+		postcode     TEXT NOT NULL,
+		postal_city  TEXT NOT NULL,
+		geo_locality TEXT NOT NULL,
+		n            INTEGER NOT NULL,
+		divergent    INTEGER NOT NULL, -- 1 when postal_city != geo_locality (the alias signal)
+		source       TEXT NOT NULL,
+		release      TEXT NOT NULL
+	);
+`)
+const insert = db.prepare(
+	"INSERT INTO postal_city_alias (postcode, postal_city, geo_locality, n, divergent, source, release) VALUES (?, ?, ?, ?, ?, ?, ?)",
+)
+db.exec("BEGIN")
+let divergent = 0
+for (const r of rows) {
+	const isDivergent = r.postal_city !== r.geo_locality ? 1 : 0
+	divergent += isDivergent
+	insert.run(r.postcode, r.postal_city, r.geo_locality, Number(r.n), isDivergent, "overture:US", String(args.release))
+}
+db.exec("COMMIT")
+db.exec(`
+	CREATE INDEX idx_pca_postcode ON postal_city_alias (postcode);
+	CREATE INDEX idx_pca_pair ON postal_city_alias (postal_city, geo_locality);
+	PRAGMA wal_checkpoint(TRUNCATE);
+	VACUUM;
+`)
+db.close()
+console.log(`${rows.length} (postcode, postal_city, geo_locality) pairs (n >= ${MIN_COUNT}) → ${args.out}`)
+console.log(`divergent pairs: ${divergent} (${((100 * divergent) / Math.max(1, rows.length)).toFixed(1)}%)`)


### PR DESCRIPTION
Partial #475 (the asset + the honest measurement; resolver consumption deferred — see below). Builds `postal-city-alias-us.db` (19,880 pairs, 51.3% divergent, 2.1MB) from 45.9M dual-evidence Overture rows.

**The measurement flipped a finding:** joining the table against the NAD holdout's 461 named locality misses explained exactly **1** — NAD localities are census names, not postal names, so that eval can't exhibit the vanity-city mode. The real gap is **census-designation surfaces (54%, NJ townships dominant)** → filed **#498** (the #386 suffix-credit class, US edition, with the Barre City ≠ Barre Town hierarchy guard). The NAD eval note now carries a correction block per `feedback-no-silent-gate-drift` — corrections apply to my findings too.

**#475 status after this PR:** table built + provenance'd; consumption (soft-score name-credit + mismatch-detector skip) stays open, gated on an eval whose *inputs* carry postal surfaces — the claim waits for its eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)