### PR TITLE
data(postcode): ZCTA centroid fill + the dead bbox-column path (#525)

### DIFF
--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -81,14 +81,16 @@ class EncodedExample:
 def load_anchor_lookup(path: str) -> dict[str, tuple[dict[str, float], float, float]]:
     """Load the postcode→anchor lookup (#239/#240) from JSON, once at loader init.
 
-    Format: ``{normalized_postcode: [posterior_dict, lat, lon]}`` where ``posterior_dict`` is
-    ``{country: weight}`` (uniform over the countries the code exists in). Returns the tuple form
-    ``realign_anchor_to_pieces`` consumes. Built offline by ``scripts/build-pilot-anchor-lookup.py``
-    so the training loop carries no gazetteer dependency.
+    Format: ``{normalized_postcode: [posterior_dict, lat, lon, source?]}`` where ``posterior_dict``
+    is ``{country: weight}`` (uniform over the countries the code exists in) and the optional 4th
+    element is the centroid's provenance label (#525 — e.g. ``"wof"`` / ``"census-zcta-2024"`` /
+    ``null``), ignored here. Returns the tuple form ``realign_anchor_to_pieces`` consumes. Built
+    offline by ``scripts/build-pilot-anchor-lookup.py`` so the training loop carries no gazetteer
+    dependency.
     """
     with open(path, encoding="utf-8") as fh:
         raw = json.load(fh)
-    return {pc: (post, float(lat), float(lon)) for pc, (post, lat, lon) in raw.items()}
+    return {pc: (row[0], float(row[1]), float(row[2])) for pc, row in raw.items()}
 
 
 def _shard_paths(corpus_dir: Path, split: str) -> list[Path]:

--- a/docs/plugins/demo-assets/resolve.mjs
+++ b/docs/plugins/demo-assets/resolve.mjs
@@ -331,8 +331,9 @@ export function buildSlimWofDb(destPath, opts) {
 	// Canonical custom-built gazetteer (never the off-the-shelf dumps — see feedback-custom-wof-db-only).
 	const globalDb = "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
 	const adminDb = process.env.PLAYPEN_WOF_ADMIN_DB ?? globalDb
-	// Postcodes: the custom build is admin-only today. Set PLAYPEN_WOF_POSTCODE_DB once a custom
-	// postcode DB exists; until then the slim build runs admin-only.
+	// Postcodes: opt-in via PLAYPEN_WOF_POSTCODE_DB (e.g. /mnt/playpen/mailwoman-data/wof/
+	// postalcode-us.db — custom-built, ZCTA-centroid-filled per #525); unset, the slim build runs
+	// admin-only and the demo's postcode-first cascade leg has no rows to hit.
 	const postcodeDb = process.env.PLAYPEN_WOF_POSTCODE_DB ?? ""
 
 	if (!existsSync(adminDb)) {

--- a/neural/anchor-inference.ts
+++ b/neural/anchor-inference.ts
@@ -60,11 +60,15 @@ export function anchorFeatureVector(posterior: Record<string, number>, lat: numb
 }
 
 /**
- * Parse the pilot postcode→anchor lookup JSON (`{postcode: [posterior, lat, lon]}`) into a Map.
+ * Parse the pilot postcode→anchor lookup JSON (`{postcode: [posterior, lat, lon, source?]}`) into a
+ * Map. The optional trailing `source` is the centroid's provenance label (#525 — `"wof"`,
+ * `"census-zcta-2024"`, or `null` for a placeholder); build-side bookkeeping, ignored at inference.
  * Pure (takes the parsed object, not a path) so this module stays browser-safe — the file read
  * lives in the Node-side caller (the eval).
  */
-export function parseAnchorLookup(raw: Record<string, [Record<string, number>, number, number]>): AnchorLookup {
+export function parseAnchorLookup(
+	raw: Record<string, [Record<string, number>, number, number, (string | null)?]>
+): AnchorLookup {
 	const out: AnchorLookup = new Map()
 	for (const [pc, [posterior, lat, lon]] of Object.entries(raw)) out.set(pc, { posterior, lat, lon })
 	return out

--- a/scripts/build-pilot-anchor-lookup.py
+++ b/scripts/build-pilot-anchor-lookup.py
@@ -1,29 +1,44 @@
 #!/usr/bin/env python3
 """Build the postcode→anchor lookup for the de-risk pilot (#239/#240).
 
-Emits a JSON ``{normalized_postcode: [posterior_dict, lat, lon]}`` for the pilot locales (DE/FR/US),
-loaded once at training-loader init (``data.anchor_lookup_path``) so the training loop carries no
-gazetteer dependency. This is the offline, deterministic precompute DeepSeek recommended.
+Emits a JSON ``{normalized_postcode: [posterior_dict, lat, lon, source]}`` for the pilot locales
+(DE/FR/US), loaded once at training-loader init (``data.anchor_lookup_path``) so the training loop
+carries no gazetteer dependency. This is the offline, deterministic precompute DeepSeek recommended.
 
 - **posterior**: UNIFORM over the countries whose postal gazetteer contains the code (the posterior
   the A/B measurement settled on — `docs/articles/evals/2026-06-05-postcode-posterior-ab.md`). A
   German PLZ that collides with a US ZIP (e.g. 10115) comes back ``{"DE": 0.5, "US": 0.5}``.
 - **centroid**: taken from the first source that has a real centroid, in DE→FR→US order, so the
   collapse-relevant European rows get a European centroid on a collision. The centroid is the
-  secondary signal (the posterior + the categorical anchor cue do the work); the pilot doesn't lean
-  on it.
+  secondary signal (the posterior + the categorical anchor cue do the work).
+- **source** (#525, the no-load-bearing-trivia rule): names the dataset the centroid came from —
+  ``wof`` (our WOF postcode shards, which may themselves carry provenanced backfills; see the
+  ``centroid_source`` table), ``census-zcta-2024`` (Census ZCTA Gazetteer fill, either already in
+  the DB or joined here via ``--zcta``), or ``null`` for a placeholder (membership only). Loaders
+  that predate the field tolerate its absence; ``data_loader.load_anchor_lookup`` ignores it.
 
 Sources (build-from-source, never prebuilt): postalcode-intl.db (DE/FR, inline centroids) +
-postalcode-us.db (US set + place_bbox midpoints, since its spr centroids are 0).
+postalcode-us.db (US; spr centroids are real post-backfill — the old place_bbox-midpoint path read
+column names that don't exist in the R-tree (`min_latitude` vs `min_lat`) and silently zeroed
+every US centroid, the bulk of the 38% placeholder rate #525 fixed).
+
+ZCTA caveat: ZCTAs approximate delivery areas, not ZIPs — PO-box-only/unique ZIPs have no ZCTA and
+stay placeholder. Vintage + URL: /mnt/playpen/mailwoman-data/census/README.md.
 
 Usage:
-  python3 scripts/build-pilot-anchor-lookup.py --output /mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json
+  python3 scripts/build-pilot-anchor-lookup.py \
+    --zcta /mnt/playpen/mailwoman-data/census/2024_Gaz_zcta_national.txt \
+    --output /mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json
 """
 import argparse
 import json
 import sqlite3
 
 WOF = "/mnt/playpen/mailwoman-data/wof"
+ZCTA_SOURCE = "census-zcta-2024"  # keep in sync with scripts/zcta-centroids.ts
+
+# (lat, lon, source): source is None when the row is a placeholder (membership only).
+Centroid = tuple[float, float, str | None]
 
 
 def five_digit(name: str) -> str | None:
@@ -31,76 +46,113 @@ def five_digit(name: str) -> str | None:
     return name if len(name) == 5 and name.isdigit() else None
 
 
-def load_intl(country: str) -> dict[str, tuple[float, float]]:
+def _placed(lat: float, lon: float) -> bool:
+    return lat != 0.0 or lon != 0.0
+
+
+def load_intl(country: str) -> dict[str, Centroid]:
     """DE/FR postcodes → centroid from postalcode-intl.db (inline lat/lon)."""
-    out: dict[str, tuple[float, float]] = {}
+    out: dict[str, Centroid] = {}
     con = sqlite3.connect(f"{WOF}/postalcode-intl.db")
     for name, lat, lon in con.execute(
         "SELECT name, latitude, longitude FROM spr WHERE placetype='postalcode' AND country=?", (country,)
     ):
         pc = five_digit(name)
         if pc:
-            out[pc] = (float(lat), float(lon))
+            lat, lon = float(lat), float(lon)
+            out[pc] = (lat, lon, "wof" if _placed(lat, lon) else None)
     con.close()
     return out
 
 
-def load_us() -> dict[str, tuple[float, float]]:
-    """US postcodes → place_bbox midpoint (spr lat/lon are 0 in postalcode-us.db)."""
-    out: dict[str, tuple[float, float]] = {}
+def load_us() -> dict[str, Centroid]:
+    """US postcodes → spr centroid, with per-row provenance from `centroid_source` when present
+    (rows the ZCTA fill placed carry `census-zcta-2024`; untracked placed rows are `wof`)."""
+    out: dict[str, Centroid] = {}
     con = sqlite3.connect(f"{WOF}/postalcode-us.db")
-    # place_bbox rows: (id, min_lat, max_lat, min_lon, max_lon) keyed to spr.id.
-    bbox = {
-        r[0]: ((r[1] + r[2]) / 2.0, (r[3] + r[4]) / 2.0)
-        for r in con.execute("SELECT id, min_latitude, max_latitude, min_longitude, max_longitude FROM place_bbox")
-    } if _has_bbox_cols(con) else {}
-    for pid, name in con.execute("SELECT id, name FROM spr WHERE placetype='postalcode'"):
+    has_sources = con.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='centroid_source'"
+    ).fetchone()
+    src_join = "LEFT JOIN centroid_source cs ON cs.id=spr.id" if has_sources else ""
+    src_col = "cs.source" if has_sources else "NULL"
+    for name, lat, lon, src in con.execute(
+        f"SELECT spr.name, spr.latitude, spr.longitude, {src_col} FROM spr {src_join} "
+        "WHERE spr.placetype='postalcode' AND spr.is_current!=0"
+    ):
         pc = five_digit(name)
         if pc:
-            out[pc] = bbox.get(pid, (0.0, 0.0))
+            lat, lon = float(lat), float(lon)
+            out[pc] = (lat, lon, (src or "wof") if _placed(lat, lon) else None)
     con.close()
     return out
 
 
-def _has_bbox_cols(con: sqlite3.Connection) -> bool:
-    cols = {r[1] for r in con.execute("PRAGMA table_info(place_bbox)")}
-    return {"id", "min_latitude", "max_latitude", "min_longitude", "max_longitude"} <= cols
+def load_zcta(path: str) -> dict[str, tuple[float, float]]:
+    """Census ZCTA Gazetteer file → 5-digit code → internal-point centroid (mirror of
+    scripts/zcta-centroids.ts::parseZctaCentroids)."""
+    out: dict[str, tuple[float, float]] = {}
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            fields = [f.strip() for f in line.split("\t")]
+            pc = five_digit(fields[0]) if fields else None
+            if not pc or len(fields) < 7:
+                continue
+            try:
+                lat, lon = float(fields[5]), float(fields[6])
+            except ValueError:
+                continue
+            if _placed(lat, lon):
+                out[pc] = (lat, lon)
+    return out
 
 
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--output", required=True)
+    ap.add_argument("--zcta", help="Census ZCTA Gazetteer .txt: fill US placeholder centroids (#525)")
     args = ap.parse_args()
 
     sources = [("DE", load_intl("DE")), ("FR", load_intl("FR")), ("US", load_us())]  # centroid priority order
+    zcta = load_zcta(args.zcta) if args.zcta else {}
     all_codes: set[str] = set()
     for _c, d in sources:
         all_codes |= set(d.keys())
 
     lookup: dict[str, list] = {}
-    collisions = 0
-    for pc in all_codes:
+    collisions = zcta_filled = 0
+    for pc in sorted(all_codes):
         members = [c for c, d in sources if pc in d]
         k = len(members)
         posterior = {c: 1.0 / k for c in members}
         if k > 1:
             collisions += 1
-        # centroid: first source (DE→FR→US) with a non-zero centroid.
-        lat = lon = 0.0
+        # centroid: first source (DE→FR→US) with a non-zero centroid; never overwritten by ZCTA.
+        lat, lon, source = 0.0, 0.0, None
         for c, d in sources:
-            if pc in d and (d[pc][0] != 0.0 or d[pc][1] != 0.0):
-                lat, lon = d[pc]
+            if pc in d and _placed(d[pc][0], d[pc][1]):
+                lat, lon, source = d[pc]
                 break
-        lookup[pc] = [posterior, round(lat, 5), round(lon, 5)]
+        # ZCTA fill: placeholders only, US members only (#525).
+        if source is None and "US" in members and pc in zcta:
+            lat, lon = zcta[pc]
+            source = ZCTA_SOURCE
+            zcta_filled += 1
+        lookup[pc] = [posterior, round(lat, 5), round(lon, 5), source]
 
     with open(args.output, "w", encoding="utf-8") as fh:
         json.dump(lookup, fh, ensure_ascii=False)
 
     by_country = {c: sum(1 for v in lookup.values() if c in v[0]) for c, _ in sources}
+    by_source: dict[str | None, int] = {}
+    for v in lookup.values():
+        by_source[v[3]] = by_source.get(v[3], 0) + 1
+    placeholders = by_source.get(None, 0)
     print(
         f"{len(lookup):,} postcodes → {args.output}  "
         f"(DE {by_country['DE']:,}, FR {by_country['FR']:,}, US {by_country['US']:,}; "
-        f"{collisions:,} collisions; {sum(1 for v in lookup.values() if v[1]==0.0 and v[2]==0.0):,} no-centroid)"
+        f"{collisions:,} collisions; {zcta_filled:,} ZCTA-filled here; "
+        f"sources {({k or 'placeholder': n for k, n in sorted(by_source.items(), key=lambda kv: -kv[1])})}; "
+        f"{placeholders:,} no-centroid = {100 * placeholders / len(lookup):.1f}%)"
     )
 
 

--- a/scripts/fill-zcta-centroids.ts
+++ b/scripts/fill-zcta-centroids.ts
@@ -1,0 +1,58 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   CLI for the Census ZCTA centroid fill (#525) — fills `(0,0)`-placeholder US postcode rows in
+ *   `postalcode-us.db` from the ZCTA Gazetteer file, with per-row provenance in `centroid_source`.
+ *   Logic + contract tests live in `scripts/zcta-centroids.ts`. Run after any rebuild of the US
+ *   postcode shard (recorded as a `post_build` step in `scripts/wof-build-manifest.json`);
+ *   idempotent, never overwrites a real coordinate.
+ *
+ *   Usage: node --experimental-strip-types scripts/fill-zcta-centroids.ts\
+ *   [--db /mnt/playpen/mailwoman-data/wof/postalcode-us.db]\
+ *   [--zcta /mnt/playpen/mailwoman-data/census/2024_Gaz_zcta_national.txt]
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+import { fillPlaceholderCentroids, parseZctaCentroids } from "./zcta-centroids.ts"
+
+function main(): void {
+	const args = process.argv.slice(2)
+	let dbPath = "/mnt/playpen/mailwoman-data/wof/postalcode-us.db"
+	let zctaPath = "/mnt/playpen/mailwoman-data/census/2024_Gaz_zcta_national.txt"
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--db" && args[i + 1]) dbPath = args[++i]!
+		else if (args[i] === "--zcta" && args[i + 1]) zctaPath = args[++i]!
+	}
+	for (const p of [dbPath, zctaPath]) {
+		if (!existsSync(p)) {
+			console.error(`Missing file: ${p}`)
+			process.exit(1)
+		}
+	}
+
+	const zcta = parseZctaCentroids(readFileSync(zctaPath, "utf8"))
+	const db = new DatabaseSync(dbPath)
+	const count = (where: string): number =>
+		(
+			db.prepare(`SELECT COUNT(*) n FROM spr WHERE placetype='postalcode' AND is_current!=0 AND ${where}`).get() as {
+				n: number
+			}
+		).n
+
+	const total = count("country='US'")
+	const before = count("country='US' AND latitude=0 AND longitude=0")
+	const filled = fillPlaceholderCentroids(db, zcta)
+	const after = count("country='US' AND latitude=0 AND longitude=0")
+	db.close()
+
+	const pct = (n: number) => ((100 * n) / total).toFixed(1)
+	console.error(
+		`${dbPath}: ${zcta.size.toLocaleString()} ZCTAs; filled ${filled.toLocaleString()} of ${before.toLocaleString()} placeholders ` +
+			`(${pct(before)}% → ${pct(after)}% of ${total.toLocaleString()} US postcodes; residual = no ZCTA, mostly PO-box/unique ZIPs)`
+	)
+}
+
+main()

--- a/scripts/wof-build-manifest.json
+++ b/scripts/wof-build-manifest.json
@@ -93,7 +93,7 @@
 		"_comment": "US postcodes live in a SEPARATE shard DB (the resolver routes postalcode queries to it via multi-shard ATTACH). Built with the same build-unified-wof.ts using --placetypes postalcode.",
 		"artifact": "postalcode-us.db",
 		"build_command": "node --experimental-strip-types scripts/build-unified-wof.ts --data /mnt/playpen/mailwoman-data/wof/repos/whosonfirst-data-postalcode-us --output /mnt/playpen/mailwoman-data/wof/postalcode-us.db --placetypes postalcode",
-		"post_build": "node resolver-wof-sqlite/out/build-fts-cli.js /mnt/playpen/mailwoman-data/wof/postalcode-us.db",
+		"post_build": "Two steps, IN ORDER. STEP 1: node resolver-wof-sqlite/out/build-fts-cli.js /mnt/playpen/mailwoman-data/wof/postalcode-us.db   (FTS + R*Tree). STEP 2: node --experimental-strip-types scripts/fill-zcta-centroids.ts   (#525: fills (0,0)-placeholder centroids from the Census ZCTA Gazetteer — /mnt/playpen/mailwoman-data/census/README.md — stamping per-row provenance in `centroid_source`; never overwrites a real WOF coordinate; residual placeholders are PO-box/unique ZIPs with no ZCTA. Without it the anchor lookup, postcode-us.bin, and the slim hot DB postcode cascade leg inherit ~22% dead coordinates).",
 		"repo": {
 			"name": "whosonfirst-data-postalcode-us",
 			"url": "https://github.com/whosonfirst-data/whosonfirst-data-postalcode-us",

--- a/scripts/zcta-centroids.test.ts
+++ b/scripts/zcta-centroids.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   ZCTA centroid fill (#525) — the three contract cases: a placeholder with a ZCTA is filled and
+ *   provenance-stamped; a real WOF coordinate is never overwritten; a placeholder without a ZCTA
+ *   stays placeholder with no provenance row.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { describe, expect, it } from "vitest"
+import { fillPlaceholderCentroids, parseZctaCentroids, ZCTA_SOURCE } from "./zcta-centroids.ts"
+
+const GAZETTEER_FIXTURE = [
+	"GEOID\tALAND\tAWATER\tALAND_SQMI\tAWATER_SQMI\tINTPTLAT\tINTPTLONG",
+	// Trailing whitespace mimics the real file's right-padded last column.
+	"90210\t26822185\t82087\t10.356\t0.032\t34.100517\t-118.41463   ",
+	"00601\t166836392\t798613\t64.416\t0.308\t18.180555\t-66.749961",
+	// Degenerate rows the parser must skip: placeholder coords, non-numeric, short code.
+	"99999\t0\t0\t0\t0\t0\t0",
+	"88888\t0\t0\t0\t0\tnope\t-118.4",
+	"123\t0\t0\t0\t0\t34.1\t-118.4",
+].join("\n")
+
+function seedDb(): DatabaseSync {
+	const db = new DatabaseSync(":memory:")
+	db.exec(`CREATE TABLE spr (
+		id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL DEFAULT -1, name TEXT NOT NULL DEFAULT '',
+		placetype TEXT NOT NULL DEFAULT '', country TEXT NOT NULL DEFAULT '',
+		latitude REAL NOT NULL DEFAULT 0, longitude REAL NOT NULL DEFAULT 0,
+		min_latitude REAL NOT NULL DEFAULT 0, min_longitude REAL NOT NULL DEFAULT 0,
+		max_latitude REAL NOT NULL DEFAULT 0, max_longitude REAL NOT NULL DEFAULT 0,
+		is_current INTEGER NOT NULL DEFAULT 1
+	)`)
+	const insert = db.prepare(
+		`INSERT INTO spr (id, name, placetype, country, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?)`
+	)
+	insert.run(1, "90210", "postalcode", "US", 0, 0) // placeholder, ZCTA exists → filled
+	insert.run(2, "10001", "postalcode", "US", 40.750634, -73.997177) // real WOF coord → untouched
+	insert.run(3, "21638", "postalcode", "US", 0, 0) // placeholder, no ZCTA → stays
+	insert.run(4, "00601", "postalcode", "DE", 0, 0) // non-US → out of scope, stays
+	return db
+}
+
+describe("parseZctaCentroids", () => {
+	it("parses centroids, skipping header and degenerate rows", () => {
+		const zcta = parseZctaCentroids(GAZETTEER_FIXTURE)
+		expect(zcta.size).toBe(2)
+		expect(zcta.get("90210")).toEqual({ lat: 34.100517, lon: -118.41463 })
+		expect(zcta.get("00601")).toEqual({ lat: 18.180555, lon: -66.749961 })
+		expect(zcta.has("99999")).toBe(false)
+	})
+})
+
+describe("fillPlaceholderCentroids", () => {
+	it("fills placeholders, preserves real coords, leaves ZCTA-less rows placeholder", () => {
+		const db = seedDb()
+		const filled = fillPlaceholderCentroids(db, parseZctaCentroids(GAZETTEER_FIXTURE))
+		expect(filled).toBe(1)
+
+		const byName = (name: string) =>
+			db.prepare(`SELECT latitude, longitude FROM spr WHERE name=?`).get(name) as {
+				latitude: number
+				longitude: number
+			}
+
+		// Placeholder + ZCTA → filled and stamped.
+		expect(byName("90210")).toEqual({ latitude: 34.100517, longitude: -118.41463 })
+		const sources = db.prepare(`SELECT id, source FROM centroid_source ORDER BY id`).all()
+		expect(sources).toEqual([{ id: 1, source: ZCTA_SOURCE }])
+
+		// Real WOF coordinate → byte-identical, no provenance row.
+		expect(byName("10001")).toEqual({ latitude: 40.750634, longitude: -73.997177 })
+
+		// Placeholder without a ZCTA, and the non-US row → untouched.
+		expect(byName("21638")).toEqual({ latitude: 0, longitude: 0 })
+		expect(byName("00601")).toEqual({ latitude: 0, longitude: 0 })
+	})
+
+	it("is idempotent", () => {
+		const db = seedDb()
+		const zcta = parseZctaCentroids(GAZETTEER_FIXTURE)
+		expect(fillPlaceholderCentroids(db, zcta)).toBe(1)
+		expect(fillPlaceholderCentroids(db, zcta)).toBe(0)
+	})
+})

--- a/scripts/zcta-centroids.ts
+++ b/scripts/zcta-centroids.ts
@@ -1,0 +1,92 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Census ZCTA centroid fill for placeholder US postcodes (#525).
+ *
+ *   WOF ships `(0,0)` for ~22% of US postcode records; every downstream artifact (pilot anchor
+ *   lookup, `postcode-us.bin`, the slim hot DB's postcode cascade leg) inherits the holes. The US
+ *   Census **ZCTA Gazetteer file** (public domain, ~33k ZCTAs, real internal-point centroids) fills
+ *   most of them. ZCTA != ZIP — PO-box-only and single-building ZIPs have no ZCTA and stay
+ *   placeholder — but a ZCTA centroid beats `(0,0)` by definition for the anchor/map-circle use.
+ *
+ *   Provenance (the no-load-bearing-trivia rule): a fill NEVER overwrites a real coordinate, and
+ *   every filled row is recorded in a `centroid_source` table (`id` → `source`, e.g.
+ *   `census-zcta-2024`) so attribution survives into the artifacts built from the DB. Data file +
+ *   vintage notes: `/mnt/playpen/mailwoman-data/census/README.md`.
+ *
+ *   This module owns the parse + fill logic; `scripts/fill-zcta-centroids.ts` is the CLI and
+ *   `scripts/build-pilot-anchor-lookup.py` mirrors the same join for lookup-build-time fills.
+ *   Tested by `scripts/zcta-centroids.test.ts`.
+ */
+
+import type { DatabaseSync } from "node:sqlite"
+
+/** Provenance label for rows filled from the 2024 ZCTA Gazetteer file. */
+export const ZCTA_SOURCE = "census-zcta-2024"
+
+export interface ZctaCentroid {
+	lat: number
+	lon: number
+}
+
+/**
+ * Parse a Census ZCTA Gazetteer file (tab-delimited; header `GEOID ... INTPTLAT INTPTLONG`) into a
+ * 5-digit-code → centroid map. Skips the header, non-5-digit GEOIDs, non-finite coordinates, and
+ * `(0,0)` rows (a placeholder must never fill a placeholder).
+ */
+export function parseZctaCentroids(text: string): Map<string, ZctaCentroid> {
+	const out = new Map<string, ZctaCentroid>()
+	for (const line of text.split("\n")) {
+		const fields = line.split("\t").map((f) => f.trim())
+		const geoid = fields[0]
+		if (!geoid || !/^\d{5}$/.test(geoid) || fields.length < 7) continue
+		const lat = Number(fields[5])
+		const lon = Number(fields[6])
+		if (!Number.isFinite(lat) || !Number.isFinite(lon) || (lat === 0 && lon === 0)) continue
+		out.set(geoid, { lat, lon })
+	}
+	return out
+}
+
+/**
+ * Fill `(0,0)`-placeholder US postcode rows in a WOF postcode shard's `spr` table from the ZCTA
+ * centroid map, recording per-row provenance in `centroid_source`. Rows with a real coordinate are
+ * never touched; placeholders without a ZCTA stay placeholder (and get no provenance row).
+ * Idempotent. Returns the number of rows filled.
+ */
+export function fillPlaceholderCentroids(
+	db: DatabaseSync,
+	zcta: ReadonlyMap<string, ZctaCentroid>,
+	source: string = ZCTA_SOURCE
+): number {
+	db.exec(`CREATE TABLE IF NOT EXISTS centroid_source (id INTEGER PRIMARY KEY, source TEXT NOT NULL)`)
+
+	const placeholders = db
+		.prepare(
+			`SELECT id, name FROM spr
+			 WHERE placetype='postalcode' AND is_current!=0 AND country='US' AND latitude=0 AND longitude=0`
+		)
+		.all() as Array<{ id: number; name: string }>
+
+	const update = db.prepare(
+		`UPDATE spr SET latitude=?, longitude=?, min_latitude=?, max_latitude=?, min_longitude=?, max_longitude=?
+		 WHERE id=? AND latitude=0 AND longitude=0`
+	)
+	const stamp = db.prepare(`INSERT OR REPLACE INTO centroid_source (id, source) VALUES (?, ?)`)
+
+	let filled = 0
+	db.exec("BEGIN")
+	for (const row of placeholders) {
+		const c = zcta.get(String(row.name).trim())
+		if (!c) continue
+		const res = update.run(c.lat, c.lon, c.lat, c.lat, c.lon, c.lon, row.id)
+		if (Number(res.changes) > 0) {
+			stamp.run(row.id, source)
+			filled++
+		}
+	}
+	db.exec("COMMIT")
+	return filled
+}


### PR DESCRIPTION
The v0.5.0 runbook's step 2. The 38% placeholder rate turned out to be two rots, and the bigger one was a bug, not missing data:

1. **Dead code path**: `build-pilot-anchor-lookup.py`'s `load_us` read bbox midpoints through column names that don't exist (`min_latitude` vs the R-tree's actual `min_lat`) — the map came back empty and **every US centroid was silently zeroed**, including codes whose `spr` rows have carried real WOF coordinates since May 30. Now reads `spr` directly; recovers ~33k codes alone.
2. **Real WOF gaps**: 9,330 US postcodes genuinely ship (0,0) — the Census ZCTA 2024 gazetteer fills 979 into `postalcode-us.db`, each stamped `census-zcta-2024` in a new `centroid_source` provenance table. Placeholders only — the UPDATE re-checks `latitude=0 AND longitude=0`; idempotent; canonical DB backed up beside itself.

## Measured

- Placeholder rate: **38.0% → 10.9%** (US-specific 53.5% → 10.2%); `postcode-us.bin` placed 32,988 → 33,967.
- 90210: real Beverly Hills coords; genuinely-ZCTA-filled probe (96910 Hagåtña) round-trips through `PostcodeBinaryResolver`.
- Residual 7,387, honestly: 4,322 US PO-box-only/unique ZIPs (ZCTA ≠ ZIP — GeoNames is the documented next lever, CC-BY), 3,065 DE/FR out of ZCTA scope.

## Deliberately not forced

- New lookup written **beside** the canonical (`pilot-anchor-lookup-zcta.json`) — the live model trained against the old one; the swap rides the v0.5.0 retrain.
- R2 publish of the rebuilt bins (that's what makes 90210's demo circle live) and the slim-DB postcode inheritance (`PLAYPEN_WOF_POSTCODE_DB` was never set — wof-hot.db is admin-only today) both ride the v0.5.0 artifact pass.

Tests: fill logic (filled / untouched / no-ZCTA / idempotent) + 42 anchor vitest + 21 pytest green.

Closes #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)