### PR TITLE
fix(reconcile): per-word inclusion bonus — end the beam's fragmentation subsidy

### DIFF
--- a/core/pipeline/reconcile.test.ts
+++ b/core/pipeline/reconcile.test.ts
@@ -436,6 +436,69 @@ describe("kryptonite catalogue — Buffalo Buffalo (post-reconcile keeps both as
 	})
 })
 
+describe("kryptonite catalogue — New York City (bare multiword famous name, no resolver evidence)", () => {
+	// Regression for the v4.4.0 demo bug (2026-06-11): `runPipeline("New York City")` produced
+	// `{region: "York", locality: "City"}` while plain argmax produced the correct
+	// `{locality: "New York City"}`. Root cause: the per-token logit aggregation gives interior
+	// fragments inflated confidence (`City` aggregates I-locality mass → 0.92 vs 0.60 for the full
+	// span) and the per-SLOT inclusion bonus charged nothing for leaving "New York" uncovered — the
+	// beam picked the bare `locality="City"` and the grouper-audit then promoted the orphaned `York`
+	// to a spurious `region`. The per-WORD inclusion bonus makes the covering interpretation win.
+	//
+	// Phrase proposals + classifier top-K below are RECORDED from the live v4.4.0 ship config
+	// (v130-boundary-40k-int8 + v0.6.0-a0 tokenizer + fst-en-US.bin) via
+	// `scripts/diag-nyc-reconcile.ts`. No resolver / parent chain — the demo passes no backend, so
+	// the reconciler must rank these on classifier + phrase evidence alone.
+	const raw = "New York City"
+	const phraseProposals: PhraseProposal[] = [
+		proposal({ start: 4, end: 13, body: "York City" }, "LOCALITY_PHRASE", 0.85),
+		proposal({ start: 0, end: 13, body: "New York City" }, "LOCALITY_PHRASE", 0.82),
+		proposal({ start: 0, end: 8, body: "New York" }, "LOCALITY_PHRASE", 0.7),
+		proposal({ start: 9, end: 13, body: "City" }, "LOCALITY_PHRASE", 0.7),
+		proposal({ start: 0, end: 3, body: "New" }, "LOCALITY_PHRASE", 0.55),
+		proposal({ start: 0, end: 13, body: "New York City" }, "VENUE_PHRASE", 0.55),
+		proposal({ start: 4, end: 8, body: "York" }, "LOCALITY_PHRASE", 0.55),
+	]
+	const classifierTopK: ClassifierCandidate[] = [
+		tagC(4, 13, "locality", 0.603),
+		tagC(4, 13, "region", 0.2397),
+		tagC(4, 13, "country", 0.0306),
+		tagC(0, 13, "locality", 0.5951),
+		tagC(0, 13, "region", 0.2472),
+		tagC(0, 13, "country", 0.0328),
+		tagC(0, 8, "locality", 0.433),
+		tagC(0, 8, "region", 0.3669),
+		tagC(0, 8, "country", 0.044),
+		tagC(9, 13, "locality", 0.9192),
+		tagC(9, 13, "country", 0.0104),
+		tagC(0, 3, "locality", 0.5792),
+		tagC(0, 3, "region", 0.2622),
+		tagC(0, 3, "country", 0.0373),
+		tagC(4, 8, "region", 0.4716),
+		tagC(4, 8, "locality", 0.2868),
+		tagC(4, 8, "country", 0.0508),
+	]
+
+	it("post-reconcile keeps the single full-span locality — no fragmentation into York/City", () => {
+		const result = reconcileSpans({ raw, phraseProposals, classifierTopK })
+		expect(result.tree.roots).toHaveLength(1)
+		const root = result.tree.roots[0]!
+		expect(root.tag).toBe("locality")
+		expect(root.value).toBe("New York City")
+	})
+
+	it("post-reconcile leaves no span uncovered for the grouper-audit to mis-promote", () => {
+		const result = reconcileSpans({ raw, phraseProposals, classifierTopK })
+		// Every phrase proposal must overlap a chosen root — an uncovered `York` proposal is what
+		// produced the spurious `region` node in the original bug.
+		for (const p of phraseProposals) {
+			const pEnd = p.span.start + p.span.body.length
+			const covered = result.tree.roots.some((r) => r.start < pEnd && p.span.start < r.end)
+			expect(covered, `proposal ${JSON.stringify(p.span.body)} should be covered`).toBe(true)
+		}
+	})
+})
+
 describe("reconcile — concordance hard veto", () => {
 	const raw = "Paris, Texas"
 	// Setup: classifier wants Paris=locality + Texas=region. Resolver candidates are *all*

--- a/core/pipeline/reconcile.ts
+++ b/core/pipeline/reconcile.ts
@@ -132,14 +132,33 @@ const DEFAULTS = {
 }
 
 /**
- * Log-space bonus per accepted slot. Counterweight for the multiplicative penalty inherent in
- * "score = ∏ confidences": each factor in [0, 1] strictly lowers the running score, which would
- * otherwise make the empty parse always win. log(2.5) — a slot whose product of factors exceeds
- * 1/2.5 = 0.4 is worth including; below that, the search prefers to skip.
+ * Log-space bonus per **word covered** by an accepted slot. Counterweight for the multiplicative
+ * penalty inherent in "score = ∏ confidences": each factor in [0, 1] strictly lowers the running
+ * score, which would otherwise make the empty parse always win. With per-word scaling, a slot is
+ * worth including when the per-word geometric mean of its factors exceeds 1/2.5 = 0.4; below that,
+ * the search prefers to skip.
+ *
+ * Why per-word and not per-slot: a constant per-slot bonus carries two structural biases, both
+ * measured on `"New York City"` (2026-06-11):
+ *
+ * 1. **Fragments beat coverage.** The per-token logit aggregation gives interior fragments inflated
+ *    confidence (`City` aggregates I-locality mass → locality 0.92 vs 0.60 for the full span), and
+ *    a per-slot bonus charges nothing for leaving the rest of the input unexplained — so the beam
+ *    picked the bare `locality="City"` (+0.475) over `locality="New York City"` (+0.199) and the
+ *    grouper-audit then promoted the orphaned `York` to a spurious `region`.
+ * 2. **More spans collect more bonuses.** For two interpretations covering the same words, the one
+ *    split into more slots banked one bonus per slot — a fragmentation subsidy.
+ *
+ * Scaling the bonus by the slot's word count makes coverage the thing being rewarded:
+ * equal-coverage interpretations collect equal bonus (the classifier/phrase/resolver factors alone
+ * decide), and an interpretation that explains more of the input out-scores one that silently drops
+ * words unless the extra evidence is genuinely weak (per-word factor mean < 0.4).
  *
  * The choice of 2.5 is a tuning constant, not a free parameter we expose — exposing it would invite
  * callers to disable inclusion entirely (defeating the purpose of the reconciler) and the sensible
- * range is narrow. Lives here rather than `ReconcileOpts` for that reason.
+ * range is narrow. Lives here rather than `ReconcileOpts` for that reason. Words are
+ * whitespace-delimited; scripts without spaces (CJK) count as one word, which degrades to the old
+ * per-slot behavior rather than misbehaving.
  */
 const INCLUSION_LOG_BONUS = Math.log(2.5)
 
@@ -157,6 +176,8 @@ interface SlotChoice {
 	classifierScore: number
 	place: ResolvedPlace | null
 	resolverScore: number
+	/** Whitespace-delimited word count of the span's surface text — scales the inclusion bonus. */
+	wordCount: number
 }
 
 interface Beam {
@@ -205,7 +226,7 @@ export function reconcileSpans(inputs: ReconcileInputs): ParseTree {
 					logSafe(slot.classifierScore) +
 					logSafe(slot.resolverScore) +
 					concordanceDelta +
-					INCLUSION_LOG_BONUS
+					INCLUSION_LOG_BONUS * slot.wordCount
 				next.push({
 					assignments: [...beam.assignments, slot],
 					logScore: beam.logScore + slotLog,
@@ -282,6 +303,7 @@ function buildSlots(inputs: ReconcileInputs, opts: Required<ReconcileOpts>): Slo
 	for (const phrase of spans) {
 		const key = spanKey(phrase.span.start, phrase.span.end)
 		const tagCandidates = topN(tagsBySpan.get(key) ?? [], opts.kTag, (c) => c.score)
+		const words = wordCountOf(inputs.raw, phrase.span)
 		for (const tagC of tagCandidates) {
 			const places = inputs.resolverCandidates
 				? inputs.resolverCandidates.candidatesFor(tagC.span, tagC.tag).slice(0, opts.kResolver)
@@ -294,6 +316,7 @@ function buildSlots(inputs: ReconcileInputs, opts: Required<ReconcileOpts>): Slo
 					classifierScore: tagC.score,
 					place: null,
 					resolverScore: 1,
+					wordCount: words,
 				})
 				continue
 			}
@@ -305,11 +328,22 @@ function buildSlots(inputs: ReconcileInputs, opts: Required<ReconcileOpts>): Slo
 					classifierScore: tagC.score,
 					place,
 					resolverScore: normalizeResolverScore(place.score),
+					wordCount: words,
 				})
 			}
 		}
 	}
 	return slots
