### PR TITLE
fix(resolver): placetype expansion + region-constraint warn + alias-bag exact tier (the demo ranking bugs)

### DIFF
--- a/core/resolver/index.ts
+++ b/core/resolver/index.ts
@@ -5,7 +5,7 @@
  */
 
 export { createWofResolver } from "./resolve.js"
-export { DEFAULT_PLACETYPE_MAP } from "./types.js"
+export { DEFAULT_PLACETYPE_MAP, PLACETYPE_FILTER_GROUPS, expandPlacetypeFilter } from "./types.js"
 export type {
 	AddressPointHit,
 	AddressPointLookup,

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -138,8 +138,8 @@ export interface AddressPointHit {
 }
 
 /**
- * Street-level exact-point lookup (#476). Implementations own their normalization — both the
- * shard build and this lookup must apply the SAME normalizer (see
+ * Street-level exact-point lookup (#476). Implementations own their normalization — both the shard
+ * build and this lookup must apply the SAME normalizer (see
  * `resolver-wof-sqlite/street-normalize.ts`). Core depends only on this contract.
  */
 export interface AddressPointLookup {
@@ -275,6 +275,43 @@ export const DEFAULT_PLACETYPE_MAP: PlacetypeMap = {
 	// backend has the postcode shard available — `WofSqlitePlaceLookup` auto-routes `postalcode`
 	// queries to a `postalcode_us` (or similarly-named) shard, falling back to main if absent.
 	postcode: "postalcode",
+}
+
+/**
+ * Placetype-equivalence groups for lookup FILTERING. WOF splits "city-like place" across several
+ * placetypes — `locality` (most cities), `borough` (Brooklyn, the Paris arrondissements, the London
+ * boroughs), and `localadmin` (FR communes, US towns/townships in New England) — but an address's
+ * locality span can name ANY of them. A backend that filters a locality query to `placetype =
+ * 'locality'` alone makes Brooklyn-the-borough (pop 2.5M) unreachable, so the fuzzy "Brooklyn Park,
+ * MN" wins instead.
+ *
+ * This table is the single source of truth for that expansion, shared by every lookup backend
+ * (`@mailwoman/resolver-wof-sqlite`, `@mailwoman/resolver-wof-wasm`, and the demo's httpvfs lookup)
+ * so the Node and browser resolvers can't drift. Keyed by the REQUESTED placetype; the value is the
+ * set the SQL filter should actually accept. Placetypes without an entry pass through unchanged —
+ * an explicit `placetype: "borough"` query stays narrow.
+ */
+export const PLACETYPE_FILTER_GROUPS: Readonly<Record<string, readonly string[]>> = {
+	locality: ["locality", "borough", "localadmin"],
+}
+
+/**
+ * Expand a placetype filter through {@link PLACETYPE_FILTER_GROUPS}, deduplicated and
+ * order-preserving (the first entry stays first — shard routing keys off it). `null`/`undefined`
+ * (no filter) passes through untouched.
+ */
+export function expandPlacetypeFilter(placetypes: null): null
+export function expandPlacetypeFilter(placetypes: readonly string[]): string[]
+export function expandPlacetypeFilter(placetypes: readonly string[] | null): string[] | null
+export function expandPlacetypeFilter(placetypes: readonly string[] | null): string[] | null {
+	if (!placetypes) return null
+	const out: string[] = []
+	for (const placetype of placetypes) {
+		for (const expanded of PLACETYPE_FILTER_GROUPS[placetype] ?? [placetype]) {
+			if (!out.includes(expanded)) out.push(expanded)
+		}
+	}
+	return out
 }
 
 /**

--- a/docs/src/shared/demo-helpers.test.ts
+++ b/docs/src/shared/demo-helpers.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Unit tests for the demo's WOF cascade (`runCascade`) against a stub lookup — the fail-loud
+ *   region-constraint behavior and the alias-exact acceptance added for the 2026-06-11 demo
+ *   resolver bugs. Integration coverage against the real hot DB lives in
+ *   `resolver-wof-wasm/hot-db.test.ts` (env-gated on `MAILWOMAN_WOF_HOT_DB`).
+ */
+
+import { describe, expect, test, vi } from "vitest"
+
+import { runCascade } from "./demo-helpers.js"
+import type { MailwomanLookupLike } from "./resources.tsx"
+
+type FindPlaceQuery = Parameters<MailwomanLookupLike["findPlace"]>[0]
+type Hit = Awaited<ReturnType<MailwomanLookupLike["findPlace"]>>[number]
+
+const NY_BBOX = { minLat: 40.4, maxLat: 45.1, minLon: -79.8, maxLon: -71.7 }
+
+function hit(partial: Partial<Hit> & { id: number; name: string }): Hit {
+	return { placetype: "locality", lat: 40, lon: -74, score: 1, ...partial }
+}
+
+function stubLookup(handler: (q: FindPlaceQuery) => Hit[]): MailwomanLookupLike {
+	return { findPlace: vi.fn(async (q: FindPlaceQuery) => handler(q)) }
+}
+
+describe("runCascade", () => {
+	test("warns and stays on the fuzzy backstop when the parsed region cannot be resolved", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		try {
+			const lookup = stubLookup((q) => {
+				if (q.placetype === "region") return [] // unresolvable region
+				if (q.placetype === "locality") return [hit({ id: 1, name: "Brooklyn Park" })]
+				return []
+			})
+			const hits = await runCascade(
+				lookup,
+				undefined,
+				[{ tag: "locality", value: "Brooklynish" }],
+				{
+					tag: "region",
+					value: "Nonexistia",
+				},
+				"Brooklynish, Nonexistia"
+			)
+			expect(hits.map((h) => h.id)).toEqual([1])
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining("did not resolve to a bbox"))
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	test("warns when the region-bbox pass finds no exact locality and the cascade widens", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		try {
+			const lookup = stubLookup((q) => {
+				if (q.placetype === "region") return [hit({ id: 10, name: "New York", placetype: "region", bbox: NY_BBOX })]
+				if (q.placetype === "locality") {
+					// Nothing inside the bbox; a fuzzy match only when unconstrained.
+					return q.bbox ? [] : [hit({ id: 2, name: "Brooklyn Park" })]
+				}
+				return []
+			})
+			const hits = await runCascade(
+				lookup,
+				undefined,
+				[{ tag: "locality", value: "brooklyn" }],
+				{
+					tag: "region",
+					value: "new york",
+				},
+				"brooklyn, new york"
+			)
+			expect(hits.map((h) => h.id)).toEqual([2])
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining("retrying without the region constraint"))
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	test("accepts a backend alias-exact hit even when the canonical name differs from the query", async () => {
+		// "New York City" is a WOF alias of the New York locality — the backend surfaces it as
+		// exactMatch: true. The cascade must treat that as a real place (early accept), not a fuzzy
+		// backstop it keeps scanning past.
+		const lookup = stubLookup((q) => {
+			if (q.placetype === "locality" && q.text === "New York City") {
+				return [hit({ id: 85977539, name: "New York", exactMatch: true })]
+			}
+			// A later node with a canonical-name match — pre-fix the cascade would skip past the
+			// alias-exact hit (treating it as fuzzy) and land here instead.
+			if (q.placetype === "locality" && q.text === "Decoy") return [hit({ id: 999, name: "Decoy" })]
+			return []
+		})
+		const hits = await runCascade(
+			lookup,
+			undefined,
+			[
+				{ tag: "locality", value: "New York City" },
+				{ tag: "locality", value: "Decoy" },
+			],
+			undefined,
+			"New York City"
+		)
+		expect(hits.map((h) => h.id)).toEqual([85977539])
+	})
+
+	test("region bbox constrains the locality lookup (bbox is forwarded to the backend)", async () => {
+		const seen: FindPlaceQuery[] = []
+		const lookup = stubLookup((q) => {
+			seen.push(q)
+			if (q.placetype === "region") return [hit({ id: 10, name: "New York", placetype: "region", bbox: NY_BBOX })]
+			if (q.placetype === "locality" && q.bbox) return [hit({ id: 3, name: "Brooklyn", placetype: "borough" })]
+			return []
+		})
+		const hits = await runCascade(
+			lookup,
+			undefined,
+			[{ tag: "locality", value: "Brooklyn" }],
+			{
+				tag: "region",
+				value: "new york",
+			},
+			"brooklyn, new york, ny"
+		)
+		expect(hits.map((h) => h.id)).toEqual([3])
+		const localityQueries = seen.filter((q) => q.placetype === "locality")
+		expect(localityQueries[0]?.bbox).toEqual(NY_BBOX)
+	})
+})

--- a/docs/src/shared/demo-helpers.ts
+++ b/docs/src/shared/demo-helpers.ts
@@ -186,9 +186,11 @@ export async function runCascade(
 	// with an unrelated same-named town). So when the specific line isn't a real place, we fall
 	// through to the one that is: the city. A fuzzy hit is kept only as a last-resort backstop.
 	const resolveLocality = async (regionBbox: Hits[number]["bbox"]): Promise<Hits> => {
-		// Prefer an exact-name match inside the region bbox; if none, retry the same nodes WITHOUT the
-		// bbox before settling for a fuzzy hit. The unconstrained retry is the safety net for a
-		// mis-resolved region (e.g. "IL" → a French département): a bad bbox can't cause a total miss.
+		// Prefer an exact match (canonical name, or the backend's alias/abbr `exactMatch` tier —
+		// "New York City" is a WOF alias of the New York locality) inside the region bbox; if none,
+		// retry the same nodes WITHOUT the bbox before settling for a fuzzy hit. The unconstrained
+		// retry is the safety net for a mis-resolved region (e.g. "IL" → a French département): a bad
+		// bbox can't cause a total miss.
 		let fuzzy: Hits = []
 		for (const bbox of regionBbox ? [regionBbox, undefined] : [undefined]) {
 			for (const node of localityNodes) {
@@ -196,8 +198,15 @@ export async function runCascade(
 				if (!text) continue
 				const cs = usable(await lookup.findPlace({ text, placetype: "locality", bbox, limit: 5 }))
 				if (cs.length === 0) continue
-				if (cs.some((c) => normName(c.name) === normName(text))) return cs
+				if (cs.some((c) => c.exactMatch || normName(c.name) === normName(text))) return cs
 				if (fuzzy.length === 0) fuzzy = cs
+			}
+			// Fail loud when the region constraint produced nothing and we're about to widen — a silent
+			// fallback here is how "brooklyn, new york" quietly resolved to Brooklyn Park, MN.
+			if (bbox) {
+				console.warn(
+					"[mailwoman demo] no exact locality match inside the resolved region's bbox — retrying without the region constraint"
+				)
 			}
 		}
 		return fuzzy
@@ -211,12 +220,23 @@ export async function runCascade(
 	// would otherwise pick).
 	let regionBbox: { minLat: number; maxLat: number; minLon: number; maxLon: number } | undefined
 	if (stateNode?.value) {
+		const regionText = expandUsRegion(String(stateNode.value))
 		const regions = await lookup.findPlace({
-			text: expandUsRegion(String(stateNode.value)),
+			text: regionText,
 			placetype: "region",
 			limit: 1,
 		})
 		regionBbox = regions[0]?.bbox
+		// Fail loud: a region the parser found but the gazetteer can't resolve (or one resolved
+		// without a bbox) means the locality lookup runs UNCONSTRAINED — same-name places anywhere
+		// in the world can win. Don't let that degrade silently.
+		if (!regionBbox) {
+			console.warn(
+				`[mailwoman demo] parsed region ${JSON.stringify(regionText)} did not resolve to a bbox` +
+					(regions.length > 0 ? ` (top hit ${JSON.stringify(regions[0]?.name)} carries no bbox)` : " (no candidates)") +
+					" — locality lookup is unconstrained"
+			)
+		}
 	}
 
 	if (postcodeNode?.value) {

--- a/docs/src/shared/httpvfs-resolver.ts
+++ b/docs/src/shared/httpvfs-resolver.ts
@@ -20,6 +20,8 @@
  *   webpack — that's what keeps the Docusaurus build warning-free.
  */
 
+import { expandPlacetypeFilter } from "@mailwoman/core/resolver"
+
 import type { DualRole, MailwomanLookupLike } from "./resources"
 
 const POPULATION_BOOST = 4.0
@@ -210,7 +212,12 @@ export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
 
 		const conds = [`place_search MATCH ${sqlStr(fts)}`, "spr.is_current != 0", "spr.is_deprecated = 0"]
 		if (query.placetype) {
-			const types = (Array.isArray(query.placetype) ? query.placetype : [query.placetype]).filter(Boolean) as string[]
+			// Shared placetype-equivalence expansion (core/resolver): a `locality` query must also reach
+			// `borough` / `localadmin` rows — Brooklyn-the-borough is a borough, not a locality, and a
+			// strict filter made it unreachable (the "Brooklyn → Brooklyn Park, MN" bug).
+			const types = expandPlacetypeFilter(
+				(Array.isArray(query.placetype) ? query.placetype : [query.placetype]).filter(Boolean) as string[]
+			)
 			if (types.length) conds.push(`spr.placetype IN (${types.map(sqlStr).join(",")})`)
 		}
 		if (query.country) conds.push(`spr.country = ${sqlStr(query.country.toUpperCase())}`)
@@ -226,6 +233,7 @@ export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
 		const sql =
 			`SELECT spr.id, spr.name, spr.placetype, spr.country, spr.latitude, spr.longitude, spr.parent_id, ` +
 			`spr.min_latitude, spr.max_latitude, spr.min_longitude, spr.max_longitude, ` +
+			`place_search.alt_names AS alt_names, ` +
 			`${hasPop ? "pp.population" : "NULL"} AS population, bm25(place_search) AS bm25 ` +
 			`FROM place_search JOIN spr ON spr.id = place_search.wof_id ` +
 			`${hasPop ? "LEFT JOIN place_population pp ON pp.id = spr.id " : ""}` +
@@ -237,23 +245,40 @@ export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
 		// an exact match, same tier as an exact name match — so it outranks a foreign region that merely
 		// token-matches "VT". Mirrors WofWasmPlaceLookup; no-op on slim DBs without `place_abbr`.
 		const abbrIds = await this.#abbrExactIds(text)
+		// Strict exact = canonical name or region abbreviation equals the query. Computed for the whole
+		// pool FIRST because the ALIAS tier below only engages when no strict exact exists.
+		const strictExact = (row: Record<string, unknown>): boolean =>
+			normName(String(row.name)) === normQuery || abbrIds.has(Number(row.id))
+		const anyStrictExact = rows.some(strictExact)
 		return rows
 			.map((row) => {
 				const pop = typeof row.population === "number" ? row.population : 0
 				const popBoost = pop > 0 ? POPULATION_BOOST * Math.min(1, Math.log10(1 + pop) / POPULATION_SCALE_LOG10) : 0
 				const adj = (row.bm25 as number) - popBoost
-				const exactTier = normName(String(row.name)) === normQuery || abbrIds.has(Number(row.id)) ? 0 : 1
+				// Alias tier: `alt_names` is the FTS row's alias bag (all `names` rows space-joined). Name
+				// boundaries are LOST in the bag, so a containment check would false-promote interior
+				// fragments ("York" matches inside "New York City") — it only engages when NO candidate is
+				// strictly exact: the "New York City" case, where the query is a WOF alias of the New York
+				// locality but no spr row bears the name. Mirrors WofWasmPlaceLookup.
+				const aliasExact =
+					!anyStrictExact &&
+					typeof row.alt_names === "string" &&
+					` ${normName(row.alt_names)} `.includes(` ${normQuery} `)
+				const exactTier = strictExact(row) || aliasExact ? 0 : 1
 				return { row, exactTier, adj }
 			})
 			.sort((a, b) => a.exactTier - b.exactTier || a.adj - b.adj)
 			.slice(0, limit)
-			.map(({ row, adj }) => ({
+			.map(({ row, adj, exactTier }) => ({
 				id: row.id as number,
 				name: row.name as string,
 				placetype: row.placetype as string,
 				lat: row.latitude as number,
 				lon: row.longitude as number,
 				score: -adj,
+				// Surfaced so the demo cascade can accept an alias-exact hit ("New York City" → New York)
+				// the same way it accepts a canonical-name match.
+				exactMatch: exactTier === 0,
 				bbox:
 					row.min_latitude != null && row.max_latitude != null && row.min_longitude != null && row.max_longitude != null
 						? {

--- a/docs/src/shared/resources.tsx
+++ b/docs/src/shared/resources.tsx
@@ -42,6 +42,12 @@ export interface MailwomanLookupLike {
 			lat: number
 			lon: number
 			score: number
+			/**
+			 * True when the candidate's name, abbreviation, or an alias EXACTLY matched the query (vs a
+			 * partial token match). The cascade accepts alias-exact hits ("New York City" → New York) the
+			 * same way it accepts canonical-name matches.
+			 */
+			exactMatch?: boolean
 			bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
 		}>
 	>

--- a/resolver-wof-sqlite/lookup.test.ts
+++ b/resolver-wof-sqlite/lookup.test.ts
@@ -155,6 +155,34 @@ const FIXTURE: FixturePlace[] = [
 		lon: 4.69,
 		ancestor_ids: [85633723],
 	},
+
+	// The Brooklyn pair: WOF files Brooklyn-the-borough (NYC, pop 2.5M) as placetype `borough`, NOT
+	// `locality`. A locality query must still reach it via the shared placetype expansion
+	// (core/resolver PLACETYPE_FILTER_GROUPS) — otherwise the only locality-typed match is the fuzzy
+	// "Brooklyn Park" and the resolver mislocates to Minnesota.
+	{
+		id: 421205765,
+		parent_id: 85633147,
+		name: "Brooklyn",
+		placetype: "borough",
+		country: "US",
+		lat: 40.64,
+		lon: -73.95,
+		// The canonical name also lives in `names` in a real WOF distribution — required for the
+		// exact-match tier (#exactMatchIds queries `names`, not `spr`).
+		alt_names: ["Brooklyn"],
+		ancestor_ids: [85633147],
+	},
+	{
+		id: 85969229,
+		parent_id: 85633147,
+		name: "Brooklyn Park",
+		placetype: "locality",
+		country: "US",
+		lat: 45.11,
+		lon: -93.35,
+		ancestor_ids: [85633147],
+	},
 ]
 
 function buildFixtureDb(): DatabaseSync {
@@ -263,10 +291,30 @@ describe("WofSqlitePlaceLookup against an inline WOF fixture", () => {
 		expect(candidates[0]).toMatchObject({ name: "Paris", country: "US", placetype: "locality" })
 	})
 
-	test('"London" with placetype: "locality" excludes the Ontario borough', async () => {
+	test('"London" with placetype: "locality" INCLUDES the Ontario borough (locality placetype expansion)', async () => {
+		// `locality` expands to locality + borough + localadmin (core/resolver PLACETYPE_FILTER_GROUPS):
+		// WOF files many city-like places (Brooklyn, the London boroughs) under `borough`/`localadmin`,
+		// and a locality span must be able to reach them.
 		const candidates = await lookup.findPlace({ text: "London", placetype: "locality" })
+		const byCountry = candidates.map((c) => `${c.country}:${c.placetype}`)
+		expect(byCountry).toContain("GB:locality")
+		expect(byCountry).toContain("CA:borough")
+	})
+
+	test('an explicit placetype: "borough" filter stays narrow (no reverse expansion)', async () => {
+		const candidates = await lookup.findPlace({ text: "London", placetype: "borough" })
 		expect(candidates.length).toBe(1)
-		expect(candidates[0]).toMatchObject({ name: "London", country: "GB" })
+		expect(candidates[0]).toMatchObject({ name: "London", country: "CA", placetype: "borough" })
+	})
+
+	test('"Brooklyn" locality query reaches the exact-named borough over the fuzzy "Brooklyn Park" locality', async () => {
+		// The live-demo bug (2026-06-11): with the borough excluded, the only locality-typed match was
+		// the partial "Brooklyn Park" → resolved to Minnesota. The expansion makes the exact-named
+		// borough reachable, and exact-match tiering puts it on top.
+		const candidates = await lookup.findPlace({ text: "Brooklyn", placetype: "locality" })
+		expect(candidates.length).toBeGreaterThan(0)
+		expect(candidates[0]).toMatchObject({ id: 421205765, name: "Brooklyn", placetype: "borough" })
+		expect(candidates[0]?.exactMatch).toBe(true)
 	})
 
 	test('"Springfield" with parentId: Illinois returns Springfield,IL first', async () => {
@@ -305,6 +353,25 @@ describe("WofSqlitePlaceLookup against an inline WOF fixture", () => {
 	test("query with special characters is sanitized — `St. (Petersburg)` does not throw", async () => {
 		// No such place in the fixture; we only assert no SQL syntax error.
 		await expect(lookup.findPlace({ text: "St. (Petersburg)" })).resolves.toEqual([])
+	})
+
+	test("exact-match tier survives a names-less (slim) DB via the place_search alias bag", async () => {
+		// Slim DBs built with `dropNames` have no `names` table — the aliases survive only inside the
+		// FTS `alt_names` token bag. #exactMatchIds must fall back to it so "Brooklyn" still tiers the
+		// exact-named borough above the fuzzy "Brooklyn Park" against a hot/slim DB.
+		const db = buildFixtureDb()
+		const withFts = new WofSqlitePlaceLookup({ database: db, buildFts: true })
+		withFts.close() // releases nothing we need — the FTS table now exists on `db`, which we own
+		db.exec(`DROP TABLE names`)
+		const lookup2 = new WofSqlitePlaceLookup({ database: db })
+		try {
+			const candidates = await lookup2.findPlace({ text: "Brooklyn", placetype: "locality" })
+			expect(candidates[0]).toMatchObject({ id: 421205765, name: "Brooklyn", placetype: "borough" })
+			expect(candidates[0]?.exactMatch).toBe(true)
+		} finally {
+			lookup2.close()
+			db.close()
+		}
 	})
 
 	test("Disposable: Symbol.dispose closes the lookup", async () => {

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -15,7 +15,7 @@ import { DatabaseSync, type SQLInputValue } from "node:sqlite"
 
 import { SqliteDialect } from "@mailwoman/core/kysley/dialect"
 
-import type { Ancestor, CoincidentLocality } from "@mailwoman/core/resolver"
+import { expandPlacetypeFilter, type Ancestor, type CoincidentLocality } from "@mailwoman/core/resolver"
 import {
 	ADDRESS_CONVENTION_TABLE,
 	resolveConvention,
@@ -551,7 +551,12 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		// With a `country` hint every abbrev resolves; bare + no-context lifts 7→10/15 US states.)
 		const ftsLimit = query.text.trim().length <= 3 ? Math.max(limit * 4, SHORT_QUERY_OVERFETCH) : limit * 4
 
-		const placetypes = normalizePlacetypes(query.placetype)
+		// Expand the placetype filter through the shared equivalence table (core/resolver): a
+		// `locality` query must also reach `borough` / `localadmin` rows — Brooklyn-the-borough
+		// (pop 2.5M) is a borough, not a locality, and a strict filter made it unreachable so the
+		// fuzzy "Brooklyn Park, MN" won instead. Order-preserving: the FIRST entry stays the
+		// requested placetype, which is what shard routing keys off below.
+		const placetypes = expandPlacetypeFilter(normalizePlacetypes(query.placetype)) as WofPlacetype[] | null
 		const ftsQuery = sanitizeFtsQuery(query.text)
 		if (!ftsQuery) return []
 
@@ -707,7 +712,10 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		// ranks above any partial match, with the weighted-sum score (incl. population) breaking ties
 		// WITHIN a tier. See the RankingWeights.exactMatchTiering docstring for why this aligns the
 		// population prior rather than overriding it. One cheap indexed lookup over the candidate ids.
-		if (this.#weights.exactMatchTiering && candidates.length > 1) {
+		// Runs even for a SINGLE candidate so `exactMatch` is stamped consistently (parity with the
+		// WASM lookup) — a sole alias hit ("New York City" → New York) must still carry the flag the
+		// demo cascade / #369 re-rank read.
+		if (this.#weights.exactMatchTiering && candidates.length > 0) {
 			const exactIds = this.#exactMatchIds(
 				sch,
 				candidates.map((c) => c.id as number),
@@ -886,24 +894,50 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 
 	/**
 	 * Among `ids`, return the subset whose name OR any alias equals `text` case-insensitively — the
-	 * exact-match tier for ranking. One indexed query over `<schema>.names`. Returns an empty set
-	 * when the shard has no `names` table (e.g. a postcode-only shard), so tiering silently no-ops
-	 * there.
+	 * exact-match tier for ranking. One indexed query over `<schema>.names`. When the shard has no
+	 * `names` table (a slim DB built with `dropNames`, or a postcode-only shard), fall back to the
+	 * self-contained `place_search` FTS content: its `alt_names` column is the same alias set,
+	 * space-joined into one token bag, so a whitespace-boundary containment check recovers the alias
+	 * tier ("New York City" → New York) that the dropped `names` table used to provide.
 	 */
 	#exactMatchIds(schemaName: string, ids: number[], text: string): Set<number> {
 		const out = new Set<number>()
 		const trimmed = text.trim()
 		if (ids.length === 0 || !trimmed) return out
+		const placeholders = ids.map(() => "?").join(", ")
 		try {
-			const placeholders = ids.map(() => "?").join(", ")
 			const rows = this.#db
 				.prepare(
 					`SELECT DISTINCT id FROM ${schemaName}.names WHERE id IN (${placeholders}) AND name = ? COLLATE NOCASE`
 				)
 				.all(...ids, trimmed) as Array<{ id: number }>
 			for (const r of rows) out.add(r.id)
+			return out
 		} catch {
-			// Shard without a `names` table → no exact-match tier. Falls back to weighted-sum order.
+			// No `names` table on this shard — fall through to the place_search alias bag.
+		}
+		try {
+			const rows = this.#db
+				.prepare(
+					`SELECT wof_id AS id, name, alt_names FROM ${schemaName}.place_search WHERE wof_id IN (${placeholders})`
+				)
+				.all(...ids) as Array<{ id: number; name: string | null; alt_names: string | null }>
+			const norm = (s: string): string => s.toLowerCase().trim().replace(/\s+/g, " ")
+			const needle = norm(trimmed)
+			for (const r of rows) {
+				if (r.name !== null && norm(r.name) === needle) out.add(r.id)
+			}
+			// Alias pass, only when NO canonical name matched: alt_names is all aliases space-joined
+			// (name boundaries are lost), so a padded substring check would false-promote interior
+			// fragments ("York" inside the alias "New York City"). Gating it on "no canonical exact in
+			// the pool" confines it to the genuine alias-query case ("New York City" itself).
+			if (out.size === 0) {
+				for (const r of rows) {
+					if (r.alt_names !== null && ` ${norm(r.alt_names)} `.includes(` ${needle} `)) out.add(r.id)
+				}
+			}
+		} catch {
+			// Shard without place_search either → no exact-match tier. Falls back to weighted-sum order.
 		}
 		return out
 	}

--- a/resolver-wof-wasm/hot-db.test.ts
+++ b/resolver-wof-wasm/hot-db.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Integration tests against a REAL production `wof-hot.db` (the slim DB the live demo serves) — the
+ *   three resolution bugs measured on the live demo 2026-06-11:
+ *
+ *   1. "Brooklyn" resolved to Brooklyn Park, MN because the locality placetype filter excluded the
+ *        `borough` row for Brooklyn (WOF id 421205765, pop 2.5M).
+ *   2. "brooklyn, new york, ny" did the same because the region-bbox-constrained pass found nothing (the
+ *        borough was filtered out) and the cascade silently fell back to unconstrained.
+ *   3. "New York City" has no spr row under that name — it's a WOF ALIAS of the New York locality
+ *        (85977539), reachable only through the FTS `alt_names` bag.
+ *
+ *   The 16 MB DB is NOT committed. Point `MAILWOMAN_WOF_HOT_DB` at a byte-copy of the live DB (e.g.
+ *   `/tmp/v440-stage/en-us/v4.4.0/wof-hot.db`, or any `wof-hot.db` staged by build-demo-assets) and
+ *   run `yarn vitest --run resolver-wof-wasm/hot-db.test.ts`. The whole suite SKIPS when the env
+ *   var is unset, so CI stays green without the artifact.
+ *
+ *   Covers all three lookup backends that must agree: the WASM lookup (this package), the Node lookup
+ *   (`@mailwoman/resolver-wof-sqlite`), and the demo cascade (`docs/src/shared/demo-helpers`, which
+ *   the live demo drives through its httpvfs lookup — same SQL + ranking as the WASM lookup).
+ */
+
+import { WofSqlitePlaceLookup } from "@mailwoman/resolver-wof-sqlite"
+import { readFile } from "node:fs/promises"
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest"
+
+import { runCascade } from "../docs/src/shared/demo-helpers.js"
+import { loadSlimWofDatabase } from "./loader.js"
+import { WofWasmPlaceLookup } from "./lookup.js"
+
+const HOT_DB_PATH = process.env.MAILWOMAN_WOF_HOT_DB
+
+const BROOKLYN_BOROUGH = 421205765
+const NEW_YORK_LOCALITY = 85977539
+
+describe.skipIf(!HOT_DB_PATH)("against the production wof-hot.db (MAILWOMAN_WOF_HOT_DB)", () => {
+	let wasmLookup: WofWasmPlaceLookup
+
+	beforeAll(async () => {
+		const bytes = await readFile(HOT_DB_PATH!)
+		const { db } = await loadSlimWofDatabase({ source: bytes })
+		wasmLookup = new WofWasmPlaceLookup({ db })
+	})
+
+	afterAll(() => {
+		wasmLookup?.close()
+	})
+
+	describe("WASM lookup", () => {
+		test('"Brooklyn" locality query → Brooklyn-the-borough (NYC), not Brooklyn Park MN', async () => {
+			const matches = await wasmLookup.findPlace({ text: "Brooklyn", placetype: "locality", limit: 5 })
+			expect(matches[0]).toMatchObject({ id: BROOKLYN_BOROUGH, name: "Brooklyn", placetype: "borough" })
+			expect(matches[0]?.exactMatch).toBe(true)
+		})
+
+		test('"New York City" → the New York locality via its WOF alias', async () => {
+			const matches = await wasmLookup.findPlace({ text: "New York City", placetype: "locality", limit: 5 })
+			expect(matches[0]).toMatchObject({ id: NEW_YORK_LOCALITY, name: "New York", placetype: "locality" })
+			expect(matches[0]?.exactMatch).toBe(true)
+		})
+	})
+
+	describe("demo cascade (runCascade over the WASM lookup)", () => {
+		test('locality "Brooklyn" alone → the borough', async () => {
+			const hits = await runCascade(
+				wasmLookup,
+				undefined,
+				[{ tag: "locality", value: "Brooklyn" }],
+				undefined,
+				"Brooklyn"
+			)
+			expect(hits[0]?.id).toBe(BROOKLYN_BOROUGH)
+		})
+
+		test('locality "brooklyn" + region "new york" → the borough (region bbox narrows)', async () => {
+			const hits = await runCascade(
+				wasmLookup,
+				undefined,
+				[{ tag: "locality", value: "brooklyn" }],
+				{ tag: "region", value: "new york" },
+				"brooklyn, new york, ny"
+			)
+			expect(hits[0]?.id).toBe(BROOKLYN_BOROUGH)
+		})
+
+		test('locality "New York City" → the New York locality', async () => {
+			const hits = await runCascade(
+				wasmLookup,
+				undefined,
+				[{ tag: "locality", value: "New York City" }],
+				undefined,
+				"New York City"
+			)
+			expect(hits[0]?.id).toBe(NEW_YORK_LOCALITY)
+		})
+
+		test("an unresolvable parsed region fails LOUD (console.warn), not silent", async () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+			try {
+				await runCascade(
+					wasmLookup,
+					undefined,
+					[{ tag: "locality", value: "Brooklyn" }],
+					{ tag: "region", value: "Zzyzx Nonexistia" },
+					"Brooklyn, Zzyzx Nonexistia"
+				)
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining("did not resolve to a bbox"))
+			} finally {
+				warn.mockRestore()
+			}
+		})
+	})
+
+	describe("Node lookup (resolver-wof-sqlite) — parity on the same DB", () => {
+		test('"Brooklyn" locality query → the borough (placetype expansion + alias-bag exact tier)', async () => {
+			const lookup = new WofSqlitePlaceLookup({ databasePath: HOT_DB_PATH! })
+			try {
+				const matches = await lookup.findPlace({ text: "Brooklyn", placetype: "locality", limit: 5 })
+				expect(matches[0]).toMatchObject({ id: BROOKLYN_BOROUGH, name: "Brooklyn", placetype: "borough" })
+				expect(matches[0]?.exactMatch).toBe(true)
+			} finally {
+				lookup.close()
+			}
+		})
+
+		test('"New York City" → the New York locality via the alias bag (no names table on the slim DB)', async () => {
+			const lookup = new WofSqlitePlaceLookup({ databasePath: HOT_DB_PATH! })
+			try {
+				const matches = await lookup.findPlace({ text: "New York City", placetype: "locality", limit: 5 })
+				expect(matches[0]).toMatchObject({ id: NEW_YORK_LOCALITY, name: "New York" })
+				expect(matches[0]?.exactMatch).toBe(true)
+			} finally {
+				lookup.close()
+			}
+		})
+	})
+})

--- a/resolver-wof-wasm/lookup.test.ts
+++ b/resolver-wof-wasm/lookup.test.ts
@@ -50,6 +50,13 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO spr VALUES (220, 101, 'York', 'locality', 'US', 39.96, -76.73, 39.9, 40.0, -76.8, -76.6, -1, 0);
 		INSERT INTO spr VALUES (221, 101, 'New York', 'locality', 'US', 40.71, -74.0, 40.5, 40.9, -74.2, -73.7, -1, 0);
 
+		-- The Brooklyn pair (live-demo bug, 2026-06-11): WOF files Brooklyn-the-borough as placetype
+		-- 'borough', NOT 'locality'. A locality query must reach it via the shared placetype expansion
+		-- (core/resolver PLACETYPE_FILTER_GROUPS) — otherwise the only locality-typed match is the
+		-- fuzzy 'Brooklyn Park' and the resolver mislocates to Minnesota.
+		INSERT INTO spr VALUES (230, 101, 'Brooklyn', 'borough', 'US', 40.64, -73.95, 40.57, 40.74, -74.04, -73.83, -1, 0);
+		INSERT INTO spr VALUES (231, 101, 'Brooklyn Park', 'locality', 'US', 45.11, -93.35, 45.07, 45.15, -93.40, -93.30, -1, 0);
+
 		INSERT INTO names (id, language, name) VALUES (100, 'eng', 'America');
 		INSERT INTO names (id, language, name) VALUES (200, 'eng', 'Chicago');
 		INSERT INTO names (id, language, name) VALUES (201, 'eng', 'Springfield');
@@ -58,6 +65,11 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO names (id, language, name) VALUES (211, 'eng', 'Greenville');
 		INSERT INTO names (id, language, name) VALUES (220, 'eng', 'York');
 		INSERT INTO names (id, language, name) VALUES (221, 'eng', 'New York');
+		-- WOF carries 'New York City' as an ALIAS of the New York locality — the FTS alt_names bag is
+		-- the slim DB's only surviving alias source, and the alias-exact tier must consult it.
+		INSERT INTO names (id, language, name) VALUES (221, 'eng', 'New York City');
+		INSERT INTO names (id, language, name) VALUES (230, 'eng', 'Brooklyn');
+		INSERT INTO names (id, language, name) VALUES (231, 'eng', 'Brooklyn Park');
 
 		-- Pre-built population aux table (production shape — build-unified-wof extracts wof:population
 		-- here at ingest; the source has no geojson table). Postcodes (300/301) carry no population row.
@@ -69,6 +81,8 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO place_population VALUES (211, 580000);
 		INSERT INTO place_population VALUES (220, 1700);
 		INSERT INTO place_population VALUES (221, 8400000);
+		INSERT INTO place_population VALUES (230, 2504700);
+		INSERT INTO place_population VALUES (231, 82000);
 
 		-- Region abbreviation tiering (#189): 'Vermontstate' (tiny pop) carries the exact abbrev 'VT';
 		-- 'Vt Plains' (huge pop) only TOKEN-matches "vt". build-slim materializes place_abbr (110→VT) so
@@ -188,6 +202,53 @@ describe("WofWasmPlaceLookup", () => {
 			// even though 'New York' has a far larger population (the ME->Maine-not-Missouri guard).
 			const matches = await lookup.findPlace({ text: "York", placetype: "locality", country: "US", limit: 5 })
 			expect(matches[0]?.name).toBe("York")
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test('"Brooklyn" locality query reaches the exact-named borough over the fuzzy "Brooklyn Park" (placetype expansion)', async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			// Live-demo bug (2026-06-11): a strict placetype='locality' filter excluded the borough, so
+			// "Brooklyn" resolved to Brooklyn Park, MN. The shared expansion (locality → locality +
+			// borough + localadmin) makes the exact-named borough reachable; exact tiering puts it first.
+			const matches = await lookup.findPlace({ text: "Brooklyn", placetype: "locality", limit: 5 })
+			expect(matches[0]).toMatchObject({ id: 230, name: "Brooklyn", placetype: "borough" })
+			expect(matches[0]?.exactMatch).toBe(true)
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test('"Brooklyn" + a New-York-ish bbox returns the borough (the region-constrained cascade path)', async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			// Mirrors "brooklyn, new york, ny": the parsed region's bbox constrains the locality lookup.
+			// Pre-expansion this returned NOTHING (the borough was filtered out, Brooklyn Park is outside
+			// the bbox), and the cascade silently fell back to the unconstrained — wrong — hit.
+			const matches = await lookup.findPlace({
+				text: "Brooklyn",
+				placetype: "locality",
+				bbox: { minLat: 40.4, maxLat: 45.1, minLon: -79.8, maxLon: -71.7 },
+				limit: 5,
+			})
+			expect(matches.map((m) => m.id)).toEqual([230])
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test('alias-exact tier: "New York City" resolves the New York locality via its WOF alias', async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			const matches = await lookup.findPlace({ text: "New York City", placetype: "locality", limit: 5 })
+			expect(matches[0]).toMatchObject({ id: 221, name: "New York" })
+			// The alias lives only in the FTS alt_names bag on a slim DB — the tier must consult it.
+			expect(matches[0]?.exactMatch).toBe(true)
 		} finally {
 			lookup.close()
 		}

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -20,7 +20,7 @@
 
 import type { Database } from "@sqlite.org/sqlite-wasm"
 
-import type { CoincidentLocality } from "@mailwoman/core/resolver"
+import { expandPlacetypeFilter, type CoincidentLocality } from "@mailwoman/core/resolver"
 import type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WofPlacetype } from "@mailwoman/resolver-wof-sqlite"
 
 export interface WofWasmPlaceLookupOpts {
@@ -104,7 +104,11 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 		const conditions: string[] = ["place_search MATCH ?", "spr.is_current != 0", "spr.is_deprecated = 0"]
 		const params: Array<string | number> = [ftsQuery]
 
-		const placetypes = normalizePlacetypes(query.placetype)
+		// Shared placetype-equivalence expansion (core/resolver): a `locality` query must also reach
+		// `borough` / `localadmin` rows. Without it, Brooklyn-the-borough (pop 2.5M, an EXACT name
+		// match) was unreachable and the fuzzy "Brooklyn Park, MN" won. Same table the Node resolver
+		// uses — the two backends can't drift.
+		const placetypes = expandPlacetypeFilter(normalizePlacetypes(query.placetype)) as WofPlacetype[] | null
 		if (placetypes && placetypes.length > 0) {
 			conditions.push(`spr.placetype IN (${placetypes.map(() => "?").join(",")})`)
 			params.push(...placetypes)
@@ -132,6 +136,7 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 		const sql =
 			`SELECT spr.id, spr.name, spr.placetype, spr.country, spr.latitude, spr.longitude, spr.parent_id, ` +
 			`spr.min_latitude, spr.max_latitude, spr.min_longitude, spr.max_longitude, ` +
+			`place_search.alt_names AS alt_names, ` +
 			`${hasPop ? "pp.population" : "NULL"} AS population, bm25(place_search) AS bm25 ` +
 			`FROM place_search JOIN spr ON spr.id = place_search.wof_id ` +
 			`${hasPop ? "LEFT JOIN place_population pp ON pp.id = spr.id " : ""}` +
@@ -152,6 +157,7 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 			max_latitude: number | null
 			min_longitude: number | null
 			max_longitude: number | null
+			alt_names: string | null
 			population: number | null
 			bm25: number
 		}>
@@ -164,9 +170,23 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 		// DBs built before place_abbr (the table is absent → empty set). This is the data-driven
 		// replacement for the demo's hardcoded `expandUsRegion` map; it also generalizes beyond US.
 		const abbrIds = this.#abbrExactIds(text)
+		// Strict exact = canonical name or region abbreviation equals the query. Computed for the whole
+		// pool FIRST because the ALIAS tier below only engages when no strict exact exists.
+		const strictExact = (row: { name: string; id: number }): boolean =>
+			normalizeName(row.name) === normQuery || abbrIds.has(row.id)
+		const anyStrictExact = rows.some(strictExact)
 		return rows
 			.map((row) => {
-				const exactTier = normalizeName(row.name) === normQuery || abbrIds.has(row.id) ? 0 : 1
+				// Alias tier: `alt_names` is the FTS row's alias bag (all `names` rows space-joined — the
+				// slim DB's only surviving alias source). Name boundaries are LOST in the bag, so a
+				// whitespace-boundary containment check would false-promote interior fragments ("York"
+				// matches inside the alias "New York City"). It therefore only engages when NO candidate
+				// is strictly exact — the "New York City" case, where the query is an alias WOF carries
+				// for the New York locality but no spr row bears the name. Mirrors the Node resolver's
+				// alias tier (`WofSqlitePlaceLookup.#exactMatchIds`).
+				const aliasExact =
+					!anyStrictExact && row.alt_names !== null && ` ${normalizeName(row.alt_names)} `.includes(` ${normQuery} `)
+				const exactTier = strictExact(row) || aliasExact ? 0 : 1
 				const popBoost =
 					row.population && row.population > 0
 						? POPULATION_BOOST * Math.min(1, Math.log10(1 + row.population) / POPULATION_SCALE_LOG10)


### PR DESCRIPTION
Three measured demo-ranking bugs, one shared root discipline: (1) `locality` filters excluded `borough`/`localadmin` in ALL THREE lookup backends (incl. `docs/src/shared/httpvfs-resolver.ts` — the one the live demo actually uses), making Brooklyn-the-borough (pop 2.5M) unreachable → `PLACETYPE_FILTER_GROUPS` in core as the single expansion table; (2) the region→bbox constraint silently widened on empty constrained passes → now warns and, post-fix-1, hits; (3) `New York City` was ALREADY in the FTS alias bag — exact-tiering never consulted `alt_names`; now it does, gated on no-strictly-exact-candidate (ungated it false-promoted, caught by tests). 222 passed incl. env-gated integration against the live hot-DB copy. Before/after on the reported queries in the agent report.

Reaches production only after a docs-build deploy (dispatched post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)