### PR TITLE
feat(resolver): house-number interpolation first slice — VT pilot, gate MISS reported (#483)

### DIFF
--- a/docs/articles/plan/2026-06-11-interpolation-design.md
+++ b/docs/articles/plan/2026-06-11-interpolation-design.md
@@ -85,9 +85,14 @@ CREATE INDEX idx_seg_street   ON street_segment (street_norm, min_hn);
 
 Keying reuses `resolver-wof-sqlite/street-normalize.ts` — the SAME function the
 address-point shard and lookup use (one normalizer, never two; the PLACETYPE_ORDER
-lesson). Geometry is a plain JSON polyline: segments are short (p95 well under a km),
-the per-row cost is small at state scale, and it keeps the reader dependency-free —
-revisit encoding only if a national build makes size hurt.
+lesson) — plus `canonicalizeRouteKey`, a route-designator fold applied by BOTH the
+builder and the lookup. Measured need: TIGER spells routes `State Rte 100` / `US Hwy 5`
+where E911/Overture say `VT ROUTE 100` / `US ROUTE 5` — the single largest street-name
+miss class in the VT eval (+3.1pp coverage from the fold alone, no tail cost). The
+address-point tier does not apply the fold yet; adopting it there needs a #476 shard
+rebuild (follow-up). Geometry is a plain JSON polyline: segments are short, the per-row
+cost is small at state scale, and it keeps the reader dependency-free — revisit encoding
+only if a national build makes size hurt.
 
 **Scoping is postcode-first, like the address-point tier.** TIGER edges carry no
 locality name, so locality scope can't be matched directly against this table — a known
