### PR TITLE
feat(policy): config-file loading with total loud validation (#478 step 1)

### DIFF
--- a/core/policy/from-config.test.ts
+++ b/core/policy/from-config.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The loud-validation contract for policy-config loading (#478). Every rejection path throws
+ *   with the offending JSON path — a config typo must never silently fall back to defaults.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { policyRegistryFromConfig } from "./from-config.js"
+
+describe("policyRegistryFromConfig", () => {
+	it("loads locale-scoped and global entries over the defaults", () => {
+		const registry = policyRegistryFromConfig({
+			"en-US": { region: { mode: "neural_preferred", confidence_threshold: 0.6 } },
+			"*": { country: { mode: "both" } },
+		})
+		expect(registry.lookup("region", "en-US").mode).toBe("neural_preferred")
+		expect(registry.lookup("region", "en-US").confidence_threshold).toBe(0.6)
+		expect(registry.lookup("region", "fr-FR").mode).toBe("rule_only") // untouched default
+		expect(registry.lookup("country", "fr-FR").mode).toBe("both") // global applies everywhere
+		expect(registry.lookup("street", "en-US").mode).toBe("rule_only") // absent tag = today's behavior
+	})
+
+	it("throws on an unknown tag, naming the path", () => {
+		expect(() => policyRegistryFromConfig({ "en-US": { streets: { mode: "both" } } })).toThrow(
+			/"en-US"\."streets" is not a ComponentTag/,
+		)
+	})
+
+	it("throws on an unknown mode", () => {
+		expect(() =>
+			policyRegistryFromConfig({ "*": { region: { mode: "neural" as never } } }),
+		).toThrow(/mode "neural" is not one of/)
+	})
+
+	it("throws on an unknown field (the minimumConfidence lesson)", () => {
+		expect(() =>
+			policyRegistryFromConfig({
+				"*": { region: { mode: "both", minimumConfidence: 0.8 } as never },
+			}),
+		).toThrow(/"minimumConfidence" is not a recognized field/)
+	})
+
+	it("throws on an out-of-range threshold", () => {
+		expect(() =>
+			policyRegistryFromConfig({ "*": { region: { mode: "both", confidence_threshold: 1.5 } } }),
+		).toThrow(/must be a number in \[0, 1\]/)
+	})
+
+	it("throws on malformed shapes rather than guessing", () => {
+		expect(() => policyRegistryFromConfig([] as never)).toThrow(/root must be an object/)
+		expect(() => policyRegistryFromConfig({ "en-US": "neural_preferred" as never })).toThrow(
+			/"en-US" must be an object/,
+		)
+		expect(() => policyRegistryFromConfig({ "*": { region: "both" as never } })).toThrow(
+			/must be an object with a "mode" field/,
+		)
+	})
+})

--- a/core/policy/from-config.ts
+++ b/core/policy/from-config.ts
@@ -1,0 +1,98 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Config-file loading for the policy registry (#478 step 1). Rolling a component from rules to
+ *   neural previously required code edits + a release; this lets an operator (or the arbitration
+ *   layer's shape overlays, #478 step 2) declare per-locale per-tag policy as data:
+ *
+ *   ```jsonc
+ *   // mailwoman.policies.json
+ *   {
+ *     "en-US": {
+ *       "region":   { "mode": "neural_preferred", "confidence_threshold": 0.6 },
+ *       "street":   { "mode": "rule_preferred" }
+ *     },
+ *     "*": {                       // global (locale-less) entries
+ *       "country":  { "mode": "both" }
+ *     }
+ *   }
+ *   ```
+ *
+ *   Validation is LOUD and total, by hard-won rule: unknown tags, unknown modes, unknown FIELDS,
+ *   and out-of-range thresholds all throw with the offending path. (A silently-accepted
+ *   `minimumConfidence` typo cost a debugging session on 2026-06-10 — `set()` is structurally
+ *   typed and won't save a JSON file. This loader is where the contract is enforced.)
+ */
+
+import { COMPONENT_TAGS, type ComponentTag } from "../types/component.js"
+import type { PolicyMode } from "./policy.js"
+import { InMemoryPolicyRegistry } from "./registry.js"
+
+const POLICY_MODES: readonly PolicyMode[] = ["rule_only", "neural_only", "both", "neural_preferred", "rule_preferred"]
+const ENTRY_FIELDS = new Set(["mode", "confidence_threshold"])
+const TAG_SET = new Set<string>(COMPONENT_TAGS)
+
+/** The JSON shape of one tag's policy in a config file. */
+export interface PolicyConfigEntry {
+	mode: PolicyMode
+	confidence_threshold?: number
+}
+
+/** The JSON shape of a policy config file: locale (or `"*"` for global) → tag → entry. */
+export type PolicyConfig = Record<string, Record<string, PolicyConfigEntry>>
+
+/**
+ * Build a registry from a parsed policy-config object. Starts from `withDefaults()` (every tag
+ * `rule_only`) and overlays the config's entries — so an absent tag behaves exactly as today.
+ * Throws on ANY unrecognized key or value; the error names the offending JSON path.
+ */
+export function policyRegistryFromConfig(config: PolicyConfig): InMemoryPolicyRegistry {
+	if (typeof config !== "object" || config === null || Array.isArray(config)) {
+		throw new Error("policy config: root must be an object of locale → tag → entry")
+	}
+	const registry = InMemoryPolicyRegistry.withDefaults()
+
+	for (const [localeKey, tags] of Object.entries(config)) {
+		if (typeof tags !== "object" || tags === null || Array.isArray(tags)) {
+			throw new Error(`policy config: "${localeKey}" must be an object of tag → entry`)
+		}
+		const locale = localeKey === "*" ? undefined : localeKey
+
+		for (const [tag, entry] of Object.entries(tags)) {
+			const path = `"${localeKey}"."${tag}"`
+			if (!TAG_SET.has(tag)) {
+				throw new Error(`policy config: ${path} is not a ComponentTag (see core/types/component.ts)`)
+			}
+			if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+				throw new Error(`policy config: ${path} must be an object with a "mode" field`)
+			}
+			for (const field of Object.keys(entry)) {
+				if (!ENTRY_FIELDS.has(field)) {
+					throw new Error(
+						`policy config: ${path}."${field}" is not a recognized field (allowed: ${[...ENTRY_FIELDS].join(", ")})`,
+					)
+				}
+			}
+			if (!POLICY_MODES.includes(entry.mode)) {
+				throw new Error(`policy config: ${path}.mode "${entry.mode}" is not one of ${POLICY_MODES.join(" | ")}`)
+			}
+			if (entry.confidence_threshold !== undefined) {
+				const t = entry.confidence_threshold
+				if (typeof t !== "number" || Number.isNaN(t) || t < 0 || t > 1) {
+					throw new Error(`policy config: ${path}.confidence_threshold must be a number in [0, 1], got ${t}`)
+				}
+			}
+
+			registry.set({
+				component: tag as ComponentTag,
+				mode: entry.mode,
+				...(entry.confidence_threshold !== undefined ? { confidence_threshold: entry.confidence_threshold } : {}),
+				...(locale ? { locale } : {}),
+			})
+		}
+	}
+
+	return registry
+}

--- a/core/policy/index.ts
+++ b/core/policy/index.ts
@@ -7,3 +7,4 @@
 export * from "./defaults.js"
 export * from "./policy.js"
 export * from "./registry.js"
+export * from "./from-config.js"


### PR DESCRIPTION
The arbitration layer's first brick, per the design reviewed on #478: `policyRegistryFromConfig` — locale ('*' = global) → tag → {mode, confidence_threshold}, overlaid on `withDefaults()` so absent tags behave exactly as today. Validation is total and names the offending JSON path; the silently-accepted-field class (the `minimumConfidence` lesson) is now a thrown error with a test. Deliberately threads nowhere new — `AddressParser` already accepts a registry; the runtime-pipeline thread arrives with the arbitration consumer (step 2), not before there's a reader. 22 policy tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)