### PR TITLE
fix(train): skip astral UTF-16-offset rows in iter_encoded (#519 stopgap)

### DIFF
--- a/corpus-python/src/mailwoman_train/data_loader.py
+++ b/corpus-python/src/mailwoman_train/data_loader.py
@@ -554,6 +554,7 @@ def iter_encoded(
     affix_relabel_lexicon = None
     if getattr(cfg_data, "affix_relabel_lexicon_path", None):
         affix_relabel_lexicon = AffixRelabelLexicon.load(cfg_data.affix_relabel_lexicon_path)
+    astral_skipped = 0
     for row in iter_rows(
         Path(cfg_data.corpus_dir),
         split,
@@ -567,6 +568,22 @@ def iter_encoded(
         augment_glue_prob=getattr(cfg_data, "augment_glue_prob", 0.0),
         affix_relabel_lexicon=affix_relabel_lexicon,
     ):
+        # v0.5.0 stopgap (#519 offset-unit mismatch): the corpus stores span offsets in UTF-16 code
+        # units, but this consumer (char_label_array_from_spans + SentencePiece pieces) is code-point-
+        # native. For astral-plane rows (~0.06% — exotic-script country-name variants like Gothic), a
+        # UTF-16 span end can exceed the code-point len(raw) and encode_row would raise
+        # span-out-of-bounds. Skip + count rather than crash a multi-hour training run. Lasting fix:
+        # emit code-point offsets in the TS build and re-align (corpus-v0.5.1). 2026-06-12.
+        _se = row.get("span_ends")
+        if _se and max(_se) > len(row["raw"]):
+            astral_skipped += 1
+            if astral_skipped <= 5 or astral_skipped % 50000 == 0:
+                logger.warning(
+                    "iter_encoded: skipped astral UTF-16-offset row #%d (span end > code-point len): %r",
+                    astral_skipped,
+                    row["raw"][:40],
+                )
+            continue
         enc = encode_row(
             tokenizer,
             row["raw"],

--- a/corpus-python/src/mailwoman_train/test_data_loader_spans.py
+++ b/corpus-python/src/mailwoman_train/test_data_loader_spans.py
@@ -203,3 +203,30 @@ def test_iter_encoded_legacy_path_passes_none(tmp_path: Path, monkeypatch) -> No
     list(iter_encoded(cfg, tokenizer=None, split="train"))
     assert captured[0]["span_starts"] is None
     assert captured[0]["span_tags"] is None
+
+
+def test_iter_encoded_skips_astral_utf16_offset_rows(tmp_path: Path, monkeypatch) -> None:
+    # The corpus stores UTF-16 span offsets (#519); this consumer is code-point-native. An astral-
+    # script row (Gothic — 2 UTF-16 units per code point) has span ends that exceed the code-point
+    # len(raw), so encode_row would raise span-out-of-bounds. iter_encoded must skip it, not crash.
+    astral = _row(
+        raw="𐍃𐌿𐌽𐌸",  # 4 code points, 8 UTF-16 units
+        tokens=["𐍃𐌿𐌽𐌸"],
+        labels=["B-country"],
+        span_starts=[0],
+        span_ends=[8],  # UTF-16 end > code-point len(raw)=4
+        span_tags=["country"],
+    )
+    corpus = _write_corpus(tmp_path, [_row(), astral])
+    captured: list[dict] = []
+
+    def fake_encode_row(tokenizer, raw, tokens, labels, max_length, **kwargs):
+        captured.append({"raw": raw, **kwargs})
+        return {"input_ids": [1], "attention_mask": [1], "labels": [0]}
+
+    monkeypatch.setattr(data_loader, "encode_row", fake_encode_row)
+    cfg = DataConfig(corpus_dir=str(corpus), country_weights={"US": 1.0}, coarse_filter=False)
+    list(iter_encoded(cfg, tokenizer=None, split="train"))
+    # Only the BMP row reached encode_row; the astral row was skipped before it (no crash).
+    assert len(captured) == 1
+    assert captured[0]["raw"] == "P.O. Box 19, Buffalo, NY 14201"


### PR DESCRIPTION
**Pre-training gate for the v0.5.0 run** — found by the read-only validation, reviewed with DeepSeek.

The v0.5.0 corpus stores char-offset spans in **UTF-16 code units** (the TS build's native unit, per the #519 spec), but the Python training consumer — `char_label_array_from_spans` + SentencePiece pieces — is **code-point-native**. For astral-plane rows (~0.06%: exotic-script country-name variants like Gothic `𐍃𐌿𐌽𐌸𐍂𐌰𐌺𐌰𐌿𐍂𐌹𐌰`, where each code point is 2 UTF-16 units), a UTF-16 span end exceeds the code-point `len(raw)` and `encode_row` raises `span out of bounds`. One such row would crash a multi-hour training run.

**This patch:** `iter_encoded` skips rows whose span ends exceed the code-point `len(raw)`, with a count + log — mirroring how the build already quarantines unalignable rows. The dropped rows are exotic-script country variants no one addresses mail in.

**Verified the SP gotcha:** SentencePiece piece offsets are code-point (the tokenizer maps SP byte offsets → char via a `byte_to_char` index keyed on `enumerate(raw)`), so this removes genuinely-unreconcilable rows rather than relocating the mismatch.

**Lasting fix (corpus-v0.5.1):** emit code-point offsets in the TS build (`Array.from(raw)` iteration) + re-align — keeps every row, and folds in #555's combining-mark fix.

Tests: new `test_iter_encoded_skips_astral_utf16_offset_rows` + 8 existing span tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)