### PR TITLE
docs: correct reconcile-as-default (retired in #566, argmax is the default)

### DIFF
--- a/docs/articles/api.mdx
+++ b/docs/articles/api.mdx
@@ -152,12 +152,12 @@ interface PipelineOpts {
 	resolveOpts?: {
 		candidatesPerLookup?: number // How many alternatives to surface (default: 1)
 	}
-	jointReconcile?: boolean // Joint decoding (default true when stages support it; false → argmax)
+	jointReconcile?: boolean // Joint decoding. Default: false (argmax) — retired as default in #566
 	forceJointReconcile?: boolean // DEPRECATED alias of jointReconcile
 }
 ```
 
-Joint reconcile requires a classifier with `parseWithLogits` support (the `NeuralAddressClassifier` has this) and the phrase grouper. When those stages are wired it is the DEFAULT — Stage 5 runs beam search over phrase proposals × classifier top-K × resolver candidates with WOF concordance scoring, falling back to argmax when the prerequisites are absent. Set `jointReconcile: false` to opt out; `forceJointReconcile` is the deprecated alias.
+Joint reconcile requires a classifier with `parseWithLogits` support (the `NeuralAddressClassifier` has this) and the phrase grouper. It runs beam search over phrase proposals × classifier top-K × resolver candidates with WOF concordance scoring. It is **opt-in (default `false`)** — argmax is the default decode. Reconcile was retired as the default in [#566](https://github.com/sister-software/mailwoman/issues/566): graded against the assembled pipeline it broke the street + house_number geocode precondition on 77–84% of clean US addresses while fixing 0%. The code and A/B harnesses remain; set `jointReconcile: true` to opt back in (`forceJointReconcile` is the deprecated alias).
 
 ## CLI
 

--- a/docs/articles/plan/reference/STAGES.mdx
+++ b/docs/articles/plan/reference/STAGES.mdx
@@ -10,7 +10,7 @@ For the narrative / why-it-exists framing, read [`concepts/the-staged-pipeline`]
 - **Last edited:** 2026-05-25.
 - **Implementation state (frozen 2026-05-25):**
   - **Shipped and wired as default:** Stage 1 (normalize), Stage 2.5 (kind classifier), Stage 2.7 (phrase grouper, rule-based), Stage 3 (neural classifier + CRF Viterbi), Stage 4a (CRF structural mask), Stage 6 (WOF SQLite resolver).
-  - **Shipped, default-on:** Stage 5 (joint reconcile — default when the phrase grouper + a `parseWithLogits` classifier are wired, argmax fallback otherwise; `jointReconcile: false` opts out, `forceJointReconcile` is the deprecated alias).
+  - **Shipped, opt-in (retired as default 2026-06-14, #566):** Stage 5 (joint reconcile). Was default-on when the phrase grouper + a `parseWithLogits` classifier were wired, but graded against the assembled pipeline it broke the street + house_number geocode precondition on 77–84% of clean US addresses while fixing 0% — so **argmax is now the default decode**. Code + A/B harnesses remain; `jointReconcile: true` opts back in (`forceJointReconcile` is the deprecated alias).
   - **Shipped but not wired as factory default:** Stage 2 (locale gate workspace exists, not in `createRuntimePipeline` factory).
   - **Scaffold only:** Stage 4b (span re-reader — unbuilt).
   - **In-flight:** CE-only C-train producing new Stage 3 weights (step 6800/50K, val_macro_f1=0.496).

--- a/docs/articles/status.mdx
+++ b/docs/articles/status.mdx
@@ -93,7 +93,7 @@ make the pipeline take the better of both per component.
 | 2.7   | Phrase grouper   | ✅ default | Rule-based span proposals before classification                                                                                                                                                            |
 | 3     | Token classify   | ✅ default | Neural encoder + rule classifiers, hybrid via policy registry (per-component modes)                                                                                                                        |
 | 4     | Sequence correct | ✅ default | Viterbi over the frozen BIO mask; postcode/unit label repairs                                                                                                                                              |
-| 5     | Reconcile        | ✅ default | Joint decoding with WOF concordance scoring — DEFAULT when the phrase grouper + a `parseWithLogits` classifier are wired (falls back to argmax otherwise); disable via `jointReconcile: false`             |
+| 5     | Reconcile        | 🚩 opt-in  | Joint decoding with WOF concordance scoring. **Retired as the default** (#566): on the assembled pipeline it broke the street + house_number geocode precondition on 77–84% of clean US addresses and fixed 0%, so argmax is now the default decode. Code + A/B harnesses remain; opt back in via `jointReconcile: true` |
 | 6     | Resolve          | 🚩 opt-in  | WOF SQLite gazetteer: admin/postcode-level candidates with coordinates, exact-match tiering, coordinate-first postcode disambiguation, opt-in `hierarchyCompletion`/`cityStateFallback`/`includeAncestors` |
 
 ## Confidence


### PR DESCRIPTION
Three source-of-truth docs still describe **joint reconcile as the default decode path**, which is stale after the reconcile retirement (#566). A developer reading them would wire the wrong path.

The 2026-06-11 codex review (`2026-06-11-codex-review.mdx:91,160`) already flagged status/api/STAGES as conflicting with the runtime on reconcile defaults; night-11 corrected them to the *then*-current default-on behavior. Then #566 retired reconcile (made argmax the default) and these three were left stale.

| doc | was | now |
| --- | --- | --- |
| `status.mdx` (stage table) | Stage 5 "✅ default" | "🚩 opt-in · retired as default (#566)" |
| `api.mdx` (PipelineOpts) | `jointReconcile` "default true" | "default false (argmax) — retired in #566" |
| `STAGES.mdx` (impl state) | "Shipped, default-on" | "Shipped, opt-in (retired as default 2026-06-14, #566)" |

**Code reality verified** at `core/pipeline/runtime-pipeline.ts:258`: `const jointEnabled = opts?.jointReconcile ?? opts?.forceJointReconcile ?? false` — argmax is the default; reconcile is opt-in via `jointReconcile: true`.

Docs-only diff. (Heads-up: docs-build is independently red until #579 lands the lockfile fix; this branch is off pre-#579 main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)