### PR TITLE
feat(situs): national address-point build driver + corrected US licensing

### DIFF
--- a/2026-06-13-GEOCODER-CAMPAIGN.md
+++ b/2026-06-13-GEOCODER-CAMPAIGN.md
@@ -126,10 +126,19 @@ ODbL obligations flow to consumers + infect derivatives), or **(b) server-side-o
 attributed results — the Pelias/Nominatim model). A product-model decision, not a blocker.
 
 **Why this keeps OSM international-only for us:** TIGER (public domain) + NAD (open) make the US fully
-distributable with zero ODbL — OSM only earns its keep where no TIGER/NAD equivalent exists. **Overture is a
-license mosaic** (NAD = public; OSM-sourced features = ODbL), so the `--license-filter` action item (Stream 2)
-keeps shipped US situs shards clean. (IANAL — confirm against current OSMF geocoding guidelines + counsel
-before shipping OSM-derived data.)
+distributable with zero ODbL — OSM only earns its keep where no TIGER/NAD equivalent exists.
+
+**✅ MEASURED 2026-06-14 — the US Overture addresses carry ZERO OSM.** A full-parquet probe of the
+2026-05-20.0 `addresses-us.parquet` (124.9M geocodable points) found the source mosaic is **NAD 85.5M
+(68%, US public domain) + OpenAddresses 39.4M (32%, government open data), and `0` OpenStreetMap rows**
+(explicit `LIKE '%osm%'` check). So the earlier "Overture is a license mosaic with OSM-sourced features
+→ filter to NAD" framing was wrong for the US: there is nothing ODbL to drop, and `--license-filter NAD`
+would discard a third of coverage (the dense urban OpenAddresses counties) for **no** licensing benefit.
+The national situs build therefore runs **unfiltered**; the only obligation is **attribution** (NAD +
+the named OpenAddresses sources), satisfied by the per-row `overture:<dataset>` provenance the builder
+stamps, summarized into `<out-dir>/ATTRIBUTION.json` by `scripts/build-national-situs.mjs`. The
+`--license-filter` flag stays for deliberately-narrowed or non-US/OSM shards. (IANAL — confirm against
+current OSMF geocoding guidelines + counsel before shipping OSM-derived data internationally.)
 
 ## Tonight's parallel structure (the shift)
 

--- a/2026-06-13-GEOCODER-CAMPAIGN.md
+++ b/2026-06-13-GEOCODER-CAMPAIGN.md
@@ -69,10 +69,16 @@ The wall — but the timing probe (2026-06-13) defused it. National street-level
   is partly in-distribution (Overture/NAD ≈ the E-911 truth lineage); **interpolation-only (66%) is the
   genuinely independent number.** Real-world read: doorstep where situs points exist (dense via Overture),
   neighborhood-via-interpolation where they don't.
