### PR TITLE
fix(core): correct __isCompiledTree detection — read core/data directly (closes #481)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,22 +45,5 @@ jobs:
       - name: Compile
         run: yarn compile
 
-      # Bridge the compiled tree to the committed dictionaries. core/utils/repo.ts's
-      # __isCompiledTree detection lands CorePackageAbsolutePath at core/out (not the
-      # documented core/), so the compiled parser reads libpostal dicts from
-      # core/out/data/... while the data physically lives at core/data/.... core/out is
-      # gitignored build output, so this symlink only exists where something creates it —
-      # locally it's made by scripts/eval/promotion-gate.sh, but CI never ran the gate, so
-      # the compiled CLI ENOENTs on first parse and the whole mailwoman/test/locale-flag.test.ts
-      # suite fails (every `mailwoman parse …`, incl. the model-free fast-paths). Mirror the
-      # gate's sanctioned bridge. Touches no path logic; the proper repo.ts-detection fix is
-      # tracked for daylight review — see #481 / #582.
-      - name: Bridge compiled data dir
-        run: |
-          if [[ ! -e core/out/data && -d core/data ]]; then
-            ln -sfn ../data core/out/data
-            echo "bridged core/out/data -> ../data so the compiled parser finds libpostal dicts"
-          fi
-
       - name: Test
         run: yarn ci:test

--- a/core/utils/repo.ts
+++ b/core/utils/repo.ts
@@ -34,13 +34,17 @@ const __dirname = dirname(fileURLToPath(import.meta.url)) as Join<[RepoRootAlias
 /**
  * The absolute path to the root of the repository.
  *
- * In compiled mode this file lives at `core/out/utils/repo.js` (3 levels deep: core → out → utils)
- * and in source mode at `core/utils/repo.ts` (2 levels deep: core → utils). Detect the mode by
- * checking whether `resolve("..", "..")` lands in the `out/` directory — uses `basename` on the
- * resolved path rather than a substring match on `__dirname`, so it survives symlinks and output
- * directory renames.
+ * In compiled mode this file lives at `core/out/utils/repo.js` (so the PARENT of `utils` is `out/`)
+ * and in source mode at `core/utils/repo.ts` (the parent is `core/`). Detect the mode by checking
+ * whether the parent directory (`resolve("..")`) is `out/` — uses `basename` on the resolved path
+ * rather than a substring match on `__dirname`, so it survives symlinks and output-directory renames.
+ *
+ * (Earlier this checked `resolve("..", "..")`, which overshoots `out/` to `core/` and so was always
+ * false — the compiled tree then resolved `CorePackageAbsolutePath` to `core/out` instead of `core/`,
+ * landing dictionary reads at the nonexistent `core/out/data` and requiring an external symlink bridge
+ * to find `core/data`. #481.)
  */
-const __isCompiledTree = basename(resolve(__dirname, "..", "..")) === OutDirectoryName
+const __isCompiledTree = basename(resolve(__dirname, "..")) === OutDirectoryName
 const __upCount = __isCompiledTree ? PathReflection.length : PathReflection.length - 1
 const RepoRootAbsolutePath = resolve(__dirname, ...Array.from({ length: __upCount }, () => ".."))
 type RepoRootAbsolutePath = RepoRootAlias

--- a/scripts/eval/promotion-gate.sh
+++ b/scripts/eval/promotion-gate.sh
@@ -126,19 +126,11 @@ fi
 
 # Arena leg (v4.4.0+: arena.perturb is a floor when the spec declares it) — heavy, ship artifact only.
 if [[ "$(node -e "console.log('arena.perturb' in (JSON.parse(require('fs').readFileSync('$GATE','utf8')).floors||{}))")" == "true" ]]; then
-	# The arena harness runs the COMPILED v0 (Pelias) parser, which loads libpostal dictionaries via
-	# core/utils/repo.ts. In the compiled tree that path resolves to core/out/data/libpostal/... but the
-	# data physically lives at core/data/... (repo.ts's __isCompiledTree lands CorePackageAbsolutePath at
-	# core/out, not the documented core/). Without the bridge below, EVERY v0 arena assertion ENOENTs →
-	# 0 assertions → the verdict reports `arena.perturb: NOT FOUND` and the floor is un-evaluable (it then
-	# hard-fails the gate for an INFRA reason, masking the real arena number — measured 2026-06-13: the
-	# real perturb pass-rate was 78%, comfortably over the 71 floor, but reported NOT FOUND). core/out is
-	# gitignored build output, so this symlink is local + reversible + touches no path logic. The proper
-	# fix (repo.ts detection vs a sanctioned build copy) is tracked for daylight review — see #481.
-	if [[ ! -e core/out/data && -d core/data ]]; then
-		ln -sfn ../data core/out/data
-		echo "[gate] bridged core/out/data -> ../data so the compiled v0 arena parser finds libpostal dicts" >&2
-	fi
+	# (Historical note: the compiled v0 arena parser used to ENOENT on libpostal dicts because
+	# repo.ts's __isCompiledTree detection landed CorePackageAbsolutePath at core/out, so dict reads
+	# went to core/out/data/... while the data lives at core/data/.... A local core/out/data symlink
+	# bridged the gap. #481 fixed the detection — the compiled tree now reads core/data directly — so
+	# no bridge is needed here anymore.)
 	MODEL="${INT8:-$MODEL}" TOKENIZER="$TOK" MODELCARD="$CARD" \
 		GAZETTEER="$GAZ" ANCHOR="$LK" CONVENTIONS="${CONV_MODE:-}" BRIDGE="${BRIDGE_MODE:-}" \
 		OUT_DIR="$OUT_DIR/arenas" scripts/eval/external-arenas.sh > "$OUT_DIR/arenas.md" 2>&1


### PR DESCRIPTION
The proper fix for the compiled-data bridge — retires the `core/out/data` symlink hack everywhere.

## Root cause
`repo.ts` detected compiled-vs-source via `basename(resolve(__dirname, "..", ".."))`. From `core/out/utils/repo.js` that lands at **`core`** (never `out`), so `__isCompiledTree` was **always false**. In the compiled tree that pushed `CorePackageAbsolutePath` to `core/out` → dictionary reads went to the nonexistent **`core/out/data`**, needing an external symlink bridge (`promotion-gate.sh` locally; #589 added one to CI) to find `core/data`.

**The published package was broken the same way.** `npm pack` ships `data/` at the package root (0 `out/data` entries), so the installed compiled package resolved dicts to `out/data` and would ENOENT on the rule-dictionary path. This fix corrects publish too, not just CI/dev.

## The fix
Detect via `basename(resolve(__dirname, ".."))` — the parent of `utils/` is `out/` in compiled mode, `core/` in source. `CorePackageAbsolutePath` now resolves to `core/` (the documented intent) in both modes, and to the package root when installed. Source-mode behavior is **unchanged** (the flag is false either way), so vitest + the codegen script (`repoRootPathBuilder`'s only consumer) are unaffected.

Removes the now-unnecessary bridge from both creation sites: the **#589 `test.yml` step** and the **`promotion-gate.sh`** symlink block.

## Verification
- Compiled CLI parses with **no** `core/out/data` symlink — probe shows the libpostal dir resolving to `core/data`.
- `locale-flag.test.ts` **9/9** without the bridge (the suite #589 was added for).
- `npm pack --dry-run`: `data/` at root, `out/utils/repo.js` present, **zero** `out/data` entries → confirms the installed layout the fix targets.
- Source mode unchanged by construction (flag false before and after).

### Pre-existing failures (not this PR)
Two local `ci:test` files fail independent of this change and **skip in CI** (gated on absent WOF DB / model): `neural-web/web-onnx-runner.test.ts` (source-mode onnxruntime-web WASM backend) and one `default-country.test.ts` assertion (the `--default-country none` test expects a foreign homonym for "NY", but WOF ranking now picks US New York at lat 42.9 — a stale resolver-ranking expectation; the parse output is healthy, proving it's unrelated to the dictionary-path fix). Filing the latter separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)