### PR TITLE
feat(address-id): @mailwoman/address-id — stable address primary key (#259)

### DIFF
--- a/address-id/index.test.ts
+++ b/address-id/index.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { createPostalAddressID, isPostalAddressID, parsePostalAddressID } from "./index.js"
+
+const AUSTIN = { latitude: 30.2672, longitude: -97.7431 }
+
+describe("createPostalAddressID", () => {
+	it("produces a well-formed `<state>.<cell>.<hash>` key", () => {
+		const id = createPostalAddressID({ coordinate: AUSTIN, address: "100 Congress Ave, Austin, TX 78701" })
+		expect(isPostalAddressID(id)).toBe(true)
+		const parsed = parsePostalAddressID(id)
+		expect(parsed).not.toBeNull()
+		expect(parsed!.state).toBe("tx") // plucked from the ZIP
+		expect(parsed!.hash).toHaveLength(16)
+	})
+
+	it("is deterministic — same inputs, same key", () => {
+		const input = { coordinate: AUSTIN, address: "100 Congress Ave, Austin, TX 78701" }
+		expect(createPostalAddressID(input)).toBe(createPostalAddressID(input))
+	})
+
+	it("canonicalizes case + whitespace so trivially-different strings key identically", () => {
+		const a = createPostalAddressID({ coordinate: AUSTIN, address: "100 Congress Ave, Austin, TX 78701" })
+		const b = createPostalAddressID({ coordinate: AUSTIN, address: "100  CONGRESS  AVE,  austin,  tx 78701" })
+		expect(a).toBe(b)
+	})
+
+	it("is jitter-stable — the same address geocoded ~10 m apart yields the same key", () => {
+		const a = createPostalAddressID({ coordinate: AUSTIN, address: "100 Congress Ave, Austin, TX 78701" })
+		const jittered = { latitude: AUSTIN.latitude + 1e-4, longitude: AUSTIN.longitude + 1e-4 } // ~14 m
+		const b = createPostalAddressID({ coordinate: jittered, address: "100 Congress Ave, Austin, TX 78701" })
+		expect(a).toBe(b)
+	})
+
+	it("distinguishes a different address at the same place (the content hash differs)", () => {
+		const a = createPostalAddressID({ coordinate: AUSTIN, address: "100 Congress Ave, Austin, TX 78701" })
+		const b = createPostalAddressID({ coordinate: AUSTIN, address: "200 Congress Ave, Austin, TX 78701" })
+		expect(a).not.toBe(b)
+	})
+
+	it("distinguishes the same address string at a far-apart place (the cell differs)", () => {
+		const seattle = { latitude: 47.6062, longitude: -122.3321 }
+		const a = createPostalAddressID({ coordinate: AUSTIN, address: "100 Main St" })
+		const b = createPostalAddressID({ coordinate: seattle, address: "100 Main St" })
+		expect(a).not.toBe(b)
+	})
+
+	it("falls back to `xx` when no state can be plucked, and honors an explicit state", () => {
+		const noState = createPostalAddressID({ coordinate: AUSTIN, address: "100 Congress Ave" })
+		expect(parsePostalAddressID(noState)!.state).toBe("xx")
+		const explicit = createPostalAddressID({ coordinate: AUSTIN, address: "100 Congress Ave", state: "TX" })
+		expect(parsePostalAddressID(explicit)!.state).toBe("tx")
+	})
+})
+
+describe("parsePostalAddressID / isPostalAddressID", () => {
+	it("rejects malformed strings", () => {
+		for (const bad of ["", "not-an-id", "tx.cell", "texas.aabb.0011223344556677", "tx..0011223344556677"]) {
+			expect(isPostalAddressID(bad)).toBe(false)
+			expect(parsePostalAddressID(bad)).toBeNull()
+		}
+	})
+})

--- a/address-id/index.ts
+++ b/address-id/index.ts
@@ -1,0 +1,132 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `@mailwoman/address-id` — turn a canonicalized + geocoded address into a STABLE, parseable
+ *   primary key: `<state>.<H3-cell>.<hash>`. The deterministic, exact-match complement to the fuzzy
+ *   matcher (`@mailwoman/match`): where the matcher decides whether two messy records are probably
+ *   the same entity, the address-id is a content-addressed key you can GROUP BY / JOIN ON without
+ *   running the matcher at all — for the common "same canonical address" case.
+ *
+ *   The three parts (see {@link createPostalAddressID}):
+ *
+ *   - **state** — a coarse region prefix (`tx`, `ca`, …), from a supplied state or plucked from the
+ *       address's ZIP ({@link @mailwoman/codex}); `xx` when unknown. Makes the key region-sortable.
+ *   - **H3 cell** — a jitter-stable locality token from the resolved coordinate (`h3-js`'s
+ *       `latLngToCell` at {@link ADDRESS_H3_RESOLUTION}). Coarse on purpose: two geocodes of the
+ *       same place a few metres apart land in the same cell.
+ *   - **hash** — a content hash of the address canonicalized by {@link @mailwoman/normalize} (so `123
+ *       Main St` and `123 MAIN STREET` hash identically). This is the identity; the cell + state
+ *       localize and partition it.
+ *
+ *   Lineage: the isp-nexus `createPostalAddressID` / `parsePostalAddressID`. `@mailwoman/normalize`
+ *   is the descendant of that era's `sanitize`, re-scoped to parser-input prep — this layer is the
+ *   keying purpose, kept separate by design. (Self-contained on `h3-js`, not `@mailwoman/spatial`,
+ *   which isn't published.)
+ */
+
+import { us } from "@mailwoman/codex"
+import { normalize } from "@mailwoman/normalize"
+import { latLngToCell } from "h3-js"
+import { createHash } from "node:crypto"
+
+/** A geographic coordinate (the geocoder/resolver shape). */
+export interface LatLng {
+	latitude: number
+	longitude: number
+}
+
+/**
+ * H3 resolution for the locality cell — coarse on purpose (~edge 174 m). The same place geocoded a
+ * few metres apart (situs vs interpolation, geocode jitter) lands in the same cell, so the key is
+ * stable; the address hash carries the precise identity. Self-contained here (not via
+ * `@mailwoman/spatial`, which isn't a published package) so this stays cleanly publishable.
+ */
+export const ADDRESS_H3_RESOLUTION = 9
+
+/**
+ * A stable address primary key, `<state>.<H3-cell>.<hash>`. Branded so it can't be confused with an
+ * arbitrary string.
+ */
+export type PostalAddressID = string & { readonly __postalAddressID: unique symbol }
+
+/** `<2-letter-state>.<hex-cell>.<hex-hash>` — lowercase, dot-delimited. */
+const POSTAL_ADDRESS_ID_PATTERN = /^([a-z]{2})\.([0-9a-f]{1,15})\.([0-9a-f]{8,})$/
+
+/**
+ * Hex chars of the address content hash kept in the key (64 bits — collision-safe at billions of
+ * keys).
+ */
+const HASH_LENGTH = 16
+
+/** Inputs for {@link createPostalAddressID}. */
+export interface CreatePostalAddressIDInput {
+	/** The resolved coordinate (the geocoder's output) — drives the locality cell. */
+	coordinate: LatLng
+	/** The address string to content-hash. Canonicalized via {@link normalize} before hashing. */
+	address: string
+	/** 2-letter region/state for the prefix. When omitted, plucked from the address's ZIP; else `xx`. */
+	state?: string
+	/** H3 resolution for the cell. Default {@link ADDRESS_H3_RESOLUTION} (jitter-stable). */
+	resolution?: number
+}
+
+/** The parsed parts of a {@link PostalAddressID}. */
+export interface ParsedPostalAddressID {
+	state: string
+	cell: string
+	hash: string
+}
+
+/**
+ * Canonicalize an address for content-hashing: {@link normalize} (NFC + whitespace + punctuation +
+ * abbreviation expansion) then uppercase, so casing/abbreviation/spacing variants key identically.
+ */
+function canonicalizeForHash(address: string): string {
+	return normalize(address).normalized.toUpperCase().trim()
+}
+
+/**
+ * Best-effort 2-letter US state from a full address: scan for `ST ZIP` occurrences (codex's
+ * `pluckStateZIPCode` anchors to a bare snippet, so it can't read a full address) and take the LAST
+ * valid one — addresses end with the state + ZIP. Returns the uppercase abbreviation or null.
+ */
+function deriveState(address: string): string | null {
+	const candidates = [...address.matchAll(/\b([A-Za-z]{2})[ ,]+\d{5}(?:-\d{4})?\b/g)]
+	for (let i = candidates.length - 1; i >= 0; i--) {
+		const abbreviation = candidates[i]![1]!.toUpperCase()
+		if (us.isUsStateAbbreviation(abbreviation)) return abbreviation
+	}
+	return null
+}
+
+/**
+ * Build a stable {@link PostalAddressID} from a geocoded, canonicalizable address. Deterministic:
+ * the same (coordinate-cell, canonical address, state) always yields the same key. Two records that
+ * resolve to the same place and share a canonical address get the SAME id — a join/dedup key that
+ * needs no matcher. (Distinct canonical address strings → distinct keys; semantic equivalence that
+ * isn't string-identical is the fuzzy matcher's job, not this one's.)
+ */
+export function createPostalAddressID(input: CreatePostalAddressIDInput): PostalAddressID {
+	const cell = latLngToCell(
+		input.coordinate.latitude,
+		input.coordinate.longitude,
+		input.resolution ?? ADDRESS_H3_RESOLUTION
+	)
+	const hash = createHash("sha256").update(canonicalizeForHash(input.address)).digest("hex").slice(0, HASH_LENGTH)
+	const state = (input.state ?? deriveState(input.address) ?? "xx").toLowerCase()
+	return `${state}.${cell}.${hash}` as PostalAddressID
+}
+
+/** Parse a {@link PostalAddressID} into its parts, or null if it isn't one. */
+export function parsePostalAddressID(id: string): ParsedPostalAddressID | null {
+	const match = POSTAL_ADDRESS_ID_PATTERN.exec(id)
+	if (!match) return null
+	return { state: match[1]!, cell: match[2]!, hash: match[3]! }
+}
+
+/** Type guard: is `value` a well-formed {@link PostalAddressID}? */
+export function isPostalAddressID(value: string): value is PostalAddressID {
+	return POSTAL_ADDRESS_ID_PATTERN.test(value)
+}

--- a/address-id/package.json
+++ b/address-id/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@mailwoman/address-id",
+	"version": "4.8.1",
+	"description": "Turn a canonicalized + geocoded address into a stable, parseable primary key (`<state>.<H3-cell>.<hash>`) for deterministic record joins / dedup — the exact-match complement to the fuzzy matcher.",
+	"license": "AGPL-3.0-only",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "address-id"
+	},
+	"type": "module",
+	"exports": {
+		"./package.json": "./package.json",
+		".": "./out/index.js"
+	},
+	"dependencies": {
+		"@mailwoman/codex": "workspace:*",
+		"@mailwoman/normalize": "workspace:*",
+		"h3-js": "^4.4.0"
+	},
+	"devDependencies": {
+		"@types/node": "^25.9.2"
+	},
+	"files": [
+		"out/**/*.js",
+		"out/**/*.js.map",
+		"out/**/*.d.ts",
+		"out/**/*.d.ts.map"
+	],
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/address-id/tsconfig.json
+++ b/address-id/tsconfig.json
@@ -7,5 +7,5 @@
 	},
 	"include": ["./**/*"],
 	"exclude": ["./out/**/*", "./**/*.test.ts", "./**/*.test.tsx"],
