### PR TITLE
feat(resolver): boundary-preserving alias-bag separator — U+E000, premise inverted (#523)

### DIFF
--- a/docs/plugins/demo-assets/resolve.mjs
+++ b/docs/plugins/demo-assets/resolve.mjs
@@ -115,10 +115,12 @@ export function buildWorkspaceAliases() {
 		aliases["@mailwoman/cartographer/styles"] = resolveWorkspaceDirEntry(cartographerDir, "styles")
 	}
 
-	// @mailwoman/resolver-wof-sqlite — FST browser-safe subpaths only.
+	// @mailwoman/resolver-wof-sqlite — browser-safe subpaths only (the FST modules plus fts.ts,
+	// whose single node:sqlite import is type-only; httpvfs-resolver.ts imports its alias-bag
+	// parser so the demo's exact tier can't drift from the Node/WASM resolvers).
 	const resolverWofDir = resolveWorkspaceDir("@mailwoman/resolver-wof-sqlite")
 	if (resolverWofDir) {
-		for (const sub of ["fst-deserialize-web", "fst-matcher", "fst-types"]) {
+		for (const sub of ["fst-deserialize-web", "fst-matcher", "fst-types", "fts"]) {
 			aliases[`@mailwoman/resolver-wof-sqlite/${sub}`] = resolveWorkspaceFile(resolverWofDir, sub)
 		}
 	}

--- a/docs/src/shared/httpvfs-resolver.ts
+++ b/docs/src/shared/httpvfs-resolver.ts
@@ -21,6 +21,10 @@
  */
 
 import { expandPlacetypeFilter } from "@mailwoman/core/resolver"
+// Browser-safe subpath (fts.ts's only node:sqlite import is type-only; aliased in
+// docs/plugins/demo-assets/resolve.mjs) — the shared alias-bag parser keeps this backend's exact
+// tier identical to the Node + WASM resolvers'.
+import { ALIAS_SEPARATOR, aliasBagExactMatch } from "@mailwoman/resolver-wof-sqlite/fts"
 
 import type { DualRole, MailwomanLookupLike } from "./resources"
 
@@ -34,13 +38,19 @@ const normName = (s: string): string => s.toLowerCase().trim().replace(/\s+/g, "
  */
 const sqlStr = (s: string): string => `'${s.replace(/'/g, "''")}'`
 
-/** Trim raw input into an FTS5-safe MATCH term. Mirrors resolver-wof-wasm's sanitizeFtsQuery intent. */
+/**
+ * Trim raw input into an FTS5-safe MATCH term. Mirrors resolver-wof-wasm's sanitizeFtsQuery intent.
+ * Unlike the Node/WASM sanitizers (which strip everything outside `\p{L}\p{N}`), this one strips a
+ * denylist — so the alias-bag separator must be stripped EXPLICITLY or a pasted U+E000 could
+ * address the boundary token in the quoted phrase below.
+ */
 function sanitizeFts(text: string): string {
 	const trimmed = text.trim()
 	const prefix = trimmed.endsWith("*")
 	const cleaned = trimmed
 		.replace(/[*]/g, " ")
-		.replace(/["'()^:{}\[\]~]/g, " ")
+		.replace(/["'()^:{}[\]~]/g, " ")
+		.replaceAll(ALIAS_SEPARATOR, " ")
 		.replace(/\s+/g, " ")
 		.trim()
 	if (!cleaned) return ""
@@ -347,15 +357,13 @@ export class WofHttpvfsPlaceLookup implements MailwomanLookupLike {
 				const pop = typeof row.population === "number" ? row.population : 0
 				const popBoost = pop > 0 ? POPULATION_BOOST * Math.min(1, Math.log10(1 + pop) / POPULATION_SCALE_LOG10) : 0
 				const adj = (row.bm25 as number) - popBoost
-				// Alias tier: `alt_names` is the FTS row's alias bag (all `names` rows space-joined). Name
-				// boundaries are LOST in the bag, so a containment check would false-promote interior
-				// fragments ("York" matches inside "New York City") — it only engages when NO candidate is
-				// strictly exact: the "New York City" case, where the query is a WOF alias of the New York
-				// locality but no spr row bears the name. Mirrors WofWasmPlaceLookup.
+				// Alias tier: `alt_names` is the FTS row's alias bag, aliases joined on the
+				// boundary-preserving ALIAS_SEPARATOR (#523). The shared parser does a per-alias equality
+				// check, ungated; on a LEGACY bag (pre-#523 slim artifact, boundaries lost) it falls back
+				// to padded containment gated on "no strictly exact candidate" so interior fragments
+				// ("York" inside "New York City") can't be false-promoted. Mirrors WofWasmPlaceLookup.
 				const aliasExact =
-					!anyStrictExact &&
-					typeof row.alt_names === "string" &&
-					` ${normName(row.alt_names)} `.includes(` ${normQuery} `)
+					typeof row.alt_names === "string" && aliasBagExactMatch(row.alt_names, normQuery, anyStrictExact)
 				const exactTier = strictExact(row) || aliasExact ? 0 : 1
 				return { row, exactTier, adj }
 			})

--- a/resolver-wof-sqlite/fts.test.ts
+++ b/resolver-wof-sqlite/fts.test.ts
@@ -10,7 +10,13 @@
 import { DatabaseSync } from "node:sqlite"
 import { describe, expect, test } from "vitest"
 
-import { buildPlaceSearchFts, PLACE_SEARCH_TABLE, placeSearchFtsExists } from "./fts.js"
+import {
+	ALIAS_SEPARATOR,
+	aliasBagExactMatch,
+	buildPlaceSearchFts,
+	PLACE_SEARCH_TABLE,
+	placeSearchFtsExists,
+} from "./fts.js"
 
 function buildBaseSchema(): DatabaseSync {
 	const db = new DatabaseSync(":memory:")
@@ -101,6 +107,66 @@ describe("buildPlaceSearchFts", () => {
 		expect(row.name).toBe("Paris")
 		expect(row.alt_names).toContain("パリ")
 		expect(row.alt_names).toContain("París")
+
+		db.close()
+	})
+
+	test("joins aliases with the boundary-preserving ALIAS_SEPARATOR token (#523)", () => {
+		const db = buildBaseSchema()
+		buildPlaceSearchFts(db)
+
+		const row = db.prepare(`SELECT alt_names FROM ${PLACE_SEARCH_TABLE} WHERE wof_id = 1`).get() as {
+			alt_names: string
+		}
+		// One boundary between the two aliases (space-padded so each alias tokenizes normally) plus
+		// the trailing format marker that distinguishes new bags from legacy single-alias ones.
+		expect(row.alt_names).toBe(`パリ ${ALIAS_SEPARATOR} París ${ALIAS_SEPARATOR}`)
+
+		db.close()
+	})
+
+	test("a phrase query cannot match ACROSS two aliases' concatenation boundary (#523)", () => {
+		const db = buildBaseSchema()
+		// Two aliases whose concatenation forms a third phrase: the bag "York <sep> New City" must
+		// not phrase-match "york new". Without the separator token, FTS5 assigns the aliases' tokens
+		// consecutive positions and the cross-boundary phrase falsely matches (see the ALIAS_SEPARATOR
+		// probe table in fts.ts — punctuation separators do NOT fix this; only an indexed token does).
+		db.exec(`
+			INSERT INTO spr VALUES (5, NULL, 'Twin Hamlet', 'locality', 'US', 40.0, -80.0, 39.9, 40.1, -80.1, -79.9, -1, 0);
+			INSERT INTO names (id, language, name) VALUES (5, 'eng', 'York');
+			INSERT INTO names (id, language, name) VALUES (5, 'eng', 'New City');
+		`)
+		buildPlaceSearchFts(db)
+
+		const match = (q: string): number[] =>
+			(
+				db.prepare(`SELECT wof_id FROM ${PLACE_SEARCH_TABLE} WHERE ${PLACE_SEARCH_TABLE} MATCH ?`).all(q) as {
+					wof_id: number
+				}[]
+			).map((r) => r.wof_id)
+
+		expect(match('"york new"')).toEqual([]) // the false cross-boundary phrase
+		expect(match('"york"')).toEqual([5]) // each alias is still individually matchable
+		expect(match('"new city"')).toEqual([5])
+
+		db.close()
+	})
+
+	test("strips an embedded U+E000 from source names so a poisoned row can't forge an alias boundary (#523)", () => {
+		const db = buildBaseSchema()
+		db.exec(`
+			INSERT INTO spr VALUES (6, NULL, 'Honest Place', 'locality', 'US', 41.0, -81.0, 40.9, 41.1, -81.1, -80.9, -1, 0);
+		`)
+		db.prepare(`INSERT INTO names (id, language, name) VALUES (6, 'eng', ?)`).run(`Evil${ALIAS_SEPARATOR}Name`)
+		buildPlaceSearchFts(db)
+
+		const row = db.prepare(`SELECT alt_names FROM ${PLACE_SEARCH_TABLE} WHERE wof_id = 6`).get() as {
+			alt_names: string
+		}
+		// Flattened to a space — ONE alias (plus the trailing format marker), no forged boundary.
+		expect(row.alt_names).toBe(`Evil Name ${ALIAS_SEPARATOR}`)
+		expect(aliasBagExactMatch(row.alt_names, "evil", false)).toBe(false) // fragment ≠ exact
+		expect(aliasBagExactMatch(row.alt_names, "evil name", false)).toBe(true) // the whole alias is
 
 		db.close()
 	})
@@ -219,6 +285,35 @@ describe("buildPlaceSearchFts", () => {
 			| undefined
 		expect(hit).toBeUndefined()
 		db.close()
+	})
+})
+
+describe("aliasBagExactMatch", () => {
+	const SEP = ALIAS_SEPARATOR
+	// What buildPlaceSearchFts emits for aliases ["York", "New City"] (note the trailing marker).
+	const separated = `York ${SEP} New City ${SEP}`
+
+	test("separated bag: per-alias equality, case/whitespace-insensitive", () => {
+		expect(aliasBagExactMatch(separated, "york", false)).toBe(true)
+		expect(aliasBagExactMatch(separated, "new city", false)).toBe(true)
+		expect(aliasBagExactMatch(separated, "city", false)).toBe(false) // interior fragment
+		expect(aliasBagExactMatch(separated, "york new", false)).toBe(false) // cross-boundary fragment
+	})
+
+	test("separated bag: ungated — an alias match counts even when another candidate is strictly exact", () => {
+		expect(aliasBagExactMatch(separated, "new city", true)).toBe(true)
+	})
+
+	test("legacy bag (no separator): padded containment, gated on anyStrictExact", () => {
+		const legacy = "York New City" // pre-#523 space-joined bag — boundaries lost
+		expect(aliasBagExactMatch(legacy, "new city", false)).toBe(true) // historical behavior preserved
+		expect(aliasBagExactMatch(legacy, "new city", true)).toBe(false) // the gate
+	})
+
+	test("null / empty bag and empty query never match", () => {
+		expect(aliasBagExactMatch(null, "york", false)).toBe(false)
+		expect(aliasBagExactMatch("", "york", false)).toBe(false)
+		expect(aliasBagExactMatch(separated, "", false)).toBe(false)
 	})
 })
 

--- a/resolver-wof-sqlite/fts.ts
+++ b/resolver-wof-sqlite/fts.ts
@@ -23,6 +23,91 @@ import type { DatabaseSync } from "node:sqlite"
 export const PLACE_SEARCH_TABLE = "place_search"
 
 /**
+ * Boundary-preserving separator between aliases in the `alt_names` bag (#523): U+E000, the first
+ * Private Use Area codepoint, written as an escape so the source stays plain ASCII.
+ *
+ * Why a PUA codepoint and not punctuation: the goal is to stop a phrase query from matching ACROSS
+ * two adjacent aliases' concatenation boundary ("York" + "New City" must not phrase-match `"york
+ * new"`). FTS5 assigns token positions to TOKENS only — separator characters never consume a
+ * position — so any character the tokenizer treats as a boundary leaves the two aliases' tokens
+ * adjacent and the false phrase match intact. The separator must therefore be an INDEXED TOKEN that
+ * sits between the aliases and breaks positional adjacency.
+ *
+ * Empirical probe (node:sqlite, `tokenize = 'unicode61 remove_diacritics 2'` — the exact config
+ * below). Bag = the aliases "York" and "New City" joined by each candidate separator; query = the
+ * cross-boundary phrase `MATCH '"york new"'`:
+ *
+ * - `' '` (the pre-#523 join, no separator) — false HIT
+ * - `' ; '` (punctuation) — false HIT
+ * - `' \u2016 '` (double vertical line) — false HIT
+ * - `' \x1F '` (ASCII unit separator) — false HIT
+ * - `' \uE000 '` (PUA, this constant) — NO match, while `'"york"'` and `'"new city"'` still match the
+ *   bag individually under every variant above.
+ *
+ * U+E000 works because unicode61 classifies it (category Co — neither space nor punctuation) as a
+ * token character, so the standalone `\uE000` between aliases is indexed as its own token and the
+ * aliases' tokens are no longer positionally adjacent. The remaining requirements also hold:
+ *
+ * - **Unreachable from queries**: `sanitizeFtsQuery` (Node + WASM resolvers) strips everything
+ *   outside `\p{L}\p{N}` from token bodies, and U+E000 is neither — no user query can ever address
+ *   the separator token. The demo's `sanitizeFts` strips it explicitly.
+ * - **Never in place names**: PUA codepoints are unassigned by definition; real-world WOF names don't
+ *   carry them. Defensively, the INSERT below also strips any embedded U+E000 from source names so
+ *   a poisoned row can't forge an alias boundary.
+ * - **Survives GROUP_CONCAT**: verified — `GROUP_CONCAT(name, ' ' || char(57344) || ' ')` emits the
+ *   codepoint intact (`57344` = 0xE000).
+ * - **Cost**: one extra token per alias boundary in the FTS document. Marginal BM25 length-norm
+ *   impact, on a column whose length stats are already the known #189 problem.
+ *
+ * Interaction with #189 (split `alt_names` into its own FTS table for independent BM25 length
+ * stats): the separator SURVIVES that split as proposed — #189 still GROUP_CONCATs all aliases into
+ * one `place_search_alt` row per place, so both the separator and the bag-parsing exact check
+ * (`aliasBagExactMatch`) carry over unchanged, just pointed at the new table. Only if #189 were
+ * instead built as one-row-per-alias would both become moot (per-alias rows give exact equality and
+ * phrase isolation for free). Sequencing: if #189 lands before the next slim-DB artifact rebuild,
+ * fold both into ONE rebuild rather than shipping two FTS schema bumps.
+ */
+export const ALIAS_SEPARATOR = "\uE000"
+
+/** `char()` argument for {@link ALIAS_SEPARATOR} in SQL — keeps the SQL text plain ASCII. */
+const ALIAS_SEPARATOR_CODEPOINT = ALIAS_SEPARATOR.codePointAt(0) as number
+
+/**
+ * Does any alias in an `alt_names` bag exactly equal the (already-normalized) query? The single
+ * shared implementation of the exact-tier alias check for every consumer of the bag — the Node
+ * resolver's `#exactMatchIds` fallback, the WASM resolver, and the demo's httpvfs resolver — so the
+ * bag format and its parsers can't drift.
+ *
+ * Two formats exist in the wild:
+ *
+ * - **Separated bags** (built since #523): aliases joined with {@link ALIAS_SEPARATOR}, plus a
+ *   trailing separator so even a single-alias bag self-identifies as separator-formatted. Split +
+ *   per-alias equality — a true exact-alias check, matching the semantics of the full `names` table
+ *   (`names.name = ? COLLATE NOCASE`), so it runs UNGATED: an alias match is an exact match whether
+ *   or not another candidate matched on its canonical name.
+ * - **Legacy bags** (pre-#523 artifacts, e.g. an already-deployed slim DB): aliases space-joined,
+ *   boundaries lost. Falls back to the historical padded-containment check, gated on
+ *   `anyStrictExact` — ungated containment would false-promote interior fragments ("York" inside
+ *   the alias "New York City") and cross-boundary fragments ("York New" across "…York" + "New…").
+ *   Delete this branch once every shipped artifact carries the separator.
+ *
+ * @param altNames The `alt_names` bag from `place_search` (null when the row has no aliases).
+ * @param normalizedQuery The query, pre-normalized: lowercased, trimmed, internal whitespace
+ *   collapsed (every consumer already normalizes this way).
+ * @param anyStrictExact Whether ANY candidate in the pool already matched strictly (canonical name
+ *   or region abbreviation). Only consulted for legacy bags.
+ */
+export function aliasBagExactMatch(altNames: string | null, normalizedQuery: string, anyStrictExact: boolean): boolean {
+	if (altNames === null || altNames === "" || !normalizedQuery) return false
+	const norm = (s: string): string => s.toLowerCase().trim().replace(/\s+/g, " ")
+	if (altNames.includes(ALIAS_SEPARATOR)) {
+		return altNames.split(ALIAS_SEPARATOR).some((alias) => norm(alias) === normalizedQuery)
+	}
+	if (anyStrictExact) return false
+	return ` ${norm(altNames)} `.includes(` ${normalizedQuery} `)
+}
+
+/**
  * Name of the R*Tree virtual table that indexes WOF places' bounding boxes for proximity / bbox
  * lookups. Built alongside `place_search` by the CLI and `buildFts: true`. Pure SQLite — no
  * extensions needed, the `rtree` virtual-table module ships with the core library.
@@ -112,12 +197,25 @@ export function buildPlaceSearchFts(db: DatabaseSync, opts: BuildPlaceSearchFtsO
 		// `-1` (modern Who's On First) and `1` (legacy Mapzen-era), both meaning "currently valid".
 		// Only `0` means "no longer current". Filtering on `= -1` strict (as Phase 4.2 did) excluded
 		// ~42% of admin-US and ~68% of postcode-US — see #91 for the diagnostic + magnitude.
+		//
+		// Aliases join on the boundary-preserving ALIAS_SEPARATOR token (#523) — space-padded so each
+		// alias still tokenizes normally — and any U+E000 embedded in a source name is defensively
+		// flattened to a space so it can't forge a boundary. A TRAILING separator marks the bag as
+		// separator-formatted even when it holds a single alias, so `aliasBagExactMatch` never
+		// mistakes a new bag for a legacy (pre-#523) one. See the ALIAS_SEPARATOR docs for the
+		// probe + rationale.
 		db.exec(`
 			INSERT INTO ${PLACE_SEARCH_TABLE} (wof_id, name, alt_names)
 			SELECT
 				spr.id,
 				spr.name,
-				COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM names WHERE names.id = spr.id), '')
+				COALESCE((
+					SELECT GROUP_CONCAT(
+						REPLACE(name, char(${ALIAS_SEPARATOR_CODEPOINT}), ' '),
+						' ' || char(${ALIAS_SEPARATOR_CODEPOINT}) || ' '
+					) || ' ' || char(${ALIAS_SEPARATOR_CODEPOINT})
+					FROM names WHERE names.id = spr.id
+				), '')
 			FROM spr
 			WHERE spr.is_current != 0
 				AND spr.is_deprecated = 0

--- a/resolver-wof-sqlite/lookup.test.ts
+++ b/resolver-wof-sqlite/lookup.test.ts
@@ -92,7 +92,9 @@ const FIXTURE: FixturePlace[] = [
 		country: "FR",
 		lat: 48.85,
 		lon: 2.34,
-		alt_names: ["Pari", "París", "パリ", "巴黎"],
+		// The canonical name also lives in `names` in a real WOF distribution — required for the
+		// exact-match tier (#exactMatchIds queries `names`, not `spr`). Same shape as Brooklyn below.
+		alt_names: ["Paris", "Pari", "París", "パリ", "巴黎"],
 		ancestor_ids: [85633723],
 	},
 	{
@@ -181,6 +183,21 @@ const FIXTURE: FixturePlace[] = [
 		country: "US",
 		lat: 45.11,
 		lon: -93.35,
+		ancestor_ids: [85633147],
+	},
+
+	// Alias-bag boundary fixture (#523): two aliases whose concatenation straddles the phrase
+	// "York New". The exact tier must never promote this place for that straddling query, while
+	// each alias on its own ("New City") still earns the exact tier.
+	{
+		id: 999000001,
+		parent_id: 85633147,
+		name: "Twin Hamlet",
+		placetype: "locality",
+		country: "US",
+		lat: 40.2,
+		lon: -76.8,
+		alt_names: ["Old York", "New City"],
 		ancestor_ids: [85633147],
 	},
 ]
@@ -331,12 +348,27 @@ describe("WofSqlitePlaceLookup against an inline WOF fixture", () => {
 	})
 
 	test("length penalty: short name beats long name for short query", async () => {
-		const candidates = await lookup.findPlace({ text: "Paris", country: "FR" })
-		const paris = candidates.find((c) => c.name === "Paris")
+		// Compare the ALIAS-FREE pair (Paris,US vs Paris-l'Hôpital,FR — both have empty alt_names
+		// bags) so this guards the NAME-column length penalty in isolation. Paris,FR is no longer a
+		// clean subject: its four aliases now carry four ALIAS_SEPARATOR tokens (#523), and that
+		// alias-doc length inflation drags its raw BM25 below the alias-free l'Hôpital row — the
+		// known shared-length-stats problem (#189), not the name-length penalty under test.
+		const candidates = await lookup.findPlace({ text: "Paris" })
+		const parisUs = candidates.find((c) => c.name === "Paris" && c.country === "US")
 		const parisLHopital = candidates.find((c) => c.name === "Paris-l'Hôpital")
-		expect(paris).toBeDefined()
+		expect(parisUs).toBeDefined()
 		expect(parisLHopital).toBeDefined()
-		expect(paris!.score).toBeGreaterThan(parisLHopital!.score)
+		expect(parisUs!.score).toBeGreaterThan(parisLHopital!.score)
+	})
+
+	test("exact-name tier keeps an alias-rich place above a partial match despite its longer alias doc (#523)", async () => {
+		// The user-visible guarantee for the pair the length-penalty test used to compare: Paris,FR's
+		// separator-inflated alias doc may cost it raw BM25, but "Paris" is an exact name match and
+		// the exact tier orders it above the partial-matching Paris-l'Hôpital regardless.
+		const candidates = await lookup.findPlace({ text: "Paris", country: "FR" })
+		const names = candidates.map((c) => c.name)
+		expect(names.indexOf("Paris")).toBeGreaterThanOrEqual(0)
+		expect(names.indexOf("Paris-l'Hôpital")).toBeGreaterThan(names.indexOf("Paris"))
 	})
 
 	test("limit defaults to 10, respected when specified", async () => {
@@ -368,6 +400,27 @@ describe("WofSqlitePlaceLookup against an inline WOF fixture", () => {
 			const candidates = await lookup2.findPlace({ text: "Brooklyn", placetype: "locality" })
 			expect(candidates[0]).toMatchObject({ id: 421205765, name: "Brooklyn", placetype: "borough" })
 			expect(candidates[0]?.exactMatch).toBe(true)
+		} finally {
+			lookup2.close()
+			db.close()
+		}
+	})
+
+	test("alias-bag boundary: a query straddling two aliases is never exact on a names-less DB (#523)", async () => {
+		// "York New" straddles the bag "Old York <sep> New City": its tokens AND-match the row, but
+		// the exact tier must NOT promote it. Pre-#523 the bag was space-joined and the padded
+		// containment check (' old york new city ' ⊇ ' york new ') false-promoted exactly this shape.
+		const db = buildFixtureDb()
+		const withFts = new WofSqlitePlaceLookup({ database: db, buildFts: true })
+		withFts.close()
+		db.exec(`DROP TABLE names`)
+		const lookup2 = new WofSqlitePlaceLookup({ database: db })
+		try {
+			const straddle = await lookup2.findPlace({ text: "York New", placetype: "locality" })
+			expect(straddle.some((c) => c.exactMatch === true)).toBe(false)
+			// A single alias still earns the exact tier from the bag alone.
+			const alias = await lookup2.findPlace({ text: "New City", placetype: "locality" })
+			expect(alias[0]).toMatchObject({ id: 999000001, exactMatch: true })
 		} finally {
 			lookup2.close()
 			db.close()

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -29,6 +29,7 @@ import {
 import { ancestorLineage } from "./ancestry.js"
 import { COINCIDENT_ROLES_TABLE, coincidentRolesExists } from "./coincident-roles.js"
 import {
+	aliasBagExactMatch,
 	buildPlaceSearchFts,
 	PLACE_BBOX_TABLE,
 	PLACE_POPULATION_TABLE,
@@ -915,9 +916,9 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 * Among `ids`, return the subset whose name OR any alias equals `text` case-insensitively — the
 	 * exact-match tier for ranking. One indexed query over `<schema>.names`. When the shard has no
 	 * `names` table (a slim DB built with `dropNames`, or a postcode-only shard), fall back to the
-	 * self-contained `place_search` FTS content: its `alt_names` column is the same alias set,
-	 * space-joined into one token bag, so a whitespace-boundary containment check recovers the alias
-	 * tier ("New York City" → New York) that the dropped `names` table used to provide.
+	 * self-contained `place_search` FTS content: its `alt_names` column is the same alias set joined
+	 * on the boundary-preserving `ALIAS_SEPARATOR` (#523), so `aliasBagExactMatch` recovers the exact
+	 * alias tier ("New York City" → New York) that the dropped `names` table used to provide.
 	 */
 	#exactMatchIds(schemaName: string, ids: number[], text: string): Set<number> {
 		const out = new Set<number>()
@@ -946,14 +947,15 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 			for (const r of rows) {
 				if (r.name !== null && norm(r.name) === needle) out.add(r.id)
 			}
-			// Alias pass, only when NO canonical name matched: alt_names is all aliases space-joined
-			// (name boundaries are lost), so a padded substring check would false-promote interior
-			// fragments ("York" inside the alias "New York City"). Gating it on "no canonical exact in
-			// the pool" confines it to the genuine alias-query case ("New York City" itself).
-			if (out.size === 0) {
-				for (const r of rows) {
-					if (r.alt_names !== null && ` ${norm(r.alt_names)} `.includes(` ${needle} `)) out.add(r.id)
-				}
+			// Alias pass via the shared bag parser (#523). Separated bags (built since #523) get a true
+			// per-alias equality check, ungated — matching the `names`-table branch above, where an
+			// alias match counts as exact regardless of other candidates. Legacy bags (no separator)
+			// fall back to padded containment, gated on "no canonical exact in the pool" because their
+			// lost boundaries would otherwise false-promote interior fragments ("York" inside the alias
+			// "New York City") or cross-alias fragments ("York New" across "…York" + "New City…").
+			const anyCanonicalExact = out.size > 0
+			for (const r of rows) {
+				if (aliasBagExactMatch(r.alt_names, needle, anyCanonicalExact)) out.add(r.id)
 			}
 		} catch {
 			// Shard without place_search either → no exact-match tier. Falls back to weighted-sum order.

--- a/resolver-wof-wasm/lookup.test.ts
+++ b/resolver-wof-wasm/lookup.test.ts
@@ -70,6 +70,12 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO names (id, language, name) VALUES (221, 'eng', 'New York City');
 		INSERT INTO names (id, language, name) VALUES (230, 'eng', 'Brooklyn');
 		INSERT INTO names (id, language, name) VALUES (231, 'eng', 'Brooklyn Park');
+		-- Alias-bag boundary fixture (#523): two aliases whose concatenation straddles the phrase
+		-- "York New". The boundary-preserving separator must keep the exact tier from promoting this
+		-- place (or 'New York', whose alias bag also straddles it) for the straddling query.
+		INSERT INTO spr VALUES (240, 101, 'Twin Hamlet', 'locality', 'US', 40.2, -76.8, 40.1, 40.3, -76.9, -76.7, -1, 0);
+		INSERT INTO names (id, language, name) VALUES (240, 'eng', 'Old York');
+		INSERT INTO names (id, language, name) VALUES (240, 'eng', 'New City');
 
 		-- Pre-built population aux table (production shape — build-unified-wof extracts wof:population
 		-- here at ingest; the source has no geojson table). Postcodes (300/301) carry no population row.
@@ -83,6 +89,7 @@ function buildFixtureWof(path: string): void {
 		INSERT INTO place_population VALUES (221, 8400000);
 		INSERT INTO place_population VALUES (230, 2504700);
 		INSERT INTO place_population VALUES (231, 82000);
+		INSERT INTO place_population VALUES (240, 50);
 
 		-- Region abbreviation tiering (#189): 'Vermontstate' (tiny pop) carries the exact abbrev 'VT';
 		-- 'Vt Plains' (huge pop) only TOKEN-matches "vt". build-slim materializes place_abbr (110→VT) so
@@ -249,6 +256,26 @@ describe("WofWasmPlaceLookup", () => {
 			expect(matches[0]).toMatchObject({ id: 221, name: "New York" })
 			// The alias lives only in the FTS alt_names bag on a slim DB — the tier must consult it.
 			expect(matches[0]?.exactMatch).toBe(true)
+		} finally {
+			lookup.close()
+		}
+	})
+
+	test('alias-bag boundary: "York New" straddling two aliases never claims the exact tier (#523)', async () => {
+		const { db } = await loadSlimWofDatabase({ source: slimBytes })
+		const lookup = new WofWasmPlaceLookup({ db })
+		try {
+			// "York New" token-matches both Twin Hamlet (bag "Old York <sep> New City") and New York
+			// (name + alias "New York City"). Pre-#523, the space-joined bags let the padded containment
+			// check false-promote BOTH (' old york new city ' and ' new york new york city ' each
+			// contain ' york new '). With the separator, no candidate may claim the exact tier.
+			const straddle = await lookup.findPlace({ text: "York New", placetype: "locality", limit: 5 })
+			expect(straddle.length).toBeGreaterThan(0) // still token-reachable…
+			expect(straddle.some((m) => m.exactMatch === true)).toBe(false) // …but never exact
+			// A single alias still earns the exact tier from the bag alone.
+			const alias = await lookup.findPlace({ text: "New City", placetype: "locality", limit: 5 })
+			expect(alias[0]).toMatchObject({ id: 240, name: "Twin Hamlet" })
+			expect(alias[0]?.exactMatch).toBe(true)
 		} finally {
 			lookup.close()
 		}

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -22,6 +22,9 @@ import type { Database } from "@sqlite.org/sqlite-wasm"
 
 import { expandPlacetypeFilter, type CoincidentLocality } from "@mailwoman/core/resolver"
 import type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WofPlacetype } from "@mailwoman/resolver-wof-sqlite"
+// Browser-safe subpath import (fts.ts's only node:sqlite import is type-only) — the shared
+// alias-bag parser keeps this backend's exact tier byte-identical to the Node resolver's.
+import { aliasBagExactMatch } from "@mailwoman/resolver-wof-sqlite/fts"
 
 export interface WofWasmPlaceLookupOpts {
 	/** Open `@sqlite.org/sqlite-wasm` Database (from `loadSlimWofDatabase`). */
@@ -177,15 +180,14 @@ export class WofWasmPlaceLookup implements PlaceLookup {
 		const anyStrictExact = rows.some(strictExact)
 		return rows
 			.map((row) => {
-				// Alias tier: `alt_names` is the FTS row's alias bag (all `names` rows space-joined — the
-				// slim DB's only surviving alias source). Name boundaries are LOST in the bag, so a
-				// whitespace-boundary containment check would false-promote interior fragments ("York"
-				// matches inside the alias "New York City"). It therefore only engages when NO candidate
-				// is strictly exact — the "New York City" case, where the query is an alias WOF carries
-				// for the New York locality but no spr row bears the name. Mirrors the Node resolver's
-				// alias tier (`WofSqlitePlaceLookup.#exactMatchIds`).
-				const aliasExact =
-					!anyStrictExact && row.alt_names !== null && ` ${normalizeName(row.alt_names)} `.includes(` ${normQuery} `)
+				// Alias tier: `alt_names` is the FTS row's alias bag (the slim DB's only surviving alias
+				// source), aliases joined on the boundary-preserving ALIAS_SEPARATOR (#523). The shared
+				// parser does a true per-alias equality check, ungated; on a LEGACY bag (pre-#523 slim
+				// artifact, boundaries lost) it falls back to padded containment gated on "no strictly
+				// exact candidate" so interior fragments ("York" inside "New York City") can't be
+				// false-promoted. Mirrors the Node resolver's alias tier
+				// (`WofSqlitePlaceLookup.#exactMatchIds`).
+				const aliasExact = aliasBagExactMatch(row.alt_names, normQuery, anyStrictExact)
 				const exactTier = strictExact(row) || aliasExact ? 0 : 1
 				const popBoost =
 					row.population && row.population > 0


### PR DESCRIPTION
The last v0.5.0 passenger's code side. The issue's premise needed **inverting**, and the agent proved it empirically before choosing:

## The finding

A character the FTS5 tokenizer treats as a *boundary* does NOT fix false phrase adjacency — FTS5 assigns positions to tokens only; separator characters never consume a position. Plain space, `;`, `‖`, even ASCII 0x1F all left the cross-boundary phrase (`"york new"` against the bag `York` + `New City`) matching. **U+E000** (Private Use Area) works because unicode61 classifies it as a token *character*: the standalone separator indexes as its own token and breaks positional adjacency (phrase → 0 hits), while each alias still matches individually. Unreachable from queries (sanitizers strip non-letter/number; the demo's denylist now strips it explicitly), survives GROUP_CONCAT, embedded occurrences in source names defensively flattened. Full probe table in the `ALIAS_SEPARATOR` doc block.

## Implementation

- One build path (`buildPlaceSearchFts`, shared by lazy-build / FTS CLI / build-slim); bags carry a trailing marker so they self-identify as separator-formatted vs legacy.
- Exact-tier bag parsing consolidated into one shared `aliasBagExactMatch` used by all three consumers (Node lookup, WASM lookup, the demo's httpvfs resolver) — separated bags get true per-alias equality ungated; legacy bags keep the old gated containment until artifacts rebuild.
- **#189 interaction recorded**: #189 as proposed still GROUP_CONCATs per place, so nothing here becomes moot — separator + parser carry over to the new table; fold both into ONE rebuild if #189 lands before the next slim-DB pass.

## Stated re-baseline (one test)

The lookup length-penalty test now compares an alias-free pair: the separator tokens lengthen Paris-FR's alias doc and flipped its raw BM25 vs an alias-free row — that's the #189 length-stats problem, not the penalty under test. The user-visible ordering for the original pair is asserted by a new exact-tier test instead.

Tests: false-adjacency regression at three levels (raw FTS / Node / WASM), single-alias exact-tier preserved, legacy gating units, poisoned-name test — 212 green across both resolver suites. **Artifact-pending**: deployed DBs run the legacy fallback until the v0.5.0 artifact pass rebuilds them, after which the legacy branch deletes.

Part of #523 (item 2 of the issue untouched, noted there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)