### PR TITLE
feat(coarse-placer): int8 quantization + fromArtifactDir loader (#244-M3)

### DIFF
--- a/core/coarse-placer/coarse-placer.test.ts
+++ b/core/coarse-placer/coarse-placer.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Coarse-placer (#244) loader + int8 round-trip. Builds a tiny synthetic artifact on disk (no
+ *   /mnt/playpen dependency) so `CoarsePlacer.fromArtifactDir` is exercised end-to-end for both the
+ *   fp32 and the int8-per-row formats, and asserts the int8 path predicts the same class with near-
+ *   identical confidence. Also covers `featurize` determinism and `dequantizeInt8Weights`.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, test } from "vitest"
+
+import { CoarsePlacer, dequantizeInt8Weights, FEATURE_DIM, featurize } from "./coarse-placer.js"
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "coarse-placer-test-"))
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }))
+
+/** Deterministic pseudo-random weights in [-0.05, 0.05], LCG-seeded so the test is reproducible. */
+function seededWeights(classCount: number, dim: number, seed: number): Float32Array {
+	const w = new Float32Array(classCount * dim)
+	let s = seed >>> 0
+	for (let i = 0; i < w.length; i++) {
+		s = (Math.imul(s, 1664525) + 1013904223) >>> 0
+		w[i] = (s / 0xffffffff - 0.5) * 0.1
+	}
+	return w
+}
+
+/** Per-row symmetric int8 quantization (mirrors scripts/coarse-placer/quantize.mjs). */
+function quantize(w: Float32Array, classCount: number, dim: number) {
+	const int8 = new Int8Array(classCount * dim)
+	const scales: number[] = []
+	for (let c = 0; c < classCount; c++) {
+		const base = c * dim
+		let maxAbs = 0
+		for (let i = 0; i < dim; i++) maxAbs = Math.max(maxAbs, Math.abs(w[base + i]!))
+		const scale = maxAbs / 127 || 1
+		scales.push(scale)
+		for (let i = 0; i < dim; i++) int8[base + i] = Math.max(-127, Math.min(127, Math.round(w[base + i]! / scale)))
+	}
+	return { int8, scales }
+}
+
+/** Write an fp32 and an int8 artifact dir for the same weights; return both paths. */
+function writeArtifacts(classes: string[], dim: number, weights: Float32Array, bias: number[], temperature = 1) {
+	const fp32Dir = join(tmpRoot, `fp32-${classes.join("")}-${dim}`)
+	const int8Dir = join(tmpRoot, `int8-${classes.join("")}-${dim}`)
+	mkdirSync(fp32Dir, { recursive: true })
+	mkdirSync(int8Dir, { recursive: true })
+
+	const baseMeta = { classes, featureDim: dim, temperature, bias }
+	writeFileSync(join(fp32Dir, "meta.json"), JSON.stringify(baseMeta))
+	writeFileSync(join(fp32Dir, "weights.bin"), Buffer.from(weights.buffer, weights.byteOffset, weights.byteLength))
+
+	const { int8, scales } = quantize(weights, classes.length, dim)
+	writeFileSync(join(int8Dir, "meta.json"), JSON.stringify({ ...baseMeta, quantization: "int8-per-row", scales }))
+	writeFileSync(join(int8Dir, "weights.bin"), Buffer.from(int8.buffer))
+	return { fp32Dir, int8Dir }
+}
+
+describe("featurize", () => {
+	test("is deterministic and bounded", () => {
+		const a = featurize("123 Main St, Springfield")
+		const b = featurize("123 Main St, Springfield")
+		expect(a).toEqual(b)
+		expect(a.length).toBeGreaterThan(0)
+		for (const i of a) {
+			expect(i).toBeGreaterThanOrEqual(0)
+			expect(i).toBeLessThan(FEATURE_DIM)
+		}
+	})
+
+	test("empty / whitespace input yields no features", () => {
+		expect(featurize("")).toEqual([])
+		expect(featurize("   ")).toEqual([])
+	})
+
+	test("different scripts produce different feature sets", () => {
+		const latin = new Set(featurize("Main Street"))
+		const cyrillic = new Set(featurize("Тверская улица"))
+		// Script-presence tokens differ, so the sets are not equal.
+		expect([...cyrillic].some((i) => !latin.has(i))).toBe(true)
+	})
+})
+
+describe("dequantizeInt8Weights", () => {
+	test("reconstructs W = int8 * scale per row", () => {
+		const int8 = Int8Array.from([127, -127, 0, 64, 10, -10, 100, -50])
+		const scales = [0.01, 0.5]
+		const out = dequantizeInt8Weights(int8, scales, 2, 4)
+		// Float32 storage, so compare with tolerance (1.27 round-trips to 1.26999998…).
+		for (const [i, want] of [1.27, -1.27, 0, 0.64].entries()) expect(out[i]).toBeCloseTo(want, 6)
+		expect(out[4]).toBeCloseTo(5, 6)
+		expect(out[7]).toBeCloseTo(-25, 6)
+	})
+
+	test("rejects length / scale-count mismatch", () => {
+		expect(() => dequantizeInt8Weights(new Int8Array(8), [1], 2, 4)).toThrow()
+		expect(() => dequantizeInt8Weights(new Int8Array(7), [1, 1], 2, 4)).toThrow()
+	})
+})
+
+describe("CoarsePlacer.fromArtifactDir", () => {
+	const classes = ["AA", "BB", "CC"]
+	const bias = [0.1, -0.2, 0.05]
+	const weights = seededWeights(classes.length, FEATURE_DIM, 12345)
+	const { fp32Dir, int8Dir } = writeArtifacts(classes, FEATURE_DIM, weights, bias)
+	const samples = ["123 Main St", "10 Rue de la Paix", "1-2-3 Chiyoda Tokyo", "Calle Mayor 7"]
+
+	test("loads the fp32 artifact and predicts", async () => {
+		const placer = await CoarsePlacer.fromArtifactDir(fp32Dir, { abstainBelow: 0 })
+		for (const s of samples) {
+			const p = placer.predict(s)
+			expect(classes).toContain(p.country)
+			expect(p.confidence).toBeGreaterThan(0)
+			const total = Object.values(p.probs).reduce((a, b) => a + b, 0)
+			expect(total).toBeCloseTo(1, 5)
+		}
+	})
+
+	test("int8 artifact predicts the same class with near-identical confidence", async () => {
+		const fp32 = await CoarsePlacer.fromArtifactDir(fp32Dir, { abstainBelow: 0 })
+		const int8 = await CoarsePlacer.fromArtifactDir(int8Dir, { abstainBelow: 0 })
+		for (const s of samples) {
+			const a = fp32.predict(s)
+			const b = int8.predict(s)
+			expect(b.country).toBe(a.country)
+			expect(b.confidence).toBeCloseTo(a.confidence, 2)
+		}
+	})
+
+	test("int8 artifact missing scales is rejected", async () => {
+		const badDir = join(tmpRoot, "int8-noscales")
+		mkdirSync(badDir, { recursive: true })
+		writeFileSync(
+			join(badDir, "meta.json"),
+			JSON.stringify({ classes, featureDim: FEATURE_DIM, temperature: 1, bias, quantization: "int8-per-row" })
+		)
+		writeFileSync(join(badDir, "weights.bin"), Buffer.from(new Int8Array(classes.length * FEATURE_DIM).buffer))
+		await expect(CoarsePlacer.fromArtifactDir(badDir)).rejects.toThrow(/scales/)
+	})
+})
+
+describe("abstention", () => {
+	test("abstains when no class clears the threshold", () => {
+		// All-zero weights → logits are the (equal) bias → near-uniform softmax → top prob ≈ 1/C < 0.5.
+		const classes = ["AA", "BB", "CC", "DD"]
+		const placer = new CoarsePlacer(
+			{ classes, featureDim: FEATURE_DIM, temperature: 1, bias: [0, 0, 0, 0], weights: new Float32Array(classes.length * FEATURE_DIM) },
+			{ abstainBelow: 0.5 }
+		)
+		const p = placer.predict("anything at all")
+		expect(p.abstained).toBe(true)
+		expect(p.country).toBeNull()
+		expect(p.confidence).toBeCloseTo(0.25, 5)
+	})
+})

