### PR TITLE
feat(codex): NZ 'Private Box' colloquial alias (#517)

### DIFF
--- a/codex/nz/delivery-service.test.ts
+++ b/codex/nz/delivery-service.test.ts
@@ -11,6 +11,7 @@ import {
 	matchNzDeliveryService,
 	normalizeNzDeliveryService,
 	NZ_DELIVERY_SERVICE_TYPES,
+	NZ_PRIVATE_BOX_ALIAS,
 } from "./delivery-service.js"
 
 describe("NZ_DELIVERY_SERVICE_TYPES", () => {
@@ -26,6 +27,25 @@ describe("NZ_DELIVERY_SERVICE_TYPES", () => {
 				expect(t.identifier).toBe("not-used")
 			}
 		}
+	})
+})
+
+describe("NZ_PRIVATE_BOX_ALIAS", () => {
+	it("is marked officiallyInvalid — not a valid ADV358 Delivery Service Type", () => {
+		// ADV358 (Oct 2021) lists exactly six types; 'Private Box' is not among them.
+		// Source: nzpost.co.nz/sites/nz/files/2021-10/adv358-address-standards.pdf (accessed 2026-06-11).
+		// Operator ruling 2026-06-11: recognize-as-used with this citation.
+		expect(NZ_PRIVATE_BOX_ALIAS.officiallyInvalid).toBe(true)
+	})
+
+	it("has the same identifier rule as PO Box — required-if-allocated", () => {
+		const poBox = NZ_DELIVERY_SERVICE_TYPES.find((t) => t.type === "PO Box")!
+		expect(NZ_PRIVATE_BOX_ALIAS.identifier).toBe(poBox.identifier)
+	})
+
+	it("is NOT present in NZ_DELIVERY_SERVICE_TYPES (kept separate per operator ruling)", () => {
+		const types = NZ_DELIVERY_SERVICE_TYPES.map((t) => t.type)
+		expect(types).not.toContain("Private Box")
 	})
 })
 
@@ -49,9 +69,31 @@ describe("matchNzDeliveryService", () => {
 		expect(matchNzDeliveryService("Post Box 12")).toMatchObject({ type: "PO Box", id: "12" })
 	})
 
