### PR TITLE
fix(corpus-python): expansion augmentations splice raw — #534's open question 3 closed

### DIFF
--- a/corpus-python/src/mailwoman_train/augment.py
+++ b/corpus-python/src/mailwoman_train/augment.py
@@ -17,19 +17,26 @@ Three augmentations, applied independently with configurable probability:
    the fused surface. Teaches the model to split the fused token at the SP-piece
    level (the v4.3.0 "glue" regression class).
 
-The expansion augmentations replace the token in the raw text AND update the
-tokens + labels lists to match; the expanded form inherits the original token's
-BIO label (B- for the first word, I- for continuation words). The glue
-augmentation mutates ``raw`` alone.
+The expansion augmentations SPLICE the expansion into ``raw`` at the token's char
+range (located via ``whitespace_spans``, same as the glue) AND update the tokens +
+labels lists to match; the expanded form inherits the original token's BIO label
+(B- for the first word, I- for continuation words). The glue augmentation mutates
+``raw`` alone. No augmentation ever rebuilds ``raw`` from the token list — a
+``" ".join(tokens)`` rebuild destroys whatever the tokens don't carry (newlines,
+double spaces) and re-quantizes spans to token boundaries (a trailing comma inside
+a ``"123,"`` token would get absorbed into the po_box span). v0.5.0 (#519) makes
+that punctuation load-bearing, so every augmented copy must keep the source raw's
+characters except for the deliberate edit (PR #534 open question 3).
 
 **Char-offset spans** (#519, v0.5.0): rows from a v0.5.0 corpus carry
 ``span_starts``/``span_ends``/``span_tags`` beside tokens/labels, and every augmented COPY this
-module yields must re-target them — the expansion augmentations rebuild ``raw`` (so the spans are
-re-derived from the new tokens/labels over the rebuilt surface), and the glue augmentation
-splices chars out of ``raw`` (so offsets at/after the splice shift left). Yielding a mutated raw
-with the source row's spans would corrupt the labels silently — the exact hazard that put the
-augmentation re-target in the same change as the loader wiring. Rows without spans (frozen
-pre-v0.5.0 corpora) pass through the legacy token path unchanged; a PARTIAL triple raises.
+module yields must re-target them by the same splice arithmetic — offsets after the edit shift by
+the replacement's length delta, a span containing the edit grows/shrinks at its end, and a span
+boundary falling strictly INSIDE the edited token is genuinely impossible to re-target (the
+replaced surface no longer exists) and raises loudly. Yielding a mutated raw with the source
+row's spans would corrupt the labels silently — the exact hazard that put the augmentation
+re-target in the same change as the loader wiring. Rows without spans (frozen pre-v0.5.0
+corpora) pass through the legacy token path unchanged; a PARTIAL triple raises.
 """
 
 from __future__ import annotations
@@ -136,40 +143,62 @@ def row_span_triple(row: dict) -> tuple[list[int], list[int], list[str]] | None:
     return starts, ends, tags
 
 
-def spans_from_token_labels(tokens: list[str], labels: list[str]) -> tuple[list[int], list[int], list[str]]:
-    """Derive a span triple for a raw REBUILT as ``" ".join(tokens)`` (the expansion augmentations'
-    surface): contiguous B-/I- runs become one span each, offsets exact by construction."""
-    starts: list[int] = []
-    ends: list[int] = []
-    tags: list[str] = []
-    cursor = 0
-    open_tag: str | None = None
-    for token, label in zip(tokens, labels):
-        begin = cursor
-        end = cursor + len(token)
-        cursor = end + 1  # single-space join
-        if label == "O":
-            open_tag = None
-            continue
-        prefix, tag = label.split("-", 1)
-        if prefix == "I" and open_tag == tag:
-            ends[-1] = end  # extend the open span across the joining space
-        else:
-            starts.append(begin)
-            ends.append(end)
-            tags.append(tag)
-        open_tag = tag
-    return starts, ends, tags
+def splice_expansion(row: dict, idx: int, expansion: str) -> dict:
+    """Return a copy of ``row`` with token ``idx``'s surface in ``raw`` replaced by ``expansion``
+    via character splicing — never a ``" ".join(tokens)`` rebuild, which would destroy whatever
+    raw carries that the tokens don't (PR #534 open question 3). Tokens + labels are updated by
+    the matching ``_expand_token`` arithmetic; everything else in raw (commas, dots, newlines,
+    double spaces) survives verbatim.
 
+    Char-offset spans (#519) are re-targeted by the same splice arithmetic, mirroring
+    ``glue_region_postcode``: with the edit at ``[s, e)`` and ``delta = len(expansion) - (e - s)``,
 
-def _with_rederived_spans(row: dict, augmented: dict) -> dict:
-    """Attach a re-derived span triple to an expansion-augmented copy when the source row carries
-    spans. The expansions rebuild ``raw`` from the new tokens, so the spans are re-derived from
-    the new tokens/labels — the source offsets address a surface that no longer exists."""
-    if row_span_triple(row) is None:
-        return augmented
-    starts, ends, tags = spans_from_token_labels(augmented["tokens"], augmented["labels"])
-    return {**augmented, "span_starts": starts, "span_ends": ends, "span_tags": tags}
+    - a span entirely before the edit is untouched,
+    - a span entirely after the edit shifts by ``delta``,
+    - a span containing the edit keeps its start and moves its end by ``delta`` (the edit is one
+      whole whitespace token, so a span covering the token shrinks/grows in place),
+    - a span boundary STRICTLY INSIDE the edited token cannot be re-targeted — the surface it
+      addressed no longer exists — and raises rather than guesses.
+    """
+    raw: str = row["raw"]
+    tokens: list[str] = row["tokens"]
+    labels: list[str] = row["labels"]
+    s, e = whitespace_spans(raw, tokens)[idx]
+    delta = len(expansion) - (e - s)
+    new_tokens, new_labels = _expand_token(tokens, labels, idx, expansion)
+    out = {
+        **row,
+        "raw": raw[:s] + expansion + raw[e:],
+        "tokens": new_tokens,
+        "labels": new_labels,
+    }
+    triple = row_span_triple(row)
+    if triple is not None:
+        starts, ends, tags = triple
+        new_starts: list[int] = []
+        new_ends: list[int] = []
+        for start, end in zip(starts, ends):
+            if end <= s:
+                # Entirely before the edit.
+                new_starts.append(start)
+                new_ends.append(end)
+            elif start >= e:
+                # Entirely after the edit: shift by the replacement's length delta.
+                new_starts.append(start + delta)
+                new_ends.append(end + delta)
+            elif start <= s and end >= e:
+                # Contains the edited token: the end moves with the splice.
+                new_starts.append(start)
+                new_ends.append(end + delta)
+            else:
+                raise ValueError(
+                    f"corrupt row: span [{start}, {end}) has a boundary inside the expanded "
+                    f"token {tokens[idx]!r} at [{s}, {e}) — un-retargetable (raw={raw!r})"
+                )
+        out["span_starts"] = new_starts
+        out["span_ends"] = new_ends
+        out["span_tags"] = list(tags)
+    return out
 
 
 def _expand_token(
@@ -260,19 +289,7 @@ def augment_row(
         ]
         if directional_indices:
             idx = rng.choice(directional_indices)
-            new_tokens, new_labels = _expand_token(
-                tokens, labels, idx, DIRECTIONALS[tokens[idx]]
-            )
-            new_raw = " ".join(new_tokens)
-            yield _with_rederived_spans(
-                row,
-                {
-                    **row,
-                    "raw": new_raw,
-                    "tokens": new_tokens,
-                    "labels": new_labels,
-                },
-            )
+            yield splice_expansion(row, idx, DIRECTIONALS[tokens[idx]])
 
     # Region+postcode glue (#513): fuse the last region token with an immediately-following
     # postcode token in raw. Letter→digit boundary only — that's the boundary SentencePiece
@@ -301,16 +318,4 @@ def augment_row(
         ]
         if region_indices:
             idx = rng.choice(region_indices)
-            new_tokens, new_labels = _expand_token(
-                tokens, labels, idx, US_STATES[tokens[idx]]
-            )
-            new_raw = " ".join(new_tokens)
-            yield _with_rederived_spans(
-                row,
-                {
-                    **row,
-                    "raw": new_raw,
-                    "tokens": new_tokens,
-                    "labels": new_labels,
-                },
-            )
+            yield splice_expansion(row, idx, US_STATES[tokens[idx]])

--- a/corpus-python/src/mailwoman_train/test_augment.py
+++ b/corpus-python/src/mailwoman_train/test_augment.py
@@ -9,7 +9,7 @@ from .augment import (
     augment_row,
     glue_region_postcode,
     row_span_triple,
-    spans_from_token_labels,
+    splice_expansion,
 )
 from .tokenizer import PieceSpan, realign_labels_to_pieces, realign_spans_to_pieces
 
@@ -261,13 +261,23 @@ def _spanned_directional_row() -> dict:
     }
 
 
-def test_expansion_rederives_spans_for_the_rebuilt_raw():
+def _assert_span_invariants(row: dict) -> None:
+    """The #519 triple invariants: in-bounds, sorted ascending by start, non-overlapping."""
+    prev_end = 0
+    for s, e in zip(row["span_starts"], row["span_ends"]):
+        assert 0 <= s < e <= len(row["raw"])
+        assert s >= prev_end
+        prev_end = e
+
+
+def test_expansion_splices_raw_and_retargets_spans():
     rng = random.Random(42)
     results = list(augment_row(_spanned_directional_row(), rng, directional_prob=1.0, region_prob=0.0))
     assert len(results) == 2
     augmented = results[1]
     assert augmented["raw"] == "350 5th Ave Northwest"
     assert _slices(augmented) == [("house_number", "350"), ("street", "5th Ave Northwest")]
+    _assert_span_invariants(augmented)
 
 
 def test_expansion_leaves_the_original_rows_spans_alone():
@@ -330,22 +340,131 @@ def test_row_span_triple_nonparallel_raises():
         row_span_triple({"raw": "x", "span_starts": [0], "span_ends": [1, 2], "span_tags": ["street"]})
 
 
-def test_spans_from_token_labels_groups_bi_runs():
-    starts, ends, tags = spans_from_token_labels(
-        ["350", "5th", "Ave", "Buffalo"],
-        ["B-house_number", "B-street", "I-street", "B-locality"],
-    )
-    raw = "350 5th Ave Buffalo"
-    assert [(t, raw[s:e]) for s, e, t in zip(starts, ends, tags)] == [
+# --- Raw splicing for expansions (PR #534 open question 3) ---------------------------------------
+# The expansions must never rebuild raw via " ".join(tokens): the join destroys whitespace
+# geometry (newlines, double spaces) and re-quantizing spans to token boundaries absorbs
+# punctuation the v0.5.0 spans deliberately exclude. The canonical probe is a dotted P.O. Box
+# beside a comma-bearing token.
+
+
+def _dotted_po_box_row() -> dict:
+    # raw:  P.O. Box 123, Buffalo NY 14201
+    #       0         1         2
+    #       0123456789012345678901234567890
+    # The po_box span [0, 12) excludes the trailing comma; the comma rides inside the "123,"
+    # whitespace token. A token-label re-derive would absorb it into the span.
+    return {
+        "raw": "P.O. Box 123, Buffalo NY 14201",
+        "tokens": ["P.O.", "Box", "123,", "Buffalo", "NY", "14201"],
+        "labels": ["B-po_box", "I-po_box", "I-po_box", "B-locality", "B-region", "B-postcode"],
+        "span_starts": [0, 14, 22, 25],
+        "span_ends": [12, 21, 24, 30],
+        "span_tags": ["po_box", "locality", "region", "postcode"],
+        "country": "US",
+        "source": "test",
+    }
+
+
+def test_expansion_preserves_intra_span_punctuation():
+    """The dotted P.O. Box survives the region expansion verbatim — dots inside the span,
+    trailing comma still outside it — and every offset addresses the NEW raw exactly."""
+    rng = random.Random(42)
+    results = list(augment_row(_dotted_po_box_row(), rng, directional_prob=0.0, region_prob=1.0))
+    assert len(results) == 2
+    augmented = results[1]
+    assert augmented["raw"] == "P.O. Box 123, Buffalo New York 14201"
+    assert _slices(augmented) == [
+        ("po_box", "P.O. Box 123"),
+        ("locality", "Buffalo"),
+        ("region", "New York"),
+        ("postcode", "14201"),
+    ]
+    _assert_span_invariants(augmented)
+    # The comma after the po_box stays in raw, outside the span.
+    assert augmented["raw"][12] == ","
+
+
+def test_expansion_preserves_whitespace_geometry():
+    """Newlines + double spaces in raw survive the splice — the exact information a
+    " ".join(tokens) rebuild destroys."""
+    row = {
+        "raw": "350 5th  Ave NW\nBuffalo",
+        "tokens": ["350", "5th", "Ave", "NW", "Buffalo"],
+        "labels": ["B-house_number", "B-street", "I-street", "I-street", "B-locality"],
+        "span_starts": [0, 4, 16],
+        "span_ends": [3, 15, 23],
+        "span_tags": ["house_number", "street", "locality"],
+        "country": "US",
+        "source": "test",
+    }
+    rng = random.Random(42)
+    augmented = list(augment_row(row, rng, directional_prob=1.0, region_prob=0.0))[1]
+    assert augmented["raw"] == "350 5th  Ave Northwest\nBuffalo"
+    assert _slices(augmented) == [
         ("house_number", "350"),
-        ("street", "5th Ave"),
+        ("street", "5th  Ave Northwest"),
         ("locality", "Buffalo"),
     ]
+    _assert_span_invariants(augmented)
 
 
-def test_spans_from_token_labels_o_breaks_the_run():
-    starts, ends, tags = spans_from_token_labels(["New", "York", ",", "NY"], ["B-region", "I-region", "O", "B-region"])
-    assert tags == ["region", "region"]
-    # Joined raw is "New York , NY": the comma is uncovered, the second region span is "NY".
-    assert (starts[0], ends[0]) == (0, 8)
-    assert (starts[1], ends[1]) == (11, 13)
+def test_expansion_legacy_row_keeps_punctuation_too():
+    """Token-only (pre-v0.5.0) rows ride the same splice: the raw keeps its punctuation even
+    though no spans need re-targeting."""
+    row = {k: v for k, v in _dotted_po_box_row().items() if not k.startswith("span_")}
+    rng = random.Random(42)
+    results = list(augment_row(row, rng, directional_prob=0.0, region_prob=1.0))
+    assert len(results) == 2
+    assert results[1]["raw"] == "P.O. Box 123, Buffalo New York 14201"
+    assert "span_starts" not in results[1]
+
+
+def test_splice_expansion_leaves_the_source_row_alone():
+    row = _dotted_po_box_row()
+    splice_expansion(row, 4, "New York")
+    assert row["raw"] == "P.O. Box 123, Buffalo NY 14201"
+    assert row["span_starts"] == [0, 14, 22, 25]
+    assert row["tokens"][4] == "NY"
+
+
+def test_splice_expansion_boundary_inside_edited_token_raises():
+    """A span boundary strictly inside the expanded token addresses a surface the splice
+    destroys — genuinely impossible to re-target, so it raises rather than guesses."""
+    row = {
+        "raw": "Buffalo NY 14201",
+        "tokens": ["Buffalo", "NY", "14201"],
+        "labels": ["B-locality", "B-region", "B-postcode"],
+        # Corrupt on purpose: the region span covers only the first char of "NY".
+        "span_starts": [0, 8, 11],
+        "span_ends": [7, 9, 16],
+        "span_tags": ["locality", "region", "postcode"],
+    }
+    with pytest.raises(ValueError, match="un-retargetable"):
+        splice_expansion(row, 1, "New York")
+
+
+def test_expansion_then_glue_compose_still_verifies():
+    """Composing the two splices (directional expansion, then region+postcode glue) keeps every
+    offset addressing the final raw."""
+    row = {
+        "raw": "350 5th Ave NW Buffalo, NY 14201",
+        "tokens": ["350", "5th", "Ave", "NW", "Buffalo,", "NY", "14201"],
+        "labels": ["B-house_number", "B-street", "I-street", "I-street", "B-locality", "B-region", "B-postcode"],
+        "span_starts": [0, 4, 15, 24, 27],
+        "span_ends": [3, 14, 22, 26, 32],
+        "span_tags": ["house_number", "street", "locality", "region", "postcode"],
+        "country": "US",
+        "source": "test",
+    }
+    expanded = splice_expansion(row, 3, "Northwest")
+    assert expanded["raw"] == "350 5th Ave Northwest Buffalo, NY 14201"
+    fused = glue_region_postcode(expanded, 5)
+    assert fused["raw"] == "350 5th Ave Northwest Buffalo, NY14201"
+    assert _slices(fused) == [
+        ("house_number", "350"),
+        ("street", "5th Ave Northwest"),
+        ("locality", "Buffalo"),
+        ("region", "NY"),
+        ("postcode", "14201"),
+    ]
+    _assert_span_invariants(fused)

--- a/corpus/src/synthesize.test.ts
+++ b/corpus/src/synthesize.test.ts
@@ -4,8 +4,9 @@
  * @author Teffen Ellis, et al.
  */
 
-import { BIO_LABELS } from "@mailwoman/core/types"
+import { BIO_LABELS, type ComponentTag } from "@mailwoman/core/types"
 import { describe, expect, it } from "vitest"
+import { alignRow } from "./align.js"
 import {
 	AUGMENTATIONS,
 	accentStrip,
@@ -27,7 +28,7 @@ import {
 	unitDesignatorExpand,
 	zipPlus4DashDrop,
 } from "./synthesize.js"
-import type { CanonicalRow } from "./types.js"
+import type { CanonicalRow, LabeledRow } from "./types.js"
 
 const baseRow = (over: Partial<CanonicalRow>): CanonicalRow => ({
 	raw: "",
@@ -488,6 +489,158 @@ describe("registry + defaults", () => {
 		const upper = out.find((r) => r.synth?.method === "case-upper")!
 		expect(upper.source_id).toBe("t-1+case-upper")
 		expect(upper.synth?.base_source_id).toBe("t-1")
+	})
+})
+
+// ===========================================================================
+// Raw-surface punctuation survival (#519 / PR #534 open question 3)
+// ===========================================================================
+//
+// Every augmentation transforms `raw` by direct string splicing (replace/case-map on the raw
+// itself — never a rebuild from a token list), and the build pipeline re-runs `alignRow` on each
+// augmented copy, deriving the char-offset span triple from the AUGMENTED raw. These probes pin
+// the property v0.5.0 makes load-bearing: intra-span punctuation (the dotted `P.O. Box` is the
+// canonical case) survives onto the augmented copy, and every span addresses the new raw exactly.
+// A future refactor that rebuilds raw from tokens would fail these.
+
+describe("augmented copies keep intra-span punctuation (#519)", () => {
+	/** Apply the augmentation, align the copy, and return the labeled row (asserting both steps). */
+	const augmentAndAlign = (id: string, row: CanonicalRow) => {
+		const out = AUGMENTATIONS[id]!(row)
+		expect(out, `${id} should apply to its fixture`).not.toBeNull()
+		const aligned = alignRow(out!)
+		expect(aligned.kind, `${id} copy should align (got ${JSON.stringify(aligned.row)})`).toBe("labeled")
+		if (aligned.kind !== "labeled") throw new Error("unreachable")
+		// Every span must address the augmented raw exactly: its slice IS the component surface.
+		const { raw, span_starts, span_ends, span_tags } = aligned.row
+		for (let i = 0; i < span_tags!.length; i++) {
+			expect(raw.slice(span_starts![i]!, span_ends![i]!)).toBe(out!.components[span_tags![i]!])
+		}
+		return aligned.row
+	}
+
+	/** The dotted po_box surface on the augmented copy — slice the span, not the tokens. */
+	const poBoxSurface = (row: LabeledRow): string => {
+		const i = row.span_tags!.indexOf("po_box")
+		expect(i).toBeGreaterThanOrEqual(0)
+		return row.raw.slice(row.span_starts![i]!, row.span_ends![i]!)
+	}
+
+	const poBoxRow = (over: Partial<CanonicalRow> = {}): CanonicalRow =>
+		baseRow({
+			raw: "P.O. Box 5, Portland, OR 97214",
+			components: { po_box: "P.O. Box 5", locality: "Portland", region: "OR", postcode: "97214" },
+			...over,
+		})
+
+	const streetRow = (street: string): CanonicalRow =>
+		baseRow({
+			raw: `P.O. Box 5, 100 ${street}, Portland, OR 97214`,
+			components: {
+				po_box: "P.O. Box 5",
+				house_number: "100",
+				street,
+				locality: "Portland",
+				region: "OR",
+				postcode: "97214",
+			},
+		})
+
+	const unitRow = (unit: string): CanonicalRow =>
+		baseRow({
+			raw: `P.O. Box 5, 123 Main St ${unit}, Portland, OR 97214`,
+			components: {
+				po_box: "P.O. Box 5",
+				house_number: "123",
+				street: "Main St",
+				unit,
+				locality: "Portland",
+				region: "OR",
+				postcode: "97214",
+			},
+		})
+
+	const cases: ReadonlyArray<[id: string, row: CanonicalRow, expectedPoBox: string]> = [
+		["case-upper", poBoxRow(), "P.O. BOX 5"],
+		["case-lower", poBoxRow(), "p.o. box 5"],
+		// drop-commas deliberately deletes the commas BETWEEN spans; the dots inside the span stay.
+		["drop-commas", poBoxRow(), "P.O. Box 5"],
+		["double-space", poBoxRow(), "P.O.  Box  5"],
+		[
+			"accent-strip",
+			poBoxRow({
+				raw: "P.O. Box 5, Mâcon 97214",
+				components: { po_box: "P.O. Box 5", locality: "Mâcon", postcode: "97214" },
+			}),
+			"P.O. Box 5",
+		],
+		["state-expand", poBoxRow(), "P.O. Box 5"],
+		[
+			"state-abbreviate",
+			poBoxRow({
+				raw: "P.O. Box 5, Portland, Oregon 97214",
+				components: { po_box: "P.O. Box 5", locality: "Portland", region: "Oregon", postcode: "97214" },
+			}),
+			"P.O. Box 5",
+		],
+		["directional-expand", streetRow("Main St NW"), "P.O. Box 5"],
+		["directional-abbreviate", streetRow("Main St Northwest"), "P.O. Box 5"],
+		["us-street-suffix-abbreviate", streetRow("Main Street"), "P.O. Box 5"],
+		["us-street-suffix-expand", streetRow("Main St"), "P.O. Box 5"],
+		["us-unit-designator-abbreviate", unitRow("Apartment 4B"), "P.O. Box 5"],
+		["us-unit-designator-expand", unitRow("Apt 4B"), "P.O. Box 5"],
+		[
+			"zip-plus4-dash-drop",
+			poBoxRow({
+				raw: "P.O. Box 5, Portland, OR 97214-1234",
+				components: { po_box: "P.O. Box 5", locality: "Portland", region: "OR", postcode: "97214-1234" },
+			}),
+			"P.O. Box 5",
+		],
+		[
+			"particle-strip",
+			baseRow({
+				raw: "B.P. 24, 10 Rue de la République, 75008 Paris",
+				country: "FR",
+				components: {
+					po_box: "B.P. 24",
+					house_number: "10",
+					street_prefix: "Rue",
+					street_prefix_particle: "de la",
+					street: "République",
+					postcode: "75008",
+					locality: "Paris",
+				},
+			}),
+			"B.P. 24",
+		],
+	]
+
+	it.each(cases)("%s: the dotted po_box span survives on the augmented copy", (id, row, expectedPoBox) => {
+		const labeled = augmentAndAlign(id, row)
+		expect(poBoxSurface(labeled)).toBe(expectedPoBox)
+	})
+
+	it("the registry probe table covers every augmentation", () => {
+		expect(new Set(cases.map(([id]) => id))).toEqual(new Set(Object.keys(AUGMENTATIONS)))
+	})
+
+	it("chained augmentations (case-upper ∘ us-street-suffix-abbreviate) still verify", () => {
+		const abbreviated = streetSuffixAbbreviate(streetRow("Main Street"))!
+		expect(abbreviated.raw).toBe("P.O. Box 5, 100 Main St, Portland, OR 97214")
+		const upper = caseUpper(abbreviated)!
+		expect(upper.source_id).toBe("t-1+us-street-suffix-abbreviate+case-upper")
+		expect(upper.synth?.base_source_id).toBe("t-1")
+		const aligned = alignRow(upper)
+		expect(aligned.kind).toBe("labeled")
+		if (aligned.kind !== "labeled") return
+		const { raw, span_starts, span_ends, span_tags } = aligned.row
+		const slice = (tag: ComponentTag) => {
+			const i = span_tags!.indexOf(tag)
+			return raw.slice(span_starts![i]!, span_ends![i]!)
+		}
+		expect(slice("po_box")).toBe("P.O. BOX 5")
+		expect(slice("street")).toBe("MAIN ST")
 	})
 })
 


### PR DESCRIPTION
Closes PR #534's open question 3 (ruled: yes). v0.5.0 makes punctuation load-bearing; augmented copies must stop silently stripping it.

## Where the bug actually lived

One-sided: all 15 TS augmentations already raw-splice (build.ts re-runs `alignRow` on each copy under `assertSpanInvariants`) — the `" ".join(tokens)` rebuild was **python-only**, in `augment.py`'s directional + region expansions, whose spans were then re-derived from token-quantized labels. Two corruptions fixed: whitespace geometry flattened by the join, and token-boundary re-quantization (a trailing comma inside a `"123,"` token absorbed into the po_box span).

## Change

New `splice_expansion()` on the #513 glue's exact pattern: char-range splice into raw, offset arithmetic on the span triple (before unchanged / after shifted / containing span end moves), `spans_from_token_labels` + `_with_rederived_spans` deleted with the surface they described. The one genuinely impossible case — a span boundary strictly inside the edited token — raises loudly naming span/range/raw (the glue's straddle-raise discipline).

## Tests

- Python: dotted `P.O. Box 123,` canonical probe, whitespace-geometry survival, legacy token-only rows, source immutability, the raise, expansion∘glue compose — affected modules 89 green (3 pre-existing failures reproduce identically on main: test_labels environmental + torch-needing collection).
- TS: table-driven probe over **every** registry augmentation with a registry-parity meta-test (pins the no-op status so a future token-join refactor fails the suite) — corpus suite 412 (+17).

Part of #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)