-	"references": [{ "path": "../address-id" }, { "path": "../match" }, { "path": "../record" }]
+	"references": [{ "path": "../codex" }, { "path": "../normalize" }]
 }

--- a/docs/articles/concepts/geocode-first-record-matching.mdx
+++ b/docs/articles/concepts/geocode-first-record-matching.mdx
@@ -218,17 +218,21 @@ conjure rarity from a single record with nothing to compare it to.
 
 ## The layers
 
-| Workspace              | Job                                                                                   |
-| ---------------------- | ------------------------------------------------------------------------------------- |
-| `@mailwoman/formatter` | The inverse of the parser: components → idiomatic localized string + a canonical key. |
-| `@mailwoman/record`    | The record schema (person / organization / address) + per-field normalizers.          |
-| `@mailwoman/match`     | Block (geo-first) → score (Fellegi-Sunter) → cluster (centroid-linkage).              |
-| _the application_      | Ingest → normalize → geocode → match → cluster → export to GeoJSON / QGIS / leads.    |
+| Workspace               | Job                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------- |
+| `@mailwoman/formatter`  | The inverse of the parser: components → idiomatic localized string + a canonical key. |
+| `@mailwoman/record`     | The record schema (person / organization / address) + per-field normalizers.          |
+| `@mailwoman/match`      | Block (geo-first) → score (Fellegi-Sunter) → cluster (centroid-linkage).              |
+| `@mailwoman/address-id` | A resolved address → a stable `state.cell.hash` primary key — the deterministic join. |
+| _the application_       | Ingest → normalize → geocode → match → cluster → export to GeoJSON / QGIS / leads.    |
 
 The formatter is the small foundation — it's also the piece this whole thread
 started as, before we understood it was one component of a matcher. The record
 layer is salvage. The match layer is the part that imploded last time, now
