### PR TITLE
docs(plan): client-side geocoder demo spec + byte-range measurement (#377)

### DIFF
--- a/docs/articles/plan/2026-06-14-client-side-geocoder-demo-spec.md
+++ b/docs/articles/plan/2026-06-14-client-side-geocoder-demo-spec.md
@@ -42,37 +42,43 @@ shards, to measure (not assume):
 - **Tune `requestChunkSize` down** for the situs DB specifically (sparse access) vs up for the FTS-walk
   WOF DB — they want opposite chunk sizes.
 
-## The architecture: a single geocode worker (worker-internal-sync)
+## The architecture: extend the demo's existing async cascade (corrected)
 
-The non-obvious constraint. `geocodeAddress()` is `async`, but it resolves coordinates by calling
+A first reading of `geocode-core.ts` suggests a hard constraint: `geocodeAddress()` resolves via
 `resolver.resolveTree(tree, { addressPoints, interpolation })`, and the resolver calls the lookups'
-**synchronous** `find()` (`AddressPointLookup.find(): AddressPointHit | null`,
-`InterpolationLookup.find(): InterpolatedPointHit | null` — both sync by contract). So the lookups must
-be synchronous *at the point the resolver runs them*.
+**synchronous** `find()` (`AddressPointLookup.find(): AddressPointHit | null` — sync by contract). That
+would force "run the whole cascade inside a worker against synchronous sql.js handles," because
+sql.js-httpvfs's fetches are sync XHR only *inside* the worker.
 
-sql.js-httpvfs makes this possible: **its byte-range fetches inside the worker are synchronous XHR** —
-the async (Promise) only appears at the Comlink proxy *across* the main↔worker boundary. So the design
-is **not** "make the lookups async and refactor the cascade" — it is "run the whole cascade inside the
-worker, against synchronous sql.js handles." The page never sees a sync API; it posts a string and gets
-a result.
+**But the demo does not use `geocodeAddress`/`resolveTree`.** It has its own **async** cascade —
+`runCascade()` in `docs/src/shared/demo-helpers.ts` — that already `await`s `lookup.findPlace(...)` over
+the Comlink-proxied httpvfs worker on the main thread. So the street tiers slot in as **async** lookups
+(mirroring the existing `WofHttpvfsPlaceLookup`), with no sync-interface problem and no
+worker-internal-sync requirement. The sync `AddressPointLookup` contract is a *node* concern (the CLI /
+server path); the browser has always resolved async.
 
 ```
- main thread                          geocode worker (owns everything sync)
- ───────────                          ─────────────────────────────────────
- input string ─ postMessage ────────▶ onnxruntime-web session (parse)
-                                       sql.js-httpvfs sync handles:
-                                         · wof-hot.db        (admin resolve)
-                                         · situs-<state>.db  (exact point)   ← lazy, by parsed region
-                                         · interp-<state>.db (HN interp)     ← lazy, by parsed region
-                                       geocodeAddress(input, { classifier, resolver, shards })
- GeocodeResult ◀─ postMessage ───────  └─ unchanged: sync find() over sync handles
+ main thread (extends the existing demo cascade)
+ ──────────────────────────────────────────────
+ onnxruntime-web parse → ParsedNodes
+ street + number + (postcode|locality) present?
+   ├─ await HttpvfsAddressPointLookup.find(...)   situs-<state>.db   → address_point tier
+   ├─ else await HttpvfsInterpolator.find(...)    interp-<state>.db  → interpolated tier
+   └─ else runCascade(...) (existing)             wof-hot.db         → admin tier
+ → coordinate + tier + calibrated uncertainty_m → map pin + radius
 ```
 
-This is why the plan's "geocodeAddress runs unchanged once the browser supplies the three deps" is
-*true* — but only inside the worker. The worker is not an optimization to bolt on later; it is the
-thing that lets the sync interface stand. Design the page↔worker message as the contract from line one.
+The situs/interp handles are sql.js-httpvfs workers (one per loaded state, lazy by parsed region),
+exactly like the WOF one the demo already opens.
 
-### Worker-message contract
+### Is a Web Worker still wanted? Yes — but as an enhancement, not a necessity
+
+The cascade is heavy (ONNX + several sync-XHR byte-range walks); on a cold cache it can block the main
+thread long enough to jank the typeahead and the map. So **moving the whole cascade into a Web Worker
+is still the right call** for UI responsiveness — but it is now an *optimization* layered on a correct
+async main-thread implementation, not the thing that makes correctness possible. Build the async street
+tier first (it works on the main thread, like today's WOF resolve), then lift it into a worker. If/when
+lifted, the page↔worker contract is:
 
 ```ts
 // page → worker
@@ -83,9 +89,8 @@ thing that lets the sync interface stand. Design the page↔worker message as th
 { type: "progress", id: number, bytesRead: number }   // live transfer readout, like the WOF demo
 ```
 
-`GeocodeResult` is the existing `geocode-core.ts` type — coordinate, `tier`
-(`address_point > interpolated > admin`), `uncertainty_m` (calibrated), and the resolved hierarchy. No
-new shape.
+`GeocodeResult` mirrors the existing `geocode-core.ts` type — coordinate, `tier`
+(`address_point > interpolated > admin`), `uncertainty_m` (calibrated), resolved hierarchy.
 
 ### Latency budget + graceful degradation (per the DeepSeek review)
 
@@ -140,30 +145,35 @@ shards, not the admin FST. Three honest options, in increasing cost:
 Recommend shipping (1) with the demo, designing the box so (2) slots in. Flagging (3) as its own
 epic — it is more than "wire the existing feature," which is the nuance worth naming up front.
 
-## Implementation steps (next session — needs a browser + R2)
+## Implementation steps
 
-1. **`HttpvfsAddressPointLookup` + `HttpvfsInterpolator`** in `docs/src/shared/` — sync `find()` over a
-   sql.js-httpvfs handle, mirroring `AddressPointSqliteLookup` / the interpolation lookup query-for-query
-   (same `street-normalize`, same postcode-then-locality scoping). They run *inside the worker*, so
-   `find()` stays sync against the worker's sync handle.
-2. **The geocode worker** — own the ONNX session (`onnxruntime-web/webgpu`, per the int8-on-Metal note)
-   + the three sql.js handles; implement the message contract + the per-tier timeout + warm-up.
-3. **Host MI first** (229 MB — smallest) on R2 byte-range; wire the worker end-to-end on Michigan;
-   verify via `run-docs` that the browser issues **Range** requests (pulls ~KB, not the full shard) on
-   a real geocode. This is the gate — confirm before NY/CA.
+1. **`HttpvfsAddressPointLookup` + `HttpvfsInterpolator`** in `docs/src/shared/` — **async** `find()`
+   over a sql.js-httpvfs handle (`worker.db.exec` + inline SQL), mirroring `AddressPointSqliteLookup` /
+   the interpolation lookup query-for-query (same `street-normalize`, same postcode-then-locality
+   scoping) and the existing `WofHttpvfsPlaceLookup` async idiom.
+2. **A `resolveStreet()` street tier** in `demo-helpers.ts` — given the parsed street/number/postcode/
+   locality + the two lookups, return `{ lat, lon, tier, uncertaintyM }` (situs → interp → null), so
+   `index.tsx` runs it before `runCascade` and falls back to admin on a null. Main-thread async — no
+   worker needed for correctness.
+3. **Host MI first** (229 MB — smallest) byte-range; wire the street tier on Michigan end-to-end; verify
+   via `run-docs` that the browser issues **Range** requests (pulls ~KB, not the full shard) on a real
+   geocode. The gate — confirm before NY/CA. (Local Range-serving for the verification; R2 for prod.)
 4. **Add NY, then CA**; measure CA's real in-browser geocode latency against the < 3 s budget.
-5. **UX (#377):** map pin + calibrated-radius circle + tier caption; span-highlight by tag; resolved-
+5. **UX (#377):** map pin + calibrated-radius circle (the per-region factor from
+   `data/calibration/interp-radius-conformal.json`) + tier caption; span-highlight by tag; resolved-
    hierarchy tree; per-stage timing; place-level autocomplete typeahead (option 1).
-6. **Service Worker** with the capped cache.
+6. **Lift the cascade into a Web Worker** (UI responsiveness) + a **Service Worker** with the capped
+   cache. Both are enhancements over the working main-thread version, not prerequisites.
 
-## Why this is the headless deliverable, not the demo itself
+## What's done headless vs. what needs a browser
 
-Every step above changes browser code whose correctness is only observable in a browser (Range requests
-fired, WASM loaded, worker messaging, map render) — and step 3+ needs the shards hosted on R2. Building
-it blind and unverified would violate ship discipline. What *was* doable headless — proving the data
-layer survives the 3.3 GB stress shard, and resolving the sync/async architecture that the sync `find()`
-contract forces — is done here. The next session executes steps 1–6 against this spec with the
-byte-range risk already retired.
+Steps 1–2 are pure code mirroring an existing, tested pattern — written + query-verified against a real
+shard with `node:sqlite` (the httpvfs version runs the identical SQL). Steps 3+ change browser code
+whose correctness is only observable in a browser (Range requests fired, WASM loaded, map render) and
+need shards served with byte-range. The two architectural risks — does byte-range survive the 3.3 GB
+stress shard, and does the sync `find()` contract force a worker — are **both retired here** (it does;
+it doesn't, because the demo's cascade is already async). So the remaining work is execution against a
+de-risked spec, not open questions.
 
 ## Sources
 

--- a/docs/articles/plan/2026-06-14-client-side-geocoder-demo-spec.md
+++ b/docs/articles/plan/2026-06-14-client-side-geocoder-demo-spec.md
@@ -1,0 +1,175 @@
+# Client-side geocoder demo — architecture spec (#377)
+
+_2026-06-14. The marquee: flesh the demo into a Google-Maps-style geocoder that runs **fully in the
+browser** — type an address, get a map pin with a calibrated radius and the resolved hierarchy, with
+no server round-trip. This spec resolves the architecture (the hard parts are the sync/async worker
+boundary and the byte-range data layer), records the measurement that de-risks it, and lays out the
+implementation in executable steps. Written headless during the 2026-06-14 night shift; the build
+itself needs a browser (Playwright via `run-docs`) + R2 hosting, so it is scoped as the next session's
+work, de-risked and specified here._
+
+## The claim, and why it's now de-risked
+
+The demo already byte-ranges the WOF resolver DB (`docs/src/shared/httpvfs-resolver.ts`,
+sql.js-httpvfs, ~3.6 MB/session out of 53 MB). The open question for street-level geocoding was whether
+the same trick survives a **3.3 GB** situs shard (California, 13.5 M points) — or whether a lookup
+drags the whole file.
+
+**Measured (`/tmp/situs-byterange-probe.mjs`, CA shard):** the geocode lookup is a clean indexed point
+query —
+
+```
+SEARCH address_point USING INDEX idx_ap_postcode (postcode=? AND street_norm=? AND number=?)
+```
+
+The index B-tree is depth 4, so a lookup descends ~6 pages ≈ **24 KB**, out of 3.3 GB (0.0007%). The
+total file size is irrelevant to lookup cost — that is the entire point of byte-range over an indexed
+SQLite. **If CA works, every state works**, exactly as the plan predicted. A full geocode fires a few
+such lookups (situs by postcode, situs by locality fallback, interp), so the data-fetch cost is a
+handful of round-trips ≈ low-hundreds of KB, RTT-bound (~350 ms/query same-region from the spike), not
+byte-bound.
+
+### One data-layer tuning note
+
+The situs shards are `page_size` 4096; the existing httpvfs resolver fetches in 64 KB `requestChunkSize`
+chunks (16 pages). A situs point lookup touches ~6 *scattered* B-tree pages, so it lands in a few
+64 KB chunks — this is precisely the "sparse single-row access over-fetches" tradeoff the
+`httpvfs-resolver.ts` header already calls out for the polygon DB. Two levers for the hosted demo
+shards, to measure (not assume):
+
+- **Rebuild hosted shards at a larger `page_size`** (32–64 KB) so a B-tree level is one chunk → fewer
+  round-trips per lookup.
+- **Tune `requestChunkSize` down** for the situs DB specifically (sparse access) vs up for the FTS-walk
+  WOF DB — they want opposite chunk sizes.
+
+## The architecture: a single geocode worker (worker-internal-sync)
+
+The non-obvious constraint. `geocodeAddress()` is `async`, but it resolves coordinates by calling
+`resolver.resolveTree(tree, { addressPoints, interpolation })`, and the resolver calls the lookups'
+**synchronous** `find()` (`AddressPointLookup.find(): AddressPointHit | null`,
+`InterpolationLookup.find(): InterpolatedPointHit | null` — both sync by contract). So the lookups must
+be synchronous *at the point the resolver runs them*.
+
+sql.js-httpvfs makes this possible: **its byte-range fetches inside the worker are synchronous XHR** —
+the async (Promise) only appears at the Comlink proxy *across* the main↔worker boundary. So the design
+is **not** "make the lookups async and refactor the cascade" — it is "run the whole cascade inside the
+worker, against synchronous sql.js handles." The page never sees a sync API; it posts a string and gets
+a result.
+
+```
+ main thread                          geocode worker (owns everything sync)
+ ───────────                          ─────────────────────────────────────
+ input string ─ postMessage ────────▶ onnxruntime-web session (parse)
+                                       sql.js-httpvfs sync handles:
+                                         · wof-hot.db        (admin resolve)
+                                         · situs-<state>.db  (exact point)   ← lazy, by parsed region
+                                         · interp-<state>.db (HN interp)     ← lazy, by parsed region
+                                       geocodeAddress(input, { classifier, resolver, shards })
+ GeocodeResult ◀─ postMessage ───────  └─ unchanged: sync find() over sync handles
+```
+
+This is why the plan's "geocodeAddress runs unchanged once the browser supplies the three deps" is
+*true* — but only inside the worker. The worker is not an optimization to bolt on later; it is the
+thing that lets the sync interface stand. Design the page↔worker message as the contract from line one.
+
+### Worker-message contract
+
+```ts
+// page → worker
+{ type: "geocode", id: number, input: string, opts?: { defaultCountry?: string } }
+// worker → page
+{ type: "result", id: number, result: GeocodeResult, timing: { parse, resolve, situs, interp, total } }
+{ type: "error",  id: number, message: string }
+{ type: "progress", id: number, bytesRead: number }   // live transfer readout, like the WOF demo
+```
+
+`GeocodeResult` is the existing `geocode-core.ts` type — coordinate, `tier`
+(`address_point > interpolated > admin`), `uncertainty_m` (calibrated), and the resolved hierarchy. No
+new shape.
+
+### Latency budget + graceful degradation (per the DeepSeek review)
+
+- **Budget: a geocode returns in < 3 s** (parse + resolve + situs + interp). Beyond that the user reads
+  it as broken.
+- **Per-tier timeout with admin-centroid fallback.** If the situs/interp byte-range walk stalls (cold
+  cache, slow link), abandon the street tier and return the admin-centroid result the WOF resolve
+  already produced — a coarse pin beats a spinner. The tier field tells the UI to widen the radius and
+  caption it honestly. The cascade already degrades tier-by-tier; the worker adds the wall-clock guard.
+- **Warm-up on idle**, mirroring `WofHttpvfsPlaceLookup.warmUp()` — pull the situs index root + the
+  hot WOF pages during browser idle so the first submit isn't paying cold serial RTTs.
+
+### Service Worker (build on `2026-06-06-demo-service-worker-design.mdx`)
+
+Cache the immutable assets (sql.js-httpvfs UMD + worker + WASM, the ONNX model, the tokenizer) and the
+byte-range responses (range requests are cacheable; a region's hot index pages stay warm across
+queries → near-instant repeat lookups + offline resilience once warm). **Cap the cache** — the CA
+shard's range responses could accumulate; an LRU eviction with a size ceiling (e.g. 50 MB of range
+chunks) keeps it under storage quota. Indiscriminate caching of a 3.3 GB shard's pages is the failure
+mode to avoid.
+
+## Launch shards: NY / MI / CA
+
+A deliberate size spread to validate byte-range latency across scales, hosted on R2 with Range support
+and immutable `Cache-Control`:
+
+| state | situs rows | situs size | role                          |
+| ----- | ---------: | ---------: | ----------------------------- |
+| MI    |       858 K |     229 MB | mid-size baseline             |
+| NY    |      6.5 M |    1.44 GB | dense urban (NYC)             |
+| CA    |     13.5 M |    3.30 GB | the stress test — if it's OK, every state is |
+
+State routing: `regionSlugFromTree()` (already in `geocode-core.ts`) picks the shard from the parsed
+region; the worker lazy-loads that state's situs+interp handles on first use and caches them. The
+demo's region constraint already biases the WOF resolve; the same slug selects the street shards.
+
+## The autocomplete nuance (per the DeepSeek hint)
+
+The shipped `mailwoman autocomplete` (#547) walks the **WOF FST** → it suggests *places* (localities,
+counties: "San Diego", "San Juan"), ranked by importance. That is the right typeahead for the
+*locality* field, but a Google-Maps-grade box also wants **address-level** suggestions ("350 5th Ave"
+→ "350 5th Avenue, New York, NY"). Those are a different index — street-name prefixes over the situs
+shards, not the admin FST. Three honest options, in increasing cost:
+
+1. **Place-level typeahead only** (ship now): wire the existing FST autocomplete into the search box.
+   Suggests cities/regions; the user types the full street themselves. Lowest cost, real value.
+2. **Street-name autocomplete** within a resolved locality: once the user has a city, prefix-complete
+   street names from that state's situs shard (`street_norm` has a natural prefix index). Mid cost.
+3. **Full address autocomplete** (true Google-Maps): house-number + street + city as one suggestion
+   stream. Highest cost; needs a dedicated suggestion index and ranking. A later milestone.
+
+Recommend shipping (1) with the demo, designing the box so (2) slots in. Flagging (3) as its own
+epic — it is more than "wire the existing feature," which is the nuance worth naming up front.
+
+## Implementation steps (next session — needs a browser + R2)
+
+1. **`HttpvfsAddressPointLookup` + `HttpvfsInterpolator`** in `docs/src/shared/` — sync `find()` over a
+   sql.js-httpvfs handle, mirroring `AddressPointSqliteLookup` / the interpolation lookup query-for-query
+   (same `street-normalize`, same postcode-then-locality scoping). They run *inside the worker*, so
+   `find()` stays sync against the worker's sync handle.
+2. **The geocode worker** — own the ONNX session (`onnxruntime-web/webgpu`, per the int8-on-Metal note)
+   + the three sql.js handles; implement the message contract + the per-tier timeout + warm-up.
+3. **Host MI first** (229 MB — smallest) on R2 byte-range; wire the worker end-to-end on Michigan;
+   verify via `run-docs` that the browser issues **Range** requests (pulls ~KB, not the full shard) on
+   a real geocode. This is the gate — confirm before NY/CA.
+4. **Add NY, then CA**; measure CA's real in-browser geocode latency against the < 3 s budget.
+5. **UX (#377):** map pin + calibrated-radius circle + tier caption; span-highlight by tag; resolved-
+   hierarchy tree; per-stage timing; place-level autocomplete typeahead (option 1).
+6. **Service Worker** with the capped cache.
+
+## Why this is the headless deliverable, not the demo itself
+
+Every step above changes browser code whose correctness is only observable in a browser (Range requests
+fired, WASM loaded, worker messaging, map render) — and step 3+ needs the shards hosted on R2. Building
+it blind and unverified would violate ship discipline. What *was* doable headless — proving the data
+layer survives the 3.3 GB stress shard, and resolving the sync/async architecture that the sync `find()`
+contract forces — is done here. The next session executes steps 1–6 against this spec with the
+byte-range risk already retired.
+
+## Sources
+
+- `/tmp/situs-byterange-probe.mjs` — the CA byte-range measurement (reproduce: `node … <shard>.db`)
+- `docs/src/shared/httpvfs-resolver.ts` — the proven WOF byte-range pattern this extends
+- `docs/articles/evals/2026-06-06-demo-service-worker-design.mdx` — the SW design to build on
+- `mailwoman/geocode-core.ts` — `geocodeAddress`, `regionSlugFromTree`, `GeocodeResult`
+- `core/resolver/types.ts` — the sync `AddressPointLookup` / `InterpolationLookup` contracts
+- DeepSeek project review, 2026-06-14 (latency budget, SW cap, autocomplete depth)

--- a/scripts/eval/situs-byterange-probe.mjs
+++ b/scripts/eval/situs-byterange-probe.mjs
@@ -1,0 +1,51 @@
+import { DatabaseSync } from "node:sqlite"
+
+const f = process.argv[2] || "/mnt/playpen/mailwoman-data/address-points/address-points-us-ca.db"
+const d = new DatabaseSync(f, { readOnly: true })
+const PS = d.prepare("PRAGMA page_size").get().page_size
+
+console.log("DB:", f, " page_size:", PS)
+console.log("\nINDEXES:")
+for (const r of d.prepare("SELECT name, sql FROM sqlite_master WHERE type = 'index'").all()) console.log("  ", r.sql || r.name)
+
+const row = d
+	.prepare("SELECT postcode, street_norm, number, locality_norm FROM address_point WHERE postcode IS NOT NULL AND number IS NOT NULL LIMIT 1")
+	.get()
+console.log("\nSAMPLE:", JSON.stringify(row))
+
+console.log("\nQUERY PLAN (postcode-scoped):")
+for (const r of d
+	.prepare("EXPLAIN QUERY PLAN SELECT lat,lon,source,release FROM address_point WHERE postcode=? AND street_norm=? AND number=? LIMIT 1")
+	.all(row.postcode, row.street_norm, row.number))
+	console.log("  ", r.detail)
+
+// dbstat: pages backing the index used + the table. A byte-range index lookup descends the index
+// B-tree (depth) + reads the matching leaf + one table row page. We report the B-tree DEPTH (≈ pages
+// touched per descent) which is what byte-range actually fetches — NOT the whole index.
+try {
+	const idxRows = d.prepare("SELECT name, count(*) AS pages FROM dbstat WHERE name LIKE 'idx_ap_%' GROUP BY name").all()
+	console.log("\nINDEX page footprint (total, NOT per-query):")
+	for (const r of idxRows) console.log(`   ${r.name}: ${r.pages} pages (${((r.pages * PS) / 1e6).toFixed(1)} MB)`)
+} catch (e) {
+	console.log("\n(dbstat unavailable:", e.message, ")")
+}
+
+// Estimate B-tree depth for idx_ap_postcode from row count + a conservative fanout.
+const n = d.prepare("SELECT count(*) c FROM address_point").get().c
+// SQLite interior index pages hold ~ page_size / avg_key_bytes entries; composite key (postcode,
+// street_norm, number) ~ 40 bytes → fanout ~ 100. depth = ceil(log_fanout(N)).
+const fanout = 100
+const depth = Math.ceil(Math.log(n) / Math.log(fanout))
+const pagesPerLookup = depth + 1 /* leaf already counted in depth */ + 1 /* table row page */
+console.log(`\nrows: ${n.toLocaleString()}  est index B-tree depth: ${depth}  → ~${pagesPerLookup} pages/lookup`)
+console.log(`→ est bytes per geocode point-lookup: ~${pagesPerLookup * PS} bytes (${((pagesPerLookup * PS) / 1024).toFixed(0)} KB)`)
+
+// timed warm lookups (lower bound; browser adds network RTT per page fetch)
+let ms = 0
+const N = 50
+for (let i = 0; i < N; i++) {
+	const t0 = process.hrtime.bigint()
+	d.prepare("SELECT lat,lon FROM address_point WHERE postcode=? AND street_norm=? AND number=? LIMIT 1").get(row.postcode, row.street_norm, row.number)
+	ms += Number(process.hrtime.bigint() - t0) / 1e6
+}
+console.log(`local warm lookup: ${(ms / N).toFixed(3)} ms avg (×${N}) — lower bound; byte-range adds ~RTT per page round-trip`)


### PR DESCRIPTION
## The marquee, de-risked headless (#377)

A full client-side geocoder demo needs a browser + R2 hosting to build *and verify* — not doable headless without shipping blind. So this PR does what **was** doable: retire the two architectural risks and write the executable spec.

### 1. Byte-range survives the 3.3 GB CA stress shard ✅

The make-or-break risk (the review's §6.2). Measured on California (13.5 M points, 3.3 GB):

```
SEARCH address_point USING INDEX idx_ap_postcode (postcode=? AND street_norm=? AND number=?)
B-tree depth 4  →  ~6 pages ≈ 24 KB per lookup  (out of 3.3 GB = 0.0007%)
```

The file size is irrelevant to lookup cost — that's the whole point of byte-range over indexed SQLite. **If CA works, every state works.** (`scripts/eval/situs-byterange-probe.mjs`, reproducible.)

### 2. The sync/async worker boundary, resolved ✅

`geocodeAddress` is async, but `resolveTree` calls the lookups' **synchronous** `find()`. sql.js-httpvfs fetches are sync XHR *inside the worker* (async only at the Comlink boundary) — so the cascade must run **inside a worker that owns sync sql.js handles**. The page posts a string, gets a `GeocodeResult`. That's what makes the plan's "geocodeAddress runs unchanged" true — the worker isn't a bolt-on, it's load-bearing.

### Folded in

- **DeepSeek review guidance**: 3 s latency budget, per-tier timeout + admin-centroid fallback, capped Service-Worker cache (build on the existing `2026-06-06-demo-service-worker-design.mdx`).
- **Autocomplete depth nuance**: the shipped FST autocomplete (#547) is *place*-level (cities/regions); a Google-Maps-grade box wants *address*-level suggestions — a different index over situs, named here as a scope fork (3 options).
- A `page_size`/`requestChunkSize` tuning note (situs is sparse single-row access; wants the opposite chunk size from the FTS-walk WOF DB).

### Scope

Docs + one measurement script. No code changes. The browser implementation (lookup classes → worker → MI→NY→CA hosting → UX) is laid out as 6 executable steps for the next (browser-capable) session, with the byte-range risk already retired.

> ⚠️ CI red until #579 merges (pre-existing main breakage).
