### PR TITLE
feat(record): context-aware legal designations — jurisdiction × domain (#668)

### DIFF
--- a/record/organization.test.ts
+++ b/record/organization.test.ts
@@ -51,3 +51,56 @@ describe("canonicalizeOrganizationName", () => {
 		expect(canonicalizeOrganizationName("Acme LLC")?.raw).toBe("Acme LLC")
 	})
 })
+
+describe("canonicalizeOrganizationName — jurisdiction × domain collisions (#668)", () => {
+	it("byte-stable default: never strips collision-prone tokens without context", () => {
+		// pt / sca / scs are NOT in the universal base — the legacy behavior keeps them.
+		expect(canonicalizeOrganizationName("Lakeside PT")?.canonical).toBe("lakeside pt")
+		expect(canonicalizeOrganizationName("Lakeside PT")?.designations).toEqual([])
+		expect(canonicalizeOrganizationName("Cardiac SCA Clinic")?.canonical).toBe("cardiac sca clinic")
+		// base forms still strip with no options (unchanged).
+		expect(canonicalizeOrganizationName("Acme LLC")?.canonical).toBe("acme")
+	})
+
+	it("strips PT for an Indonesian jurisdiction (general / no domain)", () => {
+		const org = canonicalizeOrganizationName("Maju Bersama PT", { jurisdiction: "ID" })
+		expect(org?.canonical).toBe("maju bersama")
+		expect(org?.designations).toEqual(["pt"])
+		// explicit general domain protects nothing — same result.
+		expect(canonicalizeOrganizationName("Maju Bersama PT", { jurisdiction: "ID", domain: "general" })?.canonical).toBe(
+			"maju bersama",
+		)
+	})
+
+	it("jurisdiction code is case-insensitive", () => {
+		expect(canonicalizeOrganizationName("Maju Bersama PT", { jurisdiction: "id" })?.designations).toEqual(["pt"])
+	})
+
+	it("preserves PT in the healthcare domain", () => {
+		const org = canonicalizeOrganizationName("Lakeside PT", { domain: "healthcare" })
+		expect(org?.canonical).toBe("lakeside pt")
+		expect(org?.designations).toEqual([])
+	})
+
+	it("domain protection beats the jurisdiction pack (PT kept for an ID healthcare org)", () => {
+		const org = canonicalizeOrganizationName("Maju Bersama PT", { jurisdiction: "ID", domain: "healthcare" })
+		expect(org?.canonical).toBe("maju bersama pt")
+		expect(org?.designations).toEqual([])
+	})
+
+	it("strips French commandite forms (sca / scs) only with the FR jurisdiction", () => {
+		expect(canonicalizeOrganizationName("Compagnie Générale SCA", { jurisdiction: "FR" })?.designations).toEqual([
+			"sca",
+		])
+		// but healthcare protects SCA even under FR jurisdiction.
+		expect(
+			canonicalizeOrganizationName("Cardiac SCA Clinic", { jurisdiction: "FR", domain: "healthcare" })?.canonical,
+		).toBe("cardiac sca clinic")
+	})
+
+	it("an unknown jurisdiction adds nothing (US keeps base behavior)", () => {
+		const org = canonicalizeOrganizationName("Lakeside PT LLC", { jurisdiction: "US" })
+		expect(org?.canonical).toBe("lakeside pt") // LLC stripped (base), PT kept (no US pack)
+		expect(org?.designations).toEqual(["llc"])
+	})
+})

