### PR TITLE
feat(mailwoman): coarse-placer soft prior default-on (#244)

### DIFF
--- a/mailwoman/commands/geocode.tsx
+++ b/mailwoman/commands/geocode.tsx
@@ -99,11 +99,12 @@ const OptionsSchema = zod.object({
 	placeCountry: zod
 		.boolean()
 		.optional()
-		.default(false)
+		.default(true)
 		.describe(
-			"Enable the #244 coarse-placer soft country prior. A confident whole-string country guess biases the " +
-				"resolver's locality/region ranking toward the right country (never filters); most useful when no " +
-				"--default-country / locale pins it. Off by default (byte-stable). See the coarse-placer soft-signal spec."
+			"The #244 coarse-placer soft country prior (open-set rule). A confident whole-string country guess biases " +
+				"the resolver's locality/region ranking toward the right country (never filters); most useful when no " +
+				"--default-country / locale pins it. ON by default after the M2 misroute gate (0 misroutes); pass " +
+				"--no-place-country to disable."
 		),
 	placeCountryThreshold: zod
 		.number()
@@ -183,9 +184,10 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 
 	// Coarse-placer soft country prior (#244) — opt-in. Loads the int8 model bundled in @mailwoman/core
 	// at the requested abstention threshold; a confident in-map guess feeds the resolver's anchorPosterior.
-	// The M2 open-set reject rule (reject on in-map MASS 1-P(OTHER), route on the in-map argmax) strictly
-	// dominates the max-prob rule — on the assembled gate it lifts in-map right-country 85.3→91.2% with 0
-	// regressions (see docs/articles/evals/2026-06-14-coarse-placer-m2-pipeline-gate.md), so the flag uses it.
+	// The M2 open-set reject rule (reject on in-map MASS 1-P(OTHER), route on the in-map argmax) lifts in-map
+	// right-country 85.3→91.2% with 0 regressions / 0 misroutes (the pipeline + misroute gates), so it's ON
+	// by default. --no-place-country disables it (passes `false`); a custom --place-country-threshold builds
+	// an explicit placer instead of the default-on bundled one.
 	const placer = options.placeCountry
 		? await CoarsePlacer.fromBundled({ abstainBelow: options.placeCountryThreshold, openSet: true })
 		: undefined
@@ -199,7 +201,8 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 			defaultCountry: resolverDefaultCountry(options) || undefined,
 			// Explicit --interp-calibration forces a single multiplier; unset → the per-region table (#584).
 			interpCalibration: options.interpCalibration ?? INTERP_RADIUS_CALIBRATION,
-			...(placer ? { placeCountry: (t: string) => placer.predict(t) } : {}),
+			// Enabled → our threshold-honoring placer; --no-place-country → `false` (disable the default-on prior).
+			placeCountry: placer ? (t: string) => placer.predict(t) : false,
 		})
 		return options.format === "text" ? formatText(result) : JSON.stringify(result, null, 2)
 	} finally {

--- a/mailwoman/default-placer.ts
+++ b/mailwoman/default-placer.ts
@@ -1,0 +1,45 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The default coarse-placer (#244) for the user-facing geocoding surfaces. As of the M2 misrouting
+ *   gate (0 misroutes across 2 000 in-map addresses, 10 countries — see
+ *   docs/articles/evals/2026-06-14-coarse-placer-inmap-misroute.md) the soft country prior runs
+ *   **on by default**: `geocodeAddress` and `createRuntimePipeline` load THIS bundled placer unless
+ *   the caller passes their own `placeCountry` or opts out with `placeCountry: false`.
+ *
+ *   Loaded LAZILY + cached once per process: the int8 model is ~0.79 MB and `predict` is
+ *   microseconds, but the bundled-artifact read is async, so callers `await` it the first time and
+ *   reuse the cached promise after. Returns `null` (no prior, graceful) when the bundled model
+ *   can't be resolved — a stripped-down install, a missing `data/` dir — so a default-on consumer
+ *   degrades to plain resolution instead of throwing.
+ */
+
+/** Structural shape of a place-country predictor — matches `RuntimePipelineStages["placeCountry"]`. */
+export type PlaceCountryFn = (normalizedText: string) => { country: string | null; confidence: number }
+
+// Abstention threshold for the default prior — the open-set rule's flat-optimum operating point (#244 M2).
+const DEFAULT_ABSTAIN_BELOW = 0.9
+
+let cached: Promise<PlaceCountryFn | null> | null = null
+
+/**
+ * Lazy-load + cache the coarse-placer bundled in `@mailwoman/core` as a place-country fn (the M2
+ * open-set rule at the 0.9 operating point). The result is cached for the process; `null` means the
+ * model couldn't be loaded and the caller should proceed with no prior.
+ */
+export function loadDefaultPlaceCountry(): Promise<PlaceCountryFn | null> {
+	if (!cached) {
+		cached = (async (): Promise<PlaceCountryFn | null> => {
+			try {
+				const { CoarsePlacer } = await import("@mailwoman/core/coarse-placer")
+				const placer = await CoarsePlacer.fromBundled({ abstainBelow: DEFAULT_ABSTAIN_BELOW, openSet: true })
+				return (text: string) => placer.predict(text)
+			} catch {
+				return null
+			}
+		})()
+	}
+	return cached
+}

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -27,7 +27,8 @@ import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } f
 import { existsSync } from "node:fs"
 
 import { type DataReleaseManifest, readReleaseManifest, resolveShardPath } from "./data-release.js"
-import { type InterpCalibrationTable, interpCalibrationForRegion } from "./interp-calibration.js"
+import { loadDefaultPlaceCountry, type PlaceCountryFn } from "./default-placer.js"
+import { interpCalibrationForRegion, type InterpCalibrationTable } from "./interp-calibration.js"
 
 /**
  * The resolution tier that produced the coordinate. `address_point` > `interpolated` > `admin`.
@@ -85,16 +86,19 @@ export interface GeocodeDeps {
 	 */
 	interpCalibration?: number | InterpCalibrationTable
 	/**
-	 * Coarse country router (#244, soft prior). A `(text) → { country, confidence }` predictor —
-	 * typically `(t) => placer.predict(t)` for a `CoarsePlacer.fromBundled({ abstainBelow: 0.9 })`. A
+	 * Coarse country router (#244, soft prior). A `(text) → { country, confidence }` predictor. A
 	 * confident IN-MAP guess becomes an `anchorPosterior` the resolver's #369 re-rank boosts (never
 	 * filters); abstain (`null`) / off-map (`OTHER`) are no-ops, and an explicit
-	 * {@link defaultCountry} still wins (we never overwrite a caller-set posterior). Off by default →
-	 * byte-stable. Mostly orthogonal to street geocoding (the situs shards are state-keyed) but
-	 * hardens the admin-tier locality disambiguation, especially when no {@link defaultCountry} is
-	 * pinned. See docs/articles/plan/2026-06-14-coarse-placer-soft-signal-spec.md.
+	 * {@link defaultCountry} still wins (we never overwrite a caller-set posterior).
+	 *
+	 * **Default-on (#244 M2, after the misroute gate):**
+	 *
+	 * - `undefined` (default) → the bundled placer ({@link loadDefaultPlaceCountry}, open-set @ 0.9) is
+	 *   lazy-loaded and applied. Degrades to no prior if the model can't be resolved.
+	 * - A function → use it (a custom placer / threshold).
+	 * - `false` → disabled (no prior; the pre-M2 byte-stable behavior).
 	 */
-	placeCountry?: (text: string) => { country: string | null; confidence: number }
+	placeCountry?: PlaceCountryFn | false
 }
 
 /**
@@ -254,10 +258,13 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 
 	const opts: ResolveOpts = {}
 	if (deps.defaultCountry) opts.defaultCountry = deps.defaultCountry
-	// Coarse country router (#244, soft prior). A confident in-map guess feeds the resolver's
+	// Coarse country router (#244, soft prior) — DEFAULT-ON (#244 M2). undefined → the bundled placer;
+	// a function → that placer; false → disabled. A confident in-map guess feeds the resolver's
 	// anchorPosterior re-rank; abstain/OTHER are no-ops and an explicit defaultCountry isn't disturbed.
-	if (deps.placeCountry) {
-		const placed = deps.placeCountry(input)
+	const placeCountry: PlaceCountryFn | null =
+		deps.placeCountry === false ? null : (deps.placeCountry ?? (await loadDefaultPlaceCountry()))
+	if (placeCountry) {
+		const placed = placeCountry(input)
 		if (placed.country && placed.country !== "OTHER" && !opts.anchorPosterior) {
 			opts.anchorPosterior = { [placed.country]: placed.confidence }
 			opts.anchorWeight = COARSE_PLACER_ANCHOR_WEIGHT

--- a/mailwoman/runtime-pipeline.ts
+++ b/mailwoman/runtime-pipeline.ts
@@ -25,6 +25,7 @@ import { detectLocale as defaultDetectLocale } from "@mailwoman/locale-gate"
 import { normalize } from "@mailwoman/normalize"
 import { groupPhrases as defaultGroupPhrases } from "@mailwoman/phrase-grouper"
 import { computeQueryShape } from "@mailwoman/query-shape"
+import { loadDefaultPlaceCountry } from "./default-placer.js"
 
 export interface CreateRuntimePipelineOpts {
 	/** The Stage 3 classifier — typically a `NeuralAddressClassifier`. */
