### PR TITLE
fix(phrase-grouper): exclude the house number from STREET_PHRASE (#565)

### DIFF
--- a/phrase-grouper/group.test.ts
+++ b/phrase-grouper/group.test.ts
@@ -173,10 +173,13 @@ describe("scoreHyphenatedCompound", () => {
 })
 
 describe("scoreStreetPhrase", () => {
-	it("emits STREET_PHRASE spanning house number + name + suffix", () => {
+	it("emits STREET_PHRASE for name + suffix, EXCLUDING the leading house number (#565)", () => {
+		// The house number is NOT part of the street phrase — the NUMERIC rule proposes it separately, so
+		// the reconciler can type the number and the street as distinct nodes instead of fusing them.
 		const out = scoreStreetPhrase(tokenizeSegment("350 5th Ave", 0), "350 5th Ave")
 		expect(out).toHaveLength(1)
-		expect(out[0]!.span.body).toBe("350 5th Ave")
+		expect(out[0]!.span.body).toBe("5th Ave")
+		// A preceding house number is still strong evidence this is a street → high confidence.
 		expect(out[0]!.confidence).toBeGreaterThanOrEqual(0.85)
 	})
 

--- a/phrase-grouper/kryptonite.test.ts
+++ b/phrase-grouper/kryptonite.test.ts
@@ -140,17 +140,18 @@ describe("kryptonite catalogue — 350 5th Ave, New York, NY 10118 (canonical)",
 
 	it("surfaces all canonical components", () => {
 		expectProposal(out, { kind: "NUMERIC", body: "350", minConfidence: 0.9 })
-		expectProposal(out, { kind: "STREET_PHRASE", body: "350 5th Ave", minConfidence: 0.85 })
+		expectProposal(out, { kind: "STREET_PHRASE", body: "5th Ave", minConfidence: 0.85 })
 		expectProposal(out, { kind: "LOCALITY_PHRASE", body: "New York", minConfidence: 0.65 })
 		expectProposal(out, { kind: "REGION_ABBREVIATION", body: "NY", minConfidence: 0.7 })
 		expectProposal(out, { kind: "POSTCODE", body: "10118", minConfidence: 0.5 })
 	})
 
-	it("the STREET_PHRASE includes the house number (350 5th Ave, not just 5th Ave)", () => {
+	it("the STREET_PHRASE EXCLUDES the house number (5th Ave, not 350 5th Ave) — #565", () => {
+		// The house number lives in its own NUMERIC proposal; bundling it into STREET_PHRASE is what let
+		// the reconciler fuse "350 5th Ave" into one node and drop the street (#566). Keep them separate.
 		const streetPhrases = out.filter((p) => p.kindHypothesis === "STREET_PHRASE")
-		const withNumber = streetPhrases.find((p) => p.span.body === "350 5th Ave")
-		expect(withNumber).toBeDefined()
-		expect(withNumber!.confidence).toBeGreaterThanOrEqual(0.85)
+		expect(streetPhrases.find((p) => p.span.body === "5th Ave")).toBeDefined()
+		expect(streetPhrases.find((p) => p.span.body === "350 5th Ave")).toBeUndefined()
 	})
 
 	it("New York is a single LOCALITY_PHRASE proposal (not two separate)", () => {

--- a/phrase-grouper/rules.ts
+++ b/phrase-grouper/rules.ts
@@ -551,12 +551,22 @@ export function scoreStreetPhrase(tokens: ReadonlyArray<SegmentToken>, text: str
 		// Need at least one preceding token (or a numeric house number) for STREET_PHRASE — a
 		// suffix-only token "Street" alone isn't a street phrase.
 		if (start === suffixIdx) continue
+		// #565: a leading ALL-DIGIT token is a house NUMBER, not part of the street name. Exclude it from
+		// the STREET_PHRASE span — the NUMERIC rule already proposes the house number separately — so the
+		// joint reconciler types the house number and the street as DISTINCT nodes instead of fusing the
+		// whole run ("3075 Hill Street") into one (the regression behind #566). Ordinals ("5th Ave") are
+		// part of the name and stay.
+		let hadHouseNumber = false
+		if (isAllDigit(tokens[start]!.body)) {
+			start += 1
+			hadHouseNumber = true
+			if (start === suffixIdx) continue // only "<number> <suffix>" remained — no street name to phrase
+		}
 		const startTok = tokens[start]!
 		const endTok = tokens[suffixIdx]!
-		const hasLeadingNumeric = isAllDigit(startTok.body) || /^\d+(st|nd|rd|th)$/i.test(startTok.body)
-		// Canonical NUMERIC + capitalized + SUFFIX scores high; capitalized-run + SUFFIX scores
-		// slightly lower since it could also be a venue.
-		const confidence = hasLeadingNumeric ? 0.9 : 0.75
+		// A preceding (now-excluded) house number is still strong evidence this run is a street → high
+		// confidence. A capitalized-run + suffix with no number scores slightly lower (could be a venue).
+		const confidence = hadHouseNumber ? 0.9 : 0.75
 		out.push({
 			span: makeSection(text, startTok.start, endTok.end),
 			kindHypothesis: "STREET_PHRASE",


### PR DESCRIPTION
Closes #565.

## Root cause

The `STREET_PHRASE` rule deliberately spanned a leading numeric house number ("350 5th Ave"), so `reconcileSpans` fused the whole run into one node and dropped the street — the regression that forced reconcile off as the default (#566).

## Fix

Exclude a leading **all-digit** token from the STREET_PHRASE span — the `NUMERIC` rule already proposes the house number separately, so the reconciler can type the number and the street as **distinct** nodes. Ordinals like "5th Ave" stay (part of the name). A preceding house number still scores the phrase 0.9 (strong evidence it's a street, not a venue).

## Verification

- With `jointReconcile` on, street + house_number now **separate**: "3075 Hill Street" → hn=3075 / st="Hill Street", "350 5th Ave" → hn=350 / st="5th Ave" (3/3).
- Reconcile's street+HN+postcode precondition on US addresses recovers **~20% → 91.7%** (argmax stays 100%).
- phrase-grouper tests updated to the corrected behavior — **65/65** green.

## Scope

This unblocks **re-enabling reconcile for the FR/EU multi-locale work** (where it keeps OOD streets intact). Actually re-promoting reconcile to default is a separate decision that needs the golden re-gate (does it now beat argmax on FR/EU without regressing US?) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)