### PR TITLE
chore(release): add the matcher family + address-id to the automated publish track

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,7 +152,7 @@ jobs:
           set -uo pipefail
           yarn compile
           FAILED=()
-          for ws in core spatial normalize query-shape kind-classifier locale-gate phrase-grouper codex classifiers corpus neural neural-weights-en-us neural-weights-fr-fr mailwoman; do
+          for ws in core spatial normalize query-shape kind-classifier locale-gate phrase-grouper codex classifiers corpus neural neural-weights-en-us neural-weights-fr-fr formatter record match address-id registry mailwoman; do
             echo "::group::publish ${ws}"
             if RELEASE_IT_WORKSPACES_PATH_TO_WORKSPACE="./${ws}" node scripts/publish-workspace.mjs; then
               echo "  ✓ ${ws}"

--- a/.release-it.json
+++ b/.release-it.json
@@ -16,6 +16,11 @@
 				"neural",
 				"neural-weights-en-us",
 				"neural-weights-fr-fr",
+				"formatter",
+				"record",
+				"match",
+				"address-id",
+				"registry",
 				"mailwoman"
 			],
 			"publish": true,

--- a/address-id/package.json
+++ b/address-id/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mailwoman/address-id",
-	"version": "4.8.1",
+	"version": "4.9.0",
 	"description": "Turn a canonicalized + geocoded address into a stable, parseable primary key (`<state>.<H3-cell>.<hash>`) for deterministic record joins / dedup — the exact-match complement to the fuzzy matcher.",
 	"license": "AGPL-3.0-only",
 	"repository": {


### PR DESCRIPTION
Brings the record-matcher packages onto the automated release track (following #657's spatial). `.release-it.json` + `publish.yml`'s `publish_only` loop now include **formatter, record, match, address-id, registry** (dependency order, before `mailwoman`).

- **formatter / record / match / registry** — already on npm at 4.8.1 with Trusted Publishing configured, so the next CI release version-bumps + publishes them via OIDC like every other workspace. (release-it syncs all listed workspaces to one version, so they unify onto the 4.9.0 track.)
- **address-id** — new; bumped 4.8.1 → **4.9.0** to match the track it joins (its deps codex/normalize are 4.9.0). Verified it packs clean (`workspace:*` → concrete 4.9.0 deps, `out/` present).

**Operator action required before the next release dispatch:** `@mailwoman/address-id` needs a one-time **manual first publish + Trusted Publisher setup** — npm rejects an OIDC first-publish of a new package name (E404). Steps are in the PR thread / my message. The other four don't (already TP-configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)