### PR TITLE
fix(corpus): NFC-normalize in align + bounds-quarantine + resume — v0.5.0 build crash recovery

### DIFF
--- a/corpus/src/align.test.ts
+++ b/corpus/src/align.test.ts
@@ -336,20 +336,29 @@ describe("alignRow — char-offset span emission (#519, v0.5.0 format)", () => {
 		expect(result.row.span_tags).toEqual([])
 	})
 
-	it("throws loudly on a non-NFC raw, naming the row's source_id", () => {
+	it("normalizes a non-NFC raw to NFC instead of throwing (keeps the row; spans over the NFC raw)", () => {
 		// NFD: "é" as base letter + combining acute — two code units where NFC has one.
 		const nfdRaw = "10 Rue de la Re\u0301publique, 75008 Paris"
 		expect(nfdRaw.normalize("NFC")).not.toBe(nfdRaw)
-		expect(() =>
-			alignRow(
-				baseRow({
-					raw: nfdRaw,
-					country: "FR",
-					source_id: "nfd-row-42",
-					components: { locality: "Paris", postcode: "75008" },
-				})
-			)
-		).toThrowError(/not NFC-normalized.*nfd-row-42/s)
+		const result = alignRow(
+			baseRow({
+				raw: nfdRaw,
+				country: "FR",
+				source_id: "nfd-row-42",
+				components: { locality: "Paris", postcode: "75008" },
+			})
+		)
+		expect(result.kind).toBe("labeled")
+		if (result.kind !== "labeled") return
+		// Stored raw is the NFC form (single normalization form — #519 principle preserved).
+		const nfcRaw = nfdRaw.normalize("NFC")
+		expect(result.row.raw).toBe(nfcRaw)
+		// Spans located over the NFC raw → slicing by each span yields the component text.
+		const located = result.row.span_tags.map(
+			(tag, i) => `${tag}:${nfcRaw.slice(result.row.span_starts[i]!, result.row.span_ends[i]!)}`
+		)
+		expect(located).toContain("locality:Paris")
+		expect(located).toContain("postcode:75008")
 	})
 
 	it("does not throw on a non-NFC raw that is empty-ish (raw-empty quarantine wins)", () => {

--- a/corpus/src/align.ts
+++ b/corpus/src/align.ts
@@ -83,34 +83,34 @@ export function alignRow(row: CanonicalRow, opts: AlignOptions = {}): AlignmentR
 		return { kind: "quarantined", row: { row, reason: "raw-empty" } }
 	}
 
-	// Build-time NFC assertion (#519 ruling 2: the converter's Unicode-mismatch class dissolves
-	// into this check). Char-offset spans over `raw` are only meaningful under ONE normalization
-	// form; a non-NFC raw corrupts every downstream offset silently. Loud failure, naming the row.
-	if (row.raw.normalize("NFC") !== row.raw) {
-		throw new Error(
-			`alignRow: raw is not NFC-normalized (source=${row.source}, source_id=${row.source_id}). ` +
-				`Char-offset spans over a non-NFC raw are ambiguous downstream — normalize at the adapter boundary. ` +
-				`raw=${JSON.stringify(row.raw)}`
-		)
+	// #519 NFC handling — relaxed from a hard throw to normalization (2026-06-12, DeepSeek-validated):
+	// one non-NFC row (e.g. a non-Latin name variant like "দক্ষিণ কোরিয়া") must not crash a multi-hour
+	// build. Normalize `raw` AND every component value to NFC, compute spans over the NFC raw, and
+	// store the NFC raw — preserving the #519 single-normalization-form principle while keeping the row.
+	const raw = row.raw.normalize("NFC")
+	const components = { ...row.components }
+	for (const key in components) {
+		const v = components[key as keyof typeof components]
+		if (typeof v === "string") components[key as keyof typeof components] = v.normalize("NFC")
 	}
 
 	const componentSpans: ComponentSpan[] = []
 	const claimed: Array<[number, number]> = []
 
-	const haystack = caseInsensitive ? row.raw.toLowerCase() : row.raw
+	const haystack = caseInsensitive ? raw.toLowerCase() : raw
 
 	// Longest value first: a short component must not claim a word that a longer, more specific
 	// component owns ("Alaska Regional Dr, Alaska" — region "Alaska" stealing the street's first
 	// word quarantined the street; pilot2's residual class). Emit order is unaffected — spans are
 	// re-sorted by start below.
-	const entries = (Object.entries(row.components) as Array<[ComponentTag, string | undefined]>).sort(
+	const entries = (Object.entries(components) as Array<[ComponentTag, string | undefined]>).sort(
 		(a, b) => (b[1]?.length ?? 0) - (a[1]?.length ?? 0)
 	)
 	for (const [tag, value] of entries) {
 		if (!value) continue
 
 		const needle = caseInsensitive ? value.toLowerCase() : value
-		const span = locateSpan({ haystack, needle, raw: row.raw, claimed, maxEditDistance })
+		const span = locateSpan({ haystack, needle, raw, claimed, maxEditDistance })
 
 		if (!span) {
 			return {
@@ -119,17 +119,32 @@ export function alignRow(row: CanonicalRow, opts: AlignOptions = {}): AlignmentR
 			}
 		}
 
+		// Defensive bounds quarantine (2026-06-12): locateSpan's fuzzy/boundary logic can over-run the
+		// raw by a code unit on some non-Latin / combining-mark strings (e.g. Bengali name variants),
+		// yielding a span past the end. An out-of-bounds offset can never be a valid char span —
+		// quarantine the row rather than crash assertSpanInvariants and take down a multi-hour build.
+		// (If this class proves large in the quarantine report, locateSpan's boundary logic needs a
+		// combining-mark fix to KEEP these non-Latin rows.)
+		if (span.start < 0 || span.end > raw.length || span.start >= span.end) {
+			return {
+				kind: "quarantined",
+				row: { row, reason: `span-out-of-bounds:${tag}` },
+			}
+		}
+
 		componentSpans.push({ tag, start: span.start, end: span.end })
 		claimed.push([span.start, span.end])
 	}
 
 	componentSpans.sort((a, b) => a.start - b.start)
-	assertSpanInvariants(componentSpans, row)
-	const tokens = tokenizer.tokenize(row.raw)
+	assertSpanInvariants(componentSpans, { ...row, raw })
+	const tokens = tokenizer.tokenize(raw)
 	const labels = labelTokens(tokens, componentSpans)
 
 	const labeled: LabeledRow = {
 		...row,
+		raw,
+		components,
 		tokens: tokens.map((t) => t.text),
 		labels,
 		// The v0.5.0 char-offset triple (#519): the located spans, emitted verbatim. The token

--- a/corpus/src/build.ts
+++ b/corpus/src/build.ts
@@ -47,7 +47,7 @@
  *   self-contained.
  */
 
-import { createReadStream, createWriteStream, type WriteStream } from "node:fs"
+import { createReadStream, createWriteStream, existsSync, readFileSync, type WriteStream } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { createInterface } from "node:readline"
@@ -138,6 +138,19 @@ export async function buildCorpus(opts: BuildCorpusOptions): Promise<BuildCorpus
 			opts.onProgress?.("adapter-run", `skipped ${adapter.id} (no input configured)`)
 			continue
 		}
+		// Opt-in resume (MAILWOMAN_RESUME=1): if a complete per-adapter canonical.jsonl + MANIFEST.json
+		// already exist, reuse them instead of re-emitting. The MANIFEST is written only after the
+		// canonical is fully flushed, so its presence guarantees completeness; row order is identical,
+		// so downstream holdout-split determinism is preserved. Recovers an align-phase crash without
+		// redoing the (expensive) emit phase. Default (unset) re-emits, preserving correctness. (2026-06-12.)
+		const adapterDir = join(intermediateDir, adapter.id)
+		const cachedManifest = join(adapterDir, "MANIFEST.json")
+		if (process.env.MAILWOMAN_RESUME === "1" && existsSync(cachedManifest) && existsSync(join(adapterDir, "canonical.jsonl"))) {
+			const cached = JSON.parse(readFileSync(cachedManifest, "utf8")) as AdapterRunManifest
+			opts.onProgress?.("adapter-run", `resumed ${adapter.id} (reused ${cached.yielded} canonical rows)`)
+			adapterRuns.push(cached)
+			continue
+		}
 		opts.onProgress?.("adapter-run", `running ${adapter.id}`)
 		const m = await runAdapter({
 			adapter,
@@ -185,7 +198,18 @@ export async function buildCorpus(opts: BuildCorpusOptions): Promise<BuildCorpus
 				}
 			}
 			for (const r of fanned) {
-				const result = alignRow(r)
+				let result: ReturnType<typeof alignRow>
+				try {
+					result = alignRow(r)
+				} catch (err) {
+					// Last-resort robustness (2026-06-12): no single row may crash a multi-hour build.
+					// alignRow's targeted paths normalize/quarantine known issues with specific reasons;
+					// this catches any UNKNOWN throw (e.g. assertSpanInvariants on an unforeseen span
+					// shape) → quarantine + continue. A spike in `align-threw` reasons is a finding.
+					writeQuarantine(r, `align-threw:${(err as Error).message.slice(0, 160)}`)
+					quarantined++
+					continue
+				}
 				if (result.kind === "labeled") {
 					const split = splitForRow(result.row, holdouts)
 					labeledStreams[split].write(`${JSON.stringify(result.row)}\n`)


### PR DESCRIPTION
Recovers the v0.5.0 full-build crash — it died in the align phase ~2.5h in on a wof-admin Bengali name variant ("দক্ষিণ কোরিয়া").

**Failure modes:**
1. alignRow's #519 NFC assertion `throw` on the non-NFC raw — one row in ~690M crashed the build.
2. After normalizing, `locateSpan`'s fuzzy/boundary pass over-ran the raw by a code unit on the combining-mark string (span `[0,14)` over len 13) → `assertSpanInvariants` threw.

**Fixes** (the NFC question was DeepSeek-validated):
- **align — normalize, don't throw.** raw + every component value → NFC, spans computed over the NFC raw, NFC raw stored. Preserves the #519 single-normalization-form principle; keeps the (valuable, multi-locale) row. `assertSpanInvariants` now sees the NFC raw.
- **align — bounds-quarantine.** Any out-of-bounds span → quarantine (`span-out-of-bounds:<tag>`), not crash. ~479 such rows in the wof-admin pass; the combining-mark `locateSpan` over-run is a follow-up to KEEP these rows rather than drop them.
- **build — try/catch safety net** around `alignRow` → quarantine on any unknown throw, so no single row crashes a multi-hour unattended build.
- **build — opt-in resume** (`MAILWOMAN_RESUME=1`): reuse complete per-adapter `canonical.jsonl` + `MANIFEST.json` instead of re-emitting. Recovered this crash without redoing the ~2.5h emit phase.

28/28 align tests pass (the non-NFC test now asserts the normalize-not-throw contract). The v0.5.0 build is re-running in resume mode with these fixes and progressing clean (1.1GB labeled, 0 crash).

**Flag for review:** this relaxes the #519 *deliberate* hard assertion. The principle (char-offsets over one normalization form) is preserved; the brittleness (one non-NFC row kills the whole build) is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)