### PR TITLE
docs(evals): reconcile re-gate post-#565 — keep retired (argmax default)

### DIFF
--- a/docs/articles/evals/2026-06-14-reconcile-regate-post-565.md
+++ b/docs/articles/evals/2026-06-14-reconcile-regate-post-565.md
@@ -1,0 +1,131 @@
+# Re-gating joint-reconcile after the #565 grouper fix
+
+_2026-06-14. We retired joint-reconcile to argmax (#566) after an audit found it broke the
+street + house-number geocode precondition on 77–84% of clean US addresses. The root cause — the
+phrase grouper bundling the house number into the street phrase — was then fixed (#565). This report
+answers the obvious follow-up: now that the destructive mechanism is gone, does reconcile earn its way
+back as the default (or at least FR-scoped, the locale #427 claimed it helped)? Graded on the assembled
+pipeline in both modes, the answer is no. #565 repaired the structural break, but reconcile is still
+strictly worse than argmax on tag values — worst on the exact locale it was supposed to help. Argmax
+stays the default; the parked re-promotion decision is resolved as "keep retired."_
+
+## Why we re-gated
+
+The retirement was a de-promotion under fire — the geocoder needed a clean street and a separate house
+number, reconcile was merging them, so we flipped the default to argmax and moved on. But two things
+left the door open:
+
+1. The **#427 claim** that joint-reconcile helped FR/EU. If true, retiring it would cost those locales
+   something, and an FR-scoped re-promotion via the policy registry might be the right shape.
+2. The **#565 grouper fix** removed the specific mechanism (house-number bundling) that the retirement
+   audit blamed for the 77–84% precondition break. With that gone, reconcile might now be neutral-or-
+   better.
+
+So the question is sharp and worth a real measurement: **run the pipeline with `jointReconcile: true`
+and see whether it beats-or-matches argmax (`jointReconcile: false`, the #566 default) — on FR without
+regressing US — grading the assembled pipeline, never raw neural.** Grading raw neural is the mistake
+that hid the original regression for months; we do not repeat it.
+
+## What we measured
+
+Two harnesses, both comparing the **assembled runtime pipeline** in argmax mode vs reconcile mode (same
+weights, same grouper, only the `jointReconcile` flag differs):
+
+- `scripts/eval/reconcile-regate.mjs` — per-tag recall on golden v0.1.2, US and FR graded separately.
+- `scripts/eval/reconcile-precondition-regate.mjs` — the share of rows that keep a separate
+  `street` + `house_number` + `postcode` (the geocoder precondition), on the Travis/OpenAddresses
+  holdout (`/tmp/ood-truth.jsonl`, n=1965). This holdout is the same non-circular real-points file used
+  in the retirement audit — E-911 / parcel-centroid provenance, disjoint from training and from grouper
+  tuning, so the precondition number is not gamed.
+
+### Per-tag recall — reconcile is worse, everywhere it isn't flat
+
+**US — golden v0.1.2, n=2956 addresses**
+
+| tag          | argmax | reconcile | Δ (rec − argmax) |
+| ------------ | -----: | --------: | ---------------: |
+| house_number |  99.8% |     99.5% |           −0.3pp |
+| street       |  95.3% |     92.9% |       **−2.4pp** |
+| locality     |  97.7% |     95.9% |           −1.8pp |
+| region       |  55.7% |     56.2% |           +0.5pp |
+| postcode     |  72.2% |     72.7% |           +0.5pp |
+| venue        |  95.2% |     95.0% |           −0.2pp |
+| unit         | 100.0% |    100.0% |           +0.0pp |
+
+**FR — golden v0.1.2, n=1551 addresses**
+
+| tag          | argmax | reconcile |    Δ (rec − argmax) |
+| ------------ | -----: | --------: | ------------------: |
+| house_number |  83.0% |     84.8% |              +1.8pp |
+| street       |  79.4% |     65.7% | **−13.7pp** |
+| locality     |  80.2% |     76.5% |              −3.6pp |
+| region       |  17.4% |     10.5% |              −6.8pp |
+| postcode     |  63.9% |     63.4% |              −0.5pp |
+| venue        | 100.0% |    100.0% |              +0.0pp |
+
+US has no offsetting win — street regresses 2.4pp, locality 1.8pp, everything else flat. FR is the
+damning column: reconcile takes **street from 79.4% to 65.7% (−13.7pp)**, with locality and region also
+down. Its only gain anywhere is FR house_number (+1.8pp). The locale #427 said reconcile helps is the
+locale it hurts most.
+
+### Precondition — #565 worked, but reconcile still isn't at parity
+
+**Travis/OA holdout, n=1965 (predominantly Austin TX)**
+
+| mode      | street+HN+postcode preserved | reconcile BREAKS (argmax had it, lost it) | reconcile FIXES |
+| --------- | ---------------------------: | ----------------------------------------: | --------------: |
+| argmax    |              1965 (100.0%) |                                         — |               — |
+| reconcile |               1854 (94.4%) |                            **111 (5.6%)** |        0 (0.0%) |
+
+This is the good news and the verdict in one table. The #565 fix is real: the precondition break
+collapsed from the retirement audit's **77–84% to 5.6%**. But argmax preserves the precondition on
+**100%** of these rows; reconcile still drops the street to `null` on 5.6%, and fixes nothing argmax
+missed. The break pattern is consistent — multi-word residential streets:
+
+```
+7425 Marble Ridge Drive, Austin, TX 78747   argmax: st=Marble…  reconcile: st=null
+11407 Saddle Mountain Trail, Austin, TX 78739  argmax: st=Saddle…  reconcile: st=null
+5712 Sunny Vista Drive, Austin, TX 78749    argmax: st=Sunny…   reconcile: st=null
+```
+
+## The mechanism
+
+#565 fixed the grouper's house-number bundling — the structural break that the retirement blamed. What
+this re-gate shows is that reconcile's harm was never only structural. By **merging** tokens into one
+candidate span rather than **selecting** the neural argmax, reconcile destroys internal street
+structure that argmax keeps intact. On FR that is the `Rue de la <X>` / `Chemin du <X>` prefix +
+particle + core pattern — the merge collapses it and the street value falls apart (−13.7pp). On US
+multi-word residential streets it drops the span entirely (the 5.6% precondition break). Argmax avoids
+both failure modes for the same reason: it commits to the model's per-token decision instead of
+re-deriving a span from phrase proposals. This is design-level behavior of the reconcile path, not a
+second bundling bug to patch.
+
+## Verdict — keep reconcile retired
+
+Both gates fail. Reconcile loses tag-value accuracy on US and FR with no locale where it wins overall,
+and it still breaks the geocoder precondition on 5.6% of rows where argmax never does. There is no slice
+— not even FR — where re-promotion is net-positive. **Argmax stays the default. Joint-reconcile remains
+opt-in (`jointReconcile: true`) and undefaulted; this report is the record of why.** The #427 "reconcile
+helps FR" claim was an artifact of grading raw neural — the same blind spot that hid the original
+regression.
+
+Independent of the reconcile decision, the **argmax-FR street ceiling of 79.4%** is its own open
+question (and the FR street/region recall generally) — that is a model + FR-grouper matter, not a
+reconcile one, and is left to the FR parity track. Worth capturing as a learning item; not a
+prerequisite for this verdict.
+
+## Resolved parked decision
+
+> Re-promote reconcile + scope — **resolved: no.** Keep retired (argmax default). Evidence: this report.
+> Concurred by an independent review (DeepSeek, 2026-06-14).
+
+## Reproduce
+
+```bash
+yarn compile
+node scripts/eval/reconcile-regate.mjs data/eval/golden/v0.1.2/us.jsonl data/eval/golden/v0.1.2/fr.jsonl
+node scripts/eval/reconcile-precondition-regate.mjs /tmp/ood-truth.jsonl
+```
+
+See also: [`2026-06-14-reconcile-retirement.md`](./2026-06-14-reconcile-retirement.md) (the de-promotion
+that prompted this re-gate).

--- a/scripts/eval/reconcile-precondition-regate.mjs
+++ b/scripts/eval/reconcile-precondition-regate.mjs
@@ -1,0 +1,77 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ *
+ *   Reconcile precondition RE-GATE (post-#565). The retirement audit showed joint-reconcile BROKE the
+ *   forward-geocoder precondition (a SEPARATE street + house_number + postcode) on 77–84% of US rows
+ *   vs argmax. The #565 grouper HN-bundling fix was supposed to repair that. This compares the
+ *   assembled pipeline in argmax mode (`jointReconcile: false`, the #566 default) vs reconcile mode
+ *   (`jointReconcile: true`) on an OA-format holdout, counting how often each preserves the
+ *   precondition — and crucially how often reconcile still BREAKS a precondition argmax had.
+ *
+ *   This is the A.2 gate: reconcile may only be re-promoted if it preserves the precondition at
+ *   parity with argmax (does not break it on a meaningful fraction of rows).
+ *
+ *   Usage: node scripts/eval/reconcile-precondition-regate.mjs <holdout.jsonl> [cap]
+ *   Holdout rows carry `input` (OA format). Requires compiled out/.
+ */
+import { readFileSync } from "node:fs"
+
+const root = new URL("../../", import.meta.url)
+const { NeuralAddressClassifier } = await import(new URL("neural/out/index.js", root).href)
+const { createRuntimePipeline } = await import(new URL("mailwoman/out/runtime-pipeline.js", root).href)
+const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+const pipeline = createRuntimePipeline({ classifier })
+
+const tagvals = (tree) => {
+	const o = { street: null, house_number: null, postcode: null }
+	const st = [...tree.roots]
+	while (st.length) {
+		const n = st.pop()
+		if (n.tag === "street" && o.street === null && n.value.trim()) o.street = n.value.trim()
+		if (n.tag === "house_number" && o.house_number === null && n.value.trim()) o.house_number = n.value.trim()
+		if (n.tag === "postcode" && o.postcode === null && n.value.trim()) o.postcode = n.value.trim()
+		st.push(...n.children)
+	}
+	return o
+}
+
+const rows = readFileSync(process.argv[2] || "/tmp/ood-truth.jsonl", "utf8")
+	.trim()
+	.split("\n")
+	.map((l) => JSON.parse(l))
+const cap = Number(process.argv[3] || rows.length)
+let n = 0,
+	argPrecond = 0,
+	recPrecond = 0,
+	recBreaks = 0,
+	recFixes = 0
+const broke = []
+for (const r of rows.slice(0, cap)) {
+	const input = r.input ?? r.raw
+	if (!input) continue
+	n++
+	const arg = tagvals((await pipeline(input, { jointReconcile: false })).tree)
+	const rec = tagvals((await pipeline(input, { jointReconcile: true })).tree)
+	const ap = !!(arg.street && arg.house_number && arg.postcode)
+	const cp = !!(rec.street && rec.house_number && rec.postcode)
+	if (ap) argPrecond++
+	if (cp) recPrecond++
+	if (ap && !cp) {
+		recBreaks++
+		if (broke.length < 14)
+			broke.push(
+				`${input}\n      argmax:    hn=${arg.house_number} st=${arg.street} pc=${arg.postcode}\n      reconcile: hn=${rec.house_number} st=${rec.street} pc=${rec.postcode}`
+			)
+	}
+	if (cp && !ap) recFixes++
+}
+const pc = (x) => `${((100 * x) / n).toFixed(1)}%`
+console.log(`reconcile precondition re-gate (n=${n})`)
+console.log(`  street+HN+postcode precondition:  argmax ${argPrecond} (${pc(argPrecond)})  |  reconcile ${recPrecond} (${pc(recPrecond)})`)
+console.log(`  reconcile BREAKS it (argmax had it, reconcile lost it): ${recBreaks} (${pc(recBreaks)})  <-- the retirement metric`)
+console.log(`  reconcile FIXES it (reconcile had it, argmax didn't):   ${recFixes} (${pc(recFixes)})`)
+if (broke.length) {
+	console.log(`\n  sample reconcile-broke-the-precondition cases:`)
+	for (const s of broke) console.log(`   - ${s}`)
+}

--- a/scripts/eval/reconcile-regate.mjs
+++ b/scripts/eval/reconcile-regate.mjs
@@ -1,0 +1,100 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ *
+ *   Reconcile RE-GATE (post-#565). The grouper HN-bundling fix (#565) re-enabled joint-reconcile's
+ *   street/HN precondition (US 20% → 91.7% in the bundling audit). Open question for re-promotion:
+ *   does running the pipeline with `jointReconcile: true` now BEAT-OR-MATCH argmax (reconcile off,
+ *   the #566 default) on FR/EU **without regressing US**? This grades the ASSEMBLED pipeline in both
+ *   modes — never raw-neural F1 — which is the lesson of the retirement (see
+ *   docs/articles/evals/2026-06-14-reconcile-retirement.md).
+ *
+ *   For each golden file it prints a per-tag recall table: raw-neural (reference) | argmax | reconcile
+ *   | Δ(reconcile − argmax), flagging any tag where reconcile moves ≥2pp either way. The decision
+ *   metric is the per-locale Δ column, US vs FR.
+ *
+ *   Usage: node scripts/eval/reconcile-regate.mjs <golden-a.jsonl> [golden-b.jsonl ...]
+ *   Requires compiled out/ (yarn compile).
+ */
+import { basename } from "node:path"
+import { readFileSync } from "node:fs"
+
+const root = new URL("../../", import.meta.url)
+const { NeuralAddressClassifier } = await import(new URL("neural/out/index.js", root).href)
+const { createRuntimePipeline } = await import(new URL("mailwoman/out/runtime-pipeline.js", root).href)
+const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+const pipeline = createRuntimePipeline({ classifier })
+
+const STREET = new Set(["street", "street_prefix", "street_prefix_particle", "street_suffix"])
+const TAGS = ["house_number", "street", "locality", "region", "postcode", "venue", "unit"]
+const norm = (s) =>
+	(s || "")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+
+function collect(tree) {
+	const byTag = {}
+	const st = [...tree.roots]
+	const streetParts = []
+	while (st.length) {
+		const n = st.pop()
+		if (STREET.has(n.tag) && n.value?.trim()) streetParts.push({ s: n.start, v: n.value.trim() })
+		;(byTag[n.tag] ??= []).push(n.value?.trim() || "")
+		st.push(...(n.children || []))
+	}
+	streetParts.sort((a, b) => a.s - b.s)
+	byTag.__street_assembled = [streetParts.map((p) => p.v).join(" ")]
+	return byTag
+}
+function hit(byTag, tag, goldVal) {
+	const g = norm(goldVal)
+	if (tag === "street") {
+		const a = norm(byTag.__street_assembled?.[0])
+		if (a && (a === g || a.includes(g) || g.includes(a))) return true
+	}
+	const vals = (byTag[tag] || []).map(norm)
+	return vals.some((v) => v && (v === g || v.includes(g) || g.includes(v)))
+}
+
+const files = process.argv.slice(2)
+const pct = (h, n) => (n ? ((100 * h) / n).toFixed(1) : "  - ")
+
+for (const f of files) {
+	const acc = { raw: {}, argmax: {}, rec: {} }
+	for (const t of TAGS) for (const k of ["raw", "argmax", "rec"]) acc[k][t] = { h: 0, n: 0 }
+	let n = 0
+	for (const line of readFileSync(f, "utf8").trim().split("\n")) {
+		const r = JSON.parse(line)
+		if (!r.raw || !r.components) continue
+		n++
+		const rawT = collect(await classifier.parse(r.raw, { postcodeRepair: true }))
+		const argT = collect((await pipeline(r.raw, { jointReconcile: false })).tree)
+		const recT = collect((await pipeline(r.raw, { jointReconcile: true })).tree)
+		for (const [tag, gv] of Object.entries(r.components)) {
+			if (!TAGS.includes(tag)) continue
+			acc.raw[tag].n++, (acc.argmax[tag].n++, acc.rec[tag].n++)
+			if (hit(rawT, tag, gv)) acc.raw[tag].h++
+			if (hit(argT, tag, gv)) acc.argmax[tag].h++
+			if (hit(recT, tag, gv)) acc.rec[tag].h++
+		}
+	}
+	console.log(`\n=== ${basename(f)}  (n=${n} addresses) ===`)
+	console.log(`tag             raw      argmax   reconcile   Δ(rec−argmax)`)
+	let worst = 0
+	for (const t of TAGS) {
+		const a = acc.argmax[t],
+			c = acc.rec[t],
+			rw = acc.raw[t]
+		if (a.n === 0) continue
+		const ap = (100 * a.h) / a.n,
+			cp = (100 * c.h) / c.n,
+			d = cp - ap
+		if (d < worst) worst = d
+		const flag = d <= -2 ? "  <-- reconcile WORSE" : d >= 2 ? "  <-- reconcile better" : ""
+		console.log(
+			`${t.padEnd(14)} ${pct(rw.h, rw.n).padStart(5)}%   ${pct(a.h, a.n).padStart(5)}%   ${pct(c.h, c.n).padStart(6)}%   ${(d >= 0 ? "+" : "") + d.toFixed(1)}pp${flag}`
+		)
+	}
+	console.log(`worst Δ(rec−argmax) on this file: ${worst.toFixed(1)}pp  ${worst <= -2 ? "→ REGRESSION" : "→ no regression ≥2pp"}`)
+}


### PR DESCRIPTION
## Resolves a parked decision: keep joint-reconcile retired

After the #565 grouper fix repaired joint-reconcile's precondition break (the retirement audit's 77–84% → **5.6%**), the open question was whether reconcile now earns re-promotion — at least FR-scoped, the locale #427 claimed it helped. **It does not.** Graded on the **assembled pipeline** in both modes (never raw neural — that blind spot is what hid the original regression):

**Per-tag recall, golden v0.1.2**

| tag | US argmax | US reconcile | Δ | FR argmax | FR reconcile | Δ |
|---|---:|---:|---:|---:|---:|---:|
| street | 95.3% | 92.9% | **−2.4** | 79.4% | 65.7% | **−13.7** |
| locality | 97.7% | 95.9% | −1.8 | 80.2% | 76.5% | −3.6 |
| region | 55.7% | 56.2% | +0.5 | 17.4% | 10.5% | −6.8 |
| house_number | 99.8% | 99.5% | −0.3 | 83.0% | 84.8% | +1.8 |

(US n=2956, FR n=1551.) Reconcile's only gain anywhere is FR house_number; the locale it was meant to help is the one it hurts most.

**Precondition, Travis/OA holdout (n=1965, non-circular, disjoint from training/grouper tuning)**

| mode | street+HN+postcode preserved | reconcile BREAKS | FIXES |
|---|---:|---:|---:|
| argmax | **100.0%** | — | — |
| reconcile | 94.4% | **111 (5.6%)** | 0 |

#565 collapsed the precondition break from 77–84% to 5.6% — real progress — but argmax preserves it on 100% and reconcile still drops multi-word residential streets to `null`. Reconcile is **strictly worse than argmax** with no net-positive slice.

## What's in this PR

- `docs/articles/evals/2026-06-14-reconcile-regate-post-565.md` — the report + resolved parked decision.
- `scripts/eval/reconcile-regate.mjs`, `scripts/eval/reconcile-precondition-regate.mjs` — the two A/B harnesses (argmax vs reconcile).

**No behavior change** — argmax is already the #566 default; this documents *why* and closes the door on re-promotion. Concurred by independent review (DeepSeek). Docs + eval-tooling only.

> ⚠️ CI install will be red until **#579** (lockfile fix) merges — that's the pre-existing main breakage, not this branch. Merge #579 first.
