### PR TITLE
feat(corpus): glue-class augmentation — region+postcode fusion (#513 lever 1)

### DIFF
--- a/corpus-python/src/mailwoman_train/augment.py
+++ b/corpus-python/src/mailwoman_train/augment.py
@@ -1,6 +1,6 @@
 """Training-time augmentation: expand abbreviations to teach token equivalence.
 
-Two augmentations, applied independently with configurable probability:
+Three augmentations, applied independently with configurable probability:
 
 1. **Directional expansion**: "NW" → "Northwest", "SE" → "Southeast", etc.
    Teaches the model that both abbreviated and expanded directionals are the same
@@ -10,15 +10,25 @@ Two augmentations, applied independently with configurable probability:
    Only US state abbreviations for now. Teaches the model that "NY" and "New York"
    are both B-region, improving locality/region disambiguation.
 
-Both augmentations replace the token in the raw text AND update the tokens + labels
-lists to match. The expanded form inherits the original token's BIO label (B- for
-the first word, I- for continuation words).
+3. **Region+postcode glue** (#513): "NY 14201" → "NY14201" in ``raw`` ONLY — the
+   ``tokens`` + ``labels`` lists stay split. ``whitespace_spans`` locates tokens by
+   substring search (no whitespace requirement), so the char-offset piece projection
+   still lands B-region on the letter pieces and B/I-postcode on the digit pieces of
+   the fused surface. Teaches the model to split the fused token at the SP-piece
+   level (the v4.3.0 "glue" regression class).
+
+The expansion augmentations replace the token in the raw text AND update the
+tokens + labels lists to match; the expanded form inherits the original token's
+BIO label (B- for the first word, I- for continuation words). The glue
+augmentation mutates ``raw`` alone.
 """
 
 from __future__ import annotations
 
 import random
 from typing import Iterator
+
+from .tokenizer import whitespace_spans
 
 # US directional abbreviations → expanded forms.
 DIRECTIONALS: dict[str, str] = {
@@ -118,11 +128,22 @@ def _expand_token(
     return new_tokens, new_labels
 
 
+def glue_region_postcode(row: dict, idx: int) -> dict:
+    """Return a copy of ``row`` with the whitespace between token ``idx`` (region) and
+    token ``idx + 1`` (postcode) removed from ``raw``. Tokens + labels are untouched —
+    the split labels project onto the fused surface via char offsets (see module doc)."""
+    spans = whitespace_spans(row["raw"], row["tokens"])
+    region_end = spans[idx][1]
+    postcode_begin = spans[idx + 1][0]
+    return {**row, "raw": row["raw"][:region_end] + row["raw"][postcode_begin:]}
+
+
 def augment_row(
     row: dict,
     rng: random.Random,
     directional_prob: float = 0.3,
     region_prob: float = 0.3,
+    glue_prob: float = 0.0,
 ) -> Iterator[dict]:
     """Yield the original row, then optionally an augmented copy.
 
@@ -152,6 +173,24 @@ def augment_row(
                 "tokens": new_tokens,
                 "labels": new_labels,
             }
+
+    # Region+postcode glue (#513): fuse the last region token with an immediately-following
+    # postcode token in raw. Letter→digit boundary only — that's the boundary SentencePiece
+    # is guaranteed to split (the eval's glue class); letter→letter fusions (e.g. GB outcodes)
+    # could yield a piece straddling the label boundary, which the char projection cannot
+    # represent (first-char label wins). The prob guard keeps the rng stream bit-identical
+    # for configs that leave the knob at 0.
+    if glue_prob > 0 and rng.random() < glue_prob:
+        glue_indices = [
+            i
+            for i in range(len(tokens) - 1)
+            if labels[i] in ("B-region", "I-region")
+            and labels[i + 1] == "B-postcode"
+            and tokens[i][-1:].isalpha()
+            and tokens[i + 1][:1].isdigit()
+        ]
+        if glue_indices:
+            yield glue_region_postcode(row, rng.choice(glue_indices))
 
     # Region-abbreviation expansion: find region-labeled abbreviations and expand one.
     if rng.random() < region_prob:

--- a/corpus-python/src/mailwoman_train/config.py
+++ b/corpus-python/src/mailwoman_train/config.py
@@ -35,6 +35,11 @@ class DataConfig:
     # Probability (0-1) that each augmentation fires per row. 0 = disabled.
     augment_directional_prob: float = 0.0
     augment_region_prob: float = 0.0
+    # Region+postcode glue augmentation (#513): probability that a row with a region token
+    # immediately followed by a postcode token yields an extra copy with the pair fused in
+    # raw ("NY 14201" -> "NY14201") while tokens/labels stay split — the model learns to
+    # split the fused surface at the SP-piece level. 0 = disabled (rng-stream bit-identical).
+    augment_glue_prob: float = 0.0
     # Postcode-anchor lookup (#239/#240). Path to the JSON {postcode: [posterior, lat, lon]} table
     # (built by scripts/build-pilot-anchor-lookup.py). When set AND model.use_postcode_anchor is on,
     # the loader projects per-piece anchor features onto each row. None → no anchor features.

--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -397,6 +397,7 @@ def iter_rows(
     row_limit: int | None = None,
     augment_directional_prob: float = 0.0,
     augment_region_prob: float = 0.0,
+    augment_glue_prob: float = 0.0,
     affix_relabel_lexicon: "AffixRelabelLexicon | None" = None,
     shuffle_buffer: int = 131072,
 ) -> Iterator[dict]:
@@ -446,14 +447,16 @@ def iter_rows(
             buf.append(next(upstream))
     except StopIteration:
         pass
-    do_augment = augment_directional_prob > 0 or augment_region_prob > 0
+    do_augment = augment_directional_prob > 0 or augment_region_prob > 0 or augment_glue_prob > 0
 
     def _emit(row: dict) -> Iterator[dict]:
         # Relabel runs AFTER augmentation so label-inheriting directional expansions are caught
         # (#511 — see relabel.py). augment_row yields fresh dicts but shares the labels list with
         # the source row on the no-op path, so relabel copies before mutating.
         if do_augment:
-            for augmented in augment_row(row, rng, augment_directional_prob, augment_region_prob):
+            for augmented in augment_row(
+                row, rng, augment_directional_prob, augment_region_prob, augment_glue_prob
+            ):
                 if affix_relabel_lexicon is not None:
                     augmented = {**augmented, "labels": list(augmented["labels"])}
                     relabel_row(augmented, affix_relabel_lexicon)
@@ -521,6 +524,7 @@ def iter_encoded(
         row_limit=row_limit,
         augment_directional_prob=cfg_data.augment_directional_prob,
         augment_region_prob=cfg_data.augment_region_prob,
+        augment_glue_prob=getattr(cfg_data, "augment_glue_prob", 0.0),
         affix_relabel_lexicon=affix_relabel_lexicon,
     ):
         enc = encode_row(

--- a/corpus-python/src/mailwoman_train/test_augment.py
+++ b/corpus-python/src/mailwoman_train/test_augment.py
@@ -2,7 +2,8 @@
 
 import random
 
-from .augment import augment_row, _expand_token
+from .augment import augment_row, glue_region_postcode, _expand_token
+from .tokenizer import PieceSpan, realign_labels_to_pieces
 
 
 def test_expand_token_single_word():
@@ -106,3 +107,121 @@ def test_augment_row_region_only_expands_region_labeled():
     # PA (labeled B-street) should NOT be expanded — only DC (B-region) should
     assert augmented["tokens"][0] == "PA"
     assert "District" in augmented["tokens"]
+
+
+# --- Region+postcode glue (#513) ---------------------------------------------------------------
+
+
+def _glue_row() -> dict:
+    return {
+        "raw": "123 Main St Buffalo NY 14201",
+        "tokens": ["123", "Main", "St", "Buffalo", "NY", "14201"],
+        "labels": ["B-house_number", "B-street", "I-street", "B-locality", "B-region", "B-postcode"],
+        "country": "US",
+        "source": "tiger",
+    }
+
+
+def test_glue_fuses_raw_only():
+    row = _glue_row()
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=0.0, region_prob=0.0, glue_prob=1.0))
+    assert len(results) == 2
+    assert results[0] is row
+    fused = results[1]
+    assert fused["raw"] == "123 Main St Buffalo NY14201"
+    # Tokens + labels stay split — the whole point of the augmentation.
+    assert fused["tokens"] == row["tokens"]
+    assert fused["labels"] == row["labels"]
+
+
+def test_glue_preserves_original_punctuation():
+    row = {
+        "raw": "Buffalo, NY 14201",
+        "tokens": ["Buffalo", ",", "NY", "14201"],
+        "labels": ["B-locality", "O", "B-region", "B-postcode"],
+        "country": "US",
+        "source": "tiger",
+    }
+    fused = glue_region_postcode(row, 2)
+    # Splices the original raw (comma spacing intact), not a re-join of tokens.
+    assert fused["raw"] == "Buffalo, NY14201"
+
+
+def test_glue_fuses_last_token_of_multi_token_region():
+    row = {
+        "raw": "Springfield New York 10001",
+        "tokens": ["Springfield", "New", "York", "10001"],
+        "labels": ["B-locality", "B-region", "I-region", "B-postcode"],
+        "country": "US",
+        "source": "tiger",
+    }
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=0.0, region_prob=0.0, glue_prob=1.0))
+    assert len(results) == 2
+    assert results[1]["raw"] == "Springfield New York10001"
+
+
+def test_glue_requires_digit_leading_postcode():
+    # GB-style letter-leading postcode: fusing would create a letter→letter boundary
+    # SentencePiece may not split — must NOT fire.
+    row = {
+        "raw": "London England SW1A 1AA",
+        "tokens": ["London", "England", "SW1A", "1AA"],
+        "labels": ["B-locality", "B-region", "B-postcode", "I-postcode"],
+        "country": "GB",
+        "source": "wof-admin",
+    }
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=0.0, region_prob=0.0, glue_prob=1.0))
+    assert len(results) == 1
+
+
+def test_glue_requires_adjacency():
+    row = {
+        "raw": "Buffalo NY USA 14201",
+        "tokens": ["Buffalo", "NY", "USA", "14201"],
+        "labels": ["B-locality", "B-region", "B-country", "B-postcode"],
+        "country": "US",
+        "source": "tiger",
+    }
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=0.0, region_prob=0.0, glue_prob=1.0))
+    assert len(results) == 1
+
+
+def test_glue_default_off_preserves_rng_stream():
+    # glue_prob=0 must not consume an rng draw — existing recipes stay bit-identical.
+    # (directional + region each always draw once; glue must not add a third.)
+    ref = random.Random(7)
+    ref.random(), ref.random()
+    expected = ref.random()
+    rng = random.Random(7)
+    list(augment_row(_glue_row(), rng, directional_prob=0.0, region_prob=0.0, glue_prob=0.0))
+    assert rng.random() == expected
+
+
+def test_glued_raw_projects_split_labels_onto_pieces():
+    """The load-bearing property (#513): the fused surface with SPLIT tokens/labels projects
+    B-region onto the letter pieces and B/I-postcode onto the digit pieces via char offsets.
+    Mock pieces mirror the v0.6.0-a0 tokenizer's letter/digit split (verified empirically:
+    1020 fused state+ZIP rows, zero pieces straddling the letter→digit boundary)."""
+    row = {
+        "raw": "Buffalo NY 14201",
+        "tokens": ["Buffalo", "NY", "14201"],
+        "labels": ["B-locality", "B-region", "B-postcode"],
+    }
+    fused = glue_region_postcode(row, 1)
+    assert fused["raw"] == "Buffalo NY14201"
+
+    def _piece(text: str, begin: int, end: int) -> PieceSpan:
+        return PieceSpan(piece=text, piece_id=0, char_begin=begin, char_end=end)
+
+    pieces = [
+        _piece("Buffalo", 0, 7),
+        _piece("NY", 8, 10),
+        _piece("142", 10, 13),
+        _piece("01", 13, 15),
+    ]
+    bio = realign_labels_to_pieces(fused["raw"], fused["tokens"], fused["labels"], pieces)
+    assert bio == ["B-locality", "B-region", "B-postcode", "I-postcode"]


### PR DESCRIPTION
Loader-side augmentation for the v4.3.0 glue regression: fuses a region token with the following postcode token in `raw` while tokens/labels stay split — the char-offset piece projection carries the split labels onto the fused surface (verified on the production tokenizer: zero straddling pieces across all 51 state codes; this also explains how v4.2.0 split glued tokens with no explicit supervision).

- `augment_glue_prob` in DataConfig (default 0.0; rng stream bit-identical when off, test-asserted)
- Letter→digit boundary guard (GB-style letter-leading postcodes excluded — the one straddle-risk class)
- 7 new tests; full suite 50 passed

Pre-registered bar (in `gates/v4.4.0-boundary.json`, committed before this lever existed): perturb arena ≥ 71 with affix floors unchanged. Suggested knob for the probe: 0.2–0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)