### PR TITLE
feat(interpolation): Method 2 address-point interpolation — Cook PASSES gate, VT improved-still-MISS (#483)

### DIFF
--- a/docs/articles/plan/2026-06-11-interpolation-design.md
+++ b/docs/articles/plan/2026-06-11-interpolation-design.md
@@ -190,10 +190,10 @@ Same eval, same gate, same seed-42 5000-key sampling, on a dense county: Cook Co
 field, so the point shard is PIP-filtered against the TIGER2023 COUNTY polygon via the
 builder's new `--county-fips` flag; 1,460,216 points, 231 ZIPs).
 
-| county | coverage | p50 | p90 | gate (≤50 / ≤150) |
-| --- | ---: | ---: | ---: | --- |
-| Cook IL (dense) | 87.8% | 41 m | 79 m | **PASS** |
-| Vermont (rural, re-run) | 82.0% | 66 m | 249 m | **MISS** (unchanged) |
+| county                  | coverage |  p50 |   p90 | gate (≤50 / ≤150)    |
+| ----------------------- | -------: | ---: | ----: | -------------------- |
+| Cook IL (dense)         |    87.8% | 41 m |  79 m | **PASS**             |
+| Vermont (rural, re-run) |    82.0% | 66 m | 249 m | **MISS** (unchanged) |
 
 Cook's median claimed uncertainty (half segment length) is 80 m vs Vermont's 137 m — the
 segment geometry itself is the divide. **Verdict: the VT gate miss is substantially a
@@ -202,6 +202,44 @@ the gate where segments are short; long sparse rural segments cap precision belo
 gate. Per the resolution-ladder plan this keeps Method 2 (address-point interpolation) as
 the corrective for the sparse stratum, and any county-stratified gate re-baseline remains
 an operator sign-off, not made here.
+
+## Method 2 — address-point interpolation (2026-06-12, resolution-ladder Phase 1 step 2)
+
+`resolver-wof-sqlite/address-point-interpolation.ts` (`AddressPointInterpolator`): bracket the
+query number with REAL neighbor points from the #476 shard on the same route-folded street key
+(`street_key`, a new shard column — the fold adoption the pilot deferred), interpolate linearly
+in house-number space between the bracket's centroids; single-sided bracket = extrapolation
+along the two nearest same-side numbers, capped at one pair-span (`t ≤ 2`), with an explicitly
+larger `uncertaintyM`; no bracket = fall through to TIGER range interpolation. Hits carry
+`method: "address_point" | "tiger_range"` + `bracket: "both" | "single"`.
+
+**Non-circularity:** the lookup excludes every row at the queried house number by construction —
+a held-out key is only ever interpolated from non-held-out neighbor numbers. (This is also
+production-faithful: an on-file number is the exact tier's answer, never this tier's.) The
+prior eval had no shard-side holdout to lean on, so the guarantee lives in the lookup, not the
+sampler.
+
+Same eval (`--mode ladder`), same gate, same seed-42 samples. Pre-registered question: does
+Method 2 clear the gate on its bracketed stratum?
+
+| stratum                               | VT n |       VT p50/p90 | Cook n |    Cook p50/p90 |
+| ------------------------------------- | ---: | ---------------: | -----: | --------------: |
+| method 2 — bracketed (both-sided)     | 4200 | **50 m / 182 m** |   4807 | **42 m / 61 m** |
+| method 2 — single-sided extrapolation |  382 |     74 m / 223 m |    121 |    46 m / 102 m |
+| tiger_range fallback                  |  301 |     69 m / 237 m |     54 |    47 m / 124 m |
+| all hits (ladder)                     | 4883 |     53 m / 191 m |   4982 |     42 m / 62 m |
+| tiger-alone, same sample (baseline)   | 4100 |     66 m / 249 m |   4389 |     41 m / 79 m |
+
+- **Coverage: VT 82.0% → 97.7%, Cook 87.8% → 99.6%** — bracketing answers most of TIGER's
+  name-absent/range-gap miss classes because the neighbor points ARE the E911/Overture names.
+- **Gate on the bracketed stratum: Cook PASS (42/61). VT MISS — p50 50.5 m (over by 0.5 m),
+  p90 182 m.** Stated plainly: Method 2 moved VT's bracketed p90 249 → 182 m and its p50
+  66 → 50.5 m, and that is still a miss. Not re-baselined.
+- The VT residual is wide-bracket concentrated, and the claimed `uncertaintyM` (half bracket
+  span) predicts it: bracketed rows claiming ≤ 100 m (71.4% of the stratum) measure p50 42 m /
+  p90 116 m — inside the gate — while the > 250 m claims (7.2%) measure p50 143 m / p90 917 m.
+  The Phase 5 calibrated-confidence work is the principled home for acting on that (per-tier
+  P(error < X) by claimed uncertainty), not a quiet stratum re-cut here.
 
 ## Open questions
 

--- a/docs/articles/plan/2026-06-11-interpolation-design.md
+++ b/docs/articles/plan/2026-06-11-interpolation-design.md
@@ -183,6 +183,26 @@ truth is unknowable; measuring on known points is the only honest proxy.
   building), segment subdivision at OA point anchors, ZIP+4 snapping (#525). No rollout
   until a gate pass or a STATED re-baseline with operator sign-off.
 
+## Density characterization (2026-06-12, resolution-ladder Phase 1 step 1)
+
+Same eval, same gate, same seed-42 5000-key sampling, on a dense county: Cook County IL
+(FIPS 17031; TIGER2023 EDGES + a county-scoped #476 shard — Overture carries no county
+field, so the point shard is PIP-filtered against the TIGER2023 COUNTY polygon via the
+builder's new `--county-fips` flag; 1,460,216 points, 231 ZIPs).
+
+| county | coverage | p50 | p90 | gate (≤50 / ≤150) |
+| --- | ---: | ---: | ---: | --- |
+| Cook IL (dense) | 87.8% | 41 m | 79 m | **PASS** |
+| Vermont (rural, re-run) | 82.0% | 66 m | 249 m | **MISS** (unchanged) |
+
+Cook's median claimed uncertainty (half segment length) is 80 m vs Vermont's 137 m — the
+segment geometry itself is the divide. **Verdict: the VT gate miss is substantially a
+rural-geometry artifact, not a method error.** TIGER uniform-spacing interpolation clears
+the gate where segments are short; long sparse rural segments cap precision below the
+gate. Per the resolution-ladder plan this keeps Method 2 (address-point interpolation) as
+the corrective for the sparse stratum, and any county-stratified gate re-baseline remains
+an operator sign-off, not made here.
+
 ## Open questions
 
 1. **Workspace split.** This slice implements inside `resolver-wof-sqlite` (the module is

--- a/resolver-wof-sqlite/address-point-interpolation.test.ts
+++ b/resolver-wof-sqlite/address-point-interpolation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for address-point interpolation — Method 2 of the resolution ladder (#483). Seeds an
+ *   in-memory `address_point` fixture (the schema `scripts/build-address-point-shard.ts` builds,
+ *   with the `street_key` route-fold column), then asserts both-sided bracketing, self-number
+ *   exclusion (the non-circularity guarantee), unit-sibling centroids, single-sided extrapolation +
+ *   its cap, route-key folding, and the no-bracket fall-through to the TIGER segment fallback.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { AddressPointInterpolator } from "./address-point-interpolation.js"
+import { StreetInterpolator } from "./interpolation.js"
+
+interface SeedPoint {
+	street_key: string
+	number: string
+	postcode: string
+	lat: number
+	lon: number
+}
+
+function seedPoints(db: DatabaseSync, points: SeedPoint[]): void {
+	db.exec(`
+		CREATE TABLE address_point (
+			street_norm   TEXT NOT NULL,
+			street_key    TEXT NOT NULL,
+			number        TEXT NOT NULL,
+			unit          TEXT,
+			postcode      TEXT,
+			locality_norm TEXT,
+			street_raw    TEXT NOT NULL,
+			lat           REAL NOT NULL,
+			lon           REAL NOT NULL,
+			source        TEXT NOT NULL,
+			release       TEXT NOT NULL
+		)
+	`)
+	const ins = db.prepare(
+		`INSERT INTO address_point (street_norm, street_key, number, unit, postcode, locality_norm, street_raw, lat, lon, source, release)
+		 VALUES (?, ?, ?, NULL, ?, NULL, ?, ?, ?, 'overture:test', '2026-05-20.0')`
+	)
+	for (const p of points) {
+		ins.run(p.street_key, p.street_key, p.number, p.postcode, p.street_key, p.lat, p.lon)
+	}
+}
+
+// All fixtures live on straight east-west streets near the equator so longitude is a direct
+// proxy for position (0.001 deg ≈ 111 m).
+let db: DatabaseSync
+let interpolator: AddressPointInterpolator
+
+beforeAll(() => {
+	db = new DatabaseSync(":memory:")
+	seedPoints(db, [
+		// Both-sided bracket fixture: known points at 100 and 200.
+		{ street_key: "main street", number: "100", postcode: "05601", lat: 0, lon: 0 },
+		{ street_key: "main street", number: "200", postcode: "05601", lat: 0, lon: 0.001 },
+		// Self-exclusion fixture on its own street: a point AT the queryable number 150,
+		// deliberately far off the street line — querying 150 must interpolate the
+		// 100/200 bracket, never answer from this row.
+		{ street_key: "elm street", number: "100", postcode: "05601", lat: 0, lon: 0 },
+		{ street_key: "elm street", number: "150", postcode: "05601", lat: 0.5, lon: 0.5 },
+		{ street_key: "elm street", number: "200", postcode: "05601", lat: 0, lon: 0.001 },
+		// Unit-sibling centroid fixture: two rows for 300, centroid at lon 0.003.
+		{ street_key: "main street", number: "300", postcode: "05601", lat: 0, lon: 0.0029 },
+		{ street_key: "main street", number: "300", postcode: "05601", lat: 0, lon: 0.0031 },
+		// Single-sided fixture: numbers 10 and 20 only (queries above extrapolate east).
+		{ street_key: "hill road", number: "10", postcode: "05601", lat: 1, lon: 0 },
+		{ street_key: "hill road", number: "20", postcode: "05601", lat: 1, lon: 0.001 },
+		// One lone point — never enough to bracket or extrapolate.
+		{ street_key: "lone lane", number: "7", postcode: "05601", lat: 2, lon: 0 },
+		// Route-fold fixture, stored under the canonical key.
+		{ street_key: "state route 100", number: "1000", postcode: "05601", lat: 3, lon: 0 },
+		{ street_key: "state route 100", number: "1100", postcode: "05601", lat: 3, lon: 0.001 },
+	])
+	interpolator = new AddressPointInterpolator({ database: db })
+})
+
+afterAll(() => {
+	interpolator.close()
+	db.close()
+})
+
+describe("AddressPointInterpolator", () => {
+	it("interpolates a both-sided bracket linearly in house-number space", () => {
+		const hit = interpolator.find({ street: "Main St", number: "125", postcode: "05601" })
+		expect(hit).not.toBeNull()
+		expect(hit!.interpolated).toBe(true)
+		expect(hit!.method).toBe("address_point")
+		expect(hit!.bracket).toBe("both")
+		// 125 is 25% of the way from 100 → 200 (the 150 self-row is excluded, see below).
+		expect(hit!.lat).toBeCloseTo(0, 9)
+		expect(hit!.lon).toBeCloseTo(0.00025, 9)
+		// Half the ~111 m bracket span.
+		expect(hit!.uncertaintyM).toBeGreaterThan(40)
+		expect(hit!.uncertaintyM).toBeLessThan(70)
+		expect(hit!.source).toBe("overture:test")
+		expect(hit!.release).toBe("2026-05-20.0")
+	})
+
+	it("never answers from a point at the queried number itself (non-circular by construction)", () => {
+		// A row for 150 EXISTS (off the street line at lat 0.5). The answer must come from the
+		// 100/200 bracket instead — in production the exact tier owns on-file numbers.
+		const hit = interpolator.find({ street: "Elm St", number: "150", postcode: "05601" })
+		expect(hit!.bracket).toBe("both")
+		expect(hit!.lat).toBeCloseTo(0, 9)
+		expect(hit!.lon).toBeCloseTo(0.0005, 9)
+	})
+
+	it("collapses unit siblings to the number's centroid before bracketing", () => {
+		// 250 brackets between 200 (lon 0.001) and 300 (centroid lon 0.003): midpoint 0.002.
+		const hit = interpolator.find({ street: "Main St", number: "250", postcode: "05601" })
+		expect(hit!.bracket).toBe("both")
+		expect(hit!.lon).toBeCloseTo(0.002, 9)
+	})
+
+	it("extrapolates a single-sided bracket with an explicitly larger uncertainty", () => {
+		// 25 extrapolates past 20 along the 10→20 line: t = 1.5 → lon 0.0015.
+		const hit = interpolator.find({ street: "Hill Rd", number: "25", postcode: "05601" })
+		expect(hit).not.toBeNull()
+		expect(hit!.method).toBe("address_point")
+		expect(hit!.bracket).toBe("single")
+		expect(hit!.lat).toBeCloseTo(1, 9)
+		expect(hit!.lon).toBeCloseTo(0.0015, 9)
+		// Pair span (~111 m) + overshoot (~56 m) — strictly more than a both-sided half-span.
+		expect(hit!.uncertaintyM).toBeGreaterThan(140)
+	})
+
+	it("caps extrapolation at one pair-span beyond the nearest point", () => {
+		// 30 is exactly t = 2 (allowed); 31 is past the cap (no fallback → null).
+		const atCap = interpolator.find({ street: "Hill Rd", number: "30", postcode: "05601" })
+		expect(atCap!.bracket).toBe("single")
+		expect(atCap!.lon).toBeCloseTo(0.002, 9)
+		expect(interpolator.find({ street: "Hill Rd", number: "31", postcode: "05601" })).toBeNull()
+	})
+
+	it("matches the route-folded street key from either route spelling", () => {
+		const hit = interpolator.find({ street: "VT ROUTE 100", number: "1050", postcode: "05601" })
+		expect(hit).not.toBeNull()
+		expect(hit!.lat).toBeCloseTo(3, 9)
+		expect(hit!.lon).toBeCloseTo(0.0005, 9)
+	})
+
+	it("returns null with no bracket and no fallback (lone point, unknown street, wrong ZIP, non-numeric)", () => {
+		expect(interpolator.find({ street: "Lone Ln", number: "9", postcode: "05601" })).toBeNull()
+		expect(interpolator.find({ street: "Nowhere St", number: "5", postcode: "05601" })).toBeNull()
+		expect(interpolator.find({ street: "Main St", number: "125", postcode: "99999" })).toBeNull()
+		expect(interpolator.find({ street: "Main St", number: "12-34", postcode: "05601" })).toBeNull()
+	})
+
+	it("falls through to the TIGER segment fallback when bracketing cannot answer", () => {
+		const segDb = new DatabaseSync(":memory:")
+		segDb.exec(`
+			CREATE TABLE street_segment (
+				street_norm  TEXT NOT NULL,
+				side         TEXT NOT NULL,
+				from_hn      INTEGER NOT NULL,
+				to_hn        INTEGER NOT NULL,
+				min_hn       INTEGER NOT NULL,
+				max_hn       INTEGER NOT NULL,
+				parity       TEXT NOT NULL,
+				postcode     TEXT,
+				county_fips  TEXT NOT NULL,
+				street_raw   TEXT NOT NULL,
+				geometry     TEXT NOT NULL,
+				source       TEXT NOT NULL,
+				release      TEXT NOT NULL
+			)
+		`)
+		segDb
+			.prepare(
+				`INSERT INTO street_segment VALUES
+				 ('lone lane', 'L', 1, 99, 1, 99, 'odd', '05601', '50023', 'Lone Ln', '[[0,2],[0.001,2]]', 'tiger:edges', 'TIGER2023')`
+			)
+			.run()
+		const tiger = new StreetInterpolator({ database: segDb })
+		const ladder = new AddressPointInterpolator({ database: db, fallback: tiger })
+
+		// 'lone lane' has one point — Method 2 cannot bracket; TIGER answers, flagged as such.
+		const hit = ladder.find({ street: "Lone Ln", number: "51", postcode: "05601" })
+		expect(hit).not.toBeNull()
+		expect(hit!.method).toBe("tiger_range")
+		expect(hit!.parityMatched).toBe(true)
+		expect(hit!.lat).toBeCloseTo(2, 9)
+
+		// A both-sided bracket still wins over the fallback…
+		const bracketed = ladder.find({ street: "Main St", number: "125", postcode: "05601" })
+		expect(bracketed!.method).toBe("address_point")
+
+		// …and a query without a postcode delegates straight to the fallback's scoping policy.
+		const noScope = ladder.find({ street: "Lone Ln", number: "51" })
+		expect(noScope!.method).toBe("tiger_range")
+
+		ladder.close()
+		tiger.close()
+		segDb.close()
+	})
+})

--- a/resolver-wof-sqlite/address-point-interpolation.ts
+++ b/resolver-wof-sqlite/address-point-interpolation.ts
@@ -1,0 +1,184 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Address-point interpolation — "Method 2" of the resolution ladder (#483, Phase 1 of
+ *   `docs/articles/plan/2026-06-11-resolution-ladder.md`): when the exact address-point tier (#476)
+ *   misses a house number, bracket the number with REAL neighbor points on the same street from the
+ *   same #476 shard and interpolate linearly in house-number space between them. Real occupancy
+ *   replaces TIGER's uniform-spacing assumption — the dominant error term of the TIGER pilot's gate
+ *   miss; TIGER range interpolation (`StreetInterpolator`) demotes to the fallback for streets too
+ *   sparse to bracket.
+ *
+ *   Matching key is `street_key` — THE shared normalizer plus the route fold
+ *   (`canonicalizeRouteKey`), identical at build time (`scripts/build-address-point-shard.ts`) and
+ *   query time, by construction. Scope is postcode-first like the segment tier; a query without a
+ *   postcode goes straight to the fallback (which carries its own statewide-ambiguity abstention).
+ *
+ *   Bracketing contract:
+ *
+ *   - Neighbor candidates NEVER include the queried number itself (any unit/duplicate row of it) — in
+ *       production the exact tier would already have answered an on-file number, and in the eval
+ *       this is what makes grading against the same shard non-circular by construction.
+ *   - Both-sided bracket (`bracket: "both"`): linear interpolation between the nearest known number
+ *       below and above; `uncertaintyM` = half the distance between them.
+ *   - Single-sided (`bracket: "single"`): linear extrapolation along the two nearest known numbers on
+ *       that side, capped at one pair-span beyond the nearest point (`t ≤ 2` — beyond that the line
+ *       carries no evidence and the query falls through); `uncertaintyM` = the pair distance plus
+ *       the extrapolated overshoot, explicitly larger than the both-sided radius.
+ *   - No bracket (no neighbors, a single known number, or past the extrapolation cap): fall through to
+ *       the TIGER fallback when configured, else null.
+ *
+ *   Standalone like the segment tier — core wiring rides the Phase 2 ordered `spatialTiers` list.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+
+import { haversineKm } from "./geo.js"
+import type { InterpolatedHit, InterpolationQuery, StreetInterpolator } from "./interpolation.js"
+import { canonicalizeRouteKey, normalizeStreetForKey } from "./street-normalize.js"
+
+/**
+ * Extrapolation cap for a single-sided bracket: at most one pair-span beyond the nearest known
+ * point (`t = 2`). Past it, the two-point line carries no evidence about the query number.
+ */
+const MAX_EXTRAPOLATION_T = 2
+
+interface PointRow {
+	n: number
+	lat: number
+	lon: number
+	source: string
+	release: string
+}
+
+/** One known house number on the street: the centroid of its rows (unit siblings collapse). */
+interface NumberAnchor {
+	n: number
+	lat: number
+	lon: number
+	source: string
+	release: string
+}
+
+export class AddressPointInterpolator {
+	readonly #db: DatabaseSync
+	readonly #ownsDb: boolean
+	readonly #fallback: StreetInterpolator | undefined
+	readonly #byPostcode
+
+	constructor(opts: { dbPath?: string; database?: DatabaseSync; fallback?: StreetInterpolator }) {
+		if (opts.database) {
+			this.#db = opts.database
+			this.#ownsDb = false
+		} else if (opts.dbPath) {
+			this.#db = new DatabaseSync(opts.dbPath, { readOnly: true })
+			this.#ownsDb = true
+		} else {
+			throw new Error("AddressPointInterpolator: one of dbPath or database is required")
+		}
+		this.#fallback = opts.fallback
+		// Strictly-numeric neighbor numbers on the route-folded street key within the ZIP. The
+		// queried number itself is excluded HERE (see module doc: non-circular by construction).
+		this.#byPostcode = this.#db.prepare(
+			`SELECT CAST(number AS INTEGER) AS n, lat, lon, source, release
+			 FROM address_point
+			 WHERE postcode = ? AND street_key = ?
+				AND number GLOB '[0-9]*' AND number NOT GLOB '*[^0-9]*'
+				AND CAST(number AS INTEGER) != ?`
+		)
+	}
+
+	find(query: InterpolationQuery): InterpolatedHit | null {
+		const streetKey = canonicalizeRouteKey(normalizeStreetForKey(query.street))
+		const numberRaw = query.number.trim()
+		if (!streetKey || !/^\d+$/.test(numberRaw)) return null
+		const n = Number(numberRaw)
+
+		// Postcode scope only in this slice — without one, the segment fallback owns the
+		// statewide-ambiguity abstention; duplicating it here would be a second policy.
+		if (!query.postcode) return this.#fallback?.find(query) ?? null
+
+		const rows = this.#byPostcode.all(query.postcode.trim(), streetKey, n) as unknown as PointRow[]
+		const hit = rows.length >= 2 ? interpolateFromNeighbors(rows, n) : null
+		return hit ?? this.#fallback?.find(query) ?? null
+	}
+
+	close(): void {
+		if (this.#ownsDb) this.#db.close()
+	}
+}
+
+/** Collapse rows to one centroid anchor per distinct house number, sorted ascending. */
+function anchorsByNumber(rows: readonly PointRow[]): NumberAnchor[] {
+	const byN = new Map<number, PointRow[]>()
+	for (const row of rows) {
+		const group = byN.get(row.n)
+		if (group) group.push(row)
+		else byN.set(row.n, [row])
+	}
+	return [...byN.entries()]
+		.map(([n, group]) => ({
+			n,
+			lat: group.reduce((sum, r) => sum + r.lat, 0) / group.length,
+			lon: group.reduce((sum, r) => sum + r.lon, 0) / group.length,
+			source: group[0]!.source,
+			release: group[0]!.release,
+		}))
+		.sort((a, b) => a.n - b.n)
+}
+
+function interpolateFromNeighbors(rows: readonly PointRow[], n: number): InterpolatedHit | null {
+	const anchors = anchorsByNumber(rows)
+
+	// Nearest known number below and above the query (the rows never contain n itself).
+	let below: NumberAnchor | undefined
+	let above: NumberAnchor | undefined
+	for (const anchor of anchors) {
+		if (anchor.n < n) below = anchor
+		else {
+			above = anchor
+			break
+		}
+	}
+
+	if (below && above) {
+		const t = (n - below.n) / (above.n - below.n)
+		const spanM = haversineKm(below.lat, below.lon, above.lat, above.lon) * 1000
+		return {
+			lat: below.lat + (above.lat - below.lat) * t,
+			lon: below.lon + (above.lon - below.lon) * t,
+			interpolated: true,
+			method: "address_point",
+			bracket: "both",
+			uncertaintyM: Math.round(spanM / 2),
+			source: below.source,
+			release: below.release,
+		}
+	}
+
+	// Single-sided: extrapolate along the two nearest known numbers on the populated side.
+	// `near` is the anchor closest to n, `far` the next one out; t > 1 by construction.
+	const side = below ? anchors.slice(-2) : anchors.slice(0, 2)
+	if (side.length < 2) return null
+	const [far, near] = below ? [side[0]!, side[1]!] : [side[1]!, side[0]!]
+	const t = (n - far.n) / (near.n - far.n)
+	if (t > MAX_EXTRAPOLATION_T) return null
+
+	const lat = far.lat + (near.lat - far.lat) * t
+	const lon = far.lon + (near.lon - far.lon) * t
+	const pairM = haversineKm(near.lat, near.lon, far.lat, far.lon) * 1000
+	const overshootM = haversineKm(lat, lon, near.lat, near.lon) * 1000
+	return {
+		lat,
+		lon,
+		interpolated: true,
+		method: "address_point",
+		bracket: "single",
+		// Explicitly larger than the both-sided radius: the whole pair span plus the overshoot.
+		uncertaintyM: Math.round(pairM + overshootM),
+		source: near.source,
+		release: near.release,
+	}
+}

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -61,8 +61,14 @@ export {
 	type WofReverseGeocoderOpts,
 } from "./reverse.js"
 
+export { AddressPointInterpolator } from "./address-point-interpolation.js"
 export { AddressPointSqliteLookup } from "./address-point.js"
-export { StreetInterpolator, type InterpolatedHit, type InterpolationQuery } from "./interpolation.js"
+export {
+	StreetInterpolator,
+	type InterpolatedHit,
+	type InterpolationMethod,
+	type InterpolationQuery,
+} from "./interpolation.js"
 export {
 	deriveSchemaName,
 	pickShardForPlacetype,

--- a/resolver-wof-sqlite/interpolation.ts
+++ b/resolver-wof-sqlite/interpolation.ts
@@ -31,18 +31,40 @@ import { DatabaseSync } from "node:sqlite"
 import { haversineKm } from "./geo.js"
 import { canonicalizeRouteKey, normalizeStreetForKey } from "./street-normalize.js"
 
+/**
+ * How an interpolated answer was computed (#483 Method 2):
+ *
+ * - `address_point` — bracketed/extrapolated between REAL neighbor points from the #476 shard
+ *   (`AddressPointInterpolator`), replacing TIGER's uniform-spacing assumption with occupancy.
+ * - `tiger_range` — linear position within a TIGER segment's theoretical house-number range
+ *   (`StreetInterpolator`), the fallback for streets too sparse to bracket.
+ */
+export type InterpolationMethod = "address_point" | "tiger_range"
+
 /** One interpolated coordinate estimate. Never an exact situs point — see `uncertaintyM`. */
 export interface InterpolatedHit {
 	lat: number
 	lon: number
 	/** Always true — the tier's honesty flag, mirrored into `resolution_tier` when wired. */
 	interpolated: true
+	/** Which rung answered — see {@link InterpolationMethod}. */
+	method: InterpolationMethod
 	/**
-	 * True when the matched segment side's parity agrees with the house number (or the side is
-	 * `mixed`). False = opposite-side fallback: usually the right block, wrong side of the street.
+	 * `tiger_range` only. True when the matched segment side's parity agrees with the house number
+	 * (or the side is `mixed`). False = opposite-side fallback: usually the right block, wrong side
+	 * of the street.
 	 */
-	parityMatched: boolean
-	/** Half the matched segment's polyline length, meters — the honest uncertainty radius. */
+	parityMatched?: boolean
+	/**
+	 * `address_point` only. `both` = the query number sits between two known neighbor numbers;
+	 * `single` = neighbors exist on one side only (extrapolated, larger `uncertaintyM`).
+	 */
+	bracket?: "both" | "single"
+	/**
+	 * Honest uncertainty radius in meters: half the matched segment's polyline length
+	 * (`tiger_range`), half the bracket span (`address_point`/`both`), or the explicitly larger
+	 * extrapolation penalty (`address_point`/`single`).
+	 */
 	uncertaintyM: number
 	/** Provenance, e.g. `"tiger:edges"`. */
 	source: string
@@ -138,6 +160,7 @@ export class StreetInterpolator {
 			lat,
 			lon,
 			interpolated: true,
+			method: "tiger_range",
 			parityMatched,
 			uncertaintyM: Math.round((lengthKm * 1000) / 2),
 			source: best.source,

--- a/scripts/build-address-point-shard.ts
+++ b/scripts/build-address-point-shard.ts
@@ -33,7 +33,11 @@ import { DuckDBInstance } from "@duckdb/node-api"
 
 // Cross-tree source import (.ts explicit): this script runs via --experimental-strip-types,
 // not from compiled out/ — the lookup tier imports the same module intra-package.
-import { normalizeLocalityForKey, normalizeStreetForKey } from "../resolver-wof-sqlite/street-normalize.ts"
+import {
+	canonicalizeRouteKey,
+	normalizeLocalityForKey,
+	normalizeStreetForKey,
+} from "../resolver-wof-sqlite/street-normalize.ts"
 
 const { values: args } = parseArgs({
 	options: {
@@ -90,6 +94,7 @@ db.exec(`
 	PRAGMA journal_mode = WAL;
 	CREATE TABLE address_point (
 		street_norm   TEXT NOT NULL,
+		street_key    TEXT NOT NULL, -- canonicalizeRouteKey(street_norm): the route-fold key (#483 Method 2)
 		number        TEXT NOT NULL,
 		unit          TEXT,
 		postcode      TEXT,
@@ -103,8 +108,8 @@ db.exec(`
 `)
 
 const insert = db.prepare(
-	`INSERT INTO address_point (street_norm, number, unit, postcode, locality_norm, street_raw, lat, lon, source, release)
-	 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	`INSERT INTO address_point (street_norm, street_key, number, unit, postcode, locality_norm, street_raw, lat, lon, source, release)
+	 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 )
 db.exec("BEGIN")
 let kept = 0
@@ -115,6 +120,7 @@ for (const r of rows) {
 	const locality = r.locality ? normalizeLocalityForKey(String(r.locality)) : null
 	insert.run(
 		streetNorm,
+		canonicalizeRouteKey(streetNorm),
 		String(r.number).trim().toLowerCase(),
 		r.unit ? String(r.unit).trim().toLowerCase() : null,
 		r.postcode ? String(r.postcode).trim() : null,
@@ -131,6 +137,7 @@ db.exec("COMMIT")
 db.exec(`
 	CREATE INDEX idx_ap_postcode ON address_point (postcode, street_norm, number);
 	CREATE INDEX idx_ap_locality ON address_point (locality_norm, street_norm, number);
+	CREATE INDEX idx_ap_streetkey ON address_point (postcode, street_key);
 	PRAGMA wal_checkpoint(TRUNCATE);
 	VACUUM;
 `)

--- a/scripts/build-address-point-shard.ts
+++ b/scripts/build-address-point-shard.ts
@@ -15,7 +15,13 @@
  *
  *   Usage: node --experimental-strip-types scripts/build-address-point-shard.ts\
  *   --state VT [--release 2026-05-20.0]\
- *   [--out /mnt/playpen/mailwoman-data/address-points/address-points-us-vt.db]
+ *   [--out /mnt/playpen/mailwoman-data/address-points/address-points-us-vt.db]\
+ *   [--county-fips 17031 --county-boundary /tmp/tiger-county/tl_2023_us_county.shp]
+ *
+ *   County scoping (#483 density characterization): Overture carries no county field, so an optional
+ *   `--county-fips` filter does a point-in-polygon against the TIGER COUNTY boundary shapefile
+ *   (`--county-boundary`, same TIGER vintage as the EDGES the interpolation shard reads) — keeps a
+ *   county-scoped gold comparable to a county-scoped segment table.
  */
 
 import { mkdirSync, rmSync } from "node:fs"
@@ -34,10 +40,16 @@ const { values: args } = parseArgs({
 		state: { type: "string" },
 		release: { type: "string", default: "2026-05-20.0" },
 		out: { type: "string" },
+		"county-fips": { type: "string" },
+		"county-boundary": { type: "string", default: "/tmp/tiger-county/tl_2023_us_county.shp" },
 	},
 })
 if (!args.state) {
 	console.error("--state required (US state abbreviation, e.g. VT)")
+	process.exit(1)
+}
+if (args["county-fips"] && !/^\d{5}$/.test(args["county-fips"])) {
+	console.error("--county-fips must be a 5-digit state+county FIPS (e.g. 17031)")
 	process.exit(1)
 }
 const STATE = args.state.toUpperCase()
@@ -49,6 +61,15 @@ rmSync(OUT, { force: true }) // idempotent rebuild — never append across relea
 
 const instance = await DuckDBInstance.create()
 const duck = await instance.connect()
+// Optional county scope: PIP against the TIGER COUNTY polygon (GEOID = state+county FIPS).
+// DuckDB hoists the scalar subquery to a constant, so the per-row cost is the containment test.
+let countyFilter = ""
+if (args["county-fips"]) {
+	await duck.run("INSTALL spatial; LOAD spatial;")
+	countyFilter = `AND ST_Contains(
+			(SELECT geom FROM ST_Read('${args["county-boundary"]}') WHERE GEOID = '${args["county-fips"]}'),
+			ST_Point(lon, lat))`
+}
 const result = await duck.runAndReadAll(`
 	SELECT
 		number, street, unit, postcode,
@@ -59,6 +80,7 @@ const result = await duck.runAndReadAll(`
 	WHERE address_levels[1].value = '${STATE}'
 		AND nullif(trim(street), '') IS NOT NULL
 		AND nullif(trim(number), '') IS NOT NULL
+		${countyFilter}
 `)
 const rows = result.getRowObjects() as Record<string, unknown>[]
 console.log(`${rows.length} ${STATE} rows from ${path.basename(PARQUET)}`)

--- a/scripts/eval/interpolation-eval.ts
+++ b/scripts/eval/interpolation-eval.ts
@@ -14,6 +14,19 @@
  *   strictly-numeric house numbers — the only inputs the tier models (the non-numeric share is
  *   reported, not hidden).
  *
+ *   Two modes:
+ *
+ *   - `--mode tiger` (default): the TIGER pilot's eval, unchanged — `StreetInterpolator` alone, gate
+ *       graded on all hits.
+ *   - `--mode ladder`: Method 2 (`AddressPointInterpolator` over the SAME #476 shard that supplies the
+ *       gold) with the TIGER tier as fall-through, reported per method/bracket stratum.
+ *       Non-circular by construction: the lookup excludes every row at the queried house number, so
+ *       a held-out key is only ever interpolated from non-held-out neighbor numbers (in production
+ *       the exact tier owns on-file numbers anyway). The pre-registered Phase 1 question — does
+ *       Method 2 clear the gate on its BRACKETED (both-sided) stratum? — is what the gate line
+ *       grades. The TIGER-only result on the same sample is reported alongside for the coverage
+ *       shift.
+ *
  *   NOTE: imports the WORKTREE's compiled module by relative path (run `yarn compile` first) — the
  *   bare `@mailwoman/resolver-wof-sqlite` specifier would resolve through the parent checkout's
  *   node_modules to a build without this module.
@@ -21,13 +34,14 @@
  *   Usage: yarn compile && node scripts/eval/interpolation-eval.ts\
  *   [--points /mnt/playpen/mailwoman-data/address-points/address-points-us-vt.db]\
  *   [--segments /mnt/playpen/mailwoman-data/interpolation/interpolation-us-vt.db]\
- *   [--sample 5000] [--seed 42]
+ *   [--mode tiger|ladder] [--sample 5000] [--seed 42]
  */
 
 import { createHash } from "node:crypto"
 import { DatabaseSync } from "node:sqlite"
 import { parseArgs } from "node:util"
 
+import { AddressPointInterpolator } from "../../resolver-wof-sqlite/out/address-point-interpolation.js"
 import { haversineKm } from "../../resolver-wof-sqlite/out/geo.js"
 import { StreetInterpolator } from "../../resolver-wof-sqlite/out/interpolation.js"
 
@@ -41,11 +55,17 @@ const { values: args } = parseArgs({
 			type: "string",
 			default: "/mnt/playpen/mailwoman-data/interpolation/interpolation-us-vt.db",
 		},
+		mode: { type: "string", default: "tiger" },
 		sample: { type: "string", default: "5000" },
 		seed: { type: "string", default: "42" },
 	},
 })
 const SAMPLE = Number(args.sample)
+const MODE = args.mode as "tiger" | "ladder"
+if (MODE !== "tiger" && MODE !== "ladder") {
+	console.error(`--mode must be tiger or ladder, got ${String(args.mode)}`)
+	process.exit(1)
+}
 
 // Pre-registered gate from the #483 issue — restated, never silently relaxed.
 const GATE_P50_M = 50
@@ -94,27 +114,42 @@ const gold: GoldRow[] = eligible
 	.map((x) => x.row)
 
 const interpolator = new StreetInterpolator({ dbPath: args.segments! })
+// Ladder mode: Method 2 over the gold shard itself (self-number exclusion makes that
+// non-circular — see module doc), TIGER as the fall-through.
+const ladder = MODE === "ladder" ? new AddressPointInterpolator({ dbPath: args.points!, fallback: interpolator }) : null
 
 interface Outcome {
 	errorM: number
-	parityMatched: boolean
+	parityMatched?: boolean
 	uncertaintyM: number
+	method: "address_point" | "tiger_range"
+	bracket?: "both" | "single"
 }
 
 const hits: Outcome[] = []
+// Ladder mode also runs the TIGER tier alone on the same sample — the coverage/error shift.
+const tigerAlone: number[] = []
 let misses = 0
 for (const row of gold) {
-	const hit = interpolator.find({ street: row.street_raw, number: row.number, postcode: row.postcode })
-	if (!hit) {
+	const query = { street: row.street_raw, number: row.number, postcode: row.postcode }
+	const hit = (ladder ?? interpolator).find(query)
+	if (hit) {
+		hits.push({
+			errorM: haversineKm(row.lat, row.lon, hit.lat, hit.lon) * 1000,
+			parityMatched: hit.parityMatched,
+			uncertaintyM: hit.uncertaintyM,
+			method: hit.method,
+			bracket: hit.bracket,
+		})
+	} else {
 		misses++
-		continue
 	}
-	hits.push({
-		errorM: haversineKm(row.lat, row.lon, hit.lat, hit.lon) * 1000,
-		parityMatched: hit.parityMatched,
-		uncertaintyM: hit.uncertaintyM,
-	})
+	if (ladder) {
+		const tigerHit = interpolator.find(query)
+		if (tigerHit) tigerAlone.push(haversineKm(row.lat, row.lon, tigerHit.lat, tigerHit.lon) * 1000)
+	}
 }
+ladder?.close()
 interpolator.close()
 
 function percentile(sorted: number[], p: number): number {
@@ -140,28 +175,44 @@ function report(label: string, outcomes: Outcome[]): void {
 
 const queried = gold.length
 const coverage = queried === 0 ? 0 : hits.length / queried
-const parityHits = hits.filter((h) => h.parityMatched)
-const fallbackHits = hits.filter((h) => !h.parityMatched)
-const allErrors = hits
-	.map((h) => h.errorM)
-	.slice()
-	.sort((a, b) => a - b)
-const p50 = percentile(allErrors, 50)
-const p90 = percentile(allErrors, 90)
 const within = (m: number) => hits.filter((h) => h.errorM <= m).length / Math.max(1, hits.length)
 
-console.log(`interpolation eval — segments: ${args.segments}`)
+console.log(`interpolation eval (mode: ${MODE}) — segments: ${args.segments}`)
 console.log(`gold: ${args.points}`)
 console.log(
 	`eligibility: ${totals.all_rows} points · ${totals.non_numeric} non-numeric number (${((100 * totals.non_numeric) / totals.all_rows).toFixed(1)}%) · ${totals.no_postcode} without postcode (${((100 * totals.no_postcode) / totals.all_rows).toFixed(1)}%)`
 )
 console.log(`sampled ${queried} distinct (street, number, postcode) keys (seed ${args.seed})`)
 console.log("")
-console.log(`coverage: ${hits.length}/${queried} found a segment (${(100 * coverage).toFixed(1)}%)`)
+console.log(`coverage: ${hits.length}/${queried} answered (${(100 * coverage).toFixed(1)}%)`)
 console.log(`coord error vs truth (haversine):`)
 report("all hits", hits)
-report("parity-matched", parityHits)
-report("opposite-side fallback", fallbackHits)
+let gateRows = hits
+let gateLabel = "all hits"
+if (MODE === "ladder") {
+	const both = hits.filter((h) => h.method === "address_point" && h.bracket === "both")
+	const single = hits.filter((h) => h.method === "address_point" && h.bracket === "single")
+	const tigerFallback = hits.filter((h) => h.method === "tiger_range")
+	report("method 2 — bracketed (both-sided)", both)
+	report("method 2 — single-sided extrapolation", single)
+	report("tiger_range fallback", tigerFallback)
+	const tigerSorted = tigerAlone.slice().sort((a, b) => a - b)
+	console.log(
+		`  tiger-alone on this sample (the shift baseline): coverage ${((100 * tigerAlone.length) / Math.max(1, queried)).toFixed(1)}% · p50 ${Math.round(percentile(tigerSorted, 50))}m · p90 ${Math.round(percentile(tigerSorted, 90))}m`
+	)
+	// The pre-registered Phase 1 question: does Method 2 clear the gate on its BRACKETED stratum?
+	gateRows = both
+	gateLabel = "method-2 bracketed stratum"
+} else {
+	report(
+		"parity-matched",
+		hits.filter((h) => h.parityMatched)
+	)
+	report(
+		"opposite-side fallback",
+		hits.filter((h) => !h.parityMatched)
+	)
+}
 console.log(
 	`within: ≤50m ${(100 * within(50)).toFixed(1)}% · ≤100m ${(100 * within(100)).toFixed(1)}% · ≤500m ${(100 * within(500)).toFixed(1)}% · ≤1km ${(100 * within(1000)).toFixed(1)}%`
 )
@@ -172,11 +223,17 @@ const medianUncertainty = percentile(
 		.sort((a, b) => a - b),
 	50
 )
-console.log(`claimed uncertainty (half segment length): median ${Math.round(medianUncertainty)}m`)
+console.log(`claimed uncertainty: median ${Math.round(medianUncertainty)}m`)
 console.log("")
+const gateErrors = gateRows
+	.map((h) => h.errorM)
+	.slice()
+	.sort((a, b) => a - b)
+const p50 = percentile(gateErrors, 50)
+const p90 = percentile(gateErrors, 90)
 const p50Pass = p50 <= GATE_P50_M
 const p90Pass = p90 <= GATE_P90_M
 console.log(
-	`gate (#483 pre-registered): p50 ≤ ${GATE_P50_M}m → ${Math.round(p50)}m ${p50Pass ? "PASS" : "MISS"} · p90 ≤ ${GATE_P90_M}m → ${Math.round(p90)}m ${p90Pass ? "PASS" : "MISS"}`
+	`gate (#483 pre-registered, on ${gateLabel}): p50 ≤ ${GATE_P50_M}m → ${Math.round(p50)}m ${p50Pass ? "PASS" : "MISS"} · p90 ≤ ${GATE_P90_M}m → ${Math.round(p90)}m ${p90Pass ? "PASS" : "MISS"}`
 )
 process.exitCode = p50Pass && p90Pass ? 0 : 1


### PR DESCRIPTION
Phase 1 of the resolution-ladder plan, executed in the pre-registered order.

## Step 1 — density verdict: the VT miss is rural-geometry ARTIFACT

Cook County IL (265,653 TIGER segment-sides; #476 shard county-scoped via a new `--county-fips` PIP filter) on the **unchanged** gate:

| county | coverage | p50 | p90 | gate ≤50/≤150 |
|---|---:|---:|---:|---|
| Cook IL | 87.8% | 41 m | 79 m | **PASS** |
| VT (reproduced exactly) | 82.0% | 66 m | 249 m | MISS |

## Step 2 — Method 2 (`AddressPointInterpolator`)

Bracket the query number with #476 Overture points on the route-folded street key → interpolate in house-number space; single-sided = capped extrapolation with larger `uncertaintyM`; no bracket = fall through to TIGER. Non-circularity is structural: the lookup excludes every row at the queried number, so held-out keys interpolate only from non-held-out neighbors (also production-faithful — on-file numbers belong to the exact tier).

| stratum | VT p50/p90 (n) | Cook p50/p90 (n) |
|---|---:|---:|
| Method 2 bracketed | **50.5 / 182 (4200) — MISS** | **42 / 61 (4807) — PASS** |
| single-sided | 74 / 223 (382) | 46 / 102 (121) |
| TIGER fallback | 69 / 237 (301) | 47 / 124 (54) |

**Coverage: VT 82.0 → 97.7%, Cook 87.8 → 99.6%** — bracketing absorbs TIGER's name-absent/range-gap miss classes because neighbor points carry the E911/Overture names.

**Plainly: second VT miss on record** (p50 by 0.5 m, p90 by 32 m), not re-baselined. The residual is wide-bracket concentrated and the claimed `uncertaintyM` already predicts it (≤100 m claims measure 42/116 — inside the gate; >250 m claims measure 143/917). That's the Phase-5 calibrated-confidence shape. The gate decision — county/density-stratified vs confidence-banded — is an operator call, stated on #483.

Tests: 8 new bracketing units (self-exclusion, centroid collapse, extrapolation cap, route fold, fallthrough), suite 198 green, TIGER-mode eval output byte-identical to the recorded baseline.

Part of #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)