### PR TITLE
viz(record-matcher): cross-dataset linking map on the house stack (#618)

### DIFF
--- a/scripts/record-matcher/viz/cross-dataset-map.ts
+++ b/scripts/record-matcher/viz/cross-dataset-map.ts
@@ -19,8 +19,12 @@
  *   domains; a file:// page shows accurate markers on a blank basemap). e.g. `python3 -m
  *   http.server -d <dir>` then open the page; or use `render-map.mjs` against the served URL.
  *
+ *   `--cross-agency-only` keeps just the entities whose sources span >1 AGENCY (the two FCC datasets
+ *   count as one) — the harder cross-agency slice; most raw links are FCC-internal (RHC ↔
+ *   commitments).
+ *
  *   Run: node --experimental-strip-types scripts/record-matcher/viz/cross-dataset-map.ts\
- *   [--in <links.geojson>] [--out-html /tmp/cross-dataset-map.html]
+ *   [--in <links.geojson>] [--out-html /tmp/cross-dataset-map.html] [--cross-agency-only]
  */
 
 import { toMapHTML } from "@mailwoman/registry"
@@ -37,37 +41,59 @@ const OUT = arg("out-html", "/tmp/cross-dataset-map.html")
 const SOURCE_LABELS: Record<string, string> = {
 	nppes: "NPPES",
 	"fcc-rhc": "FCC RHC",
+	"fcc-rhc-commitments": "FCC commitments",
 	"txhhsc-nursing": "TX HHSC",
 }
 const label = (s: string) => SOURCE_LABELS[s] ?? s
 
-const geojson = JSON.parse(readFileSync(IN, "utf8")) as {
+// Which AGENCY each source belongs to. The two FCC datasets (RHC posted-services + commitments) are
+// ONE agency — so an NPPES↔FCC or FCC↔TX link is cross-AGENCY, but an RHC↔commitments link is not.
+// `--cross-agency-only` keeps just the entities whose sources span >1 agency: the harder, more
+// striking "no shared key ACROSS agencies" slice (most of the raw links are FCC-internal).
+const SOURCE_AGENCY: Record<string, string> = {
+	nppes: "CMS",
+	"fcc-rhc": "FCC",
+	"fcc-rhc-commitments": "FCC",
+	"txhhsc-nursing": "TX HHSC",
+}
+const agencyOf = (s: string) => SOURCE_AGENCY[s] ?? s
+const CROSS_AGENCY_ONLY = process.argv.includes("--cross-agency-only")
+
+const sourcesOf = (f: { properties: Record<string, unknown> | null }) =>
+	Array.isArray(f.properties?.["sources"]) ? (f.properties!["sources"] as string[]) : []
+
+const parsed = JSON.parse(readFileSync(IN, "utf8")) as {
 	type: "FeatureCollection"
 	features: Array<{ properties: Record<string, unknown> | null }>
 }
+const total = parsed.features.length
+const geojson = CROSS_AGENCY_ONLY
+	? { ...parsed, features: parsed.features.filter((f) => new Set(sourcesOf(f).map(agencyOf)).size > 1) }
+	: parsed
 
 // Synthesize a `bucket` per entity = its sorted source-combination, so toMapHTML colors by the link
 // TYPE (two-source vs the rarer all-three-source spans) rather than the binary cross/single status.
 let triple = 0
 const comboCounts = new Map<string, number>()
 for (const f of geojson.features) {
-	const sources = Array.isArray(f.properties?.["sources"]) ? (f.properties!["sources"] as string[]) : []
-	const combo = [...new Set(sources)].sort()
+	const combo = [...new Set(sourcesOf(f))].sort()
 	const bucket = combo.map(label).join(" + ") || "unlinked"
 	if (f.properties) f.properties["bucket"] = bucket
-	if (combo.length >= 3) triple++
+	if (new Set(combo.map(agencyOf)).size >= 3) triple++
 	comboCounts.set(bucket, (comboCounts.get(bucket) ?? 0) + 1)
 }
 
+const kept = geojson.features.length
+const scope = CROSS_AGENCY_ONLY ? "across agencies" : "across sources"
 const html = toMapHTML(geojson as never, {
-	title: `Cross-dataset entity links — ${geojson.features.length} resolved across sources (no shared key)`,
+	title: `Cross-dataset entity links — ${kept} resolved ${scope} (no shared key)`,
 	flavor: "light",
 	colorBy: "bucket",
 })
 
 writeFileSync(OUT, html)
-console.error(`[written] ${OUT}  (${geojson.features.length} cross-source entities)`)
+console.error(`[written] ${OUT}  (${kept}${CROSS_AGENCY_ONLY ? ` of ${total} cross-AGENCY` : ""} entities)`)
 console.error(`  source combinations:`)
 for (const [combo, n] of [...comboCounts.entries()].sort((a, b) => b[1] - a[1]))
 	console.error(`    ${n.toString().padStart(4)}  ${combo}`)
-console.error(`  spanning all three sources: ${triple}`)
+console.error(`  spanning all three agencies: ${triple}`)

--- a/scripts/record-matcher/viz/cross-dataset-map.ts
+++ b/scripts/record-matcher/viz/cross-dataset-map.ts
@@ -1,0 +1,73 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The cross-dataset linking map — the marquee record-matcher proof, on a map.
+ *
+ *   The matcher resolves entities ACROSS independent sources (NPPES provider registry, FCC RHC
+ *   funding, TX HHSC facility licensing) with NO shared key — purely on the geocoded location +
+ *   name agreement. This renders the `cross-dataset-links` GeoJSON (every entity that resolved
+ *   across ≥2 sources) on the HOUSE map stack via {@link toMapHTML} (MapLibre GL + a Protomaps
+ *   basemap). Each entity is colored by its SOURCE COMBINATION (a synthesized `bucket`), so the
+ *   entities spanning all three sources stand out from the two-source links.
+ *
+ *   Neutral entity-resolution view: it shows what resolved to what and how confidently (cohesion
+ *   sizes the marker). It does NOT interpret coverage/eligibility — that is the consumer's call.
+ *
+ *   SERVE THE OUTPUT OVER LOCALHOST (the house tile server CORS-restricts to localhost + the docs
+ *   domains; a file:// page shows accurate markers on a blank basemap). e.g. `python3 -m
+ *   http.server -d <dir>` then open the page; or use `render-map.mjs` against the served URL.
+ *
+ *   Run: node --experimental-strip-types scripts/record-matcher/viz/cross-dataset-map.ts\
+ *   [--in <links.geojson>] [--out-html /tmp/cross-dataset-map.html]
+ */
+
+import { toMapHTML } from "@mailwoman/registry"
+import { readFileSync, writeFileSync } from "node:fs"
+
+function arg(name: string, fallback = ""): string {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+}
+
+const IN = arg("in", "/mnt/playpen/mailwoman-data/record-matcher/2026-06-16-cross-dataset-links.geojson")
+const OUT = arg("out-html", "/tmp/cross-dataset-map.html")
+
+const SOURCE_LABELS: Record<string, string> = {
+	nppes: "NPPES",
+	"fcc-rhc": "FCC RHC",
+	"txhhsc-nursing": "TX HHSC",
+}
+const label = (s: string) => SOURCE_LABELS[s] ?? s
+
+const geojson = JSON.parse(readFileSync(IN, "utf8")) as {
+	type: "FeatureCollection"
+	features: Array<{ properties: Record<string, unknown> | null }>
+}
+
+// Synthesize a `bucket` per entity = its sorted source-combination, so toMapHTML colors by the link
+// TYPE (two-source vs the rarer all-three-source spans) rather than the binary cross/single status.
+let triple = 0
+const comboCounts = new Map<string, number>()
+for (const f of geojson.features) {
+	const sources = Array.isArray(f.properties?.["sources"]) ? (f.properties!["sources"] as string[]) : []
+	const combo = [...new Set(sources)].sort()
+	const bucket = combo.map(label).join(" + ") || "unlinked"
+	if (f.properties) f.properties["bucket"] = bucket
+	if (combo.length >= 3) triple++
+	comboCounts.set(bucket, (comboCounts.get(bucket) ?? 0) + 1)
+}
+
+const html = toMapHTML(geojson as never, {
+	title: `Cross-dataset entity links — ${geojson.features.length} resolved across sources (no shared key)`,
+	flavor: "light",
+	colorBy: "bucket",
+})
+
+writeFileSync(OUT, html)
+console.error(`[written] ${OUT}  (${geojson.features.length} cross-source entities)`)
+console.error(`  source combinations:`)
+for (const [combo, n] of [...comboCounts.entries()].sort((a, b) => b[1] - a[1]))
+	console.error(`    ${n.toString().padStart(4)}  ${combo}`)
+console.error(`  spanning all three sources: ${triple}`)

--- a/scripts/record-matcher/viz/render-map.mjs
+++ b/scripts/record-matcher/viz/render-map.mjs
@@ -1,0 +1,48 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Render a {@link toMapHTML} page (MapLibre GL + Protomaps basemap) to a PNG via headless Chromium.
+ *
+ *   Two house-stack constraints make this fiddlier than the Plotly/SVG renderers:
+ *
+ *   - MapLibre needs a real WebGL context → ANGLE's SwiftShader software rasterizer (the same flags the
+ *       3D Plotly render uses).
+ *   - The basemap tiles come from `tiles.sister.software`, which CORS-restricts to localhost + the docs
+ *       domains — so the page MUST be SERVED OVER LOCALHOST, not opened as a file (a file:// page
+ *       renders accurate markers on a blank basemap). Serve the output dir first, e.g. `python3 -m
+ *       http.server 8899 -d <dir>`, then point this at `http://localhost:8899/<page>.html`.
+ *
+ *   The map paints asynchronously after the network settles; we wait for networkidle, then a fixed
+ *   beat for the basemap tiles + marker layer to finish compositing.
+ *
+ *   Run: node scripts/record-matcher/viz/render-map.mjs <served-url> <out.png>
+ */
+
+import { chromium } from "playwright"
+
+const url = process.argv[2]
+const out = process.argv[3]
+if (!url || !out) {
+	console.error("usage: render-map.mjs <served-localhost-url> <out.png>")
+	process.exit(1)
+}
+
+const browser = await chromium.launch({
+	args: ["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader", "--ignore-gpu-blocklist"],
+})
+const page = await browser.newPage({ viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 })
+
+const errors = []
+page.on("console", (m) => m.type() === "error" && errors.push(m.text()))
+page.on("pageerror", (e) => errors.push(String(e)))
+
+await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 })
+// MapLibre composites tiles + the marker layer async after the network settles; give it a beat.
+await page.waitForTimeout(4_000)
+await page.screenshot({ path: out })
+await browser.close()
+
+console.error(`[map-render] ${out}; console errors=${errors.length}`)
+for (const e of errors.slice(0, 6)) console.error("  " + e)


