### PR TITLE
chore(training): REPRODUCIBILITY.md + pinned-toolchain verifier (#480 safe parts)

### DIFF
--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -1,0 +1,62 @@
+# Reproducing a shipped model (worked example: v4.2.0)
+
+The "clone + train" recipe (#480). A shipped model is reproducible from five inputs; this
+page names exactly where each lives and the commands that consume them. The worked example
+is **v4.2.0** (`v1.0.2-consolidation-runB`); substitute per the eval-ledger row
+(`evals/scores-by-version.json`) for any other version — every row records the same five.
+
+## The five inputs
+
+| Input | v4.2.0 value | Where it lives |
+| --- | --- | --- |
+| Training code | `corpus-python/src/mailwoman_train/` @ the release tag | this repo |
+| Config | `corpus-python/src/mailwoman_train/configs/v1.0.2-consolidation-runB.yaml` | this repo |
+| Corpus | `corpus-v0.4.12-consolidation` (Parquet shards + MANIFEST) | R2 `mailwoman-assets` bucket → Modal volume `mailwoman-training` at `/data/corpus/versioned/` |
+| Tokenizer | `v0.6.0-a0/tokenizer.model` (md5 `b6137e8c…`) | same volume, `/data/models/tokenizer/` |
+| Aux lookups | `pilot-anchor-lookup.json` + `anchor-lexicon-v1.json` | volume `/data/anchor/`, `/data/gazetteer/` — rebuildable from source: `scripts/build-pilot-anchor-lookup.py`, `scripts/build-gazetteer-anchor-lexicon.mjs` (needs the custom WOF DBs + codex) |
+
+> **Honest caveats (the #480 gaps, still open):** the corpus + tokenizer are snapshots on
+> R2/Modal, not derivable offline from the repo (adapters fetch from live sources that age);
+> overlay corpus manifests reference base corpora by absolute volume path (strict-mode
+> loader is the planned guard); `init_from`/curriculum state is recorded in the model card's
+> recipe text, not yet machine-checked on resume.
+
+## The commands
+
+```bash
+# 1. Train (Modal A100, ~35 min for a 20k continue; ~$2-3)
+modal run -d scripts/modal/train_remote.py --config corpus-python/src/mailwoman_train/configs/v1.0.2-consolidation-runB.yaml --resume auto
+
+# 2. Export ONNX (on Modal — local onnxruntime can trip ShapeInferenceError on dynamo graphs)
+modal run scripts/modal/train_remote.py::export_onnx --output-dir=/data/output-v101-runB-s42 --step=020000
+modal volume get mailwoman-training output-v101-runB-s42/model.onnx ./model-fp32.onnx --force
+
+# 3. Quantize int8 (local, PINNED toolchain — see below; verify the md5 is deterministic by running twice)
+corpus-python/.venv/bin/python -m mailwoman_train.cli quantize --input ./model-fp32.onnx --output ./model-int8.onnx
+
+# 4. Gate (one command — the gate spec is the contract)
+scripts/eval/promotion-gate.sh --model ./model-fp32.onnx --int8 ./model-int8.onnx --gate scripts/eval/gates/v4.2.0-ship.json
+```
+
+Expected: int8 md5 `9eb4a99f6db06cccff57939f657c09f9` (v4.2.0's shipped bytes), gate PASS
+12/12. A different md5 with a passing gate = toolchain drift — see the verifier below
+before trusting anything.
+
+## The pinned export/quant toolchain
+
+`torch==2.12.0 · transformers==5.9.0 · onnx==1.21.0 · onnxruntime==1.26.0 · onnxscript==0.7.0`
+(the v4.1.0 set; source of truth is `scripts/modal/train_remote.py`'s training image).
+**This set is load-bearing**: opset ≤17 + the `value_info` strip in `quantize.py` are what
+keep the int8 graph Safari-WebGPU-safe. Check your local env against it:
+
+```bash
+scripts/verify-export-quant-versions.sh   # exits nonzero on any mismatch
+```
+
+## Eval procedure invariants
+
+Gaz-trained models (v4.2.0+) are ALWAYS evaluated with
+`--gazetteer-lexicon data/gazetteer/anchor-lexicon-v1.json --suppress-gaz-near-postcode`
+(zero-filled clues depress country recall and fake an affix crash). Never compare F1 across
+tokenizer versions. fp32-to-fp32 for measurement; int8 for ship claims. Recompile
+(`yarn compile`) before any eval — harnesses load `core/out`.

--- a/scripts/verify-export-quant-versions.sh
+++ b/scripts/verify-export-quant-versions.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+#
+# Verify the LOCAL export/quant toolchain matches the pinned training-image set (#480).
+#
+# Why this exists: the set was once unpinned (`>=`) and drifted between v0.9.3 and v0.9.7,
+# silently breaking int8 quant for Safari WebGPU (the value_info/opset incident — see
+# project-v4.1.0-release + the pinned block in scripts/modal/train_remote.py, which is the
+# SOURCE OF TRUTH this script reads). Run before any local quantize; CI-able (exit 1 on
+# mismatch). A bumped dep here is never a free upgrade — it must re-prove the Safari int8
+# graph (opset ≤17, value_info strip) end to end.
+set -euo pipefail
+
+PYTHON="${PYTHON:-corpus-python/.venv/bin/python}"
+TRAIN_REMOTE="scripts/modal/train_remote.py"
+
+[[ -x "$PYTHON" ]] || { echo "✗ $PYTHON not found — create the corpus-python venv first" >&2; exit 2; }
+
+# Local quantize needs only the QUANT subset (onnx, onnxruntime) — export runs on Modal,
+# where the full image pins apply. Export-side packages absent locally are a WARNING;
+# present-but-mismatched is a FAILURE either way (a wrong version is worse than a missing one).
+QUANT_PKGS="onnx onnxruntime"
+
+fail=0
+while IFS='==' read -r pkg pinned; do
+	pkg=$(echo "$pkg" | tr -d ' "',)
+	pinned=$(echo "$pinned" | tr -d ' "',=)
+	[[ -z "$pkg" || -z "$pinned" ]] && continue
+	actual=$("$PYTHON" -c "import importlib.metadata as m; print(m.version('$pkg'))" 2>/dev/null || echo "MISSING")
+	if [[ "$actual" == "$pinned" ]]; then
+		echo "✓ $pkg $actual"
+	elif [[ "$actual" == "MISSING" && " $QUANT_PKGS " != *" $pkg "* ]]; then
+		echo "⚠ $pkg: not installed locally (export-side; required on Modal, fine here)"
+	else
+		echo "✗ $pkg: local=$actual pinned=$pinned" >&2
+		fail=1
+	fi
+done < <(grep -oE '"(torch|transformers|onnx|onnxruntime|onnxscript)==[0-9.]+"' "$TRAIN_REMOTE")
+
+if [[ $fail -ne 0 ]]; then
+	echo "" >&2
+	echo "Toolchain drift vs $TRAIN_REMOTE — do NOT quantize for release with this env." >&2
+	exit 1
+fi
+echo "toolchain matches the pinned training-image set"


### PR DESCRIPTION
The #480 items that don't touch the training loader: the clone-and-train recipe (v4.2.0 worked example, five inputs, four commands, expected md5, honest caveats) + `verify-export-quant-versions.sh` (pins read from train_remote.py as source of truth; quant-subset required locally, export-side warns). Remaining #480 scope (loader strict-mode, curriculum stamping, snapshot publishing) stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)