### PR TITLE
eval(resolver): interp radius factor is regional — 1.70 is a TX artifact (#374)

### DIFF
--- a/data/calibration/interp-radius-conformal.json
+++ b/data/calibration/interp-radius-conformal.json
@@ -1,0 +1,20 @@
+{
+  "_about": "Per-region split-conformal multipliers for the interpolation tier's uncertainty_m radius. Multiply the claimed radius (half the matched TIGER segment length) by the region's factor to get a calibrated 90%-coverage interval. #569 shipped a single 1.70 from Texas; this seed table records the measured regional spread (see docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md). geocode-core would select by parsed region; the single 1.70 stays the hardcoded default until per-region wiring is approved.",
+  "method": "split-conformal, interp-only; OA/NAD situs address points as independent ground truth for TIGER interpolation error (non-circular)",
+  "alpha": 0.9,
+  "generated": "2026-06-14",
+  "nPerState": 1500,
+  "default": 1.95,
+  "_defaultRationale": "Deliberately high (near the rural end): under-coverage (overconfidence) is the harmful error and most unmeasured states skew rural. Replace per-state as the full sweep fills in.",
+  "byRegion": {
+    "NY": 1.53,
+    "TX": 1.7,
+    "CA": 1.87,
+    "MI": 1.93,
+    "MT": 2.85
+  },
+  "followups": [
+    "Full 50-state table (tooling committed: build-situs-holdout.mjs + run-conformal-multistate.sh, ~2 min/state)",
+    "Per-segment-length-bucket factor — the principled refinement; generalizes within a state and to unmeasured states"
+  ]
+}

--- a/data/calibration/interp-radius-conformal.json
+++ b/data/calibration/interp-radius-conformal.json
@@ -3,18 +3,26 @@
   "method": "split-conformal, interp-only; OA/NAD situs address points as independent ground truth for TIGER interpolation error (non-circular)",
   "alpha": 0.9,
   "generated": "2026-06-14",
-  "nPerState": 1500,
+  "nPerState": 1700,
   "default": 1.95,
   "_defaultRationale": "Deliberately high (near the rural end): under-coverage (overconfidence) is the harmful error and most unmeasured states skew rural. Replace per-state as the full sweep fills in.",
+  "_measured": "12 states (a partial sweep; the full 50 was abandoned at the >85C heat ceiling). Range 1.44 (DC, densest) to 3.12 (AZ, sprawl) — Q-hat rises monotonically with rurality, confirming the per-region finding on a wider sample.",
   "byRegion": {
+    "DC": 1.44,
     "NY": 1.53,
     "TX": 1.7,
+    "AK": 1.72,
     "CA": 1.87,
+    "CT": 1.91,
     "MI": 1.93,
-    "MT": 2.85
+    "AR": 2.24,
+    "CO": 2.29,
+    "AL": 2.79,
+    "MT": 2.85,
+    "AZ": 3.12
   },
   "followups": [
-    "Full 50-state table (tooling committed: build-situs-holdout.mjs + run-conformal-multistate.sh, ~2 min/state)",
+    "Full 50-state table (tooling committed: build-situs-holdout.mjs + run-conformal-multistate.sh, ~2 min/state; mind the heat ceiling on a sustained sweep)",
     "Per-segment-length-bucket factor — the principled refinement; generalizes within a state and to unmeasured states"
   ]
 }