@@ -103,8 +108,12 @@ Given `{ street, number, postcode? }`:
 1. **Normalize** street via `normalizeStreetForKey`; parse `number` as a non-negative
    integer (non-numeric → no answer, this tier doesn't guess).
 2. **Candidate fetch** — rows with `street_norm` equal and `min_hn ≤ n ≤ max_hn`,
-   postcode-scoped when a postcode is given. On zero postcode-scoped rows, retry
-   statewide; abstain if the statewide candidates disagree on postcode.
+   postcode-scoped when a postcode is given. A given ZIP that scopes to nothing is a
+   MISS, not a statewide guess — the statewide retry was built and MEASURED (2026-06-11
+   VT eval): +2.3pp coverage but a poisoned tail (p99 1.0 → 20.8 km, max 204 km — a
+   statewide-unique name can live in a far-away town), so it was reverted. Queries
+   WITHOUT a postcode match statewide and abstain unless every candidate agrees on a
+   single ZIP.
 3. **Parity match** — prefer sides whose `parity` equals the number's parity, then
    `mixed`, then opposite-parity as a last resort (an opposite-parity hit is usually the
    right block, wrong side of the street — tens of meters, not kilometers; the result
@@ -155,6 +164,24 @@ deterministic held-out sample of Vermont points:
 These are points the exact tier would mostly HIT — the eval uses them precisely because
 truth is known. The production value is the complement (numbers with no point), where
 truth is unknowable; measuring on known points is the only honest proxy.
+
+## Pilot results (2026-06-11, VT, 5000-key sample, seed 42)
+
+- **Coverage 82.0%** (4100/5000 found a segment). Miss composition: 469 name-absent in
+  TIGER (private roads, new subdivisions, E911-only names like `CHARBO UNKNOWN 6`), 232
+  range-gaps within the right ZIP+name, 166 ZIP-mismatches (name+range exists in a
+  neighbouring ZIP — the class the rejected statewide retry would have answered, badly),
+  33 range-gaps statewide.
+- **Coord error vs truth: p50 66 m, p90 249 m** (p99 1.0 km; parity-matched n=3927 p50
+  65 m / fallback n=173 p50 116 m). Median claimed uncertainty (half segment length)
+  137 m — the p50 error sits inside the claimed radius.
+- **Gate: MISS.** The pre-registered #483 gate (p50 ≤ 50 m, p90 ≤ 150 m) is NOT met —
+  stated plainly, not re-baselined. The shortfall tracks rural Vermont's long sparse
+  segments (median claimed uncertainty 137 m: the geometry itself caps precision) and
+  TIGER's uniform-spacing assumption. Next levers, in measured-first order: re-run on a
+  denser county (the gate may simply be a rural-geometry artifact — measure before
+  building), segment subdivision at OA point anchors, ZIP+4 snapping (#525). No rollout
+  until a gate pass or a STATED re-baseline with operator sign-off.
 
 ## Open questions
 

--- a/docs/articles/plan/2026-06-11-interpolation-design.md
+++ b/docs/articles/plan/2026-06-11-interpolation-design.md
@@ -45,7 +45,7 @@ TIGER conventions that shape the schema:
   street can be a ZIP boundary). We emit one ROW PER SIDE, not per edge.
 - **Parity is per side, by convention but not by contract.** Typically one side of a US
   street is odd and the other even, and TIGER's from/to numbers usually agree on parity
-  (~97.7% of Vermont sides). When from/to parity DISAGREES the side is recorded
+  (Vermont: 137,248 of 137,256 sides). When from/to parity DISAGREES the side is recorded
   `parity = "mixed"` and matches either parity. Per-side fidelity is an open question
   below — we measure it, we don't assume it.
 - **Ranges may descend.** `from > to` means house numbers decrease walking from-node →
@@ -165,8 +165,9 @@ truth is unknowable; measuring on known points is the only honest proxy.
    **Operator call** before this grows beyond a pilot: stay (one fewer package, shared
    normalizer stays intra-package) vs split (independent versioning of the TIGER data
    contract). Nothing in this slice blocks either answer.
-2. **Odd/even fidelity.** Vermont measures ~97.7% of address-carrying sides
-   parity-consistent, but TIGER does not guarantee it nationally; the `mixed` bucket and
+2. **Odd/even fidelity.** Vermont measures 99.99% of address-carrying sides
+   parity-consistent (8 `mixed` of 137,256), but a clean from/to pair doesn't prove the
+   real houses obey it, and TIGER does not guarantee it nationally; the `mixed` bucket and
    the opposite-parity fallback are the pressure valves. The eval's parity-split
    reporting is the instrument — if fallback hits dominate the error tail in a denser
    state, revisit before national rollout.

--- a/docs/articles/plan/2026-06-11-interpolation-design.md
+++ b/docs/articles/plan/2026-06-11-interpolation-design.md
@@ -30,14 +30,14 @@ The same per-county shapefiles the real-intersection eval already reads
 `www2.census.gov/geo/tiger/TIGER2023/EDGES/tl_2023_<countyfips>_edges.zip` into
 `/tmp/tiger-edges/`). Each road edge carries:
 
-| Field                 | Meaning                                                        |
-| --------------------- | -------------------------------------------------------------- |
-| `FULLNAME`            | Street name as TIGER spells it (`State Route 12`, `Main St`)   |
-| `LFROMADD`/`LTOADD`   | House-number range on the LEFT side, walking from→to node      |
-| `RFROMADD`/`RTOADD`   | House-number range on the RIGHT side                           |
-| `ZIPL`/`ZIPR`         | ZIP code per side                                              |
-| `MTFCC`               | Feature class — `S1…` is a road                                |
-| `geom`                | The segment polyline (WGS84 lon/lat)                           |
+| Field               | Meaning                                                      |
+| ------------------- | ------------------------------------------------------------ |
+| `FULLNAME`          | Street name as TIGER spells it (`State Route 12`, `Main St`) |
+| `LFROMADD`/`LTOADD` | House-number range on the LEFT side, walking from→to node    |
+| `RFROMADD`/`RTOADD` | House-number range on the RIGHT side                         |
+| `ZIPL`/`ZIPR`       | ZIP code per side                                            |
+| `MTFCC`             | Feature class — `S1…` is a road                              |
+| `geom`              | The segment polyline (WGS84 lon/lat)                         |
 
 TIGER conventions that shape the schema:
 
@@ -116,7 +116,7 @@ Given `{ street, number, postcode? }`:
    length to the point at fraction `t`. Descending ranges need no special case: `t` is
    computed against the raw from/to, which already encodes direction.
 6. **Answer** — `{ lat, lon, interpolated: true, parityMatched, uncertaintyM, source,
-   release }` where `uncertaintyM` is half the segment's polyline length in meters.
+release }` where `uncertaintyM` is half the segment's polyline length in meters.
 
 No side-of-street offset in this slice: TIGER centerline + half-segment uncertainty is
 the honest claim. Offsetting perpendicular by ~10 m to the matched side is a cheap

--- a/docs/articles/plan/2026-06-11-interpolation-design.md
+++ b/docs/articles/plan/2026-06-11-interpolation-design.md
@@ -1,0 +1,179 @@
+# House-number interpolation — design (#483, slice 1)
+
+First slice of the interpolation tier scoped in
+[2026-06-11-geocoder-table-stakes-scoping.md](./2026-06-11-geocoder-table-stakes-scoping.md):
+"123 Main St" where no address point exists → estimate the coordinate between known ranges
+along the street segment. This document covers the pilot — a Vermont-scoped TIGER EDGES
+segment table, a standalone interpolation module in `resolver-wof-sqlite`, and the honest
+eval that grades it against real address points.
+
+## Where it sits in the resolution ladder
+
+```
+exact address point  (#476, AddressPointSqliteLookup — situs coordinate, tier "address_point")
+        ↓ miss
+interpolation        (#483, StreetInterpolator — THIS DOC, tier "interpolated")
+        ↓ miss
+admin centroid       (locality/region/country — the existing WOF resolver answer)
+```
+
+The interpolator only ever answers when the exact-point tier missed, and its answer is
+always flagged: `interpolated: true` plus an `uncertaintyM` radius (half the matched
+segment's length — the honest default from the #483 issue). Same honesty convention as
+`reverse.ts`'s `containment: "approximate"` and the demo's approximate circles: data
+reality surfaced per result, never hidden.
+
+## Data: TIGER EDGES
+
+The same per-county shapefiles the real-intersection eval already reads
+(`scripts/eval/build-intersection-real.ts`, DuckDB spatial `ST_Read`, downloaded from
+`www2.census.gov/geo/tiger/TIGER2023/EDGES/tl_2023_<countyfips>_edges.zip` into
+`/tmp/tiger-edges/`). Each road edge carries:
+
+| Field                 | Meaning                                                        |
+| --------------------- | -------------------------------------------------------------- |
+| `FULLNAME`            | Street name as TIGER spells it (`State Route 12`, `Main St`)   |
+| `LFROMADD`/`LTOADD`   | House-number range on the LEFT side, walking from→to node      |
+| `RFROMADD`/`RTOADD`   | House-number range on the RIGHT side                           |
+| `ZIPL`/`ZIPR`         | ZIP code per side                                              |
+| `MTFCC`               | Feature class — `S1…` is a road                                |
+| `geom`                | The segment polyline (WGS84 lon/lat)                           |
+
+TIGER conventions that shape the schema:
+
+- **Sides are independent.** Left and right carry separate ranges and separate ZIPs (a
+  street can be a ZIP boundary). We emit one ROW PER SIDE, not per edge.
+- **Parity is per side, by convention but not by contract.** Typically one side of a US
+  street is odd and the other even, and TIGER's from/to numbers usually agree on parity
+  (~97.7% of Vermont sides). When from/to parity DISAGREES the side is recorded
+  `parity = "mixed"` and matches either parity. Per-side fidelity is an open question
+  below — we measure it, we don't assume it.
+- **Ranges may descend.** `from > to` means house numbers decrease walking from-node →
+  to-node. The row keeps the raw from/to (the interpolation position needs the
+  direction); the index columns store `min`/`max` for range matching.
+- **Ranges are potential, not actual.** TIGER ranges are theoretical capacity
+  (`100–198`), not occupancy. Interpolating assumes uniform spacing across the range —
+  the classic source of interpolation error, which is exactly what the eval measures.
+- **Non-numeric house numbers exist** (hyphenated Queens-style `12-34`, alphanumeric
+  suffixes). The pilot keeps numeric-only sides and counts what it skips.
+
+## Segment table schema
+
+One SQLite DB per state, built by `scripts/build-interpolation-shard.ts` (the
+`build-address-point-shard.ts` pattern: idempotent rebuild, provenance per row, THE shared
+street normalizer):
+
+```sql
+CREATE TABLE street_segment (
+  street_norm  TEXT NOT NULL,   -- normalizeStreetForKey(FULLNAME) — the shared normalizer
+  side         TEXT NOT NULL,   -- 'L' | 'R'
+  from_hn      INTEGER NOT NULL,-- raw TIGER from (may exceed to_hn)
+  to_hn        INTEGER NOT NULL,
+  min_hn       INTEGER NOT NULL,-- min(from,to) — range-match column
+  max_hn       INTEGER NOT NULL,
+  parity       TEXT NOT NULL,   -- 'odd' | 'even' | 'mixed'
+  postcode     TEXT,            -- ZIPL or ZIPR for this side
+  county_fips  TEXT NOT NULL,   -- scope + provenance
+  street_raw   TEXT NOT NULL,   -- FULLNAME as shipped
+  geometry     TEXT NOT NULL,   -- JSON [[lon,lat],…] polyline, from-node first
+  source       TEXT NOT NULL,   -- 'tiger:edges'
+  release      TEXT NOT NULL    -- 'TIGER2023'
+);
+CREATE INDEX idx_seg_postcode ON street_segment (postcode, street_norm, min_hn);
+CREATE INDEX idx_seg_street   ON street_segment (street_norm, min_hn);
+```
+
+Keying reuses `resolver-wof-sqlite/street-normalize.ts` — the SAME function the
+address-point shard and lookup use (one normalizer, never two; the PLACETYPE_ORDER
+lesson). Geometry is a plain JSON polyline: segments are short (p95 well under a km),
+the per-row cost is small at state scale, and it keeps the reader dependency-free —
+revisit encoding only if a national build makes size hurt.
+
+**Scoping is postcode-first, like the address-point tier.** TIGER edges carry no
+locality name, so locality scope can't be matched directly against this table — a known
+limitation of this slice (see open questions). Queries without a postcode fall back to a
+statewide street-name match, which is honest but ambiguous for common names ("Main
+Street" exists in many towns); the lookup ABSTAINS when the statewide candidates span
+multiple postcodes with no way to pick.
+
+## Query algorithm (`resolver-wof-sqlite/interpolation.ts`)
+
+Given `{ street, number, postcode? }`:
+
+1. **Normalize** street via `normalizeStreetForKey`; parse `number` as a non-negative
+   integer (non-numeric → no answer, this tier doesn't guess).
+2. **Candidate fetch** — rows with `street_norm` equal and `min_hn ≤ n ≤ max_hn`,
+   postcode-scoped when a postcode is given. On zero postcode-scoped rows, retry
+   statewide; abstain if the statewide candidates disagree on postcode.
+3. **Parity match** — prefer sides whose `parity` equals the number's parity, then
+   `mixed`, then opposite-parity as a last resort (an opposite-parity hit is usually the
+   right block, wrong side of the street — tens of meters, not kilometers; the result
+   reports `parityMatched: false` so callers and the eval can see it).
+4. **Pick** the tightest range (smallest `max_hn − min_hn`) among the preferred group —
+   the most specific claim wins.
+5. **Interpolate** — `t = (n − from_hn) / (to_hn − from_hn)` (0.5 when the range is a
+   single number), clamped to [0, 1], then walk the polyline by cumulative haversine arc
+   length to the point at fraction `t`. Descending ranges need no special case: `t` is
+   computed against the raw from/to, which already encodes direction.
+6. **Answer** — `{ lat, lon, interpolated: true, parityMatched, uncertaintyM, source,
+   release }` where `uncertaintyM` is half the segment's polyline length in meters.
+
+No side-of-street offset in this slice: TIGER centerline + half-segment uncertainty is
+the honest claim. Offsetting perpendicular by ~10 m to the matched side is a cheap
+follow-up once the eval says the centerline is the dominant error term (it isn't — range
+uniformity is).
+
+## Resolver tier placement
+
+`core/resolver/resolve.ts` already runs the exact-point tier via `opts.addressPoints`
+(`applyAddressPoint`, stamping `resolution_tier: "address_point"`). The interpolation
+tier slots in immediately after it as the fall-through: same `(street, number, postcode,
+locality)` extraction, consulted ONLY when the exact tier missed, stamping
+`resolution_tier: "interpolated"` + the uncertainty metadata.
+
+**This slice ships the module standalone and does NOT wire core.** The wiring needs a
+second `ResolveOpts` member (or a widening of `addressPoints` into an ordered tier list)
+and that interface decision deserves its own review — noted as a follow-up on #483
+rather than smuggled into the pilot. The module's `find()` signature is deliberately
+identical in shape to `AddressPointLookup.find()` so the wiring is mechanical when it
+lands.
+
+## Eval — honest-eval pattern at street grain
+
+`scripts/eval/interpolation-eval.ts`, self-reporting. The gold is the #476 address-point
+shard (`address-points-us-vt.db`, Overture 2026-05-20.0 — NAD/E911-lineage situs
+points): an independent source from TIGER, so grading against it is non-circular. For a
+deterministic held-out sample of Vermont points:
+
+- query `(street_raw, number, postcode)` through the interpolator,
+- **coverage** — fraction that found a segment at all,
+- **coord error** — haversine meters vs the true point, reported p50/p90 (plus the
+  parity-matched/fallback split),
+- graded against the #483 pre-registered gate: **p50 ≤ 50 m, p90 ≤ 150 m** on the VT
+  holdout before any rollout.
+
+These are points the exact tier would mostly HIT — the eval uses them precisely because
+truth is known. The production value is the complement (numbers with no point), where
+truth is unknowable; measuring on known points is the only honest proxy.
+
+## Open questions
+
+1. **Workspace split.** This slice implements inside `resolver-wof-sqlite` (the module is
+   small, shares the normalizer + geo helpers, and ships nothing by default). The scoping
+   note leaned toward a new `@mailwoman/resolver-interpolation` workspace — different
+   data lifecycle (TIGER yearly vintages vs WOF), the slim/fat split the demo taught.
+   **Operator call** before this grows beyond a pilot: stay (one fewer package, shared
+   normalizer stays intra-package) vs split (independent versioning of the TIGER data
+   contract). Nothing in this slice blocks either answer.
+2. **Odd/even fidelity.** Vermont measures ~97.7% of address-carrying sides
+   parity-consistent, but TIGER does not guarantee it nationally; the `mixed` bucket and
+   the opposite-parity fallback are the pressure valves. The eval's parity-split
+   reporting is the instrument — if fallback hits dominate the error tail in a denser
+   state, revisit before national rollout.
+3. **Locality scope.** TIGER carries ZIPs, not locality names. A locality-only query
+   (no postcode) currently rides the statewide fallback + abstention. Joining ZIP →
+   locality via the postcode shard (or place ancestry) would restore locality scoping —
+   follow-up, not pilot.
+4. **ZIP+4 snapping** — deferred to #525 (needs the ZCTA work as a prior), per scoping.
+5. **EU rollout** — OSM Karlsruhe-schema `addr:interpolation` ways, with the ODbL
+   share-alike treatment documented in #26. Out of scope for the US pilot.

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -51,7 +51,7 @@ export {
 	type GeojsonPosition,
 } from "./geo.js"
 
-export { ancestorLineage, PLACETYPE_DEPTH, placetypeDepth, type AncestorPlaceRow } from "./ancestry.js"
+export { PLACETYPE_DEPTH, ancestorLineage, placetypeDepth, type AncestorPlaceRow } from "./ancestry.js"
 
 export {
 	WofReverseGeocoder,
@@ -61,6 +61,8 @@ export {
 	type WofReverseGeocoderOpts,
 } from "./reverse.js"
 
+export { AddressPointSqliteLookup } from "./address-point.js"
+export { StreetInterpolator, type InterpolatedHit, type InterpolationQuery } from "./interpolation.js"
 export {
 	deriveSchemaName,
 	pickShardForPlacetype,
@@ -68,4 +70,3 @@ export {
 	type ResolvedShard,
 	type ShardConfig,
 } from "./sharding.js"
-export { AddressPointSqliteLookup } from "./address-point.js"

--- a/resolver-wof-sqlite/interpolation.test.ts
+++ b/resolver-wof-sqlite/interpolation.test.ts
@@ -1,0 +1,244 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the house-number interpolation tier (#483). Seeds an in-memory `street_segment` fixture
+ *   (the schema `scripts/build-interpolation-shard.ts` builds), then asserts parity-aware matching,
+ *   boundary/descending-range interpolation, postcode scoping + the no-scope abstention, and the
+ *   no-match fall-through.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { StreetInterpolator } from "./interpolation.js"
+
+interface SeedSegment {
+	street_norm: string
+	side: "L" | "R"
+	from_hn: number
+	to_hn: number
+	parity: "odd" | "even" | "mixed"
+	postcode: string | null
+	geometry: [number, number][]
+}
+
+function seed(db: DatabaseSync, segments: SeedSegment[]): void {
+	db.exec(`
+		CREATE TABLE street_segment (
+			street_norm  TEXT NOT NULL,
+			side         TEXT NOT NULL,
+			from_hn      INTEGER NOT NULL,
+			to_hn        INTEGER NOT NULL,
+			min_hn       INTEGER NOT NULL,
+			max_hn       INTEGER NOT NULL,
+			parity       TEXT NOT NULL,
+			postcode     TEXT,
+			county_fips  TEXT NOT NULL,
+			street_raw   TEXT NOT NULL,
+			geometry     TEXT NOT NULL,
+			source       TEXT NOT NULL,
+			release      TEXT NOT NULL
+		)
+	`)
+	const ins = db.prepare(
+		`INSERT INTO street_segment
+		 (street_norm, side, from_hn, to_hn, min_hn, max_hn, parity, postcode, county_fips, street_raw, geometry, source, release)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, '50023', ?, ?, 'tiger:edges', 'TIGER2023')`
+	)
+	for (const s of segments) {
+		ins.run(
+			s.street_norm,
+			s.side,
+			s.from_hn,
+			s.to_hn,
+			Math.min(s.from_hn, s.to_hn),
+			Math.max(s.from_hn, s.to_hn),
+			s.parity,
+			s.postcode,
+			s.street_norm,
+			JSON.stringify(s.geometry)
+		)
+	}
+}
+
+// A straight 0.001-degree east-west street on the equator (~111 m): even 100–198 on the
+// right, odd 101–199 on the left, both in ZIP 05601.
+const MAIN_EVEN: SeedSegment = {
+	street_norm: "main street",
+	side: "R",
+	from_hn: 100,
+	to_hn: 198,
+	parity: "even",
+	postcode: "05601",
+	geometry: [
+		[0, 0],
+		[0.001, 0],
+	],
+}
+const MAIN_ODD: SeedSegment = { ...MAIN_EVEN, side: "L", from_hn: 101, to_hn: 199, parity: "odd" }
+
+let db: DatabaseSync
+let interpolator: StreetInterpolator
+
+beforeAll(() => {
+	db = new DatabaseSync(":memory:")
+	seed(db, [
+		MAIN_EVEN,
+		MAIN_ODD,
+		// Same street name, different town/ZIP — the postcode-scoping + abstention fixture.
+		{
+			...MAIN_EVEN,
+			postcode: "05602",
+			geometry: [
+				[1, 1],
+				[1.001, 1],
+			],
+		},
+		// Descending range: numbers DECREASE walking from-node → to-node.
+		{
+			street_norm: "river road",
+			side: "R",
+			from_hn: 500,
+			to_hn: 400,
+			parity: "even",
+			postcode: "05601",
+			geometry: [
+				[0, 1],
+				[0.001, 1],
+			],
+		},
+		// Single-number "range" — answer is the segment midpoint.
+		{
+			street_norm: "depot square",
+			side: "L",
+			from_hn: 7,
+			to_hn: 7,
+			parity: "odd",
+			postcode: "05601",
+			geometry: [
+				[0, 2],
+				[0.001, 2],
+			],
+		},
+		// Odd number on a street with ONLY an even side on record — the parity fallback.
+		{
+			street_norm: "mill street",
+			side: "R",
+			from_hn: 2,
+			to_hn: 98,
+			parity: "even",
+			postcode: "05601",
+			geometry: [
+				[0, 3],
+				[0.001, 3],
+			],
+		},
+		// Mixed-parity side matches either parity without the fallback flag.
+		{
+			street_norm: "bridge street",
+			side: "L",
+			from_hn: 1,
+			to_hn: 50,
+			parity: "mixed",
+			postcode: "05601",
+			geometry: [
+				[0, 4],
+				[0.001, 4],
+			],
+		},
+	])
+	interpolator = new StreetInterpolator({ database: db })
+})
+
+afterAll(() => {
+	interpolator.close()
+	db.close()
+})
+
+describe("StreetInterpolator", () => {
+	it("interpolates linearly along the segment, parity-matched to the even side", () => {
+		const hit = interpolator.find({ street: "Main St", number: "150", postcode: "05601" })
+		expect(hit).not.toBeNull()
+		expect(hit!.interpolated).toBe(true)
+		expect(hit!.parityMatched).toBe(true)
+		// t = (150 − 100) / 98 along a straight segment → lon = 0.001 × t.
+		expect(hit!.lon).toBeCloseTo(0.001 * (50 / 98), 9)
+		expect(hit!.lat).toBeCloseTo(0, 9)
+		expect(hit!.source).toBe("tiger:edges")
+		expect(hit!.release).toBe("TIGER2023")
+	})
+
+	it("routes an odd number to the odd side of the same street", () => {
+		const hit = interpolator.find({ street: "Main Street", number: "151", postcode: "05601" })
+		expect(hit!.parityMatched).toBe(true)
+		expect(hit!.lon).toBeCloseTo(0.001 * (50 / 98), 9)
+	})
+
+	it("answers the exact from/to boundaries with the segment endpoints", () => {
+		const atFrom = interpolator.find({ street: "Main St", number: "100", postcode: "05601" })
+		expect(atFrom!.lon).toBeCloseTo(0, 9)
+		const atTo = interpolator.find({ street: "Main St", number: "198", postcode: "05601" })
+		expect(atTo!.lon).toBeCloseTo(0.001, 9)
+	})
+
+	it("handles a descending range (from > to) by walking the geometry in range direction", () => {
+		// 450 is 50% of the way from 500 → 400, so 50% along the polyline from the from-node.
+		const hit = interpolator.find({ street: "River Rd", number: "450", postcode: "05601" })
+		expect(hit!.lon).toBeCloseTo(0.0005, 9)
+		expect(hit!.lat).toBeCloseTo(1, 9)
+		// And the from-boundary sits at the polyline START even though it's the range MAX.
+		const atFrom = interpolator.find({ street: "River Rd", number: "500", postcode: "05601" })
+		expect(atFrom!.lon).toBeCloseTo(0, 9)
+	})
+
+	it("answers a single-number range with the segment midpoint", () => {
+		const hit = interpolator.find({ street: "Depot Sq", number: "7", postcode: "05601" })
+		expect(hit!.lon).toBeCloseTo(0.0005, 9)
+		expect(hit!.lat).toBeCloseTo(2, 9)
+	})
+
+	it("falls back to the opposite-parity side, flagged parityMatched: false", () => {
+		const hit = interpolator.find({ street: "Mill St", number: "51", postcode: "05601" })
+		expect(hit).not.toBeNull()
+		expect(hit!.parityMatched).toBe(false)
+		expect(hit!.lat).toBeCloseTo(3, 9)
+	})
+
+	it("treats a mixed-parity side as parity-matched for either parity", () => {
+		const odd = interpolator.find({ street: "Bridge St", number: "25", postcode: "05601" })
+		const even = interpolator.find({ street: "Bridge St", number: "26", postcode: "05601" })
+		expect(odd!.parityMatched).toBe(true)
+		expect(even!.parityMatched).toBe(true)
+	})
+
+	it("reports half the segment length as the uncertainty radius", () => {
+		const hit = interpolator.find({ street: "Main St", number: "150", postcode: "05601" })
+		// 0.001 degrees of equatorial longitude ≈ 111.2 m → half ≈ 56 m.
+		expect(hit!.uncertaintyM).toBeGreaterThan(40)
+		expect(hit!.uncertaintyM).toBeLessThan(70)
+	})
+
+	it("scopes by postcode — the same street name in another ZIP answers from ITS segment", () => {
+		const hit = interpolator.find({ street: "Main St", number: "150", postcode: "05602" })
+		expect(hit!.lat).toBeCloseTo(1, 9)
+	})
+
+	it("abstains without a postcode when the name spans multiple ZIPs", () => {
+		expect(interpolator.find({ street: "Main St", number: "150" })).toBeNull()
+	})
+
+	it("answers without a postcode when the statewide match is unambiguous", () => {
+		const hit = interpolator.find({ street: "River Rd", number: "450" })
+		expect(hit).not.toBeNull()
+		expect(hit!.lat).toBeCloseTo(1, 9)
+	})
+
+	it("falls through on no matching street, out-of-range number, wrong ZIP, or non-numeric input", () => {
+		expect(interpolator.find({ street: "Nowhere Ln", number: "5", postcode: "05601" })).toBeNull()
+		expect(interpolator.find({ street: "Main St", number: "999", postcode: "05601" })).toBeNull()
+		expect(interpolator.find({ street: "Main St", number: "150", postcode: "99999" })).toBeNull()
+		expect(interpolator.find({ street: "Main St", number: "12-34", postcode: "05601" })).toBeNull()
+		expect(interpolator.find({ street: "Main St", number: "", postcode: "05601" })).toBeNull()
+	})
+})

--- a/resolver-wof-sqlite/interpolation.test.ts
+++ b/resolver-wof-sqlite/interpolation.test.ts
@@ -147,6 +147,20 @@ beforeAll(() => {
 				[0.001, 4],
 			],
 		},
+		// Stored under the CANONICAL route key (as the builder writes it from TIGER's
+		// "State Rte 100") — the query side must fold "VT ROUTE 100" to the same key.
+		{
+			street_norm: "state route 100",
+			side: "L",
+			from_hn: 1001,
+			to_hn: 1099,
+			parity: "odd",
+			postcode: "05601",
+			geometry: [
+				[0, 5],
+				[0.001, 5],
+			],
+		},
 	])
 	interpolator = new StreetInterpolator({ database: db })
 })
@@ -232,6 +246,14 @@ describe("StreetInterpolator", () => {
 		const hit = interpolator.find({ street: "River Rd", number: "450" })
 		expect(hit).not.toBeNull()
 		expect(hit!.lat).toBeCloseTo(1, 9)
+	})
+
+	it("matches a TIGER-spelled route key from the E911/Overture route spelling", () => {
+		// TIGER says "State Rte 100"; E911/Overture say "VT ROUTE 100" — both fold to the same
+		// canonical key (build side stores it folded, query side folds before matching).
+		const hit = interpolator.find({ street: "VT ROUTE 100", number: "1043", postcode: "05601" })
+		expect(hit).not.toBeNull()
+		expect(hit!.lat).toBeCloseTo(5, 9)
 	})
 
 	it("falls through on no matching street, out-of-range number, wrong ZIP, or non-numeric input", () => {

--- a/resolver-wof-sqlite/interpolation.ts
+++ b/resolver-wof-sqlite/interpolation.ts
@@ -1,0 +1,184 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   House-number interpolation (#483): when the exact address-point tier (#476, `address-point.ts`)
+ *   misses, estimate the coordinate from TIGER street-segment ranges — parity-aware range match,
+ *   then linear interpolation along the segment polyline. Design:
+ *   `docs/articles/plan/2026-06-11-interpolation-design.md`.
+ *
+ *   Reads the per-state shard built by `scripts/build-interpolation-shard.ts` (`street_segment`: one
+ *   row per TIGER edge SIDE — independent left/right ranges, ZIPs, parity). Query-side
+ *   normalization is THE shared normalizer (`street-normalize.ts`) — identical to build-side, by
+ *   construction.
+ *
+ *   Every answer is honest about being an estimate: `interpolated: true`, `parityMatched` (false when
+ *   only the opposite side's range contained the number — usually the right block, wrong side of
+ *   the street), and `uncertaintyM` (half the matched segment's length — the #483 issue's honest
+ *   default). Scoping is postcode-first; without a postcode the statewide name match must agree on
+ *   a single postcode or the lookup ABSTAINS (a common street name spanning towns is ambiguity, not
+ *   an answer).
+ *
+ *   Standalone in this slice — core tier wiring (`resolution_tier: "interpolated"` after the
+ *   exact-point fall-through) is a noted follow-up on #483, so the `find()` shape mirrors
+ *   `AddressPointLookup.find()` to keep that wiring mechanical.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+
+import { haversineKm } from "./geo.js"
+import { normalizeStreetForKey } from "./street-normalize.js"
+
+/** One interpolated coordinate estimate. Never an exact situs point — see `uncertaintyM`. */
+export interface InterpolatedHit {
+	lat: number
+	lon: number
+	/** Always true — the tier's honesty flag, mirrored into `resolution_tier` when wired. */
+	interpolated: true
+	/**
+	 * True when the matched segment side's parity agrees with the house number (or the side is
+	 * `mixed`). False = opposite-side fallback: usually the right block, wrong side of the street.
+	 */
+	parityMatched: boolean
+	/** Half the matched segment's polyline length, meters — the honest uncertainty radius. */
+	uncertaintyM: number
+	/** Provenance, e.g. `"tiger:edges"`. */
+	source: string
+	/** Pinned data vintage, e.g. `"TIGER2023"`. */
+	release: string
+}
+
+export interface InterpolationQuery {
+	street: string
+	number: string
+	/** ZIP scope — strongly preferred; without it common street names abstain (see module doc). */
+	postcode?: string
+}
+
+interface SegmentRow {
+	from_hn: number
+	to_hn: number
+	min_hn: number
+	max_hn: number
+	parity: string
+	postcode: string | null
+	geometry: string
+	source: string
+	release: string
+}
+
+export class StreetInterpolator {
+	readonly #db: DatabaseSync
+	readonly #ownsDb: boolean
+	readonly #byPostcode
+	readonly #byStreet
+
+	constructor(opts: { dbPath?: string; database?: DatabaseSync }) {
+		if (opts.database) {
+			this.#db = opts.database
+			this.#ownsDb = false
+		} else if (opts.dbPath) {
+			this.#db = new DatabaseSync(opts.dbPath, { readOnly: true })
+			this.#ownsDb = true
+		} else {
+			throw new Error("StreetInterpolator: one of dbPath or database is required")
+		}
+		const columns = `from_hn, to_hn, min_hn, max_hn, parity, postcode, geometry, source, release`
+		this.#byPostcode = this.#db.prepare(
+			`SELECT ${columns} FROM street_segment
+			 WHERE postcode = ? AND street_norm = ? AND min_hn <= ? AND max_hn >= ?`
+		)
+		this.#byStreet = this.#db.prepare(
+			`SELECT ${columns} FROM street_segment
+			 WHERE street_norm = ? AND min_hn <= ? AND max_hn >= ?`
+		)
+	}
+
+	find(query: InterpolationQuery): InterpolatedHit | null {
+		const streetNorm = normalizeStreetForKey(query.street)
+		const numberRaw = query.number.trim()
+		// Strictly-numeric house numbers only — this tier estimates, it doesn't guess at
+		// hyphenated/alphanumeric schemes the ranges don't model.
+		if (!streetNorm || !/^\d+$/.test(numberRaw)) return null
+		const n = Number(numberRaw)
+
+		let rows: SegmentRow[]
+		if (query.postcode) {
+			rows = this.#byPostcode.all(query.postcode.trim(), streetNorm, n, n) as unknown as SegmentRow[]
+		} else {
+			rows = this.#byStreet.all(streetNorm, n, n) as unknown as SegmentRow[]
+			// No scope given: a name matching ranges across several ZIPs is ambiguous — abstain.
+			const postcodes = new Set(rows.map((r) => r.postcode ?? ""))
+			if (postcodes.size > 1) return null
+		}
+		if (rows.length === 0) return null
+
+		// Parity preference: exact side first, then 'mixed' (matches either), then the
+		// opposite side as a flagged fallback.
+		const wantOdd = n % 2 === 1
+		const exact = rows.filter((r) => r.parity === (wantOdd ? "odd" : "even"))
+		const mixed = rows.filter((r) => r.parity === "mixed")
+		const preferred = exact.length > 0 ? exact : mixed
+		const pool = preferred.length > 0 ? preferred : rows
+		const parityMatched = preferred.length > 0
+
+		// Tightest range wins — the most specific claim about where this number lives.
+		const best = pool.reduce((a, b) => (b.max_hn - b.min_hn < a.max_hn - a.min_hn ? b : a))
+
+		const polyline = JSON.parse(best.geometry) as [number, number][]
+		const span = best.to_hn - best.from_hn
+		const t = span === 0 ? 0.5 : clamp01((n - best.from_hn) / span)
+		const [lon, lat, lengthKm] = pointAlong(polyline, t)
+		return {
+			lat,
+			lon,
+			interpolated: true,
+			parityMatched,
+			uncertaintyM: Math.round((lengthKm * 1000) / 2),
+			source: best.source,
+			release: best.release,
+		}
+	}
+
+	close(): void {
+		if (this.#ownsDb) this.#db.close()
+	}
+}
+
+function clamp01(t: number): number {
+	return t < 0 ? 0 : t > 1 ? 1 : t
+}
+
+/**
+ * Point at fraction `t` of the polyline's total arc length (haversine), plus the total length in
+ * km. `t` is assumed clamped to [0, 1].
+ */
+function pointAlong(polyline: readonly [number, number][], t: number): [lon: number, lat: number, lengthKm: number] {
+	const legs: number[] = []
+	let total = 0
+	for (let i = 1; i < polyline.length; i++) {
+		const [aLon, aLat] = polyline[i - 1]!
+		const [bLon, bLat] = polyline[i]!
+		const d = haversineKm(aLat, aLon, bLat, bLon)
+		legs.push(d)
+		total += d
+	}
+	if (total === 0) {
+		const [lon, lat] = polyline[0]!
+		return [lon, lat, 0]
+	}
+	let remaining = t * total
+	for (let i = 0; i < legs.length; i++) {
+		const leg = legs[i]!
+		if (remaining <= leg || i === legs.length - 1) {
+			const f = leg === 0 ? 0 : clamp01(remaining / leg)
+			const [aLon, aLat] = polyline[i]!
+			const [bLon, bLat] = polyline[i + 1]!
+			return [aLon + (bLon - aLon) * f, aLat + (bLat - aLat) * f, total]
+		}
+		remaining -= leg
+	}
+	const [lon, lat] = polyline[polyline.length - 1]!
+	return [lon, lat, total]
+}

--- a/resolver-wof-sqlite/interpolation.ts
+++ b/resolver-wof-sqlite/interpolation.ts
@@ -16,9 +16,10 @@
  *   Every answer is honest about being an estimate: `interpolated: true`, `parityMatched` (false when
  *   only the opposite side's range contained the number — usually the right block, wrong side of
  *   the street), and `uncertaintyM` (half the matched segment's length — the #483 issue's honest
- *   default). Scoping is postcode-first; without a postcode the statewide name match must agree on
- *   a single postcode or the lookup ABSTAINS (a common street name spanning towns is ambiguity, not
- *   an answer).
+ *   default). Scoping is postcode-first (a given ZIP that scopes to nothing is a MISS — the
+ *   statewide retry was measured and rejected, see `find()`); without a postcode the statewide name
+ *   match must agree on a single postcode or the lookup ABSTAINS (a common street name spanning
+ *   towns is ambiguity, not an answer).
  *
  *   Standalone in this slice — core tier wiring (`resolution_tier: "interpolated"` after the
  *   exact-point fall-through) is a noted follow-up on #483, so the `find()` shape mirrors
@@ -28,7 +29,7 @@
 import { DatabaseSync } from "node:sqlite"
 
 import { haversineKm } from "./geo.js"
-import { normalizeStreetForKey } from "./street-normalize.js"
+import { canonicalizeRouteKey, normalizeStreetForKey } from "./street-normalize.js"
 
 /** One interpolated coordinate estimate. Never an exact situs point — see `uncertaintyM`. */
 export interface InterpolatedHit {
@@ -96,7 +97,7 @@ export class StreetInterpolator {
 	}
 
 	find(query: InterpolationQuery): InterpolatedHit | null {
-		const streetNorm = normalizeStreetForKey(query.street)
+		const streetNorm = canonicalizeRouteKey(normalizeStreetForKey(query.street))
 		const numberRaw = query.number.trim()
 		// Strictly-numeric house numbers only — this tier estimates, it doesn't guess at
 		// hyphenated/alphanumeric schemes the ranges don't model.
@@ -105,10 +106,13 @@ export class StreetInterpolator {
 
 		let rows: SegmentRow[]
 		if (query.postcode) {
+			// A given ZIP that scopes to nothing is a MISS, not a statewide guess: the retry was
+			// measured (2026-06-11 VT eval) at +2.3pp coverage for a poisoned tail (p99 1.0 → 20.8
+			// km, max 204 km — a unique name statewide can live in a far-away town).
 			rows = this.#byPostcode.all(query.postcode.trim(), streetNorm, n, n) as unknown as SegmentRow[]
 		} else {
-			rows = this.#byStreet.all(streetNorm, n, n) as unknown as SegmentRow[]
 			// No scope given: a name matching ranges across several ZIPs is ambiguous — abstain.
+			rows = this.#byStreet.all(streetNorm, n, n) as unknown as SegmentRow[]
 			const postcodes = new Set(rows.map((r) => r.postcode ?? ""))
 			if (postcodes.size > 1) return null
 		}

--- a/resolver-wof-sqlite/street-normalize.test.ts
+++ b/resolver-wof-sqlite/street-normalize.test.ts
@@ -3,15 +3,14 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   The collision contract for the address-point normalizer (#476): variants that refer to
- *   the same street MUST normalize identically; distinct streets must not. Build-side and
- *   lookup-side both import the same function, so these tests are the whole correctness
- *   story for the keying.
+ *   The collision contract for the address-point normalizer (#476): variants that refer to the same
+ *   street MUST normalize identically; distinct streets must not. Build-side and lookup-side both
+ *   import the same function, so these tests are the whole correctness story for the keying.
  */
 
 import { describe, expect, it } from "vitest"
 
-import { normalizeLocalityForKey, normalizeStreetForKey } from "./street-normalize.js"
+import { canonicalizeRouteKey, normalizeLocalityForKey, normalizeStreetForKey } from "./street-normalize.js"
 
 describe("normalizeStreetForKey", () => {
 	it("collides USPS suffix variants", () => {
@@ -54,5 +53,31 @@ describe("normalizeLocalityForKey", () => {
 	it("folds without street semantics", () => {
 		expect(normalizeLocalityForKey("St. Albans")).toEqual("st albans")
 		expect(normalizeLocalityForKey("Montréal")).toEqual("montreal")
+	})
+})
+
+describe("canonicalizeRouteKey", () => {
+	it("folds TIGER and E911/Overture route spellings to the same key", () => {
+		// TIGER "State Rte 100" → normalizeStreetForKey → "state route 100" already; the E911
+		// spelling needs the designator fold to meet it.
+		expect(canonicalizeRouteKey(normalizeStreetForKey("State Rte 100"))).toEqual("state route 100")
+		expect(canonicalizeRouteKey(normalizeStreetForKey("VT ROUTE 100"))).toEqual("state route 100")
+		expect(canonicalizeRouteKey(normalizeStreetForKey("US Hwy 5"))).toEqual("us route 5")
+		expect(canonicalizeRouteKey(normalizeStreetForKey("US ROUTE 5"))).toEqual("us route 5")
+	})
+
+	it("keeps the post-designator tail (letter suffixes, trailing directionals)", () => {
+		expect(canonicalizeRouteKey(normalizeStreetForKey("State Rte 22A"))).toEqual("state route 22a")
+		expect(canonicalizeRouteKey(normalizeStreetForKey("VT ROUTE 22A"))).toEqual("state route 22a")
+		expect(canonicalizeRouteKey(normalizeStreetForKey("US Hwy 5 S"))).toEqual(
+			canonicalizeRouteKey(normalizeStreetForKey("US ROUTE 5 S"))
+		)
+	})
+
+	it("never folds non-route names", () => {
+		expect(canonicalizeRouteKey(normalizeStreetForKey("State Street"))).toEqual("state street")
+		expect(canonicalizeRouteKey(normalizeStreetForKey("Old Route 100"))).toEqual("old route 100")
+		// Bare "Route N" stays unfolded — the designator (US vs state) is unknown.
+		expect(canonicalizeRouteKey(normalizeStreetForKey("Route 100"))).toEqual("route 100")
 	})
 })

--- a/resolver-wof-sqlite/street-normalize.ts
+++ b/resolver-wof-sqlite/street-normalize.ts
@@ -3,20 +3,19 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   THE street normalizer for the address-point tier (#476). One function, used by BOTH the
- *   shard builder (`scripts/build-address-point-shard.ts`) and the lookup tier
- *   (`address-point.ts`) — never two implementations (the PLACETYPE_ORDER lesson: parallel
- *   copies silently corrupt).
+ *   THE street normalizer for the address-point tier (#476). One function, used by BOTH the shard
+ *   builder (`scripts/build-address-point-shard.ts`) and the lookup tier (`address-point.ts`) —
+ *   never two implementations (the PLACETYPE_ORDER lesson: parallel copies silently corrupt).
  *
  *   Normalization contract (deliberately aggressive — both sides apply the same function, so
- *   collisions only need to be *consistent*, not linguistically perfect):
+ *   collisions only need to be _consistent_, not linguistically perfect):
  *
- *   1. Lowercase, NFKD-fold diacritics, collapse whitespace, strip punctuation (periods,
- *      commas, apostrophes).
- *   2. Expand USPS directional abbreviations at the FIRST and LAST token position (`n` →
- *      `north`, `se` → `southeast`) — Overture sources abbreviate inconsistently.
- *   3. Canonicalize a trailing USPS street-type token via the codex suffix table to its
- *      canonical full form (`st`/`str`/`street` → `street`).
+ *   1. Lowercase, NFKD-fold diacritics, collapse whitespace, strip punctuation (periods, commas,
+ *        apostrophes).
+ *   2. Expand USPS directional abbreviations at the FIRST and LAST token position (`n` → `north`, `se` →
+ *        `southeast`) — Overture sources abbreviate inconsistently.
+ *   3. Canonicalize a trailing USPS street-type token via the codex suffix table to its canonical full
+ *        form (`st`/`str`/`street` → `street`).
  *
  *   Numbered streets are left as digits (`5th` stays `5th`) — both sides see the same bytes.
  */
@@ -35,8 +34,8 @@ function fold(input: string): string {
 }
 
 /**
- * Normalize a street name for address-point keying. Same function at build time and lookup
- * time — see module docstring for the contract.
+ * Normalize a street name for address-point keying. Same function at build time and lookup time —
+ * see module docstring for the contract.
  */
 export function normalizeStreetForKey(street: string): string {
 	const tokens = fold(street).split(" ")
@@ -46,7 +45,8 @@ export function normalizeStreetForKey(street: string): string {
 	// tokens, where "W" may be an initial in a person-named street). The codex expands
 	// compounds to two words ("SE" → "SOUTH EAST"); we key on the spaceless form
 	// ("southeast"), and also merge an already-written two-token pair ("South East …").
-	const edgeDirectional = (raw: string) => AbbreviationToDirectional.get(raw.toUpperCase())?.toLowerCase().replace(" ", "")
+	const edgeDirectional = (raw: string) =>
+		AbbreviationToDirectional.get(raw.toUpperCase())?.toLowerCase().replace(" ", "")
 	const mergePair = (a?: string, b?: string) =>
 		a && b && /^(north|south)$/.test(a) && /^(east|west)$/.test(b) ? a + b : undefined
 
@@ -80,4 +80,28 @@ export function normalizeStreetForKey(street: string): string {
 /** Normalize a locality name for address-point keying (fold only — no street semantics). */
 export function normalizeLocalityForKey(locality: string): string {
 	return fold(locality)
+}
+
+/**
+ * Fold numbered-route designators to a canonical key, applied AFTER {@link normalizeStreetForKey}.
+ * Sources disagree systematically on how they spell a route: TIGER says `State Rte 100` / `US Hwy
+ * 5` where E911/Overture say `VT ROUTE 100` / `US ROUTE 5` — the dominant street-name miss class in
+ * the #483 interpolation eval (rural addresses live on routes). `us <designator> N…` folds to `us
+ * route N…`; `state <designator> N…` and `<2-letter-prefix> <designator> N…` (the state
+ * abbreviation form) fold to `state route N…`. Only digit-leading route numbers fold — `State
+ * Street` and friends never match.
+ *
+ * Used by BOTH the segment-shard builder (`scripts/build-interpolation-shard.ts`) and the
+ * interpolation lookup — same one-function discipline as {@link normalizeStreetForKey}. The
+ * address-point tier (#476) does NOT apply it yet: adopting it there requires a shard rebuild
+ * (noted on #483).
+ *
+ * A same-numbered US and state route stay DISTINCT keys (`us route 5` vs `state route 5`); only the
+ * BARE `route N` form is ambiguous (designator unknown) and it stays unfolded — a bare-route query
+ * therefore misses, honestly, rather than guessing a designator.
+ */
+export function canonicalizeRouteKey(streetNorm: string): string {
+	const match = /^(us|state|[a-z]{2}) (?:route|rte|rt|highway|hwy) (\d.*)$/.exec(streetNorm)
+	if (!match) return streetNorm
+	return `${match[1] === "us" ? "us" : "state"} route ${match[2]}`
 }

--- a/scripts/build-interpolation-shard.ts
+++ b/scripts/build-interpolation-shard.ts
@@ -1,0 +1,193 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build a per-state STREET-SEGMENT shard (#483) from TIGER EDGES: side-aware house-number
+ *   ranges + segment polylines, keyed by THE shared street normalizer
+ *   (`resolver-wof-sqlite/street-normalize.ts` — same function the interpolation lookup
+ *   applies at query time; one normalizer, never two). The interpolation tier's data half;
+ *   design in `docs/articles/plan/2026-06-11-interpolation-design.md`.
+ *
+ *   One row PER SIDE per address-carrying road edge (left and right carry independent
+ *   ranges and ZIPs in TIGER). Parity is derived from the from/to numbers ('odd' | 'even' |
+ *   'mixed'); descending ranges keep their raw from/to (direction matters for the
+ *   interpolation position) alongside min/max index columns. Non-numeric ranges
+ *   (hyphenated, alphanumeric) are skipped and counted.
+ *
+ *   Inputs: TIGER EDGES shapefiles per county (the same files the intersection eval reads),
+ *   downloaded to --edges-dir from:
+ *     https://www2.census.gov/geo/tiger/TIGER2023/EDGES/tl_2023_<countyfips>_edges.zip
+ *
+ *   Usage:
+ *     node --experimental-strip-types scripts/build-interpolation-shard.ts \
+ *       --state VT [--edges-dir /tmp/tiger-edges] [--release TIGER2023] \
+ *       [--out /mnt/playpen/mailwoman-data/interpolation/interpolation-us-vt.db]
+ */
+
+import { globSync, mkdirSync, rmSync } from "node:fs"
+import * as path from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { DuckDBInstance } from "@duckdb/node-api"
+
+// Cross-tree source import (.ts explicit): this script runs via --experimental-strip-types,
+// not from compiled out/ — the lookup tier imports the same module intra-package.
+import { normalizeStreetForKey } from "../resolver-wof-sqlite/street-normalize.ts"
+
+/** State abbreviation → state FIPS prefix, for picking county files out of --edges-dir. */
+const STATE_FIPS: Record<string, string> = {
+	VT: "50",
+	IL: "17",
+	NJ: "34",
+}
+
+const { values: args } = parseArgs({
+	options: {
+		state: { type: "string" },
+		"edges-dir": { type: "string", default: "/tmp/tiger-edges" },
+		release: { type: "string", default: "TIGER2023" },
+		out: { type: "string" },
+	},
+})
+if (!args.state || !STATE_FIPS[args.state.toUpperCase()]) {
+	console.error(`--state required (one of: ${Object.keys(STATE_FIPS).join(", ")} — extend STATE_FIPS for others)`)
+	process.exit(1)
+}
+const STATE = args.state.toUpperCase()
+const OUT =
+	args.out ?? `/mnt/playpen/mailwoman-data/interpolation/interpolation-us-${STATE.toLowerCase()}.db`
+
+const shapefiles = globSync(`${args["edges-dir"]}/tl_*_${STATE_FIPS[STATE]}???_edges.shp`).sort()
+if (shapefiles.length === 0) {
+	console.error(`no tl_*_${STATE_FIPS[STATE]}???_edges.shp under ${args["edges-dir"]} — download TIGER EDGES first`)
+	process.exit(1)
+}
+console.log(`${shapefiles.length} county shapefiles for ${STATE}`)
+
+mkdirSync(path.dirname(OUT), { recursive: true })
+rmSync(OUT, { force: true }) // idempotent rebuild — never append across releases
+
+const db = new DatabaseSync(OUT)
+db.exec(`
+	PRAGMA journal_mode = WAL;
+	CREATE TABLE street_segment (
+		street_norm  TEXT NOT NULL,
+		side         TEXT NOT NULL,
+		from_hn      INTEGER NOT NULL,
+		to_hn        INTEGER NOT NULL,
+		min_hn       INTEGER NOT NULL,
+		max_hn       INTEGER NOT NULL,
+		parity       TEXT NOT NULL,
+		postcode     TEXT,
+		county_fips  TEXT NOT NULL,
+		street_raw   TEXT NOT NULL,
+		geometry     TEXT NOT NULL,
+		source       TEXT NOT NULL,
+		release      TEXT NOT NULL
+	);
+`)
+const insert = db.prepare(
+	`INSERT INTO street_segment
+	 (street_norm, side, from_hn, to_hn, min_hn, max_hn, parity, postcode, county_fips, street_raw, geometry, source, release)
+	 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+)
+
+/** Strictly-numeric house number → integer, else null (hyphenated/alphanumeric skipped). */
+function parseHn(raw: unknown): number | null {
+	if (raw === null || raw === undefined) return null
+	const s = String(raw).trim()
+	if (!/^\d+$/.test(s)) return null
+	return Number(s)
+}
+
+function parityOf(from: number, to: number): "odd" | "even" | "mixed" {
+	const f = from % 2
+	if (f !== to % 2) return "mixed"
+	return f === 1 ? "odd" : "even"
+}
+
+const instance = await DuckDBInstance.create()
+const duck = await instance.connect()
+await duck.run("INSTALL spatial; LOAD spatial;")
+
+let sides = 0
+let skippedNonNumeric = 0
+const parityCounts = { odd: 0, even: 0, mixed: 0 }
+
+db.exec("BEGIN")
+for (const shp of shapefiles) {
+	const countyFips = path.basename(shp).match(/tl_\d+_(\d{5})_edges/)?.[1] ?? "unknown"
+	// Address-carrying road edges only; geometry as GeoJSON text so the JS side stays
+	// shapefile-free (same ST_Read approach as build-intersection-real.ts).
+	const result = await duck.runAndReadAll(`
+		SELECT FULLNAME AS name, LFROMADD, LTOADD, RFROMADD, RTOADD, ZIPL, ZIPR,
+			ST_AsGeoJSON(geom) AS geojson
+		FROM ST_Read('${shp}')
+		WHERE MTFCC LIKE 'S1%' AND FULLNAME IS NOT NULL
+			AND (LFROMADD IS NOT NULL OR RFROMADD IS NOT NULL)
+	`)
+	for (const r of result.getRowObjects() as Record<string, unknown>[]) {
+		const streetRaw = String(r.name)
+		const streetNorm = normalizeStreetForKey(streetRaw)
+		if (!streetNorm) continue
+		const geom = JSON.parse(String(r.geojson)) as { type: string; coordinates: number[][] }
+		if (geom.type !== "LineString" || geom.coordinates.length < 2) continue
+		// Round to 1e-6 deg (~0.1 m) — shapefile floats carry noise digits that bloat the JSON.
+		const polyline = JSON.stringify(geom.coordinates.map(([lon, lat]) => [
+			Math.round(lon! * 1e6) / 1e6,
+			Math.round(lat! * 1e6) / 1e6,
+		]))
+
+		for (const [side, fromRaw, toRaw, zip] of [
+			["L", r.LFROMADD, r.LTOADD, r.ZIPL],
+			["R", r.RFROMADD, r.RTOADD, r.ZIPR],
+		] as const) {
+			if (fromRaw === null && toRaw === null) continue
+			const from = parseHn(fromRaw)
+			const to = parseHn(toRaw)
+			if (from === null || to === null) {
+				skippedNonNumeric++
+				continue
+			}
+			const parity = parityOf(from, to)
+			parityCounts[parity]++
+			insert.run(
+				streetNorm,
+				side,
+				from,
+				to,
+				Math.min(from, to),
+				Math.max(from, to),
+				parity,
+				zip === null || zip === undefined ? null : String(zip),
+				countyFips,
+				streetRaw,
+				polyline,
+				"tiger:edges",
+				String(args.release),
+			)
+			sides++
+		}
+	}
+	console.log(`  ${countyFips}: done (${sides} sides so far)`)
+}
+db.exec("COMMIT")
+db.exec(`
+	CREATE INDEX idx_seg_postcode ON street_segment (postcode, street_norm, min_hn);
+	CREATE INDEX idx_seg_street   ON street_segment (street_norm, min_hn);
+	PRAGMA wal_checkpoint(TRUNCATE);
+	VACUUM;
+`)
+const stats = db
+	.prepare(
+		"SELECT count(*) AS n, count(DISTINCT street_norm) AS streets, count(DISTINCT postcode) AS postcodes FROM street_segment",
+	)
+	.get() as Record<string, number>
+db.close()
+
+console.log(`${sides} segment-sides → ${OUT}`)
+console.log(`distinct streets: ${stats.streets} · postcodes: ${stats.postcodes}`)
+console.log(`parity: odd ${parityCounts.odd} · even ${parityCounts.even} · mixed ${parityCounts.mixed}`)
+console.log(`skipped non-numeric ranges: ${skippedNonNumeric}`)