-standing on coordinates instead of strings.
+standing on coordinates instead of strings. The address-id is the cheap certainty
+beside the probabilistic match: when two records resolve to the same place _and_
+share a canonical address, they collapse on a deterministic key — no scoring, no
+threshold — and the matcher spends its effort only on the genuinely-messy rest.
 
 ## Why you can't find the comparable project
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"record",
 		"match",
 		"registry",
+		"address-id",
 		"neural",
 		"neural-web",
 		"neural-weights-en-us",

--- a/registry/address-key.test.ts
+++ b/registry/address-key.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { isPostalAddressID } from "@mailwoman/address-id"
+import { block } from "@mailwoman/match"
+import { describe, expect, it } from "vitest"
+import { addressIdBlockingKey, postalAddressId } from "./address-key.js"
+import type { SourceRecord } from "./types.js"
+
+function record(id: string, raw: string, lat: number, lon: number, geocoded = true): SourceRecord {
+	return {
+		id,
+		address: {
+			components: {},
+			canonicalKey: raw.toLowerCase(),
+			raw,
+			...(geocoded
+				? { geocode: { coordinate: { latitude: lat, longitude: lon }, tier: "address_point", uncertaintyMeters: 1 } }
+				: {}),
+		},
+	}
+}
+
+describe("postalAddressId", () => {
+	it("derives a stable id from a geocoded record", () => {
+		const id = postalAddressId(record("1", "100 Congress Ave, Austin, TX 78701", 30.2672, -97.7431))
+		expect(id).not.toBeNull()
+		expect(isPostalAddressID(id!)).toBe(true)
+	})
+
+	it("gives the same id to two records at the same place with the same address", () => {
+		const a = postalAddressId(record("1", "100 Congress Ave, Austin, TX 78701", 30.2672, -97.7431))
+		const b = postalAddressId(record("2", "100 CONGRESS AVE, austin, tx 78701", 30.2672, -97.7431))
+		expect(a).toBe(b)
+	})
+
+	it("returns null for an un-geocoded record (no coordinate → no locality cell)", () => {
+		expect(postalAddressId(record("3", "100 Congress Ave", 0, 0, false))).toBeNull()
+	})
+})
+
+describe("addressIdBlockingKey", () => {
+	it("blocks records that share an address-id together", () => {
+		const a = record("1", "100 Congress Ave, Austin, TX 78701", 30.2672, -97.7431)
+		const b = record("2", "100 Congress Ave, Austin, TX 78701", 30.2672, -97.7431)
+		const c = record("3", "1 Infinite Loop, Cupertino, CA 95014", 37.3318, -122.0312)
+		const { pairs } = block([a, b, c], [addressIdBlockingKey()])
+		// a + b share the address-id → one candidate pair; c is alone.
+		expect(pairs).toHaveLength(1)
+		expect([pairs[0]![0].id, pairs[0]![1].id].sort()).toEqual(["1", "2"])
+	})
+})