@@ -57,15 +58,19 @@ export interface CreateRuntimePipelineOpts {
 	 */
 	groupPhrases?: RuntimePipelineStages["groupPhrases"]
 	/**
-	 * Coarse country router (#244, soft prior). A `(normalizedText) → { country, confidence }`
-	 * predictor — typically `(t) => placer.predict(t)` for a `CoarsePlacer` loaded via
-	 * `CoarsePlacer.fromBundled({ abstainBelow: 0.9 })`. A confident in-map guess becomes a soft
-	 * country prior the resolver re-rank boosts (never filters); off by default (no wiring) →
-	 * byte-stable. See docs/articles/plan/2026-06-14-coarse-placer-soft-signal-spec.md.
+	 * Coarse country router (#244, soft prior) — **default-on (#244 M2, after the misroute gate).** A
+	 * confident in-map guess becomes a soft country prior the resolver re-rank boosts (never
+	 * filters).
+	 *
+	 * - `undefined` (default) → the bundled placer ({@link loadDefaultPlaceCountry}, open-set @ 0.9) is
+	 *   lazy-loaded on the first pipeline call and applied (no prior if the model can't be
+	 *   resolved).
+	 * - A function → use it (a custom placer / threshold).
+	 * - `false` → disabled (no prior; byte-stable pre-M2 behavior).
 	 *
 	 * @see RuntimePipelineStages.placeCountry
 	 */
-	placeCountry?: RuntimePipelineStages["placeCountry"]
+	placeCountry?: RuntimePipelineStages["placeCountry"] | false
 }
 
 /**
@@ -94,16 +99,29 @@ export function createRuntimePipeline(
 		classifier: opts.classifier,
 		fst: opts.fst,
 		resolver: opts.resolver,
-		// Coarse country router (#244). Off unless the caller wires it — keeps the default pipeline
-		// byte-stable. When present, a confident in-map guess feeds the resolver's anchorPosterior re-rank.
-		placeCountry: opts.placeCountry,
+		// Coarse country router (#244) — DEFAULT-ON (#244 M2). A function override is wired here; the
+		// `undefined` default is lazy-loaded on the first call (below) so the sync factory stays sync;
+		// `false` disables it. A confident in-map guess feeds the resolver's anchorPosterior re-rank.
+		placeCountry: typeof opts.placeCountry === "function" ? opts.placeCountry : undefined,
 		// Default locale gate: rule-based from @mailwoman/locale-gate. Derives locale from
 		// QueryShape character class (CJK→ja-JP, Cyrillic→ru-RU, Arabic→ar) + known-format
 		// hits (us_zip→en-US, fr_postcode→fr-FR, uk_postcode→en-GB). Caller-hint wins when set.
 		detectLocale: opts.detectLocale ?? defaultDetectLocale,
 	}
 
-	return (raw: string, runOpts?: PipelineOpts) => runPipeline(raw, stages, runOpts)
+	// Default-on lazy wiring: when the caller neither supplied a placeCountry fn nor disabled it
+	// (`false`), load the bundled placer once on the first call and inject it. Done in the returned
+	// (async) function so the factory itself stays synchronous.
+	const autoPlaceCountry = opts.placeCountry === undefined
+	let placeCountryResolved = !autoPlaceCountry
+	return async (raw: string, runOpts?: PipelineOpts): Promise<PipelineResult> => {
+		if (!placeCountryResolved) {
+			placeCountryResolved = true
+			const fn = await loadDefaultPlaceCountry()
+			if (fn) stages.placeCountry = fn
+		}
+		return runPipeline(raw, stages, runOpts)
+	}
 }
 
 // Re-export the types so consumers don't need to import from both `mailwoman` and `@mailwoman/core/pipeline`.

--- a/mailwoman/test/geocode-core-place-country.test.ts
+++ b/mailwoman/test/geocode-core-place-country.test.ts
@@ -36,11 +36,27 @@ function captureResolver(): { resolver: Resolver; seen: ResolveOpts[] } {
 const emptyTree: AddressTree = { raw: "x", roots: [] }
 
 describe("geocodeAddress — coarse-placer soft prior (#244)", () => {
-	test("no placeCountry stage ⇒ resolver sees no anchorPosterior (byte-stable)", async () => {
+	test("placeCountry: false ⇒ no anchorPosterior (the disable / byte-stable path)", async () => {
 		const { resolver, seen } = captureResolver()
-		await geocodeAddress("12 rue de la Paix, Paris", { classifier: fakeClassifier(emptyTree), resolver })
+		await geocodeAddress("12 rue de la Paix, Paris", {
+			classifier: fakeClassifier(emptyTree),
+			resolver,
+			placeCountry: false,
+		})
 		expect(seen[0]?.anchorPosterior).toBeUndefined()
 		expect(seen[0]?.anchorWeight).toBeUndefined()
+	})
+
+	test("default-on (no placeCountry) ⇒ the bundled placer injects a posterior for an in-map address", async () => {
+		const { resolver, seen } = captureResolver()
+		// No `placeCountry` → geocodeAddress lazy-loads the bundled coarse-placer (#244 M2 default-on).
+		await geocodeAddress("350 5th Ave, New York, NY 10118", { classifier: fakeClassifier(emptyTree), resolver })
+		const post = seen[0]?.anchorPosterior
+		expect(post, "default-on should inject a country posterior for a clear in-map address").toBeDefined()
+		const keys = Object.keys(post ?? {})
+		expect(keys).toHaveLength(1)
+		expect(keys[0]).toMatch(/^[A-Z]{2}$/) // a 2-letter in-map country
+		expect(seen[0]?.anchorWeight).toBe(1.0)
 	})
 
 	test("a confident in-map guess injects an anchorPosterior + weight", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
 				find: "@mailwoman/core/parser/proposal-pipeline",
 				replacement: resolve(here, "core/parser/proposal-pipeline.ts"),
 			},
+			// coarse-placer (#244) is a single-file subpath (no index.ts), so the generic core/$1/index.ts
+			// rule below would mis-resolve it. Map it to the file directly.
+			{ find: "@mailwoman/core/coarse-placer", replacement: resolve(here, "core/coarse-placer/coarse-placer.ts") },
 			{ find: /^@mailwoman\/core\/(.+)$/, replacement: resolve(here, "core/$1/index.ts") },
 			{ find: /^@mailwoman\/core$/, replacement: resolve(here, "core/index.ts") },
 			// Sibling workspaces.


### PR DESCRIPTION
Flips the #244 coarse-placer soft country prior to **on by default** on the user-facing geocoding surfaces, now that the misroute gate has passed. Caps the M1→M2 arc (#606, #608, #609).

## Why now
The across-11 misroute gate (#609) resolved 2000 in-map addresses (10 countries, country tokens stripped) and found **0 misroutes, 0 regressions** — the prior never pushes an in-map address to the wrong in-map country. The open-set rule (#608) lifts in-map right-country to 91.2% on the assembled gate. So the prior is net-positive and safe to default on.

## What changes
- **`mailwoman/default-placer.ts`** (new): `loadDefaultPlaceCountry()` lazy-loads + caches the bundled coarse-placer (open-set @ 0.9) once per process; returns `null` gracefully if the model can't be resolved (degrades to no prior — never throws).
- **`geocodeAddress`**: `placeCountry` is now `PlaceCountryFn | false`. `undefined` → default-on (bundled), a function → custom, `false` → disabled. One chokepoint, so **both the CLI and the `/api/geocode` server** light up.
- **`createRuntimePipeline`**: same tri-state; the `undefined` default lazy-loads on the first call (kept in the returned async fn so the sync factory stays sync).
- **CLI `geocode`**: `--place-country` defaults **true**; **`--no-place-country`** disables.

## Verified
- Live: `geocode "Lebanon, TN 37087"` → **Tennessee** by default; → **Italy** with `--no-place-country`.
- 76 touched tests green (byte-stable case → `placeCountry: false`; new default-on test asserts the bundled placer injects).
- **`ci:smoke` passes** — clean install + `parse` still runs with the new lazy `@mailwoman/core/coarse-placer` import (graceful-null if absent).

## Opt-out
Per-call `placeCountry: false`; CLI `--no-place-country`. The prior never filters (tier-safe re-rank), so a wrong off-map guess costs ~nothing.

Arc: M1 #606 · M2 open-set #608 · misroute gate #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)