### PR TITLE
fix(spatial): add repository field — unblock provenance publish of 4.10.0

### DIFF
--- a/spatial/package.json
+++ b/spatial/package.json
@@ -2,7 +2,12 @@
 	"name": "@mailwoman/spatial",
 	"version": "4.10.0",
 	"description": "Spatial analysis, geocoding, and other geo-related utilities.",
-	"license": "AGPL-3.0",
+	"license": "AGPL-3.0-only",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "spatial"
+	},
 	"contributors": [
 		{
 			"name": "Teffen Ellis",


### PR DESCRIPTION
## Why

The `v4.10.0` release published **18 of 19** workspaces, then E422'd on `@mailwoman/spatial`:

```
npm error 422 — Error verifying sigstore provenance bundle: Failed to validate
repository information: package.json: "repository.url" is "", expected to match
"https://github.com/sister-software/mailwoman" from provenance
```

`@mailwoman/spatial` was the lone workspace with **no `repository` field**. npm provenance (now on, since the repo is public) cross-checks `package.json` `repository.url` against the OIDC attestation — empty → reject. The earlier manual `spatial` publish predated provenance, so it never surfaced.

Result: `spatial` is stuck at `4.9.0` on npm while everything else is `4.10.0`.

## Fix

- Add the `repository` field (`directory: "spatial"`), matching every other workspace.
- Normalize the deprecated `AGPL-3.0` SPDX id → `AGPL-3.0-only` (monorepo convention; was an npm warning, not the failure).

## After merge

Dispatch **NPM Publish → `publish_only=true`** on `main`: it publishes `spatial@4.10.0` (now with a valid `repository.url` + provenance) while every already-`4.10.0` workspace `--tolerate-republish` no-ops. Verified locally — the packed tarball carries the `repository.url`, translates `@mailwoman/core` → `4.10.0`, and contains no symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)