### PR TITLE
eval(#524): demo-cascade smoke pass — whole-stack lens, found a real bug on first run

### DIFF
--- a/data/eval/external/demo-cascade-smoke.README.md
+++ b/data/eval/external/demo-cascade-smoke.README.md
@@ -1,0 +1,74 @@
+# Demo-cascade smoke rows (`demo-cascade-smoke.jsonl`)
+
+The whole-stack smoke eval (#524). Every other gate lens is per-layer; this file
+exists because three production bugs (#520 gazetteer-feeds crash, #521 reconcile
+fragmentation subsidy, #522 resolver placetype exclusion) all shipped through
+green per-layer gates on 2026-06-11. Nothing in the battery ran
+parse → reconcile → resolve as ONE pass the way the demo (and any real consumer)
+does — the operator's browser glance found all three in five minutes.
+
+Runner: [`scripts/eval/demo-cascade-smoke.ts`](../../../scripts/eval/demo-cascade-smoke.ts)
+(compose `runPipeline` + the demo's `runCascade` over the Node lookup against the
+slim `wof-hot.db` the demo serves). Wired as an env-gated leg of
+`scripts/eval/promotion-gate.sh` — it runs whenever the hot DB is present and
+skips with a loud note when it isn't.
+
+## The convention
+
+- **Rows assert the RESOLVED WOF PLACE ID** — the top cascade hit's `id` — not
+  parse components. A row passes only when the entire stack lands on the right
+  place. (`expect.name` / `expect.placetype` are human-readable cross-checks,
+  not graded.)
+- **Whole-stack**: each `input` goes through the FULL pipeline — neural parse
+  with the ship config (gazetteer lexicon, postcode anchor, conventions mask,
+  span bridge, FST), joint reconcile, grouper audit, then the demo's cascade
+  (postcode → locality-with-region-bbox → raw text) against the slim hot DB.
+- **Additions welcome, but ids MUST be verified against the gazetteer** before a
+  row is committed: query the staged `wof-hot.db` directly (e.g. via
+  `WofSqlitePlaceLookup.findPlace`) and confirm the id, name, placetype, and
+  rough coordinates identify the place you mean. Never pin an id by copying the
+  runner's own output — that bakes the current behavior in as truth, which is
+  exactly the failure mode this eval exists to catch.
+- **Do not massage a failing row.** A FAIL here is a finding (it may be a real
+  bug — that is the point). If the gazetteer itself changes (a WOF id genuinely
+  supersedes another), update the row with a note explaining the re-verification.
+
+## Row schema
+
+One JSON object per line (blank lines and `#`/`//` comment lines are skipped):
+
+```json
+{
+	"input": "Brooklyn",
+	"expect": { "id": 421205765, "name": "Brooklyn", "placetype": "borough" },
+	"note": "why this row exists / what failure mode it pins",
+	"source": "#522"
+}
+```
+
+- `input` (required): the raw query, verbatim as a user would type it.
+- `expect` (required): exactly ONE of
+  - `id` — positive-integer WOF id the top cascade hit must carry, or
+  - `anchor_centroid: true` — the cascade must dead-end (no WOF row, e.g. a
+    bare US ZIP on the slim DB, which ships **no postalcode rows**) and the
+    demo's anchor-centroid fallback (`postcode-us.bin`) must fire instead.
+- `note` / `source` (optional strings): provenance + intent.
+
+Schema validation lives in `scripts/eval/demo-cascade-rows.ts` (unit-tested in
+`demo-cascade-rows.test.ts`); a malformed row fails LOUD naming the row number.
+
+## Provenance of the initial 21 rows (2026-06-11)
+
+- The three 2026-06-11 bug reproductions (#521/#522): `New York City` (+
+  lowercase variant), `Brooklyn`, `brooklyn, new york, ny`.
+- The nine demo presets from `docs/src/shared/demo-helpers.ts`
+  (`EXAMPLE_ADDRESSES`), including both Berlin orders and the Paris street
+  fall-through.
+- Bare famous names (`Chicago`, `Seattle`, `San Francisco`, `Berlin`, `Paris`)
+  plus known-hard shapes: `Saint Paul, MN` (multi-token locality fragmentation
+  kryptonite), `Springfield, IL` (same-name disambiguation — population alone
+  picks the MO Springfield), `Washington, DC` (region-abbreviation expansion).
+
+All ids verified against the staged `v4.4.0` `wof-hot.db`
+(`/tmp/v440-stage/en-us/v4.4.0/wof-hot.db`, the byte-copy of what the live demo
+serves) on 2026-06-11.

--- a/data/eval/external/demo-cascade-smoke.jsonl
+++ b/data/eval/external/demo-cascade-smoke.jsonl
@@ -1,0 +1,21 @@
+{"input":"New York City","expect":{"id":85977539,"name":"New York","placetype":"locality"},"note":"bare multiword famous name; WOF alias of the New York locality — reachable only through the alt_names bag","source":"#521 #522 (2026-06-11 demo bugs)"}
+{"input":"new york city","expect":{"id":85977539,"name":"New York","placetype":"locality"},"note":"lowercase variant of the alias row — exact-match tier must be case-insensitive","source":"#522"}
+{"input":"Brooklyn","expect":{"id":421205765,"name":"Brooklyn","placetype":"borough"},"note":"the locality placetype filter excluded the borough row; pre-fix this resolved to Brooklyn Park, MN","source":"#522"}
+{"input":"brooklyn, new york, ny","expect":{"id":421205765,"name":"Brooklyn","placetype":"borough"},"note":"region-bbox-constrained pass found nothing pre-fix and the cascade silently fell back unconstrained","source":"#522"}
+{"input":"Chicago","expect":{"id":85940195,"name":"Chicago","placetype":"locality"},"note":"bare famous name, single token","source":"#524"}
+{"input":"Seattle","expect":{"id":101730401,"name":"Seattle","placetype":"locality"},"note":"bare famous name, single token","source":"#524"}
+{"input":"San Francisco","expect":{"id":85922583,"name":"San Francisco","placetype":"locality"},"note":"bare famous two-token name; exact tier must beat the South San Francisco token collision","source":"#524"}
+{"input":"Washington, DC","expect":{"id":85931779,"name":"Washington","placetype":"locality"},"note":"locality + region abbreviation; DC expands to District of Columbia for the bbox","source":"#524"}
+{"input":"Saint Paul, MN","expect":{"id":85953191,"name":"St. Paul","placetype":"locality"},"note":"multi-token locality, the Saint-Albans fragmentation kryptonite; gazetteer name is the abbreviated alias","source":"#524"}
+{"input":"Springfield, IL","expect":{"id":85940429,"name":"Springfield","placetype":"locality"},"note":"same-name disambiguation: population ranking alone picks Springfield MO (85971363) — the region bbox must constrain","source":"#524"}
+{"input":"Berlin","expect":{"id":101909779,"name":"Berlin","placetype":"locality"},"note":"famous-name population ranking with no hardcoded country: Berlin DE 3.7M, not Berlin NH","source":"demo cascade failure-mode notes"}
+{"input":"Paris","expect":{"id":101751119,"name":"Paris","placetype":"locality"},"note":"famous-name population ranking: Paris FR, not Paris TX","source":"#524"}
+{"input":"1600 Pennsylvania Ave NW, Washington, DC 20500","expect":{"id":85931779,"name":"Washington","placetype":"locality"},"note":"White House preset; the slim hot DB ships NO postalcode rows, so the postcode leg misses and the locality leg must carry","source":"demo preset"}
+{"input":"350 5th Ave, New York, NY 10118","expect":{"id":85977539,"name":"New York","placetype":"locality"},"note":"Empire State preset","source":"demo preset"}
+{"input":"Pier 39, San Francisco, CA 94133","expect":{"id":85922583,"name":"San Francisco","placetype":"locality"},"note":"Pier 39 preset — venue prefix ahead of the locality","source":"demo preset"}
+{"input":"1060 W Addison St, Chicago, IL 60613","expect":{"id":85940195,"name":"Chicago","placetype":"locality"},"note":"Wrigley Field preset","source":"demo preset"}
+{"input":"400 Broad St, Seattle, WA 98109","expect":{"id":101730401,"name":"Seattle","placetype":"locality"},"note":"Space Needle preset","source":"demo preset"}
+{"input":"90210","expect":{"anchor_centroid":true},"note":"ZIP-only preset: no postalcode rows in the slim DB, no locality — the anchor-centroid fallback (postcode-us.bin) must fire","source":"demo preset"}
+{"input":"Straußstraße 27, 12623 Berlin","expect":{"id":101909779,"name":"Berlin","placetype":"locality"},"note":"Berlin native-order preset (house number after street, postcode before city)","source":"demo preset"}
+{"input":"5 Hauptstraße, Berlin, Berlin 10115","expect":{"id":101909779,"name":"Berlin","placetype":"locality"},"note":"Berlin city-state preset (intl order, dual-role locality+region)","source":"demo preset"}
+{"input":"181 Rue du Chevaleret, Paris","expect":{"id":101751119,"name":"Paris","placetype":"locality"},"note":"Paris street fall-through preset: a mis-tagged street span must fall through to the real city","source":"demo preset"}

--- a/scripts/eval/demo-cascade-rows.test.ts
+++ b/scripts/eval/demo-cascade-rows.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Row-schema contract tests for the demo-cascade smoke eval (#524). The runner must fail LOUD —
+ *   naming the row — on any malformed row, and the committed row file must always satisfy its own
+ *   schema (id verification against the gazetteer is the author's job; shape is CI's).
+ */
+
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+import { parseSmokeRows } from "./demo-cascade-rows.js"
+
+const here = fileURLToPath(new URL(".", import.meta.url))
+
+const valid = (over: Record<string, unknown> = {}) =>
+	JSON.stringify({ input: "Brooklyn", expect: { id: 421205765, name: "Brooklyn" }, ...over })
+
+describe("parseSmokeRows", () => {
+	it("parses a valid id-asserting row", () => {
+		const rows = parseSmokeRows(valid(), "test.jsonl")
+		expect(rows).toHaveLength(1)
+		expect(rows[0]).toMatchObject({ input: "Brooklyn", expect: { id: 421205765 } })
+	})
+
+	it("parses a valid anchor-centroid row", () => {
+		const rows = parseSmokeRows(JSON.stringify({ input: "90210", expect: { anchor_centroid: true } }), "test.jsonl")
+		expect(rows[0]?.expect.anchor_centroid).toBe(true)
+	})
+
+	it("skips blank lines and comment lines", () => {
+		const rows = parseSmokeRows(`\n# comment\n// also a comment\n${valid()}\n`, "test.jsonl")
+		expect(rows).toHaveLength(1)
+	})
+
+	it("names the row on invalid JSON", () => {
+		expect(() => parseSmokeRows(`${valid()}\nnot json{`, "test.jsonl")).toThrow(/test\.jsonl: row 2.*invalid JSON/s)
+	})
+
+	it("names the row on a missing input", () => {
+		expect(() => parseSmokeRows(JSON.stringify({ expect: { id: 1 } }), "rows.jsonl")).toThrow(
+			/rows\.jsonl: row 1.*`input` must be a non-empty string/s
+		)
+	})
+
+	it("rejects an empty-string input", () => {
+		expect(() => parseSmokeRows(valid({ input: "  " }), "rows.jsonl")).toThrow(/non-empty string/)
+	})
+
+	it("rejects a missing expect", () => {
+		expect(() => parseSmokeRows(JSON.stringify({ input: "x" }), "rows.jsonl")).toThrow(/`expect` must be an object/)
+	})
+
+	it("rejects a row with BOTH id and anchor_centroid", () => {
+		expect(() => parseSmokeRows(valid({ expect: { id: 5, anchor_centroid: true } }), "rows.jsonl")).toThrow(
+			/exactly one of/
+		)
+	})
+
+	it("rejects a row with NEITHER id nor anchor_centroid", () => {
+		expect(() => parseSmokeRows(valid({ expect: { name: "Brooklyn" } }), "rows.jsonl")).toThrow(/exactly one of/)
+	})
+
+	it("rejects a non-integer id", () => {
+		expect(() => parseSmokeRows(valid({ expect: { id: "421205765" } }), "rows.jsonl")).toThrow(
+			/`expect.id` must be a positive integer/
+		)
+		expect(() => parseSmokeRows(valid({ expect: { id: 1.5 } }), "rows.jsonl")).toThrow(/positive integer/)
+		expect(() => parseSmokeRows(valid({ expect: { id: -3 } }), "rows.jsonl")).toThrow(/positive integer/)
+	})
+
+	it("rejects an unknown expect key (typo guard)", () => {
+		expect(() => parseSmokeRows(valid({ expect: { wof_id: 1 } }), "rows.jsonl")).toThrow(
+			/unknown `expect` key "wof_id"/
+		)
+	})
+
+	it("rejects an unknown top-level key", () => {
+		expect(() => parseSmokeRows(valid({ comment: "nope" }), "rows.jsonl")).toThrow(/unknown key "comment"/)
+	})
+
+	it("rejects a non-string note", () => {
+		expect(() => parseSmokeRows(valid({ note: 42 }), "rows.jsonl")).toThrow(/`note` must be a string/)
+	})
+
+	it("rejects an empty file — never a vacuous pass", () => {
+		expect(() => parseSmokeRows("\n\n# only comments\n", "rows.jsonl")).toThrow(/no rows found/)
+	})
+
+	it("echoes the offending line in the error", () => {
+		expect(() => parseSmokeRows(JSON.stringify({ input: "x", expect: {} }), "rows.jsonl")).toThrow(/row: \{"input"/)
+	})
+})
+
+describe("the committed row file", () => {
+	it("data/eval/external/demo-cascade-smoke.jsonl satisfies the schema", () => {
+		const file = resolve(here, "../../data/eval/external/demo-cascade-smoke.jsonl")
+		const rows = parseSmokeRows(readFileSync(file, "utf8"), file)
+		expect(rows.length).toBeGreaterThanOrEqual(20)
+		// Every id-asserting row carries the human-readable cross-checks the README asks for.
+		for (const row of rows) {
+			if (row.expect.id !== undefined) expect(row.expect.name, row.input).toBeTruthy()
+		}
+	})
+})

--- a/scripts/eval/demo-cascade-rows.ts
+++ b/scripts/eval/demo-cascade-rows.ts
@@ -1,0 +1,136 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Row schema + loud validation for the demo-cascade smoke eval (#524). Split out of the runner
+ *   (`demo-cascade-smoke.ts`) so the schema contract is unit-testable without loading the model /
+ *   the hot DB — a malformed row must fail NAMING the row, never silently skip or crash mid-run.
+ *
+ *   Row convention (see `data/eval/external/demo-cascade-smoke.README.md`): each row asserts the
+ *   RESOLVED WOF PLACE ID of the top cascade hit — the whole-stack contract — not parse components.
+ *   Exactly one of `expect.id` (a verified WOF id) or `expect.anchor_centroid` (postcode-only dead
+ *   ends where the slim DB has no row and the demo synthesizes an anchor-centroid hit) per row.
+ */
+
+export interface SmokeRowExpect {
+	/** The WOF place id the cascade's TOP hit must carry. Verified against the gazetteer. */
+	id?: number
+	/** Human-readable cross-check (not graded — the id is the assertion). */
+	name?: string
+	/** Human-readable cross-check (not graded — the id is the assertion). */
+	placetype?: string
+	/**
+	 * The cascade dead-ends (no WOF row) and the demo's anchor-centroid fallback must fire instead.
+	 * Mutually exclusive with `id`.
+	 */
+	anchor_centroid?: boolean
+}
+
+export interface SmokeRow {
+	input: string
+	expect: SmokeRowExpect
+	/** Why this row is here (bug number, preset name, failure mode it pins). */
+	note?: string
+	/** Provenance: issue / preset / report the row came from. */
+	source?: string
+}
+
+const EXPECT_KEYS = new Set(["id", "name", "placetype", "anchor_centroid"])
+const ROW_KEYS = new Set(["input", "expect", "note", "source"])
+
+class SmokeRowError extends Error {
+	constructor(sourceLabel: string, rowNumber: number, detail: string, rowText?: string) {
+		super(
+			`${sourceLabel}: row ${rowNumber} is malformed — ${detail}` +
+				(rowText !== undefined ? `\n  row: ${rowText.length > 200 ? rowText.slice(0, 200) + "…" : rowText}` : "")
+		)
+		this.name = "SmokeRowError"
+	}
+}
+
+/**
+ * Parse + validate a JSONL smoke-row file. Throws a {@link SmokeRowError} naming the 1-based row
+ * number (and echoing the offending line) on ANY malformed row. Returns at least one row — an empty
+ * file is an error, not a vacuous pass.
+ */
+export function parseSmokeRows(text: string, sourceLabel: string): SmokeRow[] {
+	const lines = text.split("\n")
+	const rows: SmokeRow[] = []
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i]!.trim()
+		if (!line || line.startsWith("//") || line.startsWith("#")) continue
+		const rowNumber = i + 1
+
+		let parsed: unknown
+		try {
+			parsed = JSON.parse(line)
+		} catch (error) {
+			throw new SmokeRowError(sourceLabel, rowNumber, `invalid JSON (${(error as Error).message})`, line)
+		}
+
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+			throw new SmokeRowError(sourceLabel, rowNumber, "row must be a JSON object", line)
+		}
+		const row = parsed as Record<string, unknown>
+
+		for (const key of Object.keys(row)) {
+			if (!ROW_KEYS.has(key)) {
+				throw new SmokeRowError(sourceLabel, rowNumber, `unknown key ${JSON.stringify(key)}`, line)
+			}
+		}
+
+		if (typeof row.input !== "string" || row.input.trim() === "") {
+			throw new SmokeRowError(sourceLabel, rowNumber, "`input` must be a non-empty string", line)
+		}
+		if (typeof row.expect !== "object" || row.expect === null || Array.isArray(row.expect)) {
+			throw new SmokeRowError(sourceLabel, rowNumber, "`expect` must be an object", line)
+		}
+		const expect = row.expect as Record<string, unknown>
+		for (const key of Object.keys(expect)) {
+			if (!EXPECT_KEYS.has(key)) {
+				throw new SmokeRowError(
+					sourceLabel,
+					rowNumber,
+					`unknown \`expect\` key ${JSON.stringify(key)} (allowed: ${[...EXPECT_KEYS].join(", ")})`,
+					line
+				)
+			}
+		}
+
+		const hasId = expect.id !== undefined
+		const hasAnchor = expect.anchor_centroid !== undefined
+		if (hasId === hasAnchor) {
+			throw new SmokeRowError(
+				sourceLabel,
+				rowNumber,
+				"`expect` must carry exactly one of `id` (a verified WOF id) or `anchor_centroid: true`",
+				line
+			)
+		}
+		if (hasId && (typeof expect.id !== "number" || !Number.isInteger(expect.id) || expect.id <= 0)) {
+			throw new SmokeRowError(sourceLabel, rowNumber, "`expect.id` must be a positive integer WOF id", line)
+		}
+		if (hasAnchor && expect.anchor_centroid !== true) {
+			throw new SmokeRowError(sourceLabel, rowNumber, "`expect.anchor_centroid` must be literally `true`", line)
+		}
+		for (const key of ["name", "placetype"] as const) {
+			if (expect[key] !== undefined && typeof expect[key] !== "string") {
+				throw new SmokeRowError(sourceLabel, rowNumber, `\`expect.${key}\` must be a string when present`, line)
+			}
+		}
+		for (const key of ["note", "source"] as const) {
+			if (row[key] !== undefined && typeof row[key] !== "string") {
+				throw new SmokeRowError(sourceLabel, rowNumber, `\`${key}\` must be a string when present`, line)
+			}
+		}
+
+		rows.push(row as unknown as SmokeRow)
+	}
+
+	if (rows.length === 0) {
+		throw new Error(`${sourceLabel}: no rows found — an empty smoke file is an error, not a vacuous pass`)
+	}
+	return rows
+}

--- a/scripts/eval/demo-cascade-smoke.ts
+++ b/scripts/eval/demo-cascade-smoke.ts
@@ -1,0 +1,255 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Demo-cascade smoke eval (#524) — the whole-stack lens the per-layer gate battery lacks.
+ *
+ *   Runs each row of `data/eval/external/demo-cascade-smoke.jsonl` through the FULL stack exactly the
+ *   way the demo (and any real consumer) composes it: neural parse with the ship config (gazetteer
+ *   lexicon + postcode anchor + conventions mask + span bridge + FST) → `runPipeline`'s joint
+ *   reconcile + grouper audit → the demo's `runCascade` (postcode → locality-with-region-bbox → raw
+ *   text) over the Node lookup against the slim `wof-hot.db` the demo serves. Each row asserts the
+ *   RESOLVED WOF PLACE ID of the top hit — not parse components. See the row README
+ *   (`data/eval/external/demo-cascade-smoke.README.md`) for the convention.
+ *
+ *   Why: on 2026-06-11 three production bugs (#520/#521/#522) shipped through green gates because
+ *   every gate lens is per-layer. Two of the three would have been caught by exactly this pass.
+ *
+ *   Usage (after `yarn compile`):
+ *
+ *   ```
+ *   node --experimental-strip-types scripts/eval/demo-cascade-smoke.ts \
+ *   [--stage-dir /tmp/v440-stage/en-us/v4.4.0] [--db <wof-hot.db>] [--model <onnx>] \
+ *   [--tokenizer <tokenizer.model>] [--card <model-card.json>] [--fst <fst.bin>] \
+ *   [--gazetteer-lexicon <lexicon.json>] [--file <rows.jsonl>] [--json <sidecar.json>] \
+ *   [--explain]
+ * ```
+ *
+ *   Defaults point at the staged demo release dir (`--stage-dir`, the byte-copies of what the live
+ *   demo serves); `MAILWOMAN_WOF_HOT_DB` overrides the DB path (same env the #522 integration tests
+ *   use). Exit 0 = the run completed (row failures are reported in the table + sidecar; the
+ *   promotion-gate verdict enforces any floor). Exit 2 = missing artifacts / malformed rows.
+ *
+ *   Measurement only: this script changes no pipeline or resolver behavior.
+ */
+
+import { runPipeline } from "@mailwoman/core/pipeline"
+import type { AnchorLookup } from "@mailwoman/neural"
+import { NeuralAddressClassifier, parseGazetteerLexicon, PostcodeBinaryResolver } from "@mailwoman/neural"
+import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
+import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+import { groupPhrases } from "@mailwoman/phrase-grouper"
+import { computeQueryShape } from "@mailwoman/query-shape"
+import { WofSqlitePlaceLookup } from "@mailwoman/resolver-wof-sqlite"
+import { deserializeFst } from "@mailwoman/resolver-wof-sqlite/fst-serialize"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import * as path from "node:path"
+
+// The demo's own composition helpers — imported (read-only) from the demo source so the smoke eval
+// measures the REAL cascade, not a re-implementation that can drift from it.
+import { flattenTree, runCascade } from "../../docs/src/shared/demo-helpers.ts"
+import { parseSmokeRows, type SmokeRow } from "./demo-cascade-rows.ts"
+
+const argv = process.argv.slice(2)
+const arg = (k: string, d?: string) => {
+	const i = argv.indexOf(k)
+	return i >= 0 ? argv[i + 1] : d
+}
+
+const STAGE = arg("--stage-dir", "/tmp/v440-stage/en-us/v4.4.0")!
+const DB = arg("--db", process.env.MAILWOMAN_WOF_HOT_DB ?? path.join(STAGE, "wof-hot.db"))!
+const MODEL = arg("--model", path.join(STAGE, "model.onnx"))!
+const TOK = arg("--tokenizer", path.join(STAGE, "tokenizer.model"))!
+const CARD = arg("--card", path.join(STAGE, "model-card.json"))!
+const FST = arg("--fst", path.join(STAGE, "fst-en-US.bin"))!
+const GAZ = arg("--gazetteer-lexicon", "data/gazetteer/anchor-lexicon-v1.json")!
+const FILE = arg("--file", "data/eval/external/demo-cascade-smoke.jsonl")!
+const JSON_OUT = arg("--json")
+const EXPLAIN = argv.includes("--explain")
+
+// ── Preflight: every artifact loud-missing, never a vague ENOENT mid-run ────────────────────────
+const missing = Object.entries({
+	db: DB,
+	model: MODEL,
+	tokenizer: TOK,
+	"model-card": CARD,
+	fst: FST,
+	gazetteer: GAZ,
+	rows: FILE,
+})
+	.filter(([, p]) => !existsSync(p))
+	.map(([k, p]) => `  ${k}: ${p}`)
+if (missing.length > 0) {
+	console.error(
+		`✗ demo-cascade smoke: missing artifacts —\n${missing.join("\n")}\n` +
+			"  Stage a demo release (build-demo-assets) or point --stage-dir / MAILWOMAN_WOF_HOT_DB at one."
+	)
+	process.exit(2)
+}
+
+let rows: SmokeRow[]
+try {
+	rows = parseSmokeRows(readFileSync(FILE, "utf8"), FILE)
+} catch (error) {
+	console.error(`✗ ${(error as Error).message}`)
+	process.exit(2)
+}
+
+// ── Ship-config classifier (mirrors neural-web's loadNeuralClassifierFromUrls defaults) ─────────
+const card = JSON.parse(readFileSync(CARD, "utf8"))
+
+// Postcode anchor channel from the staged binaries — the same artifacts the demo fetches. Merge
+// mirrors neural-web's mergeAnchorLookups: union posteriors, mean non-zero centroids.
+function mergeAnchorLookups(lookups: readonly AnchorLookup[]): AnchorLookup {
+	if (lookups.length === 1) return lookups[0]!
+	const merged: AnchorLookup = new Map()
+	for (const lookup of lookups) {
+		for (const [postcode, entry] of lookup) {
+			const existing = merged.get(postcode)
+			if (!existing) {
+				merged.set(postcode, { posterior: { ...entry.posterior }, lat: entry.lat, lon: entry.lon })
+				continue
+			}
+			for (const country of Object.keys(entry.posterior)) existing.posterior[country] = 1
+			if (entry.lat !== 0 || entry.lon !== 0) {
+				if (existing.lat === 0 && existing.lon === 0) {
+					existing.lat = entry.lat
+					existing.lon = entry.lon
+				} else {
+					existing.lat = (existing.lat + entry.lat) / 2
+					existing.lon = (existing.lon + entry.lon) / 2
+				}
+			}
+		}
+	}
+	return merged
+}
+
+const postcodeBinaries = ["postcode-us.bin", "postcode-de.bin", "postcode-fr.bin"]
+	.map((f) => path.join(STAGE, f))
+	.filter((p) => existsSync(p))
+if (postcodeBinaries.length === 0) {
+	console.warn(`⚠ no postcode-*.bin under ${STAGE} — anchor channel unfed (anchor-trained models will degrade)`)
+}
+const anchorLookup =
+	postcodeBinaries.length > 0
+		? mergeAnchorLookups(postcodeBinaries.map((p) => new PostcodeBinaryResolver(readFileSync(p)).toAnchorLookup()))
+		: undefined
+
+const [tokenizer, runner] = await Promise.all([MailwomanTokenizer.loadFromFile(TOK), OnnxRunner.create(MODEL)])
+const classifier = new NeuralAddressClassifier({
+	tokenizer,
+	runner,
+	labels: card.labels,
+	...(anchorLookup ? { postcodeAnchorLookup: anchorLookup } : {}),
+	gazetteerLexicon: parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))),
+	suppressGazetteerNearPostcode: true,
+	addressSystemConventions: "auto",
+	bridgePunctuationGaps: true,
+})
+const fst = deserializeFst(readFileSync(FST))
+const lookup = new WofSqlitePlaceLookup({ databasePath: DB })
+
+// ── Run ──────────────────────────────────────────────────────────────────────────────────────────
+interface RowResult {
+	input: string
+	expected: SmokeRow["expect"]
+	actual: { id: number; name: string; placetype: string; anchorCentroid?: boolean } | null
+	pass: boolean
+	note?: string
+}
+
+const results: RowResult[] = []
+for (const row of rows) {
+	const { tree } = await runPipeline(row.input, {
+		computeQueryShape,
+		groupPhrases,
+		classifier: classifier as unknown as Parameters<typeof runPipeline>[1]["classifier"],
+		fst: fst as Parameters<typeof runPipeline>[1]["fst"],
+	})
+
+	// Node selection copied VERBATIM from the demo page (docs/src/pages/demo/index.tsx) — same
+	// locality/city filter, same highest-confidence region pick, same postcode find.
+	const nodes = flattenTree(tree)
+	const localityNodes = nodes.filter((n) => n.tag === "locality" || n.tag === "city")
+	const stateNode = nodes
+		.filter((n) => n.tag === "region" || n.tag === "state")
+		.sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))[0]
+	const postcodeNode = nodes.find((n) => n.tag === "postcode" || n.tag === "postal_code")
+
+	const hits = await runCascade(
+		lookup as unknown as Parameters<typeof runCascade>[0],
+		postcodeNode,
+		localityNodes,
+		stateNode,
+		row.input
+	)
+
+	// The demo's anchor-centroid fallback for postcode-only dead ends (WOF placeholder zeros / the
+	// slim DB's absent postalcode rows): synthesize the approximate hit from the anchor channel.
+	let anchorCentroid = false
+	if (hits.length === 0 && postcodeNode?.value && anchorLookup) {
+		const anchorHit = anchorLookup.get(String(postcodeNode.value).toUpperCase())
+		if (anchorHit && (anchorHit.lat !== 0 || anchorHit.lon !== 0)) anchorCentroid = true
+	}
+
+	const top = hits[0]
+	const actual = top
+		? { id: top.id, name: top.name, placetype: String(top.placetype) }
+		: anchorCentroid
+			? { id: 0, name: `${postcodeNode?.value} (anchor centroid)`, placetype: "postcode", anchorCentroid: true }
+			: null
+
+	const pass = row.expect.anchor_centroid === true ? anchorCentroid : top?.id === row.expect.id
+	results.push({ input: row.input, expected: row.expect, actual, pass, ...(row.note ? { note: row.note } : {}) })
+
+	if (EXPLAIN) {
+		console.error(`\n-- ${JSON.stringify(row.input)}`)
+		console.error(
+			`   parse: postcode=${JSON.stringify(postcodeNode?.value)} localities=${JSON.stringify(localityNodes.map((n) => n.value))} region=${JSON.stringify(stateNode?.value)}`
+		)
+		for (const h of hits.slice(0, 3)) {
+			console.error(`   hit: id=${h.id} ${h.name} (${h.placetype}) score=${h.score?.toFixed?.(2)}`)
+		}
+	}
+}
+lookup.close()
+
+// ── Report ───────────────────────────────────────────────────────────────────────────────────────
+const passCount = results.filter((r) => r.pass).length
+const passRate = Number(((100 * passCount) / results.length).toFixed(1))
+
+console.log(`# Demo-cascade smoke (#524) — whole-stack parse→reconcile→resolve`)
+console.log(`model: ${MODEL}`)
+console.log(`db: ${DB}`)
+console.log("")
+console.log("| # | input | expected | actual | result |")
+console.log("| - | ----- | -------- | ------ | ------ |")
+results.forEach((r, i) => {
+	const exp = r.expected.anchor_centroid
+		? "anchor centroid"
+		: `${r.expected.id} (${r.expected.name ?? "?"}${r.expected.placetype ? `, ${r.expected.placetype}` : ""})`
+	const act = r.actual
+		? r.actual.anchorCentroid
+			? "anchor centroid"
+			: `${r.actual.id} (${r.actual.name}, ${r.actual.placetype})`
+		: "NO HIT"
+	console.log(`| ${i + 1} | ${r.input} | ${exp} | ${act} | ${r.pass ? "PASS" : "FAIL"} |`)
+})
+console.log("")
+console.log(`**${passCount}/${results.length} pass (${passRate}%)**`)
+
+if (JSON_OUT) {
+	const sidecar = {
+		label: "demo-cascade-smoke",
+		issue: 524,
+		generated: new Date().toISOString(),
+		db: DB,
+		model: MODEL,
+		rows: results,
+		summary: { total: results.length, pass: passCount, fail: results.length - passCount, pass_rate_pct: passRate },
+	}
+	writeFileSync(JSON_OUT, JSON.stringify(sidecar, null, "\t"))
+	console.log(`\nsidecar: ${JSON_OUT}`)
+}

