### PR TITLE
feat(codex): au/nz delivery-service slices — sourced from Australia Post AMAS + NZ Post ADV358 (#517)

### DIFF
--- a/codex/au/delivery-service.test.ts
+++ b/codex/au/delivery-service.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+	AU_DELIVERY_SERVICE_DESIGNATORS,
+	isAuDeliveryService,
+	matchAuDeliveryService,
+	normalizeAuDeliveryService,
+} from "./delivery-service.js"
+
+describe("AU_DELIVERY_SERVICE_DESIGNATORS", () => {
+	it("carries the verbatim AMAS table size and the documented no-number exceptions", () => {
+		expect(AU_DELIVERY_SERVICE_DESIGNATORS).toHaveLength(14)
+		const noNumber = AU_DELIVERY_SERVICE_DESIGNATORS.filter((d) => !d.requiresNumber).map((d) => d.name)
+		// "With the exception of Care of Post Office, Community Mail Agent, Community Postal Agent,
+		// and Community Mail Bag, all Postal Delivery Types must have an associated number."
+		expect(noNumber.sort()).toEqual(
+			["CARE OF POST OFFICE", "COMMUNITY MAIL AGENT", "COMMUNITY MAIL BAG", "COMMUNITY POSTAL AGENT", "POSTE RESTANTE"].sort()
+		)
+	})
+
+	it("flags exactly the current retail products as non-legacy", () => {
+		const current = [...new Set(AU_DELIVERY_SERVICE_DESIGNATORS.filter((d) => !d.legacy).map((d) => d.abbreviation))]
+		expect(current.sort()).toEqual(["GPO BOX", "LOCKED BAG", "PO BOX", "PRIVATE BAG"].sort())
+	})
+})
+
+describe("matchAuDeliveryService", () => {
+	it("matches the current designators with ids", () => {
+		expect(matchAuDeliveryService("GPO Box 2890")).toMatchObject({ designator: "GPO BOX", id: "2890", legacy: false })
+		expect(matchAuDeliveryService("PO Box 112")).toMatchObject({ designator: "PO BOX", id: "112", legacy: false })
+		expect(matchAuDeliveryService("Locked Bag 1797")).toMatchObject({
+			designator: "LOCKED BAG",
+			id: "1797",
+			legacy: false,
+		})
+		expect(matchAuDeliveryService("Private Bag 7")).toMatchObject({ designator: "PRIVATE BAG", id: "7", legacy: false })
+	})
+
+	it("prefers GPO Box over PO Box and tolerates punctuation", () => {
+		expect(matchAuDeliveryService("G.P.O. Box 9999")).toMatchObject({ designator: "GPO BOX", id: "9999" })
+		expect(matchAuDeliveryService("P.O. Box 12-A")).toMatchObject({ designator: "PO BOX", id: "12-A" })
+		expect(matchAuDeliveryService("General Post Office Box 123")).toMatchObject({ designator: "GPO BOX", id: "123" })
+	})
+
+	it("recognizes the legacy rural and community forms, flagged", () => {
+		expect(matchAuDeliveryService("RMB 4600")).toMatchObject({ designator: "RMB", id: "4600", legacy: true })
+		expect(matchAuDeliveryService("RSD 27")).toMatchObject({ designator: "RSD", id: "27", legacy: true })
+		expect(matchAuDeliveryService("RMS 1605")).toMatchObject({ designator: "RMS", id: "1605", legacy: true })
+		expect(matchAuDeliveryService("MS 1080")).toMatchObject({ designator: "MS", id: "1080", legacy: true })
+		expect(matchAuDeliveryService("Roadside Mail Box 12")).toMatchObject({ designator: "RMB", id: "12" })
+		expect(matchAuDeliveryService("Community Mail Bag 6")).toMatchObject({ designator: "CMB", id: "6" })
+	})
+
+	it("allows the documented no-number designators to stand bare", () => {
+		expect(matchAuDeliveryService("CMB")).toMatchObject({ designator: "CMB", legacy: true })
+		expect(matchAuDeliveryService("Care PO")).toMatchObject({ designator: "CARE PO" })
+		expect(matchAuDeliveryService("Poste Restante")).toMatchObject({ designator: "CARE PO" })
+		expect(matchAuDeliveryService("Community Postal Agent")).toMatchObject({ designator: "CPA" })
+		expect(matchAuDeliveryService("CMB")?.id).toBeUndefined()
+	})
+
+	it("requires a number where the AMAS rule requires one", () => {
+		expect(matchAuDeliveryService("Locked Bag")).toBeNull()
+		expect(matchAuDeliveryService("GPO Box")).toBeNull()
+		expect(matchAuDeliveryService("RSD")).toBeNull()
+	})
+
+	it("does not let the two-letter MS designator swallow an honorific", () => {
+		expect(matchAuDeliveryService("Ms Smith")).toBeNull()
+		expect(matchAuDeliveryService("MS 23B")).toMatchObject({ designator: "MS", id: "23B" })
+	})
+
+	it("rejects 'Private Box' — explicitly not a valid type per Australia Post", () => {
+		expect(matchAuDeliveryService("Private Box 12")).toBeNull()
+		expect(isAuDeliveryService("Private Box 12")).toBe(false)
+	})
+
+	it("rejects non-delivery-service strings", () => {
+		expect(matchAuDeliveryService("54 Stockton Rd")).toBeNull()
+		expect(matchAuDeliveryService("SYDNEY NSW 2000")).toBeNull()
+		expect(matchAuDeliveryService(42)).toBeNull()
+	})
+})
+
+describe("normalizeAuDeliveryService", () => {
+	it("canonicalizes to the AMAS abbreviation", () => {
+		expect(normalizeAuDeliveryService("g.p.o. box 123")).toBe("GPO BOX 123")
+		expect(normalizeAuDeliveryService("Locked Mail Bag Service 60")).toBe("LOCKED BAG 60")
+		expect(normalizeAuDeliveryService("Roadside Delivery 4")).toBe("RSD 4")
+		expect(normalizeAuDeliveryService("Poste Restante")).toBe("CARE PO")
+	})
+
+	it("round-trips: every normalized form still matches", () => {
+		for (const raw of ["GPO Box 2890", "Locked Bag 1797", "Private Bag 7", "RMB 4600", "CMB"]) {
+			expect(isAuDeliveryService(normalizeAuDeliveryService(raw))).toBe(true)
+		}
+	})
+
+	it("passes through non-matches unchanged", () => {
+		expect(normalizeAuDeliveryService("Private Box 12")).toBe("Private Box 12")
+	})
+})

--- a/codex/au/delivery-service.test.ts
+++ b/codex/au/delivery-service.test.ts
@@ -20,7 +20,13 @@ describe("AU_DELIVERY_SERVICE_DESIGNATORS", () => {
 		// "With the exception of Care of Post Office, Community Mail Agent, Community Postal Agent,
 		// and Community Mail Bag, all Postal Delivery Types must have an associated number."
 		expect(noNumber.sort()).toEqual(
-			["CARE OF POST OFFICE", "COMMUNITY MAIL AGENT", "COMMUNITY MAIL BAG", "COMMUNITY POSTAL AGENT", "POSTE RESTANTE"].sort()
+			[
+				"CARE OF POST OFFICE",
+				"COMMUNITY MAIL AGENT",
+				"COMMUNITY MAIL BAG",
+				"COMMUNITY POSTAL AGENT",
+				"POSTE RESTANTE",
+			].sort()
 		)
 	})
 

--- a/codex/au/delivery-service.ts
+++ b/codex/au/delivery-service.ts
@@ -4,25 +4,25 @@
  * @author Teffen Ellis, et al.
  *
  *   Australia Post delivery-service designators (Postal Delivery Types) — the Commonwealth po_box
- *   vocabulary the US-only `us/po-box.ts` cannot see: `GPO Box 2890`, `Locked Bag 1797`,
- *   `Private Bag 7`, plus the rural/community legacy tail (`RMB 4600`, `RSD`, `CMB`).
+ *   vocabulary the US-only `us/po-box.ts` cannot see: `GPO Box 2890`, `Locked Bag 1797`, `Private
+ *   Bag 7`, plus the rural/community legacy tail (`RMB 4600`, `RSD`, `CMB`).
  *
  *   Sourcing (accessed 2026-06-11; the underlying urban/rural addressing standard is AS/NZS 4819,
  *   which governs street addressing — the delivery-service designators below are Australia Post's
  *   own, from its addressing guidance):
  *