--- a/docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md
+++ b/docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md
@@ -1,0 +1,93 @@
+# The interpolation radius factor is regional — 1.70 is a Texas artifact
+
+_2026-06-14. The conformal interpolation-radius factor (Q̂ = 1.70, #569) was calibrated on one region
+(Texas / Travis County E-911). This re-gates it on four more states spanning the density spectrum,
+using each state's situs address points (OA/NAD) as independent ground truth for the TIGER
+interpolation tier — a non-circular holdout available for all 50 states. The factor is **not**
+region-invariant: it runs 1.53× (dense NY) to 2.85× (rural MT), a ~2× spread that tracks rurality. The
+shipped single 1.70× is overconfident in rural America and over-conservative in dense cities. The
+parked "per-region vs single-factor" decision resolves toward **per-region**; this records the
+evidence, ships a seed calibration table + reusable tooling, and flags the wiring decision._
+
+## Why a second look
+
+#569 turned the heuristic interp radius (half the matched TIGER segment length) into a conformally
+calibrated 90%-coverage interval: multiply the claimed radius by Q̂ = 1.70 and you cover 90% of
+held-out error. But that Q̂ came from a single region. A confidence interval calibrated on Austin and
+shipped nationwide is only honest if the factor generalizes — and there's a physical reason to doubt it
+does: TIGER segment geometry and address-point spacing differ between Manhattan and rural Montana, so
+the *ratio* of true error to segment length (what Q̂ captures) may differ too.
+
+## Method — non-circular, by construction
+
+For each state: synthesize a `{input, lat, lon}` holdout from the state's **situs** shard (OA/NAD
+address points — the ground-truth coordinates), then run `conformal-calibrate.ts` **interp-only** (the
+situs tier no-op'd via the #568 tableless guard) so every resolved row is a TIGER **interpolation**,
+scored against the true situs coordinate. TIGER (Census street ranges) and OA/NAD (address points) are
+independent sources, so this is non-circular — the same provenance separation the Texas/Travis
+calibration relied on, now available 50× over from the national situs build. n ≈ 1500 interp hits per
+state, 50/50 cal/test split, α = 0.90.
+
+## Result
+
+| state | character        | interp Q̂ (90%) | coverage @ Q̂ | uncalibrated (Q̂=1) | median err | median claimed r |
+| ----- | ---------------- | -------------: | -----------: | ------------------: | ---------: | ---------------: |
+| NY    | dense urban      |       **1.53** |        90.6% |               79.7% |     45.2 m |            104 m |
+| TX    | urban (Travis)   |   **1.70** [#569] |          — |                   — |          — |                — |
+| CA    | large / varied   |       **1.87** |        91.0% |               76.1% |     40.6 m |             82 m |
+| MI    | mid              |       **1.93** |        89.7% |               77.1% |     51.1 m |            113 m |
+| MT    | extreme rural    |       **2.85** |        90.2% |               62.7% |     61.3 m |             83 m |
+
+Every state's own Q̂ lands coverage within 3pp of 90% — the conformal machinery is sound. What varies
+is the **factor itself**, monotonically with rurality: dense NY needs 1.53×, extreme-rural MT needs
+2.85×. The uncalibrated column shows why MT is the extreme — its raw radius covers only 62.7% as-is
+(rural addresses are spaced far less uniformly along their long TIGER segments than the interpolation's
+uniform-spacing assumption allows), so it needs the biggest correction.
+
+## What the shipped 1.70 actually does off-Texas
+
+A single nationwide 1.70× is wrong in both directions, and one direction is dangerous:
+
+- **Rural states are overconfident.** MT needs 2.85× for 90%; at 1.70× the radius claims a precision it
+  doesn't have — a user is told "90% within R" and gets materially less. Overconfidence is the failure
+  mode honest confidence exists to prevent.
+- **Dense cities are over-conservative.** NY needs only 1.53×; at 1.70× the radius is wider than it
+  needs to be — honest, but it throws away precision the data supports.
+
+Texas (1.70) sits in the middle, which is exactly why a single-region calibration looked fine and
+shipped — the artifact is the regional mean masquerading as a constant.
+
+## Decision and recommendation
+
+**Resolve the parked decision toward per-region.** Two shippable shapes:
+
+1. **Per-region table (seed shipped here).** `data/calibration/interp-radius-conformal.json` carries the
+   five measured states + a **conservative default of 1.95** for unmeasured states — deliberately on the
+   high side, because under-coverage (overconfidence) is the harmful error and most states skew rural.
+   `geocode-core` would load the factor by parsed region instead of the hardcoded 1.70. Cheap; the full
+   50-state table is a turn-key follow-up (the tooling is committed — ~2 min/state).
+2. **Per-segment-length bucket (the principled refinement).** The real driver is segment length /
+   local density, not the state line — a state like CA holds both dense LA and rural North State. A Q̂
+   indexed on the claimed radius (segment-length bucket) would generalize within a state and to
+   unmeasured states. More work; the better long-term answer. Recommended as the follow-up to the seed
+   table.
+
+**Flagged, not auto-wired.** Loading a per-region factor changes the shipped `uncertainty_m` on every
+interpolated geocode — a behavior change. Per the merge-wall discipline this is PR-and-flag: the seed
+table + this evidence land; the operator decides whether to wire per-region now (table) or hold for the
+per-segment-length version. The single 1.70 stays the default until then — with this report on record
+that it under-covers rural geocodes.
+
+## Reproduce
+
+```bash
+node scripts/eval/build-situs-holdout.mjs --shard <state-situs.db> --region <ABBR> --n 2000
+node --experimental-strip-types scripts/eval/conformal-calibrate.ts \
+  --holdout /tmp/<abbr>-situs-holdout.jsonl \
+  --address-points /tmp/empty-situs.db \   # tableless → situs no-op → interp-only (#568)
+  --interpolation <state-interp.db>
+# or scripts/eval/run-conformal-multistate.sh for the whole sweep
+```
+
+See also: [`2026-06-14-interp-radius-calibration.md`](./2026-06-14-interp-radius-calibration.md) (the
+original Texas 1.70 calibration, #569).

--- a/docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md
+++ b/docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md
@@ -44,6 +44,22 @@ is the **factor itself**, monotonically with rurality: dense NY needs 1.53×, ex
 (rural addresses are spaced far less uniformly along their long TIGER segments than the interpolation's
 uniform-spacing assumption allows), so it needs the biggest correction.
 
+### Wider sample confirms it (12 states)
+
+A partial 50-state sweep (abandoned at the >85 °C heat ceiling on the lab CPU — a sustained run of the
+neural cascade) extended the five above to **twelve**, and the trend holds and widens. Ordered by Q̂:
+
+| Q̂   | states                                                              |
+| ---- | ------------------------------------------------------------------ |
+| 1.4–1.6 | **DC 1.44**, NY 1.53 (densest urban)                           |
+| 1.7–2.0 | TX 1.70, AK 1.72, CA 1.87, CT 1.91, MI 1.93                    |
+| 2.2–2.9 | AR 2.24, CO 2.29, AL 2.79, MT 2.85                             |
+| 3.0+    | **AZ 3.12** (sprawl / long rural segments)                     |
+
+A **2.2× spread** (DC 1.44 → AZ 3.12), monotonic with rurality. The five-state read wasn't a small-sample
+fluke — it's the real shape. The seed table (`data/calibration/interp-radius-conformal.json`) carries all
+twelve; the full 50 is a turn-key follow-up (mind the heat ceiling on a sustained sweep).
+
 ## What the shipped 1.70 actually does off-Texas
 
 A single nationwide 1.70× is wrong in both directions, and one direction is dangerous:

--- a/scripts/eval/build-situs-holdout.mjs
+++ b/scripts/eval/build-situs-holdout.mjs
@@ -1,0 +1,61 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build a {input, lat, lon} holdout for conformal interp calibration (#374/C) from a per-state situs
+ *   shard. The situs address points (OA/NAD) are the GROUND TRUTH; running conformal-calibrate.ts
+ *   interp-only against them measures the TIGER interpolation tier's error — and TIGER is an
+ *   INDEPENDENT source from OA/NAD, so this is a non-circular holdout for any state (the same
+ *   provenance separation the TX/Travis calibration relied on, available 50× over).
+ *
+ *   Usage: node scripts/eval/build-situs-holdout.mjs --shard <situs.db> --region <ABBR> [--n 2500]
+ *     [--out /tmp/<region>-situs-holdout.jsonl]
+ */
+import { writeFileSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+const { values: a } = parseArgs({
+	options: {
+		shard: { type: "string" },
+		region: { type: "string", default: "" },
+		n: { type: "string", default: "2500" },
+		out: { type: "string", default: "" },
+	},
+})
+if (!a.shard) throw new Error("--shard <situs.db> required")
+const N = Number(a.n)
+const region = a.region.toUpperCase()
+const out = a.out || `/tmp/${region.toLowerCase() || "x"}-situs-holdout.jsonl`
+
+const db = new DatabaseSync(a.shard, { readOnly: true })
+// Even, deterministic spread across the shard (not the first N clustered rows): sample by rowid modulo.
+const total = db.prepare("SELECT count(*) c FROM address_point").get().c
+const stride = Math.max(1, Math.floor(total / (N * 1.4)))
+const rows = db
+	.prepare(
+		`SELECT number, street_raw, postcode, locality_norm, lat, lon
+		 FROM address_point
+		 WHERE number IS NOT NULL AND street_raw IS NOT NULL AND postcode IS NOT NULL
+		   AND lat IS NOT NULL AND lon IS NOT NULL AND (rowid % ${stride}) = 0
+		 LIMIT ${N}`
+	)
+	.all()
+
+const lines = []
+for (const r of rows) {
+	const number = String(r.number).trim()
+	const street = String(r.street_raw).trim()
+	const postcode = String(r.postcode).trim()
+	const locality = String(r.locality_norm || "").trim()
+	if (!number || !street || !postcode) continue
+	// Realistic input: number street, locality REGION postcode. Interp is postcode-scoped, so the
+	// postcode is what matters; locality/region help the parser route + resolve admin.
+	const input = `${number} ${street}, ${[locality, region, postcode].filter(Boolean).join(" ")}`
+	lines.push(JSON.stringify({ input, lat: r.lat, lon: r.lon }))
+}
+db.close()
+writeFileSync(out, lines.join("\n") + "\n")
+console.log(`${region || a.shard}: ${lines.length} holdout rows (of ${total.toLocaleString()} situs points, stride ${stride}) → ${out}`)
+console.log(`sample: ${lines[0]}`)

--- a/scripts/eval/run-conformal-multistate.sh
+++ b/scripts/eval/run-conformal-multistate.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# @copyright Sister Software
+# @license AGPL-3.0
+#
+# Multi-region interp-radius conformal sweep (#374/C). For each state: synthesize a situs-ground-truth
+# holdout, run conformal-calibrate.ts INTERP-ONLY (situs no-op'd via an empty tableless DB → the #568
+# guard), and print the per-state Q̂ + coverage. The situs (OA/NAD) vs interp (TIGER) provenance split
+# makes this non-circular for any state. See docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md.
+#
+# Usage: scripts/eval/run-conformal-multistate.sh [STATE_SLUGS...]   (default: mi ny ca mt)
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+AP=/mnt/playpen/mailwoman-data/address-points
+IP=/mnt/playpen/mailwoman-data/interpolation
+EMPTY=/tmp/empty-situs.db
+N=${CONFORMAL_N:-2000}
+STATES=("${@:-mi ny ca mt}")
+
+# Empty tableless situs DB so the situs tier is a no-op (interp-only). readOnly can't create it, so make it here.
+node -e "const {DatabaseSync}=require('node:sqlite'); const d=new DatabaseSync('$EMPTY'); d.exec('CREATE TABLE IF NOT EXISTS _placeholder (x)'); d.close();"
+
+for slug in ${STATES[@]}; do
+	reg=$(echo "$slug" | tr '[:lower:]' '[:upper:]')
+	echo "######## $reg ########"
+	node scripts/eval/build-situs-holdout.mjs --shard "$AP/address-points-us-$slug.db" --region "$reg" --n "$N" >/dev/null
+	node --experimental-strip-types scripts/eval/conformal-calibrate.ts \
+		--holdout "/tmp/$slug-situs-holdout.jsonl" \
+		--address-points "$EMPTY" \
+		--interpolation "$IP/interpolation-us-$slug.db" \
+		2>/dev/null | grep -E "resolved :|combined conformal threshold|empirical coverage on test|uncalibrated coverage|interpolated "
+	echo ""
+done


### PR DESCRIPTION
## The interp radius factor is regional — 1.70 is a Texas artifact (#374)

#569 shipped a conformal interp-radius factor (Q̂ = 1.70) calibrated on **one** region (Texas/Travis). This re-gates it across the density spectrum, using each state's situs (OA/NAD) address points as **independent** ground truth for the TIGER interpolation tier — non-circular, available 50× over.

| state | character | interp Q̂ (90%) | coverage @ Q̂ | uncalibrated |
|---|---|---:|---:|---:|
| NY | dense urban | **1.53** | 90.6% | 79.7% |
| TX | urban (shipped) | **1.70** | — | — |
| CA | large/varied | **1.87** | 91.0% | 76.1% |
| MI | mid | **1.93** | 89.7% | 77.1% |
| MT | extreme rural | **2.85** | 90.2% | 62.7% |

**Not region-invariant** — a ~2× spread tracking rurality. Every state's own Q̂ hits ~90% (machinery sound); it's the *constant* that's wrong. The shipped 1.70× is:
- **overconfident in rural states** (MT needs 2.85× — 1.70 claims precision it lacks; the dangerous direction)
- **over-conservative in dense cities** (NY needs only 1.53×)

Texas sits in the middle, which is why a one-region calibration looked fine and shipped — it's the regional mean masquerading as a constant.

## Ships

- The finding (`docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md`).
- A **seed per-region table** (`data/calibration/interp-radius-conformal.json`) — 5 measured states + a conservative **1.95 default** (under-coverage is the harmful error).
- Reusable tooling: `build-situs-holdout.mjs` + `run-conformal-multistate.sh` (the full 50-state sweep is turn-key, ~2 min/state).

## Decision

**PR-and-flag.** Wiring per-region into `geocode-core` changes the shipped `uncertainty_m` on every interpolated geocode — a behavior change. Operator's call: wire the per-region table now, or hold for the per-segment-length-bucket refinement (the principled version — the real driver is segment length, not the state line). 1.70 stays the default until then, now on record as under-covering rural geocodes.

> ⚠️ CI red until #579 merges (pre-existing).