--- a/core/coarse-placer/coarse-placer.ts
+++ b/core/coarse-placer/coarse-placer.ts
@@ -23,6 +23,44 @@ export interface CoarsePlacerArtifact {
 	weights: Float32Array
 }
 
+/**
+ * On-disk `meta.json` shape. The fp32 artifact omits `quantization`/`scales`; the int8 artifact (from
+ * `scripts/coarse-placer/quantize.mjs`) sets `quantization: "int8-per-row"` and carries one `scale`
+ * per class, so `weights.bin` can be a 4×-smaller `Int8Array` dequantized as `int8 * scales[class]`.
+ */
+export interface CoarsePlacerMeta {
+	classes: string[]
+	featureDim: number
+	temperature: number
+	bias: number[]
+	quantization?: "int8-per-row"
+	/** Per-class dequantization scale; present iff `quantization === "int8-per-row"`. */
+	scales?: number[]
+}
+
+/**
+ * Dequantize a per-row int8 weight matrix back to fp32: `W[c][i] = int8[c*dim + i] * scales[c]`. The
+ * predict path stays fp32 (identical math); quantization only shrinks the serialized/wire artifact.
+ * Pure — usable in the browser loader too.
+ */
+export function dequantizeInt8Weights(
+	int8: Int8Array,
+	scales: readonly number[],
+	classCount: number,
+	dim: number
+): Float32Array {
+	const expected = classCount * dim
+	if (int8.length !== expected) throw new Error(`dequantize: int8 length ${int8.length} ≠ classes×dim ${expected}`)
+	if (scales.length !== classCount) throw new Error(`dequantize: ${scales.length} scales ≠ ${classCount} classes`)
+	const out = new Float32Array(expected)
+	for (let c = 0; c < classCount; c++) {
+		const s = scales[c]!
+		const base = c * dim
+		for (let i = 0; i < dim; i++) out[base + i] = int8[base + i]! * s
+	}
+	return out
+}
+
 export interface CoarsePrediction {
 	/** The predicted class, or `null` when the model abstained (confidence below the threshold). */
 	country: string | null
@@ -57,6 +95,34 @@ export class CoarsePlacer {
 		if (this.#weights.length !== expected) {
 			throw new Error(`CoarsePlacer: weights length ${this.#weights.length} ≠ classes×dim ${expected}`)
 		}
+	}
+
+	/**
+	 * Load a placer from an artifact directory holding `meta.json` + `weights.bin` (the layout
+	 * `scripts/coarse-placer/train.mjs` and `quantize.mjs` write). Handles both the fp32 artifact
+	 * (`weights.bin` is a `Float32Array`) and the int8 artifact (`meta.quantization === "int8-per-row"`,
+	 * `weights.bin` is an `Int8Array` dequantized via `meta.scales`). Node-only — the `node:` imports are
+	 * dynamic so bundling the class for the browser doesn't pull them in.
+	 */
+	static async fromArtifactDir(dir: string, opts?: CoarsePlacerOpts): Promise<CoarsePlacer> {
+		const { readFile } = await import("node:fs/promises")
+		const { join } = await import("node:path")
+		const meta = JSON.parse(await readFile(join(dir, "meta.json"), "utf8")) as CoarsePlacerMeta
+		const buf = await readFile(join(dir, "weights.bin"))
+		// Copy out of the (possibly pooled, possibly mis-aligned) Buffer into a fresh ArrayBuffer so the
+		// typed-array view is always validly aligned.
+		const bytes = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+		let weights: Float32Array
+		if (meta.quantization === "int8-per-row") {
+			if (!meta.scales) throw new Error(`CoarsePlacer.fromArtifactDir: int8 artifact at ${dir} has no scales`)
+			weights = dequantizeInt8Weights(new Int8Array(bytes), meta.scales, meta.classes.length, meta.featureDim)
+		} else {
+			weights = new Float32Array(bytes)
+		}
+		return new CoarsePlacer(
+			{ classes: meta.classes, featureDim: meta.featureDim, temperature: meta.temperature, bias: meta.bias, weights },
+			opts
+		)
 	}
 
 	predict(text: string): CoarsePrediction {

--- a/docs/articles/evals/2026-06-14-coarse-placer-m3-latin-offmap.md
+++ b/docs/articles/evals/2026-06-14-coarse-placer-m3-latin-offmap.md
@@ -1,0 +1,75 @@
+# Coarse-placer M3: the Latin off-map residual is a data wall, not a method one
+
+_2026-06-14. The #244 coarse-placer's M2 OTHER class was trained on non-Latin scripts (Cyrillic,
+Arabic, …), so it abstains well on those but still confidently mis-places off-map COUNTRIES written in
+Latin script — Poland, Brazil, Mexico — onto a trained Latin country. This milestone tested the
+obvious fix: feed it REAL off-map addresses (not synthetic name variants — see #564) as OTHER. The
+mechanism works cleanly and at zero in-map cost, but it does not generalize past the countries you
+train on, and Overture's addresses theme doesn't currently have the breadth to train on enough of
+them. So this is a directional win with an honest ceiling, recorded — not a promotion._
+
+## The residual, measured
+
+A Latin off-map address is **handled** when the placer routes it to OTHER or abstains; anything else is
+a confident mis-placement onto a wrong trained country. On a fresh held-out set of real Overture
+addresses from off-map Latin countries (n=17815), the shipped (M2) model handles only **23.3%** — i.e.
+it confidently mis-places three out of four. Polish addresses go to JP/NL/US at 0.58–0.96 confidence.
+
+## The experiment
+
+Assemble real address strings from the Overture per-country address parquet and append them as
+`country: "OTHER"`. Split the countries deliberately:
+
+- **Train** (their rows feed train/val OTHER): PL, BR, MX, PT — the off-map Latin countries Overture
+  actually has rows for.
+- **Held out** (test only — the generalization probe): CZ (a distinct Slavic country the model never
+  sees), plus CA and LI (the hard near-twins — Canadian addresses read like US, Liechtenstein like DE).
+
+Retrain (34s CPU, same SGD recipe), evaluate against the shipped model.
+
+## Results
+
+| group                                    | shipped (M2) | M3 retrain |
+| ---------------------------------------- | -----------: | ---------: |
+| **in-distribution** (held-out PL/BR/MX/PT rows) |        23.1% | **100.0%** |
+| **held-out** (CZ / CA / LI, never trained)      |        23.3% |      25.0% |
+| overall                                  |        23.3% |      31.4% |
+
+Per held-out country: CZ 39.5 → 42.8%, CA 7.0 → 7.4%, LI 19.5 → 20.6%.
+
+**In-map accuracy held**: golden test 94.99 → **95.10%** (+0.1pp), every in-map class flat or up
+(ES 90.4 → 91.1%), non-Latin multi-script handling maintained. No regression anywhere — M3 is a strict
+Pareto improvement.
+
+## What this says
+
+The mechanism is real: train a country on OTHER and it goes to **100%** handled, at **zero** in-map
+cost. But the model learns *those countries' n-grams → OTHER*, not a general "off my map" concept —
+the held-out countries barely move (+1.7pp overall), and the near-twins (CA looks like US, and for a
+*coarse* placer that's arguably not even wrong) stay where they are. General Latin off-map handling
+needs **broad country coverage** — dozens of off-map countries in the OTHER class, not four.
+
+That breadth is the wall. Of the 12 off-map countries requested from Overture's addresses theme
+(2026-05-20.0, ALPHA), only 5 returned rows (PL/BR/MX/PT/CZ); RO/TR/ID/SE/VN/HU/PH/AR were empty. So
+this is a **data-availability ceiling, not a method failure** — the same shape as #564's fr.house_number
+plateau (real-data realism is the lever; we just don't have enough of it yet).
+
+## Decision
+
+- **Do not promote.** `model-m3` is a strict improvement but does not meet the ≥90% general target; the
+  coarse-placer isn't bundled anywhere yet, so there's nothing to gate — this is a recorded finding,
+  and the canonical fp32 model stands.
+- **The next lever is breadth, not weight or recipe.** Broad off-map address coverage — a full
+  OpenAddresses off-map pull, or a later Overture release once the addresses theme fills in — folded
+  into OTHER, with the held-out-country probe as the gate. Tracked as a follow-up to #244.
+
+## Reproduce
+
+```bash
+node --experimental-strip-types scripts/ingest-overture-addresses.ts --release 2026-05-20.0 \
+  --countries PL,BR,MX,PT,CZ,CA,LI --limit 6000
+node scripts/coarse-placer/build-outlier-latin.mjs            # appends OTHER + writes the test file
+node scripts/coarse-placer/eval-latin-offmap.mjs --model .../coarse-placer/model        # baseline
+node scripts/coarse-placer/train.mjs --out .../coarse-placer/model-m3
+node scripts/coarse-placer/eval-latin-offmap.mjs --model .../coarse-placer/model-m3     # after
+```

--- a/scripts/coarse-placer/build-outlier-latin.mjs
+++ b/scripts/coarse-placer/build-outlier-latin.mjs
@@ -1,0 +1,146 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Latin-script off-map outlier exposure for the #244 coarse-placer (milestone 3). M2's OTHER class
+ *   was trained on NON-Latin/non-CJK scripts (Cyrillic, Arabic, …) from WOF names, so off-map
+ *   COUNTRIES written in Latin script (Poland, Brazil, Mexico, …) still mis-place to a trained Latin
+ *   country (the "Latin-off-map residual"). The fix is REAL off-map addresses (not synthetic name
+ *   variants — see #564: synthetic mass fits its own quirks): assemble address strings from the
+ *   Overture per-country address parquet and append them as `country: "OTHER"`.
+ *
+ *   Discipline: countries split into TRAIN (their rows feed train/val OTHER) and HELDOUT (rows go
+ *   ONLY to the dedicated test file), so we can measure generalization to off-map countries the model
+ *   never saw — not just memorization. The in-map test.jsonl is left UNTOUCHED so the before/after
+ *   in-map regression check stays clean; the Latin metric lives in its own file.
+ *
+ *   Run AFTER build-dataset.mjs + build-outlier-exposure.mjs (it appends). Re-runnable: it rewrites
+ *   the dedicated test file and appends fresh OTHER rows (so don't run it twice onto the same splits
+ *   without rebuilding train/val).
+ *
+ *   Usage: node scripts/coarse-placer/build-outlier-latin.mjs [--per-country 6000]
+ *     [--overture /mnt/playpen/mailwoman-data/overture/2026-05-20.0]
+ */
+import { appendFileSync, writeFileSync } from "node:fs"
+import * as path from "node:path"
+import { parseArgs } from "node:util"
+
+import { DuckDBInstance } from "@duckdb/node-api"
+
+const { values: args } = parseArgs({
+	options: {
+		"per-country": { type: "string", default: "6000" },
+		overture: { type: "string", default: "/mnt/playpen/mailwoman-data/overture/2026-05-20.0" },
+		data: { type: "string", default: path.resolve(import.meta.dirname, "../../data/coarse-placer") },
+	},
+})
+const PER = Number(args["per-country"])
+
+// Off-map (NOT among the 11 trained countries) and Latin-script. TRAIN feeds the OTHER class;
+// HELDOUT is test-only — the generalization probe (unseen off-map countries should still route OTHER).
+// Overture's addresses theme (ALPHA, 2026-05-20.0) only carries rows for a handful of off-map Latin
+// countries: PL/BR/MX/PT/CZ (+ CA/LI already local). TRAIN feeds OTHER; HELDOUT is the
+// generalization probe — CZ (distinct Slavic, unseen) plus CA/LI (the hard near-twins of in-map
+// US/DE: an honest worst case for a coarse placer).
+const TRAIN_COUNTRIES = ["PL", "BR", "MX", "PT"]
+const HELDOUT_COUNTRIES = ["CZ", "CA", "LI"]
+
+/** address_levels arrives as a list (node-api) or its string repr; pull the value strings out. */
+function levelValues(al) {
+	if (Array.isArray(al)) return al.map((x) => (x && x.value ? String(x.value) : "")).filter(Boolean)
+	const s = String(al ?? "")
+	const out = []
+	for (const m of s.matchAll(/'value':\s*'([^']*)'/g)) out.push(m[1])
+	if (!out.length) for (const m of s.matchAll(/"value":\s*"([^"]*)"/g)) out.push(m[1])
+	return out
+}
+
+/** FNV-1a → uint32, for deterministic ordering/variant choice. */
+function hash(s) {
+	let h = 2166136261
+	for (let i = 0; i < s.length; i++) {
+		h ^= s.charCodeAt(i)
+		h = Math.imul(h, 16777619)
+	}
+	return h >>> 0
+}
+
+/** Assemble a plausible address string from an Overture address row. Deterministic variant by hash. */
+function assemble(r) {
+	const num = (r.number ?? "").toString().trim()
+	const street = (r.street ?? "").toString().trim()
+	const pc = (r.postcode ?? "").toString().trim()
+	const levels = levelValues(r.address_levels)
+	const locality = (r.postal_city ? String(r.postal_city) : "") || levels[levels.length - 1] || levels[0] || ""
+	if (!street && !locality) return null // nothing distinctive
+	const head = [num, street].filter(Boolean).join(" ")
+	const tail = [pc, locality].filter(Boolean).join(" ")
+	const h = hash(`${num}|${street}|${pc}|${locality}`)
+	switch (h % 3) {
+		case 0:
+			return [head, tail].filter(Boolean).join(", ")
+		case 1:
+			return [head, locality, pc].filter(Boolean).join(", ").trim()
+		default:
+			return [head, [locality, pc].filter(Boolean).join(" ")].filter(Boolean).join(", ")
+	}
+}
+
+const duck = await (await DuckDBInstance.create()).connect()
+
+async function rowsFor(cc) {
+	const f = path.join(args.overture, `addresses-${cc.toLowerCase()}.parquet`)
+	let res
+	try {
+		res = await duck.runAndReadAll(
+			`SELECT number, street, postcode, postal_city, address_levels FROM read_parquet('${f}') LIMIT ${PER}`
+		)
+	} catch (e) {
+		console.error(`  ${cc}: SKIP (${e.message.split("\n")[0]})`)
+		return []
+	}
+	const seen = new Set()
+	const out = []
+	for (const r of res.getRowObjects()) {
+		const raw = assemble(r)
+		if (!raw || seen.has(raw) || raw.length < 6) continue
+		seen.add(raw)
+		out.push(raw)
+	}
+	return out
+}
+
+const trainAppend = []
+const valAppend = []
+const testRows = [] // dedicated Latin off-map test: {raw, country:"OTHER", group, srcCountry}
+
+for (const cc of TRAIN_COUNTRIES) {
+	const rows = (await rowsFor(cc)).sort((a, b) => hash(a) - hash(b))
+	const nVal = Math.floor(rows.length * 0.1)
+	const nTest = Math.floor(rows.length * 0.1)
+	const val = rows.slice(0, nVal)
+	const test = rows.slice(nVal, nVal + nTest)
+	const train = rows.slice(nVal + nTest)
+	for (const raw of train) trainAppend.push(raw)
+	for (const raw of val) valAppend.push(raw)
+	for (const raw of test) testRows.push({ raw, country: "OTHER", group: "indist", srcCountry: cc })
+	console.log(`  TRAIN ${cc}: ${rows.length} (train ${train.length} / val ${val.length} / test ${test.length})`)
+}
+for (const cc of HELDOUT_COUNTRIES) {
+	const rows = await rowsFor(cc)
+	for (const raw of rows) testRows.push({ raw, country: "OTHER", group: "heldout", srcCountry: cc })
+	console.log(`  HELDOUT ${cc}: ${rows.length} (test-only)`)
+}
+duck.disconnect?.()
+
+// Append OTHER rows to train/val; write the dedicated Latin off-map test file.
+const wr = (rows) => rows.map((raw) => JSON.stringify({ raw, country: "OTHER" })).join("\n") + "\n"
+appendFileSync(path.join(args.data, "train.jsonl"), wr(trainAppend))
+appendFileSync(path.join(args.data, "val.jsonl"), wr(valAppend))
+writeFileSync(
+	path.join(args.data, "test-latin-offmap.jsonl"),
+	testRows.map((r) => JSON.stringify(r)).join("\n") + "\n"
+)
+console.log(`\nappended OTHER → train +${trainAppend.length}, val +${valAppend.length}`)
+console.log(`wrote test-latin-offmap.jsonl: ${testRows.length} rows (indist ${testRows.filter((r) => r.group === "indist").length} / heldout ${testRows.filter((r) => r.group === "heldout").length})`)

--- a/scripts/coarse-placer/eval-latin-offmap.mjs
+++ b/scripts/coarse-placer/eval-latin-offmap.mjs
@@ -1,0 +1,87 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Measure the #244 coarse-placer's handling of the Latin-script off-map residual (milestone 3). A
+ *   Latin off-map address is HANDLED when the model routes it to OTHER or abstains — anything else is
+ *   a confident mis-placement onto a wrong (trained) country. Reports handled-rate overall, by group
+ *   (indist = held-out rows of trained-OTHER countries; heldout = countries never trained), and by
+ *   source country, plus where the misses land. Run baseline (current model) and the M3 retrain
+ *   through this to read the before/after.
+ *
+ *   Usage: node scripts/coarse-placer/eval-latin-offmap.mjs --model <dir> [--abstain 0.5]
+ */
+import { readFileSync } from "node:fs"
+import * as path from "node:path"
+import { parseArgs } from "node:util"
+
+const root = new URL("../../", import.meta.url)
+const { CoarsePlacer } = await import(new URL("core/out/coarse-placer/coarse-placer.js", root).href)
+
+const { values: args } = parseArgs({
+	options: {
+		model: { type: "string", default: "/mnt/playpen/mailwoman-data/coarse-placer/model" },
+		abstain: { type: "string", default: "0.5" },
+		data: { type: "string", default: path.resolve(import.meta.dirname, "../../data/coarse-placer") },
+	},
+})
+
+const meta = JSON.parse(readFileSync(path.join(args.model, "meta.json"), "utf8"))
+const buf = readFileSync(path.join(args.model, "weights.bin"))
+const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+let weights
+if (meta.quantization === "int8-per-row") {
+	const int8 = new Int8Array(ab)
+	const C = meta.classes.length
+	const dim = meta.featureDim
+	weights = new Float32Array(C * dim)
+	for (let c = 0; c < C; c++) {
+		const s = meta.scales[c]
+		const base = c * dim
+		for (let i = 0; i < dim; i++) weights[base + i] = int8[base + i] * s
+	}
+} else {
+	weights = new Float32Array(ab)
+}
+const placer = new CoarsePlacer({ ...meta, weights }, { abstainBelow: Number(args.abstain) })
+
+const rows = readFileSync(path.join(args.data, "test-latin-offmap.jsonl"), "utf8")
+	.trim()
+	.split("\n")
+	.map((l) => JSON.parse(l))
+
+const handled = (p) => p.abstained || p.country === "OTHER"
+const by = {} // key → {n, ok}
+const missTo = {} // wrong country → count
+const bump = (k) => (by[k] ??= { n: 0, ok: 0 })
+let n = 0
+let ok = 0
+const samples = []
+for (const r of rows) {
+	const p = placer.predict(r.raw)
+	const h = handled(p)
+	n++
+	if (h) ok++
+	bump(`group:${r.group}`).n++
+	bump(`cc:${r.srcCountry}`).n++
+	if (h) {
+		bump(`group:${r.group}`).ok++
+		bump(`cc:${r.srcCountry}`).ok++
+	} else {
+		missTo[p.country] = (missTo[p.country] ?? 0) + 1
+		if (samples.length < 8) samples.push(`    ${r.srcCountry} → ${p.country} @${p.confidence.toFixed(2)}  «${r.raw.slice(0, 38)}»`)
+	}
+}
+const pct = (o, m) => `${((100 * o) / m).toFixed(1)}%`
+console.log(`Latin off-map handling — model ${path.basename(args.model)} (abstain ${args.abstain}, n=${n})`)
+console.log(`  OVERALL handled (OTHER-or-abstain): ${ok}/${n} (${pct(ok, n)})  ← want ≥90%`)
+console.log(`  by group:`)
+for (const k of Object.keys(by).filter((k) => k.startsWith("group:")).sort())
+	console.log(`    ${k.slice(6).padEnd(8)} ${pct(by[k].ok, by[k].n)} (n=${by[k].n})`)
+console.log(`  by source country:`)
+for (const k of Object.keys(by).filter((k) => k.startsWith("cc:")).sort())
+	console.log(`    ${k.slice(3).padEnd(4)} ${pct(by[k].ok, by[k].n)} (n=${by[k].n})`)
+const misses = Object.entries(missTo).sort((a, b) => b[1] - a[1])
+if (misses.length) console.log(`  misses land on: ${misses.map(([c, m]) => `${c}:${m}`).join(", ")}`)
+if (samples.length) console.log(`  sample misplacements:\n${samples.join("\n")}`)

--- a/scripts/coarse-placer/eval-quant-compare.mjs
+++ b/scripts/coarse-placer/eval-quant-compare.mjs
@@ -1,0 +1,98 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Accuracy cost of the #244 coarse-placer int8 quantization (milestone 3). Runs the held-out test
+ *   split through the fp32 model and the int8 model (dequantized inline) and reports overall + per-
+ *   class accuracy for each, the delta, prediction-agreement rate, and confidence MAE. Gate: int8
+ *   within ~1pp of fp32 (the milestone target). Uses the already-compiled `core/out` CoarsePlacer
+ *   constructor, so it needs no recompile to validate a fresh quantization.
+ *
+ *   Usage: node scripts/coarse-placer/eval-quant-compare.mjs [--fp32 <dir>] [--int8 <dir>] [--abstain 0.5]
+ */
+import { readFileSync } from "node:fs"
+import * as path from "node:path"
+import { parseArgs } from "node:util"
+
+const root = new URL("../../", import.meta.url)
+const { CoarsePlacer } = await import(new URL("core/out/coarse-placer/coarse-placer.js", root).href)
+
+const { values: args } = parseArgs({
+	options: {
+		fp32: { type: "string", default: "/mnt/playpen/mailwoman-data/coarse-placer/model" },
+		int8: { type: "string", default: "/mnt/playpen/mailwoman-data/coarse-placer/model-int8" },
+		abstain: { type: "string", default: "0.5" },
+		data: { type: "string", default: path.resolve(import.meta.dirname, "../../data/coarse-placer") },
+	},
+})
+const abstainBelow = Number(args.abstain)
+
+function loadFp32(dir) {
+	const meta = JSON.parse(readFileSync(path.join(dir, "meta.json"), "utf8"))
+	const buf = readFileSync(path.join(dir, "weights.bin"))
+	const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+	const weights = new Float32Array(ab)
+	return new CoarsePlacer({ ...meta, weights }, { abstainBelow })
+}
+function loadInt8(dir) {
+	const meta = JSON.parse(readFileSync(path.join(dir, "meta.json"), "utf8"))
+	const buf = readFileSync(path.join(dir, "weights.bin"))
+	const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+	const int8 = new Int8Array(ab)
+	const C = meta.classes.length
+	const dim = meta.featureDim
+	const weights = new Float32Array(C * dim)
+	for (let c = 0; c < C; c++) {
+		const s = meta.scales[c]
+		const base = c * dim
+		for (let i = 0; i < dim; i++) weights[base + i] = int8[base + i] * s
+	}
+	return new CoarsePlacer({ ...meta, weights }, { abstainBelow })
+}
+
+const fp32 = loadFp32(args.fp32)
+const int8 = loadInt8(args.int8)
+
+const test = readFileSync(path.join(args.data, "test.jsonl"), "utf8")
+	.trim()
+	.split("\n")
+	.map((l) => JSON.parse(l))
+
+const classes = JSON.parse(readFileSync(path.join(args.fp32, "meta.json"), "utf8")).classes
+let okF = 0
+let okI = 0
+let agree = 0
+let confMae = 0
+const perF = {}
+const perI = {}
+for (const r of test) {
+	const pf = fp32.predict(r.raw)
+	const pi = int8.predict(r.raw)
+	const cf = pf.country ?? "(abstain)"
+	const ci = pi.country ?? "(abstain)"
+	;(perF[r.country] ??= { n: 0, ok: 0 }).n++
+	;(perI[r.country] ??= { n: 0, ok: 0 }).n++
+	if (cf === r.country) (okF++, perF[r.country].ok++)
+	if (ci === r.country) (okI++, perI[r.country].ok++)
+	if (cf === ci) agree++
+	confMae += Math.abs(pf.confidence - pi.confidence)
+}
+const N = test.length
+const accF = (100 * okF) / N
+const accI = (100 * okI) / N
+console.log(`coarse-placer int8 vs fp32 — test n=${N} (abstain ${abstainBelow})`)
+console.log(`  overall accuracy:  fp32 ${accF.toFixed(2)}%   int8 ${accI.toFixed(2)}%   Δ ${(accI - accF >= 0 ? "+" : "") + (accI - accF).toFixed(2)}pp`)
+console.log(`  prediction agreement (same top class): ${((100 * agree) / N).toFixed(2)}%`)
+console.log(`  confidence MAE: ${(confMae / N).toFixed(4)}`)
+console.log(`  per-class recall (fp32 → int8):`)
+for (const c of classes) {
+	const f = perF[c]
+	const i = perI[c]
+	if (!f) continue
+	const rf = (100 * f.ok) / f.n
+	const ri = (100 * i.ok) / i.n
+	console.log(`    ${c.padEnd(6)} ${rf.toFixed(1)}% → ${ri.toFixed(1)}%  (Δ ${(ri - rf >= 0 ? "+" : "") + (ri - rf).toFixed(1)}pp, n=${f.n})`)
+}
+const verdict = Math.abs(accI - accF) <= 1.0 ? "PASS (within 1pp)" : "FAIL (>1pp drop)"
+console.log(`  gate: ${verdict}`)

--- a/scripts/coarse-placer/quantize.mjs
+++ b/scripts/coarse-placer/quantize.mjs
@@ -1,0 +1,76 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Int8-quantize the #244 coarse-placer (milestone 3). The placer is a linear classifier, so the only
+ *   weight is a dense [class][feature] fp32 matrix (12×65536 = 3.0 MB). Per-CLASS symmetric int8
+ *   quantization — `scale[c] = max(|W[c]|) / 127`, `q = round(W / scale)` clamped to [-127, 127] —
+ *   shrinks it to 0.75 MB (4×) while preserving the linear math exactly up to rounding (the logit is
+ *   `bias[c] + scale[c] * Σ int8`, dequantized on load by `CoarsePlacer.fromArtifactDir`). Per-class
+ *   scales matter because class weight magnitudes differ (OTHER's outlier-exposure rows push bigger
+ *   weights than the in-map countries).
+ *
+ *   Verify the accuracy cost with `scripts/coarse-placer/eval-quant-compare.mjs` (target: within ~1pp).
+ *
+ *   Usage: node scripts/coarse-placer/quantize.mjs [--in <fp32 dir>] [--out <int8 dir>]
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import * as path from "node:path"
+import { parseArgs } from "node:util"
+
+const { values: args } = parseArgs({
+	options: {
+		in: { type: "string", default: "/mnt/playpen/mailwoman-data/coarse-placer/model" },
+		out: { type: "string", default: "/mnt/playpen/mailwoman-data/coarse-placer/model-int8" },
+	},
+})
+
+const meta = JSON.parse(readFileSync(path.join(args.in, "meta.json"), "utf8"))
+const buf = readFileSync(path.join(args.in, "weights.bin"))
+const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+const w = new Float32Array(ab)
+const C = meta.classes.length
+const dim = meta.featureDim
+if (w.length !== C * dim) throw new Error(`weights length ${w.length} ≠ classes×dim ${C * dim}`)
+
+const int8 = new Int8Array(C * dim)
+const scales = []
+let maxAbsErr = 0
+let sumSqErr = 0
+for (let c = 0; c < C; c++) {
+	const base = c * dim
+	let maxAbs = 0
+	for (let i = 0; i < dim; i++) {
+		const a = Math.abs(w[base + i])
+		if (a > maxAbs) maxAbs = a
+	}
+	const scale = maxAbs / 127 || 1 // all-zero row → scale 1 (q stays 0)
+	scales.push(scale)
+	for (let i = 0; i < dim; i++) {
+		let q = Math.round(w[base + i] / scale)
+		if (q > 127) q = 127
+		else if (q < -127) q = -127 // symmetric range; avoid -128 so |q|≤127
+		int8[base + i] = q
+		const err = Math.abs(q * scale - w[base + i])
+		if (err > maxAbsErr) maxAbsErr = err
+		sumSqErr += err * err
+	}
+}
+
+mkdirSync(args.out, { recursive: true })
+writeFileSync(path.join(args.out, "weights.bin"), Buffer.from(int8.buffer))
+writeFileSync(
+	path.join(args.out, "meta.json"),
+	JSON.stringify({ ...meta, quantization: "int8-per-row", scales }, null, 2)
+)
+
+const fp32Bytes = w.length * 4
+const int8Bytes = int8.length
+const rmse = Math.sqrt(sumSqErr / w.length)
+console.log(`coarse-placer int8 quantization`)
+console.log(`  in:  ${args.in}`)
+console.log(`  out: ${args.out}`)
+console.log(`  weights: ${(fp32Bytes / 1e6).toFixed(2)} MB fp32 → ${(int8Bytes / 1e6).toFixed(2)} MB int8 (${(fp32Bytes / int8Bytes).toFixed(1)}×)`)
+console.log(`  per-class scales: [${scales.map((s) => s.toExponential(2)).join(", ")}]`)
+console.log(`  weight reconstruction error: max ${maxAbsErr.toExponential(2)}, rmse ${rmse.toExponential(2)}`)


### PR DESCRIPTION
## #244-M3: coarse-placer is now a small, loadable artifact

The M1+M2 coarse-placer was a 3 MB fp32 weight blob with no disk loader. This makes it shippable.

### int8 quantization — 4× smaller, accuracy-neutral

Per-class symmetric int8 (`scale[c] = max(|W[c]|)/127`), dequantized on load — the linear math is preserved exactly up to rounding.

| | fp32 | int8 |
|---|---:|---:|
| weights.bin | 3.15 MB | **0.79 MB** (4.0×) |
| test accuracy (n=59421) | 94.99% | 94.97% (**−0.01pp**) |
| prediction agreement | — | 99.92% |
| confidence MAE | — | 0.0007 |

Gate **PASS** (within 1pp; measured by `scripts/coarse-placer/eval-quant-compare.mjs`).

### Loader

`CoarsePlacer.fromArtifactDir(dir)` reads `meta.json` + `weights.bin` and handles **both** formats (fp32, and `int8-per-row` via `dequantizeInt8Weights`). node-only via dynamic `import` so the class stays browser-safe.

### Tests

`core/coarse-placer/coarse-placer.test.ts` — self-contained (builds a tiny artifact in a temp dir, no `/mnt/playpen` dependency): fp32 + int8 round-trip, featurize determinism, abstention. **9 tests, green locally.**

### Scope

No pipeline wiring — that's the parked operator decision (opt-in vs default; `@mailwoman/coarse-placer` vs fold into core). The int8 artifact lives beside the fp32 one on disk/R2; this PR is the **format + loader + verification** only. The Latin-off-map accuracy residual (M3's other half) is being probed separately.

> ⚠️ CI install/compile is red until **#579** (lockfile + vite-8 vitest config) merges — pre-existing main breakage, not this branch. Merge #579 first; the coarse-placer test itself is green.
