### PR TITLE
feat(pipeline): Stage 2.7 span proposer — both v0-win quadrants closed, default-OFF (#518)

### DIFF
--- a/core/pipeline/index.ts
+++ b/core/pipeline/index.ts
@@ -17,6 +17,8 @@ export type {
 	ScoreBreakdown,
 } from "./reconcile.js"
 export { runPipeline } from "./runtime-pipeline.js"
+export { EMPTY_SPAN_PROPOSER_LEXICON, proposeSpans } from "./span-proposer.js"
+export type { ProposedSpan, ProposedSpanKind, SpanProposerLexicon } from "./span-proposer.js"
 export { aggregateSpanLogits } from "./span-logit-aggregation.js"
 export type { SpanBounds, TokenPiece } from "./span-logit-aggregation.js"
 export type {

--- a/core/pipeline/span-proposer.test.ts
+++ b/core/pipeline/span-proposer.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Contract tests for the Stage 2.7 span proposer (M2 + M3). Load-bearing properties: unbalanced
+ *   delimiters NEVER propose; annotation confidence follows content shape (trailing-country groups
+ *   stay below consumer floors); dual-path numeric readings emit BOTH alternatives under one group;
+ *   designator proposals are codex-conditioned and suppressed inside confident annotations.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { EMPTY_SPAN_PROPOSER_LEXICON, proposeSpans, type SpanProposerLexicon } from "./span-proposer.js"
+
+/** Codex-shaped fixture lexicon (the real one is built from @mailwoman/codex in neural). */
+const LEXICON: SpanProposerLexicon = {
+	systems: new Set(["us", "au", "nz"]),
+	unitDesignators: new Set(["apt", "apartment", "suite", "ste", "unit", "rm", "room", "bldg", "building"]),
+	levelDesignators: new Set(["fl", "floor", "bsmt", "basement"]),
+	weakDesignators: new Set(["bldg", "building"]),
+	deliveryService: /\b(?:p\.?\s*o\.?\s*box|gpo\s+box|private\s+bag|locked\s+bag)\s*#?\s*(\d[\dA-Za-z-]*)\b/gi,
+}
+
+const usOnly: SpanProposerLexicon = { ...LEXICON, systems: new Set(["us"]) }
+
+describe("paired delimiters (M2)", () => {
+	it("proposes ANNOTATION_SPAN for balanced parens with aside-shaped content", () => {
+		const text = "42 Wallaby Way (rear entrance), Sydney NSW 2000"
+		const spans = proposeSpans(text, EMPTY_SPAN_PROPOSER_LEXICON)
+		const ann = spans.filter((s) => s.kind === "ANNOTATION_SPAN")
+		expect(ann).toHaveLength(1)
+		expect(text.slice(ann[0]!.start, ann[0]!.end)).toBe("(rear entrance)")
+		expect(ann[0]!.confidence).toBeGreaterThanOrEqual(0.9)
+	})
+
+	it("scores a trailing short capitalized group BELOW the consumer floor (paren-component shape)", () => {
+		const spans = proposeSpans("42 Wallaby Way, Sydney, NSW 2000 (Australia)", EMPTY_SPAN_PROPOSER_LEXICON)
+		const ann = spans.find((s) => s.kind === "ANNOTATION_SPAN")
+		expect(ann).toBeDefined()
+		expect(ann!.confidence).toBeLessThan(0.6)
+	})
+
+	it("emits NO proposal for unbalanced delimiters — never guess the missing pair", () => {
+		expect(proposeSpans('Joe\'s "Pizza, 12 Main St', EMPTY_SPAN_PROPOSER_LEXICON)).toHaveLength(0)
+		expect(proposeSpans("12 Main St (rear entrance, Springfield", EMPTY_SPAN_PROPOSER_LEXICON)).toHaveLength(0)
+		expect(proposeSpans("12 Main St ]oops[ Springfield", EMPTY_SPAN_PROPOSER_LEXICON)).toHaveLength(0)
+	})
+
+	it("proposes QUOTED_SPAN for balanced double quotes", () => {
+		const text = '"Big Company HQ", 100 Business Ave, Los Angeles, CA 90001'
+		const spans = proposeSpans(text, EMPTY_SPAN_PROPOSER_LEXICON)
+		const q = spans.filter((s) => s.kind === "QUOTED_SPAN")
+		expect(q).toHaveLength(1)
+		expect(text.slice(q[0]!.start, q[0]!.end)).toBe('"Big Company HQ"')
+	})
+
+	it("keeps a bracketed strong designator+id OUT of the annotation read ([Suite 9] is a unit)", () => {
+		const text = "212 Stuart St [Suite 9], Boston, MA 02116"
+		const spans = proposeSpans(text, LEXICON)
+		const ann = spans.find((s) => s.kind === "ANNOTATION_SPAN")
+		expect(ann!.confidence).toBeLessThan(0.6)
+		const unit = spans.find((s) => s.kind === "UNIT_PHRASE")
+		expect(unit).toBeDefined()
+		expect(text.slice(unit!.start, unit!.end)).toBe("Suite 9")
+	})
+
+	it("treats a bracketed WEAK designator as annotation ([Building A] describes)", () => {
+		const text = "100 Business Ave [Building A], Suite 500, Los Angeles, CA 90001"
+		const spans = proposeSpans(text, LEXICON)
+		const ann = spans.find((s) => s.kind === "ANNOTATION_SPAN")
+		expect(ann!.confidence).toBeGreaterThanOrEqual(0.6)
+		// The "Building A" unit proposal is suppressed inside the confident annotation…
+		const units = spans.filter((s) => s.kind === "UNIT_PHRASE")
+		// …but the real "Suite 500" outside it survives.
+		expect(units).toHaveLength(1)
+		expect(text.slice(units[0]!.start, units[0]!.end)).toBe("Suite 500")
+	})
+
+	it("suppresses designator phrases inside a confident annotation ((Apt 4 around back))", () => {
+		const text = "123 Main St (Apt 4 around back) Springfield IL 62701"
+		const spans = proposeSpans(text, LEXICON)
+		expect(spans.filter((s) => s.kind === "UNIT_PHRASE")).toHaveLength(0)
+		expect(spans.find((s) => s.kind === "ANNOTATION_SPAN")!.confidence).toBeGreaterThanOrEqual(0.6)
+	})
+
+	it("does NOT suppress designator phrases inside quotes (quotes wrap names)", () => {
+		const text = '123 Main St, "Apartment 4B", New York, NY 10001'
+		const spans = proposeSpans(text, LEXICON)
+		const unit = spans.find((s) => s.kind === "UNIT_PHRASE")
+		expect(unit).toBeDefined()
+		expect(text.slice(unit!.start, unit!.end)).toBe("Apartment 4B")
+	})
+})
+
+describe("designator + identifier", () => {
+	it("proposes UNIT_PHRASE and PO_BOX_PHRASE from the lexicon tables", () => {
+		const text = "PO Box 19, Apt 4B, Springfield"
+		const spans = proposeSpans(text, LEXICON)
+		const po = spans.find((s) => s.kind === "PO_BOX_PHRASE")
+		expect(text.slice(po!.start, po!.end)).toBe("PO Box 19")
+		const unit = spans.find((s) => s.kind === "UNIT_PHRASE")
+		expect(text.slice(unit!.start, unit!.end)).toBe("Apt 4B")
+	})
+
+	it("proposes LEVEL_PHRASE for level-class designators", () => {
+		const text = "Floor 3, 100 Main St"
+		const spans = proposeSpans(text, LEXICON)
+		const level = spans.find((s) => s.kind === "LEVEL_PHRASE")
+		expect(text.slice(level!.start, level!.end)).toBe("Floor 3")
+	})
+
+	it("emits nothing without a lexicon (codex-conditioned)", () => {
+		expect(proposeSpans("PO Box 19, Apt 4B", EMPTY_SPAN_PROPOSER_LEXICON)).toHaveLength(0)
+	})
+})
+
+describe("dual-path numeric readings (M3)", () => {
+	it("emits BOTH readings for a designator-led slash compound (Unit 4/22)", () => {
+		const text = "Unit 4/22 Smith St, Melbourne VIC 3000"
+		const spans = proposeSpans(text, LEXICON)
+		const unit = spans.find((s) => s.kind === "SPLIT_UNIT")!
+		const hn = spans.find((s) => s.kind === "SPLIT_HOUSE_NUMBER")!
+		const fused = spans.find((s) => s.kind === "FUSED_NUMBER")!
+		expect(text.slice(unit.start, unit.end)).toBe("Unit 4")
+		expect(text.slice(hn.start, hn.end)).toBe("22")
+		expect(text.slice(fused.start, fused.end)).toBe("4/22")
+		// All three are alternatives of one surface.
+		expect(new Set([unit.alternativeGroup, hn.alternativeGroup, fused.alternativeGroup]).size).toBe(1)
+		expect(unit.confidence).toBeGreaterThan(fused.confidence)
+	})
+
+	it("covers the AU leading-designator shape without vocabulary (Flat 2/14)", () => {
+		const text = "Flat 2/14 Ponsonby Rd, Auckland 1011"
+		const spans = proposeSpans(text, LEXICON)
+		const unit = spans.find((s) => s.kind === "SPLIT_UNIT")!
+		expect(text.slice(unit.start, unit.end)).toBe("Flat 2")
+		const hn = spans.find((s) => s.kind === "SPLIT_HOUSE_NUMBER")!
+		expect(text.slice(hn.start, hn.end)).toBe("14")
+	})
+
+	it("splits a bare leading compound only when AU/NZ tables are loaded (3/45 Wattle St)", () => {
+		const text = "3/45 Wattle St, Ultimo NSW 2007"
+		const auSpans = proposeSpans(text, LEXICON)
+		expect(auSpans.some((s) => s.kind === "SPLIT_UNIT")).toBe(true)
+		const usSpans = proposeSpans(text, usOnly)
+		expect(usSpans.some((s) => s.kind === "SPLIT_UNIT")).toBe(false)
+	})
+
+	it("fuses the USPS half address (123 1/2) — no split reading", () => {
+		const text = "123 1/2 Main St, Springfield, IL 62701"
+		const spans = proposeSpans(text, LEXICON)
+		const fused = spans.find((s) => s.kind === "FUSED_NUMBER")!
+		expect(text.slice(fused.start, fused.end)).toBe("123 1/2")
+		expect(spans.some((s) => s.kind === "SPLIT_UNIT")).toBe(false)
+	})
+
+	it("fuses the trailing European slash form (Hauptstraße 14/2) and skips short leaders (Hwy 50/89)", () => {
+		const de = proposeSpans("Hauptstraße 14/2, 70173 Stuttgart", LEXICON)
+		const fused = de.find((s) => s.kind === "FUSED_NUMBER")
+		expect(fused).toBeDefined()
+		expect(de.some((s) => s.kind === "SPLIT_UNIT")).toBe(false)
+		// "Hwy" (3 chars) is below the trailing-fused guard; "50/89" is part of the street.
+		const hwy = proposeSpans("Hwy 50/89 Junction, South Lake Tahoe, CA 96150", LEXICON)
+		expect(hwy.filter((s) => s.kind !== "ANNOTATION_SPAN" && s.kind !== "QUOTED_SPAN")).toHaveLength(0)
+	})
+
+	it("never proposes a reading for the ZIP+4 hyphen shape", () => {
+		const spans = proposeSpans("100 Main St, Springfield, IL 62701-1234", LEXICON)
+		expect(spans.filter((s) => s.kind === "FUSED_NUMBER")).toHaveLength(0)
+	})
+
+	it("fuses a hyphen compound in house-number position (69-10 47th Ave)", () => {
+		const text = "69-10 47th Ave, Queens, NY 11377"
+		const spans = proposeSpans(text, LEXICON)
+		const fused = spans.find((s) => s.kind === "FUSED_NUMBER")!
+		expect(text.slice(fused.start, fused.end)).toBe("69-10")
+	})
+})
+
+describe("degenerate inputs", () => {
+	it("returns [] on empty input", () => {
+		expect(proposeSpans("", LEXICON)).toEqual([])
+	})
+
+	it("returns proposals sorted by start", () => {
+		const spans = proposeSpans("PO Box 19 (rear), Apt 4B", LEXICON)
+		const starts = spans.map((s) => s.start)
+		expect(starts).toEqual([...starts].sort((a, b) => a - b))
+	})
+})

--- a/core/pipeline/span-proposer.ts
+++ b/core/pipeline/span-proposer.ts
@@ -1,0 +1,511 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Stage 2.7 span proposer — mechanisms M2 + M3 from the punctuation survey
+ *   (`docs/articles/reviews/2026-06-11-punctuation-survey.md`), the structural half of the
+ *   sub-premise direction note (`docs/articles/plan/2026-06-11-subpremise-proposer-direction.md`).
+ *
+ *   A pure function over the raw input emitting TYPED span proposals from three cue families:
+ *
+ *   1. **Paired delimiters (M2)** — balanced `()`, `[]`, `""`, `«»`, `„“` groups propose
+ *      `ANNOTATION_SPAN` / `QUOTED_SPAN`. Unbalanced delimiters of a class produce NO proposal for
+ *      that class — the proposer never guesses a missing pair (graceful degradation to today's
+ *      behavior, per the survey's unbalanced-class read).
+ *   2. **Designator + identifier** — the sub-premise grammar (`Apt 4B`, `Suite 500`, `PO Box 19`):
+ *      a closed-vocabulary leader from the injected codex-backed lexicon followed by a short
+ *      identifier proposes `UNIT_PHRASE` / `LEVEL_PHRASE` / `PO_BOX_PHRASE`.
+ *   3. **Dual-path numeric punctuation (M3, the Pelias PR #56 mechanism)** — `2/14`, `14-16`,
+ *      `123 1/2` adjacent to a number context emit BOTH readings as alternatives sharing an
+ *      `alternativeGroup`: the fused single-value reading (`FUSED_NUMBER`) AND the designator-split
+ *      reading (`SPLIT_UNIT` + `SPLIT_HOUSE_NUMBER`), locale-conditioned by which codex systems the
+ *      lexicon was built from (the AU/NZ `Flat 2/14` split exists only when those tables are
+ *      loaded). The proposer never decides between readings — downstream consumers weigh them.
+ *
+ *   The proposals are INFORMATION, not decisions (the #464 lesson): consumers treat them as phrase
+ *   priors the classifier conditions on and as structural boundaries the decode-side span bridge
+ *   must not merge across. The classifier can always disagree.
+ *
+ *   Like the phrase grouper's rules, the cues here are structural + provenance-tracked vocabulary
+ *   (codex tables injected by the caller) — no place names, no guessed designators. Core stays
+ *   codex-free: `@mailwoman/neural` builds the {@link SpanProposerLexicon} from `@mailwoman/codex`
+ *   (see `neural/span-proposer-lexicon.ts`).
+ */
+
+/** Typed kinds a span proposal may carry. See the module doc for the three cue families. */
+export type ProposedSpanKind =
+	/** A balanced `()`/`[]` group whose content reads as an aside about the address. */
+	| "ANNOTATION_SPAN"
+	/** A balanced quote group — the content is likely a NAME (venue/unit); typing is the classifier's job. */
+	| "QUOTED_SPAN"
+	/** Delivery-service designator + identifier ("PO Box 19", "GPO Box 2890", "Private Bag 7"). */
+	| "PO_BOX_PHRASE"
+	/** Secondary-unit designator + identifier ("Apt 4B", "Suite 500"). */
+	| "UNIT_PHRASE"
+	/** Level-class designator + identifier ("Floor 3", "FL 12"). */
+	| "LEVEL_PHRASE"
+	/** Dual-path FUSED reading: the punctuated numeric is ONE value ("123 1/2", "69-10", "14/2"). */
+	| "FUSED_NUMBER"
+	/** Dual-path SPLIT reading, left side: the sub-premise ("Flat 2" of "Flat 2/14", "3" of "3/45"). */
+	| "SPLIT_UNIT"
+	/** Dual-path SPLIT reading, right side: the house number ("14" of "Flat 2/14"). */
+	| "SPLIT_HOUSE_NUMBER"
+
+/** One typed span proposal. Char offsets into the raw input; `end` exclusive. */
+export interface ProposedSpan {
+	start: number
+	end: number
+	kind: ProposedSpanKind
+	/** 0..1. Confidence is shape-derived; consumers weight or floor it (it is never a verdict). */
+	confidence: number
+	/**
+	 * Alternative readings of ONE surface share a group id (M3 dual-path: the fused and split
+	 * readings of `2/14` carry the same group). Absent for single-reading proposals.
+	 */
+	alternativeGroup?: number
+	/** Provenance: which cue family + rule emitted this ("paired:()", "designator:unit", "slash:au-split"). */
+	source: string
+}
+
+/**
+ * Vocabulary the proposer conditions on — built from `@mailwoman/codex` tables by the caller
+ * (`buildCodexSpanLexicon` in `@mailwoman/neural`). All token sets are lowercase. An empty lexicon
+ * (the default) limits the proposer to the paired-delimiter cue family.
+ */
+export interface SpanProposerLexicon {
+	/** Codex system codes the lexicon was built from ("us", "au", "nz", …) — drives M3 locale conditioning. */
+	systems: ReadonlySet<string>
+	/** Leading secondary-unit designator tokens (USPS Pub-28 C2 variants: "apt", "ste", "unit", …). */
+	unitDesignators: ReadonlySet<string>
+	/** Level-class designator tokens ("floor", "fl", "bsmt", "ph", …) — typed LEVEL_PHRASE. */
+	levelDesignators: ReadonlySet<string>
+	/**
+	 * Descriptive designators ("building", "rear", "side", …) that, inside a bracketed group, read
+	 * as annotation content rather than a unit ("[Building A]" describes; "[Suite 9]" addresses).
+	 */
+	weakDesignators: ReadonlySet<string>
+	/**
+	 * Global scan regex for delivery-service designator+identifier phrases, built from the codex
+	 * po_box / delivery-service tables. Must carry the `g` flag.
+	 */
+	deliveryService?: RegExp
+}
+
+/** Empty lexicon — paired-delimiter proposals only. */
+export const EMPTY_SPAN_PROPOSER_LEXICON: SpanProposerLexicon = {
+	systems: new Set(),
+	unitDesignators: new Set(),
+	levelDesignators: new Set(),
+	weakDesignators: new Set(),
+}
+
+// ---------------------------------------------------------------------------
+// Tokenization (offset-preserving, punctuation-stripped match bodies)
+// ---------------------------------------------------------------------------
+
+interface RawToken {
+	/** Whitespace-delimited body as written. */
+	body: string
+	start: number
+	end: number
+	/** Body with leading/trailing punctuation stripped (for matching); offsets of the stripped core. */
+	stripped: string
+	strippedStart: number
+	strippedEnd: number
+}
+
+const EDGE_PUNCT = /[\s,;:.()[\]"'«»„“”]/
+
+function tokenize(text: string): RawToken[] {
+	const out: RawToken[] = []
+	let i = 0
+	while (i < text.length) {
+		while (i < text.length && /\s/.test(text[i]!)) i++
+		if (i >= text.length) break
+		const start = i
+		while (i < text.length && !/\s/.test(text[i]!)) i++
+		const body = text.slice(start, i)
+		let s = 0
+		let e = body.length
+		while (s < e && EDGE_PUNCT.test(body[s]!)) s++
+		while (e > s && EDGE_PUNCT.test(body[e - 1]!)) e--
+		out.push({
+			body,
+			start,
+			end: i,
+			stripped: body.slice(s, e),
+			strippedStart: start + s,
+			strippedEnd: start + e,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Cue family 1 — paired delimiters (M2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find balanced pairs for one open/close class. Returns null when ANY delimiter of the class is
+ * unbalanced (stray opener or closer) — the caller emits nothing for the class.
+ */
+function findBalancedPairs(text: string, open: string, close: string): Array<{ open: number; close: number }> | null {
+	const stack: number[] = []
+	const out: Array<{ open: number; close: number }> = []
+	for (let i = 0; i < text.length; i++) {
+		const ch = text[i]!
+		if (ch === open) stack.push(i)
+		else if (ch === close) {
+			const o = stack.pop()
+			if (o === undefined) return null
+			out.push({ open: o, close: i })
+		}
+	}
+	return stack.length > 0 ? null : out
+}
+
+/** Same-character quote pairing ("…"): consecutive occurrences pair up; an odd count is unbalanced. */
+function findSameCharPairs(text: string, ch: string): Array<{ open: number; close: number }> | null {
+	const positions: number[] = []
+	for (let i = 0; i < text.length; i++) if (text[i] === ch) positions.push(i)
+	if (positions.length % 2 !== 0) return null
+	const out: Array<{ open: number; close: number }> = []
+	for (let i = 0; i < positions.length; i += 2) out.push({ open: positions[i]!, close: positions[i + 1]! })
+	return out
+}
+
+/**
+ * Shape-derived annotation confidence (M2: "confidence from balance + content shape"):
+ *
+ * - Content that is EXACTLY a strong designator + identifier ("Suite 9") is probably a real
+ *   component written in brackets (gold convention 2) → very low annotation confidence, letting the
+ *   designator cue own the span.
+ * - Lowercase- or digit-leading content ("rear entrance", "2nd floor", "code 2580") is the
+ *   instruction/aside shape → high.
+ * - A short capitalized group at the very END of the input ("(Australia)", "[New Zealand]") is the
+ *   trailing-component shape (often a country) → low, below typical consumer floors.
+ * - Everything else (capitalized mid-string: "[Building A]", "(The White House)") → moderate.
+ */
+function annotationConfidence(content: string, atEndOfInput: boolean, lexicon: SpanProposerLexicon): number {
+	const tokens = content.split(/\s+/).filter(Boolean)
+	if (tokens.length === 0) return 0
+	if (tokens.length === 2) {
+		const lead = tokens[0]!.toLowerCase().replace(/\.$/, "")
+		const strong =
+			(lexicon.unitDesignators.has(lead) || lexicon.levelDesignators.has(lead)) && !lexicon.weakDesignators.has(lead)
+		if (strong && isShortIdentifier(tokens[1]!)) return 0.25
+	}
+	if (/^[\p{Ll}0-9]/u.test(content)) return 0.9
+	if (atEndOfInput && tokens.length <= 3) return 0.45
+	return 0.75
+}
+
+function proposePairedDelimiters(text: string, lexicon: SpanProposerLexicon): ProposedSpan[] {
+	const out: ProposedSpan[] = []
+	const lastNonSpace = text.trimEnd().length
+
+	const bracketClasses: Array<[string, string]> = [
+		["(", ")"],
+		["[", "]"],
+	]
+	for (const [open, close] of bracketClasses) {
+		const pairs = findBalancedPairs(text, open, close)
+		if (!pairs) continue // unbalanced — never guess the missing pair
+		for (const p of pairs) {
+			const content = text.slice(p.open + 1, p.close).trim()
+			if (!content) continue
+			const atEnd = p.close >= lastNonSpace - 1
+			out.push({
+				start: p.open,
+				end: p.close + 1,
+				kind: "ANNOTATION_SPAN",
+				confidence: annotationConfidence(content, atEnd, lexicon),
+				source: `paired:${open}${close}`,
+			})
+		}
+	}
+
+	const quotePairFinders: Array<() => Array<{ open: number; close: number }> | null> = [
+		() => findSameCharPairs(text, '"'),
+		() => findBalancedPairs(text, "“", "”"), // “ ”
+		() => findBalancedPairs(text, "«", "»"), // « »
+		// „…“ (low-9 opener, German/Czech): closes with “ — only scanned when a „ is present, so the
+		// “ ” class above (which would see a stray “) is skipped for such inputs.
+	]
+	const hasLow9 = text.includes("„")
+	for (const [idx, find] of quotePairFinders.entries()) {
+		if (hasLow9 && idx === 1) continue
+		const pairs = find()
+		if (!pairs) continue
+		for (const p of pairs) {
+			const content = text.slice(p.open + 1, p.close).trim()
+			if (!content) continue
+			out.push({ start: p.open, end: p.close + 1, kind: "QUOTED_SPAN", confidence: 0.8, source: "paired:quote" })
+		}
+	}
+	if (hasLow9) {
+		const pairs = findBalancedPairs(text, "„", "“")
+		if (pairs) {
+			for (const p of pairs) {
+				const content = text.slice(p.open + 1, p.close).trim()
+				if (!content) continue
+				out.push({ start: p.open, end: p.close + 1, kind: "QUOTED_SPAN", confidence: 0.8, source: "paired:quote" })
+			}
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Cue family 2 — designator + identifier (the sub-premise grammar)
+// ---------------------------------------------------------------------------
+
+/** Short identifier shapes per the designator grammar: "4B", "500", "#104", "B", "B99". */
+function isShortIdentifier(body: string): boolean {
+	return /^#?\d{1,6}[A-Za-z]{0,2}$/.test(body) || /^[A-Za-z]$/.test(body) || /^[A-Za-z]\d{1,4}$/.test(body)
+}
+
+function proposeDesignatorPhrases(text: string, tokens: readonly RawToken[], lexicon: SpanProposerLexicon): ProposedSpan[] {
+	const out: ProposedSpan[] = []
+
+	for (let i = 0; i < tokens.length - 1; i++) {
+		const lead = tokens[i]!.stripped.toLowerCase()
+		const isUnit = lexicon.unitDesignators.has(lead)
+		const isLevel = lexicon.levelDesignators.has(lead)
+		if (!isUnit && !isLevel) continue
+		const next = tokens[i + 1]!
+		if (next.stripped.includes("/") || next.stripped.includes("-")) continue // cue family 3 owns punctuated ids
+		if (!isShortIdentifier(next.stripped)) continue
+		const weak = lexicon.weakDesignators.has(lead)
+		out.push({
+			start: tokens[i]!.strippedStart,
+			end: next.strippedEnd,
+			kind: isLevel ? "LEVEL_PHRASE" : "UNIT_PHRASE",
+			confidence: weak ? 0.5 : 0.85,
+			source: `designator:${isLevel ? "level" : "unit"}`,
+		})
+	}
+
+	if (lexicon.deliveryService) {
+		// Fresh lastIndex per call — the lexicon regex is shared.
+		const re = new RegExp(lexicon.deliveryService.source, lexicon.deliveryService.flags)
+		for (const m of text.matchAll(re)) {
+			out.push({
+				start: m.index,
+				end: m.index + m[0].length,
+				kind: "PO_BOX_PHRASE",
+				confidence: 0.9,
+				source: "designator:delivery-service",
+			})
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Cue family 3 — dual-path numeric punctuation (M3)
+// ---------------------------------------------------------------------------
+
+const SLASH_COMPOUND = /^(\d{1,4}[A-Za-z]?)\/(\d{1,5}[A-Za-z]?)$/
+const HYPHEN_COMPOUND = /^(\d{1,4})-(\d{1,5})$/
+const FRACTION = /^\d\/\d$/
+
+/**
+ * Words that lead NUMBERED ROADS ("Hwy 50/89", "Route 1/9", "I-95") — a bounded structural
+ * category (road-type leaders), mirroring the phrase grouper's street-type sets. The
+ * leading-designator-shape fallback must not read them as sub-premise designators: a slash after a
+ * road leader is a route concurrency, not an AU unit/house split.
+ */
+const ROAD_LEADERS: ReadonlySet<string> = new Set(["hwy", "highway", "route", "rte", "sr", "cr", "interstate", "loop"])
+
+function proposeNumericReadings(
+	tokens: readonly RawToken[],
+	lexicon: SpanProposerLexicon,
+	nextGroup: () => number
+): ProposedSpan[] {
+	const out: ProposedSpan[] = []
+	const hasAuNz = lexicon.systems.has("au") || lexicon.systems.has("nz")
+
+	for (let i = 0; i < tokens.length; i++) {
+		const t = tokens[i]!
+		const prev = i > 0 ? tokens[i - 1] : undefined
+		const prevLead = prev?.stripped.toLowerCase() ?? ""
+		const prevIsDesignator = lexicon.unitDesignators.has(prevLead) || lexicon.levelDesignators.has(prevLead)
+
+		// USPS half address: "123 1/2" — the fraction belongs to house_number (one fused value).
+		if (lexicon.systems.has("us") && FRACTION.test(t.stripped) && prev && /^\d{1,5}$/.test(prev.stripped)) {
+			out.push({
+				start: prev.strippedStart,
+				end: t.strippedEnd,
+				kind: "FUSED_NUMBER",
+				confidence: 0.85,
+				source: "fraction:usps-half-address",
+			})
+			continue
+		}
+
+		const slash = SLASH_COMPOUND.exec(t.stripped)
+		if (slash) {
+			const leftEnd = t.strippedStart + slash[1]!.length
+			const rightStart = leftEnd + 1
+			// Reading A context: a unit/level designator leads ("Unit 4/22", "Flat 2/14" via the
+			// leading-shape fallback below). Reading B context: the compound itself leads the address
+			// ("3/45 Wattle St" — the AU/NZ bare sub-premise shape, only proposed when those codex
+			// systems are loaded).
+			const leadingShape =
+				!prevIsDesignator &&
+				prev !== undefined &&
+				i === 1 &&
+				/^\p{Lu}[\p{L}]{1,7}$/u.test(prev.stripped) &&
+				!ROAD_LEADERS.has(prevLead) &&
+				hasAuNz
+			if (prevIsDesignator || leadingShape) {
+				const group = nextGroup()
+				const conf = prevIsDesignator ? (hasAuNz ? 0.85 : 0.6) : 0.7
+				out.push({
+					start: prev!.strippedStart,
+					end: leftEnd,
+					kind: "SPLIT_UNIT",
+					confidence: conf,
+					alternativeGroup: group,
+					source: prevIsDesignator ? "slash:designator-split" : "slash:leading-designator-shape",
+				})
+				out.push({
+					start: rightStart,
+					end: t.strippedEnd,
+					kind: "SPLIT_HOUSE_NUMBER",
+					confidence: conf,
+					alternativeGroup: group,
+					source: "slash:designator-split",
+				})
+				out.push({
+					start: t.strippedStart,
+					end: t.strippedEnd,
+					kind: "FUSED_NUMBER",
+					confidence: 0.3,
+					alternativeGroup: group,
+					source: "slash:fused-alternative",
+				})
+			} else if (i === 0 && hasAuNz && tokens.length > 1) {
+				const group = nextGroup()
+				out.push({
+					start: t.strippedStart,
+					end: leftEnd,
+					kind: "SPLIT_UNIT",
+					confidence: 0.75,
+					alternativeGroup: group,
+					source: "slash:bare-leading-split",
+				})
+				out.push({
+					start: rightStart,
+					end: t.strippedEnd,
+					kind: "SPLIT_HOUSE_NUMBER",
+					confidence: 0.75,
+					alternativeGroup: group,
+					source: "slash:bare-leading-split",
+				})
+				out.push({
+					start: t.strippedStart,
+					end: t.strippedEnd,
+					kind: "FUSED_NUMBER",
+					confidence: 0.45,
+					alternativeGroup: group,
+					source: "slash:fused-alternative",
+				})
+			} else if (prev && /^\p{Lu}[\p{L}]{3,}$/u.test(prev.stripped)) {
+				// Trailing European form ("Hauptstraße 14/2") — one fused value after the street name.
+				// The ≥4-char guard keeps short street-type leaders ("Hwy 50/89") out of this reading.
+				out.push({
+					start: t.strippedStart,
+					end: t.strippedEnd,
+					kind: "FUSED_NUMBER",
+					confidence: 0.55,
+					source: "slash:trailing-fused",
+				})
+			}
+			continue
+		}
+
+		const hyphen = HYPHEN_COMPOUND.exec(t.stripped)
+		if (hyphen) {
+			// ZIP+4 shape is a postcode, not a house number — never propose a reading for it.
+			if (hyphen[1]!.length === 5) continue
+			const next = i + 1 < tokens.length ? tokens[i + 1] : undefined
+			const leftEnd = t.strippedStart + hyphen[1]!.length
+			if (prevIsDesignator) {
+				const group = nextGroup()
+				out.push({
+					start: prev!.strippedStart,
+					end: leftEnd,
+					kind: "SPLIT_UNIT",
+					confidence: 0.45,
+					alternativeGroup: group,
+					source: "hyphen:designator-split",
+				})
+				out.push({
+					start: leftEnd + 1,
+					end: t.strippedEnd,
+					kind: "SPLIT_HOUSE_NUMBER",
+					confidence: 0.45,
+					alternativeGroup: group,
+					source: "hyphen:designator-split",
+				})
+				out.push({
+					start: t.strippedStart,
+					end: t.strippedEnd,
+					kind: "FUSED_NUMBER",
+					confidence: 0.6,
+					alternativeGroup: group,
+					source: "hyphen:fused-alternative",
+				})
+			} else if (next && (/^\p{Lu}/u.test(next.stripped) || /^\d{1,4}(?:st|nd|rd|th)$/i.test(next.stripped))) {
+				// House-number position (a street follows — capitalized or ordinal): "69-10 47th Ave",
+				// "14-16 Smith St".
+				// Fused only — whether it is a Queens label or a range is not the parser's call (OSM
+				// models the difference with a separate tag, not syntax).
+				out.push({
+					start: t.strippedStart,
+					end: t.strippedEnd,
+					kind: "FUSED_NUMBER",
+					confidence: 0.55,
+					source: "hyphen:house-number-position",
+				})
+			}
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Propose typed spans over `text`. Pure and synchronous; safe to run on every parse. Proposals may
+ * overlap freely ("possibilities not constraints"); alternatives of one surface share an
+ * `alternativeGroup`. Sorted by `start`, then descending confidence.
+ *
+ * Designator and numeric proposals fully inside a confident (≥ 0.6) `ANNOTATION_SPAN` are
+ * suppressed — bracketed asides describe the address ("(Apt 4 around back)"), and the annotation
+ * proposal already carries the span. Content inside QUOTED_SPANs is NOT suppressed (quotes wrap
+ * names, not asides).
+ */
+export function proposeSpans(text: string, lexicon: SpanProposerLexicon = EMPTY_SPAN_PROPOSER_LEXICON): ProposedSpan[] {
+	if (text.length === 0) return []
+	let groupCounter = 0
+	const nextGroup = (): number => groupCounter++
+
+	const paired = proposePairedDelimiters(text, lexicon)
+	const tokens = tokenize(text)
+	const inner = [...proposeDesignatorPhrases(text, tokens, lexicon), ...proposeNumericReadings(tokens, lexicon, nextGroup)]
+
+	const confidentAnnotations = paired.filter((p) => p.kind === "ANNOTATION_SPAN" && p.confidence >= 0.6)
+	const survivors = inner.filter(
+		(p) => !confidentAnnotations.some((a) => p.start >= a.start && p.end <= a.end)
+	)
+
+	const out = [...paired, ...survivors]
+	out.sort((a, b) => (a.start !== b.start ? a.start - b.start : b.confidence - a.confidence))
+	return out
+}

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -21,6 +21,7 @@ import {
 	type ComponentTag,
 	type DecoderToken,
 } from "@mailwoman/core/decoder"
+import { proposeSpans, type ProposedSpan, type SpanProposerLexicon } from "@mailwoman/core/pipeline"
 
 import { detectAddressSystem } from "./address-system.js"
 import { buildAnchorFeatures, type AnchorLookup } from "./anchor-inference.js"
@@ -31,6 +32,7 @@ import type { InferResult } from "./onnx-runner.js"
 import { repairPostcodeLabels } from "./postcode-repair.js"
 import { addEmissionMatrix, buildEmissionPriors, type QueryShapeLike } from "./query-shape-prior.js"
 import { bridgePunctuationGaps } from "./span-bridge.js"
+import { buildSpanProposalPriors, type SpanProposalPriorOpts } from "./span-proposal-prior.js"
 import { buildStreetMorphologyEmissionPriors, type StreetMorphologyPriorOpts } from "./street-morphology-prior.js"
 import { MailwomanTokenizer } from "./tokenizer.js"
 import { repairUnitLabels } from "./unit-repair.js"
@@ -119,6 +121,23 @@ export interface NeuralAddressClassifierConfig {
 	 * merged after decode. Per-parse opts override. Omit for the byte-stable pre-v4.4.0 behavior.
 	 */
 	bridgePunctuationGaps?: boolean
+	/**
+	 * Stage 2.7 span proposer (M2+M3 from the punctuation survey, #518). When set, every parse runs
+	 * `proposeSpans` (`@mailwoman/core/pipeline`) over the raw text and consumes the typed proposals
+	 * two ways: (a) as additive emission priors — the phrase-prior path; the classifier conditions on
+	 * the boundary hypotheses and can still disagree — and (b) ANNOTATION/QUOTED span boundaries feed
+	 * the span bridge as merge-crossing constraints (no same-tag merge may straddle a structural
+	 * delimiter). Build the lexicon with `buildCodexSpanLexicon` (`./span-proposer-lexicon.js`).
+	 * Per-parse opts override. Omit for the byte-stable default (no proposals, no priors, no
+	 * constraints).
+	 */
+	spanProposer?: SpanProposerConfig
+}
+
+/** Config for the Stage 2.7 span-proposer integration (see `NeuralAddressClassifierConfig.spanProposer`). */
+export interface SpanProposerConfig extends SpanProposalPriorOpts {
+	/** Codex-backed designator vocabulary (`buildCodexSpanLexicon`). */
+	lexicon: SpanProposerLexicon
 }
 
 export class NeuralAddressClassifier {
@@ -282,6 +301,15 @@ export class NeuralAddressClassifier {
 			)
 		}
 
+		// Stage 2.7 span proposer (#518, M2+M3): typed span proposals consumed as phrase priors. The
+		// per-parse opt can switch the configured proposer off (`spanProposer: false`); it cannot
+		// conjure one without a configured lexicon. Disabled = byte-stable (no proposals computed).
+		const proposerCfg = (opts?.spanProposer ?? true) ? this.cfg.spanProposer : undefined
+		const spanProposals: ProposedSpan[] = proposerCfg ? proposeSpans(text, proposerCfg.lexicon) : []
+		if (spanProposals.length > 0) {
+			emissions = addEmissionMatrix(emissions, buildSpanProposalPriors(spanProposals, pieces, this.labels, proposerCfg))
+		}
+
 		// Conventions emission mask: tags that are ungrammatical in the detected system are removed
 		// from the decoder's vocabulary outright (-1e9 ≈ log 0). Copy-on-mask — `emissions` may alias
 		// `logits`, which the per-token confidence below reads unmasked.
@@ -440,6 +468,12 @@ export interface ParseOpts {
 	calibrate?: Calibrator
 	/** Per-parse override of the config-level `bridgePunctuationGaps` (see that doc). */
 	bridgePunctuationGaps?: boolean
+	/**
+	 * Per-parse switch for the config-level `spanProposer` (see that doc). `false` disables the
+	 * configured proposer for this parse; `true`/omitted runs it when configured. Cannot enable the
+	 * stage without a configured lexicon.
+	 */
+	spanProposer?: boolean
 	/**
 	 * Address-system conventions enforcement (#511 Tier A / #478's rules-as-constraints slice).
 	 *

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -359,9 +359,11 @@ export class NeuralAddressClassifier {
 		}
 		// Punctuation-gap span bridging (v4.4.0 corrective — see span-bridge.ts): merge same-tag
 		// fragments split at unlabeled punctuation ("P.O. Box" decoding as P + O + Box). Opt-in,
-		// declared in the ship config like the conventions mask.
+		// declared in the ship config like the conventions mask. When the span proposer ran, its
+		// ANNOTATION/QUOTED boundaries become merge-crossing constraints (M2's second half).
 		if (opts?.bridgePunctuationGaps ?? this.cfg.bridgePunctuationGaps) {
-			tokens = bridgePunctuationGaps(text, tokens)
+			const blockedSpans = spanProposals.filter((p) => p.kind === "ANNOTATION_SPAN" || p.kind === "QUOTED_SPAN")
+			tokens = bridgePunctuationGaps(text, tokens, blockedSpans.length > 0 ? { blockedSpans } : undefined)
 		}
 
 		return { tokens, logits, pieces }

--- a/neural/index.ts
+++ b/neural/index.ts
@@ -13,6 +13,8 @@ export * from "./postcode-anchor.js"
 export * from "./postcode-binary-resolver.js"
 export * from "./proposal-classifier.js"
 export { addEmissionMatrix, buildEmissionPriors } from "./query-shape-prior.js"
+export * from "./span-proposal-prior.js"
+export * from "./span-proposer-lexicon.js"
 export type { BuildPriorsOpts, KnownFormatHitLike, QueryShapeLike, TokenLike } from "./query-shape-prior.js"
 export * from "./tokenizer.js"
 export {

--- a/neural/span-bridge.test.ts
+++ b/neural/span-bridge.test.ts
@@ -87,4 +87,47 @@ describe("bridgePunctuationGaps", () => {
 		const input = [tok("PO Box 989", 0, "B-po_box")]
 		expect(bridgePunctuationGaps(text, input)).toEqual(input)
 	})
+
+	describe("crossing constraint (M2 — Stage 2.7 structural boundaries)", () => {
+		it("blocks a same-tag merge whose gap contains a proposed span boundary", () => {
+			// "Joe's 'Pizza' Shop" with a quoted span over 'Pizza' — the gap " '" between two venue
+			// fragments is bridgeable (apostrophe + space), but the opening quote at index 6 is a
+			// structural boundary the merge must not straddle.
+			const text = "Joe's 'Pizza' Shop"
+			const input = [tok("Joe's", 0, "B-venue"), tok("Pizza", 7, "B-venue")]
+			// Without the constraint the bridge merges (regression guard for the test itself):
+			expect(bridgePunctuationGaps(text, input)).toHaveLength(1)
+			const out = bridgePunctuationGaps(text, input, { blockedSpans: [{ start: 6, end: 13 }] })
+			expect(out).toHaveLength(2)
+		})
+
+		it("blocks a merge across a CLOSING boundary", () => {
+			// Closing quote at index 12 sits inside the gap "' " between the fragments.
+			const text = "Joe's 'Pizza' Shop"
+			const input = [tok("Pizza", 7, "B-venue"), tok("Shop", 14, "B-venue")]
+			expect(bridgePunctuationGaps(text, input)).toHaveLength(1)
+			const out = bridgePunctuationGaps(text, input, { blockedSpans: [{ start: 6, end: 13 }] })
+			expect(out).toHaveLength(2)
+		})
+
+		it("still merges when the boundary is elsewhere (dotted po_box stays bridged)", () => {
+			const text = "P.O. BOX 19 (rear)"
+			const input = [
+				tok("P", 0, "B-po_box", 0.93),
+				tok(".", 1, "O"),
+				tok("O", 2, "B-po_box", 0.94),
+				tok(".", 3, "O"),
+				tok("BOX 19", 5, "B-po_box", 0.96),
+			]
+			const out = bridgePunctuationGaps(text, input, { blockedSpans: [{ start: 12, end: 18 }] })
+			expect(out).toHaveLength(1)
+			expect(out[0]!.piece).toBe("P.O. BOX 19")
+		})
+
+		it("no blocked spans = byte-identical to the unconstrained bridge", () => {
+			const text = "P.O. BOX 19"
+			const input = [tok("P", 0, "B-po_box"), tok(".", 1, "O"), tok("O", 2, "B-po_box"), tok("BOX 19", 5, "I-po_box")]
+			expect(bridgePunctuationGaps(text, input, {})).toEqual(bridgePunctuationGaps(text, input))
+		})
+	})
 })

--- a/neural/span-bridge.ts
+++ b/neural/span-bridge.ts
@@ -39,13 +39,46 @@ function bridgeable(gap: string): boolean {
 	return /[^\s]/.test(gap)
 }
 
+/** Options for {@link bridgePunctuationGaps}. */
+export interface BridgePunctuationOpts {
+	/**
+	 * Structural spans (from the Stage 2.7 span proposer — ANNOTATION/QUOTED groups, delimiters
+	 * inclusive) whose boundaries no merge may straddle: M2's crossing constraint, the bridge's
+	 * mirror image (the bridge merges across WEAK punctuation; this blocks merging across STRUCTURAL
+	 * punctuation). A merge is blocked when either span boundary falls inside the gap being bridged
+	 * — e.g. an apostrophe-quoted name whose closing quote sits in an otherwise-bridgeable gap.
+	 * Boundaries already inside a labeled token are the model's call, not the bridge's; only gaps
+	 * are policed.
+	 */
+	blockedSpans?: ReadonlyArray<{ start: number; end: number }>
+}
+
+/** True when a structural boundary falls inside the closed gap interval `[gapStart, gapEnd]`. */
+function crossesBlockedBoundary(
+	gapStart: number,
+	gapEnd: number,
+	blockedSpans: ReadonlyArray<{ start: number; end: number }> | undefined
+): boolean {
+	if (!blockedSpans) return false
+	for (const span of blockedSpans) {
+		// span.start = opening delimiter index; span.end = one past the closing delimiter.
+		if (span.start >= gapStart && span.start <= gapEnd) return true
+		if (span.end - 1 >= gapStart && span.end - 1 <= gapEnd) return true
+	}
+	return false
+}
+
 /**
  * Merge same-label fragments separated only by punctuation gaps. Returns a new token array where
  * the first fragment of each bridged group is widened to the group's full char range (so span
  * extraction reads the raw text straight through the punctuation), and later fragments are dropped.
  * Labels, ordering, and all non-bridged tokens are untouched.
  */
-export function bridgePunctuationGaps(text: string, input: readonly DecoderToken[]): DecoderToken[] {
+export function bridgePunctuationGaps(
+	text: string,
+	input: readonly DecoderToken[],
+	opts?: BridgePunctuationOpts
+): DecoderToken[] {
 	const out: DecoderToken[] = []
 	for (const token of input) {
 		if (token.label !== "O") {
@@ -64,7 +97,8 @@ export function bridgePunctuationGaps(text: string, input: readonly DecoderToken
 				prevTag === tag &&
 				token.start >= prev.end &&
 				skippedInsideGap &&
-				bridgeable(text.slice(prev.end, token.start))
+				bridgeable(text.slice(prev.end, token.start)) &&
+				!crossesBlockedBoundary(prev.end, token.start, opts?.blockedSpans)
 			) {
 				// Widen the previous fragment through the gap (absorbing the punctuation O tokens);
 				// keep the lower confidence so the merged span never overstates its weakest piece.

--- a/neural/span-proposal-prior.ts
+++ b/neural/span-proposal-prior.ts
@@ -1,0 +1,113 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Emission priors from Stage 2.7 span proposals — the consumption half of M2+M3 (the phrase-prior
+ *   path the sub-premise direction note names: "consumed as phrase priors today — the classifier
+ *   conditions on the boundary hypothesis and can still disagree").
+ *
+ *   Same contract as `query-shape-prior.ts`: an additive `[seqLen][numLabels]` log-bias matrix
+ *   composed onto the encoder emissions before Viterbi. Soft by construction — a confident encoder
+ *   wins; an uncertain one gets pulled toward the proposal's reading. Dual-path alternatives (M3)
+ *   simply contribute competing biases at their respective confidences; the CRF resolves them
+ *   against the model's own evidence, which IS the deferred decision the survey prescribes.
+ *
+ *   Mapping:
+ *
+ *   - `ANNOTATION_SPAN` → bias toward `O` (gold convention 2: bracketed asides are not components;
+ *     the win is that neighbors stop being poisoned). Applied only above a confidence floor so
+ *     trailing component-shaped groups ("(Australia)") are left to the model.
+ *   - `QUOTED_SPAN` → no bias. The content is a real name; typing it is the classifier's job. The
+ *     span still matters decode-side (the bridge's crossing constraint).
+ *   - `PO_BOX_PHRASE` → `po_box`; `UNIT_PHRASE`/`LEVEL_PHRASE`/`SPLIT_UNIT` → `unit` (the schema
+ *     has no level tag — levels ride `unit` until the codex level sourcing lands, #517);
+ *     `SPLIT_HOUSE_NUMBER`/`FUSED_NUMBER` → `house_number`. B- on the first overlapping piece, I-
+ *     on the rest.
+ */
+
+import type { ProposedSpan } from "@mailwoman/core/pipeline"
+
+import type { TokenLike } from "./query-shape-prior.js"
+
+export interface SpanProposalPriorOpts {
+	/** Bias magnitude for tag-mapped proposals, in log-odds units. Confidence-scaled. Default 2.0. */
+	biasScale?: number
+	/** Bias magnitude for the annotation O-prior. Confidence-scaled. Default 2.5. */
+	annotationBiasScale?: number
+	/**
+	 * Annotation proposals below this confidence contribute NO O-bias (their span still feeds the
+	 * decode-side crossing constraint). Default 0.6 — above the trailing-component shape (0.45),
+	 * below the capitalized mid-string aside (0.75).
+	 */
+	annotationConfidenceFloor?: number
+}
+
+const KIND_TO_TAG: ReadonlyMap<string, string> = new Map([
+	["PO_BOX_PHRASE", "po_box"],
+	["UNIT_PHRASE", "unit"],
+	["LEVEL_PHRASE", "unit"],
+	["SPLIT_UNIT", "unit"],
+	["SPLIT_HOUSE_NUMBER", "house_number"],
+	["FUSED_NUMBER", "house_number"],
+])
+
+/**
+ * Build the additive prior matrix for one parse. Returns all-zeros rows for pieces no proposal
+ * covers — composes harmlessly via `addEmissionMatrix`.
+ */
+export function buildSpanProposalPriors(
+	proposals: ReadonlyArray<ProposedSpan>,
+	tokens: ReadonlyArray<TokenLike>,
+	labels: ReadonlyArray<string>,
+	opts: SpanProposalPriorOpts = {}
+): number[][] {
+	const T = tokens.length
+	const L = labels.length
+	const biasScale = opts.biasScale ?? 2.0
+	const annotationBiasScale = opts.annotationBiasScale ?? 2.5
+	const annotationFloor = opts.annotationConfidenceFloor ?? 0.6
+
+	const matrix: number[][] = []
+	for (let t = 0; t < T; t++) matrix.push(new Array<number>(L).fill(0))
+	if (proposals.length === 0) return matrix
+
+	const labelToCol = new Map<string, number>()
+	for (let k = 0; k < labels.length; k++) labelToCol.set(labels[k]!, k)
+	const oCol = labelToCol.get("O")
+
+	for (const proposal of proposals) {
+		if (proposal.kind === "QUOTED_SPAN") continue
+
+		if (proposal.kind === "ANNOTATION_SPAN") {
+			if (oCol === undefined || proposal.confidence < annotationFloor) continue
+			const bias = proposal.confidence * annotationBiasScale
+			for (let t = 0; t < T; t++) {
+				if (overlaps(tokens[t]!, proposal)) {
+					matrix[t]![oCol] = Math.max(matrix[t]![oCol]!, bias)
+				}
+			}
+			continue
+		}
+
+		const tag = KIND_TO_TAG.get(proposal.kind)
+		if (!tag) continue
+		const bCol = labelToCol.get(`B-${tag}`)
+		const iCol = labelToCol.get(`I-${tag}`)
+		if (bCol === undefined) continue
+		const bias = proposal.confidence * biasScale
+		let first = true
+		for (let t = 0; t < T; t++) {
+			if (!overlaps(tokens[t]!, proposal)) continue
+			const col = first ? bCol : iCol
+			first = false
+			if (col === undefined) continue
+			matrix[t]![col] = Math.max(matrix[t]![col]!, bias)
+		}
+	}
+	return matrix
+}
+
+function overlaps(a: { start: number; end: number }, b: { start: number; end: number }): boolean {
+	return a.start < b.end && b.start < a.end
+}

--- a/neural/span-proposal-prior.ts
+++ b/neural/span-proposal-prior.ts
@@ -31,9 +31,21 @@ import type { ProposedSpan } from "@mailwoman/core/pipeline"
 import type { TokenLike } from "./query-shape-prior.js"
 
 export interface SpanProposalPriorOpts {
-	/** Bias magnitude for tag-mapped proposals, in log-odds units. Confidence-scaled. Default 2.0. */
+	/**
+	 * Bias magnitude for tag-mapped proposals, in log-odds units. Confidence-scaled. Default 5.0 —
+	 * measured on the punctuation-stress sweep (2026-06-12, v4.4.0 int8): the proposer's job is to
+	 * flip CONFIDENTLY-wrong emissions (fused `2/14` → split), which 1-2-nat query-shape-style
+	 * scales cannot reach; 5.0 moved slash +11.1 with every other class flat, and the model still
+	 * vetoes where its logit gap is larger (the bare `3/45` row stays fused).
+	 */
 	biasScale?: number
-	/** Bias magnitude for the annotation O-prior. Confidence-scaled. Default 2.5. */
+	/**
+	 * Bias magnitude for the annotation O-prior. Confidence-scaled. Default 12.0 — deliberately
+	 * near-mask strength (measured saturation point on the same sweep: bracketed +9.1, paren
+	 * regressions zero): a BALANCED bracket pair with aside-shaped content is the strongest
+	 * structural cue the proposer has, and the confidence floor (not the scale) is what protects the
+	 * component-shaped groups.
+	 */
 	annotationBiasScale?: number
 	/**
 	 * Annotation proposals below this confidence contribute NO O-bias (their span still feeds the
@@ -64,8 +76,8 @@ export function buildSpanProposalPriors(
 ): number[][] {
 	const T = tokens.length
 	const L = labels.length
-	const biasScale = opts.biasScale ?? 2.0
-	const annotationBiasScale = opts.annotationBiasScale ?? 2.5
+	const biasScale = opts.biasScale ?? 5.0
+	const annotationBiasScale = opts.annotationBiasScale ?? 12.0
 	const annotationFloor = opts.annotationConfidenceFloor ?? 0.6
 
 	const matrix: number[][] = []

--- a/neural/span-proposer-lexicon.ts
+++ b/neural/span-proposer-lexicon.ts
@@ -1,0 +1,126 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Codex-backed lexicon for the Stage 2.7 span proposer (`@mailwoman/core/pipeline`'s
+ *   `proposeSpans`). Core stays codex-free; this module assembles the proposer's designator
+ *   vocabulary from the provenance-tracked `@mailwoman/codex` tables — USPS Pub-28 C2 secondary
+ *   unit designators, USPS PO-box designators, Australia Post AMAS delivery types, NZ Post ADV358
+ *   delivery-service types. Which systems are loaded conditions the proposer's locale-dependent
+ *   readings (the AU/NZ `Flat 2/14` split exists only when those tables are present).
+ *
+ *   No entry here is hand-invented (the no-load-bearing-trivia rule): every token/pattern derives
+ *   from a codex table row. AU `MS` (Mail Service) and the identifier-less counter types (CARE PO,
+ *   CMA, CPA, Counter Delivery, Poste Restante) are excluded from the mid-text SCAN regex — a bare
+ *   two-letter designator with no required number is exactly the false-positive shape ("Ms Smith")
+ *   the AU matcher special-cases; the scan keeps only number-carrying forms.
+ */
+
+import { au, nz, us, type SystemCode } from "@mailwoman/codex"
+import type { SpanProposerLexicon } from "@mailwoman/core/pipeline"
+
+/**
+ * USPS Pub-28 C2 canonicals whose designator is DESCRIPTIVE rather than addressing ("Building A"
+ * describes the building; "Suite 9" addresses a unit). Inside a bracketed group, these read as
+ * annotation content (gold convention 2 of the punctuation-stress eval).
+ */
+const WEAK_CANONICALS: ReadonlySet<string> = new Set([
+	"BUILDING",
+	"FRONT",
+	"REAR",
+	"SIDE",
+	"UPPER",
+	"LOWER",
+	"KEY",
+	"STOP",
+])
+
+/** USPS canonicals that name a LEVEL of the building rather than a numbered unit on it. */
+const LEVEL_CANONICALS: ReadonlySet<string> = new Set(["FLOOR", "BASEMENT", "PENTHOUSE", "LOBBY"])
+
+/** AU/NZ delivery types excluded from the scan regex (no required number / two-letter ambiguity). */
+const SCAN_EXCLUDED_DELIVERY: ReadonlySet<string> = new Set([
+	"MS",
+	"CARE PO",
+	"CMA",
+	"CPA",
+	"Counter Delivery",
+	"Poste Restante",
+])
+
+/**
+ * Convert one designator phrase from a codex table into a scan-pattern fragment. Short alphabetic
+ * words (≤ 3 chars: "PO", "GPO", "RMB") are treated as initialisms with optional periods/spacing —
+ * the punctuation AMAS tells mailers to strip but deliverable mail still carries ("P.O. Box",
+ * "R.M.B 4600"). Longer words match literally with flexible whitespace.
+ */
+function phraseToPattern(phrase: string): string {
+	return phrase
+		.trim()
+		.split(/\s+/)
+		.map((word) =>
+			/^[A-Za-z]{1,3}$/.test(word) && word.toLowerCase() !== "box" && word.toLowerCase() !== "bag"
+				? word
+						.split("")
+						.map((ch) => `${ch}\\.?`)
+						.join("\\s*")
+				: word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+		)
+		.join("\\s+")
+}
+
+/**
+ * Build the span-proposer lexicon from the codex tables of the requested systems. Defaults to
+ * every system with designator tables in the codex today. The result is pure data — safe to share
+ * across parses.
+ */
+export function buildCodexSpanLexicon(systems: readonly SystemCode[] = ["us", "au", "nz"]): SpanProposerLexicon {
+	const sys = new Set<string>(systems)
+	const unitDesignators = new Set<string>()
+	const levelDesignators = new Set<string>()
+	const weakDesignators = new Set<string>()
+	const deliveryPhrases = new Set<string>()
+
+	if (sys.has("us")) {
+		for (const canonical of Object.keys(us.US_UNIT_DESIGNATOR_VARIANTS)) {
+			const variants = [canonical, ...us.US_UNIT_DESIGNATOR_VARIANTS[canonical as us.UsUnitDesignator]]
+			const target = LEVEL_CANONICALS.has(canonical) ? levelDesignators : unitDesignators
+			for (const v of variants) {
+				target.add(v.toLowerCase())
+				if (WEAK_CANONICALS.has(canonical)) weakDesignators.add(v.toLowerCase())
+			}
+		}
+		for (const phrase of us.US_PO_BOX_DESIGNATORS) deliveryPhrases.add(phrase)
+	}
+	if (sys.has("au")) {
+		for (const row of au.AU_DELIVERY_SERVICE_DESIGNATORS) {
+			if (SCAN_EXCLUDED_DELIVERY.has(row.abbreviation)) continue
+			if (!row.requiresNumber) continue
+			deliveryPhrases.add(row.abbreviation)
+			deliveryPhrases.add(row.name)
+		}
+	}
+	if (sys.has("nz")) {
+		for (const row of nz.NZ_DELIVERY_SERVICE_TYPES) {
+			if (SCAN_EXCLUDED_DELIVERY.has(row.type)) continue
+			if (row.identifier === "not-used") continue
+			deliveryPhrases.add(row.type)
+		}
+	}
+
+	// Longest-first so "GPO Box" beats "Box", "Private Bag" beats "Bag".
+	const alternatives = [...deliveryPhrases].sort((a, b) => b.length - a.length).map(phraseToPattern)
+	const deliveryService =
+		alternatives.length > 0
+			? new RegExp(String.raw`\b(?:${alternatives.join("|")})\s*#?\s*([A-Za-z]?\d[\dA-Za-z-]*)\b`, "gi")
+			: undefined
+
+	return {
+		systems: sys,
+		unitDesignators,
+		levelDesignators,
+		weakDesignators,
+		...(deliveryService ? { deliveryService } : {}),
+	}
+}

--- a/neural/test/span-proposer-wiring.test.ts
+++ b/neural/test/span-proposer-wiring.test.ts
@@ -68,8 +68,8 @@ describe("buildSpanProposalPriors", () => {
 			{ start: 0, end: 7, kind: "UNIT_PHRASE", confidence: 0.85, source: "designator:unit" },
 		]
 		const m = buildSpanProposalPriors(proposals, pieces, LABELS)
-		expect(m[0]![1]).toBeCloseTo(0.85 * 2.0) // B-unit on piece 0
-		expect(m[1]![2]).toBeCloseTo(0.85 * 2.0) // I-unit on piece 1
+		expect(m[0]![1]).toBeCloseTo(0.85 * 5.0) // B-unit on piece 0
+		expect(m[1]![2]).toBeCloseTo(0.85 * 5.0) // I-unit on piece 1
 		expect(m[2]!.every((v) => v === 0)).toBe(true) // piece 2 untouched
 		expect(m[0]![0]).toBe(0) // no O bias
 	})
@@ -79,8 +79,8 @@ describe("buildSpanProposalPriors", () => {
 		expect(buildSpanProposalPriors(low, pieces, LABELS).flat().every((v) => v === 0)).toBe(true)
 		const high: ProposedSpan[] = [{ start: 0, end: 7, kind: "ANNOTATION_SPAN", confidence: 0.9, source: "paired:()" }]
 		const m = buildSpanProposalPriors(high, pieces, LABELS)
-		expect(m[0]![0]).toBeCloseTo(0.9 * 2.5)
-		expect(m[1]![0]).toBeCloseTo(0.9 * 2.5)
+		expect(m[0]![0]).toBeCloseTo(0.9 * 12.0)
+		expect(m[1]![0]).toBeCloseTo(0.9 * 12.0)
 		expect(m[2]![0]).toBe(0)
 	})
 
@@ -97,10 +97,10 @@ describe("buildSpanProposalPriors", () => {
 			{ start: 5, end: 9, kind: "FUSED_NUMBER", confidence: 0.3, alternativeGroup: 0, source: "slash" },
 		]
 		const m = buildSpanProposalPriors(proposals, pieces, LABELS)
-		expect(m[0]![1]).toBeCloseTo(0.85 * 2.0) // B-unit on "Unit"
-		expect(m[1]![2]).toBeCloseTo(0.85 * 2.0) // I-unit on "4"
-		expect(m[1]![5]).toBeCloseTo(0.3 * 2.0) // fused B-house_number ALSO alive on "4", weaker
-		expect(m[2]![5]).toBeCloseTo(0.85 * 2.0) // split B-house_number on "22" (max over fused I-)
+		expect(m[0]![1]).toBeCloseTo(0.85 * 5.0) // B-unit on "Unit"
+		expect(m[1]![2]).toBeCloseTo(0.85 * 5.0) // I-unit on "4"
+		expect(m[1]![5]).toBeCloseTo(0.3 * 5.0) // fused B-house_number ALSO alive on "4", weaker
+		expect(m[2]![5]).toBeCloseTo(0.85 * 5.0) // split B-house_number on "22" (max over fused I-)
 	})
 
 	it("returns all-zeros for no proposals", () => {

--- a/neural/test/span-proposer-wiring.test.ts
+++ b/neural/test/span-proposer-wiring.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Contract tests for the Stage 2.7 consumption wiring: the codex-backed lexicon builder and the
+ *   span-proposal emission priors. Load-bearing properties: the lexicon derives strictly from codex
+ *   tables (no invented designators, no bare "MS" in the scan); the priors are soft additive biases
+ *   with B-/I- structure; annotation O-bias respects its confidence floor; QUOTED_SPAN contributes
+ *   no bias at all.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { proposeSpans, type ProposedSpan } from "@mailwoman/core/pipeline"
+import { buildSpanProposalPriors } from "../span-proposal-prior.js"
+import { buildCodexSpanLexicon } from "../span-proposer-lexicon.js"
+
+const LABELS = ["O", "B-unit", "I-unit", "B-po_box", "I-po_box", "B-house_number", "I-house_number"] as const
+
+describe("buildCodexSpanLexicon", () => {
+	const lexicon = buildCodexSpanLexicon()
+
+	it("carries the USPS Pub-28 C2 unit designators", () => {
+		for (const d of ["apt", "apartment", "ste", "suite", "unit", "rm"]) {
+			expect(lexicon.unitDesignators.has(d), d).toBe(true)
+		}
+		expect(lexicon.levelDesignators.has("fl")).toBe(true)
+		expect(lexicon.levelDesignators.has("floor")).toBe(true)
+		expect(lexicon.weakDesignators.has("building")).toBe(true)
+	})
+
+	it("scan regex matches the Commonwealth + USPS delivery-service surfaces", () => {
+		const re = lexicon.deliveryService!
+		for (const s of ["PO Box 19", "P.O. Box 19", "GPO Box 2890", "Private Bag 39990", "Locked Bag 1797", "CMB B99"]) {
+			re.lastIndex = 0
+			expect(re.test(s), s).toBe(true)
+		}
+	})
+
+	it("never matches the AU 'MS' honorific trap or numberless types", () => {
+		const re = lexicon.deliveryService!
+		for (const s of ["Ms Smith", "Counter Delivery", "Poste Restante"]) {
+			re.lastIndex = 0
+			expect(re.test(s), s).toBe(false)
+		}
+	})
+
+	it("locale conditioning: a us-only lexicon proposes no AU bare-leading split", () => {
+		const usOnly = buildCodexSpanLexicon(["us"])
+		const spans = proposeSpans("3/45 Wattle St, Ultimo NSW 2007", usOnly)
+		expect(spans.some((s) => s.kind === "SPLIT_UNIT")).toBe(false)
+		const full = proposeSpans("3/45 Wattle St, Ultimo NSW 2007", buildCodexSpanLexicon())
+		expect(full.some((s) => s.kind === "SPLIT_UNIT")).toBe(true)
+	})
+})
+
+describe("buildSpanProposalPriors", () => {
+	// Three fake pieces: [0,4) [5,7) [8,10)
+	const pieces = [
+		{ start: 0, end: 4 },
+		{ start: 5, end: 7 },
+		{ start: 8, end: 10 },
+	]
+
+	it("biases B- on the first covered piece and I- on the rest (unit phrase)", () => {
+		const proposals: ProposedSpan[] = [
+			{ start: 0, end: 7, kind: "UNIT_PHRASE", confidence: 0.85, source: "designator:unit" },
+		]
+		const m = buildSpanProposalPriors(proposals, pieces, LABELS)
+		expect(m[0]![1]).toBeCloseTo(0.85 * 2.0) // B-unit on piece 0
+		expect(m[1]![2]).toBeCloseTo(0.85 * 2.0) // I-unit on piece 1
+		expect(m[2]!.every((v) => v === 0)).toBe(true) // piece 2 untouched
+		expect(m[0]![0]).toBe(0) // no O bias
+	})
+
+	it("applies the annotation O-bias only above the confidence floor", () => {
+		const low: ProposedSpan[] = [{ start: 0, end: 10, kind: "ANNOTATION_SPAN", confidence: 0.45, source: "paired:()" }]
+		expect(buildSpanProposalPriors(low, pieces, LABELS).flat().every((v) => v === 0)).toBe(true)
+		const high: ProposedSpan[] = [{ start: 0, end: 7, kind: "ANNOTATION_SPAN", confidence: 0.9, source: "paired:()" }]
+		const m = buildSpanProposalPriors(high, pieces, LABELS)
+		expect(m[0]![0]).toBeCloseTo(0.9 * 2.5)
+		expect(m[1]![0]).toBeCloseTo(0.9 * 2.5)
+		expect(m[2]![0]).toBe(0)
+	})
+
+	it("QUOTED_SPAN contributes no bias (typing the name is the classifier's job)", () => {
+		const proposals: ProposedSpan[] = [{ start: 0, end: 10, kind: "QUOTED_SPAN", confidence: 0.8, source: "paired:quote" }]
+		expect(buildSpanProposalPriors(proposals, pieces, LABELS).flat().every((v) => v === 0)).toBe(true)
+	})
+
+	it("dual-path alternatives bias their own spans — both readings stay alive", () => {
+		// "Unit 4/22": SPLIT_UNIT [0,6) + SPLIT_HOUSE_NUMBER [7,9) + FUSED [5,9) at lower conf.
+		const proposals: ProposedSpan[] = [
+			{ start: 0, end: 6, kind: "SPLIT_UNIT", confidence: 0.85, alternativeGroup: 0, source: "slash" },
+			{ start: 7, end: 9, kind: "SPLIT_HOUSE_NUMBER", confidence: 0.85, alternativeGroup: 0, source: "slash" },
+			{ start: 5, end: 9, kind: "FUSED_NUMBER", confidence: 0.3, alternativeGroup: 0, source: "slash" },
+		]
+		const m = buildSpanProposalPriors(proposals, pieces, LABELS)
+		expect(m[0]![1]).toBeCloseTo(0.85 * 2.0) // B-unit on "Unit"
+		expect(m[1]![2]).toBeCloseTo(0.85 * 2.0) // I-unit on "4"
+		expect(m[1]![5]).toBeCloseTo(0.3 * 2.0) // fused B-house_number ALSO alive on "4", weaker
+		expect(m[2]![5]).toBeCloseTo(0.85 * 2.0) // split B-house_number on "22" (max over fused I-)
+	})
+
+	it("returns all-zeros for no proposals", () => {
+		expect(buildSpanProposalPriors([], pieces, LABELS).flat().every((v) => v === 0)).toBe(true)
+	})
+})

--- a/scripts/eval/score-punctuation-stress.ts
+++ b/scripts/eval/score-punctuation-stress.ts
@@ -9,8 +9,9 @@
 // identical gold, stated in the report header.
 // Usage: node --experimental-strip-types scripts/eval/score-punctuation-stress.ts --model <onnx>
 //   [--engine neural|v0] [--file data/eval/external/punctuation-stress.jsonl] [--no-ship-config]
+//   [--span-proposer]  — enable the Stage 2.7 span proposer (#518 M2+M3; default-off, NOT ship config)
 import { decodeAsJson } from "@mailwoman/core/decoder"
-import { NeuralAddressClassifier, parseAnchorLookup, parseGazetteerLexicon } from "@mailwoman/neural"
+import { buildCodexSpanLexicon, NeuralAddressClassifier, parseAnchorLookup, parseGazetteerLexicon } from "@mailwoman/neural"
 import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
 import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
 import { createAddressParser } from "mailwoman"
@@ -50,6 +51,15 @@ const neural =
 							suppressGazetteerNearPostcode: true,
 							addressSystemConventions: "auto" as const,
 							bridgePunctuationGaps: true,
+						}
+					: {}),
+				...(argv.includes("--span-proposer")
+					? {
+							spanProposer: {
+								lexicon: buildCodexSpanLexicon(),
+								...(arg("--sp-bias") ? { biasScale: +arg("--sp-bias")! } : {}),
+								...(arg("--sp-ann-bias") ? { annotationBiasScale: +arg("--sp-ann-bias")! } : {}),
+							},
 						}
 					: {}),
 			})


### PR DESCRIPTION
The M2+M3 build from the punctuation survey: typed span proposals (paired delimiters, designator+identifier, dual-path slash/hyphen) consumed as phrase priors — the classifier conditions, never obeys — plus the decode-side crossing constraint.

## Measured (v4.4.0 int8 ship config, punctuation-stress, folded view; deterministic across repeat runs)

| class | OFF | ON | v0 |
|---|--:|--:|--:|
| **bracketed** | 69.2 | **87.7** | 83.1 |
| **slash** | 58.7 | **71.7** | 71.7 |
| paren-annotation | 81.5 | 86.2 | 84.6 |
| mixed-hard | 64.3 | 69.0 | 40.5† |
| **overall** | 76.8 | **80.9** | 75.3 (2†) |

**Both pre-registered quadrants moved, no class moved down, zero deaths both ways.** Bracketed now beats v0; slash ties it. `Flat 2/14` flips to gold unit+house; bare `3/45` stays fused — the model vetoes the low-confidence split reading, which is dual-path working as designed.

## Honest notes (from the agent, kept verbatim in spirit)

- The annotation lever needed near-mask strength (annotationBiasScale 12 — the measured saturation point; stated sweep, not tuned silently). The confidence floor, not the scale, protects `(Australia)`-shaped groups (paren-component flat). This sits at the soft-prior/decision boundary — the classifier can still veto, but rarely will at that magnitude.
- The crossing constraint only fires on apostrophe/curly-quote boundaries (parens were never bridgeable) — safety net, not the bracketed lever.
- **Stage 5 (joint-reconcile) consumption NOT wired** — that's surgery on the default-ON reconcile path (PHRASE_KIND_TO_TAG, annotation-as-non-component, alternativeGroup beam awareness); the seam is documented. Classifier phrase-prior path is what shipped.
- AU/NZ `Level 5` has no codex table yet (#517); `LEVEL_PHRASE` maps to `unit` (schema has no level tag).

Default-OFF behind `cfg.spanProposer` (parity pattern): ship config untouched, disabled baseline reproduces the documented #518 numbers byte-for-byte. neural 226 + core 314 green.

Part of #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)