### PR TITLE
fix(address-id): 4.9.1 — 4.9.0 first publish shipped untranslated workspace:* deps

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -128,6 +128,8 @@ for ws in <new-workspace-dirs>; do
 done
 ```
 
+> **Use the script above (or `yarn pack -o <tmp> && npm publish <tmp>`) — never a raw `npm publish` from the workspace dir.** Yarn 4's `workspace:*` dep protocol is yarn-specific; `npm publish` ships the literal string `"workspace:*"`, and consumers then fail to install with `EUNSUPPORTEDPROTOCOL`. `yarn pack` (which `publish-workspace.mjs` runs) rewrites `workspace:*` → the concrete sibling version. This bit `@mailwoman/address-id`'s 4.9.0 first publish (shipped `"@mailwoman/codex": "workspace:*"`); it was fixed by republishing 4.9.1 from a `yarn pack`'d tarball.
+
 Then, on npmjs.com, **configure each new package's Trusted Publisher** (repo `sister-software/mailwoman`, workflow `.github/workflows/publish.yml`). After that, OIDC publishes it like every other package and you never touch it manually again.
 
 Two traps that wasted time during 4.0.0, worth knowing:

--- a/address-id/package.json
+++ b/address-id/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mailwoman/address-id",
-	"version": "4.9.0",
+	"version": "4.9.1",
 	"description": "Turn a canonicalized + geocoded address into a stable, parseable primary key (`<state>.<H3-cell>.<hash>`) for deterministic record joins / dedup — the exact-match complement to the fuzzy matcher.",
 	"license": "AGPL-3.0-only",
 	"repository": {


### PR DESCRIPTION
`@mailwoman/address-id@4.9.0` first-published with literal `workspace:*` deps (the published tarball's package.json has `"@mailwoman/codex": "workspace:*"` + normalize) — a consumer `npm install` hits `EUNSUPPORTEDPROTOCOL`. Cause: a raw `npm publish` instead of `yarn pack` (which rewrites `workspace:*` → the concrete sibling version). 4.9.0 is immutable, so this bumps to **4.9.1** for a corrected republish.

- `address-id/package.json` → 4.9.1.
- Verified the `yarn pack`'d 4.9.1 tarball has concrete deps (`codex@4.9.0`, `normalize@4.9.0`, `h3-js@^4.4.0`).
- `RELEASING.md`: explicit caution in the new-package bootstrap — use `publish-workspace.mjs` / `yarn pack`, never raw `npm publish`.

Operator republish (after merge or from this branch): `npm publish /tmp/address-id-4.9.1.tgz --access public` + `npm unpublish @mailwoman/address-id@4.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)