### PR TITLE
fix(resolver-wof-sqlite): Node lookup candidates carry bbox — region constraint un-deadened

### DIFF
--- a/resolver-wof-sqlite/exact-match-tiering.test.ts
+++ b/resolver-wof-sqlite/exact-match-tiering.test.ts
@@ -164,4 +164,14 @@ describe("findPlace — exact-match tiering", () => {
 		expect(results.length).toBe(1)
 		expect(results[0]!.name).toBe("Oregon")
 	})
+
+	test("candidates carry the spr bbox (WASM-lookup parity — the demo cascade's region constraint reads it)", async () => {
+		// Without candidate.bbox the cascade's region→bbox constraint is dead on the Node backend and
+		// locality disambiguation falls to population ranking (Springfield IL → MO, caught by the
+		// #524 smoke eval). The fixture seeds min/max as centroid ±0.5.
+		lookup = new WofSqlitePlaceLookup({ database: buildDb(REGIONS), buildFts: true })
+		const results = await lookup.findPlace({ text: "Maine", placetype: "region", country: "US" })
+		expect(results[0]!.name).toBe("Maine")
+		expect(results[0]!.bbox).toEqual({ minLat: 44.8, maxLat: 45.8, minLon: -69.7, maxLon: -68.7 })
+	})
 })

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -194,6 +194,10 @@ interface RawSearchRow {
 	rank: number // BM25 (lower = better in SQLite); we negate to get higher-is-better
 	lat: number | null
 	lon: number | null
+	min_latitude: number | null
+	max_latitude: number | null
+	min_longitude: number | null
+	max_longitude: number | null
 	population: number | null // from the place_population aux table; null when missing
 }
 
@@ -634,6 +638,7 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 				bm25(place_search) AS rank,
 				spr.latitude AS lat,
 				spr.longitude AS lon,
+				spr.min_latitude, spr.max_latitude, spr.min_longitude, spr.max_longitude,
 				${populationSelect}
 			FROM ${sch}.place_search
 			${joinClause}
@@ -702,6 +707,23 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			}
 			if (distanceKm !== undefined) candidate.distanceKm = distanceKm
 			if (row.population !== null && row.population > 0) candidate.population = row.population
+			// Candidate bbox — parity with the WASM lookup (resolver-wof-wasm/lookup.ts), whose
+			// consumers (the demo cascade's region constraint) read it. Without this the Node
+			// backend's region→bbox constraint is dead and disambiguation falls to population
+			// ranking (the Springfield-IL→MO failure the #524 smoke eval caught).
+			if (
+				row.min_latitude != null &&
+				row.max_latitude != null &&
+				row.min_longitude != null &&
+				row.max_longitude != null
+			) {
+				candidate.bbox = {
+					minLat: row.min_latitude,
+					maxLat: row.max_latitude,
+					minLon: row.min_longitude,
+					maxLon: row.max_longitude,
+				}
+			}
 			return candidate
 		})
 


### PR DESCRIPTION
The follow-up the #524 smoke eval (PR #537) earned on its first real run.

## Bug

`WofSqlitePlaceLookup.findPlace` never SELECTed `spr.min/max_latitude/longitude`, so `candidate.bbox` was always absent on the Node backend — while the WASM lookup populates it. Consequence: `runCascade`'s region→bbox constraint was **dead on Node** (every region row fired the #522 fail-loud warning), locality disambiguation fell to population ranking, and `Springfield, IL` resolved to Springfield MO. The live demo (WASM) was unaffected — pure backend-parity gap.

## Fix

Four columns added to the SELECT + the same null-guarded bbox mapping the WASM lookup uses. Parity test added (fixture seeds bbox as centroid ±0.5).

## Verified

- Smoke eval: **20/21 → 21/21**, Springfield IL row green (`85940429`).
- resolver-wof-sqlite suite: 568 passed.

With this landed, the `cascade.demo_smoke` floor for the next gate spec can be pre-registered at **100**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)