### PR TITLE
feat(server): observability — /health + /metrics (#485 piece 2)

### DIFF
--- a/2026-06-13-GEOCODER-CAMPAIGN.md
+++ b/2026-06-13-GEOCODER-CAMPAIGN.md
@@ -108,7 +108,12 @@ independent of Coverage; engines exist, this is API surface + wiring.
   `mailwoman/geocode-core.ts` (`geocodeAddress` + a per-state `ShardProvider` cache), refactored the CLI
   onto it (one implementation, re-validated byte-for-byte), and added `/api/batch` (bounded concurrency,
   per-row error isolation, BATCH_MAX guardrail). Tests 5; full server+resolver suite 49/49.
-- **Open #485:** RemoteResolver adapter, observability (latency/tier/health), versioned data switchover.
+- **✅ Observability `/health` + `/metrics` (2026-06-14, PR #572 — #485 piece 2).** `/health` = "what's
+  deployed in one curl" (model-card version + situs/interp shard counts, no model load); `/metrics` =
+  per-tier counts + latency p50/p90/p99 from a bounded reservoir, recorded per request. The instrument the
+  SLO targets need. Tests 4.
+- **Open #485:** RemoteResolver adapter (multi-instance / canary — the bigger architectural lift),
+  versioned data switchover. Prometheus exposition + calibration-drift wiring ride on `/metrics`.
 
 ### Cross-cutting — Arbitration (#478) — **Opus**
 

--- a/mailwoman/commands/serve.tsx
+++ b/mailwoman/commands/serve.tsx
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url"
 import { useEffect, useState } from "react"
 import zod from "zod"
 import type { CommandComponent } from "../sdk/cli.js"
-import { AddressRouter, GeocodeRouter, ResolveRouter } from "../server/index.js"
+import { AddressRouter, GeocodeRouter, HealthRouter, ResolveRouter } from "../server/index.js"
 
 const ClusterManager: CommandComponent<typeof ServerConfigSchema> = ({
 	options: { cpus = availableParallelism() },
@@ -112,6 +112,7 @@ const ChildThread: CommandComponent<typeof ServerConfigSchema> = ({ options: { p
 
 		// 2mb body cap accommodates a full /api/batch (up to MAILWOMAN_BATCH_MAX addresses).
 		app.use(express.json({ limit: "2mb" }))
+		app.use(HealthRouter)
 		app.use(AddressRouter)
 		app.use(GeocodeRouter)
 		app.use(ResolveRouter)

--- a/mailwoman/server/GeocodeRouter.ts
+++ b/mailwoman/server/GeocodeRouter.ts
@@ -19,6 +19,7 @@ import { type RequestHandler, Router } from "express"
 import { existsSync } from "node:fs"
 
 import { geocodeAddress, type GeocodeClassifier, type GeocodeResult, ShardProvider } from "../geocode-core.js"
+import { recordGeocode } from "./metrics.js"
 
 /** Default per-state shard root + interp calibration — mirror the CLI defaults. */
 const DATA_ROOT = process.env["MAILWOMAN_DATA_ROOT"] ?? "/mnt/playpen/mailwoman-data"
@@ -96,9 +97,13 @@ const singleHandler: RequestHandler = async (req, res) => {
 		res.status(503).json(DEPS_UNAVAILABLE)
 		return
 	}
+	const t0 = performance.now()
 	try {
-		res.status(200).json(await oneGeocode(deps, address))
+		const result = await oneGeocode(deps, address)
+		recordGeocode(performance.now() - t0, result.resolution_tier)
+		res.status(200).json(result)
 	} catch (err) {
+		recordGeocode(performance.now() - t0, "error")
 		res.status(500).json({ error: `geocode error: ${err instanceof Error ? err.message : String(err)}` })
 	}
 }
@@ -135,9 +140,13 @@ const batchHandler: RequestHandler = async (req, res) => {
 	const worker = async (): Promise<void> => {
 		for (let i = cursor++; i < inputs.length; i = cursor++) {
 			const input = inputs[i]!
+			const t0 = performance.now()
 			try {
-				results[i] = await oneGeocode(deps, input)
+				const result = await oneGeocode(deps, input)
+				recordGeocode(performance.now() - t0, result.resolution_tier)
+				results[i] = result
 			} catch (err) {
+				recordGeocode(performance.now() - t0, "error")
 				results[i] = { input, error: err instanceof Error ? err.message : String(err) }
 			}
 		}

--- a/mailwoman/server/HealthRouter.ts
+++ b/mailwoman/server/HealthRouter.ts
@@ -1,0 +1,89 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Operational endpoints (#485 observability):
+ *     - `GET /health`  — "what's deployed, in one curl": model-card name/version/locale + which WOF
+ *       gazetteer and how many per-state situs/interpolation shards are on disk. LIGHTWEIGHT — reads
+ *       JSON + counts files, never loads the model, never throws (health must answer even when broken).
+ *     - `GET /metrics` — the live geocode metrics snapshot (latency percentiles + per-tier counts).
+ */
+
+import { type RequestHandler, Router } from "express"
+import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+
+import { metricsSnapshot } from "./metrics.js"
+
+const DATA_ROOT = process.env["MAILWOMAN_DATA_ROOT"] ?? "/mnt/playpen/mailwoman-data"
+const startedAt = Date.now()
+
+/** Best-effort model-card read: env override → installed weights package → dev-tree fallback. */
+function readModelCard(): Record<string, unknown> | null {
+	const candidates: string[] = []
+	if (process.env["MAILWOMAN_MODEL_CARD"]) candidates.push(process.env["MAILWOMAN_MODEL_CARD"]!)
+	try {
+		candidates.push(createRequire(import.meta.url).resolve("@mailwoman/neural-weights-en-us/model-card.json"))
+	} catch {
+		/* package not resolvable from here — fall through */
+	}
+	candidates.push("neural-weights-en-us/model-card.json")
+	for (const p of candidates) {
+		try {
+			if (existsSync(p)) return JSON.parse(readFileSync(p, "utf8")) as Record<string, unknown>
+		} catch {
+			/* unreadable / malformed — try the next candidate */
+		}
+	}
+	return null
+}
+
+/** Count canonical per-state shards (`<prefix>-us-<2-letter>.db`) in a data subdir; 0 if absent. */
+function countShards(subdir: string, prefix: string): number {
+	try {
+		const re = new RegExp(`^${prefix}-us-[a-z]{2}\\.db$`)
+		return readdirSync(`${DATA_ROOT}/${subdir}`).filter((f) => re.test(f)).length
+	} catch {
+		return 0
+	}
+}
+
+function wofPaths(): string[] {
+	const env = process.env["MAILWOMAN_WOF_DB"]
+	const paths = env
+		? env.split(",").map((p) => p.trim()).filter(Boolean)
+		: ["/mnt/playpen/mailwoman-data/wof/admin-global-priority.db", "/mnt/playpen/mailwoman-data/wof/postalcode-us.db"]
+	return paths.filter((p) => existsSync(p))
+}
+
+const healthHandler: RequestHandler = (_req, res) => {
+	const card = readModelCard()
+	res.status(200).json({
+		status: "ok",
+		uptime_s: Math.round((Date.now() - startedAt) / 1000),
+		model: card
+			? {
+					name: card["name"],
+					version: card["version"],
+					locale: card["locale"],
+					labels: Array.isArray(card["labels"]) ? card["labels"].length : undefined,
+					format: card["format"],
+				}
+			: null,
+		data: {
+			data_root: DATA_ROOT,
+			wof_dbs: wofPaths(),
+			situs_states: countShards("address-points", "address-points"),
+			interpolation_states: countShards("interpolation", "interpolation"),
+		},
+	})
+}
+
+const metricsHandler: RequestHandler = (_req, res) => {
+	res.status(200).json(metricsSnapshot())
+}
+
+export const HealthRouter: Router = Router()
+HealthRouter.get("/health", healthHandler)
+HealthRouter.get("/metrics", metricsHandler)

--- a/mailwoman/server/index.ts
+++ b/mailwoman/server/index.ts
@@ -6,4 +6,5 @@
 
 export * from "./AddressRouter.js"
 export * from "./GeocodeRouter.js"
+export * from "./HealthRouter.js"
 export * from "./ResolveRouter.js"

--- a/mailwoman/server/metrics.ts
+++ b/mailwoman/server/metrics.ts
@@ -1,0 +1,90 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   In-process geocode metrics (#485 observability). Dependency-free: monotonic counters per
+ *   resolution tier + a bounded reservoir of recent latencies for percentile estimation. The issue
+ *   asks to MEASURE the SLO targets (p99 ≤ 100ms admin, ≤ 250ms with situs) rather than invent them —
+ *   this is the instrument. Surfaced by `GET /metrics`; reset on process restart (no persistence —
+ *   scrape it).
+ */
+
+import type { ResolutionTier } from "../geocode-core.js"
+
+/** Recent-latency reservoir size. ~2k samples gives stable p99 without unbounded memory. */
+const MAX_SAMPLES = 2048
+
+const latencies: number[] = []
+let writeIdx = 0
+
+const tierCounts: Record<ResolutionTier, number> = { address_point: 0, interpolated: 0, admin: 0 }
+let total = 0
+let errors = 0
+const startedAt = Date.now()
+
+/** Record one completed geocode: its wall-clock latency and which tier produced it (or `"error"`). */
+export function recordGeocode(latencyMs: number, tier: ResolutionTier | "error"): void {
+	total++
+	if (tier === "error") {
+		errors++
+	} else {
+		tierCounts[tier]++
+	}
+	if (latencies.length < MAX_SAMPLES) {
+		latencies.push(latencyMs)
+	} else {
+		latencies[writeIdx] = latencyMs
+		writeIdx = (writeIdx + 1) % MAX_SAMPLES
+	}
+}
+
+function percentile(sorted: number[], p: number): number {
+	if (sorted.length === 0) return 0
+	const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length))
+	return Math.round(sorted[idx]! * 100) / 100
+}
+
+export interface MetricsSnapshot {
+	uptime_s: number
+	geocode: {
+		total: number
+		errors: number
+		tiers: Record<ResolutionTier, number>
+		latency_ms: { p50: number; p90: number; p99: number; max: number } | null
+		latency_samples: number
+	}
+}
+
+/** Current metrics snapshot — sorted-reservoir percentiles + counters. */
+export function metricsSnapshot(): MetricsSnapshot {
+	const sorted = [...latencies].sort((a, b) => a - b)
+	return {
+		uptime_s: Math.round((Date.now() - startedAt) / 1000),
+		geocode: {
+			total,
+			errors,
+			tiers: { ...tierCounts },
+			latency_ms: sorted.length
+				? {
+						p50: percentile(sorted, 0.5),
+						p90: percentile(sorted, 0.9),
+						p99: percentile(sorted, 0.99),
+						max: Math.round(sorted[sorted.length - 1]! * 100) / 100,
+					}
+				: null,
+			latency_samples: sorted.length,
+		},
+	}
+}
+
+/** Test-only reset of all counters + the reservoir. */
+export function __resetMetricsForTest(): void {
+	latencies.length = 0
+	writeIdx = 0
+	tierCounts.address_point = 0
+	tierCounts.interpolated = 0
+	tierCounts.admin = 0
+	total = 0
+	errors = 0
+}

--- a/mailwoman/test/health-router.test.ts
+++ b/mailwoman/test/health-router.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the observability surface (#485): `GET /health`, `GET /metrics`, and the in-process
+ *   metrics recorder. All run unconditionally — health reads files best-effort and the recorder is
+ *   pure in-memory; neither needs WOF / weights.
+ */
+
+import express from "express"
+import { describe, expect, test } from "vitest"
+
+import { HealthRouter } from "../server/HealthRouter.js"
+import { __resetMetricsForTest, metricsSnapshot, recordGeocode } from "../server/metrics.js"
+
+function buildApp() {
+	const app = express()
+	app.use(express.json())
+	app.use(HealthRouter)
+	return app
+}
+
+async function getJson(app: express.Express, path: string) {
+	const server = app.listen(0)
+	try {
+		const port = (server.address() as { port: number }).port
+		const r = await fetch(`http://127.0.0.1:${port}${path}`)
+		return { status: r.status, body: await r.json() }
+	} finally {
+		await new Promise<void>((resolve) => server.close(() => resolve()))
+	}
+}
+
+describe("metrics recorder", () => {
+	test("counts tiers + computes latency percentiles; error tier is isolated", () => {
+		__resetMetricsForTest()
+		recordGeocode(10, "address_point")
+		recordGeocode(20, "interpolated")
+		recordGeocode(30, "admin")
+		recordGeocode(5, "error")
+		const s = metricsSnapshot()
+		expect(s.geocode.total).toBe(4)
+		expect(s.geocode.errors).toBe(1)
+		expect(s.geocode.tiers).toEqual({ address_point: 1, interpolated: 1, admin: 1 })
+		expect(s.geocode.latency_samples).toBe(4)
+		expect(s.geocode.latency_ms).not.toBeNull()
+		expect(s.geocode.latency_ms!.max).toBe(30)
+	})
+
+	test("latency_ms is null before any request", () => {
+		__resetMetricsForTest()
+		expect(metricsSnapshot().geocode.latency_ms).toBeNull()
+	})
+})
+
+describe("HealthRouter", () => {
+	test("GET /health returns status + data shape (never throws)", async () => {
+		const r = await getJson(buildApp(), "/health")
+		expect(r.status).toBe(200)
+		const body = r.body as { status: string; data: { situs_states: number; interpolation_states: number } }
+		expect(body.status).toBe("ok")
+		expect(typeof body.data.situs_states).toBe("number")
+		expect(typeof body.data.interpolation_states).toBe("number")
+	})
+
+	test("GET /metrics returns the snapshot, reflecting recorded requests", async () => {
+		__resetMetricsForTest()
+		recordGeocode(42, "address_point")
+		const r = await getJson(buildApp(), "/metrics")
+		expect(r.status).toBe(200)
+		const body = r.body as { geocode: { total: number; tiers: { address_point: number } } }
+		expect(body.geocode.total).toBe(1)
+		expect(body.geocode.tiers.address_point).toBe(1)
+	})
+})


### PR DESCRIPTION
Second piece of #485. The operational backbone — and the instrument the issue's SLO targets need ("measure first, don't invent").

## Endpoints

**`GET /health`** — "what's deployed, in one curl":
```json
{ "status": "ok",
  "model": { "name": "neural-weights-en-us", "version": "4.6.0", "locale": "en-us", "labels": 33, "format": {…} },
  "data": { "wof_dbs": [...], "situs_states": 50, "interpolation_states": 51 } }
```
Lightweight: reads JSON + counts shard files, never loads the model, never throws.

**`GET /metrics`** — in-process geocode metrics:
```json
{ "geocode": { "total": 3, "errors": 0,
    "tiers": { "address_point": 1, "interpolated": 1, "admin": 1 },
    "latency_ms": { "p50": 38, "p90": 120, "p99": 120, "max": 120 } } }
```
Per-tier counts + latency percentiles from a bounded reservoir. Recorded per request in `GeocodeRouter` (single + each batch row). Dependency-free; resets on restart (scrape it).

## Tests

`health-router.test.ts` (4) — recorder unit tests (tier counting, percentiles, error isolation, null-before-traffic) + endpoint shape. All unconditional (no WOF/weights).

## Remaining #485

RemoteResolver adapter, versioned data switchover. (Prometheus text exposition + calibration-drift wiring are natural follow-ons to `/metrics`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)