### PR TITLE
docs(agents): correct the stale TLA note in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ If a release fails partway through publishing:
 
 - Each workspace has its own `tsconfig.json` + (for `core/` and `neural/`) a `vitest.config.ts` that aliases sibling `@mailwoman/*` subpath imports to source. This lets `yarn test` run without a precompile step. The cross-package aliases are fiddly — see the file headers for the resolution rules.
 - `core/utils/repo.ts` has a `__isCompiledTree` flag that distinguishes source mode from compiled mode for path-builder math. Don't reach across that boundary without reading the comment.
-- The TLA in `core/resources/libpostal.ts` (top-level `await readdir`) is a known fragility surface. When test files import `@mailwoman/core` bare AND a subpath, Vite's TLA-aware loader treats it as a cycle — classifier base classes evaluate as `undefined`. Workaround: side-effect `import "@mailwoman/core"` at the top of the affected test file. See `classifiers/adapter.test.ts` for an example.
+- The **bare-import + subpath-import cycle** is a fragility surface. When a test file imports `@mailwoman/core` bare AND a subpath, Vite can leave the bare re-exports unbound while the slices interleave — classifier base classes evaluate as `undefined`. (`core/resources/libpostal.ts` had a top-level `await readdir` that contributed until #481 made it a lazy `getAvailableLanguages()` getter; the cycle turned out to be **structural** — Vite's bare/subpath interleaving — not TLA-driven, so it persists after the TLA removal.) Workaround: a side-effect `import "@mailwoman/core"` at the top of the affected test file forces full init first. See `classifiers/adapter.test.ts`. Full fix = import-graph hygiene (tracked on #481).
 
 ## When in doubt
 


### PR DESCRIPTION
While working #481, found AGENTS.md's TLA note is stale on two counts:

1. It calls `core/resources/libpostal.ts`'s top-level `await readdir` a live fragility — but **#481 already removed it** (it's now a lazy memoized `getAvailableLanguages()` getter; the file's own comment says "a top-level await **until #481**").
2. It attributes the bare-import + subpath-import cycle to the TLA — but `classifiers/adapter.test.ts`'s header documents the cycle is **structural** (Vite leaves the bare `@mailwoman/core` re-exports unbound when bare + subpath imports interleave), *not* TLA-driven, so the side-effect-import workaround is still required for a different reason.

Updated the note to match the code + that header. The orientation doc is the first thing agents read; a stale "known TLA fragility" misleads on both the cause and whether it still exists.

Related: posted #481 grooming showing the bundle is ~complete (the TLA-removal item is done; only import-graph hygiene + a minor gazetteer schema-validate remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)