### PR TITLE
fix(pipeline): retire joint-reconcile as the default decode path

### DIFF
--- a/2026-06-13-GEOCODER-CAMPAIGN.md
+++ b/2026-06-13-GEOCODER-CAMPAIGN.md
@@ -93,6 +93,17 @@ independent of Coverage; engines exist, this is API surface + wiring.
 Spec the policy-registry + reconcile + abstention layer now (so the pipeline is ≥v0 by construction),
 but VALIDATE after Coverage exists — it needs real tiers to calibrate. False-independence flag.
 
+**⚠️ FINDING (2026-06-14) — the existing reconcile stage was the OPPOSITE of ≥v0.** A
+reconcile-vs-raw-neural audit found joint-reconcile (#427's default) BREAKS the street+house_number
+geocode precondition on 77–84% of clean US addresses and fixes 0% (golden US+FR per-tag: street
+−25.6pp, house_number −23.1pp, worse-or-flat on every tag). The phrase grouper bundles the house
+number into `STREET_PHRASE` and `reconcileSpans` fuses the span. It was invisible because our evals
+grade **raw neural**, not the assembled pipeline — so the demo + any `createRuntimePipeline` consumer
+(the #485 service surface) were silently shipping broken parses. **Retired as default** (PR #566,
+`jointReconcile` → `false`); root cause filed as #565. Lesson for #478: the arbitration layer MUST be
+graded on the assembled pipeline against truth, never on raw-neural per-tag F1. Report:
+`docs/articles/evals/2026-06-14-reconcile-retirement.md`.
+
 ## Deferred this sprint (accuracy-broadening, not DoD-blocking)
 
 Parser multi-locale / FR-EU polish (#330/#435/#444/#241/#293/#294/#473/#296), typo-tolerance

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -241,12 +241,21 @@ export async function runPipeline(
 	// per-span verdict on orphaned spans (see the assignment + grouperAudit below).
 	let auditClassifierTopK: ClassifierCandidate[] | undefined
 
-	// Joint-reconcile path: DEFAULT as of Route A Phase II (#427). It beats argmax on every measured
-	// locale with per-field regression under 0.5% (report: docs/articles/evals/2026-06-07-route-a-
-	// phase-ii-regate.md). Set `jointReconcile: false` (or the deprecated `forceJointReconcile: false`)
-	// to force the legacy argmax sort. Still requires a phrase grouper + a `parseWithLogits` classifier;
-	// without either, the pipeline falls back to argmax regardless of the flag.
-	const jointEnabled = opts?.jointReconcile ?? opts?.forceJointReconcile ?? true
+	// Joint-reconcile path: RETIRED AS DEFAULT 2026-06-14 (#427 promoted it; this de-promotes it).
+	// A reconcile-vs-raw-neural audit on two non-circular US holdouts (Travis E-911 + 7-state
+	// OpenAddresses) found it BREAKS the street+house_number geocode precondition on 77-84% of clean
+	// US addresses and fixes 0% — the phrase grouper bundles the house number into the STREET_PHRASE
+	// ("3075 Hill Street") and reconcileSpans then fuses the whole span into one node, leaving no
+	// separate `street`. Confirmed on golden v0.1.2 US+FR (n=4507, per-tag recall vs raw argmax):
+	// street -25.6pp, house_number -23.1pp, locality -2.3pp, venue -0.6pp, region/postcode/unit flat.
+	// It is worse-or-flat on EVERY tag — including venue, the thing #427 promoted it for. The #427
+	// re-gate's "DE +25pp / IT-ES +15pp" was loose street-STRING recall on OOD inputs (where raw
+	// neural mangles the street); it never measured the geocode precondition our evals grade on raw
+	// neural, so the regression was invisible. The destructive piece is the grouper HN-bundling (see
+	// the tracked issue); until that's fixed, argmax is the correct default. Set `jointReconcile: true`
+	// to opt back into reconcile (the A/B harnesses do). Report: docs/articles/evals/2026-06-14-
+	// reconcile-retirement.md.
+	const jointEnabled = opts?.jointReconcile ?? opts?.forceJointReconcile ?? false
 	const useJointReconcile =
 		jointEnabled && phraseProposals.length > 0 && stages.classifier && "parseWithLogits" in stages.classifier
 

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -29,14 +29,17 @@ export interface PipelineOpts {
 	/** Disable fast-path shortcuts; always run the full pipeline. */
 	forceFullPipeline?: boolean
 	/**
-	 * The joint-reconcile path (Stage 5 beam search) is the DEFAULT decode path as of Route A Phase
-	 * II (#427) — it beats argmax on every measured locale (DE +25pp, IT/ES +15pp) with per-field
-	 * regression under 0.5%. It still requires a phrase grouper + a classifier exposing
-	 * `parseWithLogits`; when either is absent the pipeline falls back to the argmax sort
-	 * automatically.
+	 * The joint-reconcile path (Stage 5 beam search). Promoted to default by Route A Phase II (#427),
+	 * then RETIRED AS DEFAULT 2026-06-14: a reconcile-vs-raw-neural audit found it breaks the
+	 * street+house_number geocode precondition on 77-84% of clean US addresses (golden v0.1.2 US+FR,
+	 * n=4507: street -25.6pp, house_number -23.1pp; worse-or-flat on every tag, venue included). The
+	 * phrase grouper bundles the house number into the STREET_PHRASE and reconcileSpans fuses the
+	 * span. The #427 "DE +25pp" gains were loose street-string recall on OOD inputs, not the geocode
+	 * precondition. Default (unset) is now `false` (argmax). It still requires a phrase grouper + a
+	 * classifier exposing `parseWithLogits`; when either is absent the pipeline uses argmax regardless.
 	 *
-	 * Set `jointReconcile: false` to force the legacy argmax path (the A/B harnesses use this to
-	 * compare). Default (unset) is `true`.
+	 * Set `jointReconcile: true` to opt back into reconcile (the A/B harnesses do).
+	 * Report: docs/articles/evals/2026-06-14-reconcile-retirement.md.
 	 */
 	jointReconcile?: boolean
 	/** @deprecated Use {@link jointReconcile}. Retained as an explicit override for the A/B harnesses. */

--- a/docs/articles/evals/2026-06-14-reconcile-retirement.md
+++ b/docs/articles/evals/2026-06-14-reconcile-retirement.md
@@ -1,0 +1,105 @@
+# Retiring joint-reconcile as the default decode path
+
+_2026-06-14. A reconcile-vs-raw-neural audit, run during the geocoder campaign to quantify how often
+the shipped pipeline degrades a parse, found the joint-reconcile path (#427's default since Route A
+Phase II) breaks the street + house-number geocode precondition on 77–84% of clean US addresses and
+fixes none. This report records the measurement, the mechanism, and the decision to de-promote it back
+to argmax. The destructive piece — the phrase grouper bundling the house number into the STREET_PHRASE
+— is filed separately as the real fix._
+
+## Why we looked
+
+The forward geocoder keys its situs and interpolation tiers on a clean street name plus a separate
+house number. Building the `geocode` CLI, the situs tier silently fell through to the admin centroid on
+addresses it should have nailed. The cause was the runtime pipeline's reconcile stage merging the
+house number and street into one node. We bypassed it in the CLI (raw `classifier.parse` +
+`resolveTree`) and then ran an audit to see how widespread the damage was — because our per-tag evals
+grade **raw neural** (`classifier.parse`), not the assembled pipeline, so a pipeline-stage regression
+is invisible to every scorecard we publish.
+
+## What we measured
+
+**Precondition audit** — share of addresses where the parse yields a separate `street`, `house_number`,
+and `postcode` (the minimum the geocoder needs), on two **non-circular** US holdouts:
+
+| Holdout | raw neural | reconcile pipeline | reconcile BREAKS (raw had it, lost it) | reconcile FIXES |
+| --- | --- | --- | --- | --- |
+| Travis County E-911 (TX, n=1965) | 100.0% | 16.2% | **83.8%** (1647) | 0% |
+| OpenAddresses 7-state (n=700) | 99.7% | 22.9% | **76.9%** (538) | 0% |
+
+**Per-tag recall** — raw argmax vs the reconcile pipeline on golden v0.1.2 US+FR (n=4507, the eval
+family our parity scorecards use; loose value-match, identical for both columns so the delta is fair):
+
+| tag | raw | reconcile | delta |
+| --- | --- | --- | --- |
+| house_number | 92.7% | 69.7% | **−23.1pp** |
+| street | 92.6% | 67.0% | **−25.6pp** |
+| locality | 89.2% | 87.0% | −2.3pp |
+| region | 53.1% | 53.1% | −0.1pp |
+| postcode | 68.5% | 68.7% | +0.2pp |
+| venue | 95.5% | 95.0% | −0.6pp |
+| unit | 100.0% | 100.0% | 0.0pp |
+
+Reconcile is **worse-or-flat on every tag** — including venue, the component #427 promoted it for.
+
+## The mechanism
+
+For `3075 Hill Street, Round Rock, TX 78664`:
+
+- The **phrase grouper** proposes `STREET_PHRASE = "3075 Hill Street"` — it bundles the leading house
+  number into the street phrase (it should propose `"Hill Street"`). Same shape on `350 5th Ave` →
+  `STREET_PHRASE = "350 5th Ave"`.
+- **`reconcileSpans`** takes that span and, from the aggregated span logits, types the whole thing as a
+  single node — sometimes `house_number = "3075 Hill Street"`, sometimes `street = "109 Seminary Dr"`.
+  Either way the number and street name fuse; there is no separate `street`.
+- **Raw neural** parses it correctly: nested `street = "Hill Street"` containing `house_number = "3075"`.
+
+This is structural, not data-dependent: it fires on every "number + street name" pattern, i.e. nearly
+every US street address.
+
+## Why #427 didn't catch it
+
+The Route A Phase II re-gate reported "DE +25pp, IT/ES +15pp, per-field regression under 0.5%." A direct
+DE/ES probe shows the kernel of truth: on out-of-distribution inputs where the en-US model mangles the
+street (`Müllerstraße 12` → raw `street = "Müllerstraße 1"`, truncated), reconcile keeps the street
+string intact (`"Müllerstraße 12"`). That lifts a **loose street-string-recall** metric. But neither
+path separates the house number on those inputs — neither produces a geocodable parse — and the re-gate
+never measured the **geocode precondition** (clean street + separated house number) on standard US
+addresses. Our evals grade raw neural, so nothing downstream of the classifier was ever scored against
+truth. The blind spot was the eval target, not the math.
+
+## The decision
+
+**Retire joint-reconcile as the default.** `jointReconcile` defaults to `false` (argmax) as of this
+change (`core/pipeline/runtime-pipeline.ts`). This:
+
+- Recovers street +25.6pp and house_number +23.1pp; loses nothing measurable (region/postcode/venue/unit
+  flat, locality +2.3pp).
+- Restores the pipeline to **byte-identical** with raw neural on both holdouts (Travis 100% precondition,
+  OA 99.7%, every street/HN tag identical) — confirming the grouper-audit venue rescue, which runs in
+  both paths, injects nothing spurious on fully-parsed addresses.
+- Makes `parse` consistent with the already-fixed `geocode` CLI.
+
+The flag and the `reconcileSpans` code stay; the A/B harnesses still drive it with `jointReconcile: true`.
+This is the geocoder-sprint-correct default (US street-level is the DoD; multi-locale may degrade this
+sprint), not a deletion.
+
+## Residual
+
+The destructive piece is the **phrase grouper bundling the house number into `STREET_PHRASE`**. Fixing
+that — so the grouper proposes the bare street phrase and reconcile can separate the number — is the
+prerequisite to ever re-enabling reconcile for the multi-locale work, where its OOD street-intactness is
+genuinely useful. Filed as a tracked issue.
+
+## Reproduce
+
+```bash
+yarn compile   # both scripts read the compiled out/ trees
+# precondition audit (raw vs pipeline), any OA-format holdout:
+node scripts/eval/reconcile-precondition-audit.mjs data/eval/external/openaddresses-us-sample.jsonl 700
+# per-tag raw vs pipeline on golden:
+node scripts/eval/pertag-raw-vs-reconcile.mjs data/eval/golden/v0.1.2/us.jsonl data/eval/golden/v0.1.2/fr.jsonl
+```
+
+(The numbers above were also measured against the Travis County E-911 holdout `/tmp/ood-truth.jsonl`,
+acquired out-of-lineage from TxGIO/TNRIS — see the geocoder campaign doc.)

--- a/scripts/eval/pertag-raw-vs-reconcile.mjs
+++ b/scripts/eval/pertag-raw-vs-reconcile.mjs
@@ -1,0 +1,63 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ *
+ *   Per-tag recall: raw neural (`classifier.parse`, with street reassembled from its child
+ *   prefix/suffix nodes) vs the assembled runtime pipeline, on golden rows carrying gold `components`.
+ *   Built 2026-06-14 for the joint-reconcile retirement decision; see
+ *   docs/articles/evals/2026-06-14-reconcile-retirement.md. Value-match is loose (normalized
+ *   substring), applied identically to both columns so the delta is fair. Requires compiled `out/`.
+ *
+ *   Usage: node scripts/eval/pertag-raw-vs-reconcile.mjs <golden-a.jsonl> [golden-b.jsonl ...]
+ */
+import { readFileSync } from "node:fs"
+const root = new URL("../../", import.meta.url)
+const { NeuralAddressClassifier } = await import(new URL("neural/out/index.js", root).href)
+const { createRuntimePipeline } = await import(new URL("mailwoman/out/runtime-pipeline.js", root).href)
+const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+const pipeline = createRuntimePipeline({ classifier })
+const STREET = new Set(["street","street_prefix","street_prefix_particle","street_suffix"])
+const norm = s => (s||"").toLowerCase().replace(/[^a-z0-9]+/g," ").trim()
+function collect(tree){ // returns map tag -> [values], plus assembled street
+  const byTag = {}; const st=[...tree.roots]
+  const streetParts=[]
+  while(st.length){ const n=st.pop()
+    if(STREET.has(n.tag) && n.value?.trim()) streetParts.push({s:n.start,v:n.value.trim()})
+    ;(byTag[n.tag] ??= []).push(n.value?.trim()||"")
+    st.push(...(n.children||[])) }
+  streetParts.sort((a,b)=>a.s-b.s)
+  byTag.__street_assembled = [streetParts.map(p=>p.v).join(" ")]
+  return byTag
+}
+function hit(byTag, tag, goldVal){
+  const g=norm(goldVal)
+  if(tag==="street"){ const a=norm(byTag.__street_assembled?.[0]); if(a && (a===g||a.includes(g)||g.includes(a))) return true }
+  const vals=(byTag[tag]||[]).map(norm)
+  return vals.some(v=>v && (v===g||v.includes(g)||g.includes(v)))
+}
+const files = process.argv.slice(2)
+const tags = ["house_number","street","locality","region","postcode","venue","unit"]
+const acc = {raw:{}, rec:{}}
+for(const t of tags){acc.raw[t]={h:0,n:0};acc.rec[t]={h:0,n:0}}
+let n=0
+for(const f of files){
+  for(const line of readFileSync(f,"utf8").trim().split("\n")){
+    const r=JSON.parse(line); if(!r.raw||!r.components) continue; n++
+    const rawT=collect(await classifier.parse(r.raw,{postcodeRepair:true}))
+    const recT=collect((await pipeline(r.raw)).tree)
+    for(const [tag,gv] of Object.entries(r.components)){
+      if(!tags.includes(tag)) continue
+      acc.raw[tag].n++; if(hit(rawT,tag,gv)) acc.raw[tag].h++
+      acc.rec[tag].n++; if(hit(recT,tag,gv)) acc.rec[tag].h++
+    }
+  }
+}
+const pct=(h,n)=>n?(100*h/n).toFixed(1):"  - "
+console.log(`per-tag recall  raw-neural  vs  runtime-pipeline   (n=${n} addresses)\n`)
+console.log(`tag             raw      pipeline   delta(pipe-raw)`)
+for(const t of tags){
+  const r=acc.raw[t], c=acc.rec[t]; if(r.n===0) continue
+  const rp=100*r.h/r.n, cp=100*c.h/c.n, d=cp-rp
+  const flag = d<=-2?"  <-- pipeline WORSE":(d>=2?"  <-- pipeline better":"")
+  console.log(`${t.padEnd(14)} ${pct(r.h,r.n).padStart(5)}%   ${pct(c.h,c.n).padStart(6)}%   ${(d>=0?"+":"")+d.toFixed(1)}pp${flag}`)
+}

--- a/scripts/eval/reconcile-precondition-audit.mjs
+++ b/scripts/eval/reconcile-precondition-audit.mjs
@@ -1,0 +1,52 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ *
+ *   reconcile-vs-raw-neural precondition audit. For each row of an OA-format holdout, compares the
+ *   raw neural parse (`classifier.parse`) against the assembled runtime pipeline, counting how often
+ *   each yields a SEPARATE street + house_number + postcode (the minimum the forward geocoder needs).
+ *   Built 2026-06-14 to quantify the joint-reconcile regression; see
+ *   docs/articles/evals/2026-06-14-reconcile-retirement.md. Requires compiled `out/` trees.
+ *
+ *   Usage: node scripts/eval/reconcile-precondition-audit.mjs <holdout.jsonl> [cap]
+ */
+import { readFileSync } from "node:fs"
+const root = new URL("../../", import.meta.url)
+const { NeuralAddressClassifier } = await import(new URL("neural/out/index.js", root).href)
+const { createRuntimePipeline } = await import(new URL("mailwoman/out/runtime-pipeline.js", root).href)
+const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+const pipeline = createRuntimePipeline({ classifier })            // no resolver → parse-only
+const tagvals = (tree) => {
+  const o = { street: null, house_number: null, postcode: null }
+  const st = [...tree.roots]
+  while (st.length) { const n = st.pop()
+    if (n.tag === "street" && o.street === null && n.value.trim()) o.street = n.value.trim()
+    if (n.tag === "house_number" && o.house_number === null && n.value.trim()) o.house_number = n.value.trim()
+    if (n.tag === "postcode" && o.postcode === null && n.value.trim()) o.postcode = n.value.trim()
+    st.push(...n.children) }
+  return o
+}
+const rows = readFileSync(process.argv[2] || "/tmp/ood-truth.jsonl","utf8").trim().split("\n").map(l=>JSON.parse(l))
+const cap = Number(process.argv[3] || rows.length)
+let n=0, identical=0, recLostStreet=0, recGainedStreet=0, hnDiffers=0
+let rawPrecond=0, recPrecond=0, rawOnlyPrecond=0, recOnlyPrecond=0
+const lost=[]
+for (const r of rows.slice(0, cap)) { n++
+  const raw = tagvals(await classifier.parse(r.input, { postcodeRepair: true }))
+  const rec = tagvals((await pipeline(r.input)).tree)
+  const rp = !!(raw.street && raw.house_number && raw.postcode), cp = !!(rec.street && rec.house_number && rec.postcode)
+  if (rp) rawPrecond++; if (cp) recPrecond++
+  if (rp && !cp) { rawOnlyPrecond++; if (lost.length<14) lost.push(`${r.input}\n      raw: hn=${raw.house_number} st=${raw.street} pc=${raw.postcode}\n      rec: hn=${rec.house_number} st=${rec.street} pc=${rec.postcode}`) }
+  if (cp && !rp) recOnlyPrecond++
+  if (raw.street === rec.street && raw.house_number === rec.house_number) identical++
+  else if (raw.street && !rec.street) recLostStreet++
+  else if (!raw.street && rec.street) recGainedStreet++
+  else if (raw.house_number !== rec.house_number) hnDiffers++
+}
+const pc = (x)=>`${(100*x/n).toFixed(1)}%`
+console.log(`reconcile-vs-raw-neural audit (n=${n})`)
+console.log(`  street+HN+postcode precondition:  raw ${rawPrecond} (${pc(rawPrecond)})  |  pipeline ${recPrecond} (${pc(recPrecond)})`)
+console.log(`  pipeline BREAKS it (raw had it, pipeline lost it): ${rawOnlyPrecond} (${pc(rawOnlyPrecond)})`)
+console.log(`  pipeline FIXES it (pipeline had it, raw didn't):   ${recOnlyPrecond} (${pc(recOnlyPrecond)})`)
+console.log(`  street/HN tags identical: ${identical} (${pc(identical)})  | pipeline lost street: ${recLostStreet} | pipeline gained street: ${recGainedStreet} | hn differs: ${hnDiffers}`)
+if (lost.length) { console.log(`\n  sample pipeline-broke-the-geocode cases:`); for (const s of lost) console.log(`   - ${s}`) }


### PR DESCRIPTION
## What

Flip `jointReconcile` default `true`→`false` (argmax) in `core/pipeline/runtime-pipeline.ts`. De-promotes the joint-reconcile path that #427 made default.

## Why

A reconcile-vs-raw-neural audit (run during the geocoder campaign to quantify how often the shipped pipeline degrades a parse) found joint-reconcile **breaks the street+house_number geocode precondition on 77-84% of clean US addresses and fixes 0%**:

| Holdout (non-circular) | raw neural | reconcile pipeline | BREAKS | FIXES |
| --- | --- | --- | --- | --- |
| Travis County E-911 (TX, n=1965) | 100.0% | 16.2% | **83.8%** | 0% |
| OpenAddresses 7-state (n=700) | 99.7% | 22.9% | **76.9%** | 0% |

Per-tag recall on golden v0.1.2 US+FR (n=4507, vs raw argmax) — worse-or-flat on **every** tag, venue included:

| tag | raw | reconcile | delta |
| --- | --- | --- | --- |
| house_number | 92.7% | 69.7% | **−23.1pp** |
| street | 92.6% | 67.0% | **−25.6pp** |
| locality | 89.2% | 87.0% | −2.3pp |
| venue | 95.5% | 95.0% | −0.6pp |
| region / postcode / unit | — | — | flat |

**Mechanism:** the phrase grouper bundles the house number into `STREET_PHRASE` (`"3075 Hill Street"`), and `reconcileSpans` fuses the whole span into one node. Root cause filed as #565.

**Why it was invisible:** the #427 re-gate's "DE +25pp" was loose street-*string* recall on OOD inputs; our per-tag evals grade **raw neural** (`classifier.parse`), so a pipeline-stage regression never showed up on a scorecard. The `geocode` CLI already bypasses reconcile for this reason — this makes `parse` consistent.

## Verification

- Post-flip the pipeline is **byte-identical to raw neural** on both holdouts (Travis 100% precondition, OA 99.7%, every street/HN tag identical, zero breaks, zero spurious grouper-audit injections — venue rescue preserved, it runs in both paths).
- `core/pipeline` tests green (runtime-pipeline 33, reconcile 20, grouper-audit 9 = 62 passed).

## Scope / safety

- No users (back-compat free, per the sprint). Multi-locale may degrade this sprint; US street-level is the DoD, and DE/ES don't geocode in *either* path (neither separates the house number).
- The flag + `reconcileSpans` code **stay** — A/B harnesses drive it with `jointReconcile: true`. This is a default change, not a deletion.
- Re-enabling reconcile is gated on #565 (grouper fix) + re-validation against the **assembled pipeline** (the two new audit scripts here).

Report: `docs/articles/evals/2026-06-14-reconcile-retirement.md`
Closes the regression behind #565 (default-level); #565 tracks the structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)