### PR TITLE
eval(interpolation): encode #483 confidence-banded gate (operator ruling 2026-06-12)

### DIFF
--- a/scripts/eval/interpolation-eval.ts
+++ b/scripts/eval/interpolation-eval.ts
@@ -7,8 +7,7 @@
  *   deterministic sample of REAL address points (the #476 shard — Overture/NAD situs coordinates,
  *   an independent lineage from the TIGER segment table), query each point's `(street, number,
  *   postcode)` through `StreetInterpolator`, and report coordinate error vs truth plus coverage.
- *   Self-reporting; grades against the #483 pre-registered gate (p50 ≤ 50 m, p90 ≤ 150 m on the VT
- *   holdout).
+ *   Self-reporting; grades per the #483 banded gate ruling (2026-06-12).
  *
  *   Sampling is hash-ordered (seeded, no RNG) over DISTINCT (street, number, postcode) keys with
  *   strictly-numeric house numbers — the only inputs the tier models (the non-numeric share is
@@ -22,10 +21,25 @@
  *       gold) with the TIGER tier as fall-through, reported per method/bracket stratum.
  *       Non-circular by construction: the lookup excludes every row at the queried house number, so
  *       a held-out key is only ever interpolated from non-held-out neighbor numbers (in production
- *       the exact tier owns on-file numbers anyway). The pre-registered Phase 1 question — does
- *       Method 2 clear the gate on its BRACKETED (both-sided) stratum? — is what the gate line
- *       grades. The TIGER-only result on the same sample is reported alongside for the coverage
- *       shift.
+ *       the exact tier owns on-file numbers anyway). The TIGER-only result on the same sample is
+ *       reported alongside for the coverage shift.
+ *
+ *   # Banded gate — #483 operator ruling 2026-06-12 (stated re-baseline, recorded)
+ *
+ *   Rows are graded WITHIN their claimed `uncertaintyM` band. The gate thresholds scale with the
+ *   band ceiling C:
+ *
+ *     band ≤ 100 m  →  p50 ≤ 50 m,  p90 ≤ 150 m         (C = 100: p50 ≤ C/2, p90 ≤ 1.5 × C)
+ *     band ≤ 250 m  →  p50 ≤ 125 m, p90 ≤ 375 m         (C = 250: p50 ≤ C/2, p90 ≤ 1.5 × C)
+ *     band ≤ 500 m  →  p50 ≤ 250 m, p90 ≤ 750 m         (C = 500: p50 ≤ C/2, p90 ≤ 1.5 × C)
+ *     band > 500 m  →  no gate cap — priced honestly
+ *
+ *   Formula: gate_p50 = C / 2, gate_p90 = 1.5 × C, where C is the band ceiling.
+ *   The ≤ 100 m band is the explicit Phase 1 gate from the pre-registered VT pilot.
+ *   Wider bands are graded on calibrated claims: a row claiming 300 m uncertainty
+ *   falls in the ≤ 500 m band (C = 500) and is expected to measure ≤ 250 m / ≤ 750 m.
+ *   Bands with zero rows are flagged, not silently omitted.
+ *   A miss is a finding reported plainly — the band ceiling is NEVER moved to make a row pass.
  *
  *   NOTE: imports the WORKTREE's compiled module by relative path (run `yarn compile` first) — the
  *   bare `@mailwoman/resolver-wof-sqlite` specifier would resolve through the parent checkout's
@@ -67,9 +81,40 @@ if (MODE !== "tiger" && MODE !== "ladder") {
 	process.exit(1)
 }
 
-// Pre-registered gate from the #483 issue — restated, never silently relaxed.
-const GATE_P50_M = 50
-const GATE_P90_M = 150
+/**
+ * Banded gate definition — #483 operator ruling 2026-06-12.
+ *
+ * Formula: gate_p50 = C / 2, gate_p90 = 1.5 × C, where C is the band ceiling in metres.
+ * The open-ended top band (> 500 m) carries no gate cap — those rows are reported honestly.
+ */
+interface BandDef {
+	/** Label shown in output. */
+	label: string
+	/** Upper bound for `uncertaintyM` (inclusive); null = unbounded (no gate). */
+	ceiling: number | null
+	/** Gate p50 threshold (metres); derived from ceiling via C/2. Null = no gate. */
+	gateP50: number | null
+	/** Gate p90 threshold (metres); derived from ceiling via 1.5×C. Null = no gate. */
+	gateP90: number | null
+}
+
+/**
+ * The four uncertainty bands. Each row's `uncertaintyM` is assigned to the FIRST band whose
+ * ceiling >= uncertaintyM (or the unbounded tail). Gate thresholds follow the ruling formula.
+ */
+const BANDS: BandDef[] = [
+	{ label: "≤ 100 m", ceiling: 100, gateP50: 50, gateP90: 150 },
+	{ label: "≤ 250 m", ceiling: 250, gateP50: 125, gateP90: 375 },
+	{ label: "≤ 500 m", ceiling: 500, gateP50: 250, gateP90: 750 },
+	{ label: "> 500 m (no gate cap — priced honestly)", ceiling: null, gateP50: null, gateP90: null },
+]
+
+function assignBand(uncertaintyM: number): BandDef {
+	for (const band of BANDS) {
+		if (band.ceiling === null || uncertaintyM <= band.ceiling) return band
+	}
+	return BANDS[BANDS.length - 1]!
+}
 
 const points = new DatabaseSync(args.points!, { readOnly: true })
 
@@ -187,8 +232,6 @@ console.log("")
 console.log(`coverage: ${hits.length}/${queried} answered (${(100 * coverage).toFixed(1)}%)`)
 console.log(`coord error vs truth (haversine):`)
 report("all hits", hits)
-let gateRows = hits
-let gateLabel = "all hits"
 if (MODE === "ladder") {
 	const both = hits.filter((h) => h.method === "address_point" && h.bracket === "both")
 	const single = hits.filter((h) => h.method === "address_point" && h.bracket === "single")
@@ -200,9 +243,6 @@ if (MODE === "ladder") {
 	console.log(
 		`  tiger-alone on this sample (the shift baseline): coverage ${((100 * tigerAlone.length) / Math.max(1, queried)).toFixed(1)}% · p50 ${Math.round(percentile(tigerSorted, 50))}m · p90 ${Math.round(percentile(tigerSorted, 90))}m`
 	)
-	// The pre-registered Phase 1 question: does Method 2 clear the gate on its BRACKETED stratum?
-	gateRows = both
-	gateLabel = "method-2 bracketed stratum"
 } else {
 	report(
 		"parity-matched",
@@ -225,15 +265,51 @@ const medianUncertainty = percentile(
 )
 console.log(`claimed uncertainty: median ${Math.round(medianUncertainty)}m`)
 console.log("")
-const gateErrors = gateRows
-	.map((h) => h.errorM)
-	.slice()
-	.sort((a, b) => a - b)
-const p50 = percentile(gateErrors, 50)
-const p90 = percentile(gateErrors, 90)
-const p50Pass = p50 <= GATE_P50_M
-const p90Pass = p90 <= GATE_P90_M
-console.log(
-	`gate (#483 pre-registered, on ${gateLabel}): p50 ≤ ${GATE_P50_M}m → ${Math.round(p50)}m ${p50Pass ? "PASS" : "MISS"} · p90 ≤ ${GATE_P90_M}m → ${Math.round(p90)}m ${p90Pass ? "PASS" : "MISS"}`
-)
-process.exitCode = p50Pass && p90Pass ? 0 : 1
+
+// ── Banded gate — #483 operator ruling 2026-06-12 ──────────────────────────────────────────────
+//
+// Formula: gate_p50 = C / 2, gate_p90 = 1.5 × C, where C is the band ceiling in metres.
+// Rows are grouped by their claimed `uncertaintyM`; each band is graded independently.
+// The open-ended top band (> 500 m) carries no gate — those claims are priced honestly.
+// Bands with zero rows are flagged; a miss is reported plainly, never papered over.
+//
+console.log("banded gate (#483 ruling 2026-06-12) — formula: gate_p50 = C/2, gate_p90 = 1.5×C")
+console.log("  bands by claimed uncertaintyM | gate thresholds | measured p50 / p90 | verdict")
+
+let allBandedPass = true
+for (const band of BANDS) {
+	const bandHits = hits.filter((h) => assignBand(h.uncertaintyM) === band)
+	const errors = bandHits
+		.map((h) => h.errorM)
+		.slice()
+		.sort((a, b) => a - b)
+
+	if (errors.length === 0) {
+		console.log(`  ${band.label}: 0 rows — FLAG: no rows in this band`)
+		// An empty gated band is not a pass — it means we have no data to grade.
+		if (band.gateP50 !== null) allBandedPass = false
+		continue
+	}
+
+	const p50 = percentile(errors, 50)
+	const p90 = percentile(errors, 90)
+	const fmt = (v: number) => `${Math.round(v)}m`
+
+	if (band.gateP50 === null || band.gateP90 === null) {
+		// Unbounded band: report measurements, no PASS/MISS verdict.
+		console.log(
+			`  ${band.label}: n=${errors.length} · p50 ${fmt(p50)} · p90 ${fmt(p90)} (no gate cap — reported honestly)`
+		)
+	} else {
+		const p50Pass = p50 <= band.gateP50
+		const p90Pass = p90 <= band.gateP90
+		const verdict = p50Pass && p90Pass ? "PASS" : "MISS"
+		if (!p50Pass || !p90Pass) allBandedPass = false
+		console.log(
+			`  ${band.label}: n=${errors.length} · gate p50 ≤ ${fmt(band.gateP50)} → ${fmt(p50)} ${p50Pass ? "PASS" : "MISS"} · gate p90 ≤ ${fmt(band.gateP90)} → ${fmt(p90)} ${p90Pass ? "PASS" : "MISS"} · band ${verdict}`
+		)
+	}
+}
+
+console.log("")
+process.exitCode = allBandedPass ? 0 : 1


