### PR TITLE
feat(resolver): reverse geocoding — bbox→PIP→descent over wof-polygons (#484)

### DIFF
--- a/resolver-wof-sqlite/ancestry.ts
+++ b/resolver-wof-sqlite/ancestry.ts
@@ -1,0 +1,69 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The shared ancestor-lineage walk over the WOF `ancestors` table — one place's containment chain
+ *   joined with `spr` for canonical names + centroids, ordered NEAREST-FIRST (deepest placetype
+ *   first, country last).
+ *
+ *   Factored out of `WofSqlitePlaceLookup.ancestors()` (#404) so the reverse geocoder (`reverse.ts`,
+ *   #484) reuses the SAME walk instead of growing a second one. The placetype-specificity ordering
+ *   lives here as `PLACETYPE_DEPTH` — a single TS map instead of the previous SQL CASE, and extended
+ *   below `localadmin` (locality/borough/neighbourhood/microhood now rank correctly instead of
+ *   sorting last; forward resolution rarely saw those as ANCESTOR placetypes, reverse geocoding
+ *   always does).
+ */
+
+import type { DatabaseSync } from "node:sqlite"
+
+/**
+ * WOF placetype → containment depth, coarsest = 1. Higher = finer. Placetypes we never resolve
+ * (continent, empire, …) map to 0 and sort last. NOT the same table as the FST's `PLACETYPE_ORDER`
+ * (fst-serialize.ts) — that one is a serialization order, this one is containment depth.
+ */
+export const PLACETYPE_DEPTH: Readonly<Record<string, number>> = {
+	country: 1,
+	macroregion: 2,
+	region: 3,
+	macrocounty: 4,
+	county: 5,
+	localadmin: 6,
+	locality: 7,
+	borough: 8,
+	macrohood: 9,
+	neighbourhood: 10,
+	microhood: 11,
+}
+
+/** Containment depth for a placetype — 0 (sorts coarsest) when unknown. */
+export function placetypeDepth(placetype: string): number {
+	return PLACETYPE_DEPTH[placetype] ?? 0
+}
+
+/** One ancestor row, enriched with the `spr` columns both consumers need. */
+export interface AncestorPlaceRow {
+	id: number
+	placetype: string
+	name: string
+	country: string
+	lat: number
+	lon: number
+}
+
+/**
+ * The ancestor lineage of `id` — self excluded, nearest-first. Returns `[]` when the place has no
+ * recorded ancestry. NOT memoized here; `WofSqlitePlaceLookup` keeps its own per-id cache.
+ */
+export function ancestorLineage(db: DatabaseSync, id: number, schemaName = "main"): AncestorPlaceRow[] {
+	const rows = db
+		.prepare(
+			`SELECT a.ancestor_id AS id, a.ancestor_placetype AS placetype, s.name AS name,
+				s.country AS country, s.latitude AS lat, s.longitude AS lon
+			FROM ${schemaName}.ancestors a JOIN ${schemaName}.spr s ON s.id = a.ancestor_id
+			WHERE a.id = ? AND a.ancestor_id != a.id`
+		)
+		.all(id) as unknown as AncestorPlaceRow[]
+	rows.sort((a, b) => placetypeDepth(b.placetype) - placetypeDepth(a.placetype))
+	return rows
+}

--- a/resolver-wof-sqlite/geo.ts
+++ b/resolver-wof-sqlite/geo.ts
@@ -3,12 +3,17 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Geographic helpers for the resolver — haversine distance + bbox math.
+ *   Geographic helpers for the resolver — haversine distance, bbox math, and point-in-polygon.
  *
- *   We deliberately don't pull SpatiaLite for this. SQLite's built-in `rtree` virtual table gives us
- *   bbox filtering at the SQL level; haversine distance is a 12-line TS function that's plenty fast
- *   for the post-fetch re-rank pass (we operate on ≤ a few hundred FTS hits per query, not the
- *   whole 142k-row corpus).
+ *   We deliberately don't pull SpatiaLite (or turf) for this. SQLite's built-in `rtree` virtual
+ *   table gives us bbox filtering at the SQL level; haversine distance is a 12-line TS function and
+ *   ray-cast PIP a ~30-line one — both plenty fast for the post-fetch passes (we operate on ≤ a few
+ *   hundred candidates per query, not the whole 142k-row corpus).
+ *
+ *   The PIP implementation here is the CANONICAL port of the even-odd ray cast that previously
+ *   lived only in Python (`scripts/eval/pip-containment.py`, with a second copy in
+ *   `scripts/build-postcode-locality.py`). Keep the three in sync if the algorithm ever changes —
+ *   the eval-side Python copies grade the same containment truth this one resolves with.
  *
  *   The R*Tree index name + schema are centralized in `fts.ts` (alongside the FTS5 build).
  */
@@ -62,4 +67,74 @@ export function bboxAround(lat: number, lon: number, radiusKm: number): Bbox {
 		minLon: lon - lonDelta,
 		maxLon: lon + lonDelta,
 	}
+}
+
+/**
+ * A GeoJSON position — `[lon, lat]`, possibly with extra dimensions we ignore. WOF geometries are
+ * 2-D throughout, but the type stays open so a 3-D source doesn't break parsing.
+ */
+export type GeojsonPosition = [number, number, ...number[]]
+
+/** The two areal GeoJSON geometry types PIP can test, plus an open escape hatch (Point etc.). */
+export interface GeojsonPolygon {
+	type: "Polygon"
+	/** `[outerRing, hole1, hole2, …]` — each ring a closed list of positions. */
+	coordinates: GeojsonPosition[][]
+}
+
+export interface GeojsonMultiPolygon {
+	type: "MultiPolygon"
+	coordinates: GeojsonPosition[][][]
+}
+
+export type GeojsonGeometry = GeojsonPolygon | GeojsonMultiPolygon | { type: string; coordinates?: unknown }
+
+/**
+ * Ray-cast a point against ONE linear ring. Standard even-odd crossing count: shoot a ray along
+ * +lon and toggle on every edge crossing. Points exactly on an edge are implementation-defined
+ * (either side is acceptable for geocoding — admin boundaries are DP-simplified anyway).
+ */
+export function pointInRing(lon: number, lat: number, ring: readonly GeojsonPosition[]): boolean {
+	let inside = false
+	const n = ring.length
+	for (let i = 0, j = n - 1; i < n; j = i++) {
+		const xi = ring[i]![0]
+		const yi = ring[i]![1]
+		const xj = ring[j]![0]
+		const yj = ring[j]![1]
+		if (yi > lat !== yj > lat && lon < ((xj - xi) * (lat - yi)) / (yj - yi) + xi) {
+			inside = !inside
+		}
+	}
+	return inside
+}
+
+/**
+ * Even-odd containment over a polygon's ring list (`[outer, hole1, …]`) — being inside an odd
+ * number of rings means inside the polygon, which handles holes without ring-orientation rules.
+ */
+export function pointInPolygonRings(lon: number, lat: number, rings: readonly GeojsonPosition[][]): boolean {
+	let inside = false
+	for (const ring of rings) {
+		if (pointInRing(lon, lat, ring)) inside = !inside
+	}
+	return inside
+}
+
+/**
+ * Does an areal GeoJSON geometry contain the point?
+ *
+ * - `true` / `false` — a Polygon or MultiPolygon was tested.
+ * - `null` — the geometry isn't areal (Point, LineString, …) and CANNOT contain; callers treat this
+ *   the same as "no polygon on record" (the approximate-fallback path), never as a rejection.
+ */
+export function geometryContains(geometry: GeojsonGeometry | null | undefined, lon: number, lat: number): boolean | null {
+	if (!geometry) return null
+	if (geometry.type === "Polygon") {
+		return pointInPolygonRings(lon, lat, (geometry as GeojsonPolygon).coordinates)
+	}
+	if (geometry.type === "MultiPolygon") {
+		return (geometry as GeojsonMultiPolygon).coordinates.some((rings) => pointInPolygonRings(lon, lat, rings))
+	}
+	return null
 }

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -38,7 +38,28 @@ export {
 	type BuildPlaceSearchFtsResult,
 } from "./fts.js"
 
-export { bboxAround, haversineKm, type Bbox } from "./geo.js"
+export {
+	bboxAround,
+	geometryContains,
+	haversineKm,
+	pointInPolygonRings,
+	pointInRing,
+	type Bbox,
+	type GeojsonGeometry,
+	type GeojsonMultiPolygon,
+	type GeojsonPolygon,
+	type GeojsonPosition,
+} from "./geo.js"
+
+export { ancestorLineage, PLACETYPE_DEPTH, placetypeDepth, type AncestorPlaceRow } from "./ancestry.js"
+
+export {
+	WofReverseGeocoder,
+	type ContainmentKind,
+	type ReverseGeocodeOpts,
+	type ReverseGeocodeResult,
+	type WofReverseGeocoderOpts,
+} from "./reverse.js"
 
 export {
 	deriveSchemaName,

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -26,6 +26,7 @@ import {
 	type Strategy,
 } from "./convention.js"
 
+import { ancestorLineage } from "./ancestry.js"
 import { COINCIDENT_ROLES_TABLE, coincidentRolesExists } from "./coincident-roles.js"
 import {
 	buildPlaceSearchFts,
@@ -481,25 +482,21 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 * ordered NEAREST-FIRST (localadmin → county → region → … → country). Backs
 	 * {@link ResolveOpts.includeAncestors} (#404). Self is excluded; memoized per id. Returns `[]`
 	 * when the place has no recorded ancestry.
+	 *
+	 * The walk itself lives in `ancestry.ts` (shared with the reverse geocoder, #484); the ordering
+	 * is its `PLACETYPE_DEPTH` table — same ranking as the previous inline SQL CASE, extended below
+	 * `localadmin` so locality/neighbourhood ancestors order correctly instead of sorting last.
 	 */
 	ancestors(id: number | string): Ancestor[] {
 		const pid = typeof id === "number" ? id : Number(id)
 		if (!Number.isFinite(pid)) return []
 		const cached = this.#ancestorsCache.get(pid)
 		if (cached) return cached
-		// Nearest-first: rank by placetype specificity (descending). Unknown placetypes sort last.
-		const rows = this.#db
-			.prepare(
-				`SELECT a.ancestor_id AS id, a.ancestor_placetype AS placetype, s.name AS name
-				FROM ancestors a JOIN spr s ON s.id = a.ancestor_id
-				WHERE a.id = ? AND a.ancestor_id != a.id
-				ORDER BY CASE a.ancestor_placetype
-					WHEN 'localadmin' THEN 6 WHEN 'borough' THEN 6 WHEN 'county' THEN 5
-					WHEN 'macrocounty' THEN 4 WHEN 'region' THEN 3 WHEN 'macroregion' THEN 2
-					WHEN 'country' THEN 1 ELSE 0 END DESC`
-			)
-			.all(pid) as unknown as Array<{ id: number; placetype: string; name: string }>
-		const lineage: Ancestor[] = rows.map((r) => ({ id: r.id, placetype: r.placetype, name: r.name }))
+		const lineage: Ancestor[] = ancestorLineage(this.#db, pid).map((r) => ({
+			id: r.id,
+			placetype: r.placetype,
+			name: r.name,
+		}))
 		this.#ancestorsCache.set(pid, lineage)
 		return lineage
 	}

--- a/resolver-wof-sqlite/reverse.test.ts
+++ b/resolver-wof-sqlite/reverse.test.ts
@@ -1,0 +1,242 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the reverse geocoder (#484): the ray-cast PIP primitives, the bbox→PIP→descent walk
+ *   over an inline fixture gazetteer, and an env-gated integration pass against the REAL production
+ *   DBs.
+ *
+ *   The integration suite SKIPS unless BOTH env vars point at real artifacts (so CI stays green
+ *   without them — same pattern as `resolver-wof-wasm/hot-db.test.ts`):
+ *
+ *   - `MAILWOMAN_WOF_ADMIN_DB` — the admin gazetteer with the package-built `place_bbox` R*Tree,
+ *       e.g. `/mnt/playpen/mailwoman-data/wof/admin-global-priority.db`.
+ *   - `MAILWOMAN_WOF_POLYGONS_DB` — the polygon sidecar, e.g.
+ *       `/tmp/v440-stage/en-us/v4.4.0/wof-polygons.db` (staged by build-demo-assets).
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+import { geometryContains, pointInPolygonRings, pointInRing, type GeojsonPosition } from "./geo.js"
+import { WofReverseGeocoder } from "./reverse.js"
+
+const square = (minX: number, minY: number, maxX: number, maxY: number): GeojsonPosition[] => [
+	[minX, minY],
+	[maxX, minY],
+	[maxX, maxY],
+	[minX, maxY],
+	[minX, minY],
+]
+
+describe("point-in-polygon primitives", () => {
+	test("pointInRing — inside / outside a square", () => {
+		const ring = square(0, 0, 10, 10)
+		expect(pointInRing(5, 5, ring)).toBe(true)
+		expect(pointInRing(15, 5, ring)).toBe(false)
+		expect(pointInRing(-1, -1, ring)).toBe(false)
+	})
+
+	test("pointInPolygonRings — a hole excludes, an island within the hole includes again", () => {
+		const rings = [square(0, 0, 10, 10), square(4, 4, 6, 6)]
+		expect(pointInPolygonRings(2, 2, rings)).toBe(true) // solid part
+		expect(pointInPolygonRings(5, 5, rings)).toBe(false) // inside the hole
+		// Even-odd: an island ring nested inside the hole flips back to inside.
+		expect(pointInPolygonRings(5, 5, [...rings, square(4.8, 4.8, 5.2, 5.2)])).toBe(true)
+	})
+
+	test("geometryContains — Polygon, MultiPolygon, and non-areal geometry", () => {
+		const polygon = { type: "Polygon", coordinates: [square(0, 0, 10, 10)] }
+		const multi = {
+			type: "MultiPolygon",
+			coordinates: [[square(0, 0, 1, 1)], [square(8, 8, 9, 9)]],
+		}
+		expect(geometryContains(polygon, 5, 5)).toBe(true)
+		expect(geometryContains(polygon, 11, 5)).toBe(false)
+		expect(geometryContains(multi, 8.5, 8.5)).toBe(true)
+		expect(geometryContains(multi, 5, 5)).toBe(false)
+		expect(geometryContains({ type: "Point", coordinates: [5, 5] }, 5, 5)).toBeNull()
+		expect(geometryContains(null, 5, 5)).toBeNull()
+	})
+})
+
+/**
+ * Fixture gazetteer — a miniature Vermont-like geography around (44.0, -72.0):
+ *
+ *   country US (1) ⊃ region (2) ⊃ county A (3, polygon) + county B (6, bbox overlaps A but polygon
+ *   rejects — the bbox-false-positive case) ⊃ localadmin town (4, point geometry, centroid near the
+ *   query point) ⊃ locality village (5, point geometry, degenerate bbox — reachable only via the
+ *   ancestors-table descent, never via the R*Tree).
+ */
+function buildFixture(): { admin: DatabaseSync; polygons: DatabaseSync } {
+	const admin = new DatabaseSync(":memory:")
+	admin.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE ancestors (id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT);
+		CREATE VIRTUAL TABLE place_bbox USING rtree(id, min_lat, max_lat, min_lon, max_lon);
+
+		INSERT INTO spr VALUES (1, -1, 'United States', 'country', 'US', 39.0, -98.0, 18.0, 72.0, -180.0, -66.0, 1, 0);
+		INSERT INTO spr VALUES (2, 1, 'Vermont', 'region', 'US', 44.0, -72.6, 42.7, 45.0, -73.5, -71.4, 1, 0);
+		INSERT INTO spr VALUES (3, 2, 'Washington County', 'county', 'US', 44.05, -72.1, 43.8, 44.3, -72.5, -71.8, 1, 0);
+		INSERT INTO spr VALUES (4, 3, 'Middlewich', 'localadmin', 'US', 44.01, -72.02, 44.01, 44.01, -72.02, -72.02, 1, 0);
+		INSERT INTO spr VALUES (5, 4, 'Middlewich Village', 'locality', 'US', 43.99, -71.98, 43.99, 43.99, -71.98, -71.98, 1, 0);
+		-- County B: bbox overlaps the query point but its polygon excludes it (bbox false positive).
+		INSERT INTO spr VALUES (6, 2, 'Orange County', 'county', 'US', 43.9, -72.3, 43.85, 44.25, -72.45, -71.85, 1, 0);
+		-- A far locality under county A — must NOT be picked (beyond maxApproximateKm).
+		INSERT INTO spr VALUES (7, 3, 'Fartown', 'locality', 'US', 44.29, -72.49, 44.29, 44.29, -72.49, -72.49, 1, 0);
+
+		INSERT INTO ancestors VALUES
+			(2, 1, 'country'),
+			(3, 2, 'region'), (3, 1, 'country'),
+			(4, 3, 'county'), (4, 2, 'region'), (4, 1, 'country'),
+			(5, 4, 'localadmin'), (5, 3, 'county'), (5, 2, 'region'), (5, 1, 'country'),
+			(6, 2, 'region'), (6, 1, 'country'),
+			(7, 3, 'county'), (7, 2, 'region'), (7, 1, 'country');
+
+		-- R*Tree mirrors spr min/max for the POLYGONAL places only (the real build skips degenerate
+		-- bboxes implicitly: a point bbox can only ever match its exact coordinate).
+		INSERT INTO place_bbox VALUES (1, 18.0, 72.0, -180.0, -66.0);
+		INSERT INTO place_bbox VALUES (2, 42.7, 45.0, -73.5, -71.4);
+		INSERT INTO place_bbox VALUES (3, 43.8, 44.3, -72.5, -71.8);
+		INSERT INTO place_bbox VALUES (6, 43.85, 44.25, -72.45, -71.85);
+	`)
+
+	const polygons = new DatabaseSync(":memory:")
+	polygons.exec(`CREATE TABLE polygons (id INTEGER PRIMARY KEY, geom TEXT NOT NULL);`)
+	const insert = polygons.prepare(`INSERT INTO polygons (id, geom) VALUES (?, ?)`)
+	// Region polygon: the whole fixture area.
+	insert.run(2, JSON.stringify({ type: "Polygon", coordinates: [square(-73.5, 42.7, -71.4, 45.0)] }))
+	// County A polygon CONTAINS the query point (44.0, -72.0)…
+	insert.run(3, JSON.stringify({ type: "Polygon", coordinates: [square(-72.5, 43.8, -71.8, 44.3)] }))
+	// …county B's polygon does NOT (its bbox row lies — DP-simplified bboxes overlap).
+	insert.run(6, JSON.stringify({ type: "Polygon", coordinates: [square(-72.45, 43.85, -71.85, 43.95)] }))
+	return { admin, polygons }
+}
+
+describe("WofReverseGeocoder over the fixture gazetteer", () => {
+	test("PIP confirms the deepest polygon, then descends to the nearest point-geometry child", async () => {
+		const { admin, polygons } = buildFixture()
+		const rg = new WofReverseGeocoder({ adminDatabase: admin, polygonDatabase: polygons })
+		const result = await rg.reverseGeocode(44.0, -72.0)
+
+		// Deepest = the locality village (descent: county A → town → village), approximate.
+		expect(result.containment).toBe("approximate")
+		expect(result.hierarchy.map((p) => p.name)).toEqual([
+			"Middlewich Village",
+			"Middlewich",
+			"Washington County",
+			"Vermont",
+			"United States",
+		])
+		// The bbox false positive (county B) must never appear.
+		expect(result.hierarchy.some((p) => p.id === 6)).toBe(false)
+		// The approximate winner carries its centroid distance.
+		expect(result.hierarchy[0]?.distanceKm).toBeGreaterThan(0)
+		rg.close()
+	})
+
+	test("polygon containment is reported when the deepest place IS polygon-confirmed", async () => {
+		const { admin, polygons } = buildFixture()
+		const rg = new WofReverseGeocoder({ adminDatabase: admin, polygonDatabase: polygons })
+		// Restrict to the polygon-bearing tiers — the deepest is then county A, PIP-confirmed.
+		const result = await rg.reverseGeocode(44.0, -72.0, { placetypes: ["country", "region", "county"] })
+		expect(result.containment).toBe("polygon")
+		expect(result.hierarchy[0]).toMatchObject({ id: 3, placetype: "county" })
+		rg.close()
+	})
+
+	test("no polygon DB → centroid-only mode, every result approximate", async () => {
+		const { admin } = buildFixture()
+		const rg = new WofReverseGeocoder({ adminDatabase: admin })
+		const result = await rg.reverseGeocode(44.0, -72.0)
+		expect(result.containment).toBe("approximate")
+		// Bbox false positives can't be vetoed without polygons; the smallest containing bbox
+		// (a county) still anchors the walk and the descent still reaches the village.
+		expect(result.hierarchy[0]?.name).toBe("Middlewich Village")
+		rg.close()
+	})
+
+	test("a point outside every bbox returns an empty hierarchy", async () => {
+		const { admin, polygons } = buildFixture()
+		const rg = new WofReverseGeocoder({ adminDatabase: admin, polygonDatabase: polygons })
+		const result = await rg.reverseGeocode(-44.0, 72.0)
+		expect(result.hierarchy).toEqual([])
+		expect(result.containment).toBe("approximate")
+		rg.close()
+	})
+
+	test("approximate steps respect maxApproximateKm", async () => {
+		const { admin, polygons } = buildFixture()
+		const rg = new WofReverseGeocoder({ adminDatabase: admin, polygonDatabase: polygons })
+		// Tiny cap: the town centroid (~2 km away) is out of reach → walk stops at county A.
+		const result = await rg.reverseGeocode(44.0, -72.0, { maxApproximateKm: 0.5 })
+		expect(result.hierarchy[0]).toMatchObject({ id: 3, placetype: "county" })
+		expect(result.containment).toBe("polygon")
+		rg.close()
+	})
+
+	test("rejects out-of-range coordinates", async () => {
+		const { admin } = buildFixture()
+		const rg = new WofReverseGeocoder({ adminDatabase: admin })
+		await expect(rg.reverseGeocode(91, 0)).rejects.toThrow(RangeError)
+		await expect(rg.reverseGeocode(0, 181)).rejects.toThrow(RangeError)
+		rg.close()
+	})
+})
+
+// --- env-gated integration against the real artifacts (see file header for paths) ---------------
+
+const ADMIN_DB = process.env.MAILWOMAN_WOF_ADMIN_DB
+const POLYGONS_DB = process.env.MAILWOMAN_WOF_POLYGONS_DB
+
+describe.skipIf(!ADMIN_DB || !POLYGONS_DB)(
+	"against the production gazetteer (MAILWOMAN_WOF_ADMIN_DB + MAILWOMAN_WOF_POLYGONS_DB)",
+	() => {
+		// Construct in beforeAll, not the describe body — the body runs at collection time even when
+		// the suite is skipped, and would try to open the (absent) DBs.
+		let rg: WofReverseGeocoder
+		beforeAll(() => {
+			rg = new WofReverseGeocoder({ adminDbPath: ADMIN_DB!, polygonDbPath: POLYGONS_DB! })
+		})
+		afterAll(() => rg?.close())
+
+		test("South Side Chicago → full chain down to the neighbourhood grain", async () => {
+			const result = await rg.reverseGeocode(41.8004427, -87.6031768)
+			const names = result.hierarchy.map((p) => p.name)
+			expect(names).toContain("Chicago")
+			expect(names).toContain("Illinois")
+			expect(names).toContain("United States")
+			// The deepest node is a point-geometry neighbourhood (Hyde Park) → approximate by honest
+			// convention, even though the Chicago locality above it is polygon-confirmed.
+			expect(result.hierarchy[0]?.placetype).toBe("neighbourhood")
+			expect(result.containment).toBe("approximate")
+		})
+
+		test("same point, locality-and-coarser only → polygon-confirmed Chicago", async () => {
+			const result = await rg.reverseGeocode(41.8004427, -87.6031768, {
+				placetypes: ["country", "region", "county", "localadmin", "locality"],
+			})
+			expect(result.hierarchy[0]).toMatchObject({ name: "Chicago", placetype: "locality" })
+			expect(result.containment).toBe("polygon")
+		})
+
+		test("Montpelier VT (point-geometry locality) → approximate, region still polygon-anchored", async () => {
+			const result = await rg.reverseGeocode(44.2601, -72.5754)
+			const names = result.hierarchy.map((p) => p.name)
+			expect(names).toContain("Vermont")
+			const deepest = result.hierarchy[0]
+			expect(["locality", "localadmin", "neighbourhood"]).toContain(deepest?.placetype)
+		})
+
+		test("middle of the North Atlantic → empty hierarchy", async () => {
+			const result = await rg.reverseGeocode(40.0, -40.0)
+			expect(result.hierarchy).toEqual([])
+		})
+	}
+)

--- a/resolver-wof-sqlite/reverse.ts
+++ b/resolver-wof-sqlite/reverse.ts
@@ -1,0 +1,377 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Reverse geocoding (#484): `(lat, lon)` → the containing admin hierarchy. Assembly over existing
+ *   machinery, per the 2026-06-11 scoping notes:
+ *
+ *   1. **Candidate fetch** — the admin DB's `place_bbox` R*Tree (built by `fts.ts`) for places whose
+ *        bbox contains the point, smallest-area-first (so the FIRST polygon confirmation is the
+ *        deepest).
+ *   2. **PIP confirmation** — ray-cast (geo.ts, the canonical TS port of
+ *        `scripts/eval/pip-containment.py`) against the polygon sidecar DB (`wof-polygons.db`,
+ *        `polygons(id, geom)` with GeoJSON text — built by `scripts/build-wof-polygons.mjs` for the
+ *        demo map). A candidate whose polygon EXISTS but rejects the point is a bbox false positive
+ *        and is dropped entirely; a candidate with no polygon row stays eligible for the approximate
+ *        fallback.
+ *   3. **Approximate descent** — WOF carries point geometry for most localities (#292: ~99% of JP
+ *        municipalities; ~half of US localities have degenerate bboxes too), so the polygon walk
+ *        usually bottoms out at county level. We then descend tier-by-tier (county → localadmin →
+ *        locality → …) through the winner's DESCENDANTS (the `ancestors` table, reversed), taking
+ *        the PIP-confirmed child when a polygon exists and the nearest-centroid child otherwise —
+ *        the latter flagged `containment: "approximate"`, the demo's honesty convention.
+ *   4. **Hierarchy assembly** — the deepest place's ancestor chain via the SAME walk forward
+ *        resolution uses (`ancestry.ts`, #404), so consumers get a symmetric tree.
+ *
+ *   Reverse quality is country-dependent (polygon coverage: see the #292 JP finding); `containment`
+ *   says so per result rather than pretending.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+
+import { ancestorLineage, placetypeDepth } from "./ancestry.js"
+import { PLACE_BBOX_TABLE } from "./fts.js"
+import { geometryContains, haversineKm, type GeojsonGeometry } from "./geo.js"
+import type { PlaceCandidate, WofPlacetype } from "./types.js"
+
+/**
+ * How the deepest returned place was confirmed:
+ *
+ * - `"polygon"` — the point ray-cast INSIDE the place's real (DP-simplified) admin boundary.
+ * - `"approximate"` — the place has no polygon on record; it won by nearest-centroid among the
+ *   candidates whose bbox (or parent) contains the point. The same honesty convention as the demo's
+ *   approximate circles — country-dependent data reality, surfaced instead of hidden.
+ */
+export type ContainmentKind = "polygon" | "approximate"
+
+export interface ReverseGeocodeResult {
+	/**
+	 * The containment chain, DEEPEST-FIRST (`[0]` is the winning place, then its ancestors up to
+	 * country) — the same tree shape forward resolution attaches via `includeAncestors`. Empty when
+	 * no candidate's bbox contains the point (open ocean, or outside the gazetteer's coverage).
+	 */
+	hierarchy: PlaceCandidate[]
+	/** Containment kind of the DEEPEST place in `hierarchy` (see {@link ContainmentKind}). */
+	containment: ContainmentKind
+}
+
+export interface WofReverseGeocoderOpts {
+	/**
+	 * Path to the admin gazetteer DB (e.g. `admin-global-priority.db`) — must carry `spr`,
+	 * `ancestors`, and the package-built `place_bbox` R*Tree (`mailwoman-wof-build-fts`). Mutually
+	 * exclusive with `adminDatabase`.
+	 */
+	adminDbPath?: string
+	/** Pre-opened admin DB — primarily for tests against an inline fixture. */
+	adminDatabase?: DatabaseSync
+	/**
+	 * Path to the polygon sidecar DB (`wof-polygons.db`, table `polygons(id, geom)`). OPTIONAL —
+	 * without it every result is `containment: "approximate"` (centroid-only mode). Mutually
+	 * exclusive with `polygonDatabase`.
+	 */
+	polygonDbPath?: string
+	/** Pre-opened polygon DB — primarily for tests. */
+	polygonDatabase?: DatabaseSync
+}
+
+export interface ReverseGeocodeOpts {
+	/**
+	 * Restrict the hierarchy to these placetypes (both the bbox candidates and the descent tiers).
+	 * Default: every admin placetype the gazetteer carries. E.g. `["region", "county", "locality"]`
+	 * to skip the neighbourhood grain.
+	 */
+	placetypes?: WofPlacetype[]
+	/**
+	 * Cap on the bbox candidate fetch. Default 128 — comfortably covers a dense metro (the most
+	 * bbox-overlapping point we've measured is a few dozen neighbourhoods + the admin chain).
+	 */
+	maxCandidates?: number
+	/**
+	 * Approximate (nearest-centroid) steps further than this from the query point are not taken —
+	 * keeps a sparse gazetteer from "refining" to a far-away sibling. Polygon-confirmed steps ignore
+	 * it (containment is exact regardless of centroid distance). Default 25 km.
+	 */
+	maxApproximateKm?: number
+}
+
+const DEFAULT_MAX_CANDIDATES = 128
+const DEFAULT_MAX_APPROXIMATE_KM = 25
+
+/**
+ * The tier ladder for the approximate descent, coarsest-first. Each tier is attempted among the
+ * CURRENT winner's descendants; a tier with no rows is skipped (e.g. counties without localadmins
+ * jump straight to locality).
+ */
+const DESCENT_TIERS: readonly WofPlacetype[] = [
+	"county",
+	"localadmin",
+	"locality",
+	"borough",
+	"neighbourhood",
+	"microhood",
+]
+
+/** Internal candidate row off `spr` (+ optional bbox area / centroid distance bookkeeping). */
+interface CandidateRow {
+	id: number
+	name: string
+	placetype: string
+	country: string | null
+	parent_id: number | null
+	lat: number
+	lon: number
+}
+
+function toPlaceCandidate(row: CandidateRow, distanceKm?: number): PlaceCandidate {
+	const c: PlaceCandidate = {
+		id: row.id,
+		name: row.name,
+		placetype: row.placetype as WofPlacetype,
+		country: row.country ?? "",
+		lat: row.lat,
+		lon: row.lon,
+		parent_id: row.parent_id ?? undefined,
+		score: 0,
+	}
+	if (distanceKm !== undefined) c.distanceKm = distanceKm
+	return c
+}
+
+export class WofReverseGeocoder implements Disposable {
+	readonly #admin: DatabaseSync
+	readonly #ownsAdmin: boolean
+	readonly #polygons: DatabaseSync | null
+	readonly #ownsPolygons: boolean
+	/**
+	 * Parsed-geometry cache. Reverse queries cluster geographically (an eval run hits the same ~15
+	 * county polygons 1400 times), so caching the JSON.parse pays for itself immediately. Bounded —
+	 * cleared wholesale at the cap rather than LRU-tracked; the polygons are DP-simplified and small,
+	 * the cap exists only to keep a long-lived server process honest.
+	 */
+	readonly #geometryCache = new Map<number, GeojsonGeometry | null>()
+	static readonly #GEOMETRY_CACHE_CAP = 4096
+
+	constructor(opts: WofReverseGeocoderOpts) {
+		if (opts.adminDatabase && opts.adminDbPath) {
+			throw new Error("WofReverseGeocoder: pass either `adminDatabase` or `adminDbPath`, not both")
+		}
+		if (!opts.adminDatabase && !opts.adminDbPath) {
+			throw new Error("WofReverseGeocoder: one of `adminDatabase` or `adminDbPath` is required")
+		}
+		if (opts.polygonDatabase && opts.polygonDbPath) {
+			throw new Error("WofReverseGeocoder: pass either `polygonDatabase` or `polygonDbPath`, not both")
+		}
+
+		this.#admin = opts.adminDatabase ?? new DatabaseSync(opts.adminDbPath!, { readOnly: true })
+		this.#ownsAdmin = !opts.adminDatabase
+		this.#polygons = opts.polygonDatabase ?? (opts.polygonDbPath ? new DatabaseSync(opts.polygonDbPath, { readOnly: true }) : null)
+		this.#ownsPolygons = !opts.polygonDatabase && Boolean(opts.polygonDbPath)
+
+		// Fail loudly up front — the R*Tree is a build artifact, not part of the upstream WOF
+		// distribution, and a missing index would otherwise surface as an opaque SQL error per query.
+		const hasBbox = this.#admin
+			.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
+			.get(PLACE_BBOX_TABLE)
+		if (!hasBbox) {
+			throw new Error(
+				`WofReverseGeocoder: the admin DB has no \`${PLACE_BBOX_TABLE}\` R*Tree. Build it with ` +
+					"`mailwoman-wof-build-fts <path-to-wof.db>` (see resolver-wof-sqlite/README.md)."
+			)
+		}
+		if (this.#polygons) {
+			const hasPolygons = this.#polygons
+				.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'polygons'`)
+				.get()
+			if (!hasPolygons) {
+				throw new Error(
+					"WofReverseGeocoder: the polygon DB has no `polygons` table. Expected a `wof-polygons.db` " +
+						"built by scripts/build-wof-polygons.mjs."
+				)
+			}
+		}
+	}
+
+	/**
+	 * Resolve a WGS-84 point to its containing admin hierarchy. Async for symmetry with
+	 * `PlaceLookup.findPlace` (the work is sync `node:sqlite` underneath — same convention).
+	 */
+	async reverseGeocode(lat: number, lon: number, opts: ReverseGeocodeOpts = {}): Promise<ReverseGeocodeResult> {
+		if (!Number.isFinite(lat) || !Number.isFinite(lon) || Math.abs(lat) > 90 || Math.abs(lon) > 180) {
+			throw new RangeError(`WofReverseGeocoder.reverseGeocode: (${lat}, ${lon}) is not a WGS-84 coordinate`)
+		}
+		const maxApproximateKm = opts.maxApproximateKm ?? DEFAULT_MAX_APPROXIMATE_KM
+		const candidates = this.#bboxCandidates(lat, lon, opts)
+
+		// PIP walk, smallest-bbox-first: the first polygon that contains the point is the deepest
+		// polygon-confirmable place. Polygon-rejected candidates are bbox false positives — dropped.
+		let winner: CandidateRow | null = null
+		let winnerConfirmed = false
+		const pointOnly: CandidateRow[] = []
+		for (const c of candidates) {
+			const contains = geometryContains(this.#geometry(c.id), lon, lat)
+			if (contains === true) {
+				winner = c
+				winnerConfirmed = true
+				break
+			}
+			if (contains === null) pointOnly.push(c)
+		}
+
+		if (!winner) {
+			// No polygon confirmed anywhere — nearest centroid among the polygon-less bbox candidates.
+			let bestKm = Infinity
+			for (const c of pointOnly) {
+				const km = haversineKm(lat, lon, c.lat, c.lon)
+				if (km < bestKm) {
+					bestKm = km
+					winner = c
+				}
+			}
+			if (!winner) return { hierarchy: [], containment: "approximate" }
+		}
+
+		// Approximate descent into finer tiers than the winner.
+		let current = winner
+		let currentConfirmed = winnerConfirmed
+		let currentDistanceKm = currentConfirmed ? undefined : haversineKm(lat, lon, current.lat, current.lon)
+		for (const tier of DESCENT_TIERS) {
+			if (placetypeDepth(tier) <= placetypeDepth(current.placetype)) continue
+			if (opts.placetypes && !opts.placetypes.includes(tier)) continue
+			const kids = this.#descendants(current.id, tier, lat, lon, maxApproximateKm)
+			let next: CandidateRow | null = null
+			let nextConfirmed = false
+			let nextKm: number | undefined
+			let bestKm = Infinity
+			for (const k of kids) {
+				const contains = geometryContains(this.#geometry(k.id), lon, lat)
+				if (contains === true) {
+					next = k
+					nextConfirmed = true
+					nextKm = undefined
+					break
+				}
+				if (contains === false) continue // known not-here — polygon rejected
+				const km = haversineKm(lat, lon, k.lat, k.lon)
+				if (km <= maxApproximateKm && km < bestKm) {
+					bestKm = km
+					next = k
+					nextConfirmed = false
+					nextKm = km
+				}
+			}
+			if (next) {
+				current = next
+				currentConfirmed = nextConfirmed
+				currentDistanceKm = nextKm
+			}
+			// An empty tier is NOT terminal — counties without localadmins jump straight to locality.
+		}
+
+		// Hierarchy assembly via the shared ancestor walk. If the descent crossed an ancestry gap
+		// (the deepest place's recorded lineage misses the PIP root), merge the root's own chain so
+		// region/country are always present when a polygon confirmed them.
+		const byId = new Map<number, PlaceCandidate>()
+		byId.set(current.id, toPlaceCandidate(current, currentDistanceKm))
+		for (const a of ancestorLineage(this.#admin, current.id)) {
+			if (!byId.has(a.id)) {
+				byId.set(a.id, { ...a, placetype: a.placetype as WofPlacetype, country: a.country ?? "", score: 0 })
+			}
+		}
+		if (!byId.has(winner.id)) {
+			byId.set(winner.id, toPlaceCandidate(winner))
+			for (const a of ancestorLineage(this.#admin, winner.id)) {
+				if (!byId.has(a.id)) {
+					byId.set(a.id, { ...a, placetype: a.placetype as WofPlacetype, country: a.country ?? "", score: 0 })
+				}
+			}
+		}
+		const hierarchy = [...byId.values()]
+		if (opts.placetypes) {
+			const allowed = new Set<string>(opts.placetypes)
+			for (let i = hierarchy.length - 1; i >= 0; i--) {
+				if (!allowed.has(hierarchy[i]!.placetype)) hierarchy.splice(i, 1)
+			}
+		}
+		hierarchy.sort((a, b) => placetypeDepth(b.placetype) - placetypeDepth(a.placetype))
+
+		return { hierarchy, containment: currentConfirmed ? "polygon" : "approximate" }
+	}
+
+	/** Bbox candidates containing the point, smallest-area-first, via the `place_bbox` R*Tree. */
+	#bboxCandidates(lat: number, lon: number, opts: ReverseGeocodeOpts): CandidateRow[] {
+		const where: string[] = [
+			"bbox.min_lat <= ?",
+			"bbox.max_lat >= ?",
+			"bbox.min_lon <= ?",
+			"bbox.max_lon >= ?",
+			"spr.is_current != 0",
+			"spr.is_deprecated = 0",
+		]
+		const params: Array<number | string> = [lat, lat, lon, lon]
+		if (opts.placetypes && opts.placetypes.length > 0) {
+			where.push(`spr.placetype IN (${opts.placetypes.map(() => "?").join(", ")})`)
+			params.push(...opts.placetypes)
+		}
+		params.push(opts.maxCandidates ?? DEFAULT_MAX_CANDIDATES)
+		return this.#admin
+			.prepare(
+				`SELECT spr.id AS id, spr.name AS name, spr.placetype AS placetype, spr.country AS country,
+					spr.parent_id AS parent_id, spr.latitude AS lat, spr.longitude AS lon
+				FROM ${PLACE_BBOX_TABLE} bbox JOIN spr ON spr.id = bbox.id
+				WHERE ${where.join(" AND ")}
+				ORDER BY (bbox.max_lat - bbox.min_lat) * (bbox.max_lon - bbox.min_lon) ASC
+				LIMIT ?`
+			)
+			.all(...params) as unknown as CandidateRow[]
+	}
+
+	/**
+	 * Descendants of `parentId` at one placetype tier, pre-filtered to a centroid window around the
+	 * query point (a generous 4× the approximate cap — polygon-holding children may legitimately have
+	 * far centroids, e.g. a sprawling consolidated city; the precise cap is applied per-candidate in
+	 * the caller, and only to centroid-fallback steps).
+	 */
+	#descendants(parentId: number, placetype: string, lat: number, lon: number, maxApproximateKm: number): CandidateRow[] {
+		const windowDeg = (maxApproximateKm * 4) / 111
+		return this.#admin
+			.prepare(
+				`SELECT s.id AS id, s.name AS name, s.placetype AS placetype, s.country AS country,
+					s.parent_id AS parent_id, s.latitude AS lat, s.longitude AS lon
+				FROM ancestors a JOIN spr s ON s.id = a.id
+				WHERE a.ancestor_id = ? AND s.placetype = ? AND s.is_current != 0 AND s.is_deprecated = 0
+					AND s.latitude BETWEEN ? AND ? AND s.longitude BETWEEN ? AND ?`
+			)
+			.all(parentId, placetype, lat - windowDeg, lat + windowDeg, lon - windowDeg, lon + windowDeg) as unknown as CandidateRow[]
+	}
+
+	/** Parsed GeoJSON geometry for a WOF id, or null when absent / unparseable / no polygon DB. */
+	#geometry(id: number): GeojsonGeometry | null {
+		if (!this.#polygons) return null
+		const cached = this.#geometryCache.get(id)
+		if (cached !== undefined) return cached
+		if (this.#geometryCache.size >= WofReverseGeocoder.#GEOMETRY_CACHE_CAP) this.#geometryCache.clear()
+		const row = this.#polygons.prepare(`SELECT geom FROM polygons WHERE id = ?`).get(id) as
+			| { geom: string }
+			| undefined
+		let geometry: GeojsonGeometry | null = null
+		if (row) {
+			try {
+				geometry = JSON.parse(row.geom) as GeojsonGeometry
+			} catch {
+				geometry = null // malformed row — treat as no-polygon rather than failing the query
+			}
+		}
+		this.#geometryCache.set(id, geometry)
+		return geometry
+	}
+
+	close(): void {
+		if (this.#ownsAdmin) this.#admin.close()
+		if (this.#ownsPolygons) this.#polygons?.close()
+	}
+
+	[Symbol.dispose](): void {
+		this.close()
+	}
+}

--- a/scripts/eval/reverse-geocode-eval.ts
+++ b/scripts/eval/reverse-geocode-eval.ts
@@ -1,0 +1,224 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Reverse-geocoding eval (#484) — the honest-eval harness, inverted. The OA held-out rows carry a
+ *   REAL government lat/lon plus gold locality/region; instead of parsing the address string we
+ *   feed the COORDINATE to `WofReverseGeocoder` and score whether the gold admin components appear
+ *   in the returned hierarchy. No parser, no model — this isolates the reverse stack (R*Tree bbox →
+ *   PIP → approximate descent → ancestor chain).
+ *
+ *   Default slice: the US/VT corpus holdout (`SPLIT_MANIFEST defaultHoldouts`), the same
+ *   leakage-free geography honest-eval.sh grades forward resolution on. Leakage matters less here
+ *   (no trained model is involved), but using the same slice keeps the numbers comparable.
+ *
+ *   Metrics:
+ *
+ *   - **region-match%** — a `region` node in the hierarchy whose name (or `names` alias — gold uses
+ *       "VT", WOF says "Vermont") matches the gold region.
+ *   - **locality-match%** — any node at localadmin grain or finer whose name/alias matches the gold
+ *       locality.
+ *   - **containment histogram** — polygon vs approximate (the honesty signal; VT localities are
+ *       mostly point-geometry in WOF, so expect approximate to dominate at the locality grain).
+ *   - **deepest-placetype distribution** — the empirical answer to the scoping doc's granularity
+ *       question (stop at locality vs descend to neighbourhood).
+ *   - **ms/query** — mean + p50/p90 over the slice.
+ *
+ *   SELF-REPORTING (eval-integrity safeguard, same convention as oa-resolver-eval.ts): the runner
+ *   prints its own markdown — never hand-type figures into docs.
+ *
+ *   Run (after `yarn compile`):
+ *
+ *   node --experimental-strip-types scripts/eval/reverse-geocode-eval.ts \
+ *     --admin-db /mnt/playpen/mailwoman-data/wof/admin-global-priority.db \
+ *     --polygons-db /tmp/v440-stage/en-us/v4.4.0/wof-polygons.db \
+ *     --states VT
+ */
+
+import { createReadStream } from "node:fs"
+import { createInterface } from "node:readline"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { placetypeDepth, WofReverseGeocoder } from "@mailwoman/resolver-wof-sqlite"
+
+const { values: args } = parseArgs({
+	options: {
+		eval: { type: "string", default: "data/eval/external/openaddresses-us-sample.jsonl" },
+		states: { type: "string", default: "VT" },
+		"admin-db": { type: "string", default: "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db" },
+		"polygons-db": { type: "string", default: "/tmp/v440-stage/en-us/v4.4.0/wof-polygons.db" },
+		limit: { type: "string" },
+		"max-approx-km": { type: "string" },
+	},
+})
+
+interface EvalRow {
+	input: string
+	lat: number
+	lon: number
+	expected: { locality?: string; region?: string; postcode?: string }
+	state: string
+}
+
+/** Case-fold + strip diacritics + collapse punctuation — same normalization as the resolver's. */
+function normalizeName(s: string): string {
+	return s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[̀-ͯ]/g, "")
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+}
+
+/**
+ * The SURFACE-normalized variant (reported as a separate, labeled metric — never silently folded
+ * into the strict one): expands the St↔Saint abbreviation and strips the trailing
+ * Town/City/Village status suffix. Both are gold-surface artifacts the honest-eval work already
+ * documented (OA says "Saint Albans Town" / "Barre City", WOF says "St. Albans" / "Barre" — same
+ * place, different convention), the name-match analogue of the PIP-vs-name-match artifact class.
+ */
+function normalizeNameLoose(s: string): string {
+	return normalizeName(s)
+		.replace(/\bst\b/g, "saint")
+		.replace(/\s+(town|city|village)$/g, "")
+		.trim()
+}
+
+function percentile(sorted: number[], p: number): number {
+	if (sorted.length === 0) return 0
+	return sorted[Math.min(sorted.length - 1, Math.floor(p * sorted.length))]!
+}
+
+const states = new Set(
+	args.states
+		.split(",")
+		.map((s) => s.trim().toUpperCase())
+		.filter(Boolean)
+)
+const limit = args.limit ? Number(args.limit) : Infinity
+const maxApproximateKm = args["max-approx-km"] ? Number(args["max-approx-km"]) : undefined
+
+const rows: EvalRow[] = []
+const rl = createInterface({ input: createReadStream(args.eval), crlfDelay: Infinity })
+for await (const line of rl) {
+	if (!line.trim()) continue
+	const row = JSON.parse(line) as EvalRow
+	if (!states.has(row.state?.toUpperCase())) continue
+	rows.push(row)
+	if (rows.length >= limit) break
+}
+if (rows.length === 0) {
+	console.error(`no rows matched states=${[...states].join(",")} in ${args.eval}`)
+	process.exit(1)
+}
+
+const rg = new WofReverseGeocoder({ adminDbPath: args["admin-db"], polygonDbPath: args["polygons-db"] })
+// Alias lookups (gold "VT" vs WOF "Vermont") go straight at the admin DB's `names` table.
+const aliasDb = new DatabaseSync(args["admin-db"], { readOnly: true })
+const aliasStmt = aliasDb.prepare(`SELECT 1 FROM names WHERE id = ? AND name = ? COLLATE NOCASE LIMIT 1`)
+const aliasCache = new Map<string, boolean>()
+function nameOrAliasMatches(id: number | string, canonicalName: string, gold: string): boolean {
+	if (normalizeName(canonicalName) === normalizeName(gold)) return true
+	const key = `${id}\u0000${gold.toLowerCase()}`
+	let hit = aliasCache.get(key)
+	if (hit === undefined) {
+		hit = aliasStmt.get(Number(id), gold) !== undefined
+		aliasCache.set(key, hit)
+	}
+	return hit
+}
+
+function looseMatches(canonicalName: string, gold: string): boolean {
+	return normalizeNameLoose(canonicalName) === normalizeNameLoose(gold)
+}
+
+let regionMatch = 0
+let regionScored = 0
+let localityMatch = 0
+let localityMatchLoose = 0
+let localityScored = 0
+const containmentCounts = new Map<string, number>()
+const deepestCounts = new Map<string, number>()
+const localityMatchByContainment = new Map<string, { n: number; match: number }>()
+const timesMs: number[] = []
+const misses: string[] = []
+let empty = 0
+
+for (const row of rows) {
+	const t0 = performance.now()
+	const result = await rg.reverseGeocode(row.lat, row.lon, maxApproximateKm ? { maxApproximateKm } : {})
+	timesMs.push(performance.now() - t0)
+
+	const deepest = result.hierarchy[0]
+	if (!deepest) {
+		empty++
+		continue
+	}
+	containmentCounts.set(result.containment, (containmentCounts.get(result.containment) ?? 0) + 1)
+	deepestCounts.set(deepest.placetype, (deepestCounts.get(deepest.placetype) ?? 0) + 1)
+
+	if (row.expected.region) {
+		regionScored++
+		const region = result.hierarchy.find((p) => p.placetype === "region")
+		if (region && nameOrAliasMatches(region.id, region.name, row.expected.region)) regionMatch++
+	}
+	if (row.expected.locality) {
+		localityScored++
+		const bucket = localityMatchByContainment.get(result.containment) ?? { n: 0, match: 0 }
+		bucket.n++
+		const fine = result.hierarchy.filter((p) => placetypeDepth(p.placetype) >= placetypeDepth("localadmin"))
+		const matched = fine.some((p) => nameOrAliasMatches(p.id, p.name, row.expected.locality!))
+		const matchedLoose = matched || fine.some((p) => looseMatches(p.name, row.expected.locality!))
+		if (matchedLoose) localityMatchLoose++
+		if (matched) {
+			localityMatch++
+			bucket.match++
+		} else if (misses.length < 12 && !matchedLoose) {
+			misses.push(
+				`  "${row.input}" → gold="${row.expected.locality}" got=[${fine.map((p) => `${p.placetype}:${p.name}`).join(", ")}] (${result.containment})`
+			)
+		}
+		localityMatchByContainment.set(result.containment, bucket)
+	}
+}
+
+rg.close()
+aliasDb.close()
+
+const pct = (num: number, den: number): string => (den ? `${((100 * num) / den).toFixed(1)}%` : "—")
+const sortedMs = [...timesMs].sort((a, b) => a - b)
+const meanMs = timesMs.reduce((a, b) => a + b, 0) / timesMs.length
+
+console.log(`### Reverse-geocode eval — ${[...states].join("/")} slice of \`${args.eval}\``)
+console.log("")
+console.log(`Admin DB: \`${args["admin-db"]}\` · polygons: \`${args["polygons-db"]}\``)
+console.log("")
+console.log(`| metric | value |`)
+console.log(`| --- | ---: |`)
+console.log(`| rows | ${rows.length} |`)
+console.log(`| empty hierarchy | ${empty} |`)
+console.log(`| region-match | ${pct(regionMatch, regionScored)} (${regionMatch}/${regionScored}) |`)
+console.log(`| locality-match (strict) | ${pct(localityMatch, localityScored)} (${localityMatch}/${localityScored}) |`)
+console.log(
+	`| locality-match (surface-normalized: St↔Saint, Town/City/Village suffix) | ${pct(localityMatchLoose, localityScored)} (${localityMatchLoose}/${localityScored}) |`
+)
+console.log(`| ms/query mean | ${meanMs.toFixed(2)} |`)
+console.log(`| ms/query p50 / p90 | ${percentile(sortedMs, 0.5).toFixed(2)} / ${percentile(sortedMs, 0.9).toFixed(2)} |`)
+console.log("")
+console.log(`Containment histogram:`)
+for (const [kind, n] of [...containmentCounts].sort((a, b) => b[1] - a[1])) {
+	const bucket = localityMatchByContainment.get(kind)
+	console.log(`- \`${kind}\`: ${n} (${pct(n, rows.length - empty)}) — locality-match ${pct(bucket?.match ?? 0, bucket?.n ?? 0)}`)
+}
+console.log("")
+console.log(`Deepest-placetype distribution (the granularity question):`)
+for (const [pt, n] of [...deepestCounts].sort((a, b) => b[1] - a[1])) {
+	console.log(`- \`${pt}\`: ${n} (${pct(n, rows.length - empty)})`)
+}
+if (misses.length > 0) {
+	console.log("")
+	console.log(`First locality misses (surface-normalized misses excluded — these are the genuine wrong-place class):`)
+	for (const m of misses) console.log(m)
+}


### PR DESCRIPTION
First slice of #484: node-side reverse geocoding in `resolver-wof-sqlite`.

## What

- **`WofReverseGeocoder`** (`reverse.ts`): `reverseGeocode(lat, lon, opts?) → { hierarchy, containment }` — hierarchy deepest-first (same tree shape as forward `includeAncestors`), `containment: "polygon" | "approximate"` describes the deepest node. Opts: `placetypes` grain cap, `maxCandidates` (128), `maxApproximateKm` (25). Works centroid-only without the polygon sidecar.
- **Walk**: `place_bbox` R*Tree candidates smallest-area-first → PIP confirm (bbox hits the polygon rejects are dropped as false positives) → tier-by-tier approximate descent through the winner's *descendants* via the `ancestors` table. The descent is load-bearing: ~half of VT locality bboxes are degenerate points, invisible to the R*Tree.
- **PIP in TS** (`geo.ts`): even-odd ray-cast (Polygon + MultiPolygon with holes) — the canonical port of `scripts/eval/pip-containment.py`; the duplication is noted at both ends.
- **`ancestry.ts`**: ancestor walk factored out, shared by forward `lookup.ts` and reverse.
- **Eval** (`scripts/eval/reverse-geocode-eval.ts`): the honest-eval harness inverted — VT held-out coordinates → hierarchy.

## First measurement (VT held-out, n=1428)

| Metric | Value |
| --- | --- |
| region-match | **100%** |
| locality-match | **83.5% strict / 91.4% surface-normalized** (St↔Saint, Town/City/Village suffix) |
| containment | 96.5% approximate / 3.5% polygon (wof-polygons.db has only 5 VT locality polygons) |
| deepest placetype | locality 80.4% / neighbourhood 19.6% |
| perf | 0.59 ms/query mean, p90 0.73 ms |

Residual strict misses are neighbor-town nearest-centroid errors in point-geometry towns (Weathersfield→Baltimore class) — a polygon-coverage gap, not a walk bug; adding localadmin polygons to `build-wof-polygons.mjs` would flip most of VT from approximate to polygon containment.

## Tests

13 in `reverse.test.ts` (PIP primitives, fixture-gazetteer walk, false-positive veto, point-geometry descent, distance cap, no-polygon mode) + integration gated on `MAILWOMAN_WOF_ADMIN_DB`/`MAILWOMAN_WOF_POLYGONS_DB` (hot-db.test.ts pattern) — 13/13 verified against the production gazetteer locally. Full resolver-wof-sqlite (173) + core/resolver (34) green.

## Not in this slice

Browser tier (httpvfs split), demo click-the-map, `/api/reverse` surface, and the nearest-address stage (waits on #476). Tracked on #484.

Closes nothing — #484 stays open for the browser/demo slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)