### PR TITLE
feat(cli): mailwoman autocomplete — FST prefix walk (#190)

### DIFF
--- a/mailwoman/commands/autocomplete.test.ts
+++ b/mailwoman/commands/autocomplete.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Unit tests for the `mailwoman autocomplete` command.
+ *
+ *   Fixture FST is built in-memory with a tiny hand-coded trie so tests don't depend on a live WOF
+ *   DB. The trie is built using `normalizeTokens` (exactly as the real builder does) to honour the
+ *   symmetry contract from issue #190.
+ */
+
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { writeFileSync } from "node:fs"
+import { describe, expect, it, beforeAll } from "vitest"
+import { FstMatcher, normalizeTokens } from "../../resolver-wof-sqlite/fst-matcher.js"
+import { serializeFst, deserializeFst } from "../../resolver-wof-sqlite/fst-serialize.js"
+import { autocomplete } from "../../resolver-wof-sqlite/fst-autocomplete.js"
+import { runAutocomplete, resolveFstPath } from "./autocomplete.js"
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+interface FixturePlace {
+	wofID: number
+	placetype: string
+	name: string
+	importance: number
+	parentChain: number[]
+}
+
+type FstNodeInternal = { edges: Map<string, number>; places: FixtureEntry[] }
+type FixtureEntry = FixturePlace & { lat: number; lon: number }
+
+/** Build a minimal FstMatcher from a list of places, using normalizeTokens exactly as the builder. */
+function buildFixtureMatcher(places: FixturePlace[]): FstMatcher {
+	const entries: FixtureEntry[] = places.map((p) => ({ ...p, lat: 0, lon: 0 }))
+	const nodes: FstNodeInternal[] = [{ edges: new Map(), places: [] }]
+
+	for (const entry of entries) {
+		const tokens = normalizeTokens(entry.name)
+		if (tokens.length === 0) continue
+		let stateId = 0
+		for (const t of tokens) {
+			const node = nodes[stateId]!
+			let next = node.edges.get(t)
+			if (next === undefined) {
+				next = nodes.length
+				nodes.push({ edges: new Map(), places: [] })
+				node.edges.set(t, next)
+			}
+			stateId = next
+		}
+		const node = nodes[stateId]!
+		if (!node.places.some((p) => p.wofID === entry.wofID)) {
+			node.places.push(entry)
+		}
+	}
+
+	return FstMatcher.fromNodes(nodes)
+}
+
+const FIXTURE_PLACES: FixturePlace[] = [
+	{ wofID: 85977539, placetype: "locality", name: "New York City", importance: 0.9, parentChain: [85688543, 85633793] },
+	{ wofID: 85688543, placetype: "region", name: "New York", importance: 0.75, parentChain: [85633793] },
+	{ wofID: 85935903, placetype: "locality", name: "New Orleans", importance: 0.6, parentChain: [85688481, 85633793] },
+	{
+		wofID: 85922583,
+		placetype: "locality",
+		name: "San Francisco",
+		importance: 0.85,
+		parentChain: [102087579, 85633793],
+	},
+	{ wofID: 85919487, placetype: "locality", name: "San Jose", importance: 0.5, parentChain: [102087579, 85633793] },
+	{ wofID: 85633793, placetype: "country", name: "United States", importance: 0.99, parentChain: [] },
+]
+
+let fixtureMatcher: FstMatcher
+let fixtureBinPath: string
+
+beforeAll(() => {
+	fixtureMatcher = buildFixtureMatcher(FIXTURE_PLACES)
+
+	// Write the serialized fixture to a temp file so runAutocomplete (which reads from disk) can be
+	// tested end-to-end.
+	const buf = serializeFst(fixtureMatcher)
+	fixtureBinPath = join(tmpdir(), `mailwoman-fst-fixture-${Date.now()}.bin`)
+	writeFileSync(fixtureBinPath, buf)
+})
+
+// ---------------------------------------------------------------------------
+// normalizeTokens symmetry smoke-test
+// ---------------------------------------------------------------------------
+
+describe("normalizeTokens symmetry", () => {
+	it("lowercases ASCII", () => {
+		expect(normalizeTokens("New York")).toEqual(["new", "york"])
+	})
+
+	it("strips punctuation", () => {
+		expect(normalizeTokens("St. Paul")).toEqual(["st", "paul"])
+	})
+
+	it("applies NFKC — composed characters are normalized but diacritics are preserved", () => {
+		// normalizeTokens applies NFKC + lowercase + punctuation strip. It does NOT decompose or
+		// strip diacritics — that's intentional so that "José" and "Jose" are treated as distinct
+		// tokens at both build time and query time (symmetry preserved).
+		const tokens = normalizeTokens("San José")
+		expect(tokens).toEqual(["san", "josé"])
+	})
+
+	it("returns empty array for whitespace-only input", () => {
+		expect(normalizeTokens("   ")).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// In-memory autocomplete (FstMatcher directly, no disk I/O)
+// ---------------------------------------------------------------------------
+
+describe("autocomplete — in-memory fixture", () => {
+	it("returns suggestions for prefix 'New'", () => {
+		const result = autocomplete(fixtureMatcher, "New", { maxSuggestions: 10 })
+		expect(result.suggestions.length).toBeGreaterThan(0)
+		const names = result.suggestions.map((s) => s.name.toLowerCase())
+		expect(names.some((n) => n.includes("new"))).toBe(true)
+	})
+
+	it("returns an exact match for 'New York'", () => {
+		const result = autocomplete(fixtureMatcher, "New York", { maxSuggestions: 10 })
+		const exactMatches = result.suggestions.filter((s) => s.completionTokens.length === 0)
+		expect(exactMatches.length).toBeGreaterThanOrEqual(1)
+		const types = exactMatches.map((s) => s.placetype)
+		expect(types).toContain("region")
+	})
+
+	it("returns no suggestions for an unknown prefix", () => {
+		const result = autocomplete(fixtureMatcher, "Xyzzyplugh")
+		expect(result.suggestions.length).toBe(0)
+	})
+
+	it("ranks by importance (prominent places first)", () => {
+		const result = autocomplete(fixtureMatcher, "San", { maxSuggestions: 5 })
+		expect(result.suggestions.length).toBeGreaterThan(0)
+		if (result.suggestions.length >= 2) {
+			expect(result.suggestions[0]!.importance).toBeGreaterThanOrEqual(result.suggestions[1]!.importance)
+		}
+	})
+
+	it("prefix 'San' yields San Francisco as the top result (highest importance)", () => {
+		// The FST is token-based: "San Fr" would require a token edge for "fr" which doesn't exist.
+		// The correct prefix is the full first token "San" — the BFS expansion then finds "Francisco"
+		// and "Jose" as the one-token continuations, ranked by importance.
+		const result = autocomplete(fixtureMatcher, "San", { maxSuggestions: 5 })
+		expect(result.suggestions.length).toBeGreaterThan(0)
+		expect(result.suggestions[0]!.name).toBe("San Francisco")
+		expect(result.suggestions[0]!.importance).toBeGreaterThan(result.suggestions[1]!.importance)
+	})
+
+	it("prefix query is case-insensitive — matches the build-time normalizer", () => {
+		const lower = autocomplete(fixtureMatcher, "new york", { maxSuggestions: 5 })
+		const upper = autocomplete(fixtureMatcher, "NEW YORK", { maxSuggestions: 5 })
+		expect(lower.suggestions.map((s) => s.wofID)).toEqual(upper.suggestions.map((s) => s.wofID))
+	})
+
+	it("respects maxSuggestions cap", () => {
+		const result = autocomplete(fixtureMatcher, "New", { maxSuggestions: 1 })
+		expect(result.suggestions.length).toBeLessThanOrEqual(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// runAutocomplete — disk round-trip
+// ---------------------------------------------------------------------------
+
+describe("runAutocomplete — disk round-trip", () => {
+	it("reads the fixture bin and returns completions for 'New'", async () => {
+		const entries = await runAutocomplete("New", { fstPath: fixtureBinPath, limit: 10 })
+		expect(entries.length).toBeGreaterThan(0)
+		const names = entries.map((e) => e.name.toLowerCase())
+		expect(names.some((n) => n.includes("new"))).toBe(true)
+	})
+
+	it("honours the limit cap", async () => {
+		const entries = await runAutocomplete("New", { fstPath: fixtureBinPath, limit: 1 })
+		expect(entries.length).toBeLessThanOrEqual(1)
+	})
+
+	it("throws a human-readable error for a missing FST path", async () => {
+		await expect(
+			runAutocomplete("New", { fstPath: "/nonexistent/path/fst-does-not-exist.bin" })
+		).rejects.toThrow(/FST binary not found/)
+	})
+
+	it("throws a human-readable error for a malformed FST buffer", async () => {
+		const badPath = join(tmpdir(), `mailwoman-fst-bad-${Date.now()}.bin`)
+		writeFileSync(badPath, Buffer.from("not-an-fst-binary"))
+		await expect(runAutocomplete("New", { fstPath: badPath })).rejects.toThrow(/Malformed FST binary/)
+	})
+
+	it("returns empty array for an unknown prefix", async () => {
+		const entries = await runAutocomplete("Xyzzyplugh", { fstPath: fixtureBinPath })
+		expect(entries).toEqual([])
+	})
+
+	it("round-trips importance and wofID through serialization", async () => {
+		const entries = await runAutocomplete("United", { fstPath: fixtureBinPath, limit: 5 })
+		const us = entries.find((e) => e.wofID === 85633793)
+		expect(us).toBeDefined()
+		// Float32 round-trip may introduce tiny epsilon; check within tolerance.
+		expect(us!.importance).toBeCloseTo(0.99, 1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// resolveFstPath
+// ---------------------------------------------------------------------------
+
+describe("resolveFstPath", () => {
+	it("returns the explicit path when given one", () => {
+		expect(resolveFstPath("/explicit/path.bin")).toBe("/explicit/path.bin")
+	})
+
+	it("falls back to the staged default when no explicit path and no env var", () => {
+		const saved = process.env["MAILWOMAN_FST_BIN"]
+		delete process.env["MAILWOMAN_FST_BIN"]
+		try {
+			expect(resolveFstPath()).toBe("/tmp/v440-stage/en-us/v4.4.0/fst-en-US.bin")
+		} finally {
+			if (saved !== undefined) process.env["MAILWOMAN_FST_BIN"] = saved
+		}
+	})
+
+	it("prefers $MAILWOMAN_FST_BIN over the staged default", () => {
+		const saved = process.env["MAILWOMAN_FST_BIN"]
+		process.env["MAILWOMAN_FST_BIN"] = "/env/path.bin"
+		try {
+			expect(resolveFstPath()).toBe("/env/path.bin")
+		} finally {
+			if (saved !== undefined) {
+				process.env["MAILWOMAN_FST_BIN"] = saved
+			} else {
+				delete process.env["MAILWOMAN_FST_BIN"]
+			}
+		}
+	})
+
+	it("explicit path takes precedence over env var", () => {
+		const saved = process.env["MAILWOMAN_FST_BIN"]
+		process.env["MAILWOMAN_FST_BIN"] = "/env/path.bin"
+		try {
+			expect(resolveFstPath("/explicit/path.bin")).toBe("/explicit/path.bin")
+		} finally {
+			if (saved !== undefined) {
+				process.env["MAILWOMAN_FST_BIN"] = saved
+			} else {
+				delete process.env["MAILWOMAN_FST_BIN"]
+			}
+		}
+	})
+})

--- a/mailwoman/commands/autocomplete.tsx
+++ b/mailwoman/commands/autocomplete.tsx
@@ -1,0 +1,175 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `mailwoman autocomplete <prefix>`
+ *
+ *   One-shot prefix completion against the FST gazetteer. Returns the top-N place suggestions
+ *   (name, placetype, WOF id, importance) that match the given prefix, ranked by importance.
+ *
+ *   The prefix normalizer is `normalizeTokens` from `fst-matcher` — the SAME function used at FST
+ *   build time — so the symmetry contract from #190 is honoured. No third normalizer.
+ *
+ *   Default FST path: $MAILWOMAN_FST_BIN, else /tmp/v440-stage/en-us/v4.4.0/fst-en-US.bin.
+ *   Pass --fst <path> to override.
+ */
+
+import { Text } from "ink"
+import { readFileSync } from "node:fs"
+import { useEffect, useState } from "react"
+import zod from "zod"
+import type { CommandComponent } from "../sdk/cli.js"
+
+export { ArgumentsSchema as args, AutocompleteConfigSchema as options }
+
+const ArgumentsSchema = zod.array(zod.string().describe("Prefix string to complete"))
+
+export const AutocompleteConfigSchema = zod.object({
+	limit: zod.coerce
+		.number()
+		.int()
+		.min(1)
+		.max(100)
+		.optional()
+		.default(10)
+		.describe("Maximum number of completions to return (default 10)"),
+	fst: zod
+		.string()
+		.optional()
+		.describe(
+			"Path to the FST binary (fst-en-US.bin). Defaults to $MAILWOMAN_FST_BIN or " +
+				"/tmp/v440-stage/en-us/v4.4.0/fst-en-US.bin."
+		),
+	json: zod
+		.boolean()
+		.optional()
+		.default(false)
+		.describe("Emit results as a JSON array instead of formatted text"),
+})
+
+/** Resolve the FST binary path from explicit flag, env var, or the staged default. */
+export function resolveFstPath(explicitPath?: string): string {
+	return (
+		explicitPath ??
+		process.env["MAILWOMAN_FST_BIN"] ??
+		"/tmp/v440-stage/en-us/v4.4.0/fst-en-US.bin"
+	)
+}
+
+export interface AutocompleteEntry {
+	name: string
+	placetype: string
+	wofID: number
+	importance: number
+	completionTokens: string[]
+}
+
+/**
+ * Load the FST from `fstPath` and run prefix autocomplete. Throws with a human-readable message on
+ * any IO or format error so callers can surface it cleanly.
+ */
+export async function runAutocomplete(
+	prefix: string,
+	opts: { fstPath: string; limit?: number }
+): Promise<AutocompleteEntry[]> {
+	const { existsSync } = await import("node:fs")
+	const fstPath = opts.fstPath
+
+	if (!existsSync(fstPath)) {
+		throw new Error(
+			`FST binary not found at ${fstPath}.\n` +
+				`Pass --fst <path>, set $MAILWOMAN_FST_BIN, or build the FST with:\n` +
+				`  mailwoman fst build --db /path/to/wof-admin.db --output fst-en-US.bin`
+		)
+	}
+
+	let buf: Buffer
+	try {
+		buf = readFileSync(fstPath)
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err)
+		throw new Error(`Failed to read FST binary at ${fstPath}: ${msg}`)
+	}
+
+	// Dynamic import keeps @mailwoman/resolver-wof-sqlite a true optional peer dep — only loaded
+	// when the autocomplete command is invoked.
+	const { deserializeFst } = await import("@mailwoman/resolver-wof-sqlite/fst-serialize")
+	const { autocomplete } = await import("@mailwoman/resolver-wof-sqlite/fst-autocomplete")
+
+	let matcher
+	try {
+		matcher = deserializeFst(buf)
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err)
+		throw new Error(`Malformed FST binary at ${fstPath}: ${msg}`)
+	}
+
+	const result = autocomplete(matcher, prefix, { maxSuggestions: opts.limit ?? 10 })
+
+	return result.suggestions.map((s) => ({
+		name: s.name,
+		placetype: s.placetype,
+		wofID: s.wofID,
+		importance: s.importance,
+		completionTokens: s.completionTokens,
+	}))
+}
+
+function formatSuggestions(entries: AutocompleteEntry[]): string {
+	if (entries.length === 0) return "(no completions)"
+	return entries
+		.map((e, i) => {
+			const completion = e.completionTokens.length > 0 ? ` [+${e.completionTokens.join(" ")}]` : ""
+			const imp = e.importance.toFixed(4)
+			return `${String(i + 1).padStart(2)}. ${e.name}${completion}  (${e.placetype}, wof:${e.wofID}, imp:${imp})`
+		})
+		.join("\n")
+}
+
+const AutocompleteCommand: CommandComponent<typeof AutocompleteConfigSchema, typeof ArgumentsSchema> = ({
+	options,
+	args,
+}) => {
+	const [output, setOutput] = useState<string>()
+	const [error, setError] = useState<string>()
+
+	useEffect(() => {
+		const prefix = args[0]
+		if (!prefix) {
+			// Intentional: surface the usage error through the same render-then-exit pattern as parse.tsx.
+			// The "cascading renders" the rule warns about are not a real cost here — the effect
+			// short-circuits with `return`.
+			// eslint-disable-next-line react-hooks/set-state-in-effect
+			setError("Usage: mailwoman autocomplete <prefix> [--limit N] [--fst <path>]")
+			return
+		}
+
+		const fstPath = resolveFstPath(options.fst)
+
+		runAutocomplete(prefix, { fstPath, limit: options.limit })
+			.then((entries) => {
+				if (options.json) {
+					setOutput(JSON.stringify(entries, null, 2))
+				} else {
+					setOutput(formatSuggestions(entries))
+				}
+			})
+			.catch((err: unknown) => {
+				const msg = err instanceof Error ? err.message : String(err)
+				setError(msg)
+			})
+	}, [args, options])
+
+	if (error) {
+		return <Text color="red">{error}</Text>
+	}
+
+	if (!output) {
+		return <Text dimColor>Searching...</Text>
+	}
+
+	return <Text>{output}</Text>
+}
+
+export default AutocompleteCommand


### PR DESCRIPTION
The one-PR autocomplete wiring per the operator's scope ruling. Built by a Sonnet agent as a delegation test — clean result.

`mailwoman autocomplete <prefix> [--limit N] [--fst <path>] [--json]`

```
$ mailwoman autocomplete "New York" --limit 5
 1. New York  (locality, wof:85977539, imp:0.8818)
 2. New York  (region, wof:85688543, imp:0.8156)
 3. New York Mills [+mills]  (locality, wof:85968759, imp:0.4698)
 ...
```

- **Symmetry contract honored**: `normalizeTokens` from `fst-matcher` at both build and query time (the #190 comment's requirement — no third normalizer), with a dedicated symmetry test block.
- Path resolution: `--fst` → `$MAILWOMAN_FST_BIN` → the staged v4.4.0 default; missing/malformed binary → loud named errors.
- 21 tests: BFS fixture walk, disk round-trip, importance ranking, case-insensitivity, error paths, path precedence. Verified against the real 127,365-place FST.
- Interactive REPL deliberately skipped: the FST is token-based; live-typing needs a within-token substring shim that belongs with #531's typo/prefix work, noted on the issue.

Demo input wiring stays out of scope per the one-PR ruling. Part of #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)