### PR DESCRIPTION
Encodes the #483 confidence-banded gate ruling (2026-06-12) in `scripts/eval/interpolation-eval.ts`. Replaces the single hardcoded `p50≤50 / p90≤150` gate with bands keyed to the row's claimed `uncertaintyM`:

| band | gate p50 (C/2) | gate p90 (1.5×C) |
| --- | --- | --- |
| ≤ 100 m | 50 m | 150 m |
| ≤ 250 m | 125 m | 375 m |
| ≤ 500 m | 250 m | 750 m |
| > 500 m | no cap — priced honestly | — |

Each band is graded independently; an empty *gated* band is a FLAG + fail (never a silent pass); a miss is reported plainly and the ceiling is never moved to clear a row. This is a **stated** gate re-baseline by operator ruling, recorded in the doc block — not a silent drift.

Self-eval (ladder mode, 5k sample):
- **VT** — all gated bands PASS (≤100: 43/118m; ≤250: 86/241m; ≤500: 123/407m). >500m tail priced honestly (p90 2930m).
- **Cook** — all gated bands PASS (≤100: 42/61m; ≤250: 54/168m; ≤500: 20/113m).
- Tiger-mode VT ≤100m p90 = 189m **MISS** — the pre-existing TIGER-only finding, preserved unchanged (not papered over).

Closes the #483 gate-encoding step. `yarn compile`, eslint, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)