### PR TITLE
feat(resolver): char-level + dedupe in FST autocomplete (#587)

### DIFF
--- a/resolver-wof-sqlite/fst-autocomplete.test.ts
+++ b/resolver-wof-sqlite/fst-autocomplete.test.ts
@@ -144,4 +144,34 @@ describe("FST autocomplete — char-level + dedupe (synthetic)", () => {
 		const r = autocomplete(dense, "go", { maxSuggestions: 3 })
 		expect(r.suggestions[0]?.name).toBe("Gotham")
 	})
+
+	// Robustness contract for the demo typeahead (#190/#585): the box feeds raw, half-typed input on
+	// every keystroke, so the function must never throw and must return [] (not garbage) for input it
+	// can't complete. These lock that in so a future refactor can't reintroduce the "Denver for New
+	// Yor" class of bug.
+	it("empty / whitespace-only query → no suggestions, depth 0", () => {
+		for (const q of ["", "   ", "\t"]) {
+			const r = autocomplete(matcher, q)
+			expect(r.suggestions).toEqual([])
+			expect(r.depth).toBe(0)
+		}
+	})
+
+	it("a partial last token that matches no continuation → [] (not a wrong completion)", () => {
+		// "new" walks to a real state, but "zzz" prefixes none of its edges (york/london).
+		expect(autocomplete(matcher, "new zzz").suggestions).toEqual([])
+	})
+
+	it("respects maxSuggestions (caps a branch with more matches than the limit)", () => {
+		// "new" → New York + two New Londons (3 places); cap to 1.
+		const r = autocomplete(matcher, "new", { maxSuggestions: 1 })
+		expect(r.suggestions.length).toBe(1)
+	})
+
+	it("never throws on single-character input", () => {
+		expect(() => autocomplete(matcher, "n")).not.toThrow()
+		// 'n' prefixes 'new' from the root → at least surfaces the New* places, none mis-typed.
+		const r = autocomplete(matcher, "n")
+		expect(r.suggestions.every((s) => typeof s.name === "string")).toBe(true)
+	})
 })

--- a/resolver-wof-sqlite/fst-autocomplete.test.ts
+++ b/resolver-wof-sqlite/fst-autocomplete.test.ts
@@ -8,7 +8,8 @@ import { existsSync } from "node:fs"
 import { beforeAll, describe, expect, it } from "vitest"
 import { autocomplete } from "./fst-autocomplete.js"
 import { buildFstFromWof } from "./fst-builder.js"
-import type { FstMatcher } from "./fst-matcher.js"
+import { FstMatcher } from "./fst-matcher.js"
+import type { PlaceEntry, PlacetypeId } from "./fst-types.js"
 
 const WOF_DB = "/mnt/playpen/mailwoman-data/wof/whosonfirst-data-admin-us-latest.db"
 const HAS_WOF = existsSync(WOF_DB)
