### PR TITLE
feat(core): in-map posterior distribution as anchorPosterior (#244 residual)

### DIFF
--- a/core/coarse-placer/coarse-placer.ts
+++ b/core/coarse-placer/coarse-placer.ts
@@ -221,6 +221,25 @@ export class CoarsePlacer {
 	}
 }
 
+/**
+ * The in-map posterior for the soft-prior DISTRIBUTION wiring (#244 residual upgrade): the
+ * per-in-map-country marginals (every class except `OTHER`) from a prediction, or `null` when the
+ * model abstained / routed off-map. Fed straight to the resolver's `anchorPosterior` so it boosts
+ * EVERY plausible in-map country proportionally — and breaks country-ambiguous ties (mass split
+ * across several in-map countries) with its own place-level evidence — instead of committing to the
+ * single argmax (the one-hot the M2 wiring shipped). Raw marginals (un-renormalized; they sum to
+ * the in-map mass `1 - P(OTHER)`), matching the one-hot's `confidence` scale so `anchorWeight` is
+ * unchanged.
+ */
+export function inMapPosterior(prediction: CoarsePrediction): Record<string, number> | null {
+	if (prediction.country === null || prediction.country === "OTHER") return null
+	const posterior: Record<string, number> = {}
+	for (const [cls, prob] of Object.entries(prediction.probs)) {
+		if (cls !== "OTHER") posterior[cls] = prob
+	}
+	return posterior
+}
+
 /** Load a coarse-placer from a JSON metadata file + a sibling `.weights.bin` (Float32). */
 export async function loadCoarsePlacer(
 	metaJson: { classes: string[]; featureDim: number; temperature: number; bias: number[] },

--- a/core/pipeline/runtime-pipeline.test.ts
+++ b/core/pipeline/runtime-pipeline.test.ts
@@ -526,6 +526,15 @@ describe("runPipeline — coarse-placer soft prior (#244)", () => {
 		})
 	})
 