--- a/scripts/build-interpolation-shard.ts
+++ b/scripts/build-interpolation-shard.ts
@@ -3,26 +3,24 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Build a per-state STREET-SEGMENT shard (#483) from TIGER EDGES: side-aware house-number
- *   ranges + segment polylines, keyed by THE shared street normalizer
- *   (`resolver-wof-sqlite/street-normalize.ts` — same function the interpolation lookup
- *   applies at query time; one normalizer, never two). The interpolation tier's data half;
- *   design in `docs/articles/plan/2026-06-11-interpolation-design.md`.
+ *   Build a per-state STREET-SEGMENT shard (#483) from TIGER EDGES: side-aware house-number ranges +
+ *   segment polylines, keyed by THE shared street normalizer
+ *   (`resolver-wof-sqlite/street-normalize.ts` — same function the interpolation lookup applies at
+ *   query time; one normalizer, never two). The interpolation tier's data half; design in
+ *   `docs/articles/plan/2026-06-11-interpolation-design.md`.
  *
- *   One row PER SIDE per address-carrying road edge (left and right carry independent
- *   ranges and ZIPs in TIGER). Parity is derived from the from/to numbers ('odd' | 'even' |
- *   'mixed'); descending ranges keep their raw from/to (direction matters for the
- *   interpolation position) alongside min/max index columns. Non-numeric ranges
- *   (hyphenated, alphanumeric) are skipped and counted.
+ *   One row PER SIDE per address-carrying road edge (left and right carry independent ranges and ZIPs
+ *   in TIGER). Parity is derived from the from/to numbers ('odd' | 'even' | 'mixed'); descending
+ *   ranges keep their raw from/to (direction matters for the interpolation position) alongside
+ *   min/max index columns. Non-numeric ranges (hyphenated, alphanumeric) are skipped and counted.
  *
  *   Inputs: TIGER EDGES shapefiles per county (the same files the intersection eval reads),
  *   downloaded to --edges-dir from:
- *     https://www2.census.gov/geo/tiger/TIGER2023/EDGES/tl_2023_<countyfips>_edges.zip
+ *   https://www2.census.gov/geo/tiger/TIGER2023/EDGES/tl_2023_<countyfips>_edges.zip
  *
- *   Usage:
- *     node --experimental-strip-types scripts/build-interpolation-shard.ts \
- *       --state VT [--edges-dir /tmp/tiger-edges] [--release TIGER2023] \
- *       [--out /mnt/playpen/mailwoman-data/interpolation/interpolation-us-vt.db]
+ *   Usage: node --experimental-strip-types scripts/build-interpolation-shard.ts\
+ *   --state VT [--edges-dir /tmp/tiger-edges] [--release TIGER2023]\
+ *   [--out /mnt/playpen/mailwoman-data/interpolation/interpolation-us-vt.db]
  */
 
 import { globSync, mkdirSync, rmSync } from "node:fs"
@@ -56,8 +54,7 @@ if (!args.state || !STATE_FIPS[args.state.toUpperCase()]) {
 	process.exit(1)
 }
 const STATE = args.state.toUpperCase()
-const OUT =
-	args.out ?? `/mnt/playpen/mailwoman-data/interpolation/interpolation-us-${STATE.toLowerCase()}.db`
+const OUT = args.out ?? `/mnt/playpen/mailwoman-data/interpolation/interpolation-us-${STATE.toLowerCase()}.db`
 
 const shapefiles = globSync(`${args["edges-dir"]}/tl_*_${STATE_FIPS[STATE]}???_edges.shp`).sort()
 if (shapefiles.length === 0) {
@@ -91,7 +88,7 @@ db.exec(`
 const insert = db.prepare(
 	`INSERT INTO street_segment
 	 (street_norm, side, from_hn, to_hn, min_hn, max_hn, parity, postcode, county_fips, street_raw, geometry, source, release)
-	 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 )
 
 /** Strictly-numeric house number → integer, else null (hyphenated/alphanumeric skipped). */
@@ -135,10 +132,9 @@ for (const shp of shapefiles) {
 		const geom = JSON.parse(String(r.geojson)) as { type: string; coordinates: number[][] }
 		if (geom.type !== "LineString" || geom.coordinates.length < 2) continue
 		// Round to 1e-6 deg (~0.1 m) — shapefile floats carry noise digits that bloat the JSON.
-		const polyline = JSON.stringify(geom.coordinates.map(([lon, lat]) => [
-			Math.round(lon! * 1e6) / 1e6,
-			Math.round(lat! * 1e6) / 1e6,
-		]))
+		const polyline = JSON.stringify(
+			geom.coordinates.map(([lon, lat]) => [Math.round(lon! * 1e6) / 1e6, Math.round(lat! * 1e6) / 1e6])
+		)
 
 		for (const [side, fromRaw, toRaw, zip] of [
 			["L", r.LFROMADD, r.LTOADD, r.ZIPL],
@@ -166,7 +162,7 @@ for (const shp of shapefiles) {
 				streetRaw,
 				polyline,
 				"tiger:edges",
-				String(args.release),
+				String(args.release)
 			)
 			sides++
 		}
@@ -182,7 +178,7 @@ db.exec(`
 `)
 const stats = db
 	.prepare(
-		"SELECT count(*) AS n, count(DISTINCT street_norm) AS streets, count(DISTINCT postcode) AS postcodes FROM street_segment",
+		"SELECT count(*) AS n, count(DISTINCT street_norm) AS streets, count(DISTINCT postcode) AS postcodes FROM street_segment"
 	)
 	.get() as Record<string, number>
 db.close()

--- a/scripts/build-interpolation-shard.ts
+++ b/scripts/build-interpolation-shard.ts
@@ -32,7 +32,7 @@ import { DuckDBInstance } from "@duckdb/node-api"
 
 // Cross-tree source import (.ts explicit): this script runs via --experimental-strip-types,
 // not from compiled out/ — the lookup tier imports the same module intra-package.
-import { normalizeStreetForKey } from "../resolver-wof-sqlite/street-normalize.ts"
+import { canonicalizeRouteKey, normalizeStreetForKey } from "../resolver-wof-sqlite/street-normalize.ts"
 
 /** State abbreviation → state FIPS prefix, for picking county files out of --edges-dir. */
 const STATE_FIPS: Record<string, string> = {
@@ -127,7 +127,7 @@ for (const shp of shapefiles) {
 	`)
 	for (const r of result.getRowObjects() as Record<string, unknown>[]) {
 		const streetRaw = String(r.name)
-		const streetNorm = normalizeStreetForKey(streetRaw)
+		const streetNorm = canonicalizeRouteKey(normalizeStreetForKey(streetRaw))
 		if (!streetNorm) continue
 		const geom = JSON.parse(String(r.geojson)) as { type: string; coordinates: number[][] }
 		if (geom.type !== "LineString" || geom.coordinates.length < 2) continue

--- a/scripts/eval/interpolation-eval.ts
+++ b/scripts/eval/interpolation-eval.ts
@@ -1,0 +1,182 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Honest eval for the house-number interpolation tier (#483) at street grain: hold out a
+ *   deterministic sample of REAL address points (the #476 shard — Overture/NAD situs coordinates,
+ *   an independent lineage from the TIGER segment table), query each point's `(street, number,
+ *   postcode)` through `StreetInterpolator`, and report coordinate error vs truth plus coverage.
+ *   Self-reporting; grades against the #483 pre-registered gate (p50 ≤ 50 m, p90 ≤ 150 m on the VT
+ *   holdout).
+ *
+ *   Sampling is hash-ordered (seeded, no RNG) over DISTINCT (street, number, postcode) keys with
+ *   strictly-numeric house numbers — the only inputs the tier models (the non-numeric share is
+ *   reported, not hidden).
+ *
+ *   NOTE: imports the WORKTREE's compiled module by relative path (run `yarn compile` first) — the
+ *   bare `@mailwoman/resolver-wof-sqlite` specifier would resolve through the parent checkout's
+ *   node_modules to a build without this module.
+ *
+ *   Usage: yarn compile && node scripts/eval/interpolation-eval.ts\
+ *   [--points /mnt/playpen/mailwoman-data/address-points/address-points-us-vt.db]\
+ *   [--segments /mnt/playpen/mailwoman-data/interpolation/interpolation-us-vt.db]\
+ *   [--sample 5000] [--seed 42]
+ */
+
+import { createHash } from "node:crypto"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { haversineKm } from "../../resolver-wof-sqlite/out/geo.js"
+import { StreetInterpolator } from "../../resolver-wof-sqlite/out/interpolation.js"
+
+const { values: args } = parseArgs({
+	options: {
+		points: {
+			type: "string",
+			default: "/mnt/playpen/mailwoman-data/address-points/address-points-us-vt.db",
+		},
+		segments: {
+			type: "string",
+			default: "/mnt/playpen/mailwoman-data/interpolation/interpolation-us-vt.db",
+		},
+		sample: { type: "string", default: "5000" },
+		seed: { type: "string", default: "42" },
+	},
+})
+const SAMPLE = Number(args.sample)
+
+// Pre-registered gate from the #483 issue — restated, never silently relaxed.
+const GATE_P50_M = 50
+const GATE_P90_M = 150
+
+const points = new DatabaseSync(args.points!, { readOnly: true })
+
+// Eligibility: numeric house number + a postcode to scope by. Report the excluded share —
+// the tier's modeling boundary, not an eval trick.
+const totals = points
+	.prepare(
+		`SELECT count(*) AS all_rows,
+			count(*) FILTER (WHERE number NOT GLOB '[0-9]*' OR number GLOB '*[^0-9]*') AS non_numeric,
+			count(*) FILTER (WHERE postcode IS NULL OR postcode = '') AS no_postcode
+		 FROM address_point`
+	)
+	.get() as { all_rows: number; non_numeric: number; no_postcode: number }
+
+interface GoldRow {
+	street_raw: string
+	number: string
+	postcode: string
+	lat: number
+	lon: number
+}
+
+// Deterministic hash-ordered sample over distinct query keys (duplicate situs points — unit
+// siblings — collapse to one query; truth = the centroid of the duplicates' coordinates).
+// Hash order is JS-side md5 (SQLite ships no hash builtin) — seeded, no RNG.
+const eligible = points
+	.prepare(
+		`SELECT street_norm, street_raw, number, postcode, avg(lat) AS lat, avg(lon) AS lon
+		 FROM address_point
+		 WHERE number GLOB '[0-9]*' AND number NOT GLOB '*[^0-9]*'
+			AND postcode IS NOT NULL AND postcode != ''
+		 GROUP BY street_norm, number, postcode`
+	)
+	.all() as unknown as (GoldRow & { street_norm: string })[]
+points.close()
+const hashOf = (r: GoldRow & { street_norm: string }) =>
+	createHash("md5").update(`${r.street_norm}|${r.number}|${r.postcode}|${args.seed}`).digest("hex")
+const gold: GoldRow[] = eligible
+	.map((r) => ({ row: r, h: hashOf(r) }))
+	.sort((a, b) => (a.h < b.h ? -1 : a.h > b.h ? 1 : 0))
+	.slice(0, SAMPLE)
+	.map((x) => x.row)
+
+const interpolator = new StreetInterpolator({ dbPath: args.segments! })
+
+interface Outcome {
+	errorM: number
+	parityMatched: boolean
+	uncertaintyM: number
+}
+
+const hits: Outcome[] = []
+let misses = 0
+for (const row of gold) {
+	const hit = interpolator.find({ street: row.street_raw, number: row.number, postcode: row.postcode })
+	if (!hit) {
+		misses++
+		continue
+	}
+	hits.push({
+		errorM: haversineKm(row.lat, row.lon, hit.lat, hit.lon) * 1000,
+		parityMatched: hit.parityMatched,
+		uncertaintyM: hit.uncertaintyM,
+	})
+}
+interpolator.close()
+
+function percentile(sorted: number[], p: number): number {
+	if (sorted.length === 0) return NaN
+	const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1)
+	return sorted[Math.max(0, idx)]!
+}
+
+function report(label: string, outcomes: Outcome[]): void {
+	const errors = outcomes
+		.map((o) => o.errorM)
+		.slice()
+		.sort((a, b) => a - b)
+	if (errors.length === 0) {
+		console.log(`  ${label}: 0 rows`)
+		return
+	}
+	const fmt = (v: number) => `${Math.round(v)}m`
+	console.log(
+		`  ${label}: n=${errors.length} · p50 ${fmt(percentile(errors, 50))} · p90 ${fmt(percentile(errors, 90))} · p99 ${fmt(percentile(errors, 99))} · max ${fmt(errors[errors.length - 1]!)}`
+	)
+}
+
+const queried = gold.length
+const coverage = queried === 0 ? 0 : hits.length / queried
+const parityHits = hits.filter((h) => h.parityMatched)
+const fallbackHits = hits.filter((h) => !h.parityMatched)
+const allErrors = hits
+	.map((h) => h.errorM)
+	.slice()
+	.sort((a, b) => a - b)
+const p50 = percentile(allErrors, 50)
+const p90 = percentile(allErrors, 90)
+const within = (m: number) => hits.filter((h) => h.errorM <= m).length / Math.max(1, hits.length)
+
+console.log(`interpolation eval — segments: ${args.segments}`)
+console.log(`gold: ${args.points}`)
+console.log(
+	`eligibility: ${totals.all_rows} points · ${totals.non_numeric} non-numeric number (${((100 * totals.non_numeric) / totals.all_rows).toFixed(1)}%) · ${totals.no_postcode} without postcode (${((100 * totals.no_postcode) / totals.all_rows).toFixed(1)}%)`
+)
+console.log(`sampled ${queried} distinct (street, number, postcode) keys (seed ${args.seed})`)
+console.log("")
+console.log(`coverage: ${hits.length}/${queried} found a segment (${(100 * coverage).toFixed(1)}%)`)
+console.log(`coord error vs truth (haversine):`)
+report("all hits", hits)
+report("parity-matched", parityHits)
+report("opposite-side fallback", fallbackHits)
+console.log(
+	`within: ≤50m ${(100 * within(50)).toFixed(1)}% · ≤100m ${(100 * within(100)).toFixed(1)}% · ≤500m ${(100 * within(500)).toFixed(1)}% · ≤1km ${(100 * within(1000)).toFixed(1)}%`
+)
+const medianUncertainty = percentile(
+	hits
+		.map((h) => h.uncertaintyM)
+		.slice()
+		.sort((a, b) => a - b),
+	50
+)
+console.log(`claimed uncertainty (half segment length): median ${Math.round(medianUncertainty)}m`)
+console.log("")
+const p50Pass = p50 <= GATE_P50_M
+const p90Pass = p90 <= GATE_P90_M
+console.log(
+	`gate (#483 pre-registered): p50 ≤ ${GATE_P50_M}m → ${Math.round(p50)}m ${p50Pass ? "PASS" : "MISS"} · p90 ≤ ${GATE_P90_M}m → ${Math.round(p90)}m ${p90Pass ? "PASS" : "MISS"}`
+)
+process.exitCode = p50Pass && p90Pass ? 0 : 1


### PR DESCRIPTION
First slice of #483: TIGER-based house-number interpolation, built and measured. **The pre-registered accuracy gate is a MISS** — stated up front, not re-baselined; nothing here is promoted into the resolve path.

## What

- **Design doc** `docs/articles/plan/2026-06-11-interpolation-design.md` — segment schema, parity rules, eval gate, open questions.
- **Segment builder** `scripts/build-interpolation-shard.ts` — TIGER2023 EDGES → one row per edge *side* (L/R carry independent ranges + ZIPs), parity derived, raw from/to preserved (descending ranges encode direction), geometry as rounded polyline. VT pilot: 137,256 segment-sides / 17,182 streets / 296 ZIPs.
- **`StreetInterpolator`** in resolver-wof-sqlite (+13 unit tests) — postcode-scoped range match → parity preference exact > mixed > flagged opposite-side fallback → tightest range wins → haversine arc-length interpolation. Output flagged `interpolated: true` with `uncertaintyM` (half segment length). Mirrors `AddressPointLookup.find()` so the tier wiring after `applyAddressPoint` is mechanical — deliberately not wired in this slice.
- **Eval** `scripts/eval/interpolation-eval.ts` — gold is the #476 Overture/NAD address-point shard (independent lineage from TIGER, non-circular); self-reports the gate verdict and exits non-zero on miss.

## Measured (VT, 5000 held-out keys, seed 42)

| metric | value | gate | verdict |
| --- | ---: | ---: | --- |
| coverage | 82.0% | — | — |
| coord p50 | 66 m | ≤ 50 m | **MISS** |
| coord p90 | 249 m | ≤ 150 m | **MISS** |
| p99 / within-500m | 1.0 km / 97% | — | — |

Two decisions were measured, not argued: statewide ZIP-miss retry **built, measured (+2.3pp coverage, p99 1.0→20.8 km), reverted** — rationale in code + doc; route-designator fold (`State Rte 100` ≡ `VT ROUTE 100`) **+3.1pp coverage at zero tail cost, kept**, applied symmetrically by builder and lookup.

## Why merge a miss

The module is not in the resolve path — this is the measurement infrastructure plus an honestly-graded pilot. The shortfall tracks rural VT's long sparse segments + TIGER's uniform-spacing assumption; the next lever is **re-running on a denser county to separate rural-geometry artifact from method error** before building anything (segment subdivision at OA anchors if it's the method). Promotion happens only when the gate passes.

## Deferred (in the design doc)

Workspace split (`@mailwoman/resolver-interpolation` — operator call), core tier wiring, ZIP-mismatch recovery (166-miss class), route-fold adoption in #476 (needs shard rebuild), ZIP+4 snapping (#525), EU/OSM rollout.

Part of #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)