### PR TITLE
feat(corpus): v0.5.0 format core — char spans beside tokens, NFC assertion, invariance gates (#519 slice 1)

### DIFF
--- a/corpus-python/src/mailwoman_train/test_span_labels.py
+++ b/corpus-python/src/mailwoman_train/test_span_labels.py
@@ -1,0 +1,257 @@
+"""Invariance gates for the v0.5.0 char-offset label format (#519 — the consult keepers, as tests).
+
+Three gates, pre-registered in the design doc (2026-06-11-char-offset-labels-design.md, blast-radius
+items 6 + 8, plus the positive case the migration exists for):
+
+(a) **Label-stream bit-identity** — on rows WITHOUT intra-span punctuation, the spans-based
+    piece-label stream must be BIT-IDENTICAL to the token-based one. Fixtures: plain US row,
+    accented FR row (NFC ``é``), multi-span DE row, all-O row.
+(b) **Channel invariance** — the anchor channel (``realign_anchor_to_pieces`` vs the spans
+    sibling) and the gazetteer painting must produce IDENTICAL tensors under both paths on those
+    fixtures (the per-piece channels key off the same substrate the migration touches).
+(c) **The punctuation win** — a row WITH intra-span punctuation ("P.O. Box 19", one po_box span
+    over chars [0, 11)) must produce the punctuation-covering label stream the token path
+    structurally cannot: continuous B/I over the period pieces instead of O-fragmented.
+
+Uses mock ``PieceSpan``s (explicit char offsets, the ``test_anchor_alignment`` pattern) so no
+SentencePiece model is needed — torch-free, runnable locally and via the Modal ``run_tests``
+entrypoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mailwoman_train.gazetteer_anchor import GazetteerLexicon, realign_gazetteer_to_pieces
+from mailwoman_train.tokenizer import (
+    PieceSpan,
+    char_label_array_from_spans,
+    encode_row,
+    realign_anchor_to_pieces,
+    realign_anchor_to_pieces_from_spans,
+    realign_labels_to_pieces,
+    realign_spans_to_pieces,
+)
+
+
+def _pieces(raw: str, chunks: list[str]) -> list[PieceSpan]:
+    """Build mock PieceSpans by locating each chunk left-to-right in ``raw``."""
+    out: list[PieceSpan] = []
+    cursor = 0
+    for chunk in chunks:
+        idx = raw.index(chunk, cursor)
+        out.append(PieceSpan(piece=chunk, piece_id=hash(chunk) % 1000 + 3, char_begin=idx, char_end=idx + len(chunk)))
+        cursor = idx + len(chunk)
+    return out
+
+
+class FakeTokenizer:
+    """Duck-typed stand-in for ``Tokenizer``: fixed pieces, pad_id 0."""
+
+    pad_id = 0
+
+    def __init__(self, pieces: list[PieceSpan]) -> None:
+        self._pieces = pieces
+
+    def encode_with_spans(self, raw: str) -> list[PieceSpan]:
+        return list(self._pieces)
+
+
+# --- Fixtures: rows WITHOUT intra-span punctuation, in both label representations -----------
+# Each: (name, raw, tokens, labels, span_starts, span_ends, span_tags, piece_chunks).
+# Piece chunks deliberately split inside words (Pennsylv|ania, Républi|que, Ber|lin) to exercise
+# the B→I flip, and give separator commas their own piece to pin the "comma outside both spans"
+# behavior on BOTH paths.
+FIXTURES = [
+    (
+        "plain-us",
+        "1600 Pennsylvania Ave NW, Washington, DC 20500",
+        ["1600", "Pennsylvania", "Ave", "NW", "Washington", "DC", "20500"],
+        ["B-house_number", "B-street", "I-street", "I-street", "B-locality", "B-region", "B-postcode"],
+        [0, 5, 26, 38, 41],
+        [4, 24, 36, 40, 46],
+        ["house_number", "street", "locality", "region", "postcode"],
+        ["1600", "Pennsylv", "ania", "Ave", "NW", ",", "Washington", ",", "DC", "20500"],
+    ),
+    (
+        "accented-fr",  # NFC é — one code unit; offsets address the composed form.
+        "10 Rue de la République, 75008 Paris",
+        ["10", "Rue", "de", "la", "République", "75008", "Paris"],
+        ["B-house_number", "B-street", "I-street", "I-street", "I-street", "B-postcode", "B-locality"],
+        [0, 3, 25, 31],
+        [2, 23, 30, 36],
+        ["house_number", "street", "postcode", "locality"],
+        ["10", "Rue", "de", "la", "Républi", "que", ",", "75008", "Paris"],
+    ),
+    (
+        "multi-span-de",
+        "Strasse 12 10115 Berlin",
+        ["Strasse", "12", "10115", "Berlin"],
+        ["B-street", "B-house_number", "B-postcode", "B-locality"],
+        [0, 8, 11, 17],
+        [7, 10, 16, 23],
+        ["street", "house_number", "postcode", "locality"],
+        ["Strasse", "12", "101", "15", "Ber", "lin"],
+    ),
+    (
+        "all-o",
+        "hello unlabeled world",
+        ["hello", "unlabeled", "world"],
+        ["O", "O", "O"],
+        [],
+        [],
+        [],
+        ["hello", "unlab", "eled", "world"],
+    ),
+]
+
+ANCHOR_LOOKUP = {
+    "10115": ({"DE": 1.0}, 52.53, 13.40),
+    "20500": ({"US": 1.0}, 38.90, -77.04),
+    "75008": ({"FR": 1.0}, 48.87, 2.32),
+}
+
+# Tiny in-memory lexicon: enough surface hits (DC code, Berlin/Paris/Washington names) to make the
+# gazetteer tensors non-trivial on the fixtures.
+LEXICON = GazetteerLexicon(
+    feature_dim=2,
+    slots=("region", "locality_homograph"),
+    bits={"region": 1, "locality_homograph": 2},
+    max_ngram=2,
+    entries={"berlin": 2, "paris": 2, "washington": 2},
+    code_entries={"DC": 1},
+)
+
+
+def _fixture_sanity(raw, tokens, labels, span_starts, span_ends, span_tags):
+    """The two representations must describe the same row before identity means anything."""
+    assert len(tokens) == len(labels)
+    assert len(span_starts) == len(span_ends) == len(span_tags)
+    for start, end in zip(span_starts, span_ends):
+        assert 0 <= start < end <= len(raw)
+
+
+# --- Gate (a): label-stream bit-identity on punctuation-free rows ---------------------------
+
+
+@pytest.mark.parametrize("name,raw,tokens,labels,starts,ends,tags,chunks", FIXTURES)
+def test_gate_a_label_stream_bit_identical(name, raw, tokens, labels, starts, ends, tags, chunks):
+    _fixture_sanity(raw, tokens, labels, starts, ends, tags)
+    pieces = _pieces(raw, chunks)
+    token_stream = realign_labels_to_pieces(raw, tokens, labels, pieces)
+    span_stream = realign_spans_to_pieces(raw, starts, ends, tags, pieces)
+    assert span_stream == token_stream, f"{name}: spans-based stream diverged from token-based"
+
+
+@pytest.mark.parametrize("name,raw,tokens,labels,starts,ends,tags,chunks", FIXTURES)
+def test_gate_a_encode_row_bit_identical(name, raw, tokens, labels, starts, ends, tags, chunks):
+    """Full encode_row output (ids + mask + label ids, padded) identical under both paths."""
+    tok = FakeTokenizer(_pieces(raw, chunks))
+    via_tokens = encode_row(tok, raw, tokens, labels, max_length=32)
+    via_spans = encode_row(tok, raw, tokens, labels, max_length=32, span_starts=starts, span_ends=ends, span_tags=tags)
+    assert via_spans == via_tokens, f"{name}: encode_row outputs diverged"
+
+
+# --- Gate (b): anchor + gazetteer channel invariance ----------------------------------------
+
+
+@pytest.mark.parametrize("name,raw,tokens,labels,starts,ends,tags,chunks", FIXTURES)
+def test_gate_b_anchor_channel_identical(name, raw, tokens, labels, starts, ends, tags, chunks):
+    pieces = _pieces(raw, chunks)
+    feats_tok, confs_tok = realign_anchor_to_pieces(raw, tokens, labels, pieces, ANCHOR_LOOKUP)
+    feats_spn, confs_spn = realign_anchor_to_pieces_from_spans(raw, starts, ends, tags, pieces, ANCHOR_LOOKUP)
+    assert confs_spn == confs_tok, f"{name}: anchor confidence diverged"
+    assert feats_spn == feats_tok, f"{name}: anchor features diverged"
+    if "postcode" in tags:
+        assert any(c > 0 for c in confs_spn), f"{name}: anchor never fired — vacuous gate"
+
+
+@pytest.mark.parametrize("name,raw,tokens,labels,starts,ends,tags,chunks", FIXTURES)
+def test_gate_b_channels_identical_through_encode_row(name, raw, tokens, labels, starts, ends, tags, chunks):
+    """Anchor + gazetteer tensors identical through the full encode_row, both label sources."""
+    tok = FakeTokenizer(_pieces(raw, chunks))
+    kwargs = dict(max_length=32, anchor_lookup=ANCHOR_LOOKUP, gazetteer_lexicon=LEXICON)
+    via_tokens = encode_row(tok, raw, tokens, labels, **kwargs)
+    via_spans = encode_row(
+        tok, raw, tokens, labels, span_starts=starts, span_ends=ends, span_tags=tags, **kwargs
+    )
+    for key in ("anchor_features", "anchor_confidence", "gazetteer_features", "gazetteer_confidence"):
+        assert via_spans[key] == via_tokens[key], f"{name}: {key} diverged"
+
+
+def test_gate_b_gazetteer_painting_fires_on_fixtures():
+    """Anti-vacuity: the gazetteer clue actually lights up on at least one fixture piece."""
+    raw = "Strasse 12 10115 Berlin"
+    pieces = _pieces(raw, ["Strasse", "12", "101", "15", "Ber", "lin"])
+    feats, confs = realign_gazetteer_to_pieces(raw, pieces, LEXICON)
+    assert any(c > 0 for c in confs)  # "Berlin" matched
+    assert feats[confs.index(1.0)] == [0.0, 1.0]  # locality_homograph bit
+
+
+# --- Gate (c): the punctuation-covering stream the token path cannot produce ----------------
+
+# "P.O. Box 19" — one po_box span over chars [0, 11) (the whole surface). Pieces give each
+# period its own piece: the token path's per-char array has O on the periods (the corpus
+# tokenizer dropped them), so the stream FRAGMENTS; the span path covers them.
+PO_RAW = "P.O. Box 19"
+PO_TOKENS = ["P", "O", "Box", "19"]
+PO_LABELS = ["B-po_box", "I-po_box", "I-po_box", "I-po_box"]
+PO_SPANS = ([0], [11], ["po_box"])
+PO_CHUNKS = ["P", ".", "O", ".", "Box", "19"]
+
+
+def test_gate_c_token_path_fragments_on_dotted_designator():
+    pieces = _pieces(PO_RAW, PO_CHUNKS)
+    token_stream = realign_labels_to_pieces(PO_RAW, PO_TOKENS, PO_LABELS, pieces)
+    # The structural blind spot, pinned: periods fall to O, splitting the entity in three.
+    assert token_stream == ["B-po_box", "O", "B-po_box", "O", "B-po_box", "I-po_box"]
+
+
+def test_gate_c_span_path_covers_the_punctuation():
+    pieces = _pieces(PO_RAW, PO_CHUNKS)
+    starts, ends, tags = PO_SPANS
+    span_stream = realign_spans_to_pieces(PO_RAW, starts, ends, tags, pieces)
+    # One continuous entity, periods included — the stream the migration exists for.
+    assert span_stream == ["B-po_box", "I-po_box", "I-po_box", "I-po_box", "I-po_box", "I-po_box"]
+    token_stream = realign_labels_to_pieces(PO_RAW, PO_TOKENS, PO_LABELS, pieces)
+    assert span_stream != token_stream
+
+
+def test_gate_c_through_encode_row():
+    tok = FakeTokenizer(_pieces(PO_RAW, PO_CHUNKS))
+    starts, ends, tags = PO_SPANS
+    via_tokens = encode_row(tok, PO_RAW, PO_TOKENS, PO_LABELS, max_length=16)
+    via_spans = encode_row(
+        tok, PO_RAW, PO_TOKENS, PO_LABELS, max_length=16, span_starts=starts, span_ends=ends, span_tags=tags
+    )
+    assert via_spans["labels"] != via_tokens["labels"]
+    assert via_spans["input_ids"] == via_tokens["input_ids"]  # only the labels differ
+
+
+# --- Loud invariant enforcement --------------------------------------------------------------
+
+
+def test_span_arrays_length_mismatch_raises():
+    with pytest.raises(ValueError, match="length mismatch"):
+        char_label_array_from_spans("abc def", [0], [3, 7], ["street"])
+
+
+def test_unsorted_spans_raise():
+    with pytest.raises(ValueError, match="not sorted"):
+        char_label_array_from_spans("abc def", [4, 0], [7, 3], ["street", "house_number"])
+
+
+def test_overlapping_spans_raise():
+    with pytest.raises(ValueError, match="overlap"):
+        char_label_array_from_spans("abc def", [0, 2], [3, 7], ["street", "locality"])
+
+
+def test_out_of_bounds_span_raises():
+    with pytest.raises(ValueError, match="out of bounds"):
+        char_label_array_from_spans("abc", [0], [4], ["street"])
+
+
+def test_partial_span_kwargs_raise():
+    tok = FakeTokenizer(_pieces("abc", ["abc"]))
+    with pytest.raises(ValueError, match="supplied together"):
+        encode_row(tok, "abc", ["abc"], ["O"], max_length=8, span_starts=[0])

--- a/corpus-python/src/mailwoman_train/tokenizer.py
+++ b/corpus-python/src/mailwoman_train/tokenizer.py
@@ -1,8 +1,13 @@
 """SentencePiece tokenizer wrapper with span info + label realignment.
 
 The corpus parquet stores ``raw`` plus a whitespace-tokenized ``tokens`` list and a parallel
-``labels`` list (BIO over those whitespace tokens). The neural model is trained over
-SentencePiece sub-tokens, which are *finer-grained* than the whitespace tokens. This module:
+``labels`` list (BIO over those whitespace tokens). As of the v0.5.0 char-offset migration
+(#519) rows additionally carry ``span_starts[]``/``span_ends[]``/``span_tags[]`` — char ranges
+over ``raw`` (sorted, non-overlapping) — which become the label source of truth; when present,
+``encode_row`` builds the per-char label array directly from the spans and skips the
+token-quantized projection (the path that made supervision punctuation-mute). The neural model
+is trained over SentencePiece sub-tokens, which are *finer-grained* than the whitespace tokens.
+This module:
 
 1. Loads the SentencePiece model trained in Phase 1 (``/data/models/tokenizer/v0.1.0/``).
 2. Encodes ``raw`` into pieces *with byte-level offsets*.
@@ -147,19 +152,59 @@ def char_label_array(
     return out
 
 
-def realign_labels_to_pieces(
+def char_label_array_from_spans(
     raw: str,
-    tokens: Sequence[str],
-    labels: Sequence[str],
+    span_starts: Sequence[int],
+    span_ends: Sequence[int],
+    span_tags: Sequence[str],
+) -> list[str]:
+    """Build the per-character BIO label array directly from char-offset spans (#519, v0.5.0).
+
+    The v0.5.0 corpus stores labels as the parallel triple ``span_starts[]/span_ends[]/span_tags[]``
+    — char ranges over ``raw``, [start, end) exclusive-end. This is the spans-native sibling of
+    ``char_label_array``: no whitespace-token indirection, so intra-span punctuation chars (the
+    ``P.O.`` periods) carry the span's label instead of falling to ``O``.
+
+    Validates the triple's manifest invariants loudly (equal lengths, sorted ascending by start,
+    non-overlapping, in-bounds) — a violation means a corrupt corpus row, never something to paper
+    over silently.
+    """
+    n = len(span_starts)
+    if len(span_ends) != n or len(span_tags) != n:
+        raise ValueError(
+            f"span arrays length mismatch: starts={n} ends={len(span_ends)} tags={len(span_tags)}"
+        )
+    out = ["O"] * len(raw)
+    prev_start = -1
+    prev_end = 0
+    for start, end, tag in zip(span_starts, span_ends, span_tags):
+        if not (0 <= start < end <= len(raw)):
+            raise ValueError(
+                f"span out of bounds: {tag}@[{start}, {end}) over raw of length {len(raw)}: {raw!r}"
+            )
+        if start < prev_start:
+            raise ValueError(f"spans not sorted: {tag}@[{start}, {end}) after [{prev_start}, {prev_end})")
+        if start < prev_end:
+            raise ValueError(f"spans overlap: {tag}@[{start}, {end}) overlaps [{prev_start}, {prev_end})")
+        out[start] = f"B-{tag}"
+        for i in range(start + 1, end):
+            out[i] = f"I-{tag}"
+        prev_start, prev_end = start, end
+    return out
+
+
+def project_char_labels_to_pieces(
+    raw: str,
+    char_labels: Sequence[str],
     pieces: Iterable[PieceSpan],
 ) -> list[str]:
-    """Project the whitespace-token BIO labels onto SP pieces.
+    """Project a per-character BIO label array onto SP pieces.
 
-    Each SP piece gets the label of the first non-whitespace char it covers; B/I semantics
-    are preserved: only the leading piece of an entity gets ``B-``, subsequent pieces in the
-    same contiguous entity span get ``I-``.
+    THE projection — both label paths (token-quantized and char-span) flow through this single
+    function, so the two cannot drift. Each SP piece gets the label of the first non-whitespace
+    char it covers; B/I semantics are recomputed per piece: only the leading piece of a contiguous
+    entity gets ``B-``, subsequent pieces get ``I-``.
     """
-    char_labels = char_label_array(raw, tokens, labels)
     out: list[str] = []
     prev_tag: str | None = None
     for piece in pieces:
@@ -169,7 +214,7 @@ def realign_labels_to_pieces(
             if i < len(raw) and not raw[i].isspace():
                 first_label = char_labels[i] if i < len(char_labels) else "O"
                 break
-        # Collapse to Stage 1 (anything outside the coarse set becomes O).
+        # Collapse to the active set (anything outside it becomes O).
         first_label = collapse_label(first_label)
         if first_label == "O":
             out.append("O")
@@ -183,6 +228,39 @@ def realign_labels_to_pieces(
             out.append(f"B-{tag}")
         prev_tag = tag
     return out
+
+
+def realign_labels_to_pieces(
+    raw: str,
+    tokens: Sequence[str],
+    labels: Sequence[str],
+    pieces: Iterable[PieceSpan],
+) -> list[str]:
+    """Project the whitespace-token BIO labels onto SP pieces (the pre-v0.5.0 token path).
+
+    Token-quantized: punctuation chars the corpus tokenizer dropped are ``O`` in the per-char
+    array, so a piece whose first non-whitespace char is intra-span punctuation gets ``O`` — the
+    structural blind spot the v0.5.0 char-span format removes. Deleted once v0.5.0 lands.
+    """
+    return project_char_labels_to_pieces(raw, char_label_array(raw, tokens, labels), pieces)
+
+
+def realign_spans_to_pieces(
+    raw: str,
+    span_starts: Sequence[int],
+    span_ends: Sequence[int],
+    span_tags: Sequence[str],
+    pieces: Iterable[PieceSpan],
+) -> list[str]:
+    """Project char-offset label spans onto SP pieces (#519, the v0.5.0 path).
+
+    Same projection as ``realign_labels_to_pieces`` (shared ``project_char_labels_to_pieces``);
+    only the per-char array construction differs — built FROM the spans, so every covered char
+    (punctuation included) carries its span's label.
+    """
+    return project_char_labels_to_pieces(
+        raw, char_label_array_from_spans(raw, span_starts, span_ends, span_tags), pieces
+    )
 
 
 def anchor_feature_vector(posterior: dict[str, float], lat: float, lon: float) -> list[float]:
@@ -236,18 +314,76 @@ def realign_anchor_to_pieces(
                 j += 1
             begin = spans[i][0]
             end = spans[j - 1][1]
-            postcode = raw[begin:end].replace(" ", "").upper()
-            hit = anchor_lookup.get(postcode)
-            if hit is not None:
-                posterior, lat, lon = hit
-                feat = anchor_feature_vector(posterior, lat, lon)
-                for c in range(begin, end):
-                    char_feat[c] = feat
-                    char_conf[c] = 1.0
+            _paint_anchor_chars(raw, begin, end, anchor_lookup, char_feat, char_conf)
             i = j
         else:
             i += 1
 
+    return _project_anchor_chars_to_pieces(raw, char_feat, char_conf, pieces)
+
+
+def realign_anchor_to_pieces_from_spans(
+    raw: str,
+    span_starts: Sequence[int],
+    span_ends: Sequence[int],
+    span_tags: Sequence[str],
+    pieces: Sequence[PieceSpan],
+    anchor_lookup: "dict[str, tuple[dict[str, float], float, float]]",
+) -> tuple[list[list[float]], list[float]]:
+    """Spans-native sibling of ``realign_anchor_to_pieces`` (#519, the v0.5.0 path).
+
+    The postcode entity's char range comes straight off the row's char-offset spans (``span_tags ==
+    "postcode"``) instead of being reconstructed from token labels + ``whitespace_spans``; lookup
+    normalization and the char→piece projection are SHARED with the token path, so the channel
+    tensor is bit-identical on rows where the postcode span equals the token-quantized range
+    (i.e. every row without intra-postcode punctuation).
+    """
+    zero = [0.0] * ANCHOR_FEATURE_DIM
+    char_feat: list[list[float]] = [zero] * len(raw)
+    char_conf: list[float] = [0.0] * len(raw)
+    for start, end, tag in zip(span_starts, span_ends, span_tags):
+        if tag != "postcode":
+            continue
+        _paint_anchor_chars(raw, start, end, anchor_lookup, char_feat, char_conf)
+    return _project_anchor_chars_to_pieces(raw, char_feat, char_conf, pieces)
+
+
+def _paint_anchor_chars(
+    raw: str,
+    begin: int,
+    end: int,
+    anchor_lookup: "dict[str, tuple[dict[str, float], float, float]]",
+    char_feat: list[list[float]],
+    char_conf: list[float],
+) -> None:
+    """Look up the postcode surface at ``raw[begin:end]`` and paint its chars on a hit.
+
+    Shared by both anchor paths — one normalization (space-stripped, uppercased), one painting
+    rule, so token-era and span-era rows cannot diverge here.
+    """
+    postcode = raw[begin:end].replace(" ", "").upper()
+    hit = anchor_lookup.get(postcode)
+    if hit is None:
+        return
+    posterior, lat, lon = hit
+    feat = anchor_feature_vector(posterior, lat, lon)
+    for c in range(begin, end):
+        char_feat[c] = feat
+        char_conf[c] = 1.0
+
+
+def _project_anchor_chars_to_pieces(
+    raw: str,
+    char_feat: Sequence[list[float]],
+    char_conf: Sequence[float],
+    pieces: Sequence[PieceSpan],
+) -> tuple[list[list[float]], list[float]]:
+    """Char→piece projection for the anchor channel — first non-whitespace char wins.
+
+    Mirrors ``project_char_labels_to_pieces`` exactly (the off-by-one DeepSeek flagged as the
+    silent run-killer); shared by both anchor paths.
+    """
+    zero = [0.0] * ANCHOR_FEATURE_DIM
     feats: list[list[float]] = []
     confs: list[float] = []
     for piece in pieces:
@@ -272,24 +408,47 @@ def encode_row(
     anchor_lookup: "dict[str, tuple[dict[str, float], float, float]] | None" = None,
     gazetteer_lexicon=None,
     gazetteer_choreography: bool = False,
+    span_starts: Sequence[int] | None = None,
+    span_ends: Sequence[int] | None = None,
+    span_tags: Sequence[str] | None = None,
 ) -> dict[str, list]:
     """Encode a single row into ``input_ids`` + ``attention_mask`` + ``label_ids``.
 
     Truncates to ``max_length`` SP pieces. Pads to ``max_length`` with the SP ``pad_id`` and
     fills the label tail with ``IGNORE_INDEX`` so cross-entropy ignores the padding.
 
+    **Label source** (#519, the v0.5.0 char-offset migration): when the row carries the span
+    triple (``span_starts``/``span_ends``/``span_tags``), the per-char label array is built FROM
+    THE SPANS and the token-quantized path is skipped — intra-span punctuation pieces get the
+    span's label, which the token path structurally cannot express. Rows without spans use the
+    legacy ``tokens``/``labels`` path unchanged, so the loader reads both corpus generations
+    during the transition; the token path is deleted once v0.5.0 lands. This is one storage
+    format change in flight, not a permanent dual-format fork.
+
     When ``anchor_lookup`` is supplied (the postcode-anchor pilot, #239/#240), also returns
     ``anchor_features`` ``(max_length, ANCHOR_FEATURE_DIM)`` and ``anchor_confidence``
     ``(max_length,)``, projected onto the SAME pieces as the labels (so a postcode anchor lands on
-    exactly its sub-tokens) and zero-padded. Absent → those keys are omitted (back-compat).
+    exactly its sub-tokens) and zero-padded. Absent → those keys are omitted (back-compat). The
+    anchor follows the label source: spans present → the postcode range comes off the spans.
 
     When ``gazetteer_lexicon`` is supplied (the gazetteer anchor, #464), also returns
     ``gazetteer_features`` ``(max_length, lexicon.feature_dim)`` and ``gazetteer_confidence``
     ``(max_length,)`` — candidate-tag-set clues painted from the RAW SURFACE only (never labels;
-    identical computation at train and inference). Absent → omitted (back-compat).
+    identical computation at train and inference, and identical under both label sources).
+    Absent → omitted (back-compat).
     """
+    has_spans = span_starts is not None or span_ends is not None or span_tags is not None
+    if has_spans and (span_starts is None or span_ends is None or span_tags is None):
+        raise ValueError(
+            "encode_row: span_starts/span_ends/span_tags must be supplied together "
+            f"(got starts={span_starts is not None} ends={span_ends is not None} "
+            f"tags={span_tags is not None})"
+        )
     spans = tokenizer.encode_with_spans(raw)
-    bio_labels = realign_labels_to_pieces(raw, tokens, labels, spans)
+    if has_spans:
+        bio_labels = realign_spans_to_pieces(raw, span_starts, span_ends, span_tags, spans)
+    else:
+        bio_labels = realign_labels_to_pieces(raw, tokens, labels, spans)
     ids = [s.piece_id for s in spans][:max_length]
     label_ids = [LABEL_TO_ID[label] for label in bio_labels][:max_length]
     attention = [1] * len(ids)
@@ -301,7 +460,12 @@ def encode_row(
     out: dict[str, list] = {"input_ids": ids, "attention_mask": attention, "labels": label_ids}
 
     if anchor_lookup is not None:
-        feats, confs = realign_anchor_to_pieces(raw, tokens, labels, list(spans), anchor_lookup)
+        if has_spans:
+            feats, confs = realign_anchor_to_pieces_from_spans(
+                raw, span_starts, span_ends, span_tags, list(spans), anchor_lookup
+            )
+        else:
+            feats, confs = realign_anchor_to_pieces(raw, tokens, labels, list(spans), anchor_lookup)
         feats = feats[:max_length]
         confs = confs[:max_length]
         zero = [0.0] * ANCHOR_FEATURE_DIM

--- a/corpus/src/align.test.ts
+++ b/corpus/src/align.test.ts
@@ -218,7 +218,7 @@ describe("alignRow — edge cases", () => {
 		expect(result.kind).toBe("quarantined")
 	})
 
-	it("preserves canonical row provenance + adds tokens/labels", () => {
+	it("preserves canonical row provenance + adds tokens/labels + spans", () => {
 		const row = baseRow({
 			raw: "Paris",
 			components: { locality: "Paris" },
@@ -233,5 +233,127 @@ describe("alignRow — edge cases", () => {
 		expect(result.row.source_id).toBe("wof-admin-2011-self")
 		expect(result.row.license).toBe("CC0-1.0")
 		expect(result.row.country).toBe("US") // baseRow default
+		expect(result.row.span_tags).toEqual(["locality"])
+		expect(result.row.span_starts).toEqual([0])
+		expect(result.row.span_ends).toEqual([5])
+	})
+})
+
+describe("alignRow — char-offset span emission (#519, v0.5.0 format)", () => {
+	it("emits the parallel span triple alongside tokens/labels (both during the transition)", () => {
+		const result = alignRow(
+			baseRow({
+				raw: "1600 Pennsylvania Ave NW, Washington, DC 20500",
+				components: {
+					house_number: "1600",
+					street: "Pennsylvania Ave NW",
+					locality: "Washington",
+					region: "DC",
+					postcode: "20500",
+				},
+			})
+		)
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		// Token path untouched.
+		expect(result.row.tokens.length).toBe(result.row.labels.length)
+		// Span triple: parallel, sorted by start, each slice round-trips to the component surface.
+		expect(result.row.span_tags).toEqual(["house_number", "street", "locality", "region", "postcode"])
+		expect(result.row.span_starts).toEqual([0, 5, 26, 38, 41])
+		expect(result.row.span_ends).toEqual([4, 24, 36, 40, 46])
+		const { raw } = result.row
+		expect(raw.slice(0, 4)).toBe("1600")
+		expect(raw.slice(5, 24)).toBe("Pennsylvania Ave NW")
+		expect(raw.slice(26, 36)).toBe("Washington")
+		expect(raw.slice(38, 40)).toBe("DC")
+		expect(raw.slice(41, 46)).toBe("20500")
+	})
+
+	it("punctuation between spans stays uncovered (the comma is outside both spans — expressible now)", () => {
+		const result = alignRow(
+			baseRow({
+				raw: "Springfield, IL",
+				components: { locality: "Springfield", region: "IL" },
+			})
+		)
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		expect(result.row.span_starts).toEqual([0, 13])
+		expect(result.row.span_ends).toEqual([11, 15])
+		// The comma at offset 11 belongs to no span.
+	})
+
+	it("accented NFC raw (é = one code unit) offsets address the composed form", () => {
+		const raw = "10 Rue de la République, 75008 Paris"
+		expect(raw.normalize("NFC")).toBe(raw) // fixture sanity: source literal is NFC
+		const result = alignRow(
+			baseRow({
+				raw,
+				country: "FR",
+				components: { house_number: "10", street: "Rue de la République", locality: "Paris", postcode: "75008" },
+			})
+		)
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		expect(result.row.span_tags).toEqual(["house_number", "street", "postcode", "locality"])
+		const streetStart = result.row.span_starts![1]!
+		const streetEnd = result.row.span_ends![1]!
+		expect(raw.slice(streetStart, streetEnd)).toBe("Rue de la République")
+	})
+
+	it("spans are sorted + non-overlapping across a variety of rows", () => {
+		const rows = [
+			baseRow({
+				raw: "12 Main St, Springfield, IL 62701",
+				components: { house_number: "12", street: "Main St", locality: "Springfield", region: "IL", postcode: "62701" },
+			}),
+			baseRow({
+				raw: "Paris Paris, France",
+				country: "FR",
+				components: { locality: "Paris", country: "France" },
+			}),
+			baseRow({ raw: "Anywhere", components: {} }),
+		]
+		for (const row of rows) {
+			const result = alignRow(row)
+			expect(result.kind).toBe("labeled")
+			if (result.kind !== "labeled") continue
+			const { span_starts, span_ends, span_tags } = result.row
+			expect(span_starts!.length).toBe(span_ends!.length)
+			expect(span_starts!.length).toBe(span_tags!.length)
+			for (let i = 1; i < span_starts!.length; i++) {
+				expect(span_starts![i]!).toBeGreaterThanOrEqual(span_ends![i - 1]!) // sorted AND non-overlapping
+			}
+		}
+	})
+
+	it("empty components → empty span arrays (all-O row)", () => {
+		const result = alignRow(baseRow({ raw: "Anywhere", components: {} }))
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		expect(result.row.span_starts).toEqual([])
+		expect(result.row.span_ends).toEqual([])
+		expect(result.row.span_tags).toEqual([])
+	})
+
+	it("throws loudly on a non-NFC raw, naming the row's source_id", () => {
+		// NFD: "é" as base letter + combining acute — two code units where NFC has one.
+		const nfdRaw = "10 Rue de la Re\u0301publique, 75008 Paris"
+		expect(nfdRaw.normalize("NFC")).not.toBe(nfdRaw)
+		expect(() =>
+			alignRow(
+				baseRow({
+					raw: nfdRaw,
+					country: "FR",
+					source_id: "nfd-row-42",
+					components: { locality: "Paris", postcode: "75008" },
+				})
+			)
+		).toThrowError(/not NFC-normalized.*nfd-row-42/s)
+	})
+
+	it("does not throw on a non-NFC raw that is empty-ish (raw-empty quarantine wins)", () => {
+		const result = alignRow(baseRow({ raw: "", components: {} }))
+		expect(result.kind).toBe("quarantined")
 	})
 })

--- a/corpus/src/align.ts
+++ b/corpus/src/align.ts
@@ -18,12 +18,19 @@
  *   4. For each token: walk the list of component spans, pick the one whose span contains the token's
  *        character range. First token in a component span → `B-<tag>`; subsequent tokens →
  *        `I-<tag>`; no overlap → `O`.
+ *   5. Emit the located char spans verbatim as `span_starts[]` / `span_ends[]` / `span_tags[]` (the
+ *        v0.5.0 char-offset format, #519). The token quantization in step 4 is the part the v0.5.0
+ *        rebuild deletes; during the transition both representations ride on every labeled row.
  *
- *   Two structural invariants the function preserves:
+ *   Structural invariants the function preserves (the span ones loudly — a violation throws rather
+ *   than quarantines, because it indicates a bug here, not bad source data):
  *
  *   - `tokens.length === labels.length` always.
  *   - Each component contributes at most one contiguous BIO run (no `B-tag … O … I-tag` gaps). This is
  *       enforced by greedy first-match span assignment + ordered token iteration.
+ *   - The span triple is sorted ascending by start and non-overlapping.
+ *   - `raw` is NFC-normalized (asserted per row; a non-NFC raw makes char offsets ambiguous downstream
+ *       — NFD `é` occupies two code units where NFC `é` occupies one — and silently so).
  */
 
 import type { BioLabel, ComponentTag } from "@mailwoman/core/types"
@@ -71,6 +78,17 @@ export function alignRow(row: CanonicalRow, opts: AlignOptions = {}): AlignmentR
 		return { kind: "quarantined", row: { row, reason: "raw-empty" } }
 	}
 
+	// Build-time NFC assertion (#519 ruling 2: the converter's Unicode-mismatch class dissolves
+	// into this check). Char-offset spans over `raw` are only meaningful under ONE normalization
+	// form; a non-NFC raw corrupts every downstream offset silently. Loud failure, naming the row.
+	if (row.raw.normalize("NFC") !== row.raw) {
+		throw new Error(
+			`alignRow: raw is not NFC-normalized (source=${row.source}, source_id=${row.source_id}). ` +
+				`Char-offset spans over a non-NFC raw are ambiguous downstream — normalize at the adapter boundary. ` +
+				`raw=${JSON.stringify(row.raw)}`
+		)
+	}
+
 	const componentSpans: ComponentSpan[] = []
 	const claimed: Array<[number, number]> = []
 
@@ -94,6 +112,7 @@ export function alignRow(row: CanonicalRow, opts: AlignOptions = {}): AlignmentR
 	}
 
 	componentSpans.sort((a, b) => a.start - b.start)
+	assertSpanInvariants(componentSpans, row)
 	const tokens = tokenizer.tokenize(row.raw)
 	const labels = labelTokens(tokens, componentSpans)
 
@@ -101,8 +120,46 @@ export function alignRow(row: CanonicalRow, opts: AlignOptions = {}): AlignmentR
 		...row,
 		tokens: tokens.map((t) => t.text),
 		labels,
+		// The v0.5.0 char-offset triple (#519): the located spans, emitted verbatim. The token
+		// quantization above is what the rebuild deletes; both ride during the transition.
+		span_starts: componentSpans.map((s) => s.start),
+		span_ends: componentSpans.map((s) => s.end),
+		span_tags: componentSpans.map((s) => s.tag),
 	}
 	return { kind: "labeled", row: labeled }
+}
+
+/**
+ * Enforce the #519 span-triple invariants — sorted ascending by start, non-overlapping — loudly.
+ *
+ * `claimed`-span bookkeeping in `locateSpan` already makes overlap impossible and the caller sorts,
+ * so a violation here is a bug in this file, not bad source data: throw (naming the row) rather
+ * than quarantine, so the corruption can't ride into a corpus.
+ */
+function assertSpanInvariants(spans: readonly ComponentSpan[], row: CanonicalRow): void {
+	for (let i = 0; i < spans.length; i++) {
+		const s = spans[i]!
+		if (!(s.start >= 0 && s.start < s.end && s.end <= row.raw.length)) {
+			throw new Error(
+				`alignRow: span out of bounds (source=${row.source}, source_id=${row.source_id}): ` +
+					`${s.tag}@[${s.start}, ${s.end}) over raw of length ${row.raw.length}`
+			)
+		}
+		if (i === 0) continue
+		const prev = spans[i - 1]!
+		if (s.start < prev.start) {
+			throw new Error(
+				`alignRow: spans not sorted (source=${row.source}, source_id=${row.source_id}): ` +
+					`${prev.tag}@[${prev.start}, ${prev.end}) precedes ${s.tag}@[${s.start}, ${s.end})`
+			)
+		}
+		if (s.start < prev.end) {
+			throw new Error(
+				`alignRow: spans overlap (source=${row.source}, source_id=${row.source_id}): ` +
+					`${prev.tag}@[${prev.start}, ${prev.end}) overlaps ${s.tag}@[${s.start}, ${s.end})`
+			)
+		}
+	}
 }
 
 /**

--- a/corpus/src/types.ts
+++ b/corpus/src/types.ts
@@ -98,7 +98,12 @@ export interface CanonicalRow extends SourceProvenance {
 
 /**
  * Output of `align.ts`. Carries everything `CanonicalRow` does, plus parallel `tokens` and `labels`
- * arrays of identical length. `labels[i]` is the BIO tag for `tokens[i]`.
+ * arrays of identical length (`labels[i]` is the BIO tag for `tokens[i]`) and — as of the v0.5.0
+ * char-offset migration (#519) — parallel char-span arrays addressing `raw` directly.
+ *
+ * The span triple is the v0.5.0 source of truth; `tokens`/`labels` remain emitted during the
+ * transition (and stay derivable afterwards: whitespace split + span lookup). The reverse
+ * derivation — today's token labels — is the lossy direction (punctuation-mute).
  */
 export interface LabeledRow extends CanonicalRow {
 	/** SentencePiece subword tokens for `raw`. */
@@ -106,6 +111,25 @@ export interface LabeledRow extends CanonicalRow {
 
 	/** BIO labels, one per token. Same length as `tokens`. */
 	labels: readonly BioLabel[]
+
+	/**
+	 * Char-offset label spans over `raw` (parallel arrays, per the #519 ruling): `span_starts[i]` is
+	 * the inclusive start offset (UTF-16 code units) of span `i`, `span_ends[i]` its exclusive end,
+	 * `span_tags[i]` its component tag. Invariants — enforced loudly by `alignRow`, documented for
+	 * every other producer: sorted ascending by start, non-overlapping. `raw` must be NFC-normalized
+	 * or the offsets are ambiguous (also enforced by `alignRow`).
+	 *
+	 * Optional during the v0.4.x → v0.5.0 transition only: alignment always emits the triple; frozen
+	 * historical corpora and not-yet-migrated synthesis paths may lack it. Required once v0.5.0 lands
+	 * and the token path is deleted.
+	 */
+	span_starts?: readonly number[]
+
+	/** Exclusive end offsets, parallel to `span_starts`. */
+	span_ends?: readonly number[]
+
+	/** Component tags, parallel to `span_starts`. */
+	span_tags?: readonly ComponentTag[]
 }
 
 /**


### PR DESCRIPTION
The approved migration's foundation: `alignRow` emits the parallel-array span triple verbatim from its existing char ranges (token path untouched for the transition; invariants throw loudly naming source_id), per-row NFC assertion (no adapter trips it — already clean), and `encode_row` consumes spans when present through the SAME projection function as the token path (bit-identity by construction, not just by test).

Gates: (a) bit-identical streams on punctuation-free fixtures incl. the NFC-é class; (b) anchor + gazetteer channel tensors identical with anti-vacuity asserts; (c) the positive case — `P.O. Box 19` produces the continuous punctuation-covering label stream the token format structurally cannot (both streams pinned as tests).

Suites: corpus 382/382, mailwoman_train 75 passed/4 skipped. Deliberately excluded (next slice, in this order per the agent's hazard catch): parquet schema columns BEFORE builders, `composeAdversarialRow` first among constructors, and loader wiring ONLY together with the augmentation/relabel re-target to spans — partial span kwargs raise loudly until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)