### PR TITLE
fix(corpus): boundary-preferred + longest-first span location — pilot GO (#519)

### DIFF
--- a/corpus/src/align.test.ts
+++ b/corpus/src/align.test.ts
@@ -357,3 +357,79 @@ describe("alignRow — char-offset span emission (#519, v0.5.0 format)", () => {
 		expect(result.kind).toBe("quarantined")
 	})
 })
+
+describe("alignRow — boundary-aligned match preference (the v0.5.0 pilot's Umak/AK bug)", () => {
+	it("a short region value does not claim the inside of an earlier word", () => {
+		// Pre-fix, leftmost-substring let region "AK" (case-insensitive) match inside "Umak",
+		// scrambling every later span — 0.088% of the pilot shard, 46 natural rows.
+		const result = alignRow(
+			baseRow({
+				raw: "Umak Cir, AK 99546",
+				components: { street: "Umak", street_suffix: "Cir", region: "AK", postcode: "99546" },
+			})
+		)
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		const { raw, span_starts, span_ends, span_tags } = result.row
+		const byTag = Object.fromEntries(span_tags!.map((t, i) => [t, raw.slice(span_starts![i]!, span_ends![i]!)]))
+		expect(byTag).toEqual({ street: "Umak", street_suffix: "Cir", region: "AK", postcode: "99546" })
+		// And specifically: the region span sits at the standalone "AK", not inside "Umak".
+		const regionIdx = span_tags!.indexOf("region")
+		expect(span_starts![regionIdx]).toBe(10)
+	})
+
+	it("intra-word matches survive as the fallback — affix supervision inside compounds", () => {
+		// street_suffix "straße" has NO boundary-aligned occurrence in "Hauptstraße"; the sub-word
+		// span is the point of the char-offset format and must not be quarantined by the fix.
+		const result = alignRow(
+			baseRow({
+				raw: "Hauptstraße 5, 10827 Berlin",
+				country: "DE",
+				components: { street: "Haupt", street_suffix: "straße", house_number: "5", postcode: "10827", locality: "Berlin" },
+			})
+		)
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		const { raw, span_starts, span_ends, span_tags } = result.row
+		const suffixIdx = span_tags!.indexOf("street_suffix")
+		expect(raw.slice(span_starts![suffixIdx]!, span_ends![suffixIdx]!)).toBe("straße")
+		expect(span_starts![suffixIdx]).toBe(5) // inside the compound, directly after "Haupt"
+	})
+
+	it("longest value locates first — a region homonym cannot steal the street's word (pilot2 residual)", () => {
+		// "Alaska" is both the region and the street's first word; locating region first claimed
+		// [0,6) and quarantined the street. Longest-first gives the street its full surface, and
+		// the region then finds its own boundary-aligned occurrence.
+		const result = alignRow(
+			baseRow({
+				raw: "Alaska Regional Dr, Alaska 99508",
+				components: { street: "Alaska Regional Dr", region: "Alaska", postcode: "99508" },
+			})
+		)
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		const { raw, span_starts, span_ends, span_tags } = result.row
+		const byTag = Object.fromEntries(span_tags!.map((t, i) => [t, [span_starts![i]!, span_ends![i]!]]))
+		expect(raw.slice(...(byTag["street"] as [number, number]))).toBe("Alaska Regional Dr")
+		expect(byTag["region"]).toEqual([20, 26])
+	})
+
+	it("the Lake/AK natural-row case from the pilot scan", () => {
+		const result = alignRow(
+			baseRow({
+				raw: "Lake Dr, AK 99692",
+				components: { street: "Lake", street_suffix: "Dr", region: "AK", postcode: "99692" },
+			})
+		)
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		const { raw, span_starts, span_ends, span_tags } = result.row
+		for (let i = 0; i < span_tags!.length; i++) {
+			const slice = raw.slice(span_starts![i]!, span_ends![i]!)
+			expect(slice.trim()).toBe(slice) // no span carries edge whitespace
+		}
+		const regionIdx = span_tags!.indexOf("region")
+		expect(raw.slice(span_starts![regionIdx]!, span_ends![regionIdx]!)).toBe("AK")
+		expect(span_starts![regionIdx]).toBe(9)
+	})
+})

--- a/corpus/src/align.ts
+++ b/corpus/src/align.ts
@@ -99,7 +99,14 @@ export function alignRow(row: CanonicalRow, opts: AlignOptions = {}): AlignmentR
 
 	const haystack = caseInsensitive ? row.raw.toLowerCase() : row.raw
 