-	it("rejects the forms ADV358 names as errors, and types that don't exist", () => {
+	it("ADV358 types do not carry the colloquial flag", () => {
+		expect(matchNzDeliveryService("PO Box 24999")?.colloquial).toBeUndefined()
+		expect(matchNzDeliveryService("Private Bag 106999")?.colloquial).toBeUndefined()
+		expect(matchNzDeliveryService("Counter Delivery")?.colloquial).toBeUndefined()
+	})
+
+	it("recognizes 'Private Box' as the colloquial NZ alias — operator ruling 2026-06-11", () => {
+		// 'Private Box' is NOT a valid ADV358 type. NZ Post's live standards pages do not list it.
+		// Source: adv358-address-standards.pdf (Oct 2021) + nzpost.co.nz/business/shipping-in-nz/
+		//   addressing-standards (accessed 2026-06-11). Operator authorizes recognition with citation.
+		expect(matchNzDeliveryService("Private Box 102")).toMatchObject({
+			type: "Private Box",
+			id: "102",
+			colloquial: true,
+		})
+		expect(matchNzDeliveryService("private box 24999")).toMatchObject({
+			type: "Private Box",
+			id: "24999",
+			colloquial: true,
+		})
+		expect(isNzDeliveryService("Private Box 102")).toBe(true)
+	})
+
+	it("rejects the forms ADV358 names as errors", () => {
 		expect(matchNzDeliveryService("PB 39990")).toBeNull()
-		expect(matchNzDeliveryService("Private Box 102")).toBeNull()
 		expect(matchNzDeliveryService("Locked Bag 1797")).toBeNull() // AU-only designator
 	})
 
@@ -69,9 +111,15 @@ describe("normalizeNzDeliveryService", () => {
 		expect(normalizeNzDeliveryService("community mail box b99")).toBe("CMB B99")
 	})
 
+	it("normalizes 'Private Box' to its recognized surface form", () => {
+		// The colloquial alias normalizes to 'Private Box <id>' (preserves the label used on real mail).
+		expect(normalizeNzDeliveryService("private box 102")).toBe("Private Box 102")
+		expect(normalizeNzDeliveryService("Private Box 24999")).toBe("Private Box 24999")
+	})
+
 	it("round-trips: every normalized form still matches", () => {
-		for (const raw of ["PO Box 24999", "Private Bag", "CMB B99", "Counter Delivery", "Poste Restante"]) {
-			expect(isNzDeliveryService(normalizeNzDeliveryService(raw))).toBe(true)
+		for (const raw of ["PO Box 24999", "Private Bag", "CMB B99", "Counter Delivery", "Poste Restante", "Private Box 102"]) {
+			expect(isNzDeliveryService(normalizeNzDeliveryService(raw)), `round-trip for "${raw}"`).toBe(true)
 		}
 	})
 

--- a/codex/nz/delivery-service.ts
+++ b/codex/nz/delivery-service.ts
@@ -4,7 +4,8 @@
  * @author Teffen Ellis, et al.
  *
  *   NZ Post delivery-service types — the second half of the Commonwealth po_box vocabulary: `PO Box
- *   24999`, `Private Bag 106999`, `CMB B99`, plus the identifier-less counter services.
+ *   24999`, `Private Bag 106999`, `CMB B99`, plus the identifier-less counter services, plus the
+ *   colloquial "Private Box" alias documented here for recognition with its 'invalid' citation.
  *
  *   Sourcing (accessed 2026-06-11):
  *
@@ -25,10 +26,17 @@
  *       punctuation-free".
  *
  *   All six types are CURRENT in the October 2021 ADV358 (including CMB — no legacy flag is needed
- *   for the NZ slice). "Private Box" — a colloquial NZ synonym for a PO Box that the postal arena's
- *   gold rows carry — does NOT appear in ADV358 or the live standards pages and is therefore
- *   excluded here (see the issue #517 sourcing note: a smaller sourced list beats a larger guessed
- *   one).
+ *   for the NZ slice).
+ *
+ *   **"Private Box" — colloquial alias, officially invalid:** ADV358 does not list "Private Box" as
+ *   a Delivery Service Type and NZ Post's live standards pages (addressing-standards, how-to-address-
+ *   mail, accessed 2026-06-11) name only the six types above. However, real NZ mail and the postal
+ *   arena's gold rows carry "Private Box" as a colloquial synonym for a numbered PO Box (same
+ *   numbered format, different label). Operator ruling 2026-06-11: "Private Box = recognize-as-used
+ *   — codex documents it unofficial/colloquial WITH the 'officially invalid' citation; the shard
+ *   teaches recognition (validity and recognition are separate disciplines, same as the AU legacy
+ *   flags)." This is encoded in {@link NZ_PRIVATE_BOX_ALIAS} — a distinct export from
+ *   {@link NZ_DELIVERY_SERVICE_TYPES} so callers can choose whether to include the unofficial form.
  * @see {@link https://www.nzpost.co.nz/sites/nz/files/2021-10/adv358-address-standards.pdf NZ Post Address Standards (ADV358, Oct 2021)}
  * @see {@link https://www.nzpost.co.nz/business/shipping-in-nz/addressing-standards NZ Post addressing standards}
  * @see {@link https://www.nzpost.co.nz/personal/sending-in-nz/how-to-address-mail NZ Post — how to address mail}
@@ -77,54 +85,106 @@ export const NZ_DELIVERY_SERVICE_TYPES = [
 export type NzDeliveryServiceTypeName = (typeof NZ_DELIVERY_SERVICE_TYPES)[number]["type"]
 
 /**
+ * Metadata for the colloquial "Private Box" alias (see the module header and operator ruling
+ * 2026-06-11). Kept separate from {@link NZ_DELIVERY_SERVICE_TYPES} because it is NOT a valid ADV358
+ * Delivery Service Type — recognition and validity are separate concerns.
+ *
+ * Sourcing: ADV358 (Oct 2021) omits "Private Box" from its Delivery Service Type list entirely.
+ * NZ Post's live standards pages (nzpost.co.nz/business/shipping-in-nz/addressing-standards and
+ * nzpost.co.nz/personal/sending-in-nz/how-to-address-mail, accessed 2026-06-11) do not list it as
+ * a valid type. Real NZ mail and the postal arena's gold rows nonetheless carry it as a colloquial
+ * synonym for a numbered PO Box. Operator ruling 2026-06-11 authorizes its inclusion here for
+ * recognition only, with this citation; corpus synthesis should treat it as a non-prescriptive form.
+ */
+export const NZ_PRIVATE_BOX_ALIAS = {
+	/** The surface form as it appears on real mail and in postal-arena gold rows. */
+	type: "Private Box",
+	/**
+	 * The description of validity status — NOT a valid ADV358 Delivery Service Type; a colloquial
+	 * NZ synonym for a numbered PO Box (same format as "PO Box <number>").
+	 */
+	description: "Colloquial NZ synonym for a numbered PO Box — NOT a valid ADV358 Delivery Service Type",
+	/** Identifier rule mirrors PO Box: a number is expected when the alias is used with one. */
+	identifier: "required-if-allocated" satisfies NzIdentifierRule,
+	/** True — this form is NOT valid per ADV358 or NZ Post's live standards pages (accessed 2026-06-11). */
+	officiallyInvalid: true,
+} as const
+
+/**
  * Per-type surface patterns (designator phrase only). Recognition is deliberately wider than the
  * prescriptive standard — mail in the wild writes "P.O. Box" even though ADV358 says `PO` is
- * punctuation-free — but it does NOT admit forms the standard names as errors of TYPE (`PB`) or
- * types that don't exist ("Private Box").
+ * punctuation-free — but it does NOT admit forms the standard names as errors of TYPE (`PB`).
+ *
+ * The colloquial "Private Box" alias is included for recognition (see {@link NZ_PRIVATE_BOX_ALIAS}
+ * and operator ruling 2026-06-11); it maps to a distinct synthetic type string so callers can
+ * distinguish it from the ADV358 types.
  */
-const TYPE_PATTERNS: ReadonlyArray<readonly [NzDeliveryServiceTypeName, string]> = [
+const TYPE_PATTERNS: ReadonlyArray<readonly [NzDeliveryServiceTypeName | "Private Box", string]> = [
 	["PO Box", String.raw`p\.?\s*o\.?\s*box|post\s+box`],
 	["Private Bag", String.raw`private\s+bag`],
+	["Private Box", String.raw`private\s+box`],
 	["Response Bag", String.raw`response\s+bag`],
 	["CMB", String.raw`community\s+mail\s+box|cmb`],
 	["Counter Delivery", String.raw`counter\s+delivery`],
 	["Poste Restante", String.raw`poste\s+restante`],
 ]
 
-const IDENTIFIER_RULES = new Map<NzDeliveryServiceTypeName, NzIdentifierRule>(
-	NZ_DELIVERY_SERVICE_TYPES.map((t) => [t.type, t.identifier])
+/** Extended type name union including the colloquial alias recognized for parsing. */
+export type NzDeliveryServiceMatchTypeName = NzDeliveryServiceTypeName | "Private Box"
+
+const IDENTIFIER_RULES = new Map<NzDeliveryServiceMatchTypeName, NzIdentifierRule>(
+	[
+		...NZ_DELIVERY_SERVICE_TYPES.map((t) => [t.type, t.identifier] as const),
+		// "Private Box" mirrors PO Box identifier rules (required-if-allocated) per the alias metadata.
+		["Private Box", NZ_PRIVATE_BOX_ALIAS.identifier],
+	]
 )
 
 // One anchored regex per type. The identifier shape follows ADV358 (alphanumeric, no spaces or
 // separators — `24999`, `B99`); the identifier-less counter services take no tail at all.
-const MATCHERS: ReadonlyArray<{ type: NzDeliveryServiceTypeName; re: RegExp }> = TYPE_PATTERNS.map(([type, src]) => {
-	const rule = IDENTIFIER_RULES.get(type)!
-	const tail = rule === "not-used" ? "" : String.raw`(?:\s+([\dA-Za-z]+))${rule === "optional" ? "?" : ""}`
-	return { type, re: new RegExp(String.raw`^\s*(${src})${tail}\s*$`, "i") }
-})
+const MATCHERS: ReadonlyArray<{ type: NzDeliveryServiceMatchTypeName; re: RegExp }> = TYPE_PATTERNS.map(
+	([type, src]) => {
+		const rule = IDENTIFIER_RULES.get(type)!
+		const tail = rule === "not-used" ? "" : String.raw`(?:\s+([\dA-Za-z]+))${rule === "optional" ? "?" : ""}`
+		return { type, re: new RegExp(String.raw`^\s*(${src})${tail}\s*$`, "i") }
+	}
+)
 
 /** Result of an NZ delivery-service parse. */
 export interface NzDeliveryServiceMatch {
-	/** The designator phrase as it appeared ("PO Box", "private bag"). */
+	/** The designator phrase as it appeared ("PO Box", "private bag", "Private Box"). */
 	matched: string
-	/** The canonical Delivery Service Type ("PO Box", "Private Bag", "CMB", …). */
-	type: NzDeliveryServiceTypeName
+	/**
+	 * The canonical Delivery Service Type or recognized alias ("PO Box", "Private Bag", "CMB", …,
+	 * "Private Box"). When `type` is "Private Box", `colloquial` is true and `officiallyInvalid` is
+	 * true — the form is not a valid ADV358 type.
+	 */
+	type: NzDeliveryServiceMatchTypeName
 	/** The Delivery Service Identifier when present ("24999", "B99"). */
 	id?: string
+	/**
+	 * True when the matched form is the colloquial "Private Box" alias — not a valid ADV358 Delivery
+	 * Service Type. Absent (undefined) for all standard ADV358 types.
+	 */
+	colloquial?: true
 }
 
 /**
  * If `input` is a standalone NZ delivery-service phrase ("PO Box 24999", "Private Bag 106999", "CMB
- * B99", bare "Private Bag", "Counter Delivery"), return the canonical type and identifier. Null
- * otherwise — including for "PB 39990" (an error of form per ADV358) and "Private Box" (not a
- * Delivery Service Type).
+ * B99", bare "Private Bag", "Counter Delivery", "Private Box 102"), return the canonical type and
+ * identifier. Null otherwise — including for "PB 39990" (an error of form per ADV358).
+ *
+ * When `type` is "Private Box", the result carries `colloquial: true` — indicating the colloquial
+ * alias (not an ADV358 Delivery Service Type; see {@link NZ_PRIVATE_BOX_ALIAS} and operator ruling
+ * 2026-06-11). Callers that want only formally-valid ADV358 types should check `!result.colloquial`.
  */
 export function matchNzDeliveryService(input: unknown): NzDeliveryServiceMatch | null {
 	if (typeof input !== "string") return null
 	for (const { type, re } of MATCHERS) {
 		const m = re.exec(input)
 		if (!m) continue
-		return { matched: m[1]!.trim(), type, ...(m[2] ? { id: m[2] } : {}) }
+		const colloquial = type === "Private Box" ? ({ colloquial: true } as const) : {}
+		return { matched: m[1]!.trim(), type, ...(m[2] ? { id: m[2] } : {}), ...colloquial }
 	}
 	return null
 }


### PR DESCRIPTION
Final #517 item: the NZ 'Private Box' colloquial alias — recognize-as-used with an `officiallyInvalid` citation (ADV358 lists six official Delivery Service Types; Private Box is absent). Per the operator ruling on #517. Scope strictly codex/nz/ (delivery-service.ts + .test.ts, 16 tests). Verified: in-scope diff. 🤖 Generated with [Claude Code](https://claude.com/claude-code)