### PR TITLE
feat(resolver): RemoteResolver — the Resolver interface over HTTP (#485 piece 3)

### DIFF
--- a/2026-06-13-GEOCODER-CAMPAIGN.md
+++ b/2026-06-13-GEOCODER-CAMPAIGN.md
@@ -112,8 +112,13 @@ independent of Coverage; engines exist, this is API surface + wiring.
   deployed in one curl" (model-card version + situs/interp shard counts, no model load); `/metrics` =
   per-tier counts + latency p50/p90/p99 from a bounded reservoir, recorded per request. The instrument the
   SLO targets need. Tests 4.
-- **Open #485:** RemoteResolver adapter (multi-instance / canary — the bigger architectural lift),
-  versioned data switchover. Prometheus exposition + calibration-drift wiring ride on `/metrics`.
+- **✅ RemoteResolver (2026-06-14, PR #573 — #485 piece 3).** The `Resolver` interface over HTTP:
+  `RemoteResolver.resolveTree` POSTs the parsed tree + serializable opts to the service's `/api/resolve-tree`,
+  which owns the shards, runs the cascade, returns the resolved tree. Drop-in for `WofResolver` → stateless
+  parser nodes + a shared resolver service, and canary diffing. Pure fetch (browser-safe). Tests 6 + a live
+  round-trip; 12/12.
+- **Open #485:** versioned data switchover (the last piece — atomic DB pointer-swap). Prometheus exposition
+  + calibration-drift wiring ride on `/metrics`.
 
 ### Cross-cutting — Arbitration (#478) — **Opus**
 

--- a/core/resolver/index.ts
+++ b/core/resolver/index.ts
@@ -4,6 +4,13 @@
  * @author Teffen Ellis, et al.
  */
 
+export { RemoteResolver, serializableResolveOpts } from "./remote-resolver.js"
+export type {
+	RemoteResolverOpts,
+	ResolveTreeRequest,
+	ResolveTreeResponse,
+	SerializableResolveOpts,
+} from "./remote-resolver.js"
 export { createWofResolver } from "./resolve.js"
 export { DEFAULT_PLACETYPE_MAP, PLACETYPE_FILTER_GROUPS, expandPlacetypeFilter } from "./types.js"
 export type {

--- a/core/resolver/remote-resolver.test.ts
+++ b/core/resolver/remote-resolver.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Unit tests for `RemoteResolver` + `serializableResolveOpts` — transport behavior with a stubbed
+ *   fetch, no network. The live round-trip against a real resolver service is covered in
+ *   `mailwoman/test/geocode-router.test.ts`.
+ */
+
+import { describe, expect, test, vi } from "vitest"
+
+import type { AddressTree } from "../decoder/types.js"
+import { RemoteResolver, serializableResolveOpts } from "./remote-resolver.js"
+import type { AddressPointLookup, InterpolationLookup, ResolveOpts } from "./types.js"
+
+const tree: AddressTree = {
+	raw: "100 Main St, Austin, TX",
+	roots: [{ tag: "region", value: "TX", start: 0, end: 2, confidence: 1, children: [] }],
+}
+
+function stubFetch(response: unknown, status = 200) {
+	return vi.fn(async () => ({
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: "",
+		json: async () => response,
+	})) as unknown as typeof fetch
+}
+
+describe("serializableResolveOpts", () => {
+	test("strips the live lookup handles, keeps the rest", () => {
+		const opts: ResolveOpts = {
+			defaultCountry: "US",
+			maxLookups: 3,
+			interpolationRadiusCalibration: 1.7,
+			addressPoints: {} as AddressPointLookup,
+			interpolation: {} as InterpolationLookup,
+		}
+		const out = serializableResolveOpts(opts)!
+		expect(out).toEqual({ defaultCountry: "US", maxLookups: 3, interpolationRadiusCalibration: 1.7 })
+		expect("addressPoints" in out).toBe(false)
+		expect("interpolation" in out).toBe(false)
+	})
+
+	test("undefined passes through", () => {
+		expect(serializableResolveOpts(undefined)).toBeUndefined()
+	})
+})
+
+describe("RemoteResolver", () => {
+	test("POSTs { tree, opts(stripped) } and returns the response tree", async () => {
+		const resolved: AddressTree = { raw: tree.raw, roots: [{ ...tree.roots[0]!, placeId: "wof:1" } as never] }
+		const fetchSpy = stubFetch({ tree: resolved })
+		const r = new RemoteResolver({ endpoint: "http://resolver/api/resolve-tree", fetch: fetchSpy })
+
+		const got = await r.resolveTree(tree, { defaultCountry: "US", addressPoints: {} as AddressPointLookup })
+
+		expect(got).toEqual(resolved)
+		const [, init] = (fetchSpy as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0]!
+		const body = JSON.parse(init.body as string)
+		expect(body.tree.raw).toBe(tree.raw)
+		expect(body.opts).toEqual({ defaultCountry: "US" }) // addressPoints stripped
+	})
+
+	test("throws on a non-2xx response", async () => {
+		const r = new RemoteResolver({ endpoint: "http://resolver/x", fetch: stubFetch({}, 503) })
+		await expect(r.resolveTree(tree)).rejects.toThrow(/HTTP 503/)
+	})
+
+	test("throws on a malformed response (no tree.roots)", async () => {
+		const r = new RemoteResolver({ endpoint: "http://resolver/x", fetch: stubFetch({ nope: true }) })
+		await expect(r.resolveTree(tree)).rejects.toThrow(/malformed/)
+	})
+
+	test("requires an endpoint", () => {
+		expect(() => new RemoteResolver({ endpoint: "" })).toThrow(/endpoint/)
+	})
+})

--- a/core/resolver/remote-resolver.ts
+++ b/core/resolver/remote-resolver.ts
@@ -1,0 +1,96 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `RemoteResolver` — the `Resolver` interface (`resolveTree`) over HTTP. The adapter the interface
+ *   docstring anticipated (Phase 4.4): a client POSTs a parsed `AddressTree` + the serializable
+ *   `ResolveOpts` to a resolver service, which owns the gazetteer + situs/interpolation shards, runs
+ *   the cascade, and returns the resolved tree. Two payoffs:
+ *
+ *     1. **Multi-instance** — stateless parser nodes (the ~30 MB ONNX model) talk to ONE resolver
+ *        service (the multi-GB gazetteer + shards). `parse` locally, `new RemoteResolver(...).resolveTree`
+ *        remotely — same interface the in-process `WofResolver` satisfies, so it's a drop-in.
+ *     2. **Canary** — point it at a second resolver build (or an adapter fronting Pelias/Nominatim/BAN)
+ *        and diff the resolved trees through the identical contract.
+ *
+ *   Pure transport: `fetch` only, no node-specific deps (runs in the browser too). The `addressPoints`
+ *   / `interpolation` opts are LIVE SQLite handles — not serializable — so they're stripped before the
+ *   POST; the resolver service supplies its own from the tree's region (the data lives server-side,
+ *   which is the whole point). All other opts (defaultCountry, calibration, hierarchyCompletion, …)
+ *   ride along.
+ */
+
+import type { AddressTree } from "../decoder/types.js"
+import type { ResolveOpts, Resolver } from "./types.js"
+
+/** `ResolveOpts` minus the non-serializable live lookup handles. What actually crosses the wire. */
+export type SerializableResolveOpts = Omit<ResolveOpts, "addressPoints" | "interpolation">
+
+/** Strip the live lookup handles from `ResolveOpts` so the rest can be JSON-serialized over HTTP. */
+export function serializableResolveOpts(opts?: ResolveOpts): SerializableResolveOpts | undefined {
+	if (!opts) return undefined
+	const { addressPoints: _ap, interpolation: _ip, ...rest } = opts
+	return rest
+}
+
+export interface RemoteResolverOpts {
+	/** Full URL of the resolver service's resolve-tree endpoint, e.g. `http://resolver:7081/api/resolve-tree`. */
+	endpoint: string
+	/** Injectable fetch (tests / custom agents). Defaults to the global `fetch`. */
+	fetch?: typeof fetch
+	/** Per-request timeout in ms. Default 10000. */
+	timeoutMs?: number
+	/** Extra headers (auth, tracing). `Content-Type: application/json` is always set. */
+	headers?: Record<string, string>
+}
+
+/** The wire request body `POST <endpoint>` expects (and the matching server handler parses). */
+export interface ResolveTreeRequest {
+	tree: AddressTree
+	opts?: SerializableResolveOpts
+}
+
+/** The wire response body the server returns. */
+export interface ResolveTreeResponse {
+	tree: AddressTree
+}
+
+export class RemoteResolver implements Resolver {
+	readonly #endpoint: string
+	readonly #fetch: typeof fetch
+	readonly #timeoutMs: number
+	readonly #headers: Record<string, string>
+
+	constructor(opts: RemoteResolverOpts) {
+		if (!opts.endpoint) throw new Error("RemoteResolver: `endpoint` is required")
+		this.#endpoint = opts.endpoint
+		this.#fetch = opts.fetch ?? globalThis.fetch
+		this.#timeoutMs = opts.timeoutMs ?? 10_000
+		this.#headers = opts.headers ?? {}
+	}
+
+	async resolveTree(tree: AddressTree, opts?: ResolveOpts): Promise<AddressTree> {
+		const controller = new AbortController()
+		const timer = setTimeout(() => controller.abort(), this.#timeoutMs)
+		try {
+			const body: ResolveTreeRequest = { tree, opts: serializableResolveOpts(opts) }
+			const res = await this.#fetch(this.#endpoint, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", ...this.#headers },
+				body: JSON.stringify(body),
+				signal: controller.signal,
+			})
+			if (!res.ok) {
+				throw new Error(`RemoteResolver: ${this.#endpoint} → HTTP ${res.status} ${res.statusText}`)
+			}
+			const json = (await res.json()) as Partial<ResolveTreeResponse>
+			if (!json || !json.tree || !Array.isArray(json.tree.roots)) {
+				throw new Error("RemoteResolver: malformed response (missing `tree.roots`)")
+			}
+			return json.tree
+		} finally {
+			clearTimeout(timer)
+		}
+	}
+}

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -88,6 +88,22 @@ export function regionToStateSlug(
 	return null
 }
 
+/** Walk a (parsed or resolved) tree for its region → the per-state shard slug (e.g. `"tx"`), else null. */
+export function regionSlugFromTree(tree: AddressTree): string | null {
+	let regionValue: string | null = null
+	let regionResolverName: string | null = null
+	const stack = [...tree.roots]
+	while (stack.length > 0) {
+		const node = stack.pop()!
+		if (node.tag === "region" && !regionValue) {
+			regionValue = node.value.trim() || null
+			regionResolverName = (node.metadata?.["resolver_name"] as string | undefined) ?? null
+		}
+		stack.push(...node.children)
+	}
+	return regionToStateSlug(regionValue, regionResolverName)
+}
+
 /** Per-state situs shard path under `<dataRoot>/address-points/`, or null if the slug/file is absent. */
 export function selectAddressPointsDb(dataRoot: string, stateSlug: string | null): string | null {
 	if (!stateSlug) return null
@@ -153,21 +169,7 @@ export class ShardProvider {
  */
 export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<GeocodeResult> {
 	const tree = await deps.classifier.parse(input, { postcodeRepair: true })
-
-	// Read the parsed region (raw value + resolver canonical name) for shard selection.
-	let regionValue: string | null = null
-	let regionResolverName: string | null = null
-	const stack = [...tree.roots]
-	while (stack.length > 0) {
-		const node = stack.pop()!
-		if (node.tag === "region" && !regionValue) {
-			regionValue = node.value.trim() || null
-			regionResolverName = (node.metadata?.["resolver_name"] as string | undefined) ?? null
-		}
-		stack.push(...node.children)
-	}
-
-	const stateSlug = regionToStateSlug(regionValue, regionResolverName)
+	const stateSlug = regionSlugFromTree(tree)
 	const { addressPoints, interpolation } = deps.shards?.(stateSlug) ?? {}
 
 	const opts: ResolveOpts = {}

--- a/mailwoman/server/GeocodeRouter.ts
+++ b/mailwoman/server/GeocodeRouter.ts
@@ -18,7 +18,16 @@ import { createWofResolver, type Resolver, type ResolverBackend } from "@mailwom
 import { type RequestHandler, Router } from "express"
 import { existsSync } from "node:fs"
 
-import { geocodeAddress, type GeocodeClassifier, type GeocodeResult, ShardProvider } from "../geocode-core.js"
+import type { AddressTree } from "@mailwoman/core/decoder"
+import type { ResolveOpts } from "@mailwoman/core/resolver"
+
+import {
+	geocodeAddress,
+	type GeocodeClassifier,
+	type GeocodeResult,
+	regionSlugFromTree,
+	ShardProvider,
+} from "../geocode-core.js"
 import { recordGeocode } from "./metrics.js"
 
 /** Default per-state shard root + interp calibration — mirror the CLI defaults. */
@@ -156,6 +165,58 @@ const batchHandler: RequestHandler = async (req, res) => {
 	res.status(200).json({ results })
 }
 
+/**
+ * `POST /api/resolve-tree` — the resolver-service endpoint that `RemoteResolver` (core) calls. Accepts
+ * an already-parsed `{ tree, opts? }`, selects this region's situs/interpolation shards (the data lives
+ * here, not on the caller), runs the FULL cascade, and returns `{ tree }`. This is what lets a
+ * stateless parser node geocode at street level against a shared resolver service.
+ */
+const resolveTreeHandler: RequestHandler = async (req, res) => {
+	const tree = req.body?.tree as AddressTree | undefined
+	if (!tree || !Array.isArray(tree.roots)) {
+		res.status(400).json({ error: "Body must be `{ tree: AddressTree, opts?: ResolveOpts }`" })
+		return
+	}
+	const incomingOpts = (req.body?.opts ?? {}) as ResolveOpts
+	const deps = await getDeps()
+	if (!deps) {
+		res.status(503).json(DEPS_UNAVAILABLE)
+		return
+	}
+	const t0 = performance.now()
+	try {
+		const { addressPoints, interpolation } = deps.shards.for(regionSlugFromTree(tree))
+		const opts: ResolveOpts = {
+			...incomingOpts,
+			defaultCountry: incomingOpts.defaultCountry ?? deps.defaultCountry,
+			...(addressPoints ? { addressPoints } : {}),
+			...(interpolation
+				? { interpolation, interpolationRadiusCalibration: incomingOpts.interpolationRadiusCalibration ?? INTERP_CALIBRATION }
+				: {}),
+		}
+		const resolved = await deps.resolver.resolveTree(tree, opts)
+		// Best-effort tier metric: read the street node's stamped tier (matches the geocode path).
+		const street = resolved.roots.flatMap((r) => collectStreetTier(r)).find(Boolean)
+		recordGeocode(performance.now() - t0, street ?? "admin")
+		res.status(200).json({ tree: resolved })
+	} catch (err) {
+		recordGeocode(performance.now() - t0, "error")
+		res.status(500).json({ error: `resolve-tree error: ${err instanceof Error ? err.message : String(err)}` })
+	}
+}
+
+/** Pull the street node's resolution tier (if any) for the metric — mirrors extractGeocodeResult. */
+function collectStreetTier(node: AddressTree["roots"][number]): Array<"address_point" | "interpolated" | "admin"> {
+	const out: Array<"address_point" | "interpolated" | "admin"> = []
+	if (node.tag === "street") {
+		const tier = node.metadata?.["resolution_tier"]
+		if (tier === "address_point" || tier === "interpolated") out.push(tier)
+	}
+	for (const child of node.children) out.push(...collectStreetTier(child))
+	return out
+}
+
 export const GeocodeRouter: Router = Router()
 GeocodeRouter.post("/api/geocode", singleHandler)
 GeocodeRouter.post("/api/batch", batchHandler)
+GeocodeRouter.post("/api/resolve-tree", resolveTreeHandler)

--- a/mailwoman/test/geocode-router.test.ts
+++ b/mailwoman/test/geocode-router.test.ts
@@ -80,4 +80,29 @@ describeIfStack("GeocodeRouter — success path against real WOF + TX shards", (
 		expect(results[0]!.input).toBe(addresses[0])
 		expect(results[1]!.input).toBe(addresses[1])
 	}, 60_000)
+
+	test("RemoteResolver round-trips a parsed tree → street-level via /api/resolve-tree", async () => {
+		const { NeuralAddressClassifier } = await import("@mailwoman/neural")
+		const { RemoteResolver } = await import("@mailwoman/core/resolver")
+		const server = buildApp().listen(0)
+		try {
+			const port = (server.address() as { port: number }).port
+			const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+			const tree = await classifier.parse("3075 Hill Street, Round Rock, TX 78664", { postcodeRepair: true })
+			const remote = new RemoteResolver({ endpoint: `http://127.0.0.1:${port}/api/resolve-tree` })
+			const resolved = await remote.resolveTree(tree, { defaultCountry: "US" })
+
+			const flat: Array<(typeof resolved.roots)[number]> = []
+			const walk = (n: (typeof resolved.roots)[number]) => {
+				flat.push(n)
+				n.children.forEach(walk)
+			}
+			resolved.roots.forEach(walk)
+			const street = flat.find((n) => n.tag === "street")
+			// The resolver service wired its own shards → the street node carries a coordinate tier.
+			expect(street?.metadata?.["resolution_tier"]).toBeDefined()
+		} finally {
+			await new Promise<void>((resolve) => server.close(() => resolve()))
+		}
+	}, 60_000)
 })


### PR DESCRIPTION
Third piece of #485. The adapter the `Resolver` interface docstring anticipated (Phase 4.4).

## What

A client implements `Resolver.resolveTree` by POSTing the parsed `AddressTree` + serializable `ResolveOpts` to a resolver service. The service owns the gazetteer + situs/interpolation shards, selects this region's shards, runs the full cascade, and returns the resolved tree. **Same interface the in-process `WofResolver` satisfies — a drop-in.**

Two payoffs:
1. **Multi-instance** — stateless parser nodes (~30MB ONNX) talk to ONE shared resolver service (multi-GB data). `parse` locally, `RemoteResolver.resolveTree` remotely.
2. **Canary** — point it at a second resolver build (or an adapter fronting Pelias/Nominatim) and diff resolved trees through the identical contract.

## Pieces

- **`core/resolver/remote-resolver.ts`** — `RemoteResolver implements Resolver`; pure `fetch` transport (browser-safe), `AbortController` timeout. `serializableResolveOpts` strips the non-serializable live lookup handles (`addressPoints`/`interpolation`) — the service supplies its own from the tree's region (the data lives server-side, which is the point). All scalar opts ride along.
- **Server `POST /api/resolve-tree`** (GeocodeRouter) — region→shard select + cascade resolve, metric-recorded. `geocode-core` exports `regionSlugFromTree`, shared by `geocodeAddress` + the endpoint.

## Tests

`remote-resolver.test.ts` (6 — opts stripping, stubbed-fetch POST/return, error paths, endpoint validation) + a **live round-trip** in `geocode-router.test.ts` (parse → `RemoteResolver` over HTTP → street node carries a resolution tier). **12/12.** CLI re-validated byte-for-byte unregressed.

## Remaining #485

Versioned data switchover (the last piece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)