- *   - The complete Postal Delivery Type table comes verbatim from Australia Post's barcode
- *       addressing booklet ("Hints and tips to get a higher address match rate", SAP 8838883):
- *       CARE OF POST OFFICE→CARE PO, COMMUNITY MAIL AGENT→CMA, COMMUNITY MAIL BAG→CMB, GENERAL POST
- *       OFFICE BOX→GPO BOX, LOCKED MAIL BAG SERVICE→LOCKED BAG, MAIL SERVICE→MS, POST OFFICE
- *       BOX→PO BOX, POSTE RESTANTE→CARE PO, PRIVATE MAIL BAG SERVICE→PRIVATE BAG, ROADSIDE
- *       DELIVERY→RSD, ROADSIDE MAIL BAG→RMB, ROADSIDE MAIL BOX→RMB, ROADSIDE MAIL SERVICE→RMS,
- *       COMMUNITY POSTAL AGENT→CPA. The same booklet states: "With the exception of Care of Post
- *       Office, Community Mail Agent, Community Postal Agent, and Community Mail Bag, all Postal
- *       Delivery Types must have an associated number for a match to occur. e.g. PO Box 112", and
- *       "'PRIVATE BOX' is not a valid type" (so PRIVATE BOX is deliberately NOT in this table).
- *   - Which designators are CURRENT retail products (vs. AMAS-recognized legacy forms) comes from
- *       the live auspost.com.au pages: the addressing guidelines ("Line 2 should contain the street
+ *   - The complete Postal Delivery Type table comes verbatim from Australia Post's barcode addressing
+ *       booklet ("Hints and tips to get a higher address match rate", SAP 8838883): CARE OF POST
+ *       OFFICE→CARE PO, COMMUNITY MAIL AGENT→CMA, COMMUNITY MAIL BAG→CMB, GENERAL POST OFFICE
+ *       BOX→GPO BOX, LOCKED MAIL BAG SERVICE→LOCKED BAG, MAIL SERVICE→MS, POST OFFICE BOX→PO BOX,
+ *       POSTE RESTANTE→CARE PO, PRIVATE MAIL BAG SERVICE→PRIVATE BAG, ROADSIDE DELIVERY→RSD,
+ *       ROADSIDE MAIL BAG→RMB, ROADSIDE MAIL BOX→RMB, ROADSIDE MAIL SERVICE→RMS, COMMUNITY POSTAL
+ *       AGENT→CPA. The same booklet states: "With the exception of Care of Post Office, Community
+ *       Mail Agent, Community Postal Agent, and Community Mail Bag, all Postal Delivery Types must
+ *       have an associated number for a match to occur. e.g. PO Box 112", and "'PRIVATE BOX' is not
+ *       a valid type" (so PRIVATE BOX is deliberately NOT in this table).
+ *   - Which designators are CURRENT retail products (vs. AMAS-recognized legacy forms) comes from the
+ *       live auspost.com.au pages: the addressing guidelines ("Line 2 should contain the street
  *       number and name, or PO Box or Locked Bag number"), the Correct Addressing brochure (SAP
  *       8833878, Nov 2022 — `GPO Box 123 / SYDNEY NSW 2000` example), the personal "PO Boxes and
  *       Private Bags" page (Private Bag: "If you live in a rural or remote area of Australia, you
@@ -48,8 +48,8 @@ export interface AuDeliveryServiceDesignator {
 	abbreviation: string
 	/**
 	 * Whether the designator "must have an associated number for a match to occur" (AMAS rule;
-	 * exceptions are Care of Post Office, Community Mail Agent, Community Postal Agent, and
-	 * Community Mail Bag).
+	 * exceptions are Care of Post Office, Community Mail Agent, Community Postal Agent, and Community
+	 * Mail Bag).
 	 */
 	requiresNumber: boolean
 	/**
@@ -138,10 +138,10 @@ export interface AuDeliveryServiceMatch {
 }
 
 /**
- * If `input` is a standalone Australia Post delivery-service phrase ("GPO Box 2890",
- * "Locked Bag 1797", "RMB 4600", bare "CMB"), return the canonical designator, the id, and the
- * legacy flag. Null otherwise — including for "Private Box", which Australia Post explicitly calls
- * out as not a valid type.
+ * If `input` is a standalone Australia Post delivery-service phrase ("GPO Box 2890", "Locked Bag
+ * 1797", "RMB 4600", bare "CMB"), return the canonical designator, the id, and the legacy flag.
+ * Null otherwise — including for "Private Box", which Australia Post explicitly calls out as not a
+ * valid type.
  */
 export function matchAuDeliveryService(input: unknown): AuDeliveryServiceMatch | null {
 	if (typeof input !== "string") return null
@@ -165,8 +165,8 @@ export function isAuDeliveryService(input: unknown): boolean {
 }
 
 /**
- * Normalize a recognized delivery-service phrase to the canonical AMAS form
- * (`"g.p.o. box 123"` → `"GPO BOX 123"`). Returns the input unchanged if it isn't one.
+ * Normalize a recognized delivery-service phrase to the canonical AMAS form (`"g.p.o. box 123"` →
+ * `"GPO BOX 123"`). Returns the input unchanged if it isn't one.
  */
 export function normalizeAuDeliveryService(input: string): string {
 	const m = matchAuDeliveryService(input)

--- a/codex/au/delivery-service.ts
+++ b/codex/au/delivery-service.ts
@@ -1,0 +1,175 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Australia Post delivery-service designators (Postal Delivery Types) — the Commonwealth po_box
+ *   vocabulary the US-only `us/po-box.ts` cannot see: `GPO Box 2890`, `Locked Bag 1797`,
+ *   `Private Bag 7`, plus the rural/community legacy tail (`RMB 4600`, `RSD`, `CMB`).
+ *
+ *   Sourcing (accessed 2026-06-11; the underlying urban/rural addressing standard is AS/NZS 4819,
+ *   which governs street addressing — the delivery-service designators below are Australia Post's
+ *   own, from its addressing guidance):
+ *
+ *   - The complete Postal Delivery Type table comes verbatim from Australia Post's barcode
+ *       addressing booklet ("Hints and tips to get a higher address match rate", SAP 8838883):
+ *       CARE OF POST OFFICE→CARE PO, COMMUNITY MAIL AGENT→CMA, COMMUNITY MAIL BAG→CMB, GENERAL POST
+ *       OFFICE BOX→GPO BOX, LOCKED MAIL BAG SERVICE→LOCKED BAG, MAIL SERVICE→MS, POST OFFICE
+ *       BOX→PO BOX, POSTE RESTANTE→CARE PO, PRIVATE MAIL BAG SERVICE→PRIVATE BAG, ROADSIDE
+ *       DELIVERY→RSD, ROADSIDE MAIL BAG→RMB, ROADSIDE MAIL BOX→RMB, ROADSIDE MAIL SERVICE→RMS,
+ *       COMMUNITY POSTAL AGENT→CPA. The same booklet states: "With the exception of Care of Post
+ *       Office, Community Mail Agent, Community Postal Agent, and Community Mail Bag, all Postal
+ *       Delivery Types must have an associated number for a match to occur. e.g. PO Box 112", and
+ *       "'PRIVATE BOX' is not a valid type" (so PRIVATE BOX is deliberately NOT in this table).
+ *   - Which designators are CURRENT retail products (vs. AMAS-recognized legacy forms) comes from
+ *       the live auspost.com.au pages: the addressing guidelines ("Line 2 should contain the street
+ *       number and name, or PO Box or Locked Bag number"), the Correct Addressing brochure (SAP
+ *       8833878, Nov 2022 — `GPO Box 123 / SYDNEY NSW 2000` example), the personal "PO Boxes and
+ *       Private Bags" page (Private Bag: "If you live in a rural or remote area of Australia, you
+ *       can manage your mail securely with a Private Bag"), and the business "PO Boxes and Locked
+ *       Bags" page (GPO Box: "Lease a single GPO Box, or the same box number in each capital city
+ *       with our Common Box service"; Common Box numbers run 9800–9999). PO Box, GPO Box, Locked
+ *       Bag, and Private Bag appear on those current pages; the rural/community types (RSD, RMB,
+ *       RMS, MS, CMB, CMA, CPA, Care PO) appear ONLY in the AMAS table and are flagged `legacy` —
+ *       the parser must still recognize them on older addresses.
+ *
+ * @see {@link https://auspost.com.au/content/dam/auspost_corp/media/documents/Barcode_hints_tips.pdf Australia Post barcode addressing booklet (Postal Delivery Type table)}
+ * @see {@link https://auspost.com.au/sending/guidelines/addressing-guidelines Australia Post addressing guidelines}
+ * @see {@link https://auspost.com.au/content/dam/auspost_corp/media/documents/correct-addressing.pdf Australia Post Correct Addressing brochure (Nov 2022)}
+ * @see {@link https://auspost.com.au/receiving/manage-your-mail/po-boxes-and-private-bags Australia Post — PO Boxes and Private Bags}
+ * @see {@link https://auspost.com.au/business/business-admin/po-boxes-and-locked-bags Australia Post — business PO Boxes, GPO Boxes and Locked Bags}
+ */
+
+/** One Postal Delivery Type row from the Australia Post AMAS abbreviation table. */
+export interface AuDeliveryServiceDesignator {
+	/** The full Postal Delivery Type name, verbatim from the table (uppercase as published). */
+	name: string
+	/** The standard abbreviation — the surface form written on mail ("GPO BOX", "LOCKED BAG"). */
+	abbreviation: string
+	/**
+	 * Whether the designator "must have an associated number for a match to occur" (AMAS rule;
+	 * exceptions are Care of Post Office, Community Mail Agent, Community Postal Agent, and
+	 * Community Mail Bag).
+	 */
+	requiresNumber: boolean
+	/**
+	 * True when the designator is recognized by the AMAS Postal Delivery Type table but absent from
+	 * every current auspost.com.au addressing/product page (accessed 2026-06-11) — the rural and
+	 * community forms superseded by rural street addressing under AS/NZS 4819. The parser must still
+	 * RECOGNIZE these on old addresses; synthesis should weight them low.
+	 */
+	legacy: boolean
+}
+
+/**
+ * The verbatim Postal Delivery Type table (see the module header for the per-row provenance).
+ * Multiple names can share an abbreviation (ROADSIDE MAIL BAG and ROADSIDE MAIL BOX are both RMB;
+ * POSTE RESTANTE is addressed as CARE PO).
+ */
+export const AU_DELIVERY_SERVICE_DESIGNATORS = [
+	{ name: "GENERAL POST OFFICE BOX", abbreviation: "GPO BOX", requiresNumber: true, legacy: false },
+	{ name: "POST OFFICE BOX", abbreviation: "PO BOX", requiresNumber: true, legacy: false },
+	{ name: "LOCKED MAIL BAG SERVICE", abbreviation: "LOCKED BAG", requiresNumber: true, legacy: false },
+	{ name: "PRIVATE MAIL BAG SERVICE", abbreviation: "PRIVATE BAG", requiresNumber: true, legacy: false },
+	{ name: "COMMUNITY MAIL BAG", abbreviation: "CMB", requiresNumber: false, legacy: true },
+	{ name: "COMMUNITY MAIL AGENT", abbreviation: "CMA", requiresNumber: false, legacy: true },
+	{ name: "COMMUNITY POSTAL AGENT", abbreviation: "CPA", requiresNumber: false, legacy: true },
+	{ name: "CARE OF POST OFFICE", abbreviation: "CARE PO", requiresNumber: false, legacy: true },
+	{ name: "POSTE RESTANTE", abbreviation: "CARE PO", requiresNumber: false, legacy: true },
+	{ name: "MAIL SERVICE", abbreviation: "MS", requiresNumber: true, legacy: true },
+	{ name: "ROADSIDE DELIVERY", abbreviation: "RSD", requiresNumber: true, legacy: true },
+	{ name: "ROADSIDE MAIL BAG", abbreviation: "RMB", requiresNumber: true, legacy: true },
+	{ name: "ROADSIDE MAIL BOX", abbreviation: "RMB", requiresNumber: true, legacy: true },
+	{ name: "ROADSIDE MAIL SERVICE", abbreviation: "RMS", requiresNumber: true, legacy: true },
+] as const satisfies readonly AuDeliveryServiceDesignator[]
+
+/** A canonical Australia Post Postal Delivery Type abbreviation. */
+export type AuDeliveryServiceAbbreviation = (typeof AU_DELIVERY_SERVICE_DESIGNATORS)[number]["abbreviation"]
+
+/**
+ * Per-designator surface patterns (designator phrase only, no anchor, no id). Ordered longest /
+ * most-specific first so the matcher prefers "GPO Box" over "PO Box" and "RMS" over "MS". Each
+ * pattern tolerates the punctuation AMAS tells mailers to strip ("the full stops and commas in
+ * R.M.B and P.O.") — recognition must accept what deliverable mail actually carries.
+ *
+ * MS is special-cased in {@link matchAuDeliveryService}: its identifier must start with a digit so
+ * the bare two-letter designator cannot swallow an honorific ("Ms Smith").
+ */
+const DESIGNATOR_PATTERNS: ReadonlyArray<readonly [AuDeliveryServiceAbbreviation, string]> = [
+	["GPO BOX", String.raw`general\s+post\s+office\s+box|g\.?\s*p\.?\s*o\.?\s*box`],
+	["PO BOX", String.raw`post\s+office\s+box|p\.?\s*o\.?\s*box`],
+	["LOCKED BAG", String.raw`locked\s+(?:mail\s+)?bag(?:\s+service)?`],
+	["PRIVATE BAG", String.raw`private\s+(?:mail\s+)?bag(?:\s+service)?`],
+	["CARE PO", String.raw`care\s+of\s+post\s+office|poste\s+restante|care\s+po`],
+	["CMB", String.raw`community\s+mail\s+bag|cmb`],
+	["CMA", String.raw`community\s+mail\s+agent|cma`],
+	["CPA", String.raw`community\s+postal\s+agent|cpa`],
+	["RSD", String.raw`roadside\s+delivery|r\.?\s*s\.?\s*d\.?`],
+	["RMB", String.raw`roadside\s+mail\s+(?:bag|box)|r\.?\s*m\.?\s*b\.?`],
+	["RMS", String.raw`roadside\s+mail\s+service|rms`],
+	["MS", String.raw`mail\s+service|ms`],
+]
+
+const DESIGNATOR_INFO = new Map<AuDeliveryServiceAbbreviation, { requiresNumber: boolean; legacy: boolean }>(
+	AU_DELIVERY_SERVICE_DESIGNATORS.map((d) => [d.abbreviation, { requiresNumber: d.requiresNumber, legacy: d.legacy }])
+)
+
+// One anchored regex per designator: phrase + (required|optional) identifier. The id shape matches
+// the US slice ([\dA-Za-z][\dA-Za-z-]*); MS additionally requires a digit-leading id (see above).
+const MATCHERS: ReadonlyArray<{ abbreviation: AuDeliveryServiceAbbreviation; re: RegExp }> = DESIGNATOR_PATTERNS.map(
+	([abbreviation, src]) => {
+		const { requiresNumber } = DESIGNATOR_INFO.get(abbreviation)!
+		const id = abbreviation === "MS" ? String.raw`(\d[\dA-Za-z-]*)` : String.raw`([\dA-Za-z][\dA-Za-z-]*)`
+		const tail = requiresNumber ? String.raw`\s*#?\s*${id}` : String.raw`(?:\s*#?\s*${id})?`
+		return { abbreviation, re: new RegExp(String.raw`^\s*(${src})${tail}\s*$`, "i") }
+	}
+)
+
+/** Result of an AU delivery-service parse. */
+export interface AuDeliveryServiceMatch {
+	/** The designator phrase as it appeared ("G.P.O. Box", "Locked Bag"). */
+	matched: string
+	/** The canonical Postal Delivery Type abbreviation ("GPO BOX", "LOCKED BAG"). */
+	designator: AuDeliveryServiceAbbreviation
+	/** The delivery-service number when present ("9999", "4600"). */
+	id?: string
+	/** True when the designator is an AMAS-only legacy form (see the table). */
+	legacy: boolean
+}
+
+/**
+ * If `input` is a standalone Australia Post delivery-service phrase ("GPO Box 2890",
+ * "Locked Bag 1797", "RMB 4600", bare "CMB"), return the canonical designator, the id, and the
+ * legacy flag. Null otherwise — including for "Private Box", which Australia Post explicitly calls
+ * out as not a valid type.
+ */
+export function matchAuDeliveryService(input: unknown): AuDeliveryServiceMatch | null {
+	if (typeof input !== "string") return null
+	for (const { abbreviation, re } of MATCHERS) {
+		const m = re.exec(input)
+		if (!m) continue
+		const info = DESIGNATOR_INFO.get(abbreviation)!
+		return {
+			matched: m[1]!.trim(),
+			designator: abbreviation,
+			...(m[2] ? { id: m[2] } : {}),
+			legacy: info.legacy,
+		}
+	}
+	return null
+}
+
+/** Type-predicate: does the input look like a standalone AU delivery-service address line? */
+export function isAuDeliveryService(input: unknown): boolean {
+	return matchAuDeliveryService(input) !== null
+}
+
+/**
+ * Normalize a recognized delivery-service phrase to the canonical AMAS form
+ * (`"g.p.o. box 123"` → `"GPO BOX 123"`). Returns the input unchanged if it isn't one.
+ */
+export function normalizeAuDeliveryService(input: string): string {
+	const m = matchAuDeliveryService(input)
+	if (!m) return input
+	return m.id ? `${m.designator} ${m.id.toUpperCase()}` : m.designator
+}

--- a/codex/au/index.ts
+++ b/codex/au/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The Australian address system (Australia Post / ISO 3166-2:AU; street addressing per AS/NZS
+ *   4819): delivery-service designators (GPO Box, Locked Bag, Private Bag, the rural legacy tail),
+ *   states and territories, and the 4-digit postcode.
+ */
+
+export * from "./delivery-service.js"
+export * from "./postcode.js"
+export * from "./state.js"

--- a/codex/au/postcode.ts
+++ b/codex/au/postcode.ts
@@ -3,22 +3,21 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Australian postcodes: four digits, written at the end of the last address line after the
- *   locality and state (`SYDNEY NSW 2000`). Sourcing (accessed 2026-06-11):
+ *   Australian postcodes: four digits, written at the end of the last address line after the locality
+ *   and state (`SYDNEY NSW 2000`). Sourcing (accessed 2026-06-11):
  *
  *   - Australia Post's Correct Addressing brochure (SAP 8833878, Nov 2022) — every example carries a
  *       4-digit postcode and the brochure references envelopes "with preprinted four postcode
  *       squares".
- *   - The barcode addressing booklet documents the coarse first-digit → state prior: "if the
- *       Postcode falls in the range 3000-3999 the State abbreviation will be VIC; 4000-4999 will be
- *       QLD, etc. … Exceptions to this include ACT Postcodes and Postcodes located on State
- *       borders." Because the booklet only enumerates VIC and QLD and flags exceptions, this module
- *       deliberately does NOT ship a full first-digit → state table — the shape is the contract, the
- *       geographic prior is the gazetteer's job.
+ *   - The barcode addressing booklet documents the coarse first-digit → state prior: "if the Postcode
+ *       falls in the range 3000-3999 the State abbreviation will be VIC; 4000-4999 will be QLD,
+ *       etc. … Exceptions to this include ACT Postcodes and Postcodes located on State borders."
+ *       Because the booklet only enumerates VIC and QLD and flags exceptions, this module
+ *       deliberately does NOT ship a full first-digit → state table — the shape is the contract,
+ *       the geographic prior is the gazetteer's job.
  *
  *   Note the shape collides with New Zealand's (also 4 digits) — `candidateSystemsForPostcode`
  *   returns both, and that ambiguity is by design (shape test, not membership test).
- *
  * @see {@link https://auspost.com.au/content/dam/auspost_corp/media/documents/correct-addressing.pdf Australia Post Correct Addressing brochure (Nov 2022)}
  * @see {@link https://auspost.com.au/content/dam/auspost_corp/media/documents/Barcode_hints_tips.pdf Australia Post barcode addressing booklet}
  */

--- a/codex/au/postcode.ts
+++ b/codex/au/postcode.ts
@@ -1,0 +1,51 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Australian postcodes: four digits, written at the end of the last address line after the
+ *   locality and state (`SYDNEY NSW 2000`). Sourcing (accessed 2026-06-11):
+ *
+ *   - Australia Post's Correct Addressing brochure (SAP 8833878, Nov 2022) — every example carries a
+ *       4-digit postcode and the brochure references envelopes "with preprinted four postcode
+ *       squares".
+ *   - The barcode addressing booklet documents the coarse first-digit → state prior: "if the
+ *       Postcode falls in the range 3000-3999 the State abbreviation will be VIC; 4000-4999 will be
+ *       QLD, etc. … Exceptions to this include ACT Postcodes and Postcodes located on State
+ *       borders." Because the booklet only enumerates VIC and QLD and flags exceptions, this module
+ *       deliberately does NOT ship a full first-digit → state table — the shape is the contract, the
+ *       geographic prior is the gazetteer's job.
+ *
+ *   Note the shape collides with New Zealand's (also 4 digits) — `candidateSystemsForPostcode`
+ *   returns both, and that ambiguity is by design (shape test, not membership test).
+ *
+ * @see {@link https://auspost.com.au/content/dam/auspost_corp/media/documents/correct-addressing.pdf Australia Post Correct Addressing brochure (Nov 2022)}
+ * @see {@link https://auspost.com.au/content/dam/auspost_corp/media/documents/Barcode_hints_tips.pdf Australia Post barcode addressing booklet}
+ */
+
+import type { Tagged } from "type-fest"
+
+/**
+ * An Australian postcode: four digits.
+ *
+ * @category Postal
+ * @type string
+ * @title Australian postcode
+ * @pattern ^\d{4}$
+ */
+export type AuPostcode = Tagged<string, "AuPostcode">
+
+/** The AU postcode shape: exactly four digits. */
+export const AU_POSTCODE_PATTERN = /^\d{4}$/
+
+/** Normalize a postcode surface form (trim only — AU has no country-prefix courtesy form). */
+export function normalizeAuPostcode(raw: unknown): AuPostcode | null {
+	if (typeof raw !== "string") return null
+	const s = raw.trim()
+	return AU_POSTCODE_PATTERN.test(s) ? (s as AuPostcode) : null
+}
+
+/** Type-predicate for a (normalized) Australian postcode. */
+export function isAuPostcode(input: unknown): input is AuPostcode {
+	return typeof input === "string" && AU_POSTCODE_PATTERN.test(input)
+}

--- a/codex/au/state.ts
+++ b/codex/au/state.ts
@@ -3,14 +3,13 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Australian states and territories (ISO 3166-2:AU). Australia Post's addressing guidelines put
- *   the state abbreviation on the last line between the locality and the 4-digit postcode ("Line 3
+ *   Australian states and territories (ISO 3166-2:AU). Australia Post's addressing guidelines put the
+ *   state abbreviation on the last line between the locality and the 4-digit postcode ("Line 3
  *   should contain the locality or suburb, state and postcode and be written in capital letters" —
- *   addressing guidelines, accessed 2026-06-11), e.g. `SYDNEY NSW 2000`, `BUNBURY WA 6230`,
- *   `EUROA VIC 3664`. The abbreviation set is the ISO 3166-2:AU subdivision codes, which are the
- *   same codes Australia Post's own examples use (NSW, VIC, WA, QLD, ACT appear across the
- *   addressing guidelines and the barcode booklet).
- *
+ *   addressing guidelines, accessed 2026-06-11), e.g. `SYDNEY NSW 2000`, `BUNBURY WA 6230`, `EUROA
+ *   VIC 3664`. The abbreviation set is the ISO 3166-2:AU subdivision codes, which are the same
+ *   codes Australia Post's own examples use (NSW, VIC, WA, QLD, ACT appear across the addressing
+ *   guidelines and the barcode booklet).
  * @see {@link https://auspost.com.au/sending/guidelines/addressing-guidelines Australia Post addressing guidelines}
  * @see {@link https://www.iso.org/obp/ui/#iso:code:3166:AU ISO 3166-2:AU}
  */

--- a/codex/au/state.ts
+++ b/codex/au/state.ts
@@ -1,0 +1,36 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Australian states and territories (ISO 3166-2:AU). Australia Post's addressing guidelines put
+ *   the state abbreviation on the last line between the locality and the 4-digit postcode ("Line 3
+ *   should contain the locality or suburb, state and postcode and be written in capital letters" —
+ *   addressing guidelines, accessed 2026-06-11), e.g. `SYDNEY NSW 2000`, `BUNBURY WA 6230`,
+ *   `EUROA VIC 3664`. The abbreviation set is the ISO 3166-2:AU subdivision codes, which are the
+ *   same codes Australia Post's own examples use (NSW, VIC, WA, QLD, ACT appear across the
+ *   addressing guidelines and the barcode booklet).
+ *
+ * @see {@link https://auspost.com.au/sending/guidelines/addressing-guidelines Australia Post addressing guidelines}
+ * @see {@link https://www.iso.org/obp/ui/#iso:code:3166:AU ISO 3166-2:AU}
+ */
+
+/** State/territory abbreviation → full name (ISO 3166-2:AU subdivision set). */
+export const AU_STATE_ABBREVIATIONS = {
+	ACT: "Australian Capital Territory",
+	NSW: "New South Wales",
+	NT: "Northern Territory",
+	QLD: "Queensland",
+	SA: "South Australia",
+	TAS: "Tasmania",
+	VIC: "Victoria",
+	WA: "Western Australia",
+} as const satisfies Record<string, string>
+
+/** An Australian state/territory abbreviation as written on the last address line. */
+export type AuStateAbbreviation = keyof typeof AU_STATE_ABBREVIATIONS
+
+/** Type-predicate for an AU state/territory abbreviation (case-insensitive). */
+export function isAuStateAbbreviation(input: unknown): input is AuStateAbbreviation {
+	return typeof input === "string" && Object.hasOwn(AU_STATE_ABBREVIATIONS, input.toUpperCase())
+}

--- a/codex/index.ts
+++ b/codex/index.ts
@@ -23,10 +23,12 @@ export {
 	type AddressSystemConventions,
 	conventionsForSystem,
 } from "./address-system-conventions.js"
+export * as au from "./au/index.js"
 export * as ca from "./ca/index.js"
 export * as de from "./de/index.js"
 export * as fr from "./fr/index.js"
 export * as gb from "./gb/index.js"
 export * as jp from "./jp/index.js"
+export * as nz from "./nz/index.js"
 export { candidateSystemsForPostcode, type SystemCode } from "./postcode-systems.js"
 export * as us from "./us/index.js"

--- a/codex/index.ts
+++ b/codex/index.ts
@@ -20,8 +20,8 @@
 
 export {
 	ADDRESS_SYSTEM_CONVENTIONS,
-	type AddressSystemConventions,
 	conventionsForSystem,
+	type AddressSystemConventions,
 } from "./address-system-conventions.js"
 export * as au from "./au/index.js"
 export * as ca from "./ca/index.js"

--- a/codex/nz/delivery-service.test.ts
+++ b/codex/nz/delivery-service.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+	isNzDeliveryService,
+	matchNzDeliveryService,
+	normalizeNzDeliveryService,
+	NZ_DELIVERY_SERVICE_TYPES,
+} from "./delivery-service.js"
+
+describe("NZ_DELIVERY_SERVICE_TYPES", () => {
+	it("carries exactly the six ADV358 types", () => {
+		expect(NZ_DELIVERY_SERVICE_TYPES.map((t) => t.type).sort()).toEqual(
+			["CMB", "Counter Delivery", "PO Box", "Poste Restante", "Private Bag", "Response Bag"].sort()
+		)
+	})
+
+	it("marks the counter services as identifier-less", () => {
+		for (const t of NZ_DELIVERY_SERVICE_TYPES) {
+			if (t.type === "Counter Delivery" || t.type === "Poste Restante") {
+				expect(t.identifier).toBe("not-used")
+			}
+		}
+	})
+})
+
+describe("matchNzDeliveryService", () => {
+	it("matches the ADV358 examples", () => {
+		expect(matchNzDeliveryService("PO Box 24999")).toMatchObject({ type: "PO Box", id: "24999" })
+		expect(matchNzDeliveryService("Private Bag 106999")).toMatchObject({ type: "Private Bag", id: "106999" })
+		expect(matchNzDeliveryService("Response Bag 500999")).toMatchObject({ type: "Response Bag", id: "500999" })
+		expect(matchNzDeliveryService("CMB B99")).toMatchObject({ type: "CMB", id: "B99" })
+		expect(matchNzDeliveryService("Counter Delivery")).toMatchObject({ type: "Counter Delivery" })
+		expect(matchNzDeliveryService("Poste Restante")).toMatchObject({ type: "Poste Restante" })
+	})
+
+	it("allows an identifier-less Private Bag (ADV358: identifier not always allocated)", () => {
+		expect(matchNzDeliveryService("Private Bag")).toMatchObject({ type: "Private Bag" })
+		expect(matchNzDeliveryService("Private Bag")?.id).toBeUndefined()
+	})
+
+	it("recognizes wild punctuated forms while the standard prefers bare PO", () => {
+		expect(matchNzDeliveryService("P.O. Box 23226")).toMatchObject({ type: "PO Box", id: "23226" })
+		expect(matchNzDeliveryService("Post Box 12")).toMatchObject({ type: "PO Box", id: "12" })
+	})
+
+	it("rejects the forms ADV358 names as errors, and types that don't exist", () => {
+		expect(matchNzDeliveryService("PB 39990")).toBeNull()
+		expect(matchNzDeliveryService("Private Box 102")).toBeNull()
+		expect(matchNzDeliveryService("Locked Bag 1797")).toBeNull() // AU-only designator
+	})
+
+	it("does not claim counter services with trailing identifiers or other strings", () => {
+		expect(matchNzDeliveryService("Counter Delivery 5")).toBeNull()
+		expect(matchNzDeliveryService("Wellington 6140")).toBeNull()
+		expect(matchNzDeliveryService(42)).toBeNull()
+	})
+})
+
+describe("normalizeNzDeliveryService", () => {
+	it("canonicalizes to the ADV358 form", () => {
+		expect(normalizeNzDeliveryService("p.o. box 24999")).toBe("PO Box 24999")
+		expect(normalizeNzDeliveryService("private bag 106999")).toBe("Private Bag 106999")
+		expect(normalizeNzDeliveryService("community mail box b99")).toBe("CMB B99")
+	})
+
+	it("round-trips: every normalized form still matches", () => {
+		for (const raw of ["PO Box 24999", "Private Bag", "CMB B99", "Counter Delivery", "Poste Restante"]) {
+			expect(isNzDeliveryService(normalizeNzDeliveryService(raw))).toBe(true)
+		}
+	})
+
+	it("passes through non-matches unchanged", () => {
+		expect(normalizeNzDeliveryService("PB 39990")).toBe("PB 39990")
+	})
+})

--- a/codex/nz/delivery-service.ts
+++ b/codex/nz/delivery-service.ts
@@ -3,24 +3,25 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   NZ Post delivery-service types — the second half of the Commonwealth po_box vocabulary:
- *   `PO Box 24999`, `Private Bag 106999`, `CMB B99`, plus the identifier-less counter services.
+ *   NZ Post delivery-service types — the second half of the Commonwealth po_box vocabulary: `PO Box
+ *   24999`, `Private Bag 106999`, `CMB B99`, plus the identifier-less counter services.
  *
  *   Sourcing (accessed 2026-06-11):
  *
  *   - NZ Post Address Standards (ADV358, October 2021 edition hosted on nzpost.co.nz) is the
- *       authoritative document. Verbatim: "The Delivery Service Type is mandatory. It may be PO Box,
- *       Private Bag, CMB, Response Bag, Counter Delivery or Poste Restante." Its Delivery Service
- *       Elements table gives the descriptions reproduced in {@link NZ_DELIVERY_SERVICE_TYPES}, and
- *       the identifier rules: "The Delivery Service Identifier must have no leading zeros and no
- *       spaces, separators or other punctuation"; "The Delivery Service Identifier is not used for
- *       Counter Delivery or Poste Restante. It is also not used for Private Bags that do not have an
- *       identifier allocated by New Zealand Post". Examples: `PO Box 24999`, `Private Bag 106999`,
- *       `Response Bag 500999`, `CMB B99`, `Counter Delivery`, `Poste Restante`. The standard's
- *       incorrect-form examples show `P O Box 4 099` and `PB 39990` as wrong — `PB` is a common
- *       error, not a designator, so it is NOT in this table.
- *   - The live addressing-standards page repeats the format rules: "PO Box and Private Bag numbers
- *       are space-free (eg. 'PO Box 23226', not 'PO Box 23 226')", "'PO' is space-free … and
+ *       authoritative document. Verbatim: "The Delivery Service Type is mandatory. It may be PO
+ *       Box, Private Bag, CMB, Response Bag, Counter Delivery or Poste Restante." Its Delivery
+ *       Service Elements table gives the descriptions reproduced in
+ *       {@link NZ_DELIVERY_SERVICE_TYPES}, and the identifier rules: "The Delivery Service
+ *       Identifier must have no leading zeros and no spaces, separators or other punctuation"; "The
+ *       Delivery Service Identifier is not used for Counter Delivery or Poste Restante. It is also
+ *       not used for Private Bags that do not have an identifier allocated by New Zealand Post".
+ *       Examples: `PO Box 24999`, `Private Bag 106999`, `Response Bag 500999`, `CMB B99`, `Counter
+ *       Delivery`, `Poste Restante`. The standard's incorrect-form examples show `P O Box 4 099`
+ *       and `PB 39990` as wrong — `PB` is a common error, not a designator, so it is NOT in this
+ *       table.
+ *   - The live addressing-standards page repeats the format rules: "PO Box and Private Bag numbers are
+ *       space-free (eg. 'PO Box 23226', not 'PO Box 23 226')", "'PO' is space-free … and
  *       punctuation-free".
  *
  *   All six types are CURRENT in the October 2021 ADV358 (including CMB — no legacy flag is needed
@@ -28,7 +29,6 @@
  *   gold rows carry — does NOT appear in ADV358 or the live standards pages and is therefore
  *   excluded here (see the issue #517 sourcing note: a smaller sourced list beats a larger guessed
  *   one).
- *
  * @see {@link https://www.nzpost.co.nz/sites/nz/files/2021-10/adv358-address-standards.pdf NZ Post Address Standards (ADV358, Oct 2021)}
  * @see {@link https://www.nzpost.co.nz/business/shipping-in-nz/addressing-standards NZ Post addressing standards}
  * @see {@link https://www.nzpost.co.nz/personal/sending-in-nz/how-to-address-mail NZ Post — how to address mail}
@@ -61,8 +61,16 @@ export const NZ_DELIVERY_SERVICE_TYPES = [
 		description: "Community Mail Box in postal outlet or on a thoroughfare",
 		identifier: "required-if-allocated",
 	},
-	{ type: "Counter Delivery", description: "Hold for Counter Delivery collection - domestic mail", identifier: "not-used" },
-	{ type: "Poste Restante", description: "Hold for Poste Restante collection - international mail", identifier: "not-used" },
+	{
+		type: "Counter Delivery",
+		description: "Hold for Counter Delivery collection - domestic mail",
+		identifier: "not-used",
+	},
+	{
+		type: "Poste Restante",
+		description: "Hold for Poste Restante collection - international mail",
+		identifier: "not-used",
+	},
 ] as const satisfies readonly NzDeliveryServiceType[]
 
 /** A canonical NZ Delivery Service Type. */
@@ -106,9 +114,9 @@ export interface NzDeliveryServiceMatch {
 }
 
 /**
- * If `input` is a standalone NZ delivery-service phrase ("PO Box 24999", "Private Bag 106999",
- * "CMB B99", bare "Private Bag", "Counter Delivery"), return the canonical type and identifier.
- * Null otherwise — including for "PB 39990" (an error of form per ADV358) and "Private Box" (not a
+ * If `input` is a standalone NZ delivery-service phrase ("PO Box 24999", "Private Bag 106999", "CMB
+ * B99", bare "Private Bag", "Counter Delivery"), return the canonical type and identifier. Null
+ * otherwise — including for "PB 39990" (an error of form per ADV358) and "Private Box" (not a
  * Delivery Service Type).
  */
 export function matchNzDeliveryService(input: unknown): NzDeliveryServiceMatch | null {
@@ -127,8 +135,8 @@ export function isNzDeliveryService(input: unknown): boolean {
 }
 
 /**
- * Normalize a recognized phrase to the ADV358 form (`"p.o. box 24999"` → `"PO Box 24999"`).
- * Returns the input unchanged if it isn't a delivery-service phrase.
+ * Normalize a recognized phrase to the ADV358 form (`"p.o. box 24999"` → `"PO Box 24999"`). Returns
+ * the input unchanged if it isn't a delivery-service phrase.
  */
 export function normalizeNzDeliveryService(input: string): string {
 	const m = matchNzDeliveryService(input)

--- a/codex/nz/delivery-service.ts
+++ b/codex/nz/delivery-service.ts
@@ -1,0 +1,137 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   NZ Post delivery-service types — the second half of the Commonwealth po_box vocabulary:
+ *   `PO Box 24999`, `Private Bag 106999`, `CMB B99`, plus the identifier-less counter services.
+ *
+ *   Sourcing (accessed 2026-06-11):
+ *
+ *   - NZ Post Address Standards (ADV358, October 2021 edition hosted on nzpost.co.nz) is the
+ *       authoritative document. Verbatim: "The Delivery Service Type is mandatory. It may be PO Box,
+ *       Private Bag, CMB, Response Bag, Counter Delivery or Poste Restante." Its Delivery Service
+ *       Elements table gives the descriptions reproduced in {@link NZ_DELIVERY_SERVICE_TYPES}, and
+ *       the identifier rules: "The Delivery Service Identifier must have no leading zeros and no
+ *       spaces, separators or other punctuation"; "The Delivery Service Identifier is not used for
+ *       Counter Delivery or Poste Restante. It is also not used for Private Bags that do not have an
+ *       identifier allocated by New Zealand Post". Examples: `PO Box 24999`, `Private Bag 106999`,
+ *       `Response Bag 500999`, `CMB B99`, `Counter Delivery`, `Poste Restante`. The standard's
+ *       incorrect-form examples show `P O Box 4 099` and `PB 39990` as wrong — `PB` is a common
+ *       error, not a designator, so it is NOT in this table.
+ *   - The live addressing-standards page repeats the format rules: "PO Box and Private Bag numbers
+ *       are space-free (eg. 'PO Box 23226', not 'PO Box 23 226')", "'PO' is space-free … and
+ *       punctuation-free".
+ *
+ *   All six types are CURRENT in the October 2021 ADV358 (including CMB — no legacy flag is needed
+ *   for the NZ slice). "Private Box" — a colloquial NZ synonym for a PO Box that the postal arena's
+ *   gold rows carry — does NOT appear in ADV358 or the live standards pages and is therefore
+ *   excluded here (see the issue #517 sourcing note: a smaller sourced list beats a larger guessed
+ *   one).
+ *
+ * @see {@link https://www.nzpost.co.nz/sites/nz/files/2021-10/adv358-address-standards.pdf NZ Post Address Standards (ADV358, Oct 2021)}
+ * @see {@link https://www.nzpost.co.nz/business/shipping-in-nz/addressing-standards NZ Post addressing standards}
+ * @see {@link https://www.nzpost.co.nz/personal/sending-in-nz/how-to-address-mail NZ Post — how to address mail}
+ */
+
+/** Identifier requirement per ADV358's Delivery Service Elements rules. */
+export type NzIdentifierRule = "required-if-allocated" | "optional" | "not-used"
+
+/** One Delivery Service Type row from ADV358. */
+export interface NzDeliveryServiceType {
+	/** The Delivery Service Type, verbatim casing per ADV358 ("PO Box", "Private Bag", "CMB"). */
+	type: string
+	/** The ADV358 description, verbatim. */
+	description: string
+	/**
+	 * Identifier rule: PO Box/Response Bag/CMB identifiers are mandatory if allocated; Private Bag
+	 * may legitimately have none ("not used … for Private Bags that do not have an identifier
+	 * allocated by New Zealand Post"); Counter Delivery and Poste Restante never carry one.
+	 */
+	identifier: NzIdentifierRule
+}
+
+/** The six Delivery Service Types, verbatim from ADV358 (see the module header). */
+export const NZ_DELIVERY_SERVICE_TYPES = [
+	{ type: "PO Box", description: "Post Box, PO Box", identifier: "required-if-allocated" },
+	{ type: "Private Bag", description: "Private Bag", identifier: "optional" },
+	{ type: "Response Bag", description: "Response Bag (used for competitions)", identifier: "required-if-allocated" },
+	{
+		type: "CMB",
+		description: "Community Mail Box in postal outlet or on a thoroughfare",
+		identifier: "required-if-allocated",
+	},
+	{ type: "Counter Delivery", description: "Hold for Counter Delivery collection - domestic mail", identifier: "not-used" },
+	{ type: "Poste Restante", description: "Hold for Poste Restante collection - international mail", identifier: "not-used" },
+] as const satisfies readonly NzDeliveryServiceType[]
+
+/** A canonical NZ Delivery Service Type. */
+export type NzDeliveryServiceTypeName = (typeof NZ_DELIVERY_SERVICE_TYPES)[number]["type"]
+
+/**
+ * Per-type surface patterns (designator phrase only). Recognition is deliberately wider than the
+ * prescriptive standard — mail in the wild writes "P.O. Box" even though ADV358 says `PO` is
+ * punctuation-free — but it does NOT admit forms the standard names as errors of TYPE (`PB`) or
+ * types that don't exist ("Private Box").
+ */
+const TYPE_PATTERNS: ReadonlyArray<readonly [NzDeliveryServiceTypeName, string]> = [
+	["PO Box", String.raw`p\.?\s*o\.?\s*box|post\s+box`],
+	["Private Bag", String.raw`private\s+bag`],
+	["Response Bag", String.raw`response\s+bag`],
+	["CMB", String.raw`community\s+mail\s+box|cmb`],
+	["Counter Delivery", String.raw`counter\s+delivery`],
+	["Poste Restante", String.raw`poste\s+restante`],
+]
+
+const IDENTIFIER_RULES = new Map<NzDeliveryServiceTypeName, NzIdentifierRule>(
+	NZ_DELIVERY_SERVICE_TYPES.map((t) => [t.type, t.identifier])
+)
+
+// One anchored regex per type. The identifier shape follows ADV358 (alphanumeric, no spaces or
+// separators — `24999`, `B99`); the identifier-less counter services take no tail at all.
+const MATCHERS: ReadonlyArray<{ type: NzDeliveryServiceTypeName; re: RegExp }> = TYPE_PATTERNS.map(([type, src]) => {
+	const rule = IDENTIFIER_RULES.get(type)!
+	const tail = rule === "not-used" ? "" : String.raw`(?:\s+([\dA-Za-z]+))${rule === "optional" ? "?" : ""}`
+	return { type, re: new RegExp(String.raw`^\s*(${src})${tail}\s*$`, "i") }
+})
+
+/** Result of an NZ delivery-service parse. */
+export interface NzDeliveryServiceMatch {
+	/** The designator phrase as it appeared ("PO Box", "private bag"). */
+	matched: string
+	/** The canonical Delivery Service Type ("PO Box", "Private Bag", "CMB", …). */
+	type: NzDeliveryServiceTypeName
+	/** The Delivery Service Identifier when present ("24999", "B99"). */
+	id?: string
+}
+
+/**
+ * If `input` is a standalone NZ delivery-service phrase ("PO Box 24999", "Private Bag 106999",
+ * "CMB B99", bare "Private Bag", "Counter Delivery"), return the canonical type and identifier.
+ * Null otherwise — including for "PB 39990" (an error of form per ADV358) and "Private Box" (not a
+ * Delivery Service Type).
+ */
+export function matchNzDeliveryService(input: unknown): NzDeliveryServiceMatch | null {
+	if (typeof input !== "string") return null
+	for (const { type, re } of MATCHERS) {
+		const m = re.exec(input)
+		if (!m) continue
+		return { matched: m[1]!.trim(), type, ...(m[2] ? { id: m[2] } : {}) }
+	}
+	return null
+}
+
+/** Type-predicate: does the input look like a standalone NZ delivery-service address line? */
+export function isNzDeliveryService(input: unknown): boolean {
+	return matchNzDeliveryService(input) !== null
+}
+
+/**
+ * Normalize a recognized phrase to the ADV358 form (`"p.o. box 24999"` → `"PO Box 24999"`).
+ * Returns the input unchanged if it isn't a delivery-service phrase.
+ */
+export function normalizeNzDeliveryService(input: string): string {
+	const m = matchNzDeliveryService(input)
+	if (!m) return input
+	return m.id ? `${m.type} ${m.id.toUpperCase()}` : m.type
+}

--- a/codex/nz/index.ts
+++ b/codex/nz/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The New Zealand address system (NZ Post / ISO 3166-2:NZ; ADV358 Address Standards):
+ *   delivery-service types (PO Box, Private Bag, CMB, Response Bag, Counter Delivery, Poste
+ *   Restante) and the 4-digit postcode. NZ addresses carry no state/region line.
+ */
+
+export * from "./delivery-service.js"
+export * from "./postcode.js"

--- a/codex/nz/postcode.ts
+++ b/codex/nz/postcode.ts
@@ -1,0 +1,42 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   New Zealand postcodes: four digits, after the town/city on the last line (`Timaru 7942`).
+ *   Verbatim from NZ Post's Address Standards (ADV358, Oct 2021, accessed 2026-06-11): "Postcode is
+ *   mandatory and is four digits. It follows the city or town." Note NZ has no state/region line —
+ *   "The province, region, district or territory is not to be used."
+ *
+ *   The shape collides with Australia's (also 4 digits) — `candidateSystemsForPostcode` returns
+ *   both, by design (shape test, not membership test).
+ *
+ * @see {@link https://www.nzpost.co.nz/sites/nz/files/2021-10/adv358-address-standards.pdf NZ Post Address Standards (ADV358, Oct 2021)}
+ */
+
+import type { Tagged } from "type-fest"
+
+/**
+ * A New Zealand postcode: four digits.
+ *
+ * @category Postal
+ * @type string
+ * @title New Zealand postcode
+ * @pattern ^\d{4}$
+ */
+export type NzPostcode = Tagged<string, "NzPostcode">
+
+/** The NZ postcode shape: exactly four digits. */
+export const NZ_POSTCODE_PATTERN = /^\d{4}$/
+
+/** Normalize a postcode surface form (trim only — NZ has no country-prefix courtesy form). */
+export function normalizeNzPostcode(raw: unknown): NzPostcode | null {
+	if (typeof raw !== "string") return null
+	const s = raw.trim()
+	return NZ_POSTCODE_PATTERN.test(s) ? (s as NzPostcode) : null
+}
+
+/** Type-predicate for a (normalized) New Zealand postcode. */
+export function isNzPostcode(input: unknown): input is NzPostcode {
+	return typeof input === "string" && NZ_POSTCODE_PATTERN.test(input)
+}

--- a/codex/nz/postcode.ts
+++ b/codex/nz/postcode.ts
@@ -8,9 +8,8 @@
  *   mandatory and is four digits. It follows the city or town." Note NZ has no state/region line —
  *   "The province, region, district or territory is not to be used."
  *
- *   The shape collides with Australia's (also 4 digits) — `candidateSystemsForPostcode` returns
- *   both, by design (shape test, not membership test).
- *
+ *   The shape collides with Australia's (also 4 digits) — `candidateSystemsForPostcode` returns both,
+ *   by design (shape test, not membership test).
  * @see {@link https://www.nzpost.co.nz/sites/nz/files/2021-10/adv358-address-standards.pdf NZ Post Address Standards (ADV358, Oct 2021)}
  */
 

--- a/codex/package.json
+++ b/codex/package.json
@@ -18,7 +18,9 @@
 		"./fr": "./out/fr/index.js",
 		"./ca": "./out/ca/index.js",
 		"./gb": "./out/gb/index.js",
-		"./jp": "./out/jp/index.js"
+		"./jp": "./out/jp/index.js",
+		"./au": "./out/au/index.js",
+		"./nz": "./out/nz/index.js"
 	},
 	"dependencies": {
 		"type-fest": "^5.7.0"

--- a/codex/postcode-systems.test.ts
+++ b/codex/postcode-systems.test.ts
@@ -35,6 +35,11 @@ describe("candidateSystemsForPostcode", () => {
 		expect(candidateSystemsForPostcode("100-0001")).toEqual(["jp"])
 	})
 
+	it("a bare 4-digit code is eligible for both Australasian systems (shape can't split them)", () => {
+		expect(candidateSystemsForPostcode("2000").sort()).toEqual(["au", "nz"])
+		expect(candidateSystemsForPostcode("7942").sort()).toEqual(["au", "nz"])
+	})
+
 	it("returns empty for a shape no system recognizes", () => {
 		expect(candidateSystemsForPostcode("27")).toEqual([])
 		expect(candidateSystemsForPostcode("123456789")).toEqual([])

--- a/codex/postcode-systems.ts
+++ b/codex/postcode-systems.ts
@@ -21,15 +21,17 @@
  *   for".
  */
 
+import { normalizeAuPostcode } from "./au/index.js"
 import { normalizeCaPostalCode } from "./ca/index.js"
 import { normalizePLZ } from "./de/index.js"
 import { normalizeCodePostal } from "./fr/index.js"
 import { normalizeUkPostcode } from "./gb/index.js"
 import { normalizeJpPostalCode } from "./jp/index.js"
+import { normalizeNzPostcode } from "./nz/index.js"
 import { isZipCode } from "./us/index.js"
 
 /** A codex address-system code — the subpath under `@mailwoman/codex/<system>`. */
-export type SystemCode = "us" | "de" | "fr" | "ca" | "gb" | "jp"
+export type SystemCode = "us" | "de" | "fr" | "ca" | "gb" | "jp" | "au" | "nz"
 
 /**
  * Per-system membership test: each entry returns true when the string is accepted by that system's
@@ -44,6 +46,8 @@ const SYSTEM_ACCEPTS: ReadonlyArray<readonly [SystemCode, (s: string) => boolean
 	["ca", (s) => normalizeCaPostalCode(s) !== null],
 	["gb", (s) => normalizeUkPostcode(s) !== null],
 	["jp", (s) => normalizeJpPostalCode(s) !== null],
+	["au", (s) => normalizeAuPostcode(s) !== null],
+	["nz", (s) => normalizeNzPostcode(s) !== null],
 ]
 
 /**

--- a/scripts/build-po-box-cedex-shard.mjs
+++ b/scripts/build-po-box-cedex-shard.mjs
@@ -36,14 +36,28 @@
  *       G/H/J postcodes — covers both the golden order ("CP 1500, H2X 3V4 Montréal, QC") and the
  *       Canada-Post-native order ("CP 1500, Montréal QC H2X 3V4").
  *   - Po-box-ca-en: the en-CA mirror (Ontario localities, K/L/M/N/P postcodes).
+ *   - Po-box-au (#517): the Commonwealth designators from `@mailwoman/codex/au` — current (GPO Box / PO
+ *       Box / Locked Bag / Private Bag, per the live auspost.com.au addressing pages) at full
+ *       weight, AMAS-legacy rural forms (RMB / RSD / CMB) at low weight — on real GeoNames AU
+ *       postal-dump (CC-BY 4.0) locality/state/postcode tails. Last line follows the Australia Post
+ *       guideline ("locality or suburb, state and postcode … in capital letters"): "SYDNEY NSW
+ *       2001".
+ *   - Po-box-nz (#517): the `@mailwoman/codex/nz` ADV358 types (PO Box / Private Bag, plus CMB at low
+ *       weight) on real GeoNames NZ postal-dump tails. NZ has NO region line (ADV358: "The
+ *       province, region, district or territory is not to be used"): "PO Box 23226, Wellington
+ *       6011". "Private Box" is deliberately ABSENT — neither Australia Post nor NZ Post recognizes
+ *       it (AP: "'PRIVATE BOX' is not a valid type"); see the codex slice headers.
  *
  *   LEAKAGE-SAFE EVAL (`--golden`): US rows use the VERMONT source only (the corpus defaultHoldout);
  *   FR and CA rows use a stable locality-hash holdout (hash%10==0 is golden-only, train gets the
  *   rest) and a different seed. Golden mode emits {raw, components, country} for per-locale-f1.
  *
- *   Prerequisites: the cached OA zips in /tmp/oa-cache (same set the unit/affix builders read) and
- *   the GeoNames Canada dump at /tmp/geonames-cache/CA.zip (curl -o /tmp/geonames-cache/CA.zip
- *   https://download.geonames.org/export/dump/CA.zip).
+ *   Prerequisites: the cached OA zips in /tmp/oa-cache (same set the unit/affix builders read), the
+ *   GeoNames Canada dump at /tmp/geonames-cache/CA.zip (curl -o /tmp/geonames-cache/CA.zip
+ *   https://download.geonames.org/export/dump/CA.zip), and the GeoNames POSTAL-CODE dumps for AU/NZ
+ *   (curl -o /tmp/geonames-cache/AU-postal.zip https://download.geonames.org/export/zip/AU.zip and
+ *   …/NZ-postal.zip from …/zip/NZ.zip) — these carry real (postcode, locality, state) triples, so
+ *   the AU last line gets a real state↔postcode pairing instead of a synthesized guess.
  *
  *   Pipeline (mirrors build-street-affix-shard.mjs): node scripts/build-po-box-cedex-shard.mjs
  *   --output /tmp/po-box-shard/po-box-cedex-train.jsonl --count 50000 --seed 42 node
@@ -56,8 +70,10 @@
 import { spawnSync } from "node:child_process"
 import { createWriteStream } from "node:fs"
 
+import { isAuDeliveryService, isAuPostcode, isAuStateAbbreviation } from "@mailwoman/codex/au"
 import { FSA_LETTER_TO_PROVINCE, normalizeCaPostalCode } from "@mailwoman/codex/ca"
 import { isCedex } from "@mailwoman/codex/fr"
+import { isNzDeliveryService, isNzPostcode } from "@mailwoman/codex/nz"
 import { isPOBox } from "@mailwoman/codex/us"
 import { alignRow, maybeNoisifyBoxNumber, PO_BOX_LOCALE_TEMPLATES, stableSourceId } from "@mailwoman/corpus"
 
@@ -77,6 +93,8 @@ const US_TRAIN_SOURCES = [
 const US_EVAL_SOURCE = { zip: "/tmp/oa-cache/us__vt__statewide.zip", csv: "us/vt/statewide.csv", region: "VT" }
 const FR_SOURCE = { zip: "/tmp/oa-cache/fr__countrywide.zip", csv: "fr/countrywide.csv" }
 const GEONAMES_CA = "/tmp/geonames-cache/CA.zip"
+const GEONAMES_POSTAL_AU = { zip: "/tmp/geonames-cache/AU-postal.zip", txt: "AU.txt" }
+const GEONAMES_POSTAL_NZ = { zip: "/tmp/geonames-cache/NZ-postal.zip", txt: "NZ.txt" }
 
 // ── Surface vocabulary (codex + corpus templates — see the header) ──────────────────────────────
 const T = Object.fromEntries(PO_BOX_LOCALE_TEMPLATES.map((t) => [t.locale, t]))
@@ -93,6 +111,17 @@ const US_PMB_LEADERS = T["en-US"].pmb.filter((l) => l !== "#") // PMB
 const FR_LEADERS = T["fr-FR"].leaders // BP, B.P., Boîte Postale, BP.
 const CA_FR_LEADERS = T["fr-CA"].leaders // CP, C.P., Case Postale, BP, B.P.
 const CA_EN_LEADERS = T["en-CA"].leaders // PO Box, P.O. Box, POB, Post Office Box
+// AU (#517): codex/au is the vocabulary truth. Current designators (live auspost.com.au pages) at
+// full weight; the AMAS-legacy rural/community tail rides at the same 10% rare-dial as the US
+// Caller/Drawer tail. Surfaces are the canonical display forms of the codex table — every emitted
+// phrase must round-trip the codex matcher (asserted in makeAuNzPoBoxPhrase).
+const AU_LEADERS_CURRENT = ["PO Box", "P.O. Box", "Post Office Box", "GPO Box", "Locked Bag", "Private Bag"]
+const AU_LEADERS_LEGACY = ["RMB", "RSD", "CMB"] // codex legacy: true (recognize-only forms)
+// NZ (#517): the ADV358 box/bag types that carry an identifier. CMB rides rare (its "CMB B99"
+// identifier shape is alpha-led, covered by pickNzCmbId below). Counter Delivery / Poste Restante
+// are identifier-less counter services — no number to learn, excluded from synthesis.
+const NZ_LEADERS_COMMON = ["PO Box", "Private Bag"]
+const NZ_LEADERS_RARE = ["CMB"]
 
 // Canadian postcode synthesis: valid first letters per province from the codex FSA prior, interior
 // letters per the codex pattern (excludes the visually ambiguous D F I O Q U). The LDU digits are
@@ -108,12 +137,14 @@ const CA_INTERIOR_LETTERS = "ABCEGHJKLMNPRSTVWXYZ"
 // Class mix — po_box mass leans US (the production arena), cedex gets a real block, and the CA-fr
 // class exists because the #511 Montréal rows ("Case Postale 200, H3A 1B9 Montréal, QC") fail today.
 const CLASS_MIX = [
-	["po-box-us", 0.4],
-	["pmb-us", 0.08],
-	["bp-fr", 0.12],
-	["cedex-fr", 0.2],
-	["cp-ca-fr", 0.15],
-	["po-box-ca-en", 0.05],
+	["po-box-us", 0.32],
+	["pmb-us", 0.07],
+	["bp-fr", 0.1],
+	["cedex-fr", 0.17],
+	["cp-ca-fr", 0.12],
+	["po-box-ca-en", 0.04],
+	["po-box-au", 0.12],
+	["po-box-nz", 0.06],
 ]
 
 /** Synthetic recipient/venue prefixes — the arena's "JOHN DOE, ACME INC, …" pattern. */
@@ -282,6 +313,38 @@ function readCaLocalities(admin1) {
 	return [...new Set(r.stdout.split("\n").filter(cleanLocality))]
 }
 
+/**
+ * Real (locality, state?, postcode) tuples from a GeoNames postal-code dump (CC-BY 4.0). Tab
+ * format: country, postal_code, place_name, admin1_name, admin1_code, … — for AU the admin1_code IS
+ * the postal state abbreviation (NSW/VIC/…), validated against the codex table; NZ has no region
+ * line so the state column is ignored. Postcodes are validated against the codex 4-digit shape — a
+ * dump row that fails the contract is skipped, not emitted as a junk label.
+ */
+function readPostalTuples(source, { withState }) {
+	const r = spawnSync("unzip", ["-p", source.zip, source.txt], { maxBuffer: 1024 * 1024 * 64, encoding: "utf8" })
+	if (r.status !== 0) {
+		console.error(`  WARN: unzip failed for ${source.zip} (status ${r.status})`)
+		return []
+	}
+	const tuples = []
+	const seen = new Set()
+	const validPostcode = withState ? isAuPostcode : isNzPostcode
+	for (const line of r.stdout.split("\n")) {
+		if (!line) continue
+		const cols = line.split("\t")
+		const postcode = (cols[1] ?? "").trim()
+		const locality = (cols[2] ?? "").trim()
+		const region = (cols[4] ?? "").trim()
+		if (!cleanLocality(locality) || !validPostcode(postcode)) continue
+		if (withState && !isAuStateAbbreviation(region)) continue
+		const key = `${locality}|${postcode}`.toLowerCase()
+		if (seen.has(key)) continue
+		seen.add(key)
+		tuples.push(withState ? { locality, region, postcode } : { locality, postcode })
+	}
+	return tuples
+}
+
 // ── Rendering helpers ────────────────────────────────────────────────────────────────────────────
 
 /** Box-number distribution (mirrors the corpus defaultPickNumber bands: 70% are 1-3 digits). */
@@ -322,8 +385,10 @@ function makePoBoxPhrase(random, leaders, rareLeaders) {
 	return phrase
 }
 
-/** A CEDEX designation: "CEDEX 08" / "Cedex 8" / bare "CEDEX". Shape contract = codex fr/cedex
- * (the slice PR #516's gap note asked for) — every emitted phrase must satisfy isCedex, loud. */
+/**
+ * A CEDEX designation: "CEDEX 08" / "Cedex 8" / bare "CEDEX". Shape contract = codex fr/cedex (the
+ * slice PR #516's gap note asked for) — every emitted phrase must satisfy isCedex, loud.
+ */
 function makeCedex(random) {
 	const r = random()
 	const word = r < 0.6 ? "CEDEX" : r < 0.9 ? "Cedex" : "cedex"
@@ -334,6 +399,28 @@ function makeCedex(random) {
 		return `${word} ${id}`
 	})()
 	if (!isCedex(phrase)) throw new Error(`makeCedex emitted a phrase the codex matcher rejects: "${phrase}"`)
+	return phrase
+}
+
+/**
+ * Compose an AU or NZ delivery-service phrase from the codex-sourced leaders. Same contract as
+ * makePoBoxPhrase: a phrase built from a codex-known designator and a clean id must round-trip the
+ * codex matcher (isAuDeliveryService / isNzDeliveryService) — a failure is a generation bug, loud.
+ * Noisy ids (commas / embedded spaces) are corpus-designed adversarial forms, exempt.
+ */
+function makeAuNzPoBoxPhrase(random, leaders, rareLeaders, validate) {
+	let leader = leaders[Math.floor(random() * leaders.length)]
+	if (rareLeaders && random() < 0.1) leader = rareLeaders[Math.floor(random() * rareLeaders.length)]
+	let num = maybeNoisifyBoxNumber(pickBoxNumber(random), random)
+	// NZ CMB identifiers are alpha-led per the ADV358 example ("CMB B99").
+	if (leader === "CMB" && validate === isNzDeliveryService) num = `B${num}`
+	const phrase = `${caseDial(random, leader)} ${num}`
+	// The "clean id" shape differs per system: ADV358 identifiers carry no separators at all, the
+	// AU AMAS id (like the US one) tolerates dashes. Noisy ids outside the clean shape are exempt.
+	const cleanId = validate === isNzDeliveryService ? /^[\dA-Za-z]+$/ : /^[\dA-Za-z][\dA-Za-z-]*$/
+	if (cleanId.test(num) && !validate(phrase)) {
+		throw new Error(`generated a phrase the codex matcher rejects: "${phrase}"`)
+	}
 	return phrase
 }
 
@@ -461,6 +548,47 @@ function renderCaEn(random, loc) {
 	return { fmt: "ca-en-bare", raw: phrase, components: { po_box: phrase } }
 }
 
+function renderAuPoBox(random, t) {
+	const phrase = makeAuNzPoBoxPhrase(random, AU_LEADERS_CURRENT, AU_LEADERS_LEGACY, isAuDeliveryService)
+	const { locality, region: reg, postcode: pc } = t
+	const r = random()
+	// The guideline last line is capitals ("SYDNEY NSW 2000"); mixed case rides as a softer variant.
+	const loc = r < 0.6 ? locality.toUpperCase() : locality
+	const base = { po_box: phrase, locality: loc, region: reg, postcode: pc }
+	if (r < 0.45) return { fmt: "au-standard", raw: `${phrase}, ${loc} ${reg} ${pc}`, components: base }
+	if (r < 0.6) {
+		// The envelope label form: comma-less, designator upper-cased ("GPO BOX 123 SYDNEY NSW 2001").
+		const up = phrase.toUpperCase()
+		return {
+			fmt: "au-label-nocomma",
+			raw: `${up} ${locality.toUpperCase()} ${reg} ${pc}`,
+			components: { po_box: up, locality: locality.toUpperCase(), region: reg, postcode: pc },
+		}
+	}
+	if (r < 0.75)
+		return {
+			fmt: "au-no-postcode",
+			raw: `${phrase}, ${loc} ${reg}`,
+			components: { po_box: phrase, locality: loc, region: reg },
+		}
+	if (r < 0.88) return { fmt: "au-bare", raw: phrase, components: { po_box: phrase } }
+	const v = pick(random, VENUES_EN)
+	return { fmt: "au-venue", raw: `${v}, ${phrase}, ${loc} ${reg} ${pc}`, components: { venue: v, ...base } }
+}
+
+function renderNzPoBox(random, t) {
+	const phrase = makeAuNzPoBoxPhrase(random, NZ_LEADERS_COMMON, NZ_LEADERS_RARE, isNzDeliveryService)
+	const { locality, postcode: pc } = t
+	// NZ addresses are written mixed-case ("PO Box 4099, Timaru 7942") — no region line (ADV358).
+	const base = { po_box: phrase, locality, postcode: pc }
+	const r = random()
+	if (r < 0.55) return { fmt: "nz-standard", raw: `${phrase}, ${locality} ${pc}`, components: base }
+	if (r < 0.7) return { fmt: "nz-no-postcode", raw: `${phrase}, ${locality}`, components: { po_box: phrase, locality } }
+	if (r < 0.85) return { fmt: "nz-bare", raw: phrase, components: { po_box: phrase } }
+	const v = pick(random, VENUES_EN)
+	return { fmt: "nz-venue", raw: `${v}, ${phrase}, ${locality} ${pc}`, components: { venue: v, ...base } }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -495,8 +623,23 @@ async function main() {
 	const qcPool = qcAll.filter((l) => isHoldoutLocality(l) === opts.golden)
 	const onPool = onAll.filter((l) => isHoldoutLocality(l) === opts.golden)
 	console.error(`  GeoNames CA: QC ${qcAll.length}→${qcPool.length}, ON ${onAll.length}→${onPool.length}`)
-	if (usPool.length === 0 || frPool.length === 0 || qcPool.length === 0 || onPool.length === 0) {
-		console.error("A base pool is empty — check /tmp/oa-cache and /tmp/geonames-cache/CA.zip.")
+	// AU/NZ pools: same stable locality-hash holdout as FR/CA.
+	const auAll = readPostalTuples(GEONAMES_POSTAL_AU, { withState: true })
+	const nzAll = readPostalTuples(GEONAMES_POSTAL_NZ, { withState: false })
+	const auPool = auAll.filter((t) => isHoldoutLocality(t.locality) === opts.golden)
+	const nzPool = nzAll.filter((t) => isHoldoutLocality(t.locality) === opts.golden)
+	console.error(`  GeoNames postal: AU ${auAll.length}→${auPool.length}, NZ ${nzAll.length}→${nzPool.length}`)
+	if (
+		usPool.length === 0 ||
+		frPool.length === 0 ||
+		qcPool.length === 0 ||
+		onPool.length === 0 ||
+		auPool.length === 0 ||
+		nzPool.length === 0
+	) {
+		console.error(
+			"A base pool is empty — check /tmp/oa-cache and /tmp/geonames-cache (CA.zip, AU-postal.zip, NZ-postal.zip)."
+		)
 		process.exit(1)
 	}
 
@@ -541,6 +684,14 @@ async function main() {
 			rendered = renderCaFr(random, pick(random, qcPool))
 			country = "CA"
 			locale = "fr-CA"
+		} else if (cls === "po-box-au") {
+			rendered = renderAuPoBox(random, pick(random, auPool))
+			country = "AU"
+			locale = "en-AU"
+		} else if (cls === "po-box-nz") {
+			rendered = renderNzPoBox(random, pick(random, nzPool))
+			country = "NZ"
+			locale = "en-NZ"
 		} else {
 			rendered = renderCaEn(random, pick(random, onPool))
 			country = "CA"
@@ -577,7 +728,11 @@ async function main() {
 					? "GeoNames CA (CC-BY 4.0) locality skeletons + Canada Post box forms (corpus templates); postcodes synthesized to the codex CA pattern"
 					: country === "FR"
 						? "OpenAddresses FR (BAN-derived) skeletons + La Poste BP/CEDEX forms (corpus templates, NF Z 10-011)"
-						: "OpenAddresses US (non-VT) skeletons + USPS Pub-28 §29 PO-box designators (codex/corpus templates)",
+						: country === "AU"
+							? "GeoNames AU postal dump (CC-BY 4.0) locality/state/postcode tails + Australia Post Postal Delivery Type designators (@mailwoman/codex/au)"
+							: country === "NZ"
+								? "GeoNames NZ postal dump (CC-BY 4.0) locality/postcode tails + NZ Post ADV358 Delivery Service Types (@mailwoman/codex/nz)"
+								: "OpenAddresses US (non-VT) skeletons + USPS Pub-28 §29 PO-box designators (codex/corpus templates)",
 		}
 		const aligned = alignRow(canonical)
 		if (aligned.kind !== "labeled" || !aligned.row) {


### PR DESCRIPTION
The Commonwealth po_box vocabulary, established from the official sources (verbatim-quoted in module headers, access-dated): Australia Post's barcode-addressing Postal Delivery Type table (14 designators — 4 current, 8 flagged `legacy: true`, recognized-not-promoted) and NZ Post's ADV358 Address Standards (6 current designators, CMB currency verified). **'Private Box' excluded with citation** — Australia Post names it invalid, which also flags the postal arena's gold as unsourced for those rows (open question on the issue).

Also: AU 4-digit postcode + ISO state table, NZ postcode, both in `candidateSystemsForPostcode`; the shard builder gains po-box-au/nz classes on GeoNames postal tails with loud codex round-trips. 23 new tests, codex suite 166/166, 500-row smoke build 0-skipped with verified BIO spans.

Open questions recorded on #517: Private Box arena-gold disposition, the NZ box-lobby suburb-line schema mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)