### PR TITLE
test(demo): #638 was a measurement artifact — the street geocoder byte-ranges correctly

### DIFF
--- a/docs/test/browser/250-demo-street-tier.spec.ts
+++ b/docs/test/browser/250-demo-street-tier.spec.ts
@@ -7,10 +7,13 @@
  *   `address_point` (exact building) tier — not the DC admin centroid. This is the marquee: a fully
  *   client-side geocoder that places an exact building from a byte-ranged shard, no server.
  *
- *   The second test guards the byte-range efficiency. It is `test.fixme` until #638 is fixed: the
- *   sql.js-httpvfs `serverMode: "full"` open path currently downloads the ENTIRE shard once to
- *   learn the file length (a redundant 114 MB GET for DC, ~3.2 GB for CA), on top of the efficient
- *   ranged page reads the lookup itself needs. Un-fixme when #638 lands and this passes.
+ *   The second test guards the byte-range efficiency: a lookup must transfer a tiny fraction of the
+ *   shard, never the whole file. It counts only GET response bodies — sql.js-httpvfs's `serverMode:
+ *   "full"` open does ONE `HEAD` to learn the file length (the length-discovery probe), and a
+ *   HEAD's `content-length` reports the full size but transfers ZERO bytes; summing it was the #638
+ *   false-alarm (the original report + an earlier version of this guard counted the HEAD as a 114
+ *   MB download). Measured against prod: 1 HEAD (0 bytes) + ~5 ranged 206 reads ≈ 280 KB of the 114
+ *   MB shard. There is no full-shard download — #638 was a measurement artifact, closed not fixed.
  *
  *   Ground truth (confirmed against the shard): street_norm "pennsylvania avenue northwest", number
  *   1600, postcode 20500 → lat 38.89768, lon -77.03655 (overture:NAD). Postcode disambiguates from
@@ -59,7 +62,7 @@ test.describe("Demo — street tier (#377)", () => {
 	})
 
 	// Un-fixme when #638 lands: the open must NOT download the whole shard to learn its length.
-	test.fixme("byte-range: a lookup transfers a fraction of the shard, never the whole file (#638)", async ({
+	test("byte-range: a lookup transfers a fraction of the shard, never the whole file (#638)", async ({
 		demo,
 		page,
 	}) => {
@@ -67,6 +70,10 @@ test.describe("Demo — street tier (#377)", () => {
 		let rangeReads = 0
 		page.on("response", (res) => {
 			if (!res.url().includes("/street/us/dc/situs.db")) return
+			// Only GET responses transfer a body. A HEAD (sql.js-httpvfs's length probe on open) carries
+			// the full file size in `content-length` but transfers ZERO bytes — counting it would falsely
+			// read as a whole-shard download (the #638 measurement trap). The 206 page reads are the lookup.
+			if (res.request().method() !== "GET") return
 			if (res.status() === 206) rangeReads++
 			situsBytes += Number(res.headers()["content-length"] ?? 0)
 		})
@@ -76,6 +83,6 @@ test.describe("Demo — street tier (#377)", () => {
 		await demo.readResult()
 
 		expect(rangeReads).toBeGreaterThan(0)
-		expect(situsBytes).toBeLessThan(DC_SITUS_BYTES / 10) // a few MB, not the whole 114 MB
+		expect(situsBytes).toBeLessThan(DC_SITUS_BYTES / 10) // a few MB of ranged reads, not the whole 114 MB
 	})
 })


### PR DESCRIPTION
**Closes #638 — not a bug.** Investigated the reported "httpvfs downloads the whole shard on open." It does not. The demo's client-side street geocoder byte-ranges correctly.

## What #638 actually was

The byte-range guard (and the original issue's diagnosis) summed `content-length` across **all** responses to `/street/us/dc/situs.db`, including the `HEAD` that sql.js-httpvfs's `serverMode: "full"` issues on open to learn the file length. **A HEAD reports the full size in `content-length` but transfers zero bytes.** Counting it read as a 114 MB download that never happened.

## Measured against prod (`1600 Pennsylvania Avenue NW, Washington, DC 20500`)

```
HEAD 200 range=(none)            len=119889920   ← length probe: 0 bytes of body
GET  206 bytes=0-65535           len=65536
GET  206 bytes=119799808-...     len=65536
GET  206 bytes=119865344-119889919 len=24576
GET  206 bytes=18939904-...      len=65536
GET  206 bytes=18350080-...      len=65536
```

**≈ 280 KB of the 114 MB shard** — exactly the efficient B-tree descent the design intends. The feared CA-3.2 GB OOM was the same misread (a HEAD reporting 3.2 GB, zero body). R2 headers + CORS are clean; a same-origin and cross-origin Playwright A/B against the real worker (byte-identical to prod) showed no full GET in either mode.

## The fix

- Count only **GET** response bodies (skip the HEAD).
- Un-`fixme` the guard — it now **passes** against prod, asserting the efficiency it was always meant to.

No chunked re-hosting, no lib patch, no R2 migration needed — the chunked-mode fix I prototyped is unnecessary and was discarded. (Local/manual e2e spec only; not wired into CI.)

Verified: `MAILWOMAN_DEMO_URL=https://mailwoman.sister.software/demo yarn test:e2e 250-demo-street-tier` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)