--- a/record/organization.ts
+++ b/record/organization.ts
@@ -10,13 +10,30 @@
  *   Corporation, LLC` collapse to the same key. We also split off a `doing business as` clause and
  *   normalize connectives (`&` → `and`), punctuation, accents, and a leading `The`.
  *
+ *   **The collision problem (#668).** A legal-form token in one jurisdiction is a meaningful word in
+ *   another domain. `PT` is Indonesia's `Perseroan Terbatas` (its LLC) — and US-healthcare shorthand
+ *   for *Physical Therapy*. `SCA` / `SCS` are French/Belgian/Luxembourg commandite forms — and, in a
+ *   clinic's name, *Sudden Cardiac Arrest* / *Spinal Cord Stimulator*. A single universal strip-list
+ *   can't be right for both: strip `PT` and you corrupt `Lakeside PT`; keep it and you leave the
+ *   legal form on an Indonesian company. So the strip-set is computed on **two axes**:
+ *
+ *   - **jurisdiction** (ISO 3166-1 alpha-2, e.g. from the resolved address country) — *adds* the
+ *     legal forms valid in that country. Collision-prone forms (`pt`, `sca`, `scs`) live here, gated
+ *     behind a known jurisdiction, NOT in the universal base.
+ *   - **domain** (an ingest-config tag, e.g. `healthcare`) — *protects* domain-meaningful tokens from
+ *     ever being stripped, even when a jurisdiction pack would add them. Domain protection wins.
+ *
+ *   `effective = (base ∪ jurisdiction-pack) − domain-protect-pack`. With no options the set is the
+ *   universal base and behavior is byte-for-byte unchanged — the new axes are strictly opt-in.
+ *
  *   Evidence honesty (per the name-canonicalization research pass): the PERSON-name side is well
  *   sourced; the ORGANIZATION side is a known evidence gap. This is a solid _canonicalization_
  *   baseline (the strip-designations principle is Winkler-grounded; the designation list draws on
- *   the ISO 20275 Entity Legal Forms register and `cleanco`). The harder org-_matching_ problems —
- *   acronym ↔ expansion (`IBM` ↔ `International Business Machines`), DBA/alias resolution beyond
- *   the simple clause, subsidiary/parent, and TF-IDF n-gram token matching — are deferred to a
- *   follow-up (a dedicated org-matching research pass + the matcher epic).
+ *   the ISO 20275 Entity Legal Forms register and `cleanco`). The jurisdiction/domain packs below
+ *   are grounded seeds, not exhaustive — extend them per ISO 20275 as locales are added. The harder
+ *   org-_matching_ problems — acronym ↔ expansion (`IBM` ↔ `International Business Machines`),
+ *   DBA/alias resolution beyond the simple clause, subsidiary/parent, and TF-IDF n-gram token
+ *   matching — are deferred to a follow-up (a dedicated org-matching research pass + the matcher epic).
  */
 
 /** A canonicalized organization name. */
@@ -32,12 +49,36 @@ export interface OrganizationName {
 }
 
 /**
- * Legal-entity designations across jurisdictions, normalized to lowercase with punctuation removed
- * (so `L.L.C.` → `llc`). Drawn from the ISO 20275 Entity Legal Forms register + `cleanco`'s common
- * set. Stripped as whole tokens wherever they occur. Deliberately excludes name-meaningful words
- * (`group`, `holdings`, `partners`, `associates`).
+ * A domain pack name. Each protects the abbreviations that are meaningful in that domain from being
+ * stripped as legal forms (see {@link DOMAIN_PROTECTED}). `general` protects nothing — the explicit
+ * "no domain" choice. Add a pack here (and to {@link DOMAIN_PROTECTED}) per ingest domain.
  */
-const DESIGNATIONS = new Set([
+export type DesignationDomain = "general" | "healthcare"
+
+/** Context for {@link canonicalizeOrganizationName}. Omit both fields for the universal base behavior. */
+export interface CanonicalizeOptions {
+	/**
+	 * ISO 3166-1 alpha-2 country code of the org's jurisdiction (typically the resolved address
+	 * country). Adds that country's legal forms — including collision-prone ones gated out of the
+	 * base — to the strip-set. Case-insensitive; unknown codes add nothing.
+	 */
+	jurisdiction?: string
+	/**
+	 * Ingest domain. Protects domain-meaningful abbreviations (e.g. `healthcare` protects `pt` /
+	 * `sca` / `scs`) from being stripped, overriding any jurisdiction pack that would add them.
+	 */
+	domain?: DesignationDomain
+}
+
+/**
+ * Universal legal-entity designations — the forms that are safe to strip regardless of jurisdiction
+ * or domain because they don't collide with common domain abbreviations. Normalized to lowercase
+ * with punctuation removed (so `L.L.C.` → `llc`). Drawn from the ISO 20275 register + `cleanco`'s
+ * common set. Stripped as whole tokens wherever they occur. Deliberately excludes name-meaningful
+ * words (`group`, `holdings`, `partners`, `associates`) AND the collision-prone forms (`pt`, `sca`,
+ * `scs`) — those last live in {@link JURISDICTION_DESIGNATIONS}, gated behind a known jurisdiction.
+ */
+const BASE_DESIGNATIONS = new Set([
 	"inc",
 	"incorporated",
 	"corp",
@@ -87,13 +128,55 @@ const DESIGNATIONS = new Set([
 	"doo",
 	"ood",
 	"ead",
-	// Belgian forms — the only ISP-Nexus FCC designations we lacked that are SAFE to add. The rest of
-	// its international set (pt, sca, scs) collide with US-healthcare abbreviations — PT = Physical
-	// Therapy, SCA = Sudden Cardiac Arrest, SCS = Spinal Cord Stimulator — so stripping them as legal
-	// designations would corrupt NPPES org names. Designation lists are domain-scoped, not universal.
+	// Belgian forms — safe to add to the base (no domain collision).
 	"bvba",
 	"sprl",
 ])
+
+/**
+ * Jurisdiction-gated legal forms (ISO 3166-1 alpha-2 → forms), added only when the jurisdiction is
+ * known. This is where the collision-prone tokens live: `pt` (Indonesia), `sca` / `scs`
+ * (French/Belgian/Luxembourg commandite forms). Stripping these is correct ONLY when we know the
+ * org's country — never in the universal base. Grounded seeds, not exhaustive; extend per ISO 20275.
+ */
+const JURISDICTION_DESIGNATIONS: Record<string, readonly string[]> = {
+	ID: ["pt", "tbk", "ud"], // Perseroan Terbatas / Terbuka (listed) / Usaha Dagang
+	FR: ["sca", "scs", "sci", "eurl", "sasu", "snc"],
+	BE: ["sca", "scs"],
+	LU: ["sca", "scs"],
+	ES: ["scs"], // Sociedad en Comandita Simple
+	IT: ["sapa", "snc"], // S.a.p.a. (commandite par actions) / società in nome collettivo
+}
+
+/**
+ * Domain protect-sets (domain → tokens never stripped). Overrides any jurisdiction pack: a token
+ * here stays in the name even if the org's jurisdiction would treat it as a legal form. `healthcare`
+ * guards the clinical abbreviations that collide with gated legal forms — `pt` (Physical Therapy),
+ * `sca` (Sudden Cardiac Arrest), `scs` (Spinal Cord Stimulator) — plus a couple of always-clinical
+ * ones for future-proofing.
+ */
+const DOMAIN_PROTECTED: Record<DesignationDomain, readonly string[]> = {
+	general: [],
+	healthcare: ["pt", "sca", "scs", "ot", "dpt"],
+}
+
+/**
+ * Compute the effective designation strip-set for the given context:
+ * `(base ∪ jurisdiction-pack) − domain-protect-pack`. Returns the shared base set unchanged when no
+ * context is given (the byte-stable default), so the common path allocates nothing.
+ */
+function resolveDesignations(options?: CanonicalizeOptions): ReadonlySet<string> {
+	const jurisdiction = options?.jurisdiction?.trim().toUpperCase()
+	const jurisdictionPack = jurisdiction ? JURISDICTION_DESIGNATIONS[jurisdiction] : undefined
+	const protectPack = options?.domain ? DOMAIN_PROTECTED[options.domain] : undefined
+
+	if (!jurisdictionPack && !protectPack?.length) return BASE_DESIGNATIONS
+
+	const set = new Set(BASE_DESIGNATIONS)
+	if (jurisdictionPack) for (const token of jurisdictionPack) set.add(token)
+	if (protectPack) for (const token of protectPack) set.delete(token)
+	return set
+}
 
 /** Splits a `doing business as` / trade-name clause from a legal name. */
 const DBA_PATTERN = /\s+(?:d\/b\/a|dba|doing business as|t\/a|trading as|a\/k\/a|aka|fka|f\/k\/a)\s+/i
@@ -103,7 +186,10 @@ const DBA_PATTERN = /\s+(?:d\/b\/a|dba|doing business as|t\/a|trading as|a\/k\/a
  * remove a leading `the`, strip legal designations, collapse whitespace. Returns the key plus the
  * designations it removed.
  */
-function canonicalizeFragment(fragment: string): { canonical: string; designations: string[] } {
+function canonicalizeFragment(
+	fragment: string,
+	designationSet: ReadonlySet<string>,
+): { canonical: string; designations: string[] } {
 	const normalized = fragment
 		.normalize("NFKD")
 		.replace(/[̀-ͯ]/g, "")
@@ -122,7 +208,7 @@ function canonicalizeFragment(fragment: string): { canonical: string; designatio
 	const kept: string[] = []
 	for (const token of normalized.split(" ")) {
 		if (!token) continue
-		if (DESIGNATIONS.has(token)) designations.push(token)
+		if (designationSet.has(token)) designations.push(token)
 		else kept.push(token)
 	}
 
@@ -132,19 +218,27 @@ function canonicalizeFragment(fragment: string): { canonical: string; designatio
 /**
  * Canonicalize an organization name: split off any `doing business as` clause, then reduce the
  * legal name to a designation-stripped key. Returns `null` for empty input.
+ *
+ * Pass {@link CanonicalizeOptions} to resolve the jurisdiction × domain collision (#668): a
+ * `jurisdiction` adds that country's legal forms, a `domain` protects its meaningful abbreviations.
+ * With no options the universal base set is used and the result is byte-for-byte the legacy behavior.
  */
-export function canonicalizeOrganizationName(input: string | null | undefined): OrganizationName | null {
+export function canonicalizeOrganizationName(
+	input: string | null | undefined,
+	options?: CanonicalizeOptions,
+): OrganizationName | null {
 	if (typeof input !== "string" || !input.trim()) return null
 
 	const raw = input
+	const designationSet = resolveDesignations(options)
 	const [legalPart, ...dbaParts] = input.split(DBA_PATTERN)
 
-	const { canonical, designations } = canonicalizeFragment(legalPart ?? "")
+	const { canonical, designations } = canonicalizeFragment(legalPart ?? "", designationSet)
 
 	const result: OrganizationName = { raw, canonical, designations }
 
 	if (dbaParts.length) {
-		const dba = canonicalizeFragment(dbaParts.join(" ")).canonical
+		const dba = canonicalizeFragment(dbaParts.join(" "), designationSet).canonical
 		if (dba) result.dba = dba
 	}
 


### PR DESCRIPTION
Closes #668.

## The collision problem

A legal-form token in one jurisdiction is a meaningful word in another domain:

| token | legal form (jurisdiction) | collides with (domain) |
|---|---|---|
| `PT` | Perseroan Terbatas — Indonesia's LLC | **Physical Therapy** (US healthcare) |
| `SCA` | Société en Commandite par Actions — FR/BE/LU | **Sudden Cardiac Arrest** |
| `SCS` | Société en Commandite Simple — FR/BE/LU/ES | **Spinal Cord Stimulator** |

A single universal strip-list can't be right for both — strip `PT` and you corrupt `Lakeside PT`; keep it and you leave the legal form on an Indonesian company.

## The two-axis fix

`canonicalizeOrganizationName` now computes the strip-set on two axes:

- **jurisdiction** (ISO 3166-1 alpha-2, e.g. the resolved address country) **adds** that country's legal forms. The collision-prone tokens (`pt`, `sca`, `scs`) live *here*, gated behind a known jurisdiction — never in the universal base.
- **domain** (an ingest-config tag, e.g. `healthcare`) **protects** its meaningful abbreviations from being stripped, overriding any jurisdiction pack. **Domain wins.**

```
effective = (base ∪ jurisdiction-pack) − domain-protect-pack
```

With **no options** the set is the universal base and the result is **byte-for-byte the legacy behavior** — the axes are strictly opt-in.

## API

```ts
canonicalizeOrganizationName(name, { jurisdiction?: string, domain?: "general" | "healthcare" })
```

Ships `general` (protects nothing) + `healthcare` (pt/sca/scs) domain packs, and ID/FR/BE/LU/ES/IT jurisdiction seeds (grounded in ISO 20275, extensible).

## Tests

8 new collision tests (15 in the file, 33 in the record suite, all green) + record typecheck clean:
- PT kept by default (byte-stable) and in the healthcare domain
- PT stripped for an Indonesian (`ID`) general org
- domain beats jurisdiction (PT kept for an ID + healthcare org)
- FR `sca`/`scs` stripped only under `FR`; protected under healthcare
- unknown jurisdiction (`US`) keeps base behavior (LLC stripped, PT kept)

## Scope

Default-safe **library capability**. Not yet wired into `resolveEntities` — threading jurisdiction (from the resolved address country) and domain (from ingest config) into the matcher changes matching behavior and wants its own eval; flagged as a follow-up.

Neutral entity-resolution framing throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)