### PR TITLE
fix(publish): make every published package clean-installable + add smoke guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,10 @@ jobs:
 
       - name: Test
         run: yarn ci:test
+
+      # Packs every published workspace + installs the tarballs into a throwaway project (no monorepo
+      # hoisting) + runs the compiled CLI. Catches the class of bug that shipped in v4.8.0: an
+      # undeclared runtime dep, an unshipped file, or a command module with an eager top-level side
+      # effect — all invisible in-repo, all fatal to a fresh `npm install`.
+      - name: Clean-install smoke test
+        run: yarn ci:smoke

--- a/core/package.json
+++ b/core/package.json
@@ -49,15 +49,23 @@
 		}
 	},
 	"dependencies": {
+		"@fragaria/address-formatter": "^6.7.1",
 		"axios": "^1.17.0",
 		"axios-cache-interceptor": "^1.12.0",
+		"change-case": "^5.4.4",
 		"d3-color": "^3.1.0",
 		"d3-scale-chromatic": "^3.1.0",
+		"fast-glob": "^3.3.3",
 		"http-status-codes": "^2.3.0",
 		"json-colorizer": "^3.0.1",
 		"kysely": "^0.29.2",
+		"lru-cache": "^10.4.3",
+		"path-ts": "^1.0.5",
 		"pino": "^10.3.1",
 		"pino-pretty": "^13.1.3",
+		"pluralize": "^8.0.0",
+		"regenerate": "^1.4.2",
+		"spliterator": "^2.0.0",
 		"table": "^6.9.0"
 	},
 	"devDependencies": {

--- a/corpus/package.json
+++ b/corpus/package.json
@@ -21,8 +21,10 @@
 		"@mailwoman/codex": "workspace:*",
 		"@mailwoman/core": "workspace:*",
 		"csv-parse": "^5.6.0",
+		"fast-glob": "^3.3.3",
 		"fastest-levenshtein": "^1.0.16",
-		"lru-cache": "^10.4.3"
+		"lru-cache": "^10.4.3",
+		"spliterator": "^2.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^25.9.2"

--- a/mailwoman/commands/wof/prepare/index.tsx
+++ b/mailwoman/commands/wof/prepare/index.tsx
@@ -6,10 +6,8 @@
 
 import { ProgressBar } from "@inkjs/ui"
 import { formatMinutes, formatQuantity, takeAsync, tallyPatternCount } from "@mailwoman/core/resources"
-import { createUnifiedIndexes, createUnifiedSchema } from "@mailwoman/resolver-wof-sqlite/unified-schema"
 import FastGlob from "fast-glob"
 import { Box, Text } from "ink"
-import { availableParallelism } from "node:os"
 import { DatabaseSync } from "node:sqlite"
 import { setImmediate } from "node:timers/promises"
 import { PathBuilder } from "path-ts"
@@ -19,15 +17,6 @@ import zod from "zod"
 import type { CommandComponent } from "../../../sdk/cli.js"
 import type { WorkerInput, WorkerOutput } from "./_app_worker.mjs"
 
-const piscina = new Piscina<WorkerInput, WorkerOutput>({
-	filename: PathBuilder.from(import.meta.dirname, "_app_worker.mjs").href,
-	idleTimeout: 1000 * 10,
-	env: {
-		WOF_DATA_DIR: process.env.WOF_DATA_DIR || "/tmp/wof-placetype-dbs",
-	},
-})
-
-const WORKER_COUNT = availableParallelism()
 const FILES_PER_BATCH = 500
 
 const ArgumentsSchema = zod.array(zod.string().describe("Path to the Who's On First data directory"))
@@ -71,9 +60,31 @@ const WOFPrepare: CommandComponent<typeof OptionsSchema, typeof ArgumentsSchema>
 
 	useEffect(() => {
 		;(async () => {
+			// Worker pool is created HERE (not at module scope) so importing this command module — which
+			// pastel does eagerly for every CLI invocation — has no side effects and ships no hard
+			// dependency on the worker being resolvable at load time.
+			const piscina = new Piscina<WorkerInput, WorkerOutput>({
+				filename: PathBuilder.from(import.meta.dirname, "_app_worker.mjs").href,
+				idleTimeout: 1000 * 10,
+				env: {
+					WOF_DATA_DIR: process.env.WOF_DATA_DIR || "/tmp/wof-placetype-dbs",
+				},
+			})
+			// The unified-DB helpers live in the optional `@mailwoman/resolver-wof-sqlite` peer. Load them
+			// lazily (only when --unified-db is requested) so the published CLI loads without that package —
+			// same graceful-optional pattern as `parse --resolve`. Without it, the standalone CLI would crash
+			// on startup importing an unpublished workspace (#481 follow-up / clean-install fix).
+			let unifiedSchema: typeof import("@mailwoman/resolver-wof-sqlite/unified-schema") | undefined
 			if (unifiedDbPath) {
+				try {
+					unifiedSchema = await import("@mailwoman/resolver-wof-sqlite/unified-schema")
+				} catch {
+					throw new Error(
+						"`wof prepare --unified-db` needs @mailwoman/resolver-wof-sqlite — install it (npm i @mailwoman/resolver-wof-sqlite) and retry."
+					)
+				}
 				const db = new DatabaseSync(unifiedDbPath, { open: true })
-				createUnifiedSchema(db)
+				unifiedSchema.createUnifiedSchema(db)
 				db.close()
 			}
 
@@ -106,7 +117,6 @@ const WOFPrepare: CommandComponent<typeof OptionsSchema, typeof ArgumentsSchema>
 			}
 
 			const tasks: Promise<void>[] = []
-			let batchCount = 0
 
 			for await (const fileNames of takeAsync(matchStream, FILES_PER_BATCH)) {
 				const filePaths = fileNames.map((f) => f.toString())
@@ -152,7 +162,7 @@ const WOFPrepare: CommandComponent<typeof OptionsSchema, typeof ArgumentsSchema>
 			await piscina.destroy()
 
 			if (unifiedDb) {
-				createUnifiedIndexes(unifiedDb)
+				unifiedSchema!.createUnifiedIndexes(unifiedDb)
 				unifiedDb.close()
 			}
 		})()

--- a/mailwoman/package.json
+++ b/mailwoman/package.json
@@ -35,13 +35,18 @@
 		"@inkjs/ui": "^2.0.0",
 		"@mailwoman/classifiers": "workspace:*",
 		"@mailwoman/core": "workspace:*",
+		"@mailwoman/corpus": "workspace:*",
 		"@mailwoman/kind-classifier": "workspace:*",
 		"@mailwoman/locale-gate": "workspace:*",
+		"@mailwoman/neural": "workspace:*",
 		"@mailwoman/normalize": "workspace:*",
 		"@mailwoman/phrase-grouper": "workspace:*",
 		"@mailwoman/query-shape": "workspace:*",
+		"chalk": "^5.6.2",
 		"change-case": "^5.4.4",
+		"d3-scale-chromatic": "^3.1.0",
 		"express": "^5.2.1",
+		"fast-glob": "^3.3.3",
 		"geojson": "^0.5.0",
 		"ink": "^7.0.5",
 		"ioredis": "^5.11.1",
@@ -52,7 +57,8 @@
 		"react": "^19.2.7",
 		"regenerate": "^1.4.2",
 		"spliterator": "^2.0.0",
-		"zod": "^4.4.3"
+		"zod": "^4.4.3",
+		"zx": "^8.8.5"
 	},
 	"peerDependencies": {
 		"@mailwoman/resolver-wof-sqlite": "workspace:*"
@@ -61,7 +67,9 @@
 		"!out/test/**/*",
 		"!**/*.ts",
 		"out/**/*.js",
+		"out/**/*.mjs",
 		"out/**/*.js.map",
+		"out/**/*.mjs.map",
 		"out/**/*.d.ts",
 		"out/**/*.d.ts.map",
 		"out/**/*.json"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"scripts": {
 		"build-docs": "yarn workspace @mailwoman/docs build",
 		"build-site": "run-s compile build-docs",
+		"ci:smoke": "node scripts/smoke-clean-install.mjs",
 		"ci:test": "vitest --run",
 		"ci:test:fast": "vitest --run --exclude './mailwoman/test/**' --exclude './resolver-wof-sqlite/fst-serialize.test.ts' --exclude './resolver-wof-sqlite/fst-builder.test.ts' --exclude './resolver-wof-sqlite/fst-autocomplete.test.ts' --exclude './neural-web/web-onnx-runner.test.ts'",
 		"compile": "NODE_OPTIONS=\"--max-old-space-size=3000\" tsc -b",

--- a/scripts/smoke-clean-install.mjs
+++ b/scripts/smoke-clean-install.mjs
@@ -1,0 +1,87 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Clean-install smoke test — the guard that would have caught the v4.8.0 broken publish.
+ *
+ *   The monorepo HOISTS dependencies, so an undeclared runtime dep (or a missing shipped file, or a
+ *   command module with an eager top-level side effect) resolves fine in-repo but crashes a fresh
+ *   `npm install`. Nothing tested that path, so several published versions shipped a `mailwoman`
+ *   CLI that crashed on startup (undeclared `path-ts`/`fast-glob`/… in core, an eager `new Piscina`
+ *   + unshipped `.mjs` worker in `wof prepare`, an eager import of the unpublished
+ *   `@mailwoman/resolver-wof-sqlite`). See #481 follow-up.
+ *
+ *   This packs every published code workspace, installs the tarballs into a throwaway project (so the
+ *   ONLY packages available are what the manifests declare — no hoisting), and runs the compiled
+ *   CLI. A missing dep / file / eager side effect surfaces as a non-zero exit here, in CI, before
+ *   publish.
+ *
+ *   Run AFTER `yarn compile`. Usage: node scripts/smoke-clean-install.mjs
+ */
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url))
+// The published code workspaces (mirrors the release set; weights packages carry no code to import).
+const WORKSPACES = {
+	"@mailwoman/core": "core",
+	"@mailwoman/codex": "codex",
+	"@mailwoman/classifiers": "classifiers",
+	"@mailwoman/kind-classifier": "kind-classifier",
+	"@mailwoman/locale-gate": "locale-gate",
+	"@mailwoman/normalize": "normalize",
+	"@mailwoman/phrase-grouper": "phrase-grouper",
+	"@mailwoman/query-shape": "query-shape",
+	"@mailwoman/neural": "neural",
+	"@mailwoman/corpus": "corpus",
+	mailwoman: "mailwoman",
+}
+
+const tmp = mkdtempSync(join(tmpdir(), "mw-smoke-"))
+const tarDir = join(tmp, "tarballs")
+const proj = join(tmp, "proj")
+execFileSync("mkdir", ["-p", tarDir, proj])
+const run = (cmd, args, cwd) => execFileSync(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" })
+
+try {
+	console.log(`[smoke] packing ${Object.keys(WORKSPACES).length} workspaces…`)
+	const deps = {}
+	for (const [name, dir] of Object.entries(WORKSPACES)) {
+		const tgz = join(tarDir, `${dir}.tgz`)
+		run("yarn", ["workspace", name, "pack", "-o", tgz], repoRoot)
+		deps[name] = `file:${tgz}`
+	}
+	writeFileSync(
+		join(proj, "package.json"),
+		JSON.stringify({ name: "mw-smoke", private: true, dependencies: deps }, null, 2)
+	)
+
+	console.log("[smoke] npm install (tarballs only — no hoisting)…")
+	run("npm", ["install", "--no-audit", "--no-fund", "--no-package-lock"], proj)
+
+	const cli = join(proj, "node_modules", "mailwoman", "out", "cli.js")
+	console.log("[smoke] mailwoman --help (loads every command module)…")
+	const help = run("node", [cli, "--help"], proj)
+	for (const c of ["parse", "geocode", "autocomplete", "reverse", "wof", "corpus"]) {
+		if (!help.includes(c)) throw new Error(`--help missing command "${c}"`)
+	}
+
+	console.log("[smoke] mailwoman parse --isolated (exercises bundled core/data dictionaries)…")
+	const out = run("node", [cli, "parse", "--isolated", "350 5th Ave, New York, NY 10118"], proj)
+	if (!out.includes("New York") || !out.includes("10118"))
+		throw new Error(`parse output unexpected:\n${out.slice(0, 400)}`)
+
+	console.log("\n[smoke] ✅ clean install + CLI run succeeded")
+} catch (err) {
+	console.error("\n[smoke] ❌ FAILED — a published package does not clean-install/run:")
+	console.error(
+		err.stdout ? `${err.message}\n--- stdout ---\n${err.stdout}\n--- stderr ---\n${err.stderr}` : (err.message ?? err)
+	)
+	process.exitCode = 1
+} finally {
+	rmSync(tmp, { recursive: true, force: true })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4654,22 +4654,30 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mailwoman/core@workspace:core"
   dependencies:
+    "@fragaria/address-formatter": "npm:^6.7.1"
     "@types/d3-color": "npm:^3.1.3"
     "@types/d3-scale-chromatic": "npm:^3.1.0"
     axios: "npm:^1.17.0"
     axios-cache-interceptor: "npm:^1.12.0"
+    change-case: "npm:^5.4.4"
     d3-color: "npm:^3.1.0"
     d3-scale-chromatic: "npm:^3.1.0"
+    fast-glob: "npm:^3.3.3"
     http-status-codes: "npm:^2.3.0"
     json-colorizer: "npm:^3.0.1"
     kysely: "npm:^0.29.2"
+    lru-cache: "npm:^10.4.3"
+    path-ts: "npm:^1.0.5"
     pino: "npm:^10.3.1"
     pino-pretty: "npm:^13.1.3"
+    pluralize: "npm:^8.0.0"
+    regenerate: "npm:^1.4.2"
+    spliterator: "npm:^2.0.0"
     table: "npm:^6.9.0"
   languageName: unknown
   linkType: soft
 
-"@mailwoman/corpus@workspace:corpus":
+"@mailwoman/corpus@workspace:*, @mailwoman/corpus@workspace:corpus":
   version: 0.0.0-use.local
   resolution: "@mailwoman/corpus@workspace:corpus"
   dependencies:
@@ -4679,8 +4687,10 @@ __metadata:
     "@mailwoman/core": "workspace:*"
     "@types/node": "npm:^25.9.2"
     csv-parse: "npm:^5.6.0"
+    fast-glob: "npm:^3.3.3"
     fastest-levenshtein: "npm:^1.0.16"
     lru-cache: "npm:^10.4.3"
+    spliterator: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -17487,13 +17497,18 @@ __metadata:
     "@inkjs/ui": "npm:^2.0.0"
     "@mailwoman/classifiers": "workspace:*"
     "@mailwoman/core": "workspace:*"
+    "@mailwoman/corpus": "workspace:*"
     "@mailwoman/kind-classifier": "workspace:*"
     "@mailwoman/locale-gate": "workspace:*"
+    "@mailwoman/neural": "workspace:*"
     "@mailwoman/normalize": "workspace:*"
     "@mailwoman/phrase-grouper": "workspace:*"
     "@mailwoman/query-shape": "workspace:*"
+    chalk: "npm:^5.6.2"
     change-case: "npm:^5.4.4"
+    d3-scale-chromatic: "npm:^3.1.0"
     express: "npm:^5.2.1"
+    fast-glob: "npm:^3.3.3"
     geojson: "npm:^0.5.0"
     ink: "npm:^7.0.5"
     ioredis: "npm:^5.11.1"
@@ -17505,6 +17520,7 @@ __metadata:
     regenerate: "npm:^1.4.2"
     spliterator: "npm:^2.0.0"
     zod: "npm:^4.4.3"
+    zx: "npm:^8.8.5"
   peerDependencies:
     "@mailwoman/resolver-wof-sqlite": "workspace:*"
   peerDependenciesMeta:


### PR DESCRIPTION
**`npm install mailwoman@4.8.0` crashes on startup.** DeepSeek's "smoke-test a fresh install" flag surfaced it: the monorepo **hoists** dependencies, so undeclared runtime deps + an unshipped file + an eager top-level side effect all resolve in-repo but break a clean install. Nothing tested that path, so it shipped (long-standing, not a 4.8.0 regression).

## What was broken (found by iterating a clean-install)
1. **`@mailwoman/core` undeclared runtime deps** — `path-ts, change-case, fast-glob, lru-cache, pluralize, regenerate, spliterator, @fragaria/address-formatter` (imported in the tokenizer, libpostal loader, identifiers, whosonfirst; resolved only via hoisting).
2. **`mailwoman` CLI undeclared deps** — `@mailwoman/corpus, @mailwoman/neural, chalk, d3-scale-chromatic, fast-glob, zx` (eager-loaded commands import them).
3. **`wof prepare` was unloadable** — it eager-imported the **unpublished** `@mailwoman/resolver-wof-sqlite` at module top-level, and instantiated `new Piscina(...)` at module scope referencing a `_app_worker.mjs` the `files` glob (`out/**/*.js`) never shipped. Since pastel eager-loads every command, this crashed the *whole* CLI on any invocation.

## The fix
- Declare the hoist-masked runtime deps (core +8, corpus +2, mailwoman +6).
- `mailwoman` ships `out/**/*.mjs` (the worker).
- `wof/prepare`: lazy-`import()` the optional `@mailwoman/resolver-wof-sqlite` (graceful "install it" message — same pattern as `parse --resolve`) and move `new Piscina` into the handler so importing the module has **no side effects**.
- **New `scripts/smoke-clean-install.mjs` + `ci:smoke` + a Test-workflow step**: packs every published workspace, installs the tarballs with **no hoisting**, runs the CLI (`--help` + `parse`). This is the guard that was missing — verified it **fails pre-fix and passes post-fix**.

## Use-case coverage (per the three primary modes)
- **CLI** (parse/corpus) — fixed; `mailwoman --help`, `parse`, `parse --isolated` all run from a clean install.
- **Library** (`import "mailwoman"` for batch geocoding) — was already clean (entry exports core/classifiers/runtime-pipeline/utils; resolver is injected/dynamic).
- **Client** (Docusaurus/RN static assets) — unaffected (imports browser workspaces directly, never the Node CLI).

Needs a **4.8.1** patch after merge (4.8.0 is broken on npm). Follow-ups noted but out of scope: `sdk/test` imports `vitest` (make it a peerDep or exclude from publish), `@mailwoman/spatial` undeclared `@googlemaps/...` (not in the release set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)