### PR TITLE
chore(release): add @mailwoman/spatial to the automated publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,7 +152,7 @@ jobs:
           set -uo pipefail
           yarn compile
           FAILED=()
-          for ws in core normalize query-shape kind-classifier locale-gate phrase-grouper codex classifiers corpus neural neural-weights-en-us neural-weights-fr-fr mailwoman; do
+          for ws in core spatial normalize query-shape kind-classifier locale-gate phrase-grouper codex classifiers corpus neural neural-weights-en-us neural-weights-fr-fr mailwoman; do
             echo "::group::publish ${ws}"
             if RELEASE_IT_WORKSPACES_PATH_TO_WORKSPACE="./${ws}" node scripts/publish-workspace.mjs; then
               echo "  ✓ ${ws}"

--- a/.release-it.json
+++ b/.release-it.json
@@ -4,6 +4,7 @@
 		"@release-it-plugins/workspaces": {
 			"workspaces": [
 				"core",
+				"spatial",
 				"normalize",
 				"query-shape",
 				"kind-classifier",

--- a/spatial/package.json
+++ b/spatial/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mailwoman/spatial",
-	"version": "1.0.0",
+	"version": "4.9.0",
 	"description": "Spatial analysis, geocoding, and other geo-related utilities.",
 	"license": "AGPL-3.0",
 	"contributors": [


### PR DESCRIPTION
`@mailwoman/spatial` is now published (4.9.0 — the core/geocoder version track; it's depended on by cartographer / tile-worker / tiger). Bring it onto the automated release track so future releases version-bump + publish it via CI/OIDC instead of by hand.

- `.release-it.json` workspaces — add `spatial` (after `core`; it deps `@mailwoman/core`).
- `publish.yml` `publish_only` recovery loop — same.
- `spatial/package.json` — commit the 1.0.0 → 4.9.0 bump (the manual publish's version), so release-it bumps from the real published version, not the stale 1.0.0.

Not added to `ci:smoke`'s WORKSPACES map: nothing it packs (the `mailwoman` install closure) depends on spatial, so the clean-install guard doesn't need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)