-	for (const [tag, value] of Object.entries(row.components) as Array<[ComponentTag, string | undefined]>) {
+	// Longest value first: a short component must not claim a word that a longer, more specific
+	// component owns ("Alaska Regional Dr, Alaska" — region "Alaska" stealing the street's first
+	// word quarantined the street; pilot2's residual class). Emit order is unaffected — spans are
+	// re-sorted by start below.
+	const entries = (Object.entries(row.components) as Array<[ComponentTag, string | undefined]>).sort(
+		(a, b) => (b[1]?.length ?? 0) - (a[1]?.length ?? 0)
+	)
+	for (const [tag, value] of entries) {
 		if (!value) continue
 
 		const needle = caseInsensitive ? value.toLowerCase() : value
@@ -191,15 +198,25 @@ function locateSpan(args: {
 	const { haystack, needle, claimed, maxEditDistance } = args
 	if (needle.length === 0) return undefined
 
-	// Pass 1: verbatim substring, leftmost non-claimed.
+	// Pass 1: verbatim substring. Word-boundary-aligned matches are PREFERRED over intra-word ones
+	// — leftmost-substring alone let a short value claim the inside of an earlier word (region "AK"
+	// matched inside "Umak"/"Lake", scrambling every later span; caught by the v0.5.0 pilot build).
+	// Intra-word matches stay allowed as the fallback because they are load-bearing for affix
+	// supervision (street_suffix "straße" inside "Hauptstraße" has no boundary-aligned occurrence —
+	// sub-word spans are the point of the char-offset format).
+	let intraWord: { start: number; end: number } | undefined
 	let from = 0
 	while (true) {
 		const idx = haystack.indexOf(needle, from)
 		if (idx < 0) break
 		const end = idx + needle.length
-		if (!overlapsClaimed(idx, end, claimed)) return { start: idx, end }
+		if (!overlapsClaimed(idx, end, claimed)) {
+			if (isBoundaryAligned(haystack, idx, end)) return { start: idx, end }
+			intraWord ??= { start: idx, end }
+		}
 		from = idx + 1
 	}
+	if (intraWord) return intraWord
 
 	if (maxEditDistance <= 0) return undefined
 
@@ -215,6 +232,15 @@ function locateSpan(args: {
 	}
 
 	return undefined
+}
+
+const WORD_CHAR = /[\p{L}\p{N}]/u
+
+/** Both needle edges sit on word boundaries of the haystack (string edges count as boundaries). */
+function isBoundaryAligned(haystack: string, start: number, end: number): boolean {
+	const before = start === 0 || !WORD_CHAR.test(haystack[start - 1]!)
+	const after = end === haystack.length || !WORD_CHAR.test(haystack[end]!)
+	return before && after
 }
 
 function overlapsClaimed(start: number, end: number, claimed: Array<[number, number]>): boolean {

--- a/docs/articles/plan/2026-06-11-v0.5.0-rebuild-plan.md
+++ b/docs/articles/plan/2026-06-11-v0.5.0-rebuild-plan.md
@@ -26,6 +26,19 @@ when scheduled.
    `GROUP_CONCAT` + the matching exact-tier check; slim-DB rebuild rides the same artifact pass.
 4. **Pilot build** (1 shard, ~1M rows): calibrates the full-build wall-clock estimate AND runs
    the invariance gates against real data before committing days of compute. THE GO/NO-GO GATE.
+
+   **RAN 2026-06-12 — verdict: GO, after two aligner fixes the gate itself caught.** Three
+   iterations (TIGER, 150k canonical → ~312k labeled, 36 s each):
+   - pilot1: 270 rows (0.088%) with corrupted spans — `locateSpan`'s leftmost-substring match let
+     region "AK" claim the inside of "Umak"/"Lake". Fix: boundary-aligned matches preferred,
+     intra-word kept as fallback (the German-affix sub-word case is load-bearing).
+   - pilot2: 0 corrupted; 21 quarantines remained — the homonym-steal class ("Alaska Regional Dr,
+     Alaska": region claimed the street's word). Fix: longest-value-first location.
+   - pilot3: **311,750 rows, 0 quarantined, 0 violations**; the python loader streamed the shard
+     with spans valid end-to-end.
+
+   **Wall-clock calibration**: 36 s per 150k canonical single-process → full ~677M labeled ≈ 22 h
+   one process; embarrassingly parallel by adapter, so a same-day build at modest parallelism.
 5. **Full from-source build** (~677M rows + the v0.4.x overlay shards re-emitted natively).
    DE holdout materializes here (SPLIT_MANIFEST picks up Saarland + Mecklenburg-Vorpommern).
 6. **Validation campaign**: invariance on sampled converted-equivalent rows, lint-corpus-shard,


### PR DESCRIPTION
The v0.5.0 pilot build ran (the runbook's step 4, THE GO/NO-GO GATE) and did exactly what it exists for — three 36-second iterations, two real aligner bugs caught and fixed:

| iteration | result |
|---|---|
| pilot1 | 270 rows (0.088%) corrupted spans — leftmost-substring let region `AK` match inside "Umak"/"Lake", scrambling every later span; 46 rows were natural (no augmentation involved) |
| pilot2 (boundary-preference fix) | 0 corrupted; 21 quarantines left — the homonym-steal class (`Alaska Regional Dr, Alaska`: region claimed the street's first word) |
| pilot3 (longest-first fix) | **311,750 rows, 0 quarantined, 0 violations**; python loader streams the shard with valid spans end-to-end |

## The fixes (both in `locateSpan` / its caller)

1. **Boundary-aligned matches preferred** — intra-word kept as the *fallback*, because sub-word affix spans (`straße` inside `Hauptstraße`) are the entire point of the char-offset format and have no boundary-aligned occurrence. A blunt boundary requirement would have quarantined the German affix corpus.
2. **Longest value locates first** — a short homonym can't steal a word a longer component owns. Emit order unchanged (spans re-sort by start before emission).

Three regression tests pin the Umak/AK class, the Hauptstraße fallback, and the Alaska homonym; corpus suite 821 green.

## Verdict recorded in the runbook

**GO.** Wall-clock calibration: 36 s per 150k canonical single-process → full ~677M labeled ≈ 22 h one process, embarrassingly parallel by adapter. The full from-source build (runbook step 5) is now an operator scheduling call.

Part of #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)