### PR TITLE
feat(geocode): wire per-region interp calibration (#374/#584)

### DIFF
--- a/mailwoman/commands/geocode.tsx
+++ b/mailwoman/commands/geocode.tsx
@@ -34,6 +34,7 @@ import { setImmediate } from "node:timers/promises"
 import { useEffect, useState } from "react"
 import zod from "zod"
 import { geocodeAddress, ShardProvider, type GeocodeResult, type ShardResolver } from "../geocode-core.js"
+import { INTERP_RADIUS_CALIBRATION } from "../interp-calibration.js"
 import type { CommandComponent } from "../sdk/cli.js"
 import { resolverDefaultCountry } from "./parse.js"
 
@@ -88,11 +89,11 @@ const OptionsSchema = zod.object({
 	interpCalibration: zod
 		.number()
 		.optional()
-		.default(1.7)
 		.describe(
 			"Conformal calibration multiplier for the interpolation tier's reported uncertainty_m (#374). " +
-				"The raw half-segment radius covers only ~72% of true errors; the default 1.7 (Travis-County " +
-				"calibration, 2026-06-14) lifts that to a ~90% bound. Pass 1 to report the raw heuristic radius."
+				"The raw half-segment radius covers only ~72% of true errors. Default (unset): the per-region " +
+				"table (#584) selects by parsed region — 1.44 (DC) … 3.12 (AZ), 1.95 for unmeasured states — " +
+				"for a ~90% bound. Pass an explicit number to force a single multiplier everywhere (1 = raw)."
 		),
 	format: zod
 		.enum(["json", "text"])
@@ -170,7 +171,8 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 			resolver,
 			shards,
 			defaultCountry: resolverDefaultCountry(options) || undefined,
-			interpCalibration: options.interpCalibration,
+			// Explicit --interp-calibration forces a single multiplier; unset → the per-region table (#584).
+			interpCalibration: options.interpCalibration ?? INTERP_RADIUS_CALIBRATION,
 		})
 		return options.format === "text" ? formatText(result) : JSON.stringify(result, null, 2)
 	} finally {

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -27,6 +27,7 @@ import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } f
 import { existsSync } from "node:fs"
 
 import { type DataReleaseManifest, readReleaseManifest, resolveShardPath } from "./data-release.js"
+import { type InterpCalibrationTable, interpCalibrationForRegion } from "./interp-calibration.js"
 
 /**
  * The resolution tier that produced the coordinate. `address_point` > `interpolated` > `admin`.
@@ -74,11 +75,13 @@ export interface GeocodeDeps {
 	/** Country constraint passed to the resolver (e.g. `"US"`). */
 	defaultCountry?: string
 	/**
-	 * Interpolation-radius conformal calibration multiplier (#374). The geocode surfaces pass 1.7
-	 * (the Travis calibration) so reported radii are an honest ~90% bound; 1 or undefined keeps the
-	 * raw half-segment heuristic. See `docs/articles/evals/2026-06-14-interp-radius-calibration.md`.
+	 * Interpolation-radius conformal calibration (#374) so reported radii are an honest ~90% bound;
+	 * `1` or `undefined` keeps the raw half-segment heuristic. Accepts either a single multiplier (the
+	 * legacy Travis 1.7) OR a per-region {@link InterpCalibrationTable} — when a table is supplied the
+	 * factor is selected by the parsed region (DC 1.44 … AZ 3.12, `default` otherwise, #584). See
+	 * `docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md`.
 	 */
-	interpCalibration?: number
+	interpCalibration?: number | InterpCalibrationTable
 }
 
 /** Lowercase 2-letter state slug from a parsed region value / resolver name, else null. */
