### PR TITLE
feat(pipeline): wire the reconciler's dormant concordance axes (#478)

### DIFF
--- a/core/pipeline/reconcile-lookups.test.ts
+++ b/core/pipeline/reconcile-lookups.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Contract tests for the reconcile concordance pre-fetch (#478): bounded queries, resolvable-tag
+ *   filtering, score-order budget spending, ancestor chaining, and graceful backend failure.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import type { ResolvedPlace, ResolverBackend } from "../resolver/types.js"
+import type { ClassifierCandidate } from "./reconcile.js"
+import { prefetchReconcileLookups } from "./reconcile-lookups.js"
+
+const place = (id: number, name: string): ResolvedPlace =>
+	({ id, name, placetype: "locality", lat: 1, lon: 2 }) as ResolvedPlace
+
+function fakeBackend(calls: Array<{ text: string; placetype?: string | string[] }>): ResolverBackend {
+	return {
+		async findPlace(query) {
+			calls.push({ text: query.text, placetype: query.placetype })
+			if (query.text === "Springfield") return [place(1, "Springfield"), place(2, "Springfield")]
+			if (query.text === "Illinois") return [place(10, "Illinois")]
+			return []
+		},
+		ancestors(id) {
+			if (id === 1) return [{ id: 10, placetype: "region", name: "Illinois" }]
+			return []
+		},
+	}
+}
+
+const cand = (start: number, end: number, tag: ClassifierCandidate["tag"], score: number): ClassifierCandidate => ({
+	span: { start, end },
+	tag,
+	score,
+})
+
+describe("prefetchReconcileLookups", () => {
+	const raw = "Springfield Illinois"
+
+	it("fetches per (span, tag) pair and serves sync lookups", async () => {
+		const calls: Array<{ text: string }> = []
+		const lookups = await prefetchReconcileLookups(fakeBackend(calls), raw, [
+			cand(0, 11, "locality", 0.9),
+			cand(12, 20, "region", 0.8),
+		])
+		expect(calls.map((c) => c.text)).toEqual(["Springfield", "Illinois"])
+		expect(lookups.resolverCandidates.candidatesFor({ start: 0, end: 11 }, "locality")).toHaveLength(2)
+		expect(lookups.resolverCandidates.candidatesFor({ start: 12, end: 20 }, "region")).toHaveLength(1)
+		// Unfetched pair = empty, never undefined.
+		expect(lookups.resolverCandidates.candidatesFor({ start: 0, end: 11 }, "region")).toEqual([])
+	})
+
+	it("chains ancestors at prefetch time for sync parentsOf", async () => {
+		const lookups = await prefetchReconcileLookups(fakeBackend([]), raw, [cand(0, 11, "locality", 0.9)])
+		const chain = lookups.parentChain.parentsOf(place(1, "Springfield"))
+		expect(chain.map((p) => p.id)).toEqual([10])
+		expect(lookups.parentChain.parentsOf(place(99, "Nowhere"))).toEqual([])
+	})
+
+	it("skips non-resolvable tags (street/house_number never hit the gazetteer)", async () => {
+		const calls: Array<{ text: string }> = []
+		await prefetchReconcileLookups(fakeBackend(calls), raw, [
+			cand(0, 11, "street", 0.99),
+			cand(0, 11, "house_number", 0.98),
+			cand(12, 20, "region", 0.5),
+		])
+		expect(calls.map((c) => c.text)).toEqual(["Illinois"])
+	})
+
+	it("respects the lookup budget in candidate order", async () => {
+		const calls: Array<{ text: string }> = []
+		const many = Array.from({ length: 20 }, (_, i) => cand(i, i + 1, "locality" as const, 1 - i / 100))
+		await prefetchReconcileLookups(fakeBackend(calls), "x".repeat(40), many, { maxLookups: 5 })
+		expect(calls).toHaveLength(5)
+	})
+
+	it("degrades a throwing backend to empty evidence", async () => {
+		const backend: ResolverBackend = {
+			async findPlace() {
+				throw new Error("backend down")
+			},
+		}
+		const lookups = await prefetchReconcileLookups(backend, raw, [cand(0, 11, "locality", 0.9)])
+		expect(lookups.resolverCandidates.candidatesFor({ start: 0, end: 11 }, "locality")).toEqual([])
+	})
+})

--- a/core/pipeline/reconcile-lookups.ts
+++ b/core/pipeline/reconcile-lookups.ts
@@ -1,0 +1,103 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Pre-fetch adapters that wire a `ResolverBackend` into the reconciler's concordance axes
+ *   (#478 step 2, re-scoped): `reconcileSpans` already implements resolver-candidate and
+ *   parent-chain scoring but the runtime pipeline never passed the lookups — the axes were
+ *   dormant, exercised only by Map-backed test fixtures.
+ *
+ *   The reconciler's beam search is SYNCHRONOUS; the backend is async. So this module does one
+ *   bounded async pre-fetch pass — `findPlace` per (phrase-span × top-k tag) pair, `ancestors`
+ *   per fetched place — and returns Map-backed lookups with the contract the reconciler expects.
+ *   Query count is capped (`maxLookups`, default 12) the same way `resolveTree` caps its walk;
+ *   pairs are visited in classifier-score order so the budget goes to the likeliest spans.
+ */
+
+import type { ResolvedPlace, ResolverBackend } from "../resolver/types.js"
+import type { ClassifierCandidate, ParentChainLookup, ResolverCandidatesLookup } from "./reconcile.js"
+
+const RESOLVABLE_TAGS = new Set(["country", "region", "locality", "dependent_locality", "county", "subregion"])
+
+export interface ReconcileLookups {
+	resolverCandidates: ResolverCandidatesLookup
+	parentChain: ParentChainLookup
+}
+
+/**
+ * Build the reconciler's concordance lookups from one bounded pre-fetch pass over the backend.
+ *
+ * @param backend The gazetteer backend (Stage 6's `WofSqlitePlaceLookup.asResolverBackend()` in
+ *   production; any structural match in tests).
+ * @param raw The normalized input text — span bounds index into this.
+ * @param classifierTopK The aggregated per-span tag candidates (score-descending preferred; the
+ *   budget follows this order).
+ * @param opts.maxLookups Hard cap on `findPlace` calls (default 12).
+ * @param opts.candidatesPerPair Max places retained per (span, tag) pair (default 3).
+ */
+export async function prefetchReconcileLookups(
+	backend: ResolverBackend,
+	raw: string,
+	classifierTopK: ReadonlyArray<ClassifierCandidate>,
+	opts?: { maxLookups?: number; candidatesPerPair?: number; defaultCountry?: string },
+): Promise<ReconcileLookups> {
+	const maxLookups = opts?.maxLookups ?? 12
+	const perPair = opts?.candidatesPerPair ?? 3
+
+	const candidateTable = new Map<string, ResolvedPlace[]>()
+	const chainTable = new Map<number | string, ResolvedPlace[]>()
+	const pairKey = (span: { start: number; end: number }, tag: string) => `${span.start}:${span.end}:${tag}`
+
+	let budget = maxLookups
+	for (const candidate of classifierTopK) {
+		if (budget <= 0) break
+		if (!RESOLVABLE_TAGS.has(candidate.tag)) continue
+		const key = pairKey(candidate.span, candidate.tag)
+		if (candidateTable.has(key)) continue
+		const text = raw.slice(candidate.span.start, candidate.span.end).trim()
+		if (!text) continue
+		budget--
+		let places: ResolvedPlace[] = []
+		try {
+			places = await backend.findPlace({
+				text,
+				placetype: candidate.tag,
+				...(opts?.defaultCountry ? { country: opts.defaultCountry } : {}),
+				limit: perPair,
+			})
+		} catch {
+			// A backend failure degrades to "no concordance evidence for this pair" — the
+			// reconciler scores without it, identical to today's behavior.
+		}
+		candidateTable.set(key, places.slice(0, perPair))
+
+		// Ancestors are synchronous + memoized backend-side; chain them now so parentsOf is a
+		// pure Map read during the beam search.
+		if (backend.ancestors) {
+			for (const place of places) {
+				if (chainTable.has(place.id)) continue
+				const chain = backend.ancestors(place.id) ?? []
+				// The reconciler's concordance check is MEMBERSHIP-ONLY (by id) — Ancestor carries no
+				// coordinates, and none are needed; zeroes satisfy the ResolvedPlace shape.
+				chainTable.set(
+					place.id,
+					chain.map((a) => ({ id: a.id, name: a.name, placetype: a.placetype, lat: 0, lon: 0 }) as ResolvedPlace),
+				)
+			}
+		}
+	}
+
+	return {
+		resolverCandidates: {
+			candidatesFor(span, tag) {
+				return candidateTable.get(pairKey(span, tag)) ?? []
+			},
+		},
+		parentChain: {
+			parentsOf(place) {
+				return chainTable.get(place.id) ?? []
+			},
+		},
+	}
+}

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -15,6 +15,7 @@
 import type { AddressNode, AddressTree } from "../decoder/types.js"
 import type { ComponentTag } from "../types/component.js"
 import type { ClassifierCandidate } from "./reconcile.js"
+import { prefetchReconcileLookups } from "./reconcile-lookups.js"
 import { reconcileSpans } from "./reconcile.js"
 import { aggregateSpanLogits } from "./span-logit-aggregation.js"
 import type {
@@ -282,10 +283,22 @@ export async function runPipeline(
 		)
 
 		if (classifierTopK.length > 0) {
+			// Concordance axes (#478): when the caller wires a backend, one bounded pre-fetch
+			// activates the resolver-candidate + parent-chain scoring the reconciler already
+			// implements. Absent backend = classifier-only reconcile (byte-stable).
+			// Country constraint from the locale gate's BCP-47 tag ("en-US" -> "US"); absent or
+			// und-like tags pass no constraint (ranking alone decides — matches resolveTree's default).
+			const localeCountry = locale.locale.split("-")[1]?.toUpperCase()
+			const lookups = stages.resolverBackend
+				? await prefetchReconcileLookups(stages.resolverBackend, normalized.normalized, classifierTopK, {
+						...(localeCountry && localeCountry.length === 2 ? { defaultCountry: localeCountry } : {}),
+					})
+				: undefined
 			const result = reconcileSpans({
 				raw: normalized.normalized,
 				phraseProposals,
 				classifierTopK,
+				...(lookups ? { resolverCandidates: lookups.resolverCandidates, parentChain: lookups.parentChain } : {}),
 			})
 			tree = result.tree
 			// The reconciler can leave a span uncovered (e.g. it picked the single-token street

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -14,7 +14,7 @@
  */
 
 import type { AddressTree } from "../decoder/types.js"
-import type { ResolveOpts, Resolver } from "../resolver/types.js"
+import type { ResolveOpts, Resolver, ResolverBackend } from "../resolver/types.js"
 import type { Section } from "../types/classifier.js"
 
 export type LocaleTag = string
@@ -191,6 +191,13 @@ export interface RuntimePipelineStages {
 	 */
 	fst?: FstMatcherLike
 	resolver?: Resolver
+	/**
+	 * The gazetteer BACKEND (lower-level than `resolver`), enabling the reconciler's concordance
+	 * axes (#478): a bounded pre-fetch turns it into the resolver-candidate + parent-chain lookups
+	 * `reconcileSpans` scores with. Optional — absent, reconcile runs classifier-only (today's
+	 * behavior, byte-stable).
+	 */
+	resolverBackend?: ResolverBackend
 }
 
 export interface PipelineTiming {


### PR DESCRIPTION
The re-scoped step 2: `reconcileSpans` has carried resolver-candidate + parent-chain scoring since Route A — exercised only by test fixtures, because the runtime pipeline never passed the lookups. Now an optional `stages.resolverBackend` activates them via one bounded pre-fetch (sync-lookup adapter over the async backend; budget follows classifier-score order; failures degrade to empty evidence). Byte-stable when absent. 71 pipeline tests green. Remaining #478 scope after this: rules-as-second-emitter (the capstone) + the one-rule shape overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)