### PR TITLE
feat(server): street-level /api/geocode + /api/batch over a shared cascade (#485 piece 1)

### DIFF
--- a/2026-06-13-GEOCODER-CAMPAIGN.md
+++ b/2026-06-13-GEOCODER-CAMPAIGN.md
@@ -103,6 +103,13 @@ Make it a callable geocoder. Reverse geocoding API (#484, engine built+green). P
 (#485 — batch, RemoteResolver, observability). Autocomplete (#190, FST built). Demo UX (#377). All
 independent of Coverage; engines exist, this is API surface + wiring.
 
+- **✅ Street-level `/api/geocode` + `/api/batch` (2026-06-14, PR #571 — #485 piece 1).** The server was
+  admin-only (`/api/resolve`); now it runs the full cascade. Extracted the cascade into
+  `mailwoman/geocode-core.ts` (`geocodeAddress` + a per-state `ShardProvider` cache), refactored the CLI
+  onto it (one implementation, re-validated byte-for-byte), and added `/api/batch` (bounded concurrency,
+  per-row error isolation, BATCH_MAX guardrail). Tests 5; full server+resolver suite 49/49.
+- **Open #485:** RemoteResolver adapter, observability (latency/tier/health), versioned data switchover.
+
 ### Cross-cutting — Arbitration (#478) — **Opus**
 
 Spec the policy-registry + reconcile + abstention layer now (so the pipeline is ≥v0 by construction),

--- a/mailwoman/commands/geocode.tsx
+++ b/mailwoman/commands/geocode.tsx
@@ -24,13 +24,18 @@
  */
 
 import { Spinner } from "@inkjs/ui"
-import { createWofResolver, type ResolveOpts, type ResolverBackend } from "@mailwoman/core/resolver"
+import { createWofResolver, type ResolverBackend } from "@mailwoman/core/resolver"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { Text } from "ink"
-import { existsSync } from "node:fs"
 import { setImmediate } from "node:timers/promises"
 import { useEffect, useState } from "react"
 import zod from "zod"
+import {
+	geocodeAddress,
+	type GeocodeResult,
+	type ShardResolver,
+	ShardProvider,
+} from "../geocode-core.js"
 import type { CommandComponent } from "../sdk/cli.js"
 import { resolverDefaultCountry } from "./parse.js"
 
@@ -101,33 +106,6 @@ const OptionsSchema = zod.object({
 })
 
 // ---------------------------------------------------------------------------
-// Output shape
-// ---------------------------------------------------------------------------
-
-/**
- * The resolution tier that produced the coordinate. `address_point` > `interpolated` > `admin`.
- * Consumers should treat coordinates differently depending on the tier:
- *   - `address_point` — rooftop / parcel centroid; uncertainty_m is a small floor (~1 m)
- *   - `interpolated`  — house-number estimate; uncertainty_m is honest (half the bracket span)
- *   - `admin`         — admin centroid; uncertainty_m is null (no sub-locality estimate available)
- */
-type ResolutionTier = "address_point" | "interpolated" | "admin"
-
-interface GeocodeResult {
-	input: string
-	lat: number | null
-	lon: number | null
-	resolution_tier: ResolutionTier
-	/** Uncertainty radius in meters. null for the admin tier. */
-	uncertainty_m: number | null
-	locality: string | null
-	region: string | null
-	postcode: string | null
-	/** Admin hierarchy from the resolver, locality → country (most specific first). */
-	hierarchy: Array<{ tag: string; value: string; lat?: number; lon?: number; placeId?: string }>
-}
-
-// ---------------------------------------------------------------------------
 // Path helpers
 // ---------------------------------------------------------------------------
 
@@ -142,56 +120,22 @@ function resolveWofPath(options: zod.infer<typeof OptionsSchema>): string {
 	return path
 }
 
-/**
- * Convert a resolved region name or abbreviation to a lowercase 2-letter state slug for shard
- * filenames (e.g. "TX" → "tx", "Texas" → null). Both the raw parsed value (e.g. "TX") and the
- * resolver's canonical name (e.g. "Texas") are checked — the raw abbreviation wins when present
- * because that's what the user typed and what the shard filenames encode.
- */
-function regionToStateSlug(regionValue: string | null | undefined, resolverName: string | null | undefined): string | null {
-	// Check raw parsed value first — abbreviations ("TX") are 2-letter and match immediately.
-	for (const candidate of [regionValue, resolverName]) {
-		if (!candidate) continue
-		const trimmed = candidate.trim()
-		if (/^[A-Za-z]{2}$/.test(trimmed)) return trimmed.toLowerCase()
-	}
-	return null
-}
-
-/**
- * Select the per-state address-points shard path from the data root + state slug.
- * Returns null when no slug is available or the file does not exist.
- */
-function selectAddressPointsDb(dataRoot: string, stateSlug: string | null): string | null {
-	if (!stateSlug) return null
-	const candidate = `${dataRoot}/address-points/address-points-us-${stateSlug}.db`
-	return existsSync(candidate) ? candidate : null
-}
-
-/**
- * Select the per-state interpolation shard path from the data root + state slug.
- * Returns null when no slug is available or the file does not exist.
- */
-function selectInterpolationDb(dataRoot: string, stateSlug: string | null): string | null {
-	if (!stateSlug) return null
-	const candidate = `${dataRoot}/interpolation/interpolation-us-${stateSlug}.db`
-	return existsSync(candidate) ? candidate : null
-}
-
 // ---------------------------------------------------------------------------
 // Core geocode logic
 // ---------------------------------------------------------------------------
 
 async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema>): Promise<string> {
-	// --- Step 1: load neural classifier (graceful degradation if weights absent) ---
-	let classifier: NeuralAddressClassifier | undefined
+	// Load the neural classifier (required for street-level; weights must be present).
+	let classifier: NeuralAddressClassifier
 	try {
 		classifier = await NeuralAddressClassifier.loadFromWeights({ locale: options.locale })
 	} catch {
-		// Weights not present — pipeline runs rule-only (queryShape / kind only). Acceptable degradation.
+		throw new Error(
+			"geocode requires the neural weights. Install @mailwoman/neural-weights-en-us (or pass --locale with installed weights)."
+		)
 	}
 
-	// --- Step 2: open WOF admin resolver ---
+	// Open the WOF admin resolver + the situs/interpolation shard provider.
 	let mod: typeof import("@mailwoman/resolver-wof-sqlite")
 	try {
 		mod = await import("@mailwoman/resolver-wof-sqlite")
@@ -202,190 +146,36 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 		)
 	}
 
-	const wofPath = resolveWofPath(options)
-	const lookup = new mod.WofSqlitePlaceLookup({ databasePath: wofPath })
+	const lookup = new mod.WofSqlitePlaceLookup({ databasePath: resolveWofPath(options) })
+	const shardProvider = new ShardProvider(mod, options.dataRoot)
+	// Explicit --address-points-db / --interpolation-db flags override per-state selection (testing a
+	// specific file); an unset tier still falls back to the region-derived per-state shard.
+	const explicitAp = options.addressPointsDb ? new mod.AddressPointSqliteLookup(options.addressPointsDb) : undefined
+	const explicitIp = options.interpolationDb ? new mod.StreetInterpolator({ dbPath: options.interpolationDb }) : undefined
+	const shards: ShardResolver =
+		explicitAp || explicitIp
+			? (slug) => {
+					const base = explicitAp && explicitIp ? {} : shardProvider.for(slug)
+					return { addressPoints: explicitAp ?? base.addressPoints, interpolation: explicitIp ?? base.interpolation }
+				}
+			: shardProvider.for
 
 	try {
-		// Step 2a: first pass — admin-only resolve so we can read the region to select shards.
 		const resolver = createWofResolver(lookup as unknown as ResolverBackend)
-		const dc = resolverDefaultCountry(options)
-		const baseResolveOpts: ResolveOpts = {}
-		if (dc) baseResolveOpts.defaultCountry = dc
-
-		// Build a resolver pipeline for the first (admin-only) pass — no address-point / interpolation
-		// yet; those need the region slug we haven't extracted yet.
-		if (!classifier) {
-			throw new Error(
-				"geocode requires the neural weights. Install @mailwoman/neural-weights-en-us (or pass --locale with installed weights)."
-			)
-		}
-		// RAW neural parse — the path the eval validated at 98.8% within 100m. NOT the runtime pipeline:
-		// its reconcile/solver stage can merge street INTO house_number (dropping the street node the
-		// coordinate tiers need — the bug that made situs silently fall to admin). Region for shard
-		// selection comes straight from the parse; no admin pre-resolve needed.
-		const firstTree = await classifier.parse(input, { postcodeRepair: true })
-
-		// --- Step 3: shard selection from resolved region ---
-		// Walk the resolved tree to find the region node's canonical name / value.
-		let regionValue: string | null = null
-		let regionResolverName: string | null = null
-		let localityValue: string | null = null
-		let postcodeValue: string | null = null
-
-		const stack = [...firstTree.roots]
-		while (stack.length > 0) {
-			const node = stack.pop()!
-			if (node.tag === "region" && !regionValue) {
-				regionValue = node.value.trim() || null
-				regionResolverName = (node.metadata?.["resolver_name"] as string | undefined) ?? null
-			}
-			if (node.tag === "locality" && !localityValue) {
-				localityValue = node.value.trim() || null
-			}
-			if (node.tag === "postcode" && !postcodeValue) {
-				postcodeValue = node.value.trim() || null
-			}
-			stack.push(...node.children)
-		}
-
-		// Determine which state shard to open. Explicit flags always win; then fall back to
-		// the region-derived slug. Missing shards → admin-only (never an error).
-		const stateSlug = regionToStateSlug(regionValue, regionResolverName)
-		const dataRoot = options.dataRoot
-
-		const addressPointsPath = options.addressPointsDb ?? selectAddressPointsDb(dataRoot, stateSlug)
-		const interpolationPath = options.interpolationDb ?? selectInterpolationDb(dataRoot, stateSlug)
-
-		// --- Step 4: second resolve pass wiring in address-point + interpolation tiers ---
-		let addressPointLookup: InstanceType<typeof mod.AddressPointSqliteLookup> | undefined
-		let interpolationLookup: InstanceType<typeof mod.StreetInterpolator> | undefined
-
-		try {
-			if (addressPointsPath) {
-				addressPointLookup = new mod.AddressPointSqliteLookup(addressPointsPath)
-			}
-			if (interpolationPath) {
-				interpolationLookup = new mod.StreetInterpolator({ dbPath: interpolationPath })
-			}
-
-			const enrichedResolveOpts: ResolveOpts = { ...baseResolveOpts }
-			if (addressPointLookup) enrichedResolveOpts.addressPoints = addressPointLookup
-			if (interpolationLookup) {
-				enrichedResolveOpts.interpolation = interpolationLookup
-				// Honest interp radius: the raw half-segment heuristic underestimates the true spread
-				// (~72% coverage); the calibration multiplier reports a ~90% bound. Default 1.7 (#374).
-				if (options.interpCalibration && options.interpCalibration !== 1) {
-					enrichedResolveOpts.interpolationRadiusCalibration = options.interpCalibration
-				}
-			}
-
-			// Single resolve pass on the raw-neural parse with the coordinate tiers wired — the eval's exact
-			// path (parse → resolveTree(addressPoints, interpolation)). Always resolves (admin even with no
-			// shards); the tiers are additive and byte-stable when absent.
-			const finalTree = await resolver.resolveTree(firstTree, enrichedResolveOpts)
-
-			// --- Step 5: extract geocode result from the resolved tree ---
-			const result = extractGeocodeResult(input, finalTree)
-
-			// Emit
-			if (options.format === "text") {
-				return formatText(result)
-			}
-			return JSON.stringify(result, null, 2)
-		} finally {
-			addressPointLookup?.close()
-			interpolationLookup?.close()
-		}
+		const result = await geocodeAddress(input, {
+			classifier,
+			resolver,
+			shards,
+			defaultCountry: resolverDefaultCountry(options) || undefined,
+			interpCalibration: options.interpCalibration,
+		})
+		return options.format === "text" ? formatText(result) : JSON.stringify(result, null, 2)
 	} finally {
+		explicitAp?.close()
+		explicitIp?.close()
+		shardProvider.close()
 		lookup.close()
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Tree extraction
-// ---------------------------------------------------------------------------
-
-import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
-
-/**
- * Walk the resolved `AddressTree` and extract the geocode result. Reads the street node's metadata
- * for the address-point / interpolation coordinate (whichever tier won), falls back to the best
- * admin centroid (locality → region → country) for the `admin` tier.
- */
-function extractGeocodeResult(input: string, tree: AddressTree): GeocodeResult {
-	// Flatten tree to a depth-first list for scanning.
-	const allNodes: AddressNode[] = []
-	const flatten = (nodes: readonly AddressNode[]) => {
-		for (const n of nodes) {
-			allNodes.push(n)
-			flatten(n.children)
-		}
-	}
-	flatten(tree.roots)
-
-	// Find street node (carries address_point / interpolated_point metadata).
-	const streetNode = allNodes.find((n) => n.tag === "street")
-
-	let lat: number | null = null
-	let lon: number | null = null
-	let tier: ResolutionTier = "admin"
-	let uncertaintyM: number | null = null
-
-	// Address-point tier: the street node's metadata key is `address_point`.
-	if (streetNode?.metadata?.["resolution_tier"] === "address_point") {
-		const ap = streetNode.metadata["address_point"] as { lat: number; lon: number } | undefined
-		if (ap) {
-			lat = ap.lat
-			lon = ap.lon
-			tier = "address_point"
-			uncertaintyM = 1 // Floor: situs point is essentially exact.
-		}
-	}
-
-	// Interpolation tier: metadata key is `interpolated_point`.
-	if (tier !== "address_point" && streetNode?.metadata?.["resolution_tier"] === "interpolated") {
-		const ip = streetNode.metadata["interpolated_point"] as { lat: number; lon: number } | undefined
-		if (ip) {
-			lat = ip.lat
-			lon = ip.lon
-			tier = "interpolated"
-			uncertaintyM = (streetNode.metadata["uncertainty_m"] as number | undefined) ?? null
-		}
-	}
-
-	// Admin tier: best admin centroid from resolved nodes.
-	if (tier === "admin") {
-		// Prefer locality, then region, then country — most specific first.
-		const adminPriority: ReadonlyArray<string> = ["locality", "dependent_locality", "region", "country"]
-		for (const tag of adminPriority) {
-			const node = allNodes.find((n) => n.tag === tag && n.lat != null && n.lon != null)
-			if (node) {
-				lat = node.lat!
-				lon = node.lon!
-				break
-			}
-		}
-	}
-
-	// Extract admin string values for the structured fields.
-	const locality =
-		allNodes.find((n) => n.tag === "locality" || n.tag === "dependent_locality")?.value?.trim() || null
-	const region = allNodes.find((n) => n.tag === "region")?.value?.trim() || null
-	const postcode = allNodes.find((n) => n.tag === "postcode")?.value?.trim() || null
-
-	// Build hierarchy: all resolved admin nodes, most specific first.
-	const HIERARCHY_TAGS = ["locality", "dependent_locality", "subregion", "region", "country"]
-	const hierarchy = allNodes
-		.filter((n) => HIERARCHY_TAGS.includes(n.tag) && (n.lat != null || n.placeId))
-		.sort((a, b) => HIERARCHY_TAGS.indexOf(a.tag) - HIERARCHY_TAGS.indexOf(b.tag))
-		.map((n) => ({
-			tag: n.tag,
-			value: n.value.trim(),
-			...(n.lat != null ? { lat: n.lat, lon: n.lon! } : {}),
-			...(n.placeId ? { placeId: n.placeId } : {}),
-		}))
-
-	return { input, lat, lon, resolution_tier: tier, uncertainty_m: uncertaintyM, locality, region, postcode, hierarchy }
 }
 
 // ---------------------------------------------------------------------------

--- a/mailwoman/commands/serve.tsx
+++ b/mailwoman/commands/serve.tsx
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url"
 import { useEffect, useState } from "react"
 import zod from "zod"
 import type { CommandComponent } from "../sdk/cli.js"
-import { AddressRouter, ResolveRouter } from "../server/index.js"
+import { AddressRouter, GeocodeRouter, ResolveRouter } from "../server/index.js"
 
 const ClusterManager: CommandComponent<typeof ServerConfigSchema> = ({
 	options: { cpus = availableParallelism() },
@@ -110,8 +110,10 @@ const ChildThread: CommandComponent<typeof ServerConfigSchema> = ({ options: { p
 	useEffect(() => {
 		const app = express()
 
-		app.use(express.json())
+		// 2mb body cap accommodates a full /api/batch (up to MAILWOMAN_BATCH_MAX addresses).
+		app.use(express.json({ limit: "2mb" }))
 		app.use(AddressRouter)
+		app.use(GeocodeRouter)
 		app.use(ResolveRouter)
 
 		// `mailwoman/server/static/` lives next to the compiled `mailwoman/out/commands/serve.js`,

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -1,0 +1,258 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Shared street-level geocode cascade — the reusable core behind the `geocode` CLI command AND the
+ *   server's `/api/geocode` + `/api/batch` endpoints (#485). One implementation of the cascade, so the
+ *   CLI and the service never drift.
+ *
+ *   Cascade (the eval-validated path — 98.8% within 100m on the non-circular Travis holdout):
+ *     1. RAW neural parse (`classifier.parse`, postcodeRepair). NOT the runtime pipeline — its
+ *        reconcile stage merges street INTO house_number, dropping the street node the coordinate
+ *        tiers need (#566).
+ *     2. Read the parsed region → pick the per-state situs + interpolation shards.
+ *     3. `resolveTree` with the coordinate tiers wired (additive; admin-only when shards absent).
+ *     4. Extract the best coordinate + resolution tier (address_point > interpolated > admin).
+ *
+ *   The cascade depends on a {@link ShardResolver} — a `(stateSlug) => { addressPoints?, interpolation? }`
+ *   function — so the CLI (honoring its explicit `--address-points-db` flags) and the server (a cached
+ *   {@link ShardProvider}) supply shards their own way without the core knowing how.
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } from "@mailwoman/core/resolver"
+import { existsSync } from "node:fs"
+
+/**
+ * The resolution tier that produced the coordinate. `address_point` > `interpolated` > `admin`.
+ *   - `address_point` — rooftop / parcel centroid; uncertainty_m is a small floor (~1 m)
+ *   - `interpolated`  — house-number estimate; uncertainty_m is honest (calibrated bracket span)
+ *   - `admin`         — admin centroid; uncertainty_m is null (no sub-locality estimate available)
+ */
+export type ResolutionTier = "address_point" | "interpolated" | "admin"
+
+export interface GeocodeResult {
+	input: string
+	lat: number | null
+	lon: number | null
+	resolution_tier: ResolutionTier
+	/** Uncertainty radius in meters. null for the admin tier. */
+	uncertainty_m: number | null
+	locality: string | null
+	region: string | null
+	postcode: string | null
+	/** Admin hierarchy from the resolver, locality → country (most specific first). */
+	hierarchy: Array<{ tag: string; value: string; lat?: number; lon?: number; placeId?: string }>
+}
+
+/** The per-state shards to wire into a single geocode resolve. Either/both may be absent (admin-only). */
+export interface StateShards {
+	addressPoints?: AddressPointLookup
+	interpolation?: InterpolationLookup
+}
+
+/** Resolve the situs/interpolation shards for a state slug (e.g. `"tx"`). `null` slug → no shards. */
+export type ShardResolver = (stateSlug: string | null) => StateShards
+
+/** The minimal classifier surface the cascade needs (a `NeuralAddressClassifier` satisfies it). */
+export interface GeocodeClassifier {
+	parse(text: string, opts?: { postcodeRepair?: boolean }): Promise<AddressTree>
+}
+
+export interface GeocodeDeps {
+	classifier: GeocodeClassifier
+	resolver: Resolver
+	/** Per-state shard resolver. Omit for admin-only geocoding. */
+	shards?: ShardResolver
+	/** Country constraint passed to the resolver (e.g. `"US"`). */
+	defaultCountry?: string
+	/**
+	 * Interpolation-radius conformal calibration multiplier (#374). The geocode surfaces pass 1.7 (the
+	 * Travis calibration) so reported radii are an honest ~90% bound; 1 or undefined keeps the raw
+	 * half-segment heuristic. See `docs/articles/evals/2026-06-14-interp-radius-calibration.md`.
+	 */
+	interpCalibration?: number
+}
+
+/** Lowercase 2-letter state slug from a parsed region value / resolver name, else null. */
+export function regionToStateSlug(
+	regionValue: string | null | undefined,
+	resolverName: string | null | undefined
+): string | null {
+	for (const candidate of [regionValue, resolverName]) {
+		if (!candidate) continue
+		const trimmed = candidate.trim()
+		if (/^[A-Za-z]{2}$/.test(trimmed)) return trimmed.toLowerCase()
+	}
+	return null
+}
+
+/** Per-state situs shard path under `<dataRoot>/address-points/`, or null if the slug/file is absent. */
+export function selectAddressPointsDb(dataRoot: string, stateSlug: string | null): string | null {
+	if (!stateSlug) return null
+	const candidate = `${dataRoot}/address-points/address-points-us-${stateSlug}.db`
+	return existsSync(candidate) ? candidate : null
+}
+
+/** Per-state interpolation shard path under `<dataRoot>/interpolation/`, or null if absent. */
+export function selectInterpolationDb(dataRoot: string, stateSlug: string | null): string | null {
+	if (!stateSlug) return null
+	const candidate = `${dataRoot}/interpolation/interpolation-us-${stateSlug}.db`
+	return existsSync(candidate) ? candidate : null
+}
+
+/** The lookup-class surface a {@link ShardProvider} needs from `@mailwoman/resolver-wof-sqlite`. */
+export interface ShardLookupFactory {
+	AddressPointSqliteLookup: new (dbPath: string) => AddressPointLookup & { close(): void }
+	StreetInterpolator: new (opts: { dbPath: string }) => InterpolationLookup & { close(): void }
+}
+
+/**
+ * Opens + CACHES per-state situs/interpolation lookups so a batch geocoding many addresses in one
+ * state opens that state's (possibly multi-GB) shards once, not once per row. Call {@link close} when
+ * done to release every cached handle.
+ */
+export class ShardProvider {
+	readonly #factory: ShardLookupFactory
+	readonly #dataRoot: string
+	readonly #cache = new Map<string, StateShards & { _ap?: { close(): void }; _ip?: { close(): void } }>()
+
+	constructor(factory: ShardLookupFactory, dataRoot: string) {
+		this.#factory = factory
+		this.#dataRoot = dataRoot
+	}
+
+	readonly for: ShardResolver = (stateSlug) => {
+		if (!stateSlug) return {}
+		const cached = this.#cache.get(stateSlug)
+		if (cached) return { addressPoints: cached.addressPoints, interpolation: cached.interpolation }
+
+		const apPath = selectAddressPointsDb(this.#dataRoot, stateSlug)
+		const ipPath = selectInterpolationDb(this.#dataRoot, stateSlug)
+		const ap = apPath ? new this.#factory.AddressPointSqliteLookup(apPath) : undefined
+		const ip = ipPath ? new this.#factory.StreetInterpolator({ dbPath: ipPath }) : undefined
+		const entry = { addressPoints: ap, interpolation: ip, _ap: ap, _ip: ip }
+		this.#cache.set(stateSlug, entry)
+		return { addressPoints: ap, interpolation: ip }
+	}
+
+	close(): void {
+		for (const e of this.#cache.values()) {
+			e._ap?.close()
+			e._ip?.close()
+		}
+		this.#cache.clear()
+	}
+}
+
+/**
+ * Run the full street-level cascade on one address and return the structured geocode result. Always
+ * returns a result (admin tier even with no coordinate shards). Throws only on a fatal parse/resolve
+ * error — callers doing batch work should catch per-row.
+ */
+export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<GeocodeResult> {
+	const tree = await deps.classifier.parse(input, { postcodeRepair: true })
+
+	// Read the parsed region (raw value + resolver canonical name) for shard selection.
+	let regionValue: string | null = null
+	let regionResolverName: string | null = null
+	const stack = [...tree.roots]
+	while (stack.length > 0) {
+		const node = stack.pop()!
+		if (node.tag === "region" && !regionValue) {
+			regionValue = node.value.trim() || null
+			regionResolverName = (node.metadata?.["resolver_name"] as string | undefined) ?? null
+		}
+		stack.push(...node.children)
+	}
+
+	const stateSlug = regionToStateSlug(regionValue, regionResolverName)
+	const { addressPoints, interpolation } = deps.shards?.(stateSlug) ?? {}
+
+	const opts: ResolveOpts = {}
+	if (deps.defaultCountry) opts.defaultCountry = deps.defaultCountry
+	if (addressPoints) opts.addressPoints = addressPoints
+	if (interpolation) {
+		opts.interpolation = interpolation
+		if (deps.interpCalibration && deps.interpCalibration !== 1) {
+			opts.interpolationRadiusCalibration = deps.interpCalibration
+		}
+	}
+
+	const resolved = await deps.resolver.resolveTree(tree, opts)
+	return extractGeocodeResult(input, resolved)
+}
+
+/**
+ * Walk the resolved tree and extract the geocode result: the street node's address-point /
+ * interpolation coordinate (whichever tier won), else the best admin centroid (locality → region →
+ * country).
+ */
+export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeResult {
+	const allNodes: AddressNode[] = []
+	const flatten = (nodes: readonly AddressNode[]) => {
+		for (const n of nodes) {
+			allNodes.push(n)
+			flatten(n.children)
+		}
+	}
+	flatten(tree.roots)
+
+	const streetNode = allNodes.find((n) => n.tag === "street")
+
+	let lat: number | null = null
+	let lon: number | null = null
+	let tier: ResolutionTier = "admin"
+	let uncertaintyM: number | null = null
+
+	if (streetNode?.metadata?.["resolution_tier"] === "address_point") {
+		const ap = streetNode.metadata["address_point"] as { lat: number; lon: number } | undefined
+		if (ap) {
+			lat = ap.lat
+			lon = ap.lon
+			tier = "address_point"
+			uncertaintyM = 1 // Floor: situs point is essentially exact.
+		}
+	}
+
+	if (tier !== "address_point" && streetNode?.metadata?.["resolution_tier"] === "interpolated") {
+		const ip = streetNode.metadata["interpolated_point"] as { lat: number; lon: number } | undefined
+		if (ip) {
+			lat = ip.lat
+			lon = ip.lon
+			tier = "interpolated"
+			uncertaintyM = (streetNode.metadata["uncertainty_m"] as number | undefined) ?? null
+		}
+	}
+
+	if (tier === "admin") {
+		const adminPriority: ReadonlyArray<string> = ["locality", "dependent_locality", "region", "country"]
+		for (const tag of adminPriority) {
+			const node = allNodes.find((n) => n.tag === tag && n.lat != null && n.lon != null)
+			if (node) {
+				lat = node.lat!
+				lon = node.lon!
+				break
+			}
+		}
+	}
+
+	const locality =
+		allNodes.find((n) => n.tag === "locality" || n.tag === "dependent_locality")?.value?.trim() || null
+	const region = allNodes.find((n) => n.tag === "region")?.value?.trim() || null
+	const postcode = allNodes.find((n) => n.tag === "postcode")?.value?.trim() || null
+
+	const HIERARCHY_TAGS = ["locality", "dependent_locality", "subregion", "region", "country"]
+	const hierarchy = allNodes
+		.filter((n) => HIERARCHY_TAGS.includes(n.tag) && (n.lat != null || n.placeId))
+		.sort((a, b) => HIERARCHY_TAGS.indexOf(a.tag) - HIERARCHY_TAGS.indexOf(b.tag))
+		.map((n) => ({
+			tag: n.tag,
+			value: n.value.trim(),
+			...(n.lat != null ? { lat: n.lat, lon: n.lon! } : {}),
+			...(n.placeId ? { placeId: n.placeId } : {}),
+		}))
+
+	return { input, lat, lon, resolution_tier: tier, uncertainty_m: uncertaintyM, locality, region, postcode, hierarchy }
+}

--- a/mailwoman/server/GeocodeRouter.ts
+++ b/mailwoman/server/GeocodeRouter.ts
@@ -1,0 +1,152 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Street-level geocoding endpoints (#485, piece 1):
+ *     - `POST /api/geocode` — `{ address }` → one {@link GeocodeResult} (parse → situs → interp → admin).
+ *     - `POST /api/batch`   — `{ addresses: string[] }` → results in input order, BOUNDED concurrency,
+ *       PER-ROW error isolation (one bad address never fails the batch — it gets an `{ error }` slot).
+ *
+ *   Runs the SAME cascade as the `geocode` CLI (`mailwoman/geocode-core.ts`), so the service and the
+ *   CLI never drift. Deps (classifier + resolver + a cached {@link ShardProvider}) are lazy-loaded
+ *   ONCE on first hit and reused; the per-state shard cache means a batch hitting many CA addresses
+ *   opens CA's situs shard once, not per row.
+ */
+
+import { createWofResolver, type Resolver, type ResolverBackend } from "@mailwoman/core/resolver"
+import { type RequestHandler, Router } from "express"
+import { existsSync } from "node:fs"
+
+import { geocodeAddress, type GeocodeClassifier, type GeocodeResult, ShardProvider } from "../geocode-core.js"
+
+/** Default per-state shard root + interp calibration — mirror the CLI defaults. */
+const DATA_ROOT = process.env["MAILWOMAN_DATA_ROOT"] ?? "/mnt/playpen/mailwoman-data"
+const INTERP_CALIBRATION = 1.7
+/** Bounded concurrency for `/api/batch`. Override with MAILWOMAN_BATCH_CONCURRENCY. */
+const BATCH_CONCURRENCY = Math.max(1, Number(process.env["MAILWOMAN_BATCH_CONCURRENCY"] ?? "8"))
+/** Hard cap on batch size — a guardrail against unbounded request bodies. */
+const BATCH_MAX = Math.max(1, Number(process.env["MAILWOMAN_BATCH_MAX"] ?? "1000"))
+
+interface GeocodeDepsBundle {
+	classifier: GeocodeClassifier
+	resolver: Resolver
+	shards: ShardProvider
+	defaultCountry?: string
+}
+
+function wofPaths(): string[] {
+	const env = process.env["MAILWOMAN_WOF_DB"]
+	if (env) return env.split(",").map((p) => p.trim()).filter(Boolean)
+	return ["/mnt/playpen/mailwoman-data/wof/admin-global-priority.db", "/mnt/playpen/mailwoman-data/wof/postalcode-us.db"].filter(
+		(p) => existsSync(p)
+	)
+}
+
+let depsPromise: Promise<GeocodeDepsBundle | null> | null = null
+
+async function getDeps(): Promise<GeocodeDepsBundle | null> {
+	if (depsPromise) return depsPromise
+	depsPromise = (async () => {
+		let neuralMod: typeof import("@mailwoman/neural")
+		let resolverMod: typeof import("@mailwoman/resolver-wof-sqlite")
+		try {
+			neuralMod = await import("@mailwoman/neural")
+			resolverMod = await import("@mailwoman/resolver-wof-sqlite")
+		} catch {
+			console.error("GeocodeRouter: @mailwoman/neural + @mailwoman/resolver-wof-sqlite are required")
+			return null
+		}
+		const paths = wofPaths()
+		if (paths.length === 0) {
+			console.error("GeocodeRouter: no WOF DBs found — set MAILWOMAN_WOF_DB")
+			return null
+		}
+		const classifier = await neuralMod.NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+		const backend = new resolverMod.WofSqlitePlaceLookup({ databasePath: paths.length === 1 ? paths[0]! : paths })
+		const resolver = createWofResolver(backend as unknown as ResolverBackend)
+		const shards = new ShardProvider(resolverMod, DATA_ROOT)
+		return { classifier, resolver, shards, defaultCountry: "US" }
+	})()
+	return depsPromise
+}
+
+function oneGeocode(deps: GeocodeDepsBundle, address: string): Promise<GeocodeResult> {
+	return geocodeAddress(address, {
+		classifier: deps.classifier,
+		resolver: deps.resolver,
+		shards: deps.shards.for,
+		defaultCountry: deps.defaultCountry,
+		interpCalibration: INTERP_CALIBRATION,
+	})
+}
+
+const DEPS_UNAVAILABLE = {
+	error: "Geocoder not available. Install @mailwoman/neural + @mailwoman/resolver-wof-sqlite and set MAILWOMAN_WOF_DB.",
+}
+
+const singleHandler: RequestHandler = async (req, res) => {
+	const address = typeof req.body?.address === "string" ? req.body.address.trim() : ""
+	if (!address) {
+		res.status(400).json({ error: "Missing `address` (string)" })
+		return
+	}
+	const deps = await getDeps()
+	if (!deps) {
+		res.status(503).json(DEPS_UNAVAILABLE)
+		return
+	}
+	try {
+		res.status(200).json(await oneGeocode(deps, address))
+	} catch (err) {
+		res.status(500).json({ error: `geocode error: ${err instanceof Error ? err.message : String(err)}` })
+	}
+}
+
+/** Per-row result: the GeocodeResult, OR an `{ input, error }` slot so one bad row never fails the batch. */
+type BatchRow = GeocodeResult | { input: string; error: string }
+
+const batchHandler: RequestHandler = async (req, res) => {
+	const addresses = req.body?.addresses
+	if (!Array.isArray(addresses) || addresses.some((a) => typeof a !== "string")) {
+		res.status(400).json({ error: "Body must be `{ addresses: string[] }`" })
+		return
+	}
+	if (addresses.length === 0) {
+		res.status(200).json({ results: [] })
+		return
+	}
+	if (addresses.length > BATCH_MAX) {
+		res.status(413).json({ error: `Batch too large: ${addresses.length} > ${BATCH_MAX} (MAILWOMAN_BATCH_MAX)` })
+		return
+	}
+	const deps = await getDeps()
+	if (!deps) {
+		res.status(503).json(DEPS_UNAVAILABLE)
+		return
+	}
+
+	const inputs: string[] = addresses.map((a) => (a as string).trim())
+	const results: BatchRow[] = new Array<BatchRow>(inputs.length)
+
+	// Bounded-concurrency worker pool over a shared cursor — results land in input order; a thrown
+	// row is isolated to its own slot. The shard cache makes same-state rows cheap after the first.
+	let cursor = 0
+	const worker = async (): Promise<void> => {
+		for (let i = cursor++; i < inputs.length; i = cursor++) {
+			const input = inputs[i]!
+			try {
+				results[i] = await oneGeocode(deps, input)
+			} catch (err) {
+				results[i] = { input, error: err instanceof Error ? err.message : String(err) }
+			}
+		}
+	}
+	await Promise.all(Array.from({ length: Math.min(BATCH_CONCURRENCY, inputs.length) }, worker))
+
+	res.status(200).json({ results })
+}
+
+export const GeocodeRouter: Router = Router()
+GeocodeRouter.post("/api/geocode", singleHandler)
+GeocodeRouter.post("/api/batch", batchHandler)

--- a/mailwoman/server/index.ts
+++ b/mailwoman/server/index.ts
@@ -5,4 +5,5 @@
  */
 
 export * from "./AddressRouter.js"
+export * from "./GeocodeRouter.js"
 export * from "./ResolveRouter.js"

--- a/mailwoman/test/geocode-router.test.ts
+++ b/mailwoman/test/geocode-router.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Unit tests for `GeocodeRouter` (#485). Schema/error paths run unconditionally; the success-path
+ *   tests gate on real WOF + per-state shards being present (same skip-if-missing pattern as the
+ *   resolver integration tests). Success-path tests also need the neural weights installed.
+ */
+
+import express from "express"
+import { existsSync } from "node:fs"
+import { describe, expect, test } from "vitest"
+
+import { GeocodeRouter } from "../server/GeocodeRouter.js"
+
+const wofPath = process.env["MAILWOMAN_WOF_DB"] ?? "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+const txSitus = "/mnt/playpen/mailwoman-data/address-points/address-points-us-tx.db"
+const hasStack = existsSync(wofPath) && existsSync(txSitus)
+const describeIfStack = describe.skipIf(!hasStack)
+
+function buildApp() {
+	const app = express()
+	app.use(express.json({ limit: "2mb" }))
+	app.use(GeocodeRouter)
+	return app
+}
+
+async function postJson(app: express.Express, path: string, body: unknown) {
+	const server = app.listen(0)
+	try {
+		const port = (server.address() as { port: number }).port
+		const r = await fetch(`http://127.0.0.1:${port}${path}`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		})
+		return { status: r.status, body: await r.json() }
+	} finally {
+		await new Promise<void>((resolve) => server.close(() => resolve()))
+	}
+}
+
+describe("GeocodeRouter — error paths (run unconditionally)", () => {
+	test("POST /api/geocode 400 when `address` is missing", async () => {
+		const r = await postJson(buildApp(), "/api/geocode", {})
+		expect(r.status).toBe(400)
+		expect((r.body as { error?: string }).error).toMatch(/address/)
+	})
+
+	test("POST /api/batch 400 when `addresses` is not a string array", async () => {
+		const r = await postJson(buildApp(), "/api/batch", { addresses: [1, 2] })
+		expect(r.status).toBe(400)
+	})
+
+	test("POST /api/batch 200 + empty results for an empty array", async () => {
+		const r = await postJson(buildApp(), "/api/batch", { addresses: [] })
+		expect(r.status).toBe(200)
+		expect((r.body as { results: unknown[] }).results).toEqual([])
+	})
+})
+
+describeIfStack("GeocodeRouter — success path against real WOF + TX shards", () => {
+	test("POST /api/geocode resolves a TX address to a street-level coordinate", async () => {
+		const r = await postJson(buildApp(), "/api/geocode", { address: "3075 Hill Street, Round Rock, TX 78664" })
+		expect(r.status).toBe(200)
+		const body = r.body as { lat: number; lon: number; resolution_tier: string; region: string }
+		expect(body.region).toBe("TX")
+		expect(["address_point", "interpolated"]).toContain(body.resolution_tier)
+		expect(typeof body.lat).toBe("number")
+		expect(typeof body.lon).toBe("number")
+	}, 60_000)
+
+	test("POST /api/batch returns results in input order, one slot per input", async () => {
+		const addresses = ["3075 Hill Street, Round Rock, TX 78664", "3029 Hill Street, Round Rock, TX 78664"]
+		const r = await postJson(buildApp(), "/api/batch", { addresses })
+		expect(r.status).toBe(200)
+		const results = (r.body as { results: Array<{ input: string }> }).results
+		expect(results).toHaveLength(2)
+		expect(results[0]!.input).toBe(addresses[0])
+		expect(results[1]!.input).toBe(addresses[1])
+	}, 60_000)
+})


### PR DESCRIPTION
First piece of #485 (the service layer). Ordered piece #1: the batch endpoint.

## Problem

The server's only geocoding endpoint was `/api/resolve` — **admin-only** (`resolveTree` with no situs/interp shards). The street-level cascade lived only in the `geocode` CLI command.

## What

**Extract the cascade** into `mailwoman/geocode-core.ts` — `geocodeAddress()` + a per-state `ShardProvider` cache + `extractGeocodeResult()` — so the CLI and the service run **one** implementation and never drift. `geocodeAddress` depends on a `ShardResolver` function, so the CLI (honoring its explicit `--address-points-db` flags) and the server supply shards their own way.

**Refactor the CLI** onto the core (thin wrapper). Re-validated byte-for-byte against the known-good spot-checks: TX/CA `address_point` 1m, NH 5m, HI 128m (calibrated) — **zero change**.

**New endpoints** (`GeocodeRouter`, mounted in `serve`):
- `POST /api/geocode` `{ address }` → `GeocodeResult` (parse → situs → interp → admin).
- `POST /api/batch` `{ addresses: string[] }` → results **in input order**, **bounded concurrency** (`MAILWOMAN_BATCH_CONCURRENCY`=8), **per-row error isolation** (a bad row gets an `{ input, error }` slot, never fails the batch), `BATCH_MAX` guardrail (413 over the cap).

The per-state shard cache means a batch hitting many CA addresses opens CA's (multi-GB) situs shard **once**, not per row. Deps lazy-load once and are reused. 2mb JSON body cap for full batches.

## Tests

`geocode-router.test.ts` (5) — error paths unconditional (400/400/200-empty), success path gated on real WOF + TX shards (single resolves TX street-level; batch returns ordered results). **Full server+resolver suite 49/49.**

## Remaining #485 (separate PRs)

RemoteResolver adapter, observability (latency histograms / tier counts / health), versioned data switchover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)