--- a/registry/address-key.ts
+++ b/registry/address-key.ts
@@ -1,0 +1,40 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The address-id consumer for the matcher (#259). Derives a stable {@link PostalAddressID} from a
+ *   resolved {@link SourceRecord} and exposes it as a blocking key — the deterministic,
+ *   exact-canonical-address complement to the fuzzy Fellegi-Sunter / GBT scoring. Two uses:
+ *
+ *   - **As a pre-dedup / join key:** `GROUP BY postalAddressId(record)` collapses records that resolve
+ *       to the same place AND share a canonical address with NO scoring at all — the cheap, certain
+ *       slice of dedup before the matcher does the fuzzy rest.
+ *   - **As a blocking key:** {@link addressIdBlockingKey} adds the address-id to the blocking union, so
+ *       records sharing one are guaranteed to be compared.
+ */
+
+import { createPostalAddressID, type PostalAddressID } from "@mailwoman/address-id"
+import { type BlockingKey, exactKey } from "@mailwoman/match"
+import type { SourceRecord } from "./types.js"
+
+/**
+ * The stable address primary key for a record, or null when it isn't geocoded (no coordinate → no
+ * locality cell) or carries no raw address to hash. Uses the resolved coordinate + the raw address;
+ * the state prefix is plucked from the address when present.
+ */
+export function postalAddressId(record: SourceRecord): PostalAddressID | null {
+	const coordinate = record.address?.geocode?.coordinate
+	const address = record.address?.raw
+	if (!coordinate || !address) return null
+	return createPostalAddressID({ coordinate, address })
+}
+
+/**
+ * A blocking key on the {@link postalAddressId} — records that resolve to the same place with the
+ * same canonical address block together. Add it to {@link defaultBlockingKeys}'s union when an exact
+ * address join should never be missed.
+ */
+export function addressIdBlockingKey(): BlockingKey<SourceRecord> {
+	return exactKey((record) => postalAddressId(record))
+}

--- a/registry/index.ts
+++ b/registry/index.ts
@@ -11,6 +11,7 @@
  *   for, finally standing on a calibrated, label-free matcher.
  */
 
+export * from "./address-key.js"
 export * from "./geojson.js"
 export * from "./ingest.js"
 export * from "./learned-scorer.js"

--- a/registry/package.json
+++ b/registry/package.json
@@ -17,6 +17,7 @@
 		"./ingest": "./out/ingest.js"
 	},
 	"dependencies": {
+		"@mailwoman/address-id": "workspace:*",
 		"@mailwoman/match": "workspace:*",
 		"@mailwoman/record": "workspace:*",
 		"csv-parse": "^5.6.0",

--- a/scripts/smoke-clean-install.mjs
+++ b/scripts/smoke-clean-install.mjs
@@ -41,6 +41,7 @@ const WORKSPACES = {
 	"@mailwoman/record": "record",
 	"@mailwoman/match": "match",
 	"@mailwoman/registry": "registry",
+	"@mailwoman/address-id": "address-id",
 	"@mailwoman/corpus": "corpus",
 	mailwoman: "mailwoman",
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
 		{ "path": "./record" },
 		{ "path": "./match" },
 		{ "path": "./registry" },
+		{ "path": "./address-id" },
 		{ "path": "./neural" },
 		{ "path": "./neural-web" },
 		{ "path": "./normalize" },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
 			{ find: /^@mailwoman\/core\/(.+)$/, replacement: resolve(here, "core/$1/index.ts") },
 			{ find: /^@mailwoman\/core$/, replacement: resolve(here, "core/index.ts") },
 			// Sibling workspaces.
+			{ find: /^@mailwoman\/address-id$/, replacement: resolve(here, "address-id/index.ts") },
 			{ find: /^@mailwoman\/classifiers\/(.+)$/, replacement: resolve(here, "classifiers/$1") },
 			{ find: /^@mailwoman\/classifiers$/, replacement: resolve(here, "classifiers/index.ts") },
 			{ find: /^@mailwoman\/corpus\/(.+)$/, replacement: resolve(here, "corpus/src/$1.ts") },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4617,6 +4617,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mailwoman/address-id@workspace:*, @mailwoman/address-id@workspace:address-id":
+  version: 0.0.0-use.local
+  resolution: "@mailwoman/address-id@workspace:address-id"
+  dependencies:
+    "@mailwoman/codex": "workspace:*"
+    "@mailwoman/normalize": "workspace:*"
+    "@types/node": "npm:^25.9.2"
+    h3-js: "npm:^4.4.0"
+  languageName: unknown
+  linkType: soft
+
 "@mailwoman/cartographer@workspace:*, @mailwoman/cartographer@workspace:cartographer":
   version: 0.0.0-use.local
   resolution: "@mailwoman/cartographer@workspace:cartographer"
@@ -4836,6 +4847,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mailwoman/registry@workspace:registry"
   dependencies:
+    "@mailwoman/address-id": "workspace:*"
     "@mailwoman/match": "workspace:*"
     "@mailwoman/record": "workspace:*"
     "@types/node": "npm:^25.9.2"


### PR DESCRIPTION
Closes #259. The Tier-2 product surface from the matcher's own list: a deterministic primary key from a resolved address, the exact-match complement to the fuzzy FS/GBT matcher.

## The key

`createPostalAddressID({ coordinate, address, state? })` → `<state>.<H3-cell>.<hash>`:
- **state** — coarse region prefix (codex ZIP pluck; `xx` if unknown), region-sortable.
- **H3 cell** — jitter-stable locality token (`h3-js` `latLngToCell` at res 9, ~174 m edge) — the same place geocoded a few metres apart stays in-cell.
- **hash** — content hash of the address canonicalized by `@mailwoman/normalize`, so `123 Main St` and `123 MAIN STREET` key identically.

Plus `parsePostalAddressID` + `isPostalAddressID`.

## Why it earns a slot

Where the matcher *decides* whether two messy records are the same entity, the address-id is a key you `GROUP BY` / `JOIN ON` with **no scoring, no threshold** — records that resolve to the same place *and* share a canonical address collapse deterministically, and the matcher spends its effort only on the genuinely-messy rest. Wired into `@mailwoman/registry`: `postalAddressId(record)` + `addressIdBlockingKey()`.

## Self-contained (the ci:smoke lesson)

Built on **`h3-js`**, not `@mailwoman/spatial` — spatial isn't a published package, so depending on it would 404 a clean `npm install` (caught by `ci:smoke`, the exact trap from the 4.8.0 break). Registered in the workspaces list, root tsconfig refs, the vitest sibling alias, and the **ci:smoke WORKSPACES map**.

## Verification

12 tests (well-formed key, deterministic, case/whitespace-canonical, jitter-stable, distinguishes different addresses + far-apart places, state fallback, malformed-string rejection; + registry consumer + blocking key). `ci:smoke` clean-install passes; `tsc -b` clean; fast suite green (2,249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)