### PR TITLE
chore(parser): hardening part 1 — one decode path, repairs-in-both, policy tests, loud lexicon validation

### DIFF
--- a/core/policy/registry.test.ts
+++ b/core/policy/registry.test.ts
@@ -98,6 +98,31 @@ describe("InMemoryPolicyRegistry — apply by mode", () => {
 		expect(out.map((p) => p.source).sort()).toEqual(["merged", "rule"])
 	})
 
+	test("merged-source proposals survive both preference modes (they are neither rule nor neural)", () => {
+		const registry = new InMemoryPolicyRegistry()
+		registry.set({ component: "country", mode: "neural_preferred" })
+		const proposals = [
+			makeProposal({ component: "country", source: "neural", confidence: 0.9 }),
+			makeProposal({ component: "country", source: "rule", confidence: 0.9 }),
+			makeProposal({ component: "country", source: "merged", confidence: 0.9 }),
+		]
+		const out = registry.apply(proposals)
+		expect(out.map((p) => p.source).sort()).toEqual(["merged", "neural"])
+	})
+
+	test("a below-threshold preferred source does NOT trigger dropping the dispreferred one", () => {
+		// Threshold runs BEFORE preference: a neural proposal that died at the threshold must not
+		// count as "neural present" — else rule proposals vanish with nothing to replace them.
+		const registry = new InMemoryPolicyRegistry()
+		registry.set({ component: "country", mode: "neural_preferred", confidence_threshold: 0.8 })
+		const proposals = [
+			makeProposal({ component: "country", source: "neural", confidence: 0.5 }),
+			makeProposal({ component: "country", source: "rule", confidence: 0.9 }),
+		]
+		const out = registry.apply(proposals)
+		expect(out.map((p) => p.source)).toEqual(["rule"])
+	})
+
 	test("rule_preferred drops neural when rule is present", () => {
 		const registry = InMemoryPolicyRegistry.withDefaults()
 		registry.set({ component: "country", mode: "rule_preferred" })

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -168,7 +168,39 @@ export class NeuralAddressClassifier {
 	/** Tokenize → infer → Viterbi (or argmax) → decoder tree. */
 	async parse(text: string, opts?: ParseOpts): Promise<AddressTree> {
 		if (text.length === 0) return { raw: text, roots: [] }
+		const { tokens } = await this.#decode(text, opts)
+		return buildAddressTree(text, tokens, opts?.calibrate ? { calibrate: opts.calibrate } : undefined)
+	}
 
+	/**
+	 * Like `parse`, but also returns the raw per-token logits and piece offsets needed for per-span
+	 * logit aggregation (Option C joint-reconcile integration). Shares the ENTIRE decode path with
+	 * `parse` (one `#decode`, #481) — including the repair passes, which previously ran only in
+	 * `parse`: reconcile must consume the same tokens the argmax path serves users, and the repair
+	 * opts were silently ignored here before. `logits` stay RAW (pre-prior, pre-repair) — they are
+	 * the model's emissions, not the decode's opinions.
+	 */
+	async parseWithLogits(text: string, opts?: ParseOpts): Promise<ParseWithLogitsResult> {
+		if (text.length === 0) {
+			return { tree: { raw: text, roots: [] }, logits: [], pieces: [] }
+		}
+		const { tokens, logits, pieces } = await this.#decode(text, opts)
+		return {
+			tree: buildAddressTree(text, tokens, opts?.calibrate ? { calibrate: opts.calibrate } : undefined),
+			logits,
+			pieces: pieces.map((p) => ({ start: p.start, end: p.end })),
+		}
+	}
+
+	/**
+	 * THE decode path (#481): tokenize → anchor/gazetteer features → infer → priors → CRF/argmax →
+	 * tokens → repairs. Both `parse` and `parseWithLogits` consume this — never fork it; the 2026-06
+	 * audit found three drift surfaces in the previous duplicated copies.
+	 */
+	async #decode(
+		text: string,
+		opts?: ParseOpts
+	): Promise<{ tokens: DecoderToken[]; logits: number[][]; pieces: ReturnType<MailwomanTokenizer["encode"]>["pieces"] }> {
 		const { pieces, ids } = this.cfg.tokenizer.encode(text)
 		// Postcode-anchor channel (#239/#240): build per-piece anchor features from the same lookup the
 		// model trained on, fed alongside the ids. No-op when no lookup is configured.
@@ -246,92 +278,7 @@ export class NeuralAddressClassifier {
 			tokens = repairUnitLabels(text, tokens).tokens
 		}
 
-		return buildAddressTree(text, tokens, opts?.calibrate ? { calibrate: opts.calibrate } : undefined)
-	}
-
-	/**
-	 * Like `parse`, but also returns the raw per-token logits and piece offsets needed for per-span
-	 * logit aggregation (Option C joint-reconcile integration).
-	 */
-	async parseWithLogits(text: string, opts?: ParseOpts): Promise<ParseWithLogitsResult> {
-		if (text.length === 0) {
-			return { tree: { raw: text, roots: [] }, logits: [], pieces: [] }
-		}
-		const { pieces, ids } = this.cfg.tokenizer.encode(text)
-		// Postcode-anchor channel (#239/#240): build per-piece anchor features from the same lookup the
-		// model trained on, fed alongside the ids. No-op when no lookup is configured.
-		const anchor = this.cfg.postcodeAnchorLookup
-			? buildAnchorFeatures(text, pieces, this.cfg.postcodeAnchorLookup)
-			: undefined
-		const gazetteer = this.cfg.gazetteerLexicon
-			? buildGazetteerFeatures(text, pieces, this.cfg.gazetteerLexicon)
-			: undefined
-		const gazFed =
-			gazetteer && anchor && this.cfg.suppressGazetteerNearPostcode
-				? suppressGazetteerNearPostcode(gazetteer, anchor.confidence)
-				: gazetteer
-		const { logits } = await this.cfg.runner.infer(ids, anchor, gazFed)
-
-		this.assertEmissionWidth(logits)
-
-		let emissions = opts?.queryShape
-			? addEmissionMatrix(
-					logits,
-					buildEmissionPriors(opts.queryShape, pieces, this.labels, {
-						biasScale: opts.queryShapeBiasScale ?? 1.0,
-						inputText: text,
-					})
-				)
-			: logits
-
-		if (opts?.fst) {
-			emissions = addEmissionMatrix(
-				emissions,
-				buildFstEmissionPriors(opts.fst, pieces, this.labels, {
-					biasScale: opts.fstBiasScale ?? 1.0,
-				})
-			)
-		}
-
-		if (opts?.fstStreetMorphology) {
-			emissions = addEmissionMatrix(
-				emissions,
-				buildStreetMorphologyEmissionPriors(
-					opts.fstStreetMorphology,
-					pieces,
-					this.labels,
-					opts.fstStreetMorphologyOpts ?? {}
-				)
-			)
-		}
-
-		const labelIndices =
-			this.decodeMode === "viterbi"
-				? viterbi({
-						emissions,
-						transitions: this.transitions,
-						startTransitions: this.startTransitions,
-						endTransitions: this.endTransitions,
-					}).path
-				: emissions.map((row) => argmaxSoftmax(row).idx)
-
-		const tokens: DecoderToken[] = pieces.map((p, i) => {
-			const idx = labelIndices[i]!
-			const probs = softmax(logits[i]!)
-			return {
-				piece: p.piece,
-				start: p.start,
-				end: p.end,
-				label: (this.labels[idx] ?? "O") as DecoderToken["label"],
-				confidence: probs[idx]!,
-			}
-		})
-
-		return {
-			tree: buildAddressTree(text, tokens, opts?.calibrate ? { calibrate: opts.calibrate } : undefined),
-			logits,
-			pieces: pieces.map((p) => ({ start: p.start, end: p.end })),
-		}
+		return { tokens, logits, pieces }
 	}
 
 	async parseJson(text: string, opts?: ParseOpts): Promise<Partial<Record<ComponentTag, string>>> {

--- a/neural/gazetteer-inference.ts
+++ b/neural/gazetteer-inference.ts
@@ -45,6 +45,23 @@ export function parseGazetteerLexicon(raw: {
 	entries: Record<string, number>
 	code_entries: Record<string, number>
 }): GazetteerLexicon {
+	// Loud validation (#481): a malformed lexicon previously surfaced as a crash deep inside
+	// buildGazetteerFeatures (or worse, silently zero-filled clues — the fake-affix-crash class).
+	// Unknown refs fail loud, never silent.
+	if (typeof raw?.feature_dim !== "number" || raw.feature_dim <= 0) {
+		throw new Error(`gazetteer lexicon: feature_dim must be a positive number, got ${raw?.feature_dim}`)
+	}
+	if (!Array.isArray(raw.slots) || raw.slots.length === 0) {
+		throw new Error("gazetteer lexicon: slots must be a non-empty array")
+	}
+	if (typeof raw.max_ngram !== "number" || raw.max_ngram < 1) {
+		throw new Error(`gazetteer lexicon: max_ngram must be >= 1, got ${raw.max_ngram}`)
+	}
+	for (const field of ["bits", "entries", "code_entries"] as const) {
+		if (typeof raw[field] !== "object" || raw[field] === null) {
+			throw new Error(`gazetteer lexicon: ${field} must be an object`)
+		}
+	}
 	return {
 		featureDim: raw.feature_dim,
 		slots: raw.slots,


### PR DESCRIPTION
Part 1 of #481 (the classifier + policy half). The duplicated parse/parseWithLogits path — which had grown a third drift surface when the consolidation added the gazetteer block to both copies — is now ONE `#decode`. Decision recorded in-code: **repairs run in both paths** (reconcile must see the tokens users get; the repair opts were silently ignored in `parseWithLogits` — opt-in flags, so no default behavior change). Policy registry gains the two genuinely missing sharp cases (merged-source survival, threshold-before-preference ordering — base coverage existed; the deep-dive's zero-coverage claim was stale). Lexicon parsing fails loud on malformed input.

Verified: 479 tests green; post-extraction int8 scorer re-runs reproduce tonight's ship-gate numbers exactly (country 89.8, affix 64.9/48.8, net −11 lines).

**Remaining #481 scope (part 2, not tonight unless time allows):** libpostal TLA removal, `__isCompiledTree` explicit marker, ParseOpts already exported (verified), grouper constant naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)