### PR TITLE
feat(registry): map view — toMapHTML() + `registry --map-out` (Tier 2)

### DIFF
--- a/mailwoman/commands/registry.tsx
+++ b/mailwoman/commands/registry.tsx
@@ -31,6 +31,7 @@ import {
 	resolveEntities,
 	streamRows,
 	toGeoJSON,
+	toMapHTML,
 	type ColumnMapping,
 	type GeocodeAddress,
 	type SourceRecord,
@@ -82,6 +83,14 @@ const OptionsSchema = zod.object({
 				"right for the big government TSVs; convert a quoted CSV first or use the single-CSV path for those."
 		),
 	out: zod.string().optional().describe("Write the GeoJSON FeatureCollection here. Default: print to stdout."),
+	mapOut: zod
+		.string()
+		.optional()
+		.describe(
+			"Also write a standalone, self-contained HTML map of the resolved entities here (open it in a browser — " +
+				"no server needed). Points are sized by records-merged and colored by cross-dataset-link status; " +
+				"cross-dataset links (entities spanning ≥2 sources) stand out. Pairs naturally with --sources."
+		),
 	trainEm: zod
 		.boolean()
 		.optional()
@@ -262,6 +271,28 @@ export function loadSources(option: string): MultiSourceSpec[] {
 }
 
 /**
+ * Write the artifacts requested via `--out` (GeoJSON) and/or `--map-out` (standalone HTML map),
+ * returning the lines to append to the run summary. Returns `null` when neither is set — the signal
+ * to dump GeoJSON to stdout (the original default). Shared by both pipeline paths.
+ */
+function writeOutputs(geojson: ReturnType<typeof toGeoJSON>, options: zod.infer<typeof OptionsSchema>): string | null {
+	if (!options.out && !options.mapOut) return null
+	const lines: string[] = []
+	if (options.out) {
+		writeFileSync(options.out, JSON.stringify(geojson, null, 2))
+		lines.push(`wrote ${geojson.features.length} features → ${options.out}`)
+	}
+	if (options.mapOut) {
+		writeFileSync(
+			options.mapOut,
+			toMapHTML(geojson, options.source ? { title: `Mailwoman — ${options.source}` } : {})
+		)
+		lines.push(`wrote map → ${options.mapOut}`)
+	}
+	return lines.join("\n")
+}
+
+/**
  * Multi-source mode (#618): stream each dataset under its own mapping + provenance label into ONE
  * combined record set, geocode, resolve, and report the entities that span ≥2 sources — the
  * cross-dataset links. No shared key required; geography is the join.
@@ -307,11 +338,8 @@ async function runMultiSource(specs: MultiSourceSpec[], options: zod.infer<typeo
 			`registry --sources: ${specs.length} sources (${perSource.join(", ")}) → ${records.length} records ` +
 			`(${geocoded} geocoded) → ${result.entities.length} entities; ${crossSource} span ≥2 sources (cross-dataset links)`
 
-		if (options.out) {
-			writeFileSync(options.out, JSON.stringify(geojson, null, 2))
-			return `${summary}\nwrote ${geojson.features.length} features → ${options.out}`
-		}
-		return JSON.stringify(geojson, null, 2)
+		const written = writeOutputs(geojson, options)
+		return written === null ? JSON.stringify(geojson, null, 2) : `${summary}\n${written}`
 	} finally {
 		close()
 	}
@@ -344,11 +372,8 @@ async function runRegistry(csvPath: string, options: zod.infer<typeof OptionsSch
 			`${result.entities.length} entities ` +
 			`(${result.candidatePairs} candidate pairs${result.droppedBlocks.length ? `, ${result.droppedBlocks.length} oversized blocks skipped` : ""})`
 
-		if (options.out) {
-			writeFileSync(options.out, JSON.stringify(geojson, null, 2))
-			return `${summary}\nwrote ${geojson.features.length} features → ${options.out}`
-		}
-		return JSON.stringify(geojson, null, 2)
+		const written = writeOutputs(geojson, options)
+		return written === null ? JSON.stringify(geojson, null, 2) : `${summary}\n${written}`
 	} finally {
 		close()
 	}

--- a/registry/index.ts
+++ b/registry/index.ts
@@ -14,6 +14,7 @@
 export * from "./address-key.js"
 export * from "./geojson.js"
 export * from "./ingest.js"
+export * from "./map-html.js"
 export * from "./learned-scorer.js"
 export * from "./models/dedup-gbt-en-us.js"
 export * from "./resolve.js"

--- a/registry/map-html.test.ts
+++ b/registry/map-html.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { describe, expect, it } from "vitest"
+import { toMapHTML } from "./map-html.js"
+import type { GeoJsonFeatureCollection } from "./types.js"
+
+function fc(features: GeoJsonFeatureCollection["features"]): GeoJsonFeatureCollection {
+	return { type: "FeatureCollection", features }
+}
+
+function point(lon: number, lat: number, props: Record<string, unknown>): GeoJsonFeatureCollection["features"][number] {
+	return { type: "Feature", geometry: { type: "Point", coordinates: [lon, lat] }, properties: props }
+}
+
+describe("toMapHTML", () => {
+	it("returns a complete, self-contained HTML document with Leaflet pinned + the data inlined", () => {
+		const html = toMapHTML(
+			fc([point(-97.7431, 30.2672, { entityId: "e1", recordCount: 2, sources: ["a", "b"], name: "Acme" })])
+		)
+		expect(html.startsWith("<!doctype html>")).toBe(true)
+		expect(html.trimEnd().endsWith("</html>")).toBe(true)
+		// Leaflet is pinned with Subresource-Integrity hashes.
+		expect(html).toContain("leaflet@1.9.4/dist/leaflet.js")
+		expect(html).toContain('integrity="sha256-')
+		// The FeatureCollection is inlined (no fetch of an external data file).
+		expect(html).toContain('"entityId":"e1"')
+		expect(html).toContain("L.map(")
+	})
+
+	it("renders an empty collection as a friendly empty state, not a broken map", () => {
+		const html = toMapHTML(fc([]))
+		expect(html).toContain("No geocoded entities")
+		expect(html).toContain("setView([20, 0], 2)")
+	})
+
+	it("escapes `</script>` inside record values so a malicious string can't break out of the inlined data", () => {
+		const html = toMapHTML(fc([point(0, 0, { entityId: "x", recordCount: 1, name: "</script><script>alert(1)" })]))
+		// The literal closing tag must NOT survive inside the data block.
+		expect(html).not.toContain("</script><script>alert(1)")
+		// It must be present in escaped < form instead.
+		expect(html).toContain("\\u003c/script")
+	})
+
+	it("auto-selects bucket coloring when any feature carries a `bucket`, else cross-dataset coloring", () => {
+		const withBuckets = toMapHTML(
+			fc([
+				point(0, 0, { entityId: "a", recordCount: 1, bucket: "enrolled", sources: ["x"] }),
+				point(1, 1, { entityId: "b", recordCount: 1, bucket: "eligible-not-enrolled", sources: ["y"] }),
+			])
+		)
+		expect(withBuckets).toContain('var mode = COLOR_BY === "auto"')
+		// Bucket labels are rendered verbatim into the legend wiring (neutral — straight from the data).
+		expect(withBuckets).toContain("enrolled")
+		expect(withBuckets).toContain("eligible-not-enrolled")
+
+		const noBuckets = toMapHTML(fc([point(0, 0, { entityId: "a", recordCount: 1, sources: ["x", "y"] })]))
+		expect(noBuckets).toContain("cross-dataset link")
+	})
+
+	it("honors the title and basemap options; falls back to OSM for an unknown basemap", () => {
+		const html = toMapHTML(fc([point(0, 0, { entityId: "a", recordCount: 1 })]), {
+			title: "Coverage reconciliation",
+			basemap: "carto-dark",
+		})
+		expect(html).toContain("<title>Coverage reconciliation</title>")
+		expect(html).toContain("dark_all")
+
+		// Unknown basemap → OSM default (the guard keeps a bad option from producing a broken tile URL).
+		const fallback = toMapHTML(fc([point(0, 0, { entityId: "a", recordCount: 1 })]), {
+			basemap: "nope" as never,
+		})
+		expect(fallback).toContain("tile.openstreetmap.org")
+	})
+
+	it("escapes the title in the document body too (not just the script)", () => {
+		const html = toMapHTML(fc([]), { title: "<b>x</b>" })
+		expect(html).toContain("<title>&lt;b&gt;x&lt;/b&gt;</title>")
+	})
+})

--- a/registry/map-html.ts
+++ b/registry/map-html.ts
@@ -1,0 +1,266 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Render resolved entities as a standalone, self-contained map you can just open in a browser —
+ *   the visual complement to {@link toGeoJSON}'s analyst/QGIS export. Until now the matcher's only
+ *   output surface was raw GeoJSON ("open it in QGIS"); this turns the same FeatureCollection into
+ *   one HTML file (Leaflet from a pinned CDN + open basemap tiles, the data inlined) that shows each
+ *   entity as a point, sized by how many records merged into it and colored by whether it spans ≥2
+ *   sources (a cross-dataset link) — or, when the features carry a `bucket` property (the
+ *   reconciliation output), colored categorically by that bucket.
+ *
+ *   This is a NEUTRAL entity-resolution view: it shows what resolved to what and how confidently
+ *   (cohesion). It draws no conclusions about the records themselves — bucket labels are rendered
+ *   verbatim from the data, never editorialized.
+ *
+ *   Pure: GeoJSON in, HTML string out. No I/O, no network at generate time. The generated page does
+ *   fetch Leaflet + map tiles from the network when opened (standard for any web map).
+ */
+
+import type { GeoJsonFeatureCollection } from "./types.js"
+
+/** Leaflet release the generated page pins (CDN + Subresource-Integrity hashes from the official dist). */
+const LEAFLET_VERSION = "1.9.4"
+const LEAFLET_CSS_SRI = "sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+const LEAFLET_JS_SRI = "sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+
+/** Basemap tile choices. All are free for reasonable use and require attribution (rendered in-map). */
+const BASEMAPS = {
+	osm: {
+		url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+		maxZoom: 19,
+	},
+	"carto-light": {
+		url: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+		attribution:
+			'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+		maxZoom: 20,
+	},
+	"carto-dark": {
+		url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+		attribution:
+			'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+		maxZoom: 20,
+	},
+} as const
+
+export interface MapHTMLOptions {
+	/** Document `<title>` + the on-map heading. Default: "Mailwoman — resolved entities". */
+	title?: string
+	/** Basemap tiles. Default: "osm". */
+	basemap?: keyof typeof BASEMAPS
+	/**
+	 * How to color the markers:
+	 *
+	 * - `"auto"` (default) — color by the `bucket` property if ANY feature carries one (reconciliation
+	 *   output), otherwise color cross-dataset links (entities spanning ≥2 sources) apart from
+	 *   single-source entities.
+	 * - `"sources"` — always color by cross-dataset link status.
+	 * - `"bucket"` — always color by the `bucket` property (features without one fall into "—").
+	 */
+	colorBy?: "auto" | "sources" | "bucket"
+}
+
+/**
+ * Escape a string for safe inlining inside an HTML `<script>` block as part of a JSON literal.
+ * `JSON.stringify` alone is not enough: a record value containing `</script>` would close the block
+ * early. Escaping `<`, `>`, and `&` to their `\uXXXX` forms keeps the JSON valid while making a
+ * `</script>` breakout impossible. (Popup rendering escapes again, client-side, against HTML
+ * injection — see the template's `esc()`.)
+ */
+function safeJsonForScript(value: unknown): string {
+	return JSON.stringify(value).replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026")
+}
+
+/** Escape text destined for the HTML document body (the heading/title), not the inlined script. */
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+}
+
+/**
+ * Render `geojson` (a {@link toGeoJSON} FeatureCollection) as a complete, standalone HTML document.
+ * Open the returned string in any browser; no server or build step. Entities without a coordinate
+ * are already absent from a `toGeoJSON` collection, so an empty collection renders a friendly
+ * "nothing to show" state rather than a broken map.
+ */
+export function toMapHTML(geojson: GeoJsonFeatureCollection, options: MapHTMLOptions = {}): string {
+	const title = options.title ?? "Mailwoman — resolved entities"
+	const basemapKey = options.basemap && options.basemap in BASEMAPS ? options.basemap : "osm"
+	const basemap = BASEMAPS[basemapKey]
+	const colorBy = options.colorBy ?? "auto"
+
+	const featureCount = geojson.features.length
+	const data = safeJsonForScript(geojson)
+
+	// The client-side script is intentionally written with string concatenation (no template literals
+	// and no `${`), so it survives being embedded in this outer template literal verbatim.
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${escapeHtml(title)}</title>
+<link
+	rel="stylesheet"
+	href="https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.css"
+	integrity="${LEAFLET_CSS_SRI}"
+	crossorigin="" />
+<style>
+	html, body { margin: 0; height: 100%; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+	#map { position: absolute; inset: 0; }
+	.mw-panel {
+		background: rgba(255,255,255,0.94); padding: 10px 12px; border-radius: 8px;
+		box-shadow: 0 1px 6px rgba(0,0,0,0.25); font-size: 12px; line-height: 1.5; color: #1a1a1a;
+	}
+	.mw-panel h1 { font-size: 14px; margin: 0 0 4px; }
+	.mw-panel .muted { color: #666; }
+	.mw-legend i { display: inline-block; width: 12px; height: 12px; margin-right: 6px; border-radius: 50%; vertical-align: -1px; }
+	.mw-popup { font-size: 12px; line-height: 1.5; max-width: 260px; }
+	.mw-popup .nm { font-weight: 600; font-size: 13px; }
+	.mw-popup dt { color: #666; }
+	.mw-popup .link { color: #e8590c; font-weight: 600; }
+	.mw-empty { position: absolute; inset: 0; display: grid; place-items: center; color: #444; }
+</style>
+</head>
+<body>
+<div id="map"></div>
+<script
+	src="https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.js"
+	integrity="${LEAFLET_JS_SRI}"
+	crossorigin=""></script>
+<script>
+"use strict";
+var DATA = ${data};
+var TITLE = ${safeJsonForScript(title)};
+var COLOR_BY = ${safeJsonForScript(colorBy)};
+var BASE_URL = ${safeJsonForScript(basemap.url)};
+var BASE_ATTR = ${safeJsonForScript(basemap.attribution)};
+var BASE_MAXZOOM = ${basemap.maxZoom};
+
+// Categorical palette (color-blind-friendly-ish) reused for buckets; cycles if there are more buckets.
+var PALETTE = ["#2f9e44", "#f08c00", "#1971c2", "#e8590c", "#9c36b5", "#0c8599", "#e03131", "#5c940d"];
+var SINGLE_COLOR = "#3388ff";   // single-source entity
+var CROSS_COLOR  = "#e8590c";   // cross-dataset link (>= 2 sources)
+
+function esc(v) {
+	if (v === null || v === undefined) return "";
+	return String(v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+// Does the data carry bucket labels? (reconciliation output)
+var hasBuckets = DATA.features.some(function (f) { return f.properties && f.properties.bucket != null; });
+var mode = COLOR_BY === "auto" ? (hasBuckets ? "bucket" : "sources") : COLOR_BY;
+
+// Stable color assignment for bucket values, in first-seen order.
+var bucketColors = {};
+(function () {
+	var i = 0;
+	DATA.features.forEach(function (f) {
+		var b = f.properties && f.properties.bucket != null ? String(f.properties.bucket) : "—";
+		if (!(b in bucketColors)) { bucketColors[b] = PALETTE[i % PALETTE.length]; i++; }
+	});
+})();
+
+function sourceCount(props) {
+	return Array.isArray(props.sources) ? props.sources.length : 0;
+}
+
+function colorFor(props) {
+	if (mode === "bucket") {
+		var b = props.bucket != null ? String(props.bucket) : "—";
+		return bucketColors[b] || SINGLE_COLOR;
+	}
+	return sourceCount(props) >= 2 ? CROSS_COLOR : SINGLE_COLOR;
+}
+
+function radiusFor(props) {
+	var n = props.recordCount || 1;
+	return Math.max(4, Math.min(20, 4 + Math.sqrt(n) * 2));
+}
+
+function popupHtml(props) {
+	var rows = [];
+	var heading = props.name || props.organization || props.entityId || "entity";
+	rows.push('<div class="nm">' + esc(heading) + '</div>');
+	if (props.organization && props.organization !== props.name) {
+		rows.push('<div>' + esc(props.organization) + '</div>');
+	}
+	if (props.address) rows.push('<div class="muted">' + esc(props.address) + '</div>');
+	rows.push('<hr style="border:none;border-top:1px solid #eee;margin:6px 0" />');
+	rows.push('<div><dt style="display:inline">records merged:</dt> ' + esc(props.recordCount) + '</div>');
+	var srcs = Array.isArray(props.sources) ? props.sources : [];
+	if (srcs.length) {
+		var cls = srcs.length >= 2 ? ' class="link"' : '';
+		rows.push('<div><dt style="display:inline">sources:</dt> <span' + cls + '>' + esc(srcs.join(", ")) + '</span>'
+			+ (srcs.length >= 2 ? ' (cross-dataset link)' : '') + '</div>');
+	}
+	if (props.bucket != null) rows.push('<div><dt style="display:inline">bucket:</dt> ' + esc(props.bucket) + '</div>');
+	if (props.cohesion != null) rows.push('<div><dt style="display:inline">cohesion:</dt> ' + esc(props.cohesion) + ' bits</div>');
+	if (props.geocodeTier) rows.push('<div><dt style="display:inline">geocode tier:</dt> ' + esc(props.geocodeTier) + '</div>');
+	return '<div class="mw-popup">' + rows.join("") + '</div>';
+}
+
+var map = L.map("map", { preferCanvas: true });
+L.tileLayer(BASE_URL, { attribution: BASE_ATTR, maxZoom: BASE_MAXZOOM }).addTo(map);
+
+if (!DATA.features.length) {
+	document.body.insertAdjacentHTML("beforeend",
+		'<div class="mw-empty"><div class="mw-panel"><h1>' + esc(TITLE) + '</h1>'
+		+ '<div class="muted">No geocoded entities to display.</div></div></div>');
+	map.setView([20, 0], 2);
+} else {
+	var layer = L.geoJSON(DATA, {
+		pointToLayer: function (feature, latlng) {
+			var p = feature.properties || {};
+			return L.circleMarker(latlng, {
+				radius: radiusFor(p), color: "#fff", weight: 1,
+				fillColor: colorFor(p), fillOpacity: 0.85
+			});
+		},
+		onEachFeature: function (feature, lyr) { lyr.bindPopup(popupHtml(feature.properties || {})); }
+	}).addTo(map);
+	map.fitBounds(layer.getBounds().pad(0.1));
+
+	// Title + summary panel (top-left).
+	var info = L.control({ position: "topleft" });
+	info.onAdd = function () {
+		var crossLinks = DATA.features.filter(function (f) { return sourceCount(f.properties || {}) >= 2; }).length;
+		var div = L.DomUtil.create("div", "mw-panel");
+		div.innerHTML = '<h1>' + esc(TITLE) + '</h1>'
+			+ '<div class="muted">' + DATA.features.length + ' entities'
+			+ (mode === "sources" ? ' &middot; ' + crossLinks + ' cross-dataset links' : '') + '</div>';
+		return div;
+	};
+	info.addTo(map);
+
+	// Legend (bottom-right): bucket categories, or the cross-dataset / single-source split.
+	var legend = L.control({ position: "bottomright" });
+	legend.onAdd = function () {
+		var div = L.DomUtil.create("div", "mw-panel mw-legend");
+		if (mode === "bucket") {
+			var html = "";
+			Object.keys(bucketColors).forEach(function (b) {
+				html += '<div><i style="background:' + bucketColors[b] + '"></i>' + esc(b) + '</div>';
+			});
+			div.innerHTML = html;
+		} else {
+			div.innerHTML = '<div><i style="background:' + CROSS_COLOR + '"></i>cross-dataset link (&ge;2 sources)</div>'
+				+ '<div><i style="background:' + SINGLE_COLOR + '"></i>single-source entity</div>'
+				+ '<div class="muted" style="margin-top:4px">marker size = records merged</div>';
+		}
+		return div;
+	};
+	legend.addTo(map);
+}
+</script>
+</body>
+</html>
+`
+}


### PR DESCRIPTION
## What

Tier 2 product surface: a **map view** for the geocode-first record matcher. Until now the matcher's only output was raw GeoJSON ("open it in QGIS"). This turns the same `toGeoJSON` FeatureCollection into **one self-contained HTML file you open in a browser** — no server, no build.

- New `toMapHTML(featureCollection, options?)` in `@mailwoman/registry` — pure (GeoJSON in, HTML string out). Leaflet pinned from CDN with Subresource-Integrity hashes; open basemap tiles (OSM / CARTO light / dark); the data inlined.
- Each entity is a point **sized by records-merged** and **colored by cross-dataset-link status** (entities spanning ≥2 sources stand out) — or **colored categorically by `bucket`** when the reconciliation output carries one (auto-detected).
- Click a point for a popup: name/org/address, sources (flagged as a cross-dataset link at ≥2), records-merged, cohesion, geocode tier.
- Wired into the CLI: **`mailwoman registry --map-out report.html`**, in both single-CSV and `--sources` modes (shared `writeOutputs` helper).

## Neutral framing

A neutral entity-resolution view: it shows *what resolved to what* and *how confidently* (cohesion). Bucket labels render **verbatim** from the data, never editorialized.

## Safety

- `</script>` inside record values is escaped (`<`/`>`/`&` → `\uXXXX`) so a string can't break out of the inlined data block.
- Popup values are escaped **client-side** against HTML injection.

## Verification

- 6 unit tests: document structure, the `</script>` escape, bucket auto-detection, options (title/basemap + unknown-basemap fallback), body-title escaping. Full registry suite: **45/45 pass**.
- Headless render of both modes (cross-dataset + reconciliation buckets): tiles load, markers + legend render, **0 console errors**. Screenshots shared with the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
