### PR TITLE
feat(registry): inferMapping — auto column-mapping from a header + registry --infer-mapping (#603)

### DIFF
--- a/mailwoman/commands/registry.tsx
+++ b/mailwoman/commands/registry.tsx
@@ -25,6 +25,7 @@ import { createWofResolver, type ResolverBackend } from "@mailwoman/core/resolve
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import {
 	geocodeAddressVia,
+	inferMapping,
 	ingestRows,
 	parseCsv,
 	resolveEntities,
@@ -59,8 +60,16 @@ const OptionsSchema = zod.object({
 		.optional()
 		.describe(
 			"Column mapping: a path to a JSON file (or inline JSON) of { id?, source?, name?, organization?, address?, " +
-				"phone?, email? }, where each field names the CSV column(s) to draw from. Merged over the built-in default; " +
-				"column names are matched case-sensitively. Inferring the mapping from the header is the #603 fast-follow."
+				"phone?, email? }, where each field names the CSV column(s) to draw from. Merged over the base (the built-in " +
+				"default, or --infer-mapping's inference); column names are matched case-sensitively."
+		),
+	inferMapping: zod
+		.boolean()
+		.optional()
+		.default(false)
+		.describe(
+			"Infer the column mapping from the header by keyword (best-effort — point it at any reasonably-named CSV). " +
+				"Used as the base instead of the built-in default; an explicit --mapping still merges on top. Single-CSV mode."
 		),
 	sources: zod
 		.string()
@@ -139,8 +148,14 @@ export const DEFAULT_MAPPING: ColumnMapping = {
 	email: "email",
 }
 
-/** Resolve --mapping (a file path or inline JSON) and merge it over {@link DEFAULT_MAPPING}. */
-export function loadMapping(option: string | undefined, source: string | undefined): ColumnMapping {
+/**
+ * Resolve --mapping (a file path or inline JSON) and merge it over `base` (default {@link DEFAULT_MAPPING}).
+ */
+export function loadMapping(
+	option: string | undefined,
+	source: string | undefined,
+	base: ColumnMapping = DEFAULT_MAPPING
+): ColumnMapping {
 	let provided: Partial<ColumnMapping> = {}
 	if (option) {
 		const text = option.trim().startsWith("{") ? option : readFileSync(option, "utf8")
@@ -150,7 +165,7 @@ export function loadMapping(option: string | undefined, source: string | undefin
 			throw new Error(`--mapping is neither a readable file nor valid JSON: ${(err as Error).message}`)
 		}
 	}
-	return { ...DEFAULT_MAPPING, ...provided, ...(source ? { source } : {}) }
+	return { ...base, ...provided, ...(source ? { source } : {}) }
 }
 
 function resolveWofPath(options: zod.infer<typeof OptionsSchema>): string {
@@ -217,14 +232,15 @@ async function buildGeocoder(
 }
 
 /**
- * One dataset in a `--sources` config: where it lives, its mapping, an optional provenance label + row cap.
+ * One dataset in a `--sources` config: where it lives, its mapping, an optional provenance label +
+ * row cap.
  */
 interface MultiSourceSpec {
 	path: string
 	delimiter?: "comma" | "tab"
 	mapping: ColumnMapping
 	source?: string
-	/** Read at most this many rows (the head of the file) — for sampling a huge source without pre-filtering. */
+	/** Read at most this many rows (the head of the file) — sampling a huge source without pre-filtering. */
 	limit?: number
 }
 
@@ -299,8 +315,11 @@ async function runMultiSource(specs: MultiSourceSpec[], options: zod.infer<typeo
 // ---------------------------------------------------------------------------
 
 async function runRegistry(csvPath: string, options: zod.infer<typeof OptionsSchema>): Promise<string> {
-	const mapping = loadMapping(options.mapping, options.source)
 	const rows = parseCsv(readFileSync(csvPath, "utf8"))
+	// --infer-mapping reads the header (the first row's keys) and guesses the mapping; an explicit --mapping
+	// still merges on top of it. Otherwise the base is the built-in default.
+	const base = options.inferMapping && rows[0] ? inferMapping(Object.keys(rows[0])) : DEFAULT_MAPPING
+	const mapping = loadMapping(options.mapping, options.source, base)
 	const { seam, close } = await buildGeocoder(options)
 
 	try {

--- a/registry/ingest.test.ts
+++ b/registry/ingest.test.ts
@@ -13,6 +13,7 @@ import {
 	type RawGeocode,
 	delimiterFor,
 	geocodeAddressVia,
+	inferMapping,
 	ingestRows,
 	parseCsv,
 	streamRows,
@@ -27,6 +28,46 @@ describe("parseCsv", () => {
 		const rows = parseCsv(CSV)
 		expect(rows).toHaveLength(2)
 		expect(rows[0]).toMatchObject({ id: "c1", name: "Dr. Robert Smith", state: "OR" })
+	})
+})
+
+describe("inferMapping", () => {
+	it("maps a tidy header to the obvious fields", () => {
+		const m = inferMapping(["id", "name", "org", "street", "city", "state", "zip", "phone", "email"])
+		expect(m).toMatchObject({ id: "id", organization: "org", phone: "phone", email: "email", name: "name" })
+		expect(m.address).toEqual(["street", "city", "state", "zip"])
+	})
+
+	it("reads a real bespoke header (TX HHSC facility), id beating org despite 'Facility'", () => {
+		const m = inferMapping([
+			"Facility ID",
+			"Facility Name",
+			"Physical Address",
+			"Physical Address CITY",
+			"Physical Address State",
+			"Physical Address Zipcode",
+			"Facility Phone Number",
+		])
+		expect(m.id).toBe("Facility ID")
+		expect(m.organization).toBe("Facility Name")
+		expect(m.phone).toBe("Facility Phone Number")
+		expect(m.address).toEqual([
+			"Physical Address",
+			"Physical Address CITY",
+			"Physical Address State",
+			"Physical Address Zipcode",
+		])
+	})
+
+	it("prefers org over a person name, and a dedicated email over the generic sweep", () => {
+		const m = inferMapping(["Organization Name", "Contact First Name", "Contact Last Name", "Contact E-mail"])
+		expect(m.organization).toBe("Organization Name")
+		expect(m.email).toBe("Contact E-mail")
+		expect(m.name).toEqual(["Contact First Name", "Contact Last Name"])
+	})
+
+	it("matches whole tokens — 'Statement' is not an address 'state'", () => {
+		expect(inferMapping(["Statement", "Notes"])).toEqual({})
 	})
 })
 

--- a/registry/ingest.ts
+++ b/registry/ingest.ts
@@ -112,6 +112,62 @@ export interface ColumnMapping {
 	attributes?: Record<string, string | string[]>
 }
 
+/**
+ * Best-effort {@link ColumnMapping} inferred from a header row — the "point it at any CSV"
+ * convenience. Each column name is matched (case- and punctuation-insensitive, on whole tokens) to
+ * a field by keyword, in a precedence that resolves the common ambiguities: a dedicated id / phone
+ * / email column is claimed before the generic sweep, an org / facility column beats a person
+ * "name", and address columns (street / city / state / zip…) collect into one multi-column field.
+ * Imperfect on bespoke headers (an explicit mapping or the LLM-assisted inference #603 is the
+ * answer there), but it nails tidy and semi-tidy files with no hand-mapping. Unmatched columns are
+ * left out.
+ */
+export function inferMapping(header: readonly string[]): ColumnMapping {
+	// Pad to whole-token boundaries so "state" doesn't match inside "statement".
+	const tok = (h: string) =>
+		` ${h
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, " ")
+			.trim()} `
+	const mapping: ColumnMapping = {}
+	const name: string[] = []
+	const address: string[] = []
+
+	for (const column of header) {
+		const h = tok(column)
+		const has = (...words: string[]): boolean => words.some((w) => h.includes(` ${w} `))
+
+		if (!mapping.email && has("email", "e mail")) mapping.email = column
+		else if (!mapping.phone && has("phone", "telephone", "tel", "mobile", "cell")) mapping.phone = column
+		else if (!mapping.id && has("id", "npi", "ein", "frn", "spin", "uuid", "guid", "key")) mapping.id = column
+		else if (has("org", "organization", "organisation", "company", "business", "facility", "agency", "employer"))
+			mapping.organization ??= column
+		else if (
+			has(
+				"street",
+				"address",
+				"addr",
+				"city",
+				"town",
+				"state",
+				"province",
+				"zip",
+				"zipcode",
+				"postal",
+				"postcode",
+				"county"
+			)
+		)
+			address.push(column)
+		else if (has("name", "first", "last", "given", "family", "middle", "surname", "fullname", "contact"))
+			name.push(column)
+	}
+
+	if (name.length) mapping.name = name.length === 1 ? name[0]! : name
+	if (address.length) mapping.address = address
+	return mapping
+}
+
 /** Options for {@link ingestRows}. */
 export interface IngestOptions {
 	/** The geocoding seam. Without it, records carry name/org but no resolved address. */


### PR DESCRIPTION
The **"point it at any CSV"** UX — deletes the hand-write-a-mapping-per-file step for reasonably-named data (Tier-2 product surface; the LLM-assisted version stays the #603 fast-follow for hard headers).

## `inferMapping(header)`
Matches each column to a field by keyword on **whole tokens**, in a precedence that resolves the common ambiguities:
- a dedicated **id / phone / email** column is claimed before the generic sweep,
- an **org / facility** column beats a person **"name"**,
- **address** columns (street / city / state / zip…) collect into one multi-column field.

Imperfect on bespoke headers, but it nails tidy + semi-tidy files — e.g. it reads the **TX HHSC facility header** correctly, with `Facility ID` → id beating `Facility` → org, and `Statement` is *not* an address `state` (whole-token match).

## `mailwoman registry <csv> --infer-mapping`
Uses the inference as the mapping base; an explicit `--mapping` still merges on top (`loadMapping` gained an optional `base`).

**Verified end-to-end:** a bespoke-header CSV (`Provider ID, Organization Name, Street Address, …`) resolves with no hand-mapping — both records geocoded → 2 entities.

4 new `inferMapping` unit tests; 25 ingest + CLI tests green.

Part of #603 / epic #615. 🤖 Generated with [Claude Code](https://claude.com/claude-code)