### PR TITLE
fix(ci): bridge compiled data dir so the Test job's CLI parse finds dicts (closes #582)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,22 @@ jobs:
       - name: Compile
         run: yarn compile
 
+      # Bridge the compiled tree to the committed dictionaries. core/utils/repo.ts's
+      # __isCompiledTree detection lands CorePackageAbsolutePath at core/out (not the
+      # documented core/), so the compiled parser reads libpostal dicts from
+      # core/out/data/... while the data physically lives at core/data/.... core/out is
+      # gitignored build output, so this symlink only exists where something creates it —
+      # locally it's made by scripts/eval/promotion-gate.sh, but CI never ran the gate, so
+      # the compiled CLI ENOENTs on first parse and the whole mailwoman/test/locale-flag.test.ts
+      # suite fails (every `mailwoman parse …`, incl. the model-free fast-paths). Mirror the
+      # gate's sanctioned bridge. Touches no path logic; the proper repo.ts-detection fix is
+      # tracked for daylight review — see #481 / #582.
+      - name: Bridge compiled data dir
+        run: |
+          if [[ ! -e core/out/data && -d core/data ]]; then
+            ln -sfn ../data core/out/data
+            echo "bridged core/out/data -> ../data so the compiled parser finds libpostal dicts"
+          fi
+
       - name: Test
         run: yarn ci:test


### PR DESCRIPTION
## The last CI red

After #579 unblocked install + the first real test run, **one** suite stayed red on every PR: `mailwoman/test/locale-flag.test.ts` (5 tests). It's the only suite that shells out to the **compiled** CLI (`execFile … out/cli.js parse …`).

## Root cause (corrects the #582 framing)

`#582` guessed this was neural-weights/WOF absence. It isn't — both parse paths gracefully fall back to the rule-only parser when weights are absent. The real cause:

- `core/utils/repo.ts`'s `__isCompiledTree` detection lands `CorePackageAbsolutePath` at **`core/out`** (not the documented `core/`), so the compiled parser reads dictionaries from `core/out/data/…` while the data physically lives at `core/data/…`.
- `core/out` is gitignored build output and `tsc -b` doesn't create the bridge. Locally it's created as a side-effect of `scripts/eval/promotion-gate.sh`; **CI never ran the gate**, so the first rule-path parse `ENOENT`s on `core/out/data/chromium-i18n/ssl-address/US.json` and every `mailwoman parse …` fails.
- The `--isolated` tests fail directly; the default-path tests fail via the no-weights `runIsolated` fallback. (Every *in-process* vitest test uses the source-mode alias → `core/data`, which is why the other 224 files pass.)

This is the same `core/out/data` bridge issue behind the night-13 `arena.perturb NOT FOUND` infra bug.

## The fix

Mirror the **sanctioned** bridge from `scripts/eval/promotion-gate.sh` (`ln -sfn ../data core/out/data`) as a Test-workflow step right after `yarn compile`. Touches no path logic; `core/out` isn't published from the Test job.

Better than the 3 options I'd listed in #582 (provision weights / point at `ci:test:fast` / self-skip): it makes the tests **genuinely pass without weights** by giving the rule-only fallback its data — no coverage dropped, no masking.

## Validation (local, weights-present tree)

| state | `--isolated` ×3 | default `parse "…"` | default `parse 10118-1234` |
|-------|-----------------|---------------------|----------------------------|
| symlink removed (simulates CI no-bridge) | **exit 1** (ENOENT) | exit 0¹ | exit 0¹ |
| symlink restored (this PR) | exit 0 | exit 0 | exit 0 |

¹ pass locally only because neural weights are present; in CI (no weights) they take the `runIsolated` fallback → need the bridge. Verified the rule-only parse of `10118-1234` emits `postcode: ["10118-1234"]`, satisfying the ZIP test's assertions.

The proper `repo.ts`-detection fix stays deferred to daylight review (**#481**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)