@@ -231,8 +234,14 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	if (addressPoints) opts.addressPoints = addressPoints
 	if (interpolation) {
 		opts.interpolation = interpolation
-		if (deps.interpCalibration && deps.interpCalibration !== 1) {
-			opts.interpolationRadiusCalibration = deps.interpCalibration
+		// Resolve to a single multiplier: a per-region table selects by the parsed region (`stateSlug`);
+		// a bare number is used as-is (legacy single-factor / explicit caller override).
+		const calibration =
+			typeof deps.interpCalibration === "object"
+				? interpCalibrationForRegion(deps.interpCalibration, stateSlug)
+				: deps.interpCalibration
+		if (calibration && calibration !== 1) {
+			opts.interpolationRadiusCalibration = calibration
 		}
 	}
 

--- a/mailwoman/interp-calibration.test.ts
+++ b/mailwoman/interp-calibration.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { INTERP_RADIUS_CALIBRATION, interpCalibrationForRegion } from "./interp-calibration.js"
+
+describe("interpCalibrationForRegion (#374/#584 per-region wiring)", () => {
+	it("selects the measured factor by region (slug is lowercase from regionToStateSlug)", () => {
+		expect(interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, "dc")).toBe(1.44)
+		expect(interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, "az")).toBe(3.12)
+		expect(interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, "tx")).toBe(1.7)
+	})
+
+	it("is case-insensitive on the region key", () => {
+		expect(interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, "CA")).toBe(1.87)
+		expect(interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, "ca")).toBe(1.87)
+	})
+
+	it("falls back to the conservative default for an unmeasured region", () => {
+		// FL isn't in the 12-state seed table → the deliberately-high default (rural-skewed).
+		expect(interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, "fl")).toBe(INTERP_RADIUS_CALIBRATION.default)
+		expect(INTERP_RADIUS_CALIBRATION.default).toBe(1.95)
+	})
+
+	it("falls back to the default for an absent region (null/undefined)", () => {
+		expect(interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, null)).toBe(1.95)
+		expect(interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, undefined)).toBe(1.95)
+	})
+
+	it("the default is at the conservative (rural) end — never below the densest measured factor", () => {
+		const measured = Object.values(INTERP_RADIUS_CALIBRATION.byRegion)
+		expect(INTERP_RADIUS_CALIBRATION.default).toBeGreaterThan(Math.min(...measured))
+	})
+})

--- a/mailwoman/interp-calibration.ts
+++ b/mailwoman/interp-calibration.ts
@@ -1,0 +1,60 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Per-region split-conformal multipliers for the interpolation tier's `uncertainty_m` radius (#374).
+ *   Multiply the raw claimed radius (half the matched TIGER segment length) by the region's factor to
+ *   get a calibrated ~90%-coverage interval.
+ *
+ *   #569 shipped a single 1.70 measured on Texas; the multi-region recalibration (#584) found the
+ *   factor is regional — Q̂ rises monotonically with rurality, 1.44 (DC, densest) → 3.12 (AZ, sprawl).
+ *   This wires the per-region selection the seed table anticipated.
+ *
+ *   SOURCE OF RECORD: `data/calibration/interp-radius-conformal.json` (the eval artifact + rationale,
+ *   `docs/articles/evals/2026-06-14-interp-multiregion-recalibration.md`). Embedded here as a constant
+ *   so the published package + the server ship it without a runtime data-file dependency. **Keep the
+ *   two in sync** — when the full 50-state sweep (followups in the JSON) fills in, update both.
+ */
+
+export interface InterpCalibrationTable {
+	/** Uppercase USPS region code → conformal multiplier. */
+	byRegion: Record<string, number>
+	/**
+	 * Multiplier for regions not in the measured set. Deliberately high (near the rural end):
+	 * under-coverage (overconfidence) is the harmful error and most unmeasured states skew rural.
+	 */
+	default: number
+}
+
+/**
+ * Measured 12-state seed table (a partial sweep; the full 50 was abandoned at the >85 °C heat ceiling).
+ * Mirrors `data/calibration/interp-radius-conformal.json` (#584).
+ */
+export const INTERP_RADIUS_CALIBRATION: InterpCalibrationTable = {
+	byRegion: {
+		DC: 1.44,
+		NY: 1.53,
+		TX: 1.7,
+		AK: 1.72,
+		CA: 1.87,
+		CT: 1.91,
+		MI: 1.93,
+		AR: 2.24,
+		CO: 2.29,
+		AL: 2.79,
+		MT: 2.85,
+		AZ: 3.12,
+	},
+	default: 1.95,
+}
+
+/**
+ * The conformal multiplier for a parsed region. `stateSlug` is the lowercase 2-letter slug from
+ * {@link regionToStateSlug} (e.g. `"tx"`); falls back to the table's conservative `default` for an
+ * unmeasured or absent region.
+ */
+export function interpCalibrationForRegion(table: InterpCalibrationTable, stateSlug: string | null | undefined): number {
+	if (!stateSlug) return table.default
+	return table.byRegion[stateSlug.toUpperCase()] ?? table.default
+}