+	it("uses the placer's full posterior distribution when supplied (vs the one-hot argmax)", async () => {
+		const { resolver, seen } = captureResolveOpts()
+		// A country-ambiguous in-map guess: argmax FR, but GB nearly as likely. The distribution lets the
+		// resolver break the tie with its own evidence instead of committing to FR.
+		const placeCountry = vi.fn(() => ({ country: "FR", confidence: 0.45, posterior: { FR: 0.45, GB: 0.4 } }))
+		await runPipeline("Birmingham", { resolver, placeCountry })
+		expect(seen[0]).toMatchObject({ anchorPosterior: { FR: 0.45, GB: 0.4 }, anchorWeight: 1.0 })
+	})
+
 	it("preserves the caller's resolveOpts fields while injecting the posterior", async () => {
 		const { resolver, seen } = captureResolveOpts()
 		const placeCountry = vi.fn(() => ({ country: "DE", confidence: 0.97 }))

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -206,7 +206,9 @@ export async function runPipeline(
 				...opts,
 				resolveOpts: {
 					...opts?.resolveOpts,
-					anchorPosterior: { [placed.country]: placed.confidence },
+					// The full in-map distribution when the placer supplies it (resolver breaks ties); else the
+					// one-hot argmax (the M2 behavior).
+					anchorPosterior: placed.posterior ?? { [placed.country]: placed.confidence },
 					anchorWeight: opts?.resolveOpts?.anchorWeight ?? COARSE_PLACER_ANCHOR_WEIGHT,
 				},
 			}

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -183,14 +183,23 @@ export interface RuntimePipelineStages {
 	detectLocale?: (input: NormalizedInputLite, shape: QueryShapeLite, opts?: { hint?: LocaleTag }) => Promise<LocaleHint>
 	classifyKind?: (input: NormalizedInputLite, shape: QueryShapeLite, locale: LocaleHint) => Promise<QueryKindResult>
 	/**
-	 * Coarse country router (#244). A `(normalizedText) → { country, confidence }` predictor (a
-	 * `CoarsePlacer.predict`); `country: null` ⇒ abstained, `"OTHER"` ⇒ off-map. When provided, a
-	 * confident IN-MAP guess becomes a SOFT country prior fed into the resolver's #369
+	 * Coarse country router (#244). A `(normalizedText) → { country, confidence, posterior? }`
+	 * predictor (a `CoarsePlacer`-backed fn); `country: null` ⇒ abstained, `"OTHER"` ⇒ off-map. When
+	 * provided, a confident IN-MAP guess becomes a SOFT country prior fed into the resolver's #369
 	 * `anchorPosterior` re-rank (boosts the right-country candidate, never filters); it defers to a
 	 * caller-supplied posterior (a stronger postcode anchor) and is a no-op on abstain/OTHER. Off by
-	 * default → byte-stable. See docs/articles/plan/2026-06-14-coarse-placer-soft-signal-spec.md.
+	 * default → byte-stable.
+	 *
+	 * `posterior` (residual upgrade) is the full per-in-map-country distribution: when present it IS
+	 * the `anchorPosterior` (so the resolver breaks country-ambiguous ties with its own place-level
+	 * evidence); when absent the coordinator falls back to the one-hot `{ [country]: confidence }`.
+	 * See docs/articles/plan/2026-06-14-coarse-placer-soft-signal-spec.md.
 	 */
-	placeCountry?: (normalizedText: string) => { country: string | null; confidence: number }
+	placeCountry?: (normalizedText: string) => {
+		country: string | null
+		confidence: number
+		posterior?: Record<string, number>
+	}
 	/**
 	 * Stage 2.7 phrase grouper. Emits coherent input-unit proposals consumed by Stage 3 (as
 	 * conditioning) and Stage 5 (as boundary candidates). Hard dep in v0.5.0; pre-v0.5.0 callers run

--- a/docs/articles/plan/2026-06-14-coarse-placer-m2-verdict.md
+++ b/docs/articles/plan/2026-06-14-coarse-placer-m2-verdict.md
@@ -81,9 +81,15 @@ only when confident). The rule — not the threshold — is the M2 lever (+5.9pp
   misroute question but can't fully validate resolution quality on thin-coverage locales. Production flows
   usually also pin locale/`defaultCountry`.) ⇒ **default-on is defensible**; the flip is the operator's call
   (a user-facing default change).
-- **Residual upgrade (documented, not needed now):** a full in-map posterior _distribution_ as the
-  `anchorPosterior` (vs today's one-hot argmax) would let the resolver break in-map ties itself — the natural
-  fix for the misrouting risk, and a clean follow-on.
+- **Residual upgrade — SHIPPED (#244):** the soft prior now feeds the full in-map posterior _distribution_
+  as the `anchorPosterior` (vs the one-hot argmax) — the placer hands the resolver every plausible country
+  weighted by mass, so the resolver breaks country-ambiguous ties with its own place-level evidence and can
+  never be committed to a wrong argmax. New `inMapPosterior()` on the core placer; `placeCountry` stage gained
+  an optional `posterior` (consumers fall back to the one-hot when absent); the default placer emits it. A/B
+  on both gates (`--distribution`): homograph **identical** (91.2%, 9 wins, 0 regressions — those wins are
+  confidently single-country, so distribution ≈ one-hot), misroute **+1 win (59 vs 58), still 0 regressions /
+  0 misroutes** — a strict, principled improvement (larger on data with more in-map ambiguity, e.g. European
+  cross-border namesakes).
 
 ## Reproduce
 

--- a/mailwoman/default-placer.ts
+++ b/mailwoman/default-placer.ts
@@ -17,7 +17,12 @@
  */
 
 /** Structural shape of a place-country predictor — matches `RuntimePipelineStages["placeCountry"]`. */
-export type PlaceCountryFn = (normalizedText: string) => { country: string | null; confidence: number }
+export type PlaceCountryFn = (normalizedText: string) => {
+	country: string | null
+	confidence: number
+	/** Full per-in-map-country distribution (#244 residual). When set it IS the `anchorPosterior`. */
+	posterior?: Record<string, number>
+}
 
 // Abstention threshold for the default prior — the open-set rule's flat-optimum operating point (#244 M2).
 const DEFAULT_ABSTAIN_BELOW = 0.9
@@ -33,9 +38,15 @@ export function loadDefaultPlaceCountry(): Promise<PlaceCountryFn | null> {
 	if (!cached) {
 		cached = (async (): Promise<PlaceCountryFn | null> => {
 			try {
-				const { CoarsePlacer } = await import("@mailwoman/core/coarse-placer")
+				const { CoarsePlacer, inMapPosterior } = await import("@mailwoman/core/coarse-placer")
 				const placer = await CoarsePlacer.fromBundled({ abstainBelow: DEFAULT_ABSTAIN_BELOW, openSet: true })
-				return (text: string) => placer.predict(text)
+				return (text: string) => {
+					const p = placer.predict(text)
+					// Hand the resolver the full in-map distribution (#244 residual): it boosts every plausible
+					// country and breaks ambiguous ties with its own evidence, instead of the lossy one-hot argmax.
+					const posterior = inMapPosterior(p)
+					return { country: p.country, confidence: p.confidence, ...(posterior ? { posterior } : {}) }
+				}
 			} catch {
 				return null
 			}

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -266,7 +266,8 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	if (placeCountry) {
 		const placed = placeCountry(input)
 		if (placed.country && placed.country !== "OTHER" && !opts.anchorPosterior) {
-			opts.anchorPosterior = { [placed.country]: placed.confidence }
+			// The full in-map distribution when supplied (resolver breaks ties); else the one-hot argmax.
+			opts.anchorPosterior = placed.posterior ?? { [placed.country]: placed.confidence }
 			opts.anchorWeight = COARSE_PLACER_ANCHOR_WEIGHT
 		}
 	}

--- a/mailwoman/test/geocode-core-place-country.test.ts
+++ b/mailwoman/test/geocode-core-place-country.test.ts
@@ -47,15 +47,22 @@ describe("geocodeAddress — coarse-placer soft prior (#244)", () => {
 		expect(seen[0]?.anchorWeight).toBeUndefined()
 	})
 
-	test("default-on (no placeCountry) ⇒ the bundled placer injects a posterior for an in-map address", async () => {
+	test("default-on (no placeCountry) ⇒ the bundled placer injects the in-map distribution for a clear address", async () => {
 		const { resolver, seen } = captureResolver()
-		// No `placeCountry` → geocodeAddress lazy-loads the bundled coarse-placer (#244 M2 default-on).
+		// No `placeCountry` → geocodeAddress lazy-loads the bundled coarse-placer (#244 default-on).
 		await geocodeAddress("350 5th Ave, New York, NY 10118", { classifier: fakeClassifier(emptyTree), resolver })
 		const post = seen[0]?.anchorPosterior
 		expect(post, "default-on should inject a country posterior for a clear in-map address").toBeDefined()
-		const keys = Object.keys(post ?? {})
-		expect(keys).toHaveLength(1)
-		expect(keys[0]).toMatch(/^[A-Z]{2}$/) // a 2-letter in-map country
+		const entries = Object.entries(post ?? {})
+		// Residual upgrade: a full per-in-map-country DISTRIBUTION, not the one-hot argmax.
+		expect(entries.length).toBeGreaterThan(1)
+		for (const [c, p] of entries) {
+			expect(c).toMatch(/^[A-Z]{2}$/) // 2-letter in-map country (never OTHER)
+			expect(p).toBeGreaterThanOrEqual(0)
+		}
+		// US is the unambiguous winner for this address.
+		const top = entries.sort((a, b) => b[1] - a[1])[0]!
+		expect(top[0]).toBe("US")
 		expect(seen[0]?.anchorWeight).toBe(1.0)
 	})
 

--- a/scripts/eval/coarse-placer-country-disambig.ts
+++ b/scripts/eval/coarse-placer-country-disambig.ts
@@ -37,7 +37,7 @@
  *   --out-md docs/articles/evals/2026-06-14-coarse-placer-country-disambig.md
  */
 
-import { CoarsePlacer } from "@mailwoman/core/coarse-placer"
+import { CoarsePlacer, inMapPosterior } from "@mailwoman/core/coarse-placer"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { createWofResolver, type ResolveOpts } from "@mailwoman/core/resolver"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
@@ -59,6 +59,8 @@ const ABSTAIN_BELOW = Number(arg("abstain-below", "0.9"))
 const ANCHOR_WEIGHT = Number(arg("anchor-weight", "1.0"))
 /** `--openset` uses the M2 in-map-mass reject rule (1 - P(OTHER)) instead of top-class prob. */
 const OPENSET = process.argv.includes("--openset")
+// `--distribution` feeds the full in-map posterior (vs the one-hot argmax) as anchorPosterior (#244 residual).
+const DISTRIBUTION = process.argv.includes("--distribution")
 
 interface HomographRow {
 	raw: string
@@ -159,9 +161,8 @@ async function main(): Promise<void> {
 		const parsed = await neural.parse(row.raw, { postcodeRepair: true })
 		const pred = placer.predict(row.raw)
 		const usePrior = !!pred.country && pred.country !== "OTHER"
-		const onOpts: ResolveOpts = usePrior
-			? { anchorPosterior: { [pred.country!]: pred.confidence }, anchorWeight: ANCHOR_WEIGHT }
-			: {}
+		const posterior = usePrior ? (DISTRIBUTION ? inMapPosterior(pred) : { [pred.country!]: pred.confidence }) : null
+		const onOpts: ResolveOpts = posterior ? { anchorPosterior: posterior, anchorWeight: ANCHOR_WEIGHT } : {}
 
 		const off = await resolvedCountry(parsed, {})
 		const on = await resolvedCountry(parsed, onOpts)

--- a/scripts/eval/coarse-placer-inmap-misroute.ts
+++ b/scripts/eval/coarse-placer-inmap-misroute.ts
@@ -27,7 +27,7 @@
  *   [--per-country 200] [--abstain-below 0.9] [--out-md <path>]
  */
 
-import { CoarsePlacer } from "@mailwoman/core/coarse-placer"
+import { CoarsePlacer, inMapPosterior } from "@mailwoman/core/coarse-placer"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { createWofResolver, type ResolveOpts } from "@mailwoman/core/resolver"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
@@ -46,6 +46,8 @@ const COUNTRIES = ["US", "FR", "GB", "CN", "NL", "IT", "DE", "JP", "ES", "KR"]
 const ANCHOR_WEIGHT = Number(arg("anchor-weight", "1.0"))
 const ABSTAIN_BELOW = Number(arg("abstain-below", "0.9"))
 const PER_COUNTRY = Number(arg("per-country", "200"))
+// `--distribution` feeds the full in-map posterior (vs one-hot argmax) as anchorPosterior (#244 residual).
+const DISTRIBUTION = process.argv.includes("--distribution")
 
 // Trailing explicit country tokens to strip so the country must be inferred (where the prior bites).
 const COUNTRY_TOKENS =
@@ -149,9 +151,8 @@ async function main(): Promise<void> {
 		const parsed = await neural.parse(s.raw, { postcodeRepair: true })
 		const pred = placer.predict(s.raw)
 		const usePrior = !!pred.country && pred.country !== "OTHER"
-		const onOpts: ResolveOpts = usePrior
-			? { anchorPosterior: { [pred.country!]: pred.confidence }, anchorWeight: ANCHOR_WEIGHT }
-			: {}
+		const posterior = usePrior ? (DISTRIBUTION ? inMapPosterior(pred) : { [pred.country!]: pred.confidence }) : null
+		const onOpts: ResolveOpts = posterior ? { anchorPosterior: posterior, anchorWeight: ANCHOR_WEIGHT } : {}
 		const off = await resolvedCountry(parsed, {})
 		const on = await resolvedCountry(parsed, onOpts)
 		rows.push({ gold: s.country, placer: pred.country, off, on })


### PR DESCRIPTION
The residual upgrade that closes the #244 coarse-placer arc (after default-on, #610): the soft prior hands the resolver the **full per-in-map-country distribution** instead of just the argmax one-hot.

## Why
Today the prior injects `{ US: 0.94 }` — the single argmax. For a country-ambiguous in-map address (mass split, e.g. 0.45 FR / 0.40 GB) that **commits to the argmax** and discards the runner-up. The distribution `{ FR: 0.45, GB: 0.40, … }` boosts every plausible country by its mass and lets the resolver break the tie with its own place-level evidence — so it can **never** be committed to a wrong argmax when the right country is also plausible.

## Change
- **`inMapPosterior(prediction)`** on the core placer — the per-in-map-country marginals (excludes `OTHER`), or `null` on abstain/off-map. Raw (sum to the in-map mass), so `anchorWeight` is unchanged.
- **`placeCountry` stage** gains an optional `posterior`; the coordinator uses `posterior ?? { [country]: confidence }` — older one-hot fns are unaffected.
- **geocode-core** + **default-placer**: same fallback; the bundled placer now emits the distribution.
- **`--distribution`** flag on both gate harnesses.

## A/B (both gates, `--distribution` vs one-hot)
| gate | one-hot | distribution |
|---|---|---|
| country-disambig (homograph) | 91.2%, 9 wins, 0 reg | **identical** |
| across-11 misroute (2000) | 58 wins, 0 misroutes | **59 wins, 0 misroutes** |

Homograph is identical because those wins are confidently single-country (distribution ≈ one-hot). The misroute set gains +1 with still 0 regressions — a strict, principled improvement, larger on data with more in-map ambiguity (European cross-border namesakes).

Tests: distribution path covered in core/pipeline + geocode-core (default-on now asserts a multi-key distribution). Arc: M1 #606 · M2 #608 · misroute #609 · default-on #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)