-- **National situs:** per-state from the same parquet (~minutes/state). **ACTION ITEM — add a
-  `--license-filter` (source allow-list) before distributing:** Overture is a license mosaic; the builder
-  already stamps `overture:<dataset>` per row (TX was 100% `overture:NAD` = public, clean), so filter to
-  NAD/public and DROP OSM-sourced (ODbL) rows so shipped shards stay license-clean. See "OSM / licensing".
+- **National situs: ✅ DONE (2026-06-14).** All 50 state shards built —
+  **124,928,159 address points, 29 GB**, 0 failures — at `/mnt/playpen/mailwoman-data/address-points/`.
+  Driver `scripts/build-national-situs.mjs` (PR #567): streams the parquet (DuckDB `fetchChunk`, after
+  `runAndReadAll` OOM'd the 13M-row states), parallelizes states via spliterator `asyncParallelIterator`
+  (the 40 not-already-built finished in **4.2 min** at concurrency 4 / 4 threads each), idempotent on a
+  completeness check (rows + `idx_ap_streetkey`). DoD spot-check across CA/IL/DC/IA/MT/VT: **all 6
+  `address_point`, 0–34 m from truth** (5 of 6 ≤1 m). **Licensing resolved (probe, not assumption):** the
+  US parquet is NAD 68.4% (public domain) + OpenAddresses 31.6% (gov open data) + **zero OSM** → built
+  **unfiltered**; `--license-filter` stays for narrowed/non-US shards. Complete attribution ledger at
+  `address-points/ATTRIBUTION.json` (regenerable via `scripts/situs-attribution-manifest.mjs`).
 - **GATED by Stream 0** (cleared). `STATE_FIPS` extended to all 50 + the national driver landed
   (`build-national-interpolation.mjs`, DE-verified). Issues: #483 (done-engine), #476, #470, #297.
 

--- a/scripts/build-address-point-shard.ts
+++ b/scripts/build-address-point-shard.ts
@@ -50,6 +50,10 @@ const { values: args } = parseArgs({
 		// allow-list (case-insensitive). Default absent = keep everything (current behaviour,
 		// byte-stable). Typical use: --license-filter NAD to retain only US-public-domain rows.
 		"license-filter": { type: "string" },
+		// DuckDB worker-thread cap for the parquet scan. Default (unset) = DuckDB's default (all
+		// cores). The national driver passes a low value so N concurrent state builds don't each
+		// grab every core (N × threads ≈ core count).
+		threads: { type: "string" },
 	},
 })
 if (!args.state) {
@@ -80,6 +84,10 @@ rmSync(OUT, { force: true }) // idempotent rebuild — never append across relea
 
 const instance = await DuckDBInstance.create()
 const duck = await instance.connect()
+// Optional thread cap (national driver sets this so concurrent state builds don't oversubscribe cores).
+if (args.threads && /^\d+$/.test(args.threads)) {
+	await duck.run(`SET threads TO ${args.threads}`)
+}
 // Optional county scope: PIP against the TIGER COUNTY polygon (GEOID = state+county FIPS).
 // DuckDB hoists the scalar subquery to a constant, so the per-row cost is the containment test.
 let countyFilter = ""

--- a/scripts/build-address-point-shard.ts
+++ b/scripts/build-address-point-shard.ts
@@ -96,22 +96,6 @@ const datasetFilter =
 		? `AND lower(sources[1].dataset) IN (${[...allowedDatasets].map((d) => `'${d}'`).join(", ")})`
 		: ""
 
-const result = await duck.runAndReadAll(`
-	SELECT
-		number, street, unit, postcode,
-		coalesce(nullif(trim(address_levels[2].value), ''), nullif(trim(postal_city), '')) AS locality,
-		sources[1].dataset AS dataset,
-		lat, lon
-	FROM read_parquet('${PARQUET}')
-	WHERE address_levels[1].value = '${STATE}'
-		AND nullif(trim(street), '') IS NOT NULL
-		AND nullif(trim(number), '') IS NOT NULL
-		${countyFilter}
-		${datasetFilter}
-`)
-const rows = result.getRowObjects() as Record<string, unknown>[]
-console.log(`${rows.length} ${STATE} rows from ${path.basename(PARQUET)}`)
-
 const db = new DatabaseSync(OUT)
 db.exec(`
 	PRAGMA journal_mode = WAL;
@@ -134,37 +118,64 @@ const insert = db.prepare(
 	`INSERT INTO address_point (street_norm, street_key, number, unit, postcode, locality_norm, street_raw, lat, lon, source, release)
 	 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 )
-db.exec("BEGIN")
-let kept = 0
-// Provenance accounting: track per-dataset counts across ALL rows returned by DuckDB.
-// When --license-filter is active DuckDB already dropped the ineligible rows, so this
-// summary reflects the kept set. We also record total parquet rows (pre-JS-normalisation
-// drop) for the kept-vs-dropped summary below.
-const datasetCounts = new Map<string, number>()
-for (const r of rows) {
-	const dataset = String(r.dataset ?? "unknown")
-	datasetCounts.set(dataset, (datasetCounts.get(dataset) ?? 0) + 1)
 
-	const streetRaw = String(r.street)
-	const streetNorm = normalizeStreetForKey(streetRaw)
-	if (!streetNorm) continue
-	const locality = r.locality ? normalizeLocalityForKey(String(r.locality)) : null
-	insert.run(
-		streetNorm,
-		canonicalizeRouteKey(streetNorm),
-		String(r.number).trim().toLowerCase(),
-		r.unit ? String(r.unit).trim().toLowerCase() : null,
-		r.postcode ? String(r.postcode).trim() : null,
-		locality,
-		streetRaw,
-		Number(r.lat),
-		Number(r.lon),
-		`overture:${r.dataset}`,
-		String(args.release)
-	)
-	kept++
+// Provenance accounting: per-dataset counts across ALL rows returned by DuckDB (pre-JS-normalisation
+// drop). When --license-filter is active DuckDB already dropped the ineligible rows, so this reflects
+// the kept set. `totalReturned` feeds the kept-vs-dropped summary below.
+const datasetCounts = new Map<string, number>()
+let kept = 0
+let totalReturned = 0
+
+// STREAM the parquet scan in DuckDB DataChunks (~2048 rows each) rather than materialising the whole
+// result with runAndReadAll().getRowObjects() — a 13.5M-row state (CA/FL/TX) blows the ~4GB V8 heap
+// that way (OOM observed 2026-06-14). stream()+fetchChunk() keeps JS memory bounded to one chunk; the
+// growing data lives in the on-disk SQLite WAL inside a single transaction.
+const stream = await duck.stream(`
+	SELECT
+		number, street, unit, postcode,
+		coalesce(nullif(trim(address_levels[2].value), ''), nullif(trim(postal_city), '')) AS locality,
+		sources[1].dataset AS dataset,
+		lat, lon
+	FROM read_parquet('${PARQUET}')
+	WHERE address_levels[1].value = '${STATE}'
+		AND nullif(trim(street), '') IS NOT NULL
+		AND nullif(trim(number), '') IS NOT NULL
+		${countyFilter}
+		${datasetFilter}
+`)
+// A streamed DataChunk carries no column names of its own (only the materialised reader sets them),
+// so pull them off the result once and hand them to each chunk's getRowObjects().
+const colNames = stream.columnNames()
+db.exec("BEGIN")
+for (let chunk = await stream.fetchChunk(); chunk && chunk.rowCount > 0; chunk = await stream.fetchChunk()) {
+	const rows = chunk.getRowObjects(colNames) as Record<string, unknown>[]
+	for (const r of rows) {
+		totalReturned++
+		const dataset = String(r.dataset ?? "unknown")
+		datasetCounts.set(dataset, (datasetCounts.get(dataset) ?? 0) + 1)
+
+		const streetRaw = String(r.street)
+		const streetNorm = normalizeStreetForKey(streetRaw)
+		if (!streetNorm) continue
+		const locality = r.locality ? normalizeLocalityForKey(String(r.locality)) : null
+		insert.run(
+			streetNorm,
+			canonicalizeRouteKey(streetNorm),
+			String(r.number).trim().toLowerCase(),
+			r.unit ? String(r.unit).trim().toLowerCase() : null,
+			r.postcode ? String(r.postcode).trim() : null,
+			locality,
+			streetRaw,
+			Number(r.lat),
+			Number(r.lon),
+			`overture:${r.dataset}`,
+			String(args.release)
+		)
+		kept++
+	}
 }
 db.exec("COMMIT")
+console.log(`${totalReturned} ${STATE} rows from ${path.basename(PARQUET)}`)
 db.exec(`
 	CREATE INDEX idx_ap_postcode ON address_point (postcode, street_norm, number);
 	CREATE INDEX idx_ap_locality ON address_point (locality_norm, street_norm, number);
@@ -201,7 +212,7 @@ if (allowedDatasets.size > 0) {
 			${countyFilter}
 	`)
 	const totalUnfiltered = Number((totalResult.getRowObjects()[0] as Record<string, unknown>).n)
-	const keptCount = rows.length
+	const keptCount = totalReturned
 	const droppedCount = totalUnfiltered - keptCount
 	console.log(
 		`\nlicense-filter: ${[...allowedDatasets].join(", ")} → kept ${keptCount.toLocaleString()} / dropped ${droppedCount.toLocaleString()} (of ${totalUnfiltered.toLocaleString()} total parquet rows for ${STATE})`

--- a/scripts/build-national-situs.mjs
+++ b/scripts/build-national-situs.mjs
@@ -4,34 +4,41 @@
  * @author Teffen Ellis, et al.
  *
  *   National ADDRESS-POINT (situs) shard build driver. The situs counterpart to
- *   `build-national-interpolation.mjs` — but simpler: there are no downloads. Every US address point
- *   already lives in one pinned Overture parquet
- *   (`/mnt/playpen/mailwoman-data/overture/<release>/addresses-us.parquet`), so this just drives the
- *   per-state `build-address-point-shard.ts` across every state that has coverage, sequentially (one
- *   DuckDB parquet reader + one SQLite writer at a time — parallelism would thrash the 6.5GB parquet
- *   and the disk for no wall-clock win; the bottleneck is the per-row SQLite insert, not CPU).
+ *   `build-national-interpolation.mjs` — but downloadless: every US address point already lives in
+ *   one pinned Overture parquet, so this drives the per-state `build-address-point-shard.ts` across
+ *   every covered state.
  *
- *   LICENSING (measured 2026-06-14, see docs/articles/evals/2026-06-14-reconcile-retirement.md's
- *   sibling note + the campaign doc): US Overture addresses are NAD (68%, US public domain) +
+ *   PARALLELISM: states build concurrently via spliterator's `asyncParallelIterator` (the house
+ *   bounded-concurrency primitive — same one `build-unified-wof.ts` uses to fan out file reads behind
+ *   a single writer). Each state is an isolated child process (its own DuckDB + SQLite heap), so N
+ *   states run at once with no shared-memory risk. To avoid oversubscribing cores, each child's DuckDB
+ *   scan is capped at `--threads` (default: cores / concurrency), so concurrency × threads ≈ cores.
+ *   The per-state steady-state bottleneck is the single-threaded SQLite insert loop, not the scan, so
+ *   N concurrent inserts is the real win. Sequentialising is still available via `--concurrency 1`.
+ *
+ *   LICENSING (measured 2026-06-14): US Overture addresses are NAD (68%, US public domain) +
  *   OpenAddresses (32%, government open data) with ZERO OpenStreetMap/ODbL rows. So the default is NO
- *   license filter — applying `--license-filter NAD` would drop 39.4M OpenAddresses points (a third of
- *   coverage, the dense urban counties) for no licensing benefit. The only obligation is ATTRIBUTION:
- *   the per-row `overture:<dataset>` provenance the builder stamps is summarized into
- *   `<out-dir>/ATTRIBUTION.json` here. Pass `--license-filter <datasets>` only to build a
- *   deliberately-narrowed shard.
+ *   license filter — `--license-filter NAD` would drop a third of coverage for no benefit. The only
+ *   obligation is ATTRIBUTION: the per-row `overture:<dataset>` provenance is summarized into
+ *   `<out-dir>/ATTRIBUTION.json`. Pass `--license-filter <datasets>` to build a narrowed shard.
  *
- *   Idempotency: a state whose output DB already exists is skipped unless `--force`.
- *   Population/coverage-ranked order (largest first) so killing early still yields the most points.
+ *   IDEMPOTENCY: a state is skipped only if its shard is COMPLETE — non-empty `address_point` table
+ *   AND the `idx_ap_streetkey` index present. A half-built shard (data inserted, indexing/VACUUM not
+ *   reached — e.g. a killed run) is detected as incomplete and rebuilt. `--force` rebuilds regardless.
  *
  *   Usage:
  *     node scripts/build-national-situs.mjs [--out-dir <path>] [--release <tag>]
- *       [--states CA,FL,...] [--license-filter NAD] [--force]
+ *       [--states CA,FL,...] [--concurrency 4] [--threads N] [--license-filter NAD] [--force]
  */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { spawn } from "node:child_process"
+import { DatabaseSync } from "node:sqlite"
+import * as os from "node:os"
 import * as path from "node:path"
-import { spawnSync } from "node:child_process"
 import { parseArgs } from "node:util"
+
+import { asyncParallelIterator } from "spliterator"
 
 const { values: args } = parseArgs({
 	options: {
@@ -39,6 +46,8 @@ const { values: args } = parseArgs({
 		release: { type: "string", default: "2026-05-20.0" },
 		states: { type: "string" },
 		"license-filter": { type: "string" },
+		concurrency: { type: "string", default: "4" },
+		threads: { type: "string" },
 		force: { type: "boolean", default: false },
 	},
 })
@@ -57,43 +66,75 @@ const states = (args.states ? args.states.split(",").map((s) => s.trim().toUpper
 const outDir = args["out-dir"]
 mkdirSync(outDir, { recursive: true })
 
+const concurrency = Math.max(1, parseInt(args.concurrency, 10) || 4)
+const cores = os.availableParallelism?.() ?? os.cpus().length
+const threads = Math.max(1, parseInt(args.threads ?? "", 10) || Math.floor(cores / concurrency))
 const builder = path.resolve(import.meta.dirname, "build-address-point-shard.ts")
+
+console.log(`national situs build — ${states.length} states, concurrency=${concurrency}, ${threads} DuckDB threads/state (of ${cores} cores)`)
+
+// A shard is COMPLETE iff its address_point table has rows AND the streetkey index exists — the index
+// is the last build step, so its presence means insert + index + VACUUM all finished.
+function isComplete(dbPath) {
+	if (!existsSync(dbPath)) return false
+	try {
+		const db = new DatabaseSync(dbPath, { readOnly: true })
+		const n = db.prepare("SELECT count(*) AS n FROM address_point").get().n
+		const idx = db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='index' AND name='idx_ap_streetkey'").get().n
+		db.close()
+		return n > 0 && idx > 0
+	} catch {
+		return false
+	}
+}
+
+function buildOneState(state) {
+	const dbPath = path.join(outDir, `address-points-us-${state.toLowerCase()}.db`)
+	if (!args.force && isComplete(dbPath)) return Promise.resolve({ state, skipped: true })
+	return new Promise((resolve) => {
+		const argv = [
+			"--experimental-strip-types", builder,
+			"--state", state, "--release", args.release, "--out", dbPath, "--threads", String(threads),
+		]
+		if (args["license-filter"]) argv.push("--license-filter", args["license-filter"])
+		const t = Date.now()
+		const child = spawn("node", argv)
+		let out = "", err = ""
+		child.stdout.on("data", (d) => (out += d))
+		child.stderr.on("data", (d) => (err += d))
+		child.on("close", (code) => resolve({ state, code, seconds: Number(((Date.now() - t) / 1000).toFixed(1)), out, err }))
+	})
+}
+
 const t0 = Date.now()
 const manifest = { release: args.release, builtAt: null, licenseFilter: args["license-filter"] ?? null, states: {}, datasetTotals: {} }
 let built = 0, skipped = 0, failed = 0, totalRows = 0
 
-for (const state of states) {
-	const dbPath = path.join(outDir, `address-points-us-${state.toLowerCase()}.db`)
-	if (existsSync(dbPath) && !args.force) {
-		console.log(`[skip] ${state} — ${path.basename(dbPath)} exists (use --force to rebuild)`)
+// asyncParallelIterator yields results AS THEY COMPLETE (out of order), capped at `concurrency` in
+// flight. Each result carries its own state, so out-of-order is fine for the state-keyed manifest.
+for await (const r of asyncParallelIterator(states, concurrency, buildOneState)) {
+	if (r.skipped) {
+		console.log(`[skip] ${r.state} — complete (use --force to rebuild)`)
 		skipped++
 		continue
 	}
-	const argv = ["--experimental-strip-types", builder, "--state", state, "--release", args.release, "--out", dbPath]
-	if (args["license-filter"]) argv.push("--license-filter", args["license-filter"])
-	const tState = Date.now()
-	const res = spawnSync("node", argv, { encoding: "utf8" })
-	const secs = ((Date.now() - tState) / 1000).toFixed(1)
-	if (res.status !== 0) {
-		console.error(`[FAIL] ${state} (${secs}s)\n${res.stderr?.slice(-600) ?? ""}`)
-		manifest.states[state] = { ok: false }
+	if (r.code !== 0) {
+		console.error(`[FAIL] ${r.state} (${r.seconds}s)\n${(r.err || "").slice(-600)}`)
+		manifest.states[r.state] = { ok: false }
 		failed++
 		continue
 	}
-	// Parse the builder's stdout: "<n> points → ..." and the per-dataset provenance lines.
-	const out = res.stdout
-	const pts = Number(out.match(/^(\d+) points →/m)?.[1] ?? 0)
+	const pts = Number(r.out.match(/^(\d+) points →/m)?.[1] ?? 0)
 	const datasets = {}
-	for (const m of out.matchAll(/^ {2}overture:(\S+)\s+([\d,]+) rows$/gm)) {
+	for (const m of r.out.matchAll(/^ {2}overture:(\S+)\s+([\d,]+) rows$/gm)) {
 		const ds = m[1], n = Number(m[2].replace(/,/g, ""))
 		datasets[ds] = n
 		manifest.datasetTotals[ds] = (manifest.datasetTotals[ds] ?? 0) + n
 	}
-	manifest.states[state] = { ok: true, points: pts, seconds: Number(secs), datasets }
+	manifest.states[r.state] = { ok: true, points: pts, seconds: r.seconds, datasets }
 	totalRows += pts
 	built++
-	console.log(`[ok]   ${state} — ${pts.toLocaleString()} points (${secs}s) → ${path.basename(dbPath)}`)
-	// Persist the manifest after every state so a kill leaves a usable partial.
+	console.log(`[ok]   ${r.state} — ${pts.toLocaleString()} points (${r.seconds}s)`)
 	manifest.builtAt = new Date(t0).toISOString().slice(0, 10)
 	writeFileSync(path.join(outDir, "ATTRIBUTION.json"), JSON.stringify(manifest, null, 2))
 }

--- a/scripts/build-national-situs.mjs
+++ b/scripts/build-national-situs.mjs
@@ -1,0 +1,108 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   National ADDRESS-POINT (situs) shard build driver. The situs counterpart to
+ *   `build-national-interpolation.mjs` — but simpler: there are no downloads. Every US address point
+ *   already lives in one pinned Overture parquet
+ *   (`/mnt/playpen/mailwoman-data/overture/<release>/addresses-us.parquet`), so this just drives the
+ *   per-state `build-address-point-shard.ts` across every state that has coverage, sequentially (one
+ *   DuckDB parquet reader + one SQLite writer at a time — parallelism would thrash the 6.5GB parquet
+ *   and the disk for no wall-clock win; the bottleneck is the per-row SQLite insert, not CPU).
+ *
+ *   LICENSING (measured 2026-06-14, see docs/articles/evals/2026-06-14-reconcile-retirement.md's
+ *   sibling note + the campaign doc): US Overture addresses are NAD (68%, US public domain) +
+ *   OpenAddresses (32%, government open data) with ZERO OpenStreetMap/ODbL rows. So the default is NO
+ *   license filter — applying `--license-filter NAD` would drop 39.4M OpenAddresses points (a third of
+ *   coverage, the dense urban counties) for no licensing benefit. The only obligation is ATTRIBUTION:
+ *   the per-row `overture:<dataset>` provenance the builder stamps is summarized into
+ *   `<out-dir>/ATTRIBUTION.json` here. Pass `--license-filter <datasets>` only to build a
+ *   deliberately-narrowed shard.
+ *
+ *   Idempotency: a state whose output DB already exists is skipped unless `--force`.
+ *   Population/coverage-ranked order (largest first) so killing early still yields the most points.
+ *
+ *   Usage:
+ *     node scripts/build-national-situs.mjs [--out-dir <path>] [--release <tag>]
+ *       [--states CA,FL,...] [--license-filter NAD] [--force]
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import * as path from "node:path"
+import { spawnSync } from "node:child_process"
+import { parseArgs } from "node:util"
+
+const { values: args } = parseArgs({
+	options: {
+		"out-dir": { type: "string", default: "/mnt/playpen/mailwoman-data/address-points" },
+		release: { type: "string", default: "2026-05-20.0" },
+		states: { type: "string" },
+		"license-filter": { type: "string" },
+		force: { type: "boolean", default: false },
+	},
+})
+
+// Coverage-ranked (largest first, from the 2026-05-20.0 parquet probe). NH + HI carry zero Overture
+// address coverage in this release, so they're absent — interpolation-only states. VI (territory)
+// included for completeness; harmless if the parser's region→slug map skips it.
+const STATES_BY_COVERAGE = [
+	"CA", "FL", "TX", "NY", "NC", "OH", "IL", "TN", "OR", "VA", "NJ", "AZ", "MA", "IN", "WA", "AL",
+	"MD", "CO", "KY", "MN", "AR", "MO", "IA", "WI", "OK", "UT", "CT", "MS", "PA", "NM", "WV", "KS",
+	"NE", "MI", "ME", "GA", "MT", "DE", "ND", "DC", "RI", "ID", "VT", "AK", "LA", "WY", "SC", "SD",
+	"NV", "VI",
+]
+
+const states = (args.states ? args.states.split(",").map((s) => s.trim().toUpperCase()) : STATES_BY_COVERAGE).filter(Boolean)
+const outDir = args["out-dir"]
+mkdirSync(outDir, { recursive: true })
+
+const builder = path.resolve(import.meta.dirname, "build-address-point-shard.ts")
+const t0 = Date.now()
+const manifest = { release: args.release, builtAt: null, licenseFilter: args["license-filter"] ?? null, states: {}, datasetTotals: {} }
+let built = 0, skipped = 0, failed = 0, totalRows = 0
+
+for (const state of states) {
+	const dbPath = path.join(outDir, `address-points-us-${state.toLowerCase()}.db`)
+	if (existsSync(dbPath) && !args.force) {
+		console.log(`[skip] ${state} — ${path.basename(dbPath)} exists (use --force to rebuild)`)
+		skipped++
+		continue
+	}
+	const argv = ["--experimental-strip-types", builder, "--state", state, "--release", args.release, "--out", dbPath]
+	if (args["license-filter"]) argv.push("--license-filter", args["license-filter"])
+	const tState = Date.now()
+	const res = spawnSync("node", argv, { encoding: "utf8" })
+	const secs = ((Date.now() - tState) / 1000).toFixed(1)
+	if (res.status !== 0) {
+		console.error(`[FAIL] ${state} (${secs}s)\n${res.stderr?.slice(-600) ?? ""}`)
+		manifest.states[state] = { ok: false }
+		failed++
+		continue
+	}
+	// Parse the builder's stdout: "<n> points → ..." and the per-dataset provenance lines.
+	const out = res.stdout
+	const pts = Number(out.match(/^(\d+) points →/m)?.[1] ?? 0)
+	const datasets = {}
+	for (const m of out.matchAll(/^ {2}overture:(\S+)\s+([\d,]+) rows$/gm)) {
+		const ds = m[1], n = Number(m[2].replace(/,/g, ""))
+		datasets[ds] = n
+		manifest.datasetTotals[ds] = (manifest.datasetTotals[ds] ?? 0) + n
+	}
+	manifest.states[state] = { ok: true, points: pts, seconds: Number(secs), datasets }
+	totalRows += pts
+	built++
+	console.log(`[ok]   ${state} — ${pts.toLocaleString()} points (${secs}s) → ${path.basename(dbPath)}`)
+	// Persist the manifest after every state so a kill leaves a usable partial.
+	manifest.builtAt = new Date(t0).toISOString().slice(0, 10)
+	writeFileSync(path.join(outDir, "ATTRIBUTION.json"), JSON.stringify(manifest, null, 2))
+}
+
+const mins = ((Date.now() - t0) / 60000).toFixed(1)
+console.log(`\n=== national situs build complete ===`)
+console.log(`built ${built} · skipped ${skipped} · failed ${failed} · ${totalRows.toLocaleString()} total points · ${mins} min`)
+console.log(`dataset families:`)
+for (const [ds, n] of Object.entries(manifest.datasetTotals).sort((a, b) => b[1] - a[1]).slice(0, 8)) {
+	console.log(`  ${ds.padEnd(28)} ${n.toLocaleString()}`)
+}
+console.log(`attribution manifest → ${path.join(outDir, "ATTRIBUTION.json")}`)

--- a/scripts/situs-attribution-manifest.mjs
+++ b/scripts/situs-attribution-manifest.mjs
@@ -1,0 +1,72 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Regenerate a COMPLETE situs attribution manifest from the address-point shards on disk. The
+ *   national build driver (`build-national-situs.mjs`) only records the states it built in a given
+ *   run, so after incremental / resumed builds its `ATTRIBUTION.json` undercounts. This reads every
+ *   `address-points-us-*.db` in the directory and aggregates the per-row `source`
+ *   (`overture:<dataset>`) provenance into a full ledger — the document we owe consumers for the
+ *   OpenAddresses attribution obligation (NAD is US public domain; the named OA sources want credit).
+ *
+ *   Usage: node scripts/situs-attribution-manifest.mjs [--out-dir <path>] [--release <tag>]
+ */
+
+import { readdirSync, writeFileSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+import * as path from "node:path"
+import { parseArgs } from "node:util"
+
+const { values: args } = parseArgs({
+	options: {
+		"out-dir": { type: "string", default: "/mnt/playpen/mailwoman-data/address-points" },
+		release: { type: "string", default: "2026-05-20.0" },
+	},
+})
+
+const outDir = args["out-dir"]
+// Canonical per-state shards only: address-points-us-<2-letter-slug>.db. Excludes county-scoped dev
+// artifacts (e.g. address-points-us-il-cook.db) that overlap a state shard and the CLI never selects.
+const shardFiles = readdirSync(outDir)
+	.filter((f) => /^address-points-us-[a-z]{2}\.db$/.test(f))
+	.sort()
+
+const manifest = { release: args.release, regeneratedFromShards: shardFiles.length, totalPoints: 0, datasetTotals: {}, states: {} }
+
+for (const file of shardFiles) {
+	const slug = file.replace(/^address-points-us-/, "").replace(/\.db$/, "")
+	let db
+	try {
+		db = new DatabaseSync(path.join(outDir, file), { readOnly: true })
+	} catch {
+		manifest.states[slug] = { ok: false, error: "unreadable" }
+		continue
+	}
+	try {
+		const rows = db.prepare("SELECT source, count(*) AS n FROM address_point GROUP BY source").all()
+		const datasets = {}
+		let points = 0
+		for (const { source, n } of rows) {
+			const ds = String(source).replace(/^overture:/, "")
+			datasets[ds] = Number(n)
+			manifest.datasetTotals[ds] = (manifest.datasetTotals[ds] ?? 0) + Number(n)
+			points += Number(n)
+		}
+		manifest.states[slug] = { ok: true, points, datasets }
+		manifest.totalPoints += points
+		console.log(`${slug.padEnd(8)} ${points.toLocaleString().padStart(12)} points · ${rows.length} sources`)
+	} finally {
+		db.close()
+	}
+}
+
+// Sort datasetTotals descending for readability.
+manifest.datasetTotals = Object.fromEntries(Object.entries(manifest.datasetTotals).sort((a, b) => b[1] - a[1]))
+
+writeFileSync(path.join(outDir, "ATTRIBUTION.json"), JSON.stringify(manifest, null, 2))
+console.log(`\n${shardFiles.length} shards · ${manifest.totalPoints.toLocaleString()} total points`)
+const top = Object.entries(manifest.datasetTotals).slice(0, 6)
+console.log(`top sources:`)
+for (const [ds, n] of top) console.log(`  ${ds.padEnd(40)} ${n.toLocaleString()}`)
+console.log(`→ ${path.join(outDir, "ATTRIBUTION.json")}`)


### PR DESCRIPTION
## What

`scripts/build-national-situs.mjs` — the situs (exact address-point) counterpart to the national interpolation driver. Downloadless: every US point already lives in the one pinned Overture parquet, so it drives the per-state `build-address-point-shard.ts` across every covered state, sequentially, idempotent, coverage-ranked (largest first). Emits `<out-dir>/ATTRIBUTION.json` from the per-row `overture:<dataset>` provenance.

## Corrected US licensing premise

A full-parquet probe of `addresses-us.parquet` (2026-05-20.0, **124.9M geocodable points**) found the source mosaic:

| family | rows | share | license |
| --- | --- | --- | --- |
| NAD | 85.5M | 68% | US public domain |
| OpenAddresses | 39.4M | 32% | government open data (attribution) |
| **OpenStreetMap** | **0** | — | (none present) |

The campaign's earlier "Overture is a license mosaic with OSM-sourced features → `--license-filter NAD`" framing was **wrong for the US**: there is nothing ODbL to drop, and filtering to NAD would discard a third of coverage (the dense urban OA counties) for no benefit. So the national build runs **unfiltered**; the only obligation is **attribution**, satisfied by the manifest. The `--license-filter` flag stays for deliberately-narrowed or non-US/OSM shards.

## Run

```bash
node scripts/build-national-situs.mjs   # all covered states → /mnt/playpen/mailwoman-data/address-points/
```

Per-state timing measured: DE 562K pts in 7.1s / 120MB → national ≈ 124.9M pts, **~30–45 min sequential, ~26GB**. NH + HI have zero Overture coverage (interpolation-only). Running detached as of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)