### PR DESCRIPTION
## What

A bonus visual (beyond the night-shift plan's tiers): the marquee record-matcher proof, **on a map**. Entities that resolved ACROSS independent sources (NPPES provider registry / FCC RHC funding / TX HHSC facility licensing) with **no shared key** — purely on the geocoded location + name agreement — rendered on the **house map stack** (MapLibre GL + Protomaps light basemap via the registry's `toMapHTML`; no Leaflet/raster), colored by source-combination.

Rendered cleanly: Protomaps basemap loaded, 219 markers concentrated over Texas, a source-combination legend, **0 console errors**.

## Honest framing — flagged for the operator (NOT embedded in docs)

Of the 219 cross-source links, **191 are FCC-internal** (RHC program ↔ commitments dataset — same agency). The genuinely cross-**agency** links — the harder "no shared key across agencies" story — are **~28**: NPPES↔TX HHSC (5), FCC↔NPPES (7+2), FCC↔TX HHSC (4), and **10 spanning all three agencies**. "219 cross-source" is accurate, but the marquee cross-agency proof is the ~28/10.

That framing call (and whether to filter the map to cross-agency links) is the operator's, and map renders are the operator's to verify per the house rules — so this PR ships the **reproducible generator only**, not a docs embed. Regenerating/reframing is one command.

## Files

- `scripts/record-matcher/viz/cross-dataset-map.ts` — reads the `cross-dataset-links` GeoJSON, synthesizes a per-entity `bucket` (sorted source-combination), calls `toMapHTML`, prints the combination breakdown.
- `scripts/record-matcher/viz/render-map.mjs` — house-stack PNG renderer (SwiftShader WebGL + the localhost-serve requirement the `tiles.sister.software` CORS imposes).

Neutral entity-resolution framing throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)