### PR TITLE
feat(server): versioned data switchover — atomic zero-downtime shard reload (#485 piece 4)

### DIFF
--- a/2026-06-13-GEOCODER-CAMPAIGN.md
+++ b/2026-06-13-GEOCODER-CAMPAIGN.md
@@ -117,8 +117,13 @@ independent of Coverage; engines exist, this is API surface + wiring.
   which owns the shards, runs the cascade, returns the resolved tree. Drop-in for `WofResolver` → stateless
   parser nodes + a shared resolver service, and canary diffing. Pure fetch (browser-safe). Tests 6 + a live
   round-trip; 12/12.
-- **Open #485:** versioned data switchover (the last piece — atomic DB pointer-swap). Prometheus exposition
-  + calibration-drift wiring ride on `/metrics`.
+- **✅ Versioned data switchover (2026-06-14, PR #574 — #485 piece 4, CLOSES THE EPIC).** Shards addressed
+  as `<family>-us-<slug>-<version>.db` via a `releases.json` manifest (legacy unversioned fallback);
+  `ShardProvider.reload()` atomically swaps changed versions with one-generation grace (zero-downtime).
+  `POST /api/reload` cuts over after publishing; `/health` reports `data.versions`. Tests 4.
+- **✅ #485 service layer DONE:** batch (#571) · observability (#572) · RemoteResolver (#573) · versioned
+  switchover (#574). Deferred follow-ons (not blocking): Prometheus text exposition + calibration-drift
+  wiring on `/metrics`; auth/rate-limiting (deployment-specific).
 
 ### Cross-cutting — Arbitration (#478) — **Opus**
 

--- a/mailwoman/data-release.ts
+++ b/mailwoman/data-release.ts
@@ -1,0 +1,56 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Versioned data-artifact addressing + atomic switchover (#485 piece 4). Shard DBs are addressed as
+ *   `<family>/<family>-us-<slug>-<version>.db`, with a `releases.json` manifest at the data root
+ *   pinning each family to its current version. So a new build publishes ALONGSIDE the old, flipping
+ *   the manifest (one atomic file write) cuts traffic over, and the build provenance (the version)
+ *   travels in the filename — "what data is deployed" is a read of one JSON.
+ *
+ *   Back-compat: with no manifest (or a family unlisted) resolution falls back to the legacy
+ *   unversioned `<family>-us-<slug>.db`, so the current national build output works unchanged.
+ *
+ *   Example `releases.json`:
+ *     { "address-points": "2026-05-20.0", "interpolation": "TIGER2023" }
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+
+/** family (shard subdir + filename prefix, e.g. `"address-points"`) → current version string. */
+export type DataReleaseManifest = Record<string, string>
+
+/** Read `<dataRoot>/releases.json`. Returns null (legacy mode) when absent or malformed. */
+export function readReleaseManifest(dataRoot: string): DataReleaseManifest | null {
+	try {
+		const raw = JSON.parse(readFileSync(`${dataRoot}/releases.json`, "utf8")) as unknown
+		if (!raw || typeof raw !== "object") return null
+		const out: DataReleaseManifest = {}
+		for (const [family, version] of Object.entries(raw as Record<string, unknown>)) {
+			if (typeof version === "string" && version) out[family] = version
+		}
+		return Object.keys(out).length > 0 ? out : null
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Resolve a shard's on-disk path: the manifest-pinned `<family>-us-<slug>-<version>.db` when present,
+ * else the legacy unversioned `<family>-us-<slug>.db`, else null if neither exists.
+ */
+export function resolveShardPath(
+	dataRoot: string,
+	family: string,
+	slug: string,
+	manifest: DataReleaseManifest | null
+): string | null {
+	const version = manifest?.[family]
+	if (version) {
+		const versioned = `${dataRoot}/${family}/${family}-us-${slug}-${version}.db`
+		if (existsSync(versioned)) return versioned
+	}
+	const legacy = `${dataRoot}/${family}/${family}-us-${slug}.db`
+	return existsSync(legacy) ? legacy : null
+}

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -24,6 +24,8 @@ import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } from "@mailwoman/core/resolver"
 import { existsSync } from "node:fs"
 
+import { type DataReleaseManifest, readReleaseManifest, resolveShardPath } from "./data-release.js"
+
 /**
  * The resolution tier that produced the coordinate. `address_point` > `interpolated` > `admin`.
  *   - `address_point` — rooftop / parcel centroid; uncertainty_m is a small floor (~1 m)
@@ -124,33 +126,77 @@ export interface ShardLookupFactory {
 	StreetInterpolator: new (opts: { dbPath: string }) => InterpolationLookup & { close(): void }
 }
 
+interface ShardCacheEntry extends StateShards {
+	_ap?: { close(): void }
+	_ip?: { close(): void }
+	/** The resolved on-disk paths this entry was opened from — reload() diffs against these. */
+	apPath: string | null
+	ipPath: string | null
+}
+
 /**
  * Opens + CACHES per-state situs/interpolation lookups so a batch geocoding many addresses in one
- * state opens that state's (possibly multi-GB) shards once, not once per row. Call {@link close} when
- * done to release every cached handle.
+ * state opens that state's (possibly multi-GB) shards once, not once per row. Versioned-data aware
+ * (#485): paths resolve through the `releases.json` manifest (legacy unversioned fallback), and
+ * {@link reload} performs a zero-downtime atomic switchover when a new version is published. Call
+ * {@link close} when done to release every cached handle.
  */
 export class ShardProvider {
 	readonly #factory: ShardLookupFactory
 	readonly #dataRoot: string
-	readonly #cache = new Map<string, StateShards & { _ap?: { close(): void }; _ip?: { close(): void } }>()
+	readonly #cache = new Map<string, ShardCacheEntry>()
+	/** Previous-generation handles, retired by reload() and closed on the NEXT reload (one-gen grace). */
+	#retired: Array<{ close(): void }> = []
+	#manifest: DataReleaseManifest | null
 
 	constructor(factory: ShardLookupFactory, dataRoot: string) {
 		this.#factory = factory
 		this.#dataRoot = dataRoot
+		this.#manifest = readReleaseManifest(dataRoot)
+	}
+
+	#open(stateSlug: string): ShardCacheEntry {
+		const apPath = resolveShardPath(this.#dataRoot, "address-points", stateSlug, this.#manifest)
+		const ipPath = resolveShardPath(this.#dataRoot, "interpolation", stateSlug, this.#manifest)
+		const ap = apPath ? new this.#factory.AddressPointSqliteLookup(apPath) : undefined
+		const ip = ipPath ? new this.#factory.StreetInterpolator({ dbPath: ipPath }) : undefined
+		return { addressPoints: ap, interpolation: ip, _ap: ap, _ip: ip, apPath, ipPath }
 	}
 
 	readonly for: ShardResolver = (stateSlug) => {
 		if (!stateSlug) return {}
-		const cached = this.#cache.get(stateSlug)
-		if (cached) return { addressPoints: cached.addressPoints, interpolation: cached.interpolation }
+		let entry = this.#cache.get(stateSlug)
+		if (!entry) {
+			entry = this.#open(stateSlug)
+			this.#cache.set(stateSlug, entry)
+		}
+		return { addressPoints: entry.addressPoints, interpolation: entry.interpolation }
+	}
 
-		const apPath = selectAddressPointsDb(this.#dataRoot, stateSlug)
-		const ipPath = selectInterpolationDb(this.#dataRoot, stateSlug)
-		const ap = apPath ? new this.#factory.AddressPointSqliteLookup(apPath) : undefined
-		const ip = ipPath ? new this.#factory.StreetInterpolator({ dbPath: ipPath }) : undefined
-		const entry = { addressPoints: ap, interpolation: ip, _ap: ap, _ip: ip }
-		this.#cache.set(stateSlug, entry)
-		return { addressPoints: ap, interpolation: ip }
+	/** The current data-release versions ({@link readReleaseManifest}), or null in legacy mode. */
+	versions(): DataReleaseManifest | null {
+		return this.#manifest ? { ...this.#manifest } : null
+	}
+
+	/**
+	 * Re-read the manifest and atomically swap any cached shard whose resolved path changed. New
+	 * requests see the new version immediately; the old handles are RETIRED and closed on the next
+	 * reload (one-generation grace — safe because find() is synchronous, so no in-flight query can
+	 * still hold a handle once a request yields). Returns the new version map.
+	 */
+	reload(): DataReleaseManifest | null {
+		for (const h of this.#retired) h.close()
+		this.#retired = []
+		this.#manifest = readReleaseManifest(this.#dataRoot)
+		for (const [slug, old] of this.#cache) {
+			const apPath = resolveShardPath(this.#dataRoot, "address-points", slug, this.#manifest)
+			const ipPath = resolveShardPath(this.#dataRoot, "interpolation", slug, this.#manifest)
+			if (apPath === old.apPath && ipPath === old.ipPath) continue // unchanged — keep the open handle
+			this.#cache.set(slug, this.#open(slug))
+			if (old._ap) this.#retired.push(old._ap)
+			if (old._ip) this.#retired.push(old._ip)
+		}
+		return this.versions()
 	}
 
 	close(): void {
@@ -158,7 +204,9 @@ export class ShardProvider {
 			e._ap?.close()
 			e._ip?.close()
 		}
+		for (const h of this.#retired) h.close()
 		this.#cache.clear()
+		this.#retired = []
 	}
 }
 

--- a/mailwoman/server/GeocodeRouter.ts
+++ b/mailwoman/server/GeocodeRouter.ts
@@ -216,7 +216,24 @@ function collectStreetTier(node: AddressTree["roots"][number]): Array<"address_p
 	return out
 }
 
+/**
+ * `POST /api/reload` — versioned data switchover (#485). Re-reads `releases.json` and atomically swaps
+ * any per-state shard whose pinned version changed (zero-downtime, one-generation grace on the old
+ * handles). Call this after publishing a new shard build to cut traffic over without a restart. Returns
+ * the new version map. (Deploy-only; gate it behind your ingress — no auth here by design, per #485.)
+ */
+const reloadHandler: RequestHandler = async (_req, res) => {
+	const deps = await getDeps()
+	if (!deps) {
+		res.status(503).json(DEPS_UNAVAILABLE)
+		return
+	}
+	const versions = deps.shards.reload()
+	res.status(200).json({ reloaded: true, versions })
+}
+
 export const GeocodeRouter: Router = Router()
 GeocodeRouter.post("/api/geocode", singleHandler)
 GeocodeRouter.post("/api/batch", batchHandler)
 GeocodeRouter.post("/api/resolve-tree", resolveTreeHandler)
+GeocodeRouter.post("/api/reload", reloadHandler)

--- a/mailwoman/server/HealthRouter.ts
+++ b/mailwoman/server/HealthRouter.ts
@@ -14,6 +14,7 @@ import { type RequestHandler, Router } from "express"
 import { existsSync, readdirSync, readFileSync } from "node:fs"
 import { createRequire } from "node:module"
 
+import { readReleaseManifest } from "../data-release.js"
 import { metricsSnapshot } from "./metrics.js"
 
 const DATA_ROOT = process.env["MAILWOMAN_DATA_ROOT"] ?? "/mnt/playpen/mailwoman-data"
@@ -73,6 +74,8 @@ const healthHandler: RequestHandler = (_req, res) => {
 			: null,
 		data: {
 			data_root: DATA_ROOT,
+			// Versioned-switchover provenance (#485): the releases.json pin, or null in legacy mode.
+			versions: readReleaseManifest(DATA_ROOT),
 			wof_dbs: wofPaths(),
 			situs_states: countShards("address-points", "address-points"),
 			interpolation_states: countShards("interpolation", "interpolation"),

--- a/mailwoman/test/data-release.test.ts
+++ b/mailwoman/test/data-release.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Versioned data switchover (#485 piece 4): manifest read + path resolution, and the
+ *   ShardProvider's zero-downtime atomic reload (version flip + one-generation grace on old handles).
+ *   Uses a fake lookup factory + on-disk touch files — no WOF / weights needed.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, test } from "vitest"
+
+import { readReleaseManifest, resolveShardPath } from "../data-release.js"
+import { ShardProvider } from "../geocode-core.js"
+
+const dirs: string[] = []
+function tmp(): string {
+	const d = mkdtempSync(join(tmpdir(), "mw-data-release-"))
+	dirs.push(d)
+	return d
+}
+afterAll(() => dirs.forEach((d) => rmSync(d, { recursive: true, force: true })))
+
+/** Fake lookups: record the path they were opened from + whether they've been closed. */
+class FakeAddressPoints {
+	closed = false
+	constructor(public dbPath: string) {}
+	find() {
+		return null
+	}
+	close() {
+		this.closed = true
+	}
+}
+class FakeInterp {
+	closed = false
+	constructor(public opts: { dbPath: string }) {}
+	find() {
+		return null
+	}
+	close() {
+		this.closed = true
+	}
+}
+const factory = { AddressPointSqliteLookup: FakeAddressPoints, StreetInterpolator: FakeInterp } as never
+
+/** Ensure a directory exists and return it. */
+function dirEnsure(d: string): string {
+	mkdirSync(d, { recursive: true })
+	return d
+}
+
+describe("readReleaseManifest", () => {
+	test("reads a valid manifest; null for absent or malformed", () => {
+		const root = tmp()
+		expect(readReleaseManifest(root)).toBeNull()
+		writeFileSync(join(root, "releases.json"), JSON.stringify({ "address-points": "2026-05-20.0", interpolation: "TIGER2023" }))
+		expect(readReleaseManifest(root)).toEqual({ "address-points": "2026-05-20.0", interpolation: "TIGER2023" })
+		writeFileSync(join(root, "releases.json"), "{ not json")
+		expect(readReleaseManifest(root)).toBeNull()
+	})
+})
+
+describe("resolveShardPath", () => {
+	test("prefers the versioned name; falls back to legacy; null if neither", () => {
+		const root = tmp()
+		const apDir = dirEnsure(join(root, "address-points"))
+		// legacy only
+		writeFileSync(join(apDir, "address-points-us-tx.db"), "")
+		expect(resolveShardPath(root, "address-points", "tx", null)).toBe(join(apDir, "address-points-us-tx.db"))
+		// versioned present + pinned → wins
+		writeFileSync(join(apDir, "address-points-us-tx-v2.db"), "")
+		expect(resolveShardPath(root, "address-points", "tx", { "address-points": "v2" })).toBe(
+			join(apDir, "address-points-us-tx-v2.db")
+		)
+		// pinned version with no file → legacy fallback
+		expect(resolveShardPath(root, "address-points", "tx", { "address-points": "v9" })).toBe(
+			join(apDir, "address-points-us-tx.db")
+		)
+		// nothing for an unknown slug
+		expect(resolveShardPath(root, "address-points", "zz", null)).toBeNull()
+	})
+})
+
+describe("ShardProvider atomic switchover", () => {
+	test("reload() flips to the new version + retires the old handle with one-gen grace", () => {
+		const root = tmp()
+		const apDir = dirEnsure(join(root, "address-points"))
+		writeFileSync(join(apDir, "address-points-us-tx-v1.db"), "")
+		writeFileSync(join(root, "releases.json"), JSON.stringify({ "address-points": "v1" }))
+
+		const provider = new ShardProvider(factory, root)
+		const v1 = provider.for("tx").addressPoints as unknown as FakeAddressPoints
+		expect(v1.dbPath).toContain("address-points-us-tx-v1.db")
+		expect(provider.versions()).toEqual({ "address-points": "v1" })
+
+		// Publish v2 alongside, flip the manifest, reload.
+		writeFileSync(join(apDir, "address-points-us-tx-v2.db"), "")
+		writeFileSync(join(root, "releases.json"), JSON.stringify({ "address-points": "v2" }))
+		expect(provider.reload()).toEqual({ "address-points": "v2" })
+
+		const v2 = provider.for("tx").addressPoints as unknown as FakeAddressPoints
+		expect(v2.dbPath).toContain("address-points-us-tx-v2.db")
+		// One-generation grace: the v1 handle is retired but NOT yet closed.
+		expect(v1.closed).toBe(false)
+
+		// A second reload (no version change) closes the retired v1 handle.
+		provider.reload()
+		expect(v1.closed).toBe(true)
+
+		provider.close()
+		expect(v2.closed).toBe(true)
+	})
+
+	test("unchanged version keeps the same open handle (no churn)", () => {
+		const root = tmp()
+		const apDir = dirEnsure(join(root, "address-points"))
+		writeFileSync(join(apDir, "address-points-us-tx-v1.db"), "")
+		writeFileSync(join(root, "releases.json"), JSON.stringify({ "address-points": "v1" }))
+		const provider = new ShardProvider(factory, root)
+		const first = provider.for("tx").addressPoints
+		provider.reload()
+		expect(provider.for("tx").addressPoints).toBe(first) // same instance — not reopened
+		provider.close()
+	})
+})


### PR DESCRIPTION
The last #485 piece. **Closes the service-layer epic.**

## What

DB shards addressed as `<family>-us-<slug>-<version>.db` with a `releases.json` manifest pinning each family's current version — so the build provenance travels in the filename, and a new build publishes **alongside** the old.

```json
// <dataRoot>/releases.json
{ "address-points": "2026-05-20.0", "interpolation": "TIGER2023" }
```

- **`mailwoman/data-release.ts`** — `readReleaseManifest` + `resolveShardPath` (manifest-pinned versioned name, **legacy unversioned fallback** so the current national build output works unchanged).
- **`ShardProvider`** is versioned-aware + gains **`reload()`**: re-reads the manifest and atomically swaps any cached shard whose pinned version changed. New requests see the new version immediately; old handles are **retired and closed on the next reload** (one-generation grace — safe because `find()` is synchronous, so no in-flight query holds a handle once a request yields). `versions()` surfaces the pins.
- **Server**: `POST /api/reload` (cut traffic over after publishing, no restart); `/health` now reports `data.versions`.

## Tests

`data-release.test.ts` (4): manifest read, path resolution (versioned → legacy → null), the **version-flip + one-gen grace**, and no-churn-on-unchanged. Fully back-compat — CLI + all router tests green (12/12), CLI re-validated unregressed in legacy mode.

## #485 — DONE

| Piece | PR |
|---|---|
| Batch endpoint | #571 |
| Observability | #572 |
| RemoteResolver | #573 |
| **Versioned switchover** | **this** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)