--- a/scripts/eval/promotion-gate-verdict.ts
+++ b/scripts/eval/promotion-gate-verdict.ts
@@ -107,6 +107,12 @@ function collect(tag: "fp32" | "int8"): Record<string, number | undefined> {
 			const m = md?.match(/\|\s*perturb\s*\|\s*\d+\s*\|\s*[\d.]+%\s*\|\s*([\d.]+)%/)
 			return m ? Number(m[1]) : undefined
 		})(),
+		// Demo-cascade smoke pass rate (#524) — whole-stack parse→reconcile→resolve against the slim
+		// hot DB. Like the arena leg it runs ONCE on the ship artifact (no fp32/int8 split); sidecar
+		// only (the leg is new — there are no pre-sidecar out-dirs to replay). Absent sidecar (DB not
+		// staged / runner errored) reads undefined → a floored spec FAILS loudly, an unfloored spec
+		// ignores it.
+		"cascade.demo_smoke": sidecar("cascade-smoke.json")?.summary?.pass_rate_pct,
 	}
 }
 

--- a/scripts/eval/promotion-gate.sh
+++ b/scripts/eval/promotion-gate.sh
@@ -17,6 +17,9 @@
 #   - Runs: per-locale-f1 (US/FR, tokenizer-enforced), score-affix (+ unit-real),
 #     score-country-homograph, de-order-eval, demo-preset-compare. When --int8 is given,
 #     re-runs the per-tag battery on the int8 artifact and enforces the fp32↔int8 delta cap.