+}
+
+/**
+ * Whitespace-delimited word count of a span's surface text, floor 1. Scales the per-slot inclusion
+ * bonus so coverage — not slot count — is what the search rewards (see `INCLUSION_LOG_BONUS`).
+ */
+function wordCountOf(raw: string, span: { start: number; end: number }): number {
+	const text = raw.slice(span.start, span.end).trim()
+	if (text.length === 0) return 1
+	return text.split(/\s+/).length
 }
 
 /**

--- a/docs/articles/concepts/reconcile-empty-parse-bonus.mdx
+++ b/docs/articles/concepts/reconcile-empty-parse-bonus.mdx
@@ -42,21 +42,32 @@ With `beamWidth = 1` (greedy), the empty beam dominates immediately and beam pru
 
 This is not specific to our use case — any joint decoder that composes confidences multiplicatively will hit it. It is what the reconciler is supposed to be doing (picking high-evidence interpretations), so the search needs a structural reason to _prefer_ accepting evidence over skipping it.
 
-## The fix — inclusion bonus
+## The fix — inclusion bonus, scaled per word
 
-Add a fixed log-bonus for each accepted slot. The bonus shifts the trade-off so accepting a high-confidence slot is net-positive in log-space.
+Add a log-bonus for each **word covered** by an accepted slot. The bonus shifts the trade-off so accepting a high-confidence slot is net-positive in log-space.
 
 In `core/pipeline/reconcile.ts`:
 
 ```ts
-const INCLUSION_LOG_BONUS = Math.log(2.5) // ≈ +0.916
+const INCLUSION_LOG_BONUS = Math.log(2.5) // ≈ +0.916, × the slot's word count
 ```
 
-What `log(2.5)` means: any slot whose **product of factors** exceeds `1/2.5 = 0.4` is net-positive in log-space and worth including. Slots below `0.4` aren't.
+What `log(2.5)` means: any slot whose **per-word geometric mean of factors** exceeds `1/2.5 = 0.4` is net-positive in log-space and worth including. Slots below that aren't.
 
-Concretely: a slot with `phrase=0.85, classifier=0.7, resolver=0.9, concordance=0.95` has product `0.508`. With the bonus added, that slot's log-contribution is `log(0.508) + log(2.5) = log(1.27) > 0`. It is net-positive and will be accepted. Drop any factor below ~0.7 across the board and the slot becomes net-negative and gets skipped — the search prefers to leave it out, which is also the right answer when evidence is weak.
+Concretely: a one-word slot with `phrase=0.85, classifier=0.7, resolver=0.9, concordance=0.95` has product `0.508`. With the bonus added, that slot's log-contribution is `log(0.508) + log(2.5) = log(1.27) > 0`. It is net-positive and will be accepted. Drop any factor below ~0.7 across the board and the slot becomes net-negative and gets skipped — the search prefers to leave it out, which is also the right answer when evidence is weak.
 
 The `2.5` is empirical. `e` (≈ 2.718) is the natural-log analogue, equivalent to "a slot with `product > 1/e` survives". We landed on 2.5 after the kryptonite fixtures rather than 2.718 — slightly more permissive, slightly easier to reason about as "factors averaging above 0.4". Future tuning should be driven by an eval corpus large enough to justify a change.
+
+### Why per word, not per slot
+
+The first implementation granted the bonus once per accepted slot. That carries two structural biases, both measured on the bare query `"New York City"` with no resolver wired (the live demo's configuration, 2026-06-11):
+
+1. **Fragments beat coverage.** The per-token logit aggregation gives interior fragments inflated confidence — `City` aggregates the I-locality mass of a token that sits _inside_ a locality, scoring `locality=0.92`, while the full `New York City` span scores `0.60`. With a flat per-slot bonus, the beam paid nothing for leaving `New York` unexplained: the bare `locality="City"` won at `+0.475` over the full span's `+0.199`, and the grouper-audit then promoted the orphaned `York` proposal to a spurious `region` node. Final output: `{region: "York", locality: "City"}` — for an input the plain argmax path parses correctly.
+2. **More spans collect more bonuses.** Two interpretations covering the same words were not scored on evidence alone — the one split into more slots banked one bonus per slot, a flat subsidy for fragmentation.
+
+Scaling the bonus by the slot's word count makes _coverage_ the thing being rewarded. Equal-coverage interpretations collect equal bonus (the evidence factors alone decide between them), and a covering interpretation out-scores one that silently drops words unless the extra evidence is genuinely weak. On the query above, the full span now wins at `+2.03` (three words' bonus) vs `+0.48` for the bare fragment.
+
+Word counting is whitespace-delimited with a floor of one — scripts without spaces (CJK) degrade to the old per-slot behavior rather than misbehaving.
 
 ## Why this knob is not public
 

--- a/scripts/diag-nyc-reconcile.ts
+++ b/scripts/diag-nyc-reconcile.ts
@@ -1,0 +1,88 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Diagnostic for the Stage 5 joint-reconcile fragmentation bug: `runPipeline("New York City")`
+ *   produces `{region: "York", locality: "City"}` while plain argmax produces the correct
+ *   `{locality: "New York City"}`. Instruments phrase proposals, classifier top-K, and the
+ *   reconcile winner for the three sentinel queries.
+ *
+ *   Run: node --experimental-strip-types scripts/diag-nyc-reconcile.ts (compile workspaces first:
+ *   yarn compile)
+ */
+
+import { decodeAsJson } from "@mailwoman/core/decoder"
+import { aggregateSpanLogits, reconcileSpans, runPipeline } from "@mailwoman/core/pipeline"
+import { NeuralAddressClassifier, parseAnchorLookup, parseGazetteerLexicon } from "@mailwoman/neural"
+import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
+import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+import { groupPhrases } from "@mailwoman/phrase-grouper"
+import { computeQueryShape } from "@mailwoman/query-shape"
+import { deserializeFst } from "@mailwoman/resolver-wof-sqlite/fst-serialize"
+import { readFileSync } from "node:fs"
+
+const TOKENIZER = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const ANCHOR = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
+const GAZ = "data/gazetteer/anchor-lexicon-v1.json"
+const MODEL = "/tmp/v130-boundary-40k-int8.onnx"
+const FST = "/tmp/v440-stage/en-us/v4.4.0/fst-en-US.bin"
+const CARD = "/tmp/v440-stage/en-us/v4.4.0/model-card.json"
+
+const card = JSON.parse(readFileSync(CARD, "utf8"))
+const classifier = new NeuralAddressClassifier({
+	tokenizer: await MailwomanTokenizer.loadFromFile(TOKENIZER),
+	runner: await OnnxRunner.create(MODEL),
+	labels: card.labels,
+	postcodeAnchorLookup: parseAnchorLookup(JSON.parse(readFileSync(ANCHOR, "utf8"))),
+	gazetteerLexicon: parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))),
+	suppressGazetteerNearPostcode: true,
+	addressSystemConventions: "auto",
+	bridgePunctuationGaps: true,
+})
+const fst = deserializeFst(readFileSync(FST))
+
+const QUERIES = ["New York City", "Brooklyn", "brooklyn, new york, ny"]
+
+for (const q of QUERIES) {
+	console.log(`\n================ ${JSON.stringify(q)} ================`)
+
+	// Plain argmax parse
+	const argmaxTree = await classifier.parse(q, { queryShape: computeQueryShape(q), fst })
+	console.log("argmax:", JSON.stringify(decodeAsJson(argmaxTree)))
+
+	// Pipeline (joint reconcile default-on)
+	const result = await runPipeline(q, { computeQueryShape, groupPhrases, classifier, fst })
+	console.log("pipeline:", JSON.stringify(decodeAsJson(result.tree)))
+
+	// ── Instrumentation: reproduce the reconcile inputs ──
+	const proposals = result.phraseProposals
+	console.log("\nphrase proposals:")
+	for (const p of proposals) {
+		console.log(
+			`  [${p.span.start},${p.span.end}) ${JSON.stringify(q.slice(p.span.start, p.span.end))} kind=${p.kindHypothesis} conf=${p.confidence.toFixed(3)}`
+		)
+	}
+
+	const { logits, pieces } = await classifier.parseWithLogits(q, { queryShape: computeQueryShape(q), fst })
+	const topK = aggregateSpanLogits(
+		logits,
+		pieces,
+		proposals.map((p) => ({ start: p.span.start, end: p.span.end })),
+		{ labels: card.labels, text: q }
+	)
+	console.log("\nclassifier top-K per span:")
+	for (const c of topK) {
+		console.log(
+			`  [${c.span.start},${c.span.end}) ${JSON.stringify(q.slice(c.span.start, c.span.end))} ${c.tag}=${c.score.toFixed(4)}`
+		)
+	}
+
+	const rec = reconcileSpans({ raw: q, phraseProposals: proposals, classifierTopK: topK })
+	console.log(
+		"\nreconcile winner:",
+		JSON.stringify(rec.tree.roots.map((r) => `${r.tag}=${r.value}@${r.confidence.toFixed(3)}`))
+	)
+	console.log("breakdown:", JSON.stringify(rec.scoreBreakdown))
+	console.log("runners-up:", JSON.stringify(rec.runnersUp.map((t) => t.roots.map((r) => `${r.tag}=${r.value}`))))
+}


### PR DESCRIPTION
Stage 5's per-slot bonus let interior fragments (inflated by per-token logit aggregation: `City` 0.92 vs 0.60 for the full span) beat covering parses while paying nothing for unexplained words — measured on `New York City` parsing as `region=York + locality=City` in the live demo and any default-pipeline consumer. The bonus now scales per word covered (the per-word geometric-mean semantics the code's docs always claimed). Kryptonite catalogue green (Saint Petersburg/Buffalo strengthened), 294/294 core, regression test from the recorded live top-K. Concept doc updated with the why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)