### PR TITLE
fix(resolver): empty/tableless shard degrades gracefully instead of crashing (#568)

### DIFF
--- a/resolver-wof-sqlite/address-point-interpolation.ts
+++ b/resolver-wof-sqlite/address-point-interpolation.ts
@@ -39,6 +39,7 @@ import type { InterpolationLookup } from "@mailwoman/core/resolver"
 
 import { haversineKm } from "./geo.js"
 import type { InterpolatedHit, InterpolationQuery, StreetInterpolator } from "./interpolation.js"
+import { hasTable } from "./sqlite-utils.js"
 import { canonicalizeRouteKey, normalizeStreetForKey } from "./street-normalize.js"
 
 /**
@@ -68,7 +69,7 @@ export class AddressPointInterpolator implements InterpolationLookup {
 	readonly #db: DatabaseSync
 	readonly #ownsDb: boolean
 	readonly #fallback: StreetInterpolator | undefined
-	readonly #byPostcode
+	readonly #byPostcode: ReturnType<DatabaseSync["prepare"]> | undefined
 
 	constructor(opts: { dbPath?: string; database?: DatabaseSync; fallback?: StreetInterpolator }) {
 		if (opts.database) {
@@ -81,15 +82,19 @@ export class AddressPointInterpolator implements InterpolationLookup {
 			throw new Error("AddressPointInterpolator: one of dbPath or database is required")
 		}
 		this.#fallback = opts.fallback
-		// Strictly-numeric neighbor numbers on the route-folded street key within the ZIP. The
-		// queried number itself is excluded HERE (see module doc: non-circular by construction).
-		this.#byPostcode = this.#db.prepare(
-			`SELECT CAST(number AS INTEGER) AS n, lat, lon, source, release
-			 FROM address_point
-			 WHERE postcode = ? AND street_key = ?
-				AND number GLOB '[0-9]*' AND number NOT GLOB '*[^0-9]*'
-				AND CAST(number AS INTEGER) != ?`
-		)
+		// Degrade gracefully on an empty/tableless shard (#568): with no `address_point` table this tier
+		// is skipped, deferring to the segment fallback rather than crashing at construction.
+		if (hasTable(this.#db, "address_point")) {
+			// Strictly-numeric neighbor numbers on the route-folded street key within the ZIP. The
+			// queried number itself is excluded HERE (see module doc: non-circular by construction).
+			this.#byPostcode = this.#db.prepare(
+				`SELECT CAST(number AS INTEGER) AS n, lat, lon, source, release
+				 FROM address_point
+				 WHERE postcode = ? AND street_key = ?
+					AND number GLOB '[0-9]*' AND number NOT GLOB '*[^0-9]*'
+					AND CAST(number AS INTEGER) != ?`
+			)
+		}
 	}
 
 	find(query: InterpolationQuery): InterpolatedHit | null {
@@ -98,9 +103,8 @@ export class AddressPointInterpolator implements InterpolationLookup {
 		if (!streetKey || !/^\d+$/.test(numberRaw)) return null
 		const n = Number(numberRaw)
 
-		// Postcode scope only in this slice — without one, the segment fallback owns the
-		// statewide-ambiguity abstention; duplicating it here would be a second policy.
-		if (!query.postcode) return this.#fallback?.find(query) ?? null
+		// No own table (empty shard) or no postcode → defer to the segment fallback rather than query.
+		if (!this.#byPostcode || !query.postcode) return this.#fallback?.find(query) ?? null
 
 		const rows = this.#byPostcode.all(query.postcode.trim(), streetKey, n) as unknown as PointRow[]
 		const hit = rows.length >= 2 ? interpolateFromNeighbors(rows, n) : null

--- a/resolver-wof-sqlite/address-point.ts
+++ b/resolver-wof-sqlite/address-point.ts
@@ -19,6 +19,7 @@ import { DatabaseSync } from "node:sqlite"
 
 import type { AddressPointHit, AddressPointLookup } from "@mailwoman/core/resolver"
 
+import { hasTable } from "./sqlite-utils.js"
 import { normalizeLocalityForKey, normalizeStreetForKey } from "./street-normalize.js"
 
 interface AddressPointRow {
@@ -30,22 +31,27 @@ interface AddressPointRow {
 
 export class AddressPointSqliteLookup implements AddressPointLookup {
 	readonly #db: DatabaseSync
-	readonly #byPostcode
-	readonly #byLocality
+	readonly #byPostcode: ReturnType<DatabaseSync["prepare"]> | undefined
+	readonly #byLocality: ReturnType<DatabaseSync["prepare"]> | undefined
 
 	constructor(dbPath: string) {
 		this.#db = new DatabaseSync(dbPath, { readOnly: true })
-		this.#byPostcode = this.#db.prepare(
-			`SELECT lat, lon, source, release FROM address_point
-			 WHERE postcode = ? AND street_norm = ? AND number = ? LIMIT 1`
-		)
-		this.#byLocality = this.#db.prepare(
-			`SELECT lat, lon, source, release FROM address_point
-			 WHERE locality_norm = ? AND street_norm = ? AND number = ? LIMIT 1`
-		)
+		// Degrade gracefully on an empty/tableless shard (interrupted build, stray 0-byte file): with no
+		// `address_point` table this lookup is a no-op miss, not a crash that loses the whole state (#568).
+		if (hasTable(this.#db, "address_point")) {
+			this.#byPostcode = this.#db.prepare(
+				`SELECT lat, lon, source, release FROM address_point
+				 WHERE postcode = ? AND street_norm = ? AND number = ? LIMIT 1`
+			)
+			this.#byLocality = this.#db.prepare(
+				`SELECT lat, lon, source, release FROM address_point
+				 WHERE locality_norm = ? AND street_norm = ? AND number = ? LIMIT 1`
+			)
+		}
 	}
 
 	find(query: { street: string; number: string; postcode?: string; locality?: string }): AddressPointHit | null {
+		if (!this.#byPostcode || !this.#byLocality) return null
 		const streetNorm = normalizeStreetForKey(query.street)
 		const number = query.number.trim().toLowerCase()
 		if (!streetNorm || !number) return null

--- a/resolver-wof-sqlite/empty-shard.test.ts
+++ b/resolver-wof-sqlite/empty-shard.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Regression test for #568: a present-but-tableless shard (an interrupted build, or a stray 0-byte
+ *   file a `sqlite3 <missing>.db "…"` diagnostic created) must make the street-level lookups a no-op
+ *   MISS, not throw `no such table` at construction and take down a whole state's geocode.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { afterAll, describe, expect, it } from "vitest"
+
+import { AddressPointSqliteLookup } from "./address-point.js"
+import { AddressPointInterpolator } from "./address-point-interpolation.js"
+import { StreetInterpolator } from "./interpolation.js"
+
+const query = { street: "Main St", number: "100", postcode: "03301" }
+const dirs: string[] = []
+
+function tablelessDbFile(): string {
+	const dir = mkdtempSync(join(tmpdir(), "mw-empty-shard-"))
+	dirs.push(dir)
+	const path = join(dir, "empty.db")
+	const seed = new DatabaseSync(path)
+	seed.exec("CREATE TABLE unrelated (x)") // a valid db file, but no address_point / street_segment table
+	seed.close()
+	return path
+}
+
+afterAll(() => {
+	for (const d of dirs) rmSync(d, { recursive: true, force: true })
+})
+
+describe("empty/tableless shard degrades gracefully (#568)", () => {
+	it("AddressPointSqliteLookup: missing address_point table → constructs, find() returns null", () => {
+		let lookup: AddressPointSqliteLookup | undefined
+		expect(() => (lookup = new AddressPointSqliteLookup(tablelessDbFile()))).not.toThrow()
+		expect(lookup!.find(query)).toBeNull()
+		lookup!.close()
+	})
+
+	it("StreetInterpolator: missing street_segment table → constructs, find() returns null", () => {
+		const db = new DatabaseSync(":memory:")
+		db.exec("CREATE TABLE unrelated (x)")
+		let interp: StreetInterpolator | undefined
+		expect(() => (interp = new StreetInterpolator({ database: db }))).not.toThrow()
+		expect(interp!.find(query)).toBeNull()
+	})
+
+	it("AddressPointInterpolator: missing address_point table → defers to fallback (null with none)", () => {
+		const db = new DatabaseSync(":memory:")
+		db.exec("CREATE TABLE unrelated (x)")
+		let interp: AddressPointInterpolator | undefined
+		expect(() => (interp = new AddressPointInterpolator({ database: db }))).not.toThrow()
+		expect(interp!.find(query)).toBeNull()
+	})
+})

--- a/resolver-wof-sqlite/interpolation.ts
+++ b/resolver-wof-sqlite/interpolation.ts
@@ -31,6 +31,7 @@ import { DatabaseSync } from "node:sqlite"
 import type { InterpolationLookup } from "@mailwoman/core/resolver"
 
 import { haversineKm } from "./geo.js"
+import { hasTable } from "./sqlite-utils.js"
 import { canonicalizeRouteKey, normalizeStreetForKey } from "./street-normalize.js"
 
 /**
@@ -96,8 +97,8 @@ interface SegmentRow {
 export class StreetInterpolator implements InterpolationLookup {
 	readonly #db: DatabaseSync
 	readonly #ownsDb: boolean
-	readonly #byPostcode
-	readonly #byStreet
+	readonly #byPostcode: ReturnType<DatabaseSync["prepare"]> | undefined
+	readonly #byStreet: ReturnType<DatabaseSync["prepare"]> | undefined
 
 	constructor(opts: { dbPath?: string; database?: DatabaseSync }) {
 		if (opts.database) {
@@ -109,18 +110,23 @@ export class StreetInterpolator implements InterpolationLookup {
 		} else {
 			throw new Error("StreetInterpolator: one of dbPath or database is required")
 		}
-		const columns = `from_hn, to_hn, min_hn, max_hn, parity, postcode, geometry, source, release`
-		this.#byPostcode = this.#db.prepare(
-			`SELECT ${columns} FROM street_segment
-			 WHERE postcode = ? AND street_norm = ? AND min_hn <= ? AND max_hn >= ?`
-		)
-		this.#byStreet = this.#db.prepare(
-			`SELECT ${columns} FROM street_segment
-			 WHERE street_norm = ? AND min_hn <= ? AND max_hn >= ?`
-		)
+		// Degrade gracefully on an empty/tableless shard (interrupted build, stray 0-byte file): with no
+		// `street_segment` table this interpolator is a no-op miss, not a crash that loses the state (#568).
+		if (hasTable(this.#db, "street_segment")) {
+			const columns = `from_hn, to_hn, min_hn, max_hn, parity, postcode, geometry, source, release`
+			this.#byPostcode = this.#db.prepare(
+				`SELECT ${columns} FROM street_segment
+				 WHERE postcode = ? AND street_norm = ? AND min_hn <= ? AND max_hn >= ?`
+			)
+			this.#byStreet = this.#db.prepare(
+				`SELECT ${columns} FROM street_segment
+				 WHERE street_norm = ? AND min_hn <= ? AND max_hn >= ?`
+			)
+		}
 	}
 
 	find(query: InterpolationQuery): InterpolatedHit | null {
+		if (!this.#byPostcode || !this.#byStreet) return null
 		const streetNorm = canonicalizeRouteKey(normalizeStreetForKey(query.street))
 		const numberRaw = query.number.trim()
 		// Strictly-numeric house numbers only — this tier estimates, it doesn't guess at

--- a/resolver-wof-sqlite/sqlite-utils.ts
+++ b/resolver-wof-sqlite/sqlite-utils.ts
@@ -1,0 +1,24 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Small shared helpers for the SQLite-backed lookups.
+ */
+
+import type { DatabaseSync } from "node:sqlite"
+
+/**
+ * True when `name` is a table in the open database. The street-level lookups use this to degrade
+ * gracefully on an empty/tableless shard — an interrupted `build-*-shard.ts`, or a stray 0-byte file
+ * (e.g. `sqlite3 <missing>.db "…"` CREATES one) — rather than throwing `no such table` at construction
+ * and taking down a whole state's geocode (#568). A missing table makes the lookup a no-op miss.
+ */
+export function hasTable(db: DatabaseSync, name: string): boolean {
+	try {
+		const row = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1").get(name)
+		return row !== undefined
+	} catch {
+		return false
+	}
+}


### PR DESCRIPTION
Closes #568.

## Problem

A present-but-tableless street-level shard — an interrupted `build-*-shard.ts`, or a stray 0-byte file (a `sqlite3 <missing>.db "…"` diagnostic *creates* one) — made `AddressPointSqliteLookup` / `StreetInterpolator` / `AddressPointInterpolator` throw `SQLITE_ERROR: no such table` at **construction**, crashing a whole state's geocode. The CLI's `existsSync` guard passes an empty file straight through.

## Fix

A shared `hasTable()` check (`sqlite-utils.ts`): each lookup prepares its statements only when its table exists; otherwise `find()` is a no-op miss (`AddressPointInterpolator` defers to its segment fallback). A *missing* shard already degraded to admin — a *corrupt* one now does too, matching the geocode CLI's documented "absent shards degrade gracefully" contract.

## Verification

- A 0-byte `address-points-us-nh.db` now yields `interpolated` (Concord NH, correct coords) instead of crashing.
- New `empty-shard.test.ts` covers all three lookups (tableless db → constructs, `find()` returns null, no throw). Resolver tests **24/24**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)