### PR TITLE
feat(resolver): conformal-calibrated interpolation radius — honest 90% confidence

### DIFF
--- a/2026-06-13-GEOCODER-CAMPAIGN.md
+++ b/2026-06-13-GEOCODER-CAMPAIGN.md
@@ -88,6 +88,15 @@ The "reasonable confidence" half. Conformal prediction over resolved coordinates
 2-region resolver — produces calibrated coverage radii. Abstention/coarse-placer router (#244) — know
 when NOT to answer. Builds on shipped isotonic calibration (#59/#368). Independent of Coverage.
 
+- **✅ Interp radius calibrated (2026-06-14, PR #569).** Split-conformal on 1562 Travis interp hits (full
+  national TX shard, situs off): the raw half-segment radius covers only 71.9% of errors; **×Q̂=1.70 →
+  91.5%** (target 90%). Median raw 87m → calibrated 148m, median error 52.7m, interp-only hit rate 79.5%.
+  Shipped opt-in (`ResolveOpts.interpolationRadiusCalibration`, byte-stable default) + on-by-default in the
+  `geocode` CLI (`--interp-calibration 1.7`). Report: `docs/articles/evals/2026-06-14-interp-radius-calibration.md`.
+- **Open:** re-calibrate multi-region (1.70 is TX-only); promote to a loadable artifact (#59 pattern);
+  abstention router (#244 — confidence-gated downgrade to admin). The 10m situs floor is conservative-safe;
+  leave it.
+
 ### Stream 4 — Callable surface (~seconds compute; pure code) — **Sonnet (each a contract)**
 
 Make it a callable geocoder. Reverse geocoding API (#484, engine built+green). Production service layer

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -157,7 +157,7 @@ function applyAddressPoint(roots: AddressNode[], lookup: AddressPointLookup): vo
  * without a postcode). Stamps a DISTINCT metadata key (`interpolated_point`, never `address_point`).
  * Additive only — admin resolution is untouched.
  */
-function applyInterpolation(roots: AddressNode[], lookup: InterpolationLookup): void {
+function applyInterpolation(roots: AddressNode[], lookup: InterpolationLookup, radiusCalibration?: number): void {
 	let street: AddressNode | undefined
 	let houseNumber: AddressNode | undefined
 	let postcode: string | undefined
@@ -174,11 +174,16 @@ function applyInterpolation(roots: AddressNode[], lookup: InterpolationLookup): 
 	if (street.metadata?.["resolution_tier"] === "address_point") return
 	const hit = lookup.find({ street: assembleStreetValue(street), number: houseNumber.value, postcode })
 	if (!hit) return
+	// Conformal-calibrated radius when the caller supplies a multiplier (#374): the raw half-segment
+	// heuristic underestimates the true spread (~72% coverage on Travis); ×1.70 → a 90% bound. Default
+	// (no multiplier) keeps the raw value, byte-stable. Preserve the raw radius for transparency.
+	const calibrated = radiusCalibration ? Math.round(hit.uncertaintyM * radiusCalibration) : hit.uncertaintyM
 	street.metadata = {
 		...street.metadata,
 		interpolated_point: { lat: hit.lat, lon: hit.lon, source: hit.source, release: hit.release },
 		resolution_tier: "interpolated",
-		uncertainty_m: hit.uncertaintyM,
+		uncertainty_m: calibrated,
+		...(radiusCalibration ? { uncertainty_raw_m: hit.uncertaintyM, uncertainty_calibration: radiusCalibration } : {}),
 		interpolation_method: hit.method,
 		...(hit.parityMatched !== undefined ? { parity_matched: hit.parityMatched } : {}),
 		...(hit.bracket !== undefined ? { interpolation_bracket: hit.bracket } : {}),
@@ -239,7 +244,7 @@ class WofResolver implements Resolver {
 		// override a real situs point (applyInterpolation also gates on resolution_tier). Opt-in;
 		// byte-stable when opts.interpolation is absent.
 		if (opts.interpolation) {
-			applyInterpolation(newRoots, opts.interpolation)
+			applyInterpolation(newRoots, opts.interpolation, opts.interpolationRadiusCalibration)
 		}
 		return { raw: tree.raw, roots: newRoots }
 	}

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -276,6 +276,18 @@ export interface ResolveOpts {
 	 * byte-stable. Independent of {@link addressPoints} (either, both, or neither may be passed).
 	 */
 	interpolation?: InterpolationLookup
+	/**
+	 * Conformal calibration multiplier for the interpolation tier's `uncertainty_m` (#374). The raw
+	 * radius is half the matched TIGER segment length — an honest-but-TIGHT prior: a split-conformal
+	 * calibration on 1562 Travis-County interp hits (2026-06-14) found it covers only ~72% of true
+	 * errors, and that multiplying by **Q̂ ≈ 1.70** yields a calibrated 90% bound (91.5% empirical).
+	 * When set, `applyInterpolation` reports `uncertainty_m = round(raw × this)` and preserves the raw
+	 * value under `uncertainty_raw_m`. Absent = raw heuristic (byte-stable). The factor is the CALLER's
+	 * (it's a property of the calibration set, not the geometry); the geocode CLI passes the TX-derived
+	 * 1.70. Re-calibrate on a multi-region holdout before treating it as national-exact.
+	 * Report: docs/articles/evals/2026-06-14-interp-radius-calibration.md.
+	 */
+	interpolationRadiusCalibration?: number
 	hierarchyCompletion?: boolean
 	/** @deprecated Renamed to {@link hierarchyCompletion} (#405 generalized #387). Still honored. */
 	cityStateFallback?: boolean

--- a/docs/articles/evals/2026-06-14-interp-radius-calibration.md
+++ b/docs/articles/evals/2026-06-14-interp-radius-calibration.md
@@ -1,0 +1,76 @@
+# Calibrating the interpolation radius — honest confidence for the street-level tier
+
+_2026-06-14. The forward geocoder's interpolation tier stamps an `uncertainty_m` radius = half the
+matched TIGER segment's length. That's an honest geometric prior, but is it a calibrated confidence
+bound? A split-conformal calibration on the Travis-County E-911 holdout says no — the raw radius is too
+tight, covering only ~72% of true errors. Multiplying by Q̂ ≈ 1.70 makes it a real 90% bound. This
+records the measurement and the opt-in wiring that ships it._
+
+## Why this is the confidence half of the DoD
+
+The definition of done is "street-level coordinate **with a calibrated confidence radius**." Coverage is
+handled by the situs + interpolation cascade (national, as of 2026-06-14). Confidence is the radius the
+geocoder reports. A radius is only meaningful if it's calibrated: if we say "±87 m" it should contain the
+truth ~90% of the time, not 72%. Otherwise the number is decoration.
+
+## The measurement
+
+Split-conformal prediction (`scripts/eval/conformal-calibrate.ts`, #374) over the **interpolation tier
+in isolation** — situs forced off (an empty-but-valid address-point db) so every resolved row falls
+through to interpolation, on the full national TX interp shard (254 counties):
+
+```
+holdout  : Travis County E-911 (1965 rows)
+resolved : 1562 interpolation hits (79.5% street-level hit rate)
+abstained: 403 (no street-level coordinate → admin-centroid)
+split    : cal=781  test=781
+
+target coverage (α = 90%)
+conformal threshold Q̂            : 1.7006   (× claimed_radius = calibrated 90% interval)
+empirical coverage on test split : 91.5%    ✓ within 3pp of target
+uncalibrated coverage (Q̂ = 1)    : 71.9%    ← the raw heuristic is too tight
+
+per-tier (interpolated, n=1562):
+  median error            52.7 m
+  median claimed radius   87.0 m   (raw half-segment)
+  median calibrated radius 148.0 m (× 1.70)
+```
+
+The half-segment heuristic **underestimates** the true spread by 1.70×. Reporting the raw radius would
+tell a user "±87 m" when the honest 90% bound is ±148 m. (The situs tier is the opposite — its fixed 10 m
+floor is conservative vs the ~1 m doorstep error we measure, which is safe; under-reporting confidence,
+as interpolation did, is the dangerous direction.)
+
+## What ships
+
+An **opt-in, byte-stable** calibration multiplier — the resolver stays calibration-agnostic (the factor
+is a property of the calibration set, not the geometry), and the caller supplies it:
+
+- `ResolveOpts.interpolationRadiusCalibration?: number` — when set, `applyInterpolation` reports
+  `uncertainty_m = round(raw × factor)` and preserves the raw value under `uncertainty_raw_m`. Absent =
+  raw heuristic (byte-stable; the 40 resolver tests are unchanged).
+- The **`geocode` CLI** passes the TX-derived **1.70** by default (`--interp-calibration`, pass `1` to
+  report the raw radius). Verified: Concord NH 3 → 5 m, Honolulu HI 75 → 128 m; situs hits unaffected.
+
+## Honest caveats / next
+
+- **The 1.70 is TX-calibrated.** TIGER's segment methodology is uniform nationwide, so it's a sound first
+  approximation, but the true Q̂ likely varies with road-network density (rural long segments vs urban
+  grids). Re-calibrate on a multi-region holdout before treating 1.70 as national-exact — and consider a
+  per-`interpolation_method` or per-segment-length-bucket Q̂ rather than one global scalar.
+- **Make it a loadable artifact.** Today the factor is a CLI constant. The principled home is a
+  calibration artifact (like the isotonic `conf=` calibrator, #59) the resolver/CLI loads — so re-calibration
+  is a data swap, not a code change.
+- **Abstention router (#244)** is the remaining confidence piece: when the calibrated radius exceeds a
+  threshold, return the coarser admin tier instead of a falsely-precise street point. The 403 no-hit rows
+  already abstain to admin; #244 generalizes that to a confidence-gated downgrade.
+
+## Reproduce
+
+```bash
+sqlite3 /tmp/empty-situs.db "CREATE TABLE address_point (street_norm TEXT NOT NULL, street_key TEXT NOT NULL, number TEXT NOT NULL, unit TEXT, postcode TEXT, locality_norm TEXT, street_raw TEXT NOT NULL, lat REAL NOT NULL, lon REAL NOT NULL, source TEXT NOT NULL, release TEXT NOT NULL);"
+node --experimental-strip-types scripts/eval/conformal-calibrate.ts \
+  --holdout /tmp/ood-truth.jsonl \
+  --address-points /tmp/empty-situs.db \
+  --interpolation /mnt/playpen/mailwoman-data/interpolation/interpolation-us-tx.db
+```

--- a/mailwoman/commands/geocode.tsx
+++ b/mailwoman/commands/geocode.tsx
@@ -84,6 +84,15 @@ const OptionsSchema = zod.object({
 			"Explicit path to an interpolation SQLite shard. Bypasses the per-state shard selection. " +
 				"Use when you already know the right shard or are testing a specific file."
 		),
+	interpCalibration: zod
+		.number()
+		.optional()
+		.default(1.7)
+		.describe(
+			"Conformal calibration multiplier for the interpolation tier's reported uncertainty_m (#374). " +
+				"The raw half-segment radius covers only ~72% of true errors; the default 1.7 (Travis-County " +
+				"calibration, 2026-06-14) lifts that to a ~90% bound. Pass 1 to report the raw heuristic radius."
+		),
 	format: zod
 		.enum(["json", "text"])
 		.optional()
@@ -261,7 +270,14 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 
 			const enrichedResolveOpts: ResolveOpts = { ...baseResolveOpts }
 			if (addressPointLookup) enrichedResolveOpts.addressPoints = addressPointLookup
-			if (interpolationLookup) enrichedResolveOpts.interpolation = interpolationLookup
+			if (interpolationLookup) {
+				enrichedResolveOpts.interpolation = interpolationLookup
+				// Honest interp radius: the raw half-segment heuristic underestimates the true spread
+				// (~72% coverage); the calibration multiplier reports a ~90% bound. Default 1.7 (#374).
+				if (options.interpCalibration && options.interpCalibration !== 1) {
+					enrichedResolveOpts.interpolationRadiusCalibration = options.interpCalibration
+				}
+			}
 
 			// Single resolve pass on the raw-neural parse with the coordinate tiers wired — the eval's exact
 			// path (parse → resolveTree(addressPoints, interpolation)). Always resolves (admin even with no


### PR DESCRIPTION
## What

The interpolation tier reported `uncertainty_m` = half the matched TIGER segment length — an honest geometric prior, but a **too-tight** confidence bound. This calibrates it.

## Measurement (split-conformal, #374)

Interpolation tier in isolation (situs forced off), Travis-County E-911 holdout, full national TX interp shard — **1562 interp hits**:

| | |
|---|---|
| conformal threshold Q̂ | **1.7006** |
| uncalibrated coverage (Q̂=1) | 71.9% ← raw radius too tight |
| calibrated coverage (×1.70) | **91.5%** ✓ (target 90%) |
| median error | 52.7 m |
| median radius: raw → calibrated | 87 m → 148 m |

The half-segment heuristic underestimates the true spread by 1.70×. (Situs's fixed 10 m floor is the opposite — conservative vs ~1 m doorstep error, which is *safe*; under-reporting confidence is the dangerous direction, and that's what interpolation did.)

## What ships (opt-in, byte-stable)

- `ResolveOpts.interpolationRadiusCalibration?: number` — resolver stays calibration-agnostic (the factor is a property of the calibration set, not the geometry). When set, `applyInterpolation` reports `round(raw × factor)` and preserves `uncertainty_raw_m`. **Absent = raw heuristic; the 40 resolver tests are unchanged.**
- `geocode` CLI passes the TX-derived **1.70** by default; `--interp-calibration 1` reports the raw radius.

Verified: Concord NH 3→5 m, Honolulu HI 75→128 m, situs hits unaffected. Resolver tests 40/40.

## Caveats / next

- **1.70 is TX-calibrated.** TIGER is uniform methodology nationwide (sound first approximation) but Q̂ likely varies with road density — re-calibrate on a multi-region holdout; consider per-method / per-segment-length-bucket Q̂.
- **Promote to a loadable artifact** (like the isotonic `conf=` calibrator, #59) so re-calibration is a data swap, not a code change.
- **Abstention router (#244)** is the remaining confidence piece — confidence-gated downgrade to admin when the calibrated radius is too large.

Report: `docs/articles/evals/2026-06-14-interp-radius-calibration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)