--- a/mailwoman/server/GeocodeRouter.ts
+++ b/mailwoman/server/GeocodeRouter.ts
@@ -30,11 +30,11 @@ import {
 	regionSlugFromTree,
 	ShardProvider,
 } from "../geocode-core.js"
+import { INTERP_RADIUS_CALIBRATION, interpCalibrationForRegion } from "../interp-calibration.js"
 import { recordGeocode } from "./metrics.js"
 
 /** Default per-state shard root + interp calibration — mirror the CLI defaults. */
 const DATA_ROOT = process.env["MAILWOMAN_DATA_ROOT"] ?? "/mnt/playpen/mailwoman-data"
-const INTERP_CALIBRATION = 1.7
 /** Bounded concurrency for `/api/batch`. Override with MAILWOMAN_BATCH_CONCURRENCY. */
 const BATCH_CONCURRENCY = Math.max(1, Number(process.env["MAILWOMAN_BATCH_CONCURRENCY"] ?? "8"))
 /** Hard cap on batch size — a guardrail against unbounded request bodies. */
@@ -94,7 +94,7 @@ function oneGeocode(deps: GeocodeDepsBundle, address: string): Promise<GeocodeRe
 		resolver: deps.resolver,
 		shards: deps.shards.for,
 		defaultCountry: deps.defaultCountry,
-		interpCalibration: INTERP_CALIBRATION,
+		interpCalibration: INTERP_RADIUS_CALIBRATION,
 	})
 }
 
@@ -193,7 +193,8 @@ const resolveTreeHandler: RequestHandler = async (req, res) => {
 	}
 	const t0 = performance.now()
 	try {
-		const { addressPoints, interpolation } = deps.shards.for(regionSlugFromTree(tree))
+		const slug = regionSlugFromTree(tree)
+		const { addressPoints, interpolation } = deps.shards.for(slug)
 		const opts: ResolveOpts = {
 			...incomingOpts,
 			defaultCountry: incomingOpts.defaultCountry ?? deps.defaultCountry,
@@ -201,7 +202,9 @@ const resolveTreeHandler: RequestHandler = async (req, res) => {
 			...(interpolation
 				? {
 						interpolation,
-						interpolationRadiusCalibration: incomingOpts.interpolationRadiusCalibration ?? INTERP_CALIBRATION,
+						interpolationRadiusCalibration:
+							incomingOpts.interpolationRadiusCalibration ??
+							interpCalibrationForRegion(INTERP_RADIUS_CALIBRATION, slug),
 					}
 				: {}),
 		}


### PR DESCRIPTION
Wires the per-region interpolation-radius calibration you approved — replaces the single hardcoded **1.70** (a Texas artifact, #569) with the **per-region conformal table** (#584). The geocoder now selects the `uncertainty_m` multiplier by parsed region.

## What changes
- **New `mailwoman/interp-calibration.ts`** — `INTERP_RADIUS_CALIBRATION` (DC 1.44 … AZ 3.12, `default: 1.95` for the 38 unmeasured states) + `interpCalibrationForRegion()`. Mirrors `data/calibration/interp-radius-conformal.json` (#584's eval artifact of record), embedded as a constant so the package + server ship it with no runtime data-file dependency.
- **`geocode-core`** — `interpCalibration` accepts `number | InterpCalibrationTable`; selects by the **same `stateSlug`** already used for shard selection. A bare number still works (legacy / explicit override), so nothing else breaks.
- **`GeocodeRouter`** (both the `geocodeAddress` path and the direct-resolve path) + the **CLI** default to the table; an explicit `--interp-calibration <n>` forces a single multiplier everywhere (`1` = raw).

## Effect on shipped `uncertainty_m`
Tighter where the old 1.70 was over-conservative (DC ×1.44), wider where it was dangerously overconfident (AZ ×3.12). The `default: 1.95` is deliberately near the rural end — under-coverage (overconfidence) is the harmful error and most unmeasured states skew rural.

## Verification
- **5/5 unit** — region selection, case-insensitivity, default fallback (absent/unmeasured), default ≥ densest measured.
- **6/6 geocode integration** — no regression; TX still resolves to 1.7 (its measured factor = the old default).
- **End-to-end** on an interpolated TX address: raw 32 m → **table 54 m** (×1.7, TX correctly selected) → forced 3.12 → 100 m. The factor flows through and scales correctly.

Follow-up (unchanged): the full 50-state sweep + the per-segment-length-bucket refinement (both in the JSON's `followups`) generalize beyond the 12 measured states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)