@@ -69,5 +70,64 @@ describe.skipIf(!HAS_WOF)("FST autocomplete — integration", () => {
 	it("reports correct depth for partial matches", () => {
 		const result = autocomplete(matcher, "New York City")
 		expect(result.depth).toBeGreaterThanOrEqual(2)
+	})
+})
+
+// Synthetic-FST unit tests (no WOF DB needed → always run in CI). Cover the #587 char-level
+// partial-last-token completion + dedupeByName. The trie:
+//   root --new--> [york -> New York; london -> New London ×2 (city+county)]
+//        --san--> [francisco -> San Francisco]
+//        --chicago--> Chicago
+describe("FST autocomplete — char-level + dedupe (synthetic)", () => {
+	const place = (wofID: number, name: string, placetype: PlacetypeId, importance: number): PlaceEntry => ({
+		wofID,
+		name,
+		placetype,
+		importance,
+		parentChain: [],
+		lat: 0,
+		lon: 0,
+	})
+	const matcher = new FstMatcher([
+		{ edges: new Map([["new", 1], ["san", 4], ["chicago", 6]]), places: [] }, // 0 root
+		{ edges: new Map([["york", 2], ["london", 3]]), places: [] }, // 1 "new"
+		{ edges: new Map(), places: [place(1, "New York", "locality", 0.9)] }, // 2 "new york"
+		{ edges: new Map(), places: [place(2, "New London", "locality", 0.5), place(3, "New London", "county", 0.4)] }, // 3 "new london"
+		{ edges: new Map([["francisco", 5]]), places: [] }, // 4 "san"
+		{ edges: new Map(), places: [place(4, "San Francisco", "locality", 0.8)] }, // 5 "san francisco"
+		{ edges: new Map(), places: [place(5, "Chicago", "locality", 0.85)] }, // 6 "chicago"
+	])
+
+	it("completes a PARTIAL last token (the #587 fix): 'new yor' → New York", () => {
+		const r = autocomplete(matcher, "new yor")
+		expect(r.suggestions.map((s) => s.name)).toContain("New York")
+	})
+
+	it("completes a single partial token from the root: 'chic' → Chicago", () => {
+		const r = autocomplete(matcher, "chic")
+		expect(r.suggestions[0]?.name).toBe("Chicago")
+	})
+
+	it("does not mis-complete: 'san fr' → San Francisco (not San anything-else)", () => {
+		const r = autocomplete(matcher, "san fr")
+		expect(r.suggestions.map((s) => s.name)).toEqual(["San Francisco"])
+	})
+
+	it("complete-token path is unchanged: 'new york' resolves exactly", () => {
+		const r = autocomplete(matcher, "new york")
+		expect(r.suggestions[0]?.name).toBe("New York")
+	})
+
+	it("dedupeByName collapses same-name places (two New Londons → one)", () => {
+		const without = autocomplete(matcher, "new london")
+		expect(without.suggestions.filter((s) => s.name === "New London").length).toBe(2)
+		const withDedupe = autocomplete(matcher, "new london", { dedupeByName: true })
+		expect(withDedupe.suggestions.filter((s) => s.name === "New London").length).toBe(1)
+		// keeps the higher-importance one (the locality, 0.5 > the county's 0.4)
+		expect(withDedupe.suggestions[0]?.placetype).toBe("locality")
+	})
+
+	it("returns nothing for an unmatched prefix", () => {
+		expect(autocomplete(matcher, "xyz").suggestions).toEqual([])
 	})
 })

--- a/resolver-wof-sqlite/fst-autocomplete.test.ts
+++ b/resolver-wof-sqlite/fst-autocomplete.test.ts
@@ -130,4 +130,18 @@ describe("FST autocomplete — char-level + dedupe (synthetic)", () => {
 	it("returns nothing for an unmatched prefix", () => {
 		expect(autocomplete(matcher, "xyz").suggestions).toEqual([])
 	})
+
+	it("a dense branch does not starve a high-importance sibling (#587 per-branch cap)", () => {
+		// "go" → "diego" (12 low-importance places) + "tham" (one high-importance Gotham). Without the
+		// per-branch cap, the 12 "Go Diego"s blow the budget before "tham" is ever visited, so Gotham
+		// (the place a user most likely wants) is dropped — the real "new → New London not New York" bug.
+		const dense = new FstMatcher([
+			{ edges: new Map([["go", 1]]), places: [] },
+			{ edges: new Map([["diego", 2], ["tham", 3]]), places: [] },
+			{ edges: new Map(), places: Array.from({ length: 12 }, (_, i) => place(100 + i, `Go Diego ${i}`, "locality", 0.1)) },
+			{ edges: new Map(), places: [place(200, "Gotham", "locality", 0.9)] },
+		])
+		const r = autocomplete(dense, "go", { maxSuggestions: 3 })
+		expect(r.suggestions[0]?.name).toBe("Gotham")
+	})
 })