+#   - Demo-cascade smoke (#524): whole-stack parse→reconcile→resolve against the slim hot DB
+#     (MAILWOMAN_WOF_HOT_DB or the v4.4.0 stage default). Skips LOUD when the DB is absent;
+#     floor key `cascade.demo_smoke` (pass-rate %) for specs that gate on it.
 #   - Collects headline numbers into <out-dir>/verdict.json with per-floor PASS/FAIL.
 #   - Exit 0 = every floor met; exit 1 = any miss (CI-able, agent-guardrail-able).
 #
@@ -104,6 +107,22 @@ run_battery() { # $1 = model path, $2 = tag (fp32|int8)
 run_battery "$MODEL" fp32
 [[ -n "$INT8" ]] && run_battery "$INT8" int8
 node --experimental-strip-types scripts/eval/demo-preset-compare.ts --model-path="${INT8:-$MODEL}" > "$OUT_DIR/presets.md"
+
+# Demo-cascade smoke (#524): the whole-stack parse→reconcile→resolve pass the per-layer battery
+# lacks (the 2026-06-11 lesson: #520/#521/#522 all shipped through green per-layer gates). Runs on
+# the ship artifact against the slim hot DB the demo serves. Env-gated like the other
+# artifact-dependent legs: skips LOUD when the DB is absent so CI stays green without it — but a
+# gate spec that floors `cascade.demo_smoke` will then FAIL on the missing sidecar (by design).
+HOT_DB="${MAILWOMAN_WOF_HOT_DB:-/tmp/v440-stage/en-us/v4.4.0/wof-hot.db}"
+HOT_STAGE="$(dirname "$HOT_DB")"
+if [[ -f "$HOT_DB" ]]; then
+	node --experimental-strip-types scripts/eval/demo-cascade-smoke.ts \
+		--db "$HOT_DB" --stage-dir "$HOT_STAGE" --model "${INT8:-$MODEL}" --tokenizer "$TOK" --card "$CARD" \
+		--gazetteer-lexicon "$GAZ" --json "$OUT_DIR/cascade-smoke.json" > "$OUT_DIR/cascade-smoke.md" \
+		|| echo "✗ demo-cascade smoke errored (see $OUT_DIR/cascade-smoke.md) — no sidecar; a floored gate spec will FAIL" >&2
+else
+	echo "⚠ demo-cascade smoke SKIPPED — no wof-hot.db at $HOT_DB (set MAILWOMAN_WOF_HOT_DB). The whole-stack lens did NOT run (#524)." | tee "$OUT_DIR/cascade-smoke.md" >&2
+fi
 
 # Arena leg (v4.4.0+: arena.perturb is a floor when the spec declares it) — heavy, ship artifact only.
 if [[ "$(node -e "console.log('arena.perturb' in (JSON.parse(require('fs').readFileSync('$GATE','utf8')).floors||{}))")" == "true" ]]; then


### PR DESCRIPTION
The whole-stack lens #524 proposed after three production bugs (#520/#521/#522) shipped through green per-layer gates. 21 rows asserting RESOLVED WOF IDs through the full parse→reconcile→resolve cascade, composed exactly as the demo does (imports the demo's own `flattenTree`/`runCascade` read-only so the lens can't drift).

## First real run: 20/21 (95.2%) — and the failure is a real bug

**Springfield, IL → Springfield MO.** Root cause: `WofSqlitePlaceLookup.findPlace` (Node backend) never returns `bbox` on candidates — the WASM lookup SELECTs and populates min/max lat/lon, the Node lookup doesn't, despite the slim DB carrying the values. Consequence: `runCascade`'s region constraint is **always dead** through the Node backend (every region row logs the #522 fail-loud warning — which is how the agent caught it), so disambiguation falls to population ranking. The live demo (WASM) is unaffected; this is a Node/WASM backend-parity gap in the #522 family. The Springfield row stays red on purpose — that's the eval working.

Secondary documented finding: the slim hot DB ships zero postalcode rows, so the postcode-first cascade leg always misses (encoded in the README as a known property, not a bug).

## What's in the box

- `data/eval/external/demo-cascade-smoke.jsonl` (21 rows, every id verified against the staged DB by direct probes) + README (id-asserting whole-stack convention)
- `scripts/eval/demo-cascade-smoke.ts` — self-reporting runner, markdown + JSON sidecar, `--explain`; DB via `MAILWOMAN_WOF_HOT_DB` else the v4.4.0 stage default
- Gate wiring: optional leg in `promotion-gate.sh` (loud skip when the DB is absent), verdict reads sidecar-first under `cascade.demo_smoke` (verified both directions). No spec floors it yet — pre-registering a floor is a v4.5.x gate-spec decision.
- Row-schema validation + 16 tests; the committed row file is schema-checked in CI.

Follow-up (separate PR, next): the ~5-line Node-lookup bbox fix, after which Springfield should flip green and the floor conversation becomes "100".

Closes #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)