### PR TITLE
feat(corpus/train): v0.5.0 spans pipeline — parquet columns, compose, audits, loader (#519 slice 2)

### DIFF
--- a/corpus-python/src/mailwoman_train/augment.py
+++ b/corpus-python/src/mailwoman_train/augment.py
@@ -21,6 +21,15 @@ The expansion augmentations replace the token in the raw text AND update the
 tokens + labels lists to match; the expanded form inherits the original token's
 BIO label (B- for the first word, I- for continuation words). The glue
 augmentation mutates ``raw`` alone.
+
+**Char-offset spans** (#519, v0.5.0): rows from a v0.5.0 corpus carry
+``span_starts``/``span_ends``/``span_tags`` beside tokens/labels, and every augmented COPY this
+module yields must re-target them — the expansion augmentations rebuild ``raw`` (so the spans are
+re-derived from the new tokens/labels over the rebuilt surface), and the glue augmentation
+splices chars out of ``raw`` (so offsets at/after the splice shift left). Yielding a mutated raw
+with the source row's spans would corrupt the labels silently — the exact hazard that put the
+augmentation re-target in the same change as the loader wiring. Rows without spans (frozen
+pre-v0.5.0 corpora) pass through the legacy token path unchanged; a PARTIAL triple raises.
 """
 
 from __future__ import annotations
@@ -98,6 +107,71 @@ US_STATES: dict[str, str] = {
 }
 
 
+SPAN_KEYS = ("span_starts", "span_ends", "span_tags")
+
+
+def row_span_triple(row: dict) -> tuple[list[int], list[int], list[str]] | None:
+    """Return the row's char-offset span triple (#519), or None for a legacy (token-only) row.
+
+    A PARTIAL triple — some keys present/non-null, others missing/null — is a corrupt row and
+    raises loudly; it must never silently fall back to the token path (the labels it would fall
+    back TO are not the labels the row was built with).
+    """
+    values = [row.get(k) for k in SPAN_KEYS]
+    present = [v is not None for v in values]
+    if not any(present):
+        return None
+    if not all(present):
+        missing = [k for k, p in zip(SPAN_KEYS, present) if not p]
+        raise ValueError(
+            f"corrupt row: partial char-offset span triple (#519) — missing {missing} "
+            f"(raw={row.get('raw')!r})"
+        )
+    starts, ends, tags = values
+    if len(starts) != len(ends) or len(starts) != len(tags):
+        raise ValueError(
+            f"corrupt row: span triple arrays not parallel — "
+            f"starts={len(starts)} ends={len(ends)} tags={len(tags)} (raw={row.get('raw')!r})"
+        )
+    return starts, ends, tags
+
+
+def spans_from_token_labels(tokens: list[str], labels: list[str]) -> tuple[list[int], list[int], list[str]]:
+    """Derive a span triple for a raw REBUILT as ``" ".join(tokens)`` (the expansion augmentations'
+    surface): contiguous B-/I- runs become one span each, offsets exact by construction."""
+    starts: list[int] = []
+    ends: list[int] = []
+    tags: list[str] = []
+    cursor = 0
+    open_tag: str | None = None
+    for token, label in zip(tokens, labels):
+        begin = cursor
+        end = cursor + len(token)
+        cursor = end + 1  # single-space join
+        if label == "O":
+            open_tag = None
+            continue
+        prefix, tag = label.split("-", 1)
+        if prefix == "I" and open_tag == tag:
+            ends[-1] = end  # extend the open span across the joining space
+        else:
+            starts.append(begin)
+            ends.append(end)
+            tags.append(tag)
+        open_tag = tag
+    return starts, ends, tags
+
+
+def _with_rederived_spans(row: dict, augmented: dict) -> dict:
+    """Attach a re-derived span triple to an expansion-augmented copy when the source row carries
+    spans. The expansions rebuild ``raw`` from the new tokens, so the spans are re-derived from
+    the new tokens/labels — the source offsets address a surface that no longer exists."""
+    if row_span_triple(row) is None:
+        return augmented
+    starts, ends, tags = spans_from_token_labels(augmented["tokens"], augmented["labels"])
+    return {**augmented, "span_starts": starts, "span_ends": ends, "span_tags": tags}
+
+
 def _expand_token(
     tokens: list[str],
     labels: list[str],
@@ -131,11 +205,34 @@ def _expand_token(
 def glue_region_postcode(row: dict, idx: int) -> dict:
     """Return a copy of ``row`` with the whitespace between token ``idx`` (region) and
     token ``idx + 1`` (postcode) removed from ``raw``. Tokens + labels are untouched —
-    the split labels project onto the fused surface via char offsets (see module doc)."""
+    the split labels project onto the fused surface via char offsets (see module doc).
+
+    Char-offset spans (#519) shift with the splice: every offset at/after the removed gap moves
+    left by the gap width, so the region span still ends at the fused boundary and the postcode
+    span starts there. A span STRADDLING the gap would be corrupt input (the gap is inter-token
+    whitespace between two differently-labeled tokens) — raises rather than guesses."""
     spans = whitespace_spans(row["raw"], row["tokens"])
     region_end = spans[idx][1]
     postcode_begin = spans[idx + 1][0]
-    return {**row, "raw": row["raw"][:region_end] + row["raw"][postcode_begin:]}
+    gap = postcode_begin - region_end
+    out = {**row, "raw": row["raw"][:region_end] + row["raw"][postcode_begin:]}
+    triple = row_span_triple(row)
+    if triple is not None:
+        starts, ends, tags = triple
+        new_starts: list[int] = []
+        new_ends: list[int] = []
+        for start, end in zip(starts, ends):
+            if start < postcode_begin < end:
+                raise ValueError(
+                    f"corrupt row: span [{start}, {end}) straddles the glue gap "
+                    f"[{region_end}, {postcode_begin}) (raw={row['raw']!r})"
+                )
+            new_starts.append(start - gap if start >= postcode_begin else start)
+            new_ends.append(end - gap if end > region_end else end)
+        out["span_starts"] = new_starts
+        out["span_ends"] = new_ends
+        out["span_tags"] = list(tags)
+    return out
 
 
 def augment_row(
@@ -167,12 +264,15 @@ def augment_row(
                 tokens, labels, idx, DIRECTIONALS[tokens[idx]]
             )
             new_raw = " ".join(new_tokens)
-            yield {
-                **row,
-                "raw": new_raw,
-                "tokens": new_tokens,
-                "labels": new_labels,
-            }
+            yield _with_rederived_spans(
+                row,
+                {
+                    **row,
+                    "raw": new_raw,
+                    "tokens": new_tokens,
+                    "labels": new_labels,
+                },
+            )
 
     # Region+postcode glue (#513): fuse the last region token with an immediately-following
     # postcode token in raw. Letter→digit boundary only — that's the boundary SentencePiece
@@ -205,9 +305,12 @@ def augment_row(
                 tokens, labels, idx, US_STATES[tokens[idx]]
             )
             new_raw = " ".join(new_tokens)
-            yield {
-                **row,
-                "raw": new_raw,
-                "tokens": new_tokens,
-                "labels": new_labels,
-            }
+            yield _with_rederived_spans(
+                row,
+                {
+                    **row,
+                    "raw": new_raw,
+                    "tokens": new_tokens,
+                    "labels": new_labels,
+                },
+            )

--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -21,6 +21,14 @@ Per Phase 2 §2:
 - Length filter: rows whose SP tokenization exceeds ``max_length`` are dropped.
 - Tokenizer alignment verification: re-tokenize a sample and assert the stored ``tokens``
   match (see ``verify_tokenizer_alignment``).
+
+v0.5.0 char-offset labels (#519): shards whose schema carries
+``span_starts``/``span_ends``/``span_tags`` stream the triple end-to-end — through the
+augmentations (which re-target it; see ``augment.py``) and the #511 relabel pass (char
+arithmetic; see ``relabel.py``) into ``encode_row``, which builds the per-char label array FROM
+the spans. Frozen pre-v0.5.0 shards carry no span columns and ride the legacy token path. A
+shard with a partial column set, or a null span value in a span-schema shard, is corrupt and
+raises loudly — never a silent fallback.
 """
 
 from __future__ import annotations
@@ -36,13 +44,19 @@ logger = logging.getLogger(__name__)
 
 import pyarrow.parquet as pq
 
-from .augment import augment_row
+from .augment import SPAN_KEYS, augment_row
 from .config import Config, DataConfig
 from .labels import IGNORE_INDEX, active_components_present, locale_id
 from .relabel import AffixRelabelLexicon, relabel_row
 from .tokenizer import Tokenizer, encode_row, whitespace_spans
 
 _REQUIRED_COLUMNS: tuple[str, ...] = ("raw", "tokens", "labels", "country", "source")
+
+# v0.5.0 char-offset label columns (#519). Presence is decided PER SHARD by schema: a v0.5.0
+# shard carries all three (and every row must be non-null in all three); a frozen pre-v0.5.0
+# shard carries none (rows ride the legacy token path). A shard with SOME of the three is
+# corrupt — loud failure, never a silent fallback.
+_SPAN_COLUMNS: tuple[str, ...] = SPAN_KEYS
 
 
 @dataclass
@@ -195,15 +209,28 @@ def _shard_row_iter(
     unreliable as a steering mechanism — PR #44).
     """
     pf = pq.ParquetFile(shard)
+    # Span-column presence is a per-shard schema fact (#519): all three or none. Partial = a
+    # corrupt shard; reading the survivors would silently train the wrong labels.
+    schema_names = set(pf.schema_arrow.names)
+    span_present = [c for c in _SPAN_COLUMNS if c in schema_names]
+    if span_present and len(span_present) != len(_SPAN_COLUMNS):
+        missing = [c for c in _SPAN_COLUMNS if c not in schema_names]
+        raise ValueError(
+            f"corrupt shard {shard}: carries span columns {span_present} but is missing {missing} "
+            "— the #519 triple is all-or-none per shard"
+        )
+    has_spans = bool(span_present)
+    columns = list(_REQUIRED_COLUMNS) + (list(_SPAN_COLUMNS) if has_spans else [])
     rg_order = list(range(pf.num_row_groups))
     rng.shuffle(rg_order)
     for rg in rg_order:
-        t = pf.read_row_group(rg, columns=list(_REQUIRED_COLUMNS))
+        t = pf.read_row_group(rg, columns=columns)
         raws = t["raw"]
         tokens_col = t["tokens"]
         labels_col = t["labels"]
         countries = t["country"]
         sources = t["source"]
+        span_cols = {c: t[c] for c in _SPAN_COLUMNS} if has_spans else None
         idx_order = list(range(t.num_rows))
         rng.shuffle(idx_order)
         for i in idx_order:
@@ -221,13 +248,24 @@ def _shard_row_iter(
                 keys = _row_components_keys(bio_labels)
                 if not active_components_present(keys):
                     continue
-            yield {
+            row = {
                 "raw": raws[i].as_py(),
                 "tokens": tokens_col[i].as_py(),
                 "labels": bio_labels,
                 "country": country,
                 "source": source,
             }
+            if span_cols is not None:
+                spans = {c: span_cols[c][i].as_py() for c in _SPAN_COLUMNS}
+                nulls = [c for c, v in spans.items() if v is None]
+                if nulls:
+                    raise ValueError(
+                        f"corrupt row in {shard} (row-group {rg}, raw={row['raw']!r}): "
+                        f"null span column(s) {nulls} in a span-schema shard — never a silent "
+                        "fallback to token labels"
+                    )
+                row.update(spans)
+            yield row
 
 
 def _source_iter(
@@ -536,6 +574,12 @@ def iter_encoded(
             anchor_lookup=anchor_lookup,
             gazetteer_lexicon=gazetteer_lexicon,
             gazetteer_choreography=getattr(cfg_data, "gazetteer_choreography", False),
+            # v0.5.0 char-offset labels (#519): rows from a span-schema shard train FROM the
+            # spans (encode_row builds the per-char label array from them; the token path is the
+            # legacy fallback for frozen corpora). encode_row raises on a partial triple.
+            span_starts=row.get("span_starts"),
+            span_ends=row.get("span_ends"),
+            span_tags=row.get("span_tags"),
         )
         # Drop rows whose non-padding length exceeds max_length (length filter §2).
         non_pad = sum(enc["attention_mask"])

--- a/corpus-python/src/mailwoman_train/relabel.py
+++ b/corpus-python/src/mailwoman_train/relabel.py
@@ -16,6 +16,15 @@ whole mix makes one consistent claim:
 Runs AFTER augmentation (see data_loader) so label-inheriting directional expansions
 ("N"->"North", still street) are caught and split too.
 
+**Char-offset spans** (#519, v0.5.0): rows carrying ``span_starts``/``span_ends``/``span_tags``
+get their street SPANS split too — pure char arithmetic on the span's whitespace words (the
+builder's exact word-splitting: ``street.trim().split(/\\s+/)``), no token indirection. The token
+labels keep their existing relabel for the transition. The two can diverge ONLY on surfaces where
+the corpus tokenizer dropped punctuation ("Main St." — tokens see "St" and split; the span path
+sees the word "St.", which is not in the lexicon, and conservatively leaves the span whole,
+exactly like the builder's parseStreet). The span path is the v0.5.0 source of truth: when a row
+has spans, encode_row trains FROM the spans.
+
 Vocab comes from the codex-generated lexicon (scripts/build-affix-relabel-lexicon.mjs ->
 data/gazetteer/affix-relabel-lexicon-v1.json) — one source of truth shared with the TS matchers.
 Matching is conservative by parity: case-insensitive, NO period stripping ("St." does not match,
@@ -29,8 +38,11 @@ prints split rate, per-rule counts, and a sample of relabeled rows for manual in
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
+
+from .augment import row_span_triple
 
 
 @dataclass(frozen=True)
@@ -86,7 +98,8 @@ def split_street_span(words: list[str], lex: AffixRelabelLexicon) -> tuple[int, 
 
 
 def relabel_row(row: dict, lex: AffixRelabelLexicon) -> bool:
-    """Relabel every street span in ``row`` (mutates ``row['labels']`` in place).
+    """Relabel every street span in ``row`` (mutates ``row['labels']`` in place; replaces the
+    char-offset span arrays when the row carries them — #519).
 
     Returns True if any span was split. Rows whose street spans don't meet the builder's
     split contract are left untouched (the shard makes no claim about them either).
@@ -116,6 +129,64 @@ def relabel_row(row: dict, lex: AffixRelabelLexicon) -> bool:
             labels[j - suffix_count] = "B-street_suffix"
             changed = True
         i = j
+    if relabel_spans(row, lex):
+        changed = True
+    return changed
+
+
+def relabel_spans(row: dict, lex: AffixRelabelLexicon) -> bool:
+    """Split every ``street`` char-offset span in ``row`` with the builder's exact semantics —
+    pure char arithmetic (#519).
+
+    The span's raw slice is whitespace-split (the builder's ``street.trim().split(/\\s+/)``,
+    punctuation intact — "St." conservatively does not match, same as parseStreet), the split
+    decision is the SAME ``split_street_span``, and the street span is replaced in place by up to
+    three spans (street_prefix / street / street_suffix) whose offsets are the matched words'
+    positions within the original span. Sortedness/non-overlap are preserved by construction —
+    every replacement lies inside the original span's range.
+
+    No-op (returns False) on rows without the triple; replaces the three arrays with fresh lists
+    when it splits, so callers holding the source row's lists are never mutated through.
+    """
+    triple = row_span_triple(row)
+    if triple is None:
+        return False
+    starts, ends, tags = triple
+    raw = row["raw"]
+    new_starts: list[int] = []
+    new_ends: list[int] = []
+    new_tags: list[str] = []
+    changed = False
+    for start, end, tag in zip(starts, ends, tags):
+        if tag != "street":
+            new_starts.append(start)
+            new_ends.append(end)
+            new_tags.append(tag)
+            continue
+        words = [(m.group(0), start + m.start(), start + m.end()) for m in re.finditer(r"\S+", raw[start:end])]
+        split = split_street_span([w[0] for w in words], lex)
+        if split is None:
+            new_starts.append(start)
+            new_ends.append(end)
+            new_tags.append(tag)
+            continue
+        prefix_count, suffix_count = split
+        changed = True
+        if prefix_count:
+            new_starts.append(words[0][1])
+            new_ends.append(words[0][2])
+            new_tags.append("street_prefix")
+        name_words = words[prefix_count : len(words) - suffix_count]
+        new_starts.append(name_words[0][1])
+        new_ends.append(name_words[-1][2])
+        new_tags.append("street")
+        new_starts.append(words[-1][1])
+        new_ends.append(words[-1][2])
+        new_tags.append("street_suffix")
+    if changed:
+        row["span_starts"] = new_starts
+        row["span_ends"] = new_ends
+        row["span_tags"] = new_tags
     return changed
 
 

--- a/corpus-python/src/mailwoman_train/test_augment.py
+++ b/corpus-python/src/mailwoman_train/test_augment.py
@@ -2,8 +2,16 @@
 
 import random
 
-from .augment import augment_row, glue_region_postcode, _expand_token
-from .tokenizer import PieceSpan, realign_labels_to_pieces
+import pytest
+
+from .augment import (
+    _expand_token,
+    augment_row,
+    glue_region_postcode,
+    row_span_triple,
+    spans_from_token_labels,
+)
+from .tokenizer import PieceSpan, realign_labels_to_pieces, realign_spans_to_pieces
 
 
 def test_expand_token_single_word():
@@ -225,3 +233,119 @@ def test_glued_raw_projects_split_labels_onto_pieces():
     ]
     bio = realign_labels_to_pieces(fused["raw"], fused["tokens"], fused["labels"], pieces)
     assert bio == ["B-locality", "B-region", "B-postcode", "I-postcode"]
+
+
+# --- Char-offset span re-target (#519) ----------------------------------------------------------
+# Every augmented COPY must carry spans consistent with ITS raw — the mutation-upstream hazard
+# this slice exists to close.
+
+
+def _slices(row: dict) -> list[tuple[str, str]]:
+    """(tag, raw slice) pairs for a row's span triple."""
+    return [
+        (t, row["raw"][s:e])
+        for s, e, t in zip(row["span_starts"], row["span_ends"], row["span_tags"])
+    ]
+
+
+def _spanned_directional_row() -> dict:
+    return {
+        "raw": "350 5th Ave NW",
+        "tokens": ["350", "5th", "Ave", "NW"],
+        "labels": ["B-house_number", "B-street", "I-street", "I-street"],
+        "span_starts": [0, 4],
+        "span_ends": [3, 14],
+        "span_tags": ["house_number", "street"],
+        "country": "US",
+        "source": "tiger",
+    }
+
+
+def test_expansion_rederives_spans_for_the_rebuilt_raw():
+    rng = random.Random(42)
+    results = list(augment_row(_spanned_directional_row(), rng, directional_prob=1.0, region_prob=0.0))
+    assert len(results) == 2
+    augmented = results[1]
+    assert augmented["raw"] == "350 5th Ave Northwest"
+    assert _slices(augmented) == [("house_number", "350"), ("street", "5th Ave Northwest")]
+
+
+def test_expansion_leaves_the_original_rows_spans_alone():
+    row = _spanned_directional_row()
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=1.0, region_prob=0.0))
+    assert results[0] is row
+    assert row["span_starts"] == [0, 4] and row["span_ends"] == [3, 14]
+
+
+def test_expanded_spans_project_identically_to_expanded_tokens():
+    """Gate: on the augmented copy, the spans-based piece stream equals the token-based one."""
+    rng = random.Random(42)
+    augmented = list(augment_row(_spanned_directional_row(), rng, directional_prob=1.0, region_prob=0.0))[1]
+    pieces = []
+    cursor = 0
+    for tok in augmented["tokens"]:
+        idx = augmented["raw"].index(tok, cursor)
+        pieces.append(PieceSpan(piece=tok, piece_id=0, char_begin=idx, char_end=idx + len(tok)))
+        cursor = idx + len(tok)
+    via_tokens = realign_labels_to_pieces(augmented["raw"], augmented["tokens"], augmented["labels"], pieces)
+    via_spans = realign_spans_to_pieces(
+        augmented["raw"], augmented["span_starts"], augmented["span_ends"], augmented["span_tags"], pieces
+    )
+    assert via_spans == via_tokens
+
+
+def test_glue_shifts_spans_with_the_splice():
+    row = {
+        **_glue_row(),
+        "span_starts": [0, 4, 12, 20, 23],
+        "span_ends": [3, 11, 19, 22, 28],
+        "span_tags": ["house_number", "street", "locality", "region", "postcode"],
+    }
+    fused = glue_region_postcode(row, 4)
+    assert fused["raw"] == "123 Main St Buffalo NY14201"
+    assert _slices(fused) == [
+        ("house_number", "123"),
+        ("street", "Main St"),
+        ("locality", "Buffalo"),
+        ("region", "NY"),
+        ("postcode", "14201"),
+    ]
+    # The source row's spans are untouched (fresh lists on the copy).
+    assert row["span_starts"] == [0, 4, 12, 20, 23]
+
+
+def test_glue_without_spans_stays_legacy():
+    fused = glue_region_postcode(_glue_row(), 4)
+    assert "span_starts" not in fused
+
+
+def test_row_span_triple_partial_raises():
+    with pytest.raises(ValueError, match="partial char-offset span triple"):
+        row_span_triple({"raw": "x", "span_starts": [0]})
+
+
+def test_row_span_triple_nonparallel_raises():
+    with pytest.raises(ValueError, match="not parallel"):
+        row_span_triple({"raw": "x", "span_starts": [0], "span_ends": [1, 2], "span_tags": ["street"]})
+
+
+def test_spans_from_token_labels_groups_bi_runs():
+    starts, ends, tags = spans_from_token_labels(
+        ["350", "5th", "Ave", "Buffalo"],
+        ["B-house_number", "B-street", "I-street", "B-locality"],
+    )
+    raw = "350 5th Ave Buffalo"
+    assert [(t, raw[s:e]) for s, e, t in zip(starts, ends, tags)] == [
+        ("house_number", "350"),
+        ("street", "5th Ave"),
+        ("locality", "Buffalo"),
+    ]
+
+
+def test_spans_from_token_labels_o_breaks_the_run():
+    starts, ends, tags = spans_from_token_labels(["New", "York", ",", "NY"], ["B-region", "I-region", "O", "B-region"])
+    assert tags == ["region", "region"]
+    # Joined raw is "New York , NY": the comma is uncovered, the second region span is "NY".
+    assert (starts[0], ends[0]) == (0, 8)
+    assert (starts[1], ends[1]) == (11, 13)

--- a/corpus-python/src/mailwoman_train/test_data_loader_spans.py
+++ b/corpus-python/src/mailwoman_train/test_data_loader_spans.py
@@ -1,0 +1,205 @@
+"""Loader wiring for the v0.5.0 char-offset span triple (#519, rebuild-plan step 4).
+
+Pins the loader-side contract:
+
+1. Rows from a span-schema shard stream the triple end-to-end — ``iter_rows`` carries it,
+   ``iter_encoded`` hands it to ``encode_row`` (which trains FROM the spans).
+2. Frozen pre-v0.5.0 shards (no span columns) ride the legacy token path: no span keys appear.
+3. Corruption is LOUD, never a silent fallback: a shard with a partial span-column set raises,
+   and a null span value inside a span-schema shard raises naming the row.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from mailwoman_train import data_loader
+from mailwoman_train.config import DataConfig
+from mailwoman_train.data_loader import iter_encoded, iter_rows
+
+FULL_SCHEMA = pa.schema(
+    [
+        ("raw", pa.string()),
+        ("tokens", pa.list_(pa.string())),
+        ("labels", pa.list_(pa.string())),
+        ("span_starts", pa.list_(pa.int32())),
+        ("span_ends", pa.list_(pa.int32())),
+        ("span_tags", pa.list_(pa.string())),
+        ("country", pa.string()),
+        ("source", pa.string()),
+    ]
+)
+
+
+def _row(**over) -> dict:
+    base = {
+        "raw": "P.O. Box 19, Buffalo, NY 14201",
+        "tokens": ["P", "O", "Box", "19", "Buffalo", "NY", "14201"],
+        "labels": ["B-po_box", "I-po_box", "I-po_box", "I-po_box", "B-locality", "B-region", "B-postcode"],
+        "span_starts": [0, 13, 22, 25],
+        "span_ends": [11, 20, 24, 30],
+        "span_tags": ["po_box", "locality", "region", "postcode"],
+        "country": "US",
+        "source": "test",
+    }
+    base.update(over)
+    return base
+
+
+def _write_corpus(tmp_path: Path, rows: list[dict], drop_columns: tuple[str, ...] = ()) -> Path:
+    corpus = tmp_path / "corpus"
+    (corpus / "train").mkdir(parents=True)
+    schema = FULL_SCHEMA
+    for col in drop_columns:
+        schema = schema.remove(schema.get_field_index(col))
+    table = pa.Table.from_pylist([{k: r.get(k) for k in schema.names} for r in rows], schema=schema)
+    pq.write_table(table, corpus / "train" / "part-0000.parquet")
+    return corpus
+
+
+def _iter(corpus: Path) -> list[dict]:
+    return list(
+        iter_rows(
+            corpus,
+            "train",
+            rng=random.Random(0),
+            country_weights={"US": 1.0},
+            coarse_filter=False,
+            shuffle_buffer=4,
+        )
+    )
+
+
+def test_span_shard_rows_carry_the_triple(tmp_path: Path) -> None:
+    corpus = _write_corpus(tmp_path, [_row()])
+    rows = _iter(corpus)
+    assert len(rows) == 1
+    assert rows[0]["span_starts"] == [0, 13, 22, 25]
+    assert rows[0]["span_ends"] == [11, 20, 24, 30]
+    assert rows[0]["span_tags"] == ["po_box", "locality", "region", "postcode"]
+
+
+def test_legacy_shard_rows_have_no_span_keys(tmp_path: Path) -> None:
+    corpus = _write_corpus(tmp_path, [_row()], drop_columns=("span_starts", "span_ends", "span_tags"))
+    rows = _iter(corpus)
+    assert len(rows) == 1
+    assert "span_starts" not in rows[0]
+
+
+def test_partial_span_columns_raise(tmp_path: Path) -> None:
+    corpus = _write_corpus(tmp_path, [_row()], drop_columns=("span_tags",))
+    with pytest.raises(ValueError, match="all-or-none"):
+        _iter(corpus)
+
+
+def test_null_span_value_in_span_shard_raises(tmp_path: Path) -> None:
+    corpus = _write_corpus(tmp_path, [_row(), _row(raw="123 Main St", span_starts=None)])
+    with pytest.raises(ValueError, match="null span column"):
+        _iter(corpus)
+
+
+def test_empty_triple_is_a_valid_all_o_row(tmp_path: Path) -> None:
+    corpus = _write_corpus(
+        tmp_path,
+        [_row(raw="hello world", tokens=["hello", "world"], labels=["O", "O"], span_starts=[], span_ends=[], span_tags=[])],
+    )
+    rows = _iter(corpus)
+    assert rows[0]["span_starts"] == []
+
+
+def test_augmentation_plus_relabel_keep_spans_consistent_end_to_end(tmp_path: Path) -> None:
+    """The mutation-upstream hazard, pinned at the loader level: with the directional expansion
+    AND the #511 relabel both on, every emitted row's spans must address ITS OWN raw."""
+    from mailwoman_train.relabel import AffixRelabelLexicon
+
+    corpus = _write_corpus(
+        tmp_path,
+        [
+            _row(
+                raw="1234 SE Division St",
+                tokens=["1234", "SE", "Division", "St"],
+                labels=["B-house_number", "B-street", "I-street", "I-street"],
+                span_starts=[0, 5],
+                span_ends=[4, 19],
+                span_tags=["house_number", "street"],
+            )
+        ],
+    )
+    lex = AffixRelabelLexicon(
+        directionals={"se": "SE", "southeast": "SE"},
+        suffixes={"st": "STREET", "street": "STREET"},
+        version="test",
+    )
+    rows = list(
+        iter_rows(
+            corpus,
+            "train",
+            rng=random.Random(0),
+            country_weights={"US": 1.0},
+            coarse_filter=False,
+            shuffle_buffer=4,
+            augment_directional_prob=1.0,
+            affix_relabel_lexicon=lex,
+        )
+    )
+    assert len(rows) == 2  # original + expanded copy
+
+    def slices(r: dict) -> list[tuple[str, str]]:
+        return [(t, r["raw"][s:e]) for s, e, t in zip(r["span_starts"], r["span_ends"], r["span_tags"])]
+
+    for r in rows:
+        for s, e in zip(r["span_starts"], r["span_ends"]):
+            assert 0 <= s < e <= len(r["raw"])
+
+    original = next(r for r in rows if r["raw"] == "1234 SE Division St")
+    assert slices(original) == [
+        ("house_number", "1234"),
+        ("street_prefix", "SE"),
+        ("street", "Division"),
+        ("street_suffix", "St"),
+    ]
+    expanded = next(r for r in rows if "Southeast" in r["raw"])
+    assert expanded["raw"] == "1234 Southeast Division St"
+    assert slices(expanded) == [
+        ("house_number", "1234"),
+        ("street_prefix", "Southeast"),
+        ("street", "Division"),
+        ("street_suffix", "St"),
+    ]
+
+
+def test_iter_encoded_hands_the_triple_to_encode_row(tmp_path: Path, monkeypatch) -> None:
+    corpus = _write_corpus(tmp_path, [_row()])
+    captured: list[dict] = []
+
+    def fake_encode_row(tokenizer, raw, tokens, labels, max_length, **kwargs):
+        captured.append({"raw": raw, **kwargs})
+        return {"input_ids": [1], "attention_mask": [1], "labels": [0]}
+
+    monkeypatch.setattr(data_loader, "encode_row", fake_encode_row)
+    cfg = DataConfig(corpus_dir=str(corpus), country_weights={"US": 1.0}, coarse_filter=False)
+    list(iter_encoded(cfg, tokenizer=None, split="train"))
+    assert len(captured) == 1
+    assert captured[0]["span_starts"] == [0, 13, 22, 25]
+    assert captured[0]["span_ends"] == [11, 20, 24, 30]
+    assert captured[0]["span_tags"] == ["po_box", "locality", "region", "postcode"]
+
+
+def test_iter_encoded_legacy_path_passes_none(tmp_path: Path, monkeypatch) -> None:
+    corpus = _write_corpus(tmp_path, [_row()], drop_columns=("span_starts", "span_ends", "span_tags"))
+    captured: list[dict] = []
+
+    def fake_encode_row(tokenizer, raw, tokens, labels, max_length, **kwargs):
+        captured.append(kwargs)
+        return {"input_ids": [1], "attention_mask": [1], "labels": [0]}
+
+    monkeypatch.setattr(data_loader, "encode_row", fake_encode_row)
+    cfg = DataConfig(corpus_dir=str(corpus), country_weights={"US": 1.0}, coarse_filter=False)
+    list(iter_encoded(cfg, tokenizer=None, split="train"))
+    assert captured[0]["span_starts"] is None
+    assert captured[0]["span_tags"] is None

--- a/corpus-python/src/mailwoman_train/test_relabel.py
+++ b/corpus-python/src/mailwoman_train/test_relabel.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 
-from .relabel import AffixRelabelLexicon, relabel_row, split_street_span
+from .relabel import AffixRelabelLexicon, relabel_row, relabel_spans, split_street_span
 
 LEX = AffixRelabelLexicon(
     directionals={
@@ -123,6 +123,132 @@ class TestRelabelRow:
             "B-street_prefix", "B-street", "B-street_suffix", "O",
             "B-street_prefix", "B-street", "B-street_suffix",
         ]
+
+
+class TestRelabelSpans:
+    """Char-arithmetic re-target of the #519 span triple — the v0.5.0 form of the pass."""
+
+    @staticmethod
+    def _slices(row):
+        return [
+            (t, row["raw"][s:e])
+            for s, e, t in zip(row["span_starts"], row["span_ends"], row["span_tags"])
+        ]
+
+    def test_splits_street_span_by_char_arithmetic(self):
+        row = {
+            "raw": "1234 SE Division St, Portland, OR 97202",
+            "tokens": ["1234", "SE", "Division", "St", "Portland", "OR", "97202"],
+            "labels": ["B-house_number", "B-street", "I-street", "I-street", "B-locality", "B-region", "B-postcode"],
+            "span_starts": [0, 5, 21, 31, 34],
+            "span_ends": [4, 19, 29, 33, 39],
+            "span_tags": ["house_number", "street", "locality", "region", "postcode"],
+        }
+        assert relabel_row(row, LEX) is True
+        assert self._slices(row) == [
+            ("house_number", "1234"),
+            ("street_prefix", "SE"),
+            ("street", "Division"),
+            ("street_suffix", "St"),
+            ("locality", "Portland"),
+            ("region", "OR"),
+            ("postcode", "97202"),
+        ]
+        # Token labels split in lockstep (transitional — both representations ride).
+        assert row["labels"][1:4] == ["B-street_prefix", "B-street", "B-street_suffix"]
+
+    def test_multiword_name_span(self):
+        row = {
+            "raw": "N Dixie Box Road",
+            "tokens": ["N", "Dixie", "Box", "Road"],
+            "labels": ["B-street", "I-street", "I-street", "I-street"],
+            "span_starts": [0],
+            "span_ends": [16],
+            "span_tags": ["street"],
+        }
+        assert relabel_row(row, LEX) is True
+        assert self._slices(row) == [
+            ("street_prefix", "N"),
+            ("street", "Dixie Box"),
+            ("street_suffix", "Road"),
+        ]
+
+    def test_no_split_leaves_spans_untouched(self):
+        row = {
+            "raw": "South County Trail 175 West",
+            "tokens": ["South", "County", "Trail", "175", "West"],
+            "labels": ["B-street", "I-street", "I-street", "I-street", "I-street"],
+            "span_starts": [0],
+            "span_ends": [27],
+            "span_tags": ["street"],
+        }
+        assert relabel_spans(row, LEX) is False
+        assert row["span_starts"] == [0] and row["span_ends"] == [27] and row["span_tags"] == ["street"]
+
+    def test_dotted_suffix_is_conservative_on_the_span_path(self):
+        # "Main St.": the corpus tokenizer dropped the period, so the TOKEN path sees "St" and
+        # splits; the span path sees the whitespace word "St." (builder parity: parseStreet
+        # splits raw words, "St." is not in the lexicon) and leaves the span whole. The span path
+        # is the v0.5.0 source of truth — conservative beats a third labeling.
+        row = {
+            "raw": "Main St.",
+            "tokens": ["Main", "St"],
+            "labels": ["B-street", "I-street"],
+            "span_starts": [0],
+            "span_ends": [8],
+            "span_tags": ["street"],
+        }
+        relabel_row(row, LEX)
+        assert row["span_tags"] == ["street"]
+        assert row["labels"] == ["B-street", "B-street_suffix"]  # token path split (legacy semantics)
+
+    def test_multiple_street_spans_intersection_style(self):
+        row = {
+            "raw": "N Main St and W Oak Ave",
+            "tokens": ["N", "Main", "St", "and", "W", "Oak", "Ave"],
+            "labels": ["B-street", "I-street", "I-street", "O", "B-street", "I-street", "I-street"],
+            "span_starts": [0, 14],
+            "span_ends": [9, 23],
+            "span_tags": ["street", "street"],
+        }
+        assert relabel_row(row, LEX) is True
+        assert self._slices(row) == [
+            ("street_prefix", "N"),
+            ("street", "Main"),
+            ("street_suffix", "St"),
+            ("street_prefix", "W"),
+            ("street", "Oak"),
+            ("street_suffix", "Ave"),
+        ]
+
+    def test_replaces_lists_instead_of_mutating(self):
+        starts = [0]
+        row = {
+            "raw": "Weaver Lane",
+            "tokens": ["Weaver", "Lane"],
+            "labels": ["B-street", "I-street"],
+            "span_starts": starts,
+            "span_ends": [11],
+            "span_tags": ["street"],
+        }
+        assert relabel_spans(row, LEX) is True
+        assert starts == [0]  # the caller's original list is not mutated through
+        assert row["span_starts"] == [0, 7]
+
+    def test_legacy_row_without_spans_is_a_no_op(self):
+        row = {"tokens": ["Weaver", "Lane"], "labels": ["B-street", "I-street"]}
+        assert relabel_spans(row, LEX) is False
+        assert relabel_row(row, LEX) is True  # token path still fires
+
+    def test_partial_triple_raises(self):
+        row = {
+            "raw": "Weaver Lane",
+            "tokens": ["Weaver", "Lane"],
+            "labels": ["B-street", "I-street"],
+            "span_starts": [0],
+        }
+        with pytest.raises(ValueError, match="partial char-offset span triple"):
+            relabel_spans(row, LEX)
 
 
 class TestLexiconLoading:

--- a/corpus-python/src/mailwoman_train/test_span_parquet.py
+++ b/corpus-python/src/mailwoman_train/test_span_parquet.py
@@ -1,0 +1,134 @@
+"""Parquet round-trip gate for the v0.5.0 span columns (#519, rebuild-plan step 1).
+
+The shard pipeline is JSONL (builders, via ``alignRow``) → ``scripts/jsonl-to-parquet.py`` →
+parquet → this package's PyArrow readers. JSONL has carried the span triple since #527; this
+test pins the two properties the parquet leg must now hold:
+
+1. **Round-trip identity** — ``span_starts``/``span_ends``/``span_tags`` written by the real
+   converter script read back bit-identical through PyArrow (the reader stack the training
+   loader uses), including the empty-triple (all-O) row.
+2. **Loud refusal** — a row missing the triple, or carrying a partial one, fails the conversion
+   with a named row. Silent loss (the pre-#519 behavior: columns simply dropped) is the hazard
+   this step exists to close.
+
+Runs the converter via subprocess so the gate covers the actual script, not a re-implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONVERTER = REPO_ROOT / "scripts" / "jsonl-to-parquet.py"
+
+
+def _row(**over) -> dict:
+    base = {
+        "raw": "1600 Pennsylvania Ave NW, Washington, DC 20500",
+        "tokens": ["1600", "Pennsylvania", "Ave", "NW", "Washington", "DC", "20500"],
+        "labels": ["B-house_number", "B-street", "I-street", "I-street", "B-locality", "B-region", "B-postcode"],
+        "span_starts": [0, 5, 26, 38, 41],
+        "span_ends": [4, 24, 36, 40, 46],
+        "span_tags": ["house_number", "street", "locality", "region", "postcode"],
+        "country": "US",
+        "locale": "en-US",
+        "source": "test",
+        "source_id": "t-1",
+        "corpus_version": "0.5.0",
+        "license": "CC0-1.0",
+        "synth_method": None,
+        "synth_base_id": None,
+    }
+    base.update(over)
+    return base
+
+
+def _convert(tmp_path: Path, rows: list[dict]) -> subprocess.CompletedProcess:
+    jsonl = tmp_path / "rows.jsonl"
+    jsonl.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    out = tmp_path / "rows.parquet"
+    return subprocess.run(
+        [sys.executable, str(CONVERTER), "--input", str(jsonl), "--output", str(out)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_span_columns_round_trip(tmp_path: Path) -> None:
+    rows = [
+        _row(source_id="t-multi"),
+        # Intra-span punctuation — offsets the token columns structurally cannot carry.
+        _row(
+            source_id="t-pobox",
+            raw="P.O. Box 19",
+            tokens=["P", "O", "Box", "19"],
+            labels=["B-po_box", "I-po_box", "I-po_box", "I-po_box"],
+            span_starts=[0],
+            span_ends=[11],
+            span_tags=["po_box"],
+        ),
+        # All-O row: a legitimately EMPTY triple must survive as [], not null.
+        _row(
+            source_id="t-all-o",
+            raw="hello world",
+            tokens=["hello", "world"],
+            labels=["O", "O"],
+            span_starts=[],
+            span_ends=[],
+            span_tags=[],
+        ),
+    ]
+    result = _convert(tmp_path, rows)
+    assert result.returncode == 0, result.stderr
+
+    table = pq.read_table(tmp_path / "rows.parquet")
+    for col in ("span_starts", "span_ends", "span_tags"):
+        assert col in table.column_names
+    by_id = {
+        sid: (starts, ends, tags)
+        for sid, starts, ends, tags in zip(
+            table["source_id"].to_pylist(),
+            table["span_starts"].to_pylist(),
+            table["span_ends"].to_pylist(),
+            table["span_tags"].to_pylist(),
+        )
+    }
+    assert by_id["t-multi"] == (
+        [0, 5, 26, 38, 41],
+        [4, 24, 36, 40, 46],
+        ["house_number", "street", "locality", "region", "postcode"],
+    )
+    assert by_id["t-pobox"] == ([0], [11], ["po_box"])
+    assert by_id["t-all-o"] == ([], [], [])
+
+
+def test_missing_span_triple_fails_loudly(tmp_path: Path) -> None:
+    row = _row(source_id="t-legacy")
+    for col in ("span_starts", "span_ends", "span_tags"):
+        del row[col]
+    result = _convert(tmp_path, [_row(source_id="t-ok"), row])
+    assert result.returncode != 0
+    assert "missing the char-offset span triple" in result.stderr
+    assert "line 2" in result.stderr
+    assert not (tmp_path / "rows.parquet").exists()
+
+
+@pytest.mark.parametrize("dropped", ["span_starts", "span_ends", "span_tags"])
+def test_partial_span_triple_fails_loudly(tmp_path: Path, dropped: str) -> None:
+    row = _row(source_id="t-partial")
+    del row[dropped]
+    result = _convert(tmp_path, [row])
+    assert result.returncode != 0
+    assert "missing the char-offset span triple" in result.stderr
+
+
+def test_nonparallel_span_triple_fails_loudly(tmp_path: Path) -> None:
+    result = _convert(tmp_path, [_row(source_id="t-skew", span_tags=["street"])])
+    assert result.returncode != 0
+    assert "not parallel" in result.stderr

--- a/corpus/src/align.ts
+++ b/corpus/src/align.ts
@@ -62,7 +62,12 @@ export interface AlignOptions {
 /** Either a successful labeled row or a quarantined one. */
 export type AlignmentResult = { kind: "labeled"; row: LabeledRow } | { kind: "quarantined"; row: QuarantinedRow }
 
-interface ComponentSpan {
+/**
+ * One located char-offset label span over a row's `raw` ([start, end) in UTF-16 code units). The
+ * element type behind the parallel `span_starts[]`/`span_ends[]`/`span_tags[]` triple on
+ * `LabeledRow` (#519).
+ */
+export interface ComponentSpan {
 	tag: ComponentTag
 	start: number
 	end: number
@@ -130,13 +135,19 @@ export function alignRow(row: CanonicalRow, opts: AlignOptions = {}): AlignmentR
 }
 
 /**
- * Enforce the #519 span-triple invariants — sorted ascending by start, non-overlapping — loudly.
+ * Enforce the #519 span-triple invariants — in-bounds, sorted ascending by start, non-overlapping —
+ * loudly.
  *
- * `claimed`-span bookkeeping in `locateSpan` already makes overlap impossible and the caller sorts,
- * so a violation here is a bug in this file, not bad source data: throw (naming the row) rather
- * than quarantine, so the corruption can't ride into a corpus.
+ * For `alignRow`: `claimed`-span bookkeeping in `locateSpan` already makes overlap impossible and
+ * the caller sorts, so a violation here is a bug in this file, not bad source data: throw (naming
+ * the row) rather than quarantine, so the corruption can't ride into a corpus. Exported for every
+ * OTHER span producer (`composeAdversarialRow`'s offset arithmetic, future synthesis paths) — any
+ * code that emits the triple without going through `alignRow` must pass its output through this.
  */
-function assertSpanInvariants(spans: readonly ComponentSpan[], row: CanonicalRow): void {
+export function assertSpanInvariants(
+	spans: readonly ComponentSpan[],
+	row: Pick<CanonicalRow, "raw" | "source" | "source_id">
+): void {
 	for (let i = 0; i < spans.length; i++) {
 		const s = spans[i]!
 		if (!(s.start >= 0 && s.start < s.end && s.end <= row.raw.length)) {

--- a/corpus/src/parquet.test.ts
+++ b/corpus/src/parquet.test.ts
@@ -30,6 +30,9 @@ const labeled = (over: Partial<LabeledRow>): LabeledRow => ({
 	license: "CC0-1.0",
 	tokens: ["Paris"],
 	labels: ["B-locality"],
+	span_starts: [0],
+	span_ends: [5],
+	span_tags: ["locality"],
 	...over,
 })
 
@@ -82,6 +85,37 @@ describe("rowToParquet", () => {
 		expect(pq.tokens).toEqual(["Paris", "France"])
 		expect(pq.labels).toEqual(["B-locality", "B-country"])
 	})
+
+	it("preserves the char-offset span triple (#519)", () => {
+		const pq = rowToParquet(
+			labeled({
+				raw: "Paris, France",
+				tokens: ["Paris", "France"],
+				labels: ["B-locality", "B-country"],
+				span_starts: [0, 7],
+				span_ends: [5, 13],
+				span_tags: ["locality", "country"],
+			})
+		)
+		expect(pq.span_starts).toEqual([0, 7])
+		expect(pq.span_ends).toEqual([5, 13])
+		expect(pq.span_tags).toEqual(["locality", "country"])
+	})
+
+	it("throws loudly when the span triple is absent (un-migrated producer)", () => {
+		expect(() => rowToParquet(labeled({ span_starts: undefined, span_ends: undefined, span_tags: undefined }))).toThrow(
+			/missing the char-offset span triple/
+		)
+	})
+
+	it("throws loudly on a partial span triple (corrupt row, never a silent fallback)", () => {
+		expect(() => rowToParquet(labeled({ span_tags: undefined }))).toThrow(/missing the char-offset span triple/)
+		expect(() => rowToParquet(labeled({ span_starts: undefined }))).toThrow(/missing the char-offset span triple/)
+	})
+
+	it("throws loudly when the span arrays are not parallel", () => {
+		expect(() => rowToParquet(labeled({ span_starts: [0, 7] }))).toThrow(/not parallel/)
+	})
 })
 
 describe("LABELED_ROW_SCHEMA", () => {
@@ -100,6 +134,12 @@ describe("LABELED_ROW_SCHEMA", () => {
 		expect(LABELED_ROW_SCHEMA.labels.repeated).toBe(true)
 	})
 
+	it("marks the span triple REPEATED, offsets as INT32 (#519)", () => {
+		expect(LABELED_ROW_SCHEMA.span_starts).toMatchObject({ type: "INT32", repeated: true })
+		expect(LABELED_ROW_SCHEMA.span_ends).toMatchObject({ type: "INT32", repeated: true })
+		expect(LABELED_ROW_SCHEMA.span_tags).toMatchObject({ type: "UTF8", repeated: true })
+	})
+
 	it("uses SHARD_COMPRESSION on every column", () => {
 		for (const def of Object.values(LABELED_ROW_SCHEMA)) {
 			expect(def.compression).toBe(SHARD_COMPRESSION)
@@ -114,6 +154,9 @@ describe("writeShards", () => {
 			"raw",
 			"tokens",
 			"labels",
+			"span_starts",
+			"span_ends",
+			"span_tags",
 			"country",
 			"locale",
 			"source",
@@ -172,6 +215,68 @@ describe("writeShards", () => {
 		expect(manifestOnDisk.total_rows).toBe(4)
 		expect(manifestOnDisk.schema).toEqual([...PARQUET_COLUMNS])
 		expect(manifestOnDisk.row_group_size).toBe(ROW_GROUP_SIZE)
+	})
+
+	it("round-trips the span triple: row → parquet → read back → spans identical (#519)", async () => {
+		const rows: LabeledRow[] = [
+			labeled({
+				source_id: "t-multi",
+				raw: "1600 Pennsylvania Ave NW, Washington, DC 20500",
+				tokens: ["1600", "Pennsylvania", "Ave", "NW", "Washington", "DC", "20500"],
+				labels: ["B-house_number", "B-street", "I-street", "I-street", "B-locality", "B-region", "B-postcode"],
+				span_starts: [0, 5, 26, 38, 41],
+				span_ends: [4, 24, 36, 40, 46],
+				span_tags: ["house_number", "street", "locality", "region", "postcode"],
+			}),
+			// Intra-span punctuation — the offsets the token columns structurally cannot carry.
+			labeled({
+				source_id: "t-pobox",
+				raw: "P.O. Box 19",
+				tokens: ["P", "O", "Box", "19"],
+				labels: ["B-po_box", "I-po_box", "I-po_box", "I-po_box"],
+				span_starts: [0],
+				span_ends: [11],
+				span_tags: ["po_box"],
+			}),
+			// All-O row: a legitimately EMPTY span triple must survive (not become a missing column).
+			labeled({
+				source_id: "t-all-o",
+				raw: "hello world",
+				components: {},
+				tokens: ["hello", "world"],
+				labels: ["O", "O"],
+				span_starts: [],
+				span_ends: [],
+				span_tags: [],
+			}),
+		]
+		const m = await writeShards({ train: asyncFrom(rows) }, { outputDir: scratch, corpusVersion: "0.5.0" })
+		const back = await readParquet(m.shards[0]!.path)
+		expect(back).toHaveLength(3)
+
+		const multi = back.find((r) => r.source_id === "t-multi")!
+		expect(multi.span_starts).toEqual([0, 5, 26, 38, 41])
+		expect(multi.span_ends).toEqual([4, 24, 36, 40, 46])
+		expect(multi.span_tags).toEqual(["house_number", "street", "locality", "region", "postcode"])
+
+		const pobox = back.find((r) => r.source_id === "t-pobox")!
+		expect(pobox.span_starts).toEqual([0])
+		expect(pobox.span_ends).toEqual([11])
+		expect(pobox.span_tags).toEqual(["po_box"])
+
+		// parquetjs reads an empty repeated field back as an absent key — normalize to [] and assert
+		// the row carries no spurious spans.
+		const allO = back.find((r) => r.source_id === "t-all-o")!
+		expect(allO.span_starts ?? []).toEqual([])
+		expect(allO.span_ends ?? []).toEqual([])
+		expect(allO.span_tags ?? []).toEqual([])
+	})
+
+	it("refuses to shard rows missing the span triple (the silent-loss hazard, loudly)", async () => {
+		const rows = [labeled({ source_id: "t-1", span_starts: undefined, span_ends: undefined, span_tags: undefined })]
+		await expect(
+			writeShards({ train: asyncFrom(rows) }, { outputDir: scratch, corpusVersion: "0.5.0" })
+		).rejects.toThrow(/missing the char-offset span triple/)
 	})
 
 	it("rolls to a new shard at rowsPerShard rows", async () => {

--- a/corpus/src/parquet.ts
+++ b/corpus/src/parquet.ts
@@ -60,6 +60,9 @@ export interface ParquetRow {
 	raw: string
 	tokens: readonly string[]
 	labels: readonly string[]
+	span_starts: readonly number[]
+	span_ends: readonly number[]
+	span_tags: readonly string[]
 	country: string
 	locale: string | null
 	source: string
@@ -76,6 +79,9 @@ export const PARQUET_COLUMNS = [
 	"raw",
 	"tokens",
 	"labels",
+	"span_starts",
+	"span_ends",
+	"span_tags",
 	"country",
 	"locale",
 	"source",
@@ -94,6 +100,12 @@ export const LABELED_ROW_SCHEMA: ParquetSchemaDefinition<ParquetRow> = {
 	raw: { type: "UTF8", compression: SHARD_COMPRESSION },
 	tokens: { type: "UTF8", repeated: true, compression: SHARD_COMPRESSION },
 	labels: { type: "UTF8", repeated: true, compression: SHARD_COMPRESSION },
+	// v0.5.0 char-offset label spans (#519): parallel arrays over `raw` (UTF-16 code units,
+	// [start, end) exclusive-end, sorted, non-overlapping). INT32 — raw is a short address string,
+	// and INT32 round-trips as `number` where parquetjs INT64 would surface bigint.
+	span_starts: { type: "INT32", repeated: true, compression: SHARD_COMPRESSION },
+	span_ends: { type: "INT32", repeated: true, compression: SHARD_COMPRESSION },
+	span_tags: { type: "UTF8", repeated: true, compression: SHARD_COMPRESSION },
 	country: { type: "UTF8", compression: SHARD_COMPRESSION },
 	locale: { type: "UTF8", compression: SHARD_COMPRESSION, optional: true },
 	source: { type: "UTF8", compression: SHARD_COMPRESSION },
@@ -147,12 +159,39 @@ export interface WriteShardsOptions {
  */
 export type PerSplitRows = Partial<Record<SplitName, AsyncIterable<LabeledRow>>>
 
-/** Project a labeled row to the Parquet schema. */
+/**
+ * Project a labeled row to the Parquet schema.
+ *
+ * The span triple is REQUIRED here (#519): `alignRow` emits it on every labeled row, so a row
+ * arriving without it came from a producer that hasn't migrated — writing it would silently drop
+ * the v0.5.0 labels from the shard (the "builders before parquet = silent loss" hazard). Loud
+ * failure, naming the row, instead.
+ */
 export function rowToParquet(row: LabeledRow): ParquetRow {
+	const { span_starts, span_ends, span_tags } = row
+	if (span_starts === undefined || span_ends === undefined || span_tags === undefined) {
+		throw new Error(
+			`rowToParquet: row is missing the char-offset span triple (#519) — ` +
+				`span_starts=${span_starts !== undefined} span_ends=${span_ends !== undefined} span_tags=${span_tags !== undefined} ` +
+				`(source=${row.source}, source_id=${row.source_id}). ` +
+				`Every parquet-bound row must carry span_starts/span_ends/span_tags; ` +
+				`producers that emit tokens/labels only have not migrated to the v0.5.0 format.`
+		)
+	}
+	if (span_starts.length !== span_ends.length || span_starts.length !== span_tags.length) {
+		throw new Error(
+			`rowToParquet: span triple arrays are not parallel — ` +
+				`starts=${span_starts.length} ends=${span_ends.length} tags=${span_tags.length} ` +
+				`(source=${row.source}, source_id=${row.source_id})`
+		)
+	}
 	return {
 		raw: row.raw,
 		tokens: row.tokens,
 		labels: row.labels,
+		span_starts,
+		span_ends,
+		span_tags,
 		country: row.country,
 		locale: row.locale ?? null,
 		source: row.source,
@@ -174,6 +213,9 @@ function appendShape(row: ParquetRow): Record<string, unknown> {
 		raw: row.raw,
 		tokens: row.tokens,
 		labels: row.labels,
+		span_starts: row.span_starts,
+		span_ends: row.span_ends,
+		span_tags: row.span_tags,
 		country: row.country,
 		source: row.source,
 		source_id: row.source_id,

--- a/corpus/src/synthesize.test.ts
+++ b/corpus/src/synthesize.test.ts
@@ -695,6 +695,85 @@ describe("composeAdversarialRow", () => {
 		}
 	})
 
+	it("re-targets the char-offset span triple onto the composed surface (#519)", () => {
+		const address = baseRow({
+			raw: "Buffalo, NY 14201",
+			components: { locality: "Buffalo", region: "NY", postcode: "14201" },
+			source_id: "wof-admin-buffalo",
+		})
+		const result = composeAdversarialRow("Buffalo Health Clinic", address, {
+			pattern: "place-name-venue",
+		})
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+
+		const { raw, span_starts, span_ends, span_tags } = result.row
+		expect(raw).toBe("Buffalo Health Clinic, Buffalo, NY 14201")
+		// One venue span over the whole venue, then the address spans shifted by venue + separator.
+		expect(span_tags).toEqual(["venue", "locality", "region", "postcode"])
+		expect(span_starts).toEqual([0, 23, 32, 35])
+		expect(span_ends).toEqual([21, 30, 34, 40])
+		// Every span reconstructs its component surface verbatim off the COMPOSED raw.
+		const surfaces = span_tags!.map((_, i) => raw.slice(span_starts![i]!, span_ends![i]!))
+		expect(surfaces).toEqual(["Buffalo Health Clinic", "Buffalo", "NY", "14201"])
+		// The separator comma + space sit outside every span (deliberately unlabeled).
+		expect(span_ends![0]!).toBeLessThanOrEqual(21)
+		expect(span_starts![1]!).toBeGreaterThanOrEqual(23)
+	})
+
+	it("composed spans satisfy the #519 invariants under every separator", () => {
+		const address = baseRow({
+			raw: "Buffalo, NY 14201",
+			components: { locality: "Buffalo", region: "NY", postcode: "14201" },
+		})
+		for (const separator of [", ", " ", "\n"]) {
+			const result = composeAdversarialRow("New York, New York Steakhouse", address, {
+				pattern: "place-shaped-venue",
+				separator,
+			})
+			expect(result.kind).toBe("labeled")
+			if (result.kind !== "labeled") continue
+			const { raw, span_starts, span_ends, span_tags } = result.row
+			expect(span_starts!.length).toBe(span_ends!.length)
+			expect(span_starts!.length).toBe(span_tags!.length)
+			for (let i = 0; i < span_starts!.length; i++) {
+				expect(span_starts![i]!).toBeGreaterThanOrEqual(0)
+				expect(span_starts![i]!).toBeLessThan(span_ends![i]!)
+				expect(span_ends![i]!).toBeLessThanOrEqual(raw.length)
+				if (i > 0) expect(span_starts![i]!).toBeGreaterThanOrEqual(span_ends![i - 1]!)
+			}
+		}
+	})
+
+	it("venue span covers internal punctuation the token path cannot express", () => {
+		const address = baseRow({
+			raw: "Montreal, QC H2X 1Y4",
+			country: "CA",
+			components: { locality: "Montreal", region: "QC", postcode: "H2X 1Y4" },
+		})
+		const result = composeAdversarialRow("P'tit St. Denis Street Café", address, {
+			pattern: "particle-honorific",
+		})
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		// The whole venue — apostrophe, period, accent included — is ONE span.
+		expect(result.row.span_tags![0]).toBe("venue")
+		expect(result.row.raw.slice(result.row.span_starts![0]!, result.row.span_ends![0]!)).toBe(
+			"P'tit St. Denis Street Café"
+		)
+	})
+
+	it("non-NFC venue quarantines with reason=venue-not-nfc (offset ambiguity guard)", () => {
+		const address = baseRow({
+			raw: "Buffalo, NY 14201",
+			components: { locality: "Buffalo", region: "NY", postcode: "14201" },
+		})
+		const nfdVenue = "Café Olé".normalize("NFD")
+		const result = composeAdversarialRow(nfdVenue, address, { pattern: "place-name-venue" })
+		expect(result.kind).toBe("quarantined")
+		if (result.kind === "quarantined") expect(result.row.reason).toBe("venue-not-nfc")
+	})
+
 	it("is deterministic: two compositions of the same inputs produce identical output", () => {
 		const address = baseRow({
 			raw: "Buffalo, NY 14201",

--- a/corpus/src/synthesize.ts
+++ b/corpus/src/synthesize.ts
@@ -32,7 +32,7 @@ import {
 	matchTrailingSuffix,
 } from "@mailwoman/codex/us"
 import type { BioLabel, ComponentTag } from "@mailwoman/core/types"
-import { alignRow } from "./align.js"
+import { alignRow, assertSpanInvariants, type ComponentSpan } from "./align.js"
 import { whitespaceTokenizer, type Tokenizer } from "./tokenize.js"
 import type { CanonicalRow, LabeledRow, QuarantinedRow } from "./types.js"
 
@@ -561,12 +561,22 @@ export type ComposeResult = { kind: "labeled"; row: LabeledRow } | { kind: "quar
  * tokens in the venue stay labeled as `venue`, never as the address's locality / region / etc.,
  * even when they share surface forms.
  *
+ * The char-offset span triple (#519) is re-targeted to the composed surface by the same
+ * deterministic boundary: one `venue` span over `[0, venue.length)` (no re-search), then the
+ * address's own spans shifted by `venue.length + separator.length` — plain offset arithmetic, no
+ * token indirection. The separator chars sit outside every span (deliberately unlabeled — now
+ * expressible). The composed triple is passed through `assertSpanInvariants` so a composition bug
+ * can't ride into a corpus.
+ *
  * The address's components are forwarded as-is (alignment ran on them and they survived); `venue`
  * is added on top with the trimmed venue string as its surface form.
  *
  * Returns `{ kind: "quarantined" }` when:
  *
  * - The venue is empty or whitespace-only.
+ * - The venue is not NFC-normalized (char offsets over a non-NFC raw are ambiguous — the same
+ *   discipline `alignRow` enforces on adapter rows, surfaced as quarantine here because the venue
+ *   is caller-supplied data).
  * - The address row fails alignment in isolation (the underlying failure reason is propagated).
  */
 export function composeAdversarialRow(
@@ -580,6 +590,11 @@ export function composeAdversarialRow(
 	const venueTrimmed = venue.trim()
 	if (!venueTrimmed) {
 		return { kind: "quarantined", row: { row: address, reason: "venue-empty" } }
+	}
+	// Char-offset spans over the composed raw are only meaningful under NFC (#519) — the address
+	// half is enforced by alignRow; the venue is caller-supplied and checked here.
+	if (venueTrimmed.normalize("NFC") !== venueTrimmed) {
+		return { kind: "quarantined", row: { row: address, reason: "venue-not-nfc" } }
 	}
 
 	const addressAligned = alignRow(address, { tokenizer })
@@ -609,6 +624,23 @@ export function composeAdversarialRow(
 		...address.components,
 	}
 
+	// Re-target the char-offset spans (#519) onto the composed surface: the venue span covers the
+	// whole trimmed venue (internal punctuation included — the token path cannot say that), and the
+	// address's spans shift right by the venue + separator length. alignRow emits the triple on
+	// every labeled row, so absence here is an alignment-contract bug, not data — fail loudly.
+	const { span_starts: addrStarts, span_ends: addrEnds, span_tags: addrTags } = addressAligned.row
+	if (addrStarts === undefined || addrEnds === undefined || addrTags === undefined) {
+		throw new Error(
+			`composeAdversarialRow: alignRow returned a labeled row without the span triple ` +
+				`(source=${address.source}, source_id=${address.source_id}) — alignment contract violation`
+		)
+	}
+	const offset = venueTrimmed.length + separator.length
+	const spans: ComponentSpan[] = [
+		{ tag: "venue", start: 0, end: venueTrimmed.length },
+		...addrTags.map((tag, i) => ({ tag, start: addrStarts[i]! + offset, end: addrEnds[i]! + offset })),
+	]
+
 	const baseSourceId = address.synth?.base_source_id ?? address.source_id
 	const method = `compose:${options.pattern}`
 
@@ -624,7 +656,11 @@ export function composeAdversarialRow(
 		synth: { method, base_source_id: baseSourceId },
 		tokens,
 		labels,
+		span_starts: spans.map((s) => s.start),
+		span_ends: spans.map((s) => s.end),
+		span_tags: spans.map((s) => s.tag),
 	}
+	assertSpanInvariants(spans, composed)
 
 	return { kind: "labeled", row: composed }
 }

--- a/scripts/audit-po-box-cedex-shard.mjs
+++ b/scripts/audit-po-box-cedex-shard.mjs
@@ -11,10 +11,12 @@
  *
  *   Checks per row:
  *
- *   1. Tokens/labels parallel arrays + well-formed BIO (no orphan I-, no tag switch mid-run).
- *   2. The po_box span covers the WHOLE designator+number phrase: the po_box-labeled tokens equal
- *        components.po_box modulo punctuation (the whitespace tokenizer drops "."/"#", so
- *        comparison is on the letter/digit stream) — same for cedex. Exactly one span per tag.
+ *   1. Tokens/labels parallel arrays + well-formed BIO (no orphan I-, no tag switch mid-run) —
+ *        transitional, while both label representations ride the shard.
+ *   2. RAW-SURFACE span check (#519): the row carries the char-offset span triple (parallel, sorted,
+ *        in-bounds), and the po_box span's raw slice equals components.po_box VERBATIM —
+ *        punctuation included ("P.O. Box 19" with the periods, the dotted blind spot the old
+ *        token-stream comparison could not see) — same for cedex. Exactly one span per tag.
  *   3. Codex round-trip: every US po_box phrase with a codex-covered designator and a clean id must
  *        satisfy `isPOBox` (POB / PMB / "#" / noisy-id forms are corpus-template territory,
  *        exempt).
@@ -39,13 +41,6 @@ const CODEX_COVERED = /^(p\.?\s*o\.?\s*box|post\s+office\s+box|firm\s+caller|cal
 const CLEAN_ID = /^[\dA-Za-z][\dA-Za-z-]*$/
 const CEDEX_SHAPE = /^cedex(\s\d{1,2})?$/i
 
-const norm = (s) =>
-	s
-		.normalize("NFC")
-		.replace(/[^\p{L}\p{N}]+/gu, " ")
-		.trim()
-		.toLowerCase()
-
 function parseArgs() {
 	const args = process.argv.slice(2)
 	const out = { samples: 8 }
@@ -60,24 +55,34 @@ function parseArgs() {
 	return out
 }
 
-/** Extract the contiguous spans for a tag from BIO labels; returns arrays of joined token text. */
-function spansOf(tokens, labels, tag) {
-	const spans = []
-	let cur = null
-	for (let i = 0; i < labels.length; i++) {
-		if (labels[i] === `B-${tag}`) {
-			if (cur) spans.push(cur)
-			cur = [tokens[i]]
-		} else if (labels[i] === `I-${tag}`) {
-			if (!cur) return { spans, malformed: true } // orphan I-
-			cur.push(tokens[i])
-		} else if (cur) {
-			spans.push(cur)
-			cur = null
+/**
+ * Validate the #519 char-offset span triple's structure (present, parallel, sorted, in-bounds) and
+ * return the raw slices per tag. Returns `{ ok: false, reason }` on a structural violation.
+ */
+function spanSlices(row) {
+	const { raw, span_starts, span_ends, span_tags } = row
+	if (!span_starts || !span_ends || !span_tags) {
+		return { ok: false, reason: "missing the char-offset span triple (#519)" }
+	}
+	if (span_starts.length !== span_ends.length || span_starts.length !== span_tags.length) {
+		return {
+			ok: false,
+			reason: `span triple not parallel: ${span_starts.length}/${span_ends.length}/${span_tags.length}`,
 		}
 	}
-	if (cur) spans.push(cur)
-	return { spans: spans.map((s) => s.join(" ")), malformed: false }
+	const byTag = new Map()
+	for (let i = 0; i < span_starts.length; i++) {
+		if (!(span_starts[i] >= 0 && span_starts[i] < span_ends[i] && span_ends[i] <= raw.length)) {
+			return { ok: false, reason: `span ${span_tags[i]}@[${span_starts[i]}, ${span_ends[i]}) out of bounds` }
+		}
+		if (i > 0 && span_starts[i] < span_ends[i - 1]) {
+			return { ok: false, reason: `spans unsorted/overlapping at index ${i}` }
+		}
+		const tag = span_tags[i]
+		if (!byTag.has(tag)) byTag.set(tag, [])
+		byTag.get(tag).push(raw.slice(span_starts[i], span_ends[i]))
+	}
+	return { ok: true, byTag }
 }
 
 function bioWellFormed(labels) {
@@ -114,13 +119,19 @@ async function main() {
 		if (!bioWellFormed(labels)) fail(row, "malformed BIO")
 		if (!c.po_box && !c.cedex) fail(row, "row carries neither po_box nor cedex")
 
-		for (const tag of ["po_box", "cedex"]) {
-			if (!c[tag]) continue
-			tagCounts[tag]++
-			const { spans, malformed } = spansOf(tokens, labels, tag)
-			if (malformed) fail(row, `orphan I-${tag}`)
-			if (spans.length !== 1) fail(row, `${tag}: expected 1 span, got ${spans.length}`)
-			else if (norm(spans[0]) !== norm(c[tag])) fail(row, `${tag} span "${spans[0]}" != component "${c[tag]}"`)
+		// RAW-surface comparison via the #519 span triple — punctuation preserved, never stripped.
+		const sliced = spanSlices(row)
+		if (!sliced.ok) {
+			fail(row, sliced.reason)
+		} else {
+			for (const tag of ["po_box", "cedex"]) {
+				if (!c[tag]) continue
+				tagCounts[tag]++
+				const slices = sliced.byTag.get(tag) ?? []
+				if (slices.length !== 1) fail(row, `${tag}: expected 1 span, got ${slices.length}`)
+				else if (slices[0].toLowerCase() !== c[tag].toLowerCase())
+					fail(row, `${tag} span "${slices[0]}" != component "${c[tag]}" (raw-surface, verbatim)`)
+			}
 		}
 
 		if (c.cedex && !CEDEX_SHAPE.test(c.cedex)) fail(row, `cedex shape: "${c.cedex}"`)

--- a/scripts/build-intersection-shard.mjs
+++ b/scripts/build-intersection-shard.mjs
@@ -4,10 +4,10 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Build the REAL-pair intersection training shard (#487). The model scores 0.0 on
- *   intersection_a/b (the intersection-real eval, v4.2.0 baseline) because the training mix has
- *   ZERO intersection-labeled rows — `synth-intersection` config weights (2.0, then 0.2) were
- *   twice a data no-op. This is the missing data.
+ *   Build the REAL-pair intersection training shard (#487). The model scores 0.0 on intersection_a/b
+ *   (the intersection-real eval, v4.2.0 baseline) because the training mix has ZERO
+ *   intersection-labeled rows — `synth-intersection` config weights (2.0, then 0.2) were twice a
+ *   data no-op. This is the missing data.
  *
  *   STREET PAIRS ARE REAL: the same TIGER 2023 EDGES extraction as the eval builder
  *   (scripts/eval/build-intersection-real.ts) — a node where two road edges (MTFCC S1*) with
@@ -18,36 +18,38 @@
  *   LEAKAGE POLICY (mirrors the affix shard's VT discipline):
  *
  *   - TRAIN counties: Cook IL (grid city) + Morris NJ (suburb).
- *   - GOLDEN (`--golden`) county: Washington VT (rural) ONLY — the corpus defaultHoldout state,
- *       never sampled by train mode.
- *   - Every crossing in data/eval/external/intersection-real.jsonl is excluded from BOTH modes, by
- *       node id AND by order-insensitive name pair (the eval shares all three counties).
+ *   - GOLDEN (`--golden`) county: Washington VT (rural) ONLY — the corpus defaultHoldout state, never
+ *       sampled by train mode.
+ *   - Every crossing in data/eval/external/intersection-real.jsonl is excluded from BOTH modes, by node
+ *       id AND by order-insensitive name pair (the eval shares all three counties).
  *
  *   RENDERING: junction-format variety per the night-10 audit — padded/TIGHT `&` and `/`, `and`,
  *   `at`, `@`, leading-phrase `corner of` / `intersection of` — crossed with tails (bare / `, ST` /
  *   `, ST ZIP` / `, City, ST [ZIP]`) and case variants (as-is / UPPER / lower). ZIPs are the
- *   crossing's own TIGER edge ZIPL (real); the locality tail comes from the OA Cook-county
- *   ZIP→city majority map (real pairing; NJ crossings get region/ZIP tails only — no OA NJ source
- *   in the cache). Span convention matches the eval gold: intersection_a/b cover each street
- *   INCLUDING directional + suffix ("S Loomis Blvd"); connector tokens are O.
+ *   crossing's own TIGER edge ZIPL (real); the locality tail comes from the OA Cook-county ZIP→city
+ *   majority map (real pairing; NJ crossings get region/ZIP tails only — no OA NJ source in the
+ *   cache). Span convention matches the eval gold: intersection_a/b cover each street INCLUDING
+ *   directional + suffix ("S Loomis Blvd"); connector tokens are O.
  *
- *   AUDIT: every emitted row is label-checked (B-count == component count; each labeled span
- *   reconstructs its component verbatim; every O token is a known connector word). Any violation
- *   fails the build. A JSON audit report (counts per form/tail/case + samples) lands next to the
- *   output.
+ *   AUDIT: every emitted row is label-checked on the RAW SURFACE via the #519 char-offset span triple
+ *   (one span per component; each span's raw slice reconstructs its component verbatim, punctuation
+ *   included; every uncovered char is connector material — whitespace, the connector punctuation,
+ *   or a known connector word). The previous token-stream comparison was punctuation-blind (the
+ *   dotted-designator lesson); raw slices are the authority now. Any violation fails the build. A
+ *   JSON audit report (counts per form/tail/case + samples) lands next to the output.
  *
  *   Inputs (already on disk; do not re-download):
  *
  *   - /tmp/tiger-edges/tl_2023_{17031,34027,50023}_edges.shp (unzipped TIGER 2023 EDGES)
  *   - /tmp/oa-cache/us__il__cook.zip (ZIP→city tails)
  *
- *   Pipeline:
- *     node scripts/build-intersection-shard.mjs --output /tmp/intersection-shard/intersection-train.jsonl \
- *       --count 40000 --seed 42
- *     node scripts/build-intersection-shard.mjs --output /tmp/intersection-shard/intersection-golden.jsonl \
- *       --golden --count 500 --seed 99
- *     python3 scripts/jsonl-to-parquet.py --input /tmp/intersection-shard/intersection-train.jsonl \
- *       --output /tmp/intersection-shard/part-intersection-train.parquet
+ *   Pipeline: node scripts/build-intersection-shard.mjs --output
+ *   /tmp/intersection-shard/intersection-train.jsonl\
+ *   --count 40000 --seed 42 node scripts/build-intersection-shard.mjs --output
+ *   /tmp/intersection-shard/intersection-golden.jsonl\
+ *   --golden --count 500 --seed 99 python3 scripts/jsonl-to-parquet.py --input
+ *   /tmp/intersection-shard/intersection-train.jsonl\
+ *   --output /tmp/intersection-shard/part-intersection-train.parquet
  */
 
 import { spawnSync } from "node:child_process"
@@ -102,8 +104,8 @@ const CASES = [
 ]
 
 /**
- * Words a connector may contribute as O tokens. The audit rejects any O token outside this set —
- * an unlabeled street/locality token would surface here.
+ * Words a connector may contribute as O tokens. The audit rejects any O token outside this set — an
+ * unlabeled street/locality token would surface here.
  */
 const CONNECTOR_O_TOKENS = new Set(["and", "at", "of", "corner", "intersection"])
 
@@ -315,41 +317,74 @@ function renderRow(random, crossing, zipCity) {
 	return { raw, components, formId: form.id, tailId: tail.id, caseId: casing.id }
 }
 
-const TOKEN_RE = /[\p{L}\p{N}\p{M}'_-]+/gu
-const tokenizeLikeAligner = (s) => (s.match(TOKEN_RE) ?? []).map((t) => t.toLowerCase())
+/** Punctuation a connector form may leave between spans (besides whitespace): `, & @ /`. */
+const CONNECTOR_PUNCT_RE = /^[\s,&@/]*$/
 
 /**
- * Label-correctness audit for one aligned row. Returns a list of violations (empty = clean):
+ * Label-correctness audit for one aligned row, on the RAW SURFACE via the #519 span triple. Returns
+ * a list of violations (empty = clean):
  *
- * 1. Tokens/labels length mismatch
- * 2. B-label count != component count (a component span captured zero tokens, or split)
- * 3. A labeled span does not reconstruct its component value token-for-token
- * 4. An O token is not a known connector word (an unlabeled street/locality token shows up here)
+ * 1. Tokens/labels length mismatch (transitional — both representations ride during v0.4.x→v0.5.0)
+ * 2. Span triple missing / non-parallel / unsorted / out of bounds (re-derived here, independent of
+ *    `alignRow`'s own assertion, so a builder bug can't vouch for itself)
+ * 3. Span count != component count, or a component without exactly one span of its tag
+ * 4. A span's raw slice does not reconstruct its component verbatim (punctuation included —
+ *    case-insensitive only because the case augmentation re-cases `raw`, not the components)
+ * 5. An uncovered char is not connector material: whitespace, connector punctuation (, & @ /), or part
+ *    of a known connector word (an unlabeled street/locality surface shows up here)
  */
 function auditRow(row, components) {
 	const errors = []
-	const { tokens, labels } = row
+	const { raw, tokens, labels, span_starts, span_ends, span_tags } = row
 	if (tokens.length !== labels.length) errors.push("tokens/labels length mismatch")
 
-	const bCount = labels.filter((l) => l.startsWith("B-")).length
-	const compCount = Object.keys(components).length
-	if (bCount !== compCount) errors.push(`B-count ${bCount} != components ${compCount}`)
+	if (!span_starts || !span_ends || !span_tags) {
+		errors.push("missing the char-offset span triple (#519)")
+		return errors
+	}
+	if (span_starts.length !== span_ends.length || span_starts.length !== span_tags.length) {
+		errors.push(`span triple not parallel: ${span_starts.length}/${span_ends.length}/${span_tags.length}`)
+		return errors
+	}
+	for (let i = 0; i < span_starts.length; i++) {
+		if (!(span_starts[i] >= 0 && span_starts[i] < span_ends[i] && span_ends[i] <= raw.length)) {
+			errors.push(`span ${span_tags[i]}@[${span_starts[i]}, ${span_ends[i]}) out of bounds`)
+		}
+		if (i > 0 && span_starts[i] < span_ends[i - 1]) {
+			errors.push(`spans unsorted/overlapping at index ${i}`)
+		}
+	}
+	if (errors.length > 0) return errors
 
-	const byTag = new Map()
-	for (let i = 0; i < tokens.length; i++) {
-		const label = labels[i]
-		if (label === "O") {
-			if (!CONNECTOR_O_TOKENS.has(tokens[i].toLowerCase())) errors.push(`illegal O token "${tokens[i]}"`)
+	const compCount = Object.keys(components).length
+	if (span_tags.length !== compCount) errors.push(`span count ${span_tags.length} != components ${compCount}`)
+
+	// Raw-surface reconstruction: each component's single span slices raw to the component verbatim.
+	for (const [tag, value] of Object.entries(components)) {
+		const indices = span_tags.map((t, i) => (t === tag ? i : -1)).filter((i) => i >= 0)
+		if (indices.length !== 1) {
+			errors.push(`${tag}: expected 1 span, got ${indices.length}`)
 			continue
 		}
-		const tag = label.slice(2)
-		if (!byTag.has(tag)) byTag.set(tag, [])
-		byTag.get(tag).push(tokens[i].toLowerCase())
+		const got = raw.slice(span_starts[indices[0]], span_ends[indices[0]])
+		if (got.toLowerCase() !== value.toLowerCase()) errors.push(`${tag} span "${got}" != component "${value}"`)
 	}
-	for (const [tag, value] of Object.entries(components)) {
-		const got = (byTag.get(tag) ?? []).join(" ")
-		const want = tokenizeLikeAligner(value).join(" ")
-		if (got !== want) errors.push(`${tag} span "${got}" != component "${want}"`)
+
+	// Negative space: every char outside the spans must be connector material.
+	let cursor = 0
+	const uncovered = []
+	for (let i = 0; i < span_starts.length; i++) {
+		if (span_starts[i] > cursor) uncovered.push(raw.slice(cursor, span_starts[i]))
+		cursor = span_ends[i]
+	}
+	if (cursor < raw.length) uncovered.push(raw.slice(cursor))
+	for (const segment of uncovered) {
+		const words = segment.match(/[\p{L}\p{N}]+/gu) ?? []
+		for (const word of words) {
+			if (!CONNECTOR_O_TOKENS.has(word.toLowerCase())) errors.push(`illegal uncovered word "${word}"`)
+		}
+		const punctOnly = segment.replace(/[\p{L}\p{N}]+/gu, "")
+		if (!CONNECTOR_PUNCT_RE.test(punctOnly)) errors.push(`illegal uncovered punctuation in "${segment}"`)
 	}
 	return errors
 }

--- a/scripts/jsonl-to-parquet.py
+++ b/scripts/jsonl-to-parquet.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-"""Convert a JSONL of LabeledRow objects to a Parquet shard matching the v0.4.0 schema.
+"""Convert a JSONL of LabeledRow objects to a Parquet shard matching the v0.5.0 schema.
 
-Schema: raw, tokens, labels, country, locale, source, source_id,
-        corpus_version, license, synth_method, synth_base_id.
+Schema: raw, tokens, labels, span_starts, span_ends, span_tags, country, locale, source,
+        source_id, corpus_version, license, synth_method, synth_base_id.
+
+The span triple (#519, v0.5.0 char-offset labels) is REQUIRED on every row: `alignRow` emits it
+on every labeled row, so a row arriving without it came from a producer that hasn't migrated —
+writing it would silently drop the v0.5.0 labels from the shard. Loud failure, naming the row
+number, instead.
 
 Usage:
   python3 scripts/jsonl-to-parquet.py --input /tmp/po-box-labeled.jsonl --output /tmp/part-po-box.parquet
@@ -21,6 +26,9 @@ REQUIRED_COLUMNS = (
     "raw",
     "tokens",
     "labels",
+    "span_starts",
+    "span_ends",
+    "span_tags",
     "country",
     "locale",
     "source",
@@ -31,10 +39,17 @@ REQUIRED_COLUMNS = (
     "synth_base_id",
 )
 
+SPAN_COLUMNS = ("span_starts", "span_ends", "span_tags")
+
 SCHEMA = pa.schema([
     ("raw", pa.string()),
     ("tokens", pa.list_(pa.string())),
     ("labels", pa.list_(pa.string())),
+    # v0.5.0 char-offset label spans (#519): parallel arrays over `raw` (UTF-16 code units,
+    # [start, end) exclusive-end, sorted, non-overlapping). int32 matches the TS writer's INT32.
+    ("span_starts", pa.list_(pa.int32())),
+    ("span_ends", pa.list_(pa.int32())),
+    ("span_tags", pa.list_(pa.string())),
     ("country", pa.string()),
     ("locale", pa.string()),
     ("source", pa.string()),
@@ -44,6 +59,28 @@ SCHEMA = pa.schema([
     ("synth_method", pa.string()),
     ("synth_base_id", pa.string()),
 ])
+
+
+def assert_span_triple(row: dict, line_no: int) -> None:
+    """Enforce the #519 span contract per row: all three present, parallel lengths.
+
+    A row with span_starts but no span_tags is a corrupt row — never a silent fallback.
+    """
+    present = [c for c in SPAN_COLUMNS if row.get(c) is not None]
+    if len(present) != len(SPAN_COLUMNS):
+        missing = [c for c in SPAN_COLUMNS if row.get(c) is None]
+        raise ValueError(
+            f"line {line_no}: row is missing the char-offset span triple (#519): "
+            f"missing {missing} (source_id={row.get('source_id')!r}). Every parquet-bound row "
+            "must carry span_starts/span_ends/span_tags; re-emit this shard through alignRow."
+        )
+    n = len(row["span_starts"])
+    if len(row["span_ends"]) != n or len(row["span_tags"]) != n:
+        raise ValueError(
+            f"line {line_no}: span triple arrays are not parallel — "
+            f"starts={len(row['span_starts'])} ends={len(row['span_ends'])} "
+            f"tags={len(row['span_tags'])} (source_id={row.get('source_id')!r})"
+        )
 
 
 def main() -> int:
@@ -56,11 +93,12 @@ def main() -> int:
     cols: dict[str, list] = {c: [] for c in REQUIRED_COLUMNS}
 
     with args.input.open("r", encoding="utf-8") as f:
-        for line in f:
+        for line_no, line in enumerate(f, start=1):
             line = line.strip()
             if not line:
                 continue
             row = json.loads(line)
+            assert_span_triple(row, line_no)
             for c in REQUIRED_COLUMNS:
                 cols[c].append(row.get(c))
 


### PR DESCRIPTION
Slice 2 of the v0.5.0 char-offset format (#519), completing the code side of the rebuild plan. Four steps, committed in the hazard-fix order recorded on #519; each green before commit. No pilot build started.

## Steps

1. **Parquet span columns** — `span_starts`/`span_ends` (INT32 repeated) + `span_tags` (UTF8 repeated) in `corpus/src/parquet.ts` AND `scripts/jsonl-to-parquet.py` (the shard pipeline's actual converter). `rowToParquet` **throws** on absent/partial/non-parallel triples — the "builders before parquet = silent loss" hazard is closed at write time. Round-trips proven both ways, including the empty all-O triple through PyArrow (verified empirically, not assumed).
2. **`composeAdversarialRow`** — venue span over `[0, len)` with punctuation included (inexpressible in the token path), address spans shifted; separator deliberately uncovered; `assertSpanInvariants` on every composed row; non-NFC venues quarantine.
3. **Builder audits → raw-surface span comparison** — finding: **all twelve builders already emit spans natively** (they label through `alignRow`), verified live across intersection/po_box/cedex/affix/german/unit/country with zero invariant violations. What moved: the two audits that compared tokenized surfaces now re-derive claims from the span triple against RAW (the dotted blind spot). Anti-vacuity probed: a truncated dotted `P.O. Box` span fails the audit.
4. **Loader + augmentation + relabel TOGETHER** (the recorded hazard): span columns are a per-shard schema fact (partial column set raises all-or-none; null in a span shard raises naming the row; legacy shards ride the token path); the #513 glue shifts offsets and raises on straddling spans; `relabel_spans` is pure char arithmetic with builder-parity word splits, replace-not-mutate. End-to-end emit-path test: augment+relabel on, every emitted row's spans address its own raw.

Tests: corpus TS → 400 (+25), corpus-python → 124 (+31, re-verified at review). The #527 invariance gates still pass.

## Open questions for the operator (none block merge)

1. **Dotted-suffix divergence in relabel** — on `Main St.`, the token path splits, the span path conservatively doesn't (`St.` isn't in the lexicon). Spans are authoritative when present, so this only bites frozen token-only corpora. If dotted-suffix splitting is wanted, the lexicon/codex needs dotted variants — a vocabulary decision, deliberately not made here.
2. **`relabel.py --audit`** is token-only — add a span mode before the pilot build's pre-train audit, or fold into `lint-corpus-shard`?
3. **Expansion augmentations** still rebuild raw via `" ".join(tokens)`, destroying intra-span punctuation on augmented *copies* (pre-existing; originals keep their punctuation supervision). Flagged because v0.5.0 makes punctuation load-bearing — move expansions to raw-splicing like the glue?

## What's next on the runbook

ZCTA join (#525) + FTS separator (#523) ride the artifact pass, then the **pilot build go/no-go** (`docs/articles/plan/2026-06-11-v0.5.0-rebuild-plan.md` step 4).

Part of #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)