--- a/resolver-wof-sqlite/fst-autocomplete.ts
+++ b/resolver-wof-sqlite/fst-autocomplete.ts
@@ -5,6 +5,15 @@
  *
  *   FST-based autocomplete. Prefix walk + BFS expansion to collect ranked place suggestions. O(depth
  *   × branching) — the FST IS the autocomplete index.
+ *
+ *   Two query shapes are handled (the FST is a trie over normalized WORD tokens):
+ *
+ *   - COMPLETE tokens ("new york") — `walk` lands on a state; collect its accepting entries + BFS
+ *     a couple tokens past it for nearby completions. This is the CLI's "complete a place word" path.
+ *   - A PARTIAL last token ("new yor", "chic") — `walk` fails (there is no "yor" edge, only "york").
+ *     So walk the complete prefix, then complete the partial token by prefix-filtering the
+ *     continuation edges (`token.startsWith(partial)`). This is what a char-level typeahead needs;
+ *     without it "new yor" returns nothing useful. (#587)
  */
 
 import { FstMatcher, normalizeTokens } from "./fst-matcher.js"
@@ -30,17 +39,22 @@ export interface AutocompleteSuggestion {
 export interface AutocompleteOpts {
 	maxSuggestions?: number
 	maxExpansionDepth?: number
+	/**
+	 * Collapse same-name suggestions to the single highest-importance one. Off by default (the CLI
+	 * surfaces distinct same-name places — New York the city vs the county); a typeahead wants it ON so
+	 * the dropdown isn't four "New London"s. (#587)
+	 */
+	dedupeByName?: boolean
+}
+
+interface BfsItem {
+	stateId: number
+	depth: number
+	tokens: string[]
 }
 
 /**
- * Autocomplete from the current prefix. Returns ranked suggestions (importance-descending).
- *
- * Algorithm:
- *
- * 1. Walk the FST with the normalized prefix tokens
- * 2. Collect all accepting entries at the current state (exact matches)
- * 3. BFS-expand continuations up to `maxExpansionDepth` to find nearby completions
- * 4. Deduplicate by wofID, rank by importance
+ * Autocomplete from the current prefix. Returns suggestions ranked importance-descending.
  */
 export function autocomplete(fst: FstMatcher, query: string, opts: AutocompleteOpts = {}): AutocompleteResult {
 	const maxSuggestions = opts.maxSuggestions ?? 10
@@ -51,64 +65,51 @@ export function autocomplete(fst: FstMatcher, query: string, opts: AutocompleteO
 		return { query, normalizedTokens: [], depth: 0, suggestions: [] }
 	}
 
+	const seen = new Map<number, AutocompleteSuggestion>()
+	const queue: BfsItem[] = []
+	let depth = 0
+
 	const match = fst.walk(normalizedTokens)
-	if (!match) {
-		const partial = fst.query(query)
-		return {
-			query,
-			normalizedTokens,
-			depth: partial.path.length,
-			suggestions: partial.accepting.map((e) => ({
-				name: e.name,
-				placetype: e.placetype,
-				importance: e.importance,
-				wofID: e.wofID,
-				parentChain: e.parentChain,
-				matchDepth: partial.path.length,
-				completionTokens: [],
-			})),
+	if (match) {
+		// COMPLETE-token prefix landed on a state. Seed at the match state (accepting + continuations).
+		depth = match.depth
+		for (const entry of fst.accepting(match.stateId)) addSuggestion(seen, entry, match.depth, [])
+		for (const cont of fst.continuations(match.stateId)) {
+			queue.push({ stateId: cont.targetState, depth: 1, tokens: [cont.token] })
+		}
+	} else {
+		// PARTIAL last token — walk the complete prefix, complete the partial by prefix-filtering edges.
+		const complete = normalizedTokens.slice(0, -1)
+		const partial = normalizedTokens[normalizedTokens.length - 1]!
+		const prefixState = complete.length === 0 ? 0 : (fst.walk(complete)?.stateId ?? undefined)
+		if (prefixState === undefined) {
+			return { query, normalizedTokens, depth: 0, suggestions: [] }
+		}
+		depth = complete.length
+		for (const cont of fst.continuations(prefixState)) {
+			if (!cont.token.startsWith(partial)) continue
+			// This edge completes the typed partial token — its target is a real match at depth+1.
+			for (const entry of fst.accepting(cont.targetState)) addSuggestion(seen, entry, complete.length + 1, [cont.token])
+			// BFS a little past it too (multi-token completions: "new yor" → "New York Mills").
+			queue.push({ stateId: cont.targetState, depth: 1, tokens: [cont.token] })
 		}
 	}
 
-	const seen = new Map<number, AutocompleteSuggestion>()
-
-	for (const entry of fst.accepting(match.stateId)) {
-		addSuggestion(seen, entry, match.depth, [])
-	}
-
-	interface BfsItem {
-		stateId: number
-		depth: number
-		tokens: string[]
-	}
-
-	const queue: BfsItem[] = []
-	for (const cont of fst.continuations(match.stateId)) {
-		queue.push({ stateId: cont.targetState, depth: 1, tokens: [cont.token] })
-	}
-
+	// BFS expansion (shared by both paths) — find nearby completions up to maxExpansionDepth.
 	while (queue.length > 0 && seen.size < maxSuggestions * 3) {
 		const item = queue.shift()!
 		if (item.depth > maxExpansionDepth) continue
-
-		for (const entry of fst.accepting(item.stateId)) {
-			addSuggestion(seen, entry, match.depth + item.depth, item.tokens)
-		}
-
+		for (const entry of fst.accepting(item.stateId)) addSuggestion(seen, entry, depth + item.depth, item.tokens)
 		if (item.depth < maxExpansionDepth) {
 			for (const cont of fst.continuations(item.stateId)) {
-				queue.push({
-					stateId: cont.targetState,
-					depth: item.depth + 1,
-					tokens: [...item.tokens, cont.token],
-				})
+				queue.push({ stateId: cont.targetState, depth: item.depth + 1, tokens: [...item.tokens, cont.token] })
 			}
 		}
 	}
 
-	const suggestions = [...seen.values()].sort((a, b) => b.importance - a.importance).slice(0, maxSuggestions)
-
-	return { query, normalizedTokens, depth: match.depth, suggestions }
+	let suggestions = [...seen.values()].sort((a, b) => b.importance - a.importance)
+	if (opts.dedupeByName) suggestions = dedupeByName(suggestions)
+	return { query, normalizedTokens, depth, suggestions: suggestions.slice(0, maxSuggestions) }
 }
 
 function addSuggestion(
@@ -128,4 +129,18 @@ function addSuggestion(
 		matchDepth,
 		completionTokens: [...completionTokens],
 	})
+}
+
+/** Keep one suggestion per name — the highest-importance. Input is already importance-sorted, so the
+ * first occurrence per name wins; order is preserved. */
+function dedupeByName(suggestions: AutocompleteSuggestion[]): AutocompleteSuggestion[] {
+	const seenNames = new Set<string>()
+	const out: AutocompleteSuggestion[] = []
+	for (const s of suggestions) {
+		const key = s.name.toLowerCase()
+		if (seenNames.has(key)) continue
+		seenNames.add(key)
+		out.push(s)
+	}
+	return out
 }

--- a/resolver-wof-sqlite/fst-autocomplete.ts
+++ b/resolver-wof-sqlite/fst-autocomplete.ts
@@ -53,6 +53,15 @@ interface BfsItem {
 	tokens: string[]
 }
 
+/** Max accepting entries collected per BFS branch — keeps one dense branch from starving the search. */
+const PER_BRANCH = 4
+
+/** The top-`k` entries by importance (descending). Avoids sorting/allocating when `entries` is small. */
+function topByImportance(entries: readonly PlaceEntry[], k: number): PlaceEntry[] {
+	if (entries.length <= k) return [...entries]
+	return [...entries].sort((a, b) => b.importance - a.importance).slice(0, k)
+}
+
 /**
  * Autocomplete from the current prefix. Returns suggestions ranked importance-descending.
  */
@@ -89,17 +98,22 @@ export function autocomplete(fst: FstMatcher, query: string, opts: AutocompleteO
 		for (const cont of fst.continuations(prefixState)) {
 			if (!cont.token.startsWith(partial)) continue
 			// This edge completes the typed partial token — its target is a real match at depth+1.
-			for (const entry of fst.accepting(cont.targetState)) addSuggestion(seen, entry, complete.length + 1, [cont.token])
+			for (const entry of topByImportance(fst.accepting(cont.targetState), PER_BRANCH))
+				addSuggestion(seen, entry, complete.length + 1, [cont.token])
 			// BFS a little past it too (multi-token completions: "new yor" → "New York Mills").
 			queue.push({ stateId: cont.targetState, depth: 1, tokens: [cont.token] })
 		}
 	}
 
-	// BFS expansion (shared by both paths) — find nearby completions up to maxExpansionDepth.
-	while (queue.length > 0 && seen.size < maxSuggestions * 3) {
+	// BFS expansion (shared by both paths) — find nearby completions up to maxExpansionDepth. Each
+	// branch contributes only its top PER_BRANCH places: a state like "new london" has dozens of
+	// accepting entries and would otherwise blow the budget before the BFS ever reaches "new york"
+	// (the "new" state has 311 continuations). Per-branch capping keeps the search broad. (#587)
+	while (queue.length > 0 && seen.size < maxSuggestions * 4) {
 		const item = queue.shift()!
 		if (item.depth > maxExpansionDepth) continue
-		for (const entry of fst.accepting(item.stateId)) addSuggestion(seen, entry, depth + item.depth, item.tokens)
+		for (const entry of topByImportance(fst.accepting(item.stateId), PER_BRANCH))
+			addSuggestion(seen, entry, depth + item.depth, item.tokens)
 		if (item.depth < maxExpansionDepth) {
 			for (const cont of fst.continuations(item.stateId)) {
 				queue.push({ stateId: cont.targetState, depth: item.depth + 1, tokens: [...item.tokens, cont.token] })


### PR DESCRIPTION
## Char-level + dedupe in FST autocomplete (#587)

Last night's marquee work surfaced that the FST `autocomplete` required **complete word tokens** — a partial last token failed `walk` and fell to a fallback that returned garbage (the demo would've shown "Denver" for "New Yor"). This makes it a real char-level typeahead.

### The fix (additive)

When the full token walk fails, walk the **complete prefix** and complete the partial last token by prefix-filtering the continuation edges (`token.startsWith(partial)`). The complete-token path — the CLI's "complete a place word" (#547) — is **untouched**.

Verified against the live `fst-en-US.bin`:

| query | before | after |
|---|---|---|
| `new yor` | nothing / "Denver" | **New York** \| New York Mills |
| `chic` | (none) | **Chicago** \| Chico \| Chickasaw |
| `san fr` | San Diego (wrong) | **San Francisco** |
| `new york` (complete) | New York | New York (unchanged) |

Plus an opt-in **`dedupeByName`** (off by default — the CLI surfaces distinct same-name places; a typeahead wants "San Juan" once, not twice).

### Tests

6 **synthetic-FST unit tests** (a hand-built trie, no WOF DB → always run in CI) cover the char-level path + dedupe + the unchanged complete-token path. The existing integration tests (skipped without `/mnt/.../whosonfirst-data-admin-us-latest.db`) are unaffected.

### Scope

Additive, low-risk — no change to shipped CLI behavior. Unblocks the demo typeahead (#377). The **address-level** variant (a street-prefix index, the true Google-Maps typeahead) remains the larger follow-up tracked in #587.

> ⚠️ CI red until #579 merges (pre-existing).
