### PR TITLE
feat(neural): span proposer default ON (#518 — operator ruling)

### DIFF
--- a/data/eval/external/punctuation-stress.README.md
+++ b/data/eval/external/punctuation-stress.README.md
@@ -34,21 +34,21 @@ Gold conventions, decided once here:
 
 `--engine v0` vs neural v4.4.0 ship config + `--fold-gold`. Gold updated 2026-06-11 per the
 operator's unbalanced-delimiter ruling (convention 4: rows 29/32/112) — unbalanced + overall
-cells shifted slightly vs the expansion-day run. Note: the set grew 62→120 on
+cells shifted slightly vs the expansion-day run. Neural column re-measured 2026-06-12 with the Stage 2.7 span proposer DEFAULT-ON (operator ruling; #544/#546) — proposer-OFF baseline preserved in the #518 thread. Note: the set grew 62→120 on
 2026-06-11 — per-class deltas vs the 62-row run reflect the composition shift (the expansion
 deliberately deepened the v0-win quadrants and added international surfaces), NOT model drift.
 
 | class            |                  v0 |     neural (v4.4.0) | Δ            |
 | ---------------- | ------------------: | ------------------: | ------------ |
 | apostrophe       |                93.3 |                84.4 | v0 +8.9      |
-| bracketed        |                83.1 |                69.2 | v0 +13.9     |
+| bracketed        |                83.1 |                87.7 | neural +4.6  |
 | care-of          |                60.0 |                85.0 | neural +25.0 |
 | dotted           |                78.2 |                81.8 | neural +3.6  |
 | hyphen           |                82.6 |                84.1 | neural +1.5  |
-| mixed-hard       |     40.5 († 1 died) |                64.3 | neural +23.8 |
-| paren-annotation |                84.6 |                81.5 | v0 +3.1      |
+| mixed-hard       |     40.5 († 1 died) |                69.0 | neural +28.5 |
+| paren-annotation |                84.6 |                86.2 | neural +1.6  |
 | paren-component  |                75.0 |                75.0 | tie          |
 | quoted-venue     |     73.8 († 1 died) |                75.4 | neural +1.6  |
-| slash            |                71.7 |                58.7 | v0 +13.0     |
+| slash            |                71.7 |                71.7 | tie          |
 | unbalanced       |                69.0 |                83.3 | neural +14.3 |
-| **overall**      | **75.3** (2 deaths) | **76.8** (0 deaths) | neural +1.5  |
+| **overall**      | **75.3** (2 deaths) | **80.9** (0 deaths) | neural +5.6  |

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -35,6 +35,7 @@ import { bridgePunctuationGaps } from "./span-bridge.js"
 import { buildSpanProposalPriors, type SpanProposalPriorOpts } from "./span-proposal-prior.js"
 import { buildStreetMorphologyEmissionPriors, type StreetMorphologyPriorOpts } from "./street-morphology-prior.js"
 import { MailwomanTokenizer } from "./tokenizer.js"
+import { buildCodexSpanLexicon } from "./span-proposer-lexicon.js"
 import { repairUnitLabels } from "./unit-repair.js"
 import { buildBioEndMask, buildBioStartMask, buildBioTransitionMask, softmax, viterbi } from "./viterbi.js"
 import type { ResolveWeightsOpts, ResolvedWeights } from "./weights.js"
@@ -128,10 +129,14 @@ export interface NeuralAddressClassifierConfig {
 	 * the boundary hypotheses and can still disagree — and (b) ANNOTATION/QUOTED span boundaries feed
 	 * the span bridge as merge-crossing constraints (no same-tag merge may straddle a structural
 	 * delimiter). Build the lexicon with `buildCodexSpanLexicon` (`./span-proposer-lexicon.js`).
-	 * Per-parse opts override. Omit for the byte-stable default (no proposals, no priors, no
-	 * constraints).
+	 * Per-parse opts override.
+	 *
+	 * DEFAULT ON (operator ruling 2026-06-12, after the #518 measurement closed both v0-win
+	 * quadrants with no class down): omitting this builds the codex lexicon lazily with the frozen
+	 * measured scales (biasScale 5.0 / annotationBiasScale 12.0). Pass `false` for the
+	 * proposer-free baseline (the pre-2026-06-12 byte-stable default).
 	 */
-	spanProposer?: SpanProposerConfig
+	spanProposer?: SpanProposerConfig | false
 }
 
 /** Config for the Stage 2.7 span-proposer integration (see `NeuralAddressClassifierConfig.spanProposer`). */
@@ -144,6 +149,8 @@ export class NeuralAddressClassifier {
 	private readonly labels: readonly string[]
 	private readonly decodeMode: "viterbi" | "argmax"
 	private readonly transitions: number[][]
+	/** Lazily-built default Stage 2.7 config (codex lexicon, frozen scales) — see `cfg.spanProposer`. */
+	#defaultProposerCfg: SpanProposerConfig | undefined
 	private readonly startTransitions: number[]
 	private readonly endTransitions: number[]
 
@@ -158,6 +165,15 @@ export class NeuralAddressClassifier {
 		}
 		this.startTransitions = cfg.startTransitions ?? buildBioStartMask(this.labels)
 		this.endTransitions = cfg.endTransitions ?? buildBioEndMask(this.labels)
+	}
+
+	/**
+	 * The default-ON Stage 2.7 config: codex lexicon (us/au/nz), frozen measured scales (the prior
+	 * builder's own defaults). Built once per instance, only when a parse actually needs it.
+	 */
+	private defaultProposer(): SpanProposerConfig {
+		this.#defaultProposerCfg ??= { lexicon: buildCodexSpanLexicon() }
+		return this.#defaultProposerCfg
 	}
 
 	/**
@@ -301,14 +317,18 @@ export class NeuralAddressClassifier {
 			)
 		}
 
-		// Stage 2.7 span proposer (#518, M2+M3): typed span proposals consumed as phrase priors. The
-		// per-parse opt can switch the configured proposer off (`spanProposer: false`); it cannot
-		// conjure one without a configured lexicon. Disabled = byte-stable (no proposals computed).
-		const proposerCfg = (opts?.spanProposer ?? true) ? this.cfg.spanProposer : undefined
+		// Stage 2.7 span proposer (#518, M2+M3): typed span proposals consumed as phrase priors.
+		// DEFAULT ON since 2026-06-12 (operator ruling): an omitted config builds the codex lexicon
+		// lazily with the frozen measured scales; `spanProposer: false` (config or per-parse) is the
+		// proposer-free baseline. Disabled = byte-stable (no proposals computed).
+		const configured = this.cfg.spanProposer === false ? undefined : (this.cfg.spanProposer ?? this.defaultProposer())
+		const proposerCfg = (opts?.spanProposer ?? true) ? configured : undefined
 		const spanProposals: ProposedSpan[] = proposerCfg ? proposeSpans(text, proposerCfg.lexicon) : []
 		if (spanProposals.length > 0) {
 			emissions = addEmissionMatrix(emissions, buildSpanProposalPriors(spanProposals, pieces, this.labels, proposerCfg))
 		}
+
+		// (defaultProposer lives below decode helpers — one lazy build per classifier instance.)
 
 		// Conventions emission mask: tags that are ungrammatical in the detected system are removed
 		// from the decoder's vocabulary outright (-1e9 ≈ log 0). Copy-on-mask — `emissions` may alias


### PR DESCRIPTION
Operator ruling 2026-06-12: enable by default. `cfg.spanProposer` omitted → lazy codex lexicon with the frozen measured scales; `false` → the proposer-free baseline (config or per-parse).

Verified on the v4.4.0 int8 artifact, all flag-free:
- punctuation-stress folded **80.9** (bracketed 87.7 — beats v0's 83.1; slash 71.7 — ties v0); README table re-measured, OFF baseline preserved on #518
- demo-cascade smoke **21/21**
- affix per-tag at/above floors (prefix 93.6 / suffix 96.6 / street 90.6)
- neural + core suites green (the 2 web-onnx-runner failures are pre-existing environmental — onnxruntime-web's wasm fetch fails offline; reproduces on clean main)

Part of #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)