### PR TITLE
eval(#109): H3-cell robustness check — org-name 68.1% holds

### DIFF
--- a/docs/articles/evals/2026-06-16-dedup-dual-level-benchmark.md
+++ b/docs/articles/evals/2026-06-16-dedup-dual-level-benchmark.md
@@ -51,10 +51,13 @@ NPI-as-truth OVER-SEGMENTS: one org holds many NPIs, so the matcher's correct co
 | GBT (shipped default) | site                 |     38.9% |  95.7% | **55.3%** |     +1.7pp | 0.553 |         208 |
 | GBT (shipped default) | **org-name**         |     53.3% |  70.4% | **60.7%** |     +7.1pp | 0.606 |          92 |
 | GBT (shipped default) | **org-name (coord)** |     64.6% |  72.0% | **68.1%** |    +14.5pp | 0.680 |          76 |
+| GBT (shipped default) | org-name (H3 res 11) |     64.6% |  72.0% | **68.1%** |    +14.5pp | 0.680 |          76 |
 
 The F1 **climbs as the yardstick gets honest**: GBT **53.6% (NPI) → 55.3% (site) → 60.7% (org-name)**, the over-merge collapsing (109 → 92) and precision rising (43.7% → 53.3%). The clusters are IDENTICAL across the three columns — the climb is purely the ruler ceasing to charge the matcher for the correct same-org merges the gold set proved (`2026-06-16-dedup-gold-set-tx120.md`: 120/120 same org, 0 genuine over-merges).
 
 **Tier 2D — tightening the org-name ruler with the geocode coordinate.** The org-name truth above blocks by the address STRING (`addressFrequencyKey`), so two records at one building whose text differs — `1504 Taub LOOP` vs `1504 Taub LP STE 100` — key apart and the merge is still charged as an error. Block by the GEOCODED BUILDING instead (union co-located NPIs within 50 m whose org names agree, same Jaccard gate) and the truth tightens further: GBT **org-name 60.7% → org-name-coord 68.1%** (+7.4pp), 956 → 928 classes, over 1000/1000 geocoded NPIs. The string org-name F1 is a conservative LOWER bound; the coordinate one is tighter (the Jaccard gate still blocks distinct co-located orgs). Both are honest — the coordinate is the geocode-first key.
+
+**Task 4 (#109) — H3-cell robustness check.** Re-keying the same building-grain co-location on an H3 cell (res 11) instead of the 50 m haversine radius — the deterministic, O(n) "geocode-first cell" the issue suggested — gives GBT **org-name-h3 68.1%** (928 classes), vs the haversine 68.1% (928). Within noise of the haversine grain — the ~68.1% coord-grain F1 is robust to the co-location method, not an artifact of the 50 m threshold.
 
 **Takeaways:** (1) The dedup model's REAL quality is the **org-name F1 ~60.7%**, not the NPI-level 53.6% — the difference was NPI over-segmentation, not model error. (2) The #625 lever was the YARDSTICK, not the scorer: the corroboration-feature experiment (reverted) couldn't move precision because the over-merge was mostly correct. (3) The remaining org-name over-merge (92 clusters) is the genuine frontier — small, approaching the ceiling's ~1.6% irreducible (`2026-06-16-dedup-ceiling.md`). (4) Trust the large eval: a 50-NPI smoke misled on the site delta (+5–7pp vs this run's ±2pp).
 

--- a/scripts/record-matcher/nppes-dedup-benchmark.ts
+++ b/scripts/record-matcher/nppes-dedup-benchmark.ts
@@ -40,6 +40,7 @@ import {
 	type ResolvedEntity,
 	type SourceRecord,
 } from "@mailwoman/registry"
+import { latLngToCell } from "h3-js"
 import { writeFileSync } from "node:fs"
 import { resolve as resolvePath } from "node:path"
 import { pathToFileURL } from "node:url"
@@ -427,6 +428,52 @@ async function main(): Promise<void> {
 	const geocodedNpis = [...npiPrimary.keys()].filter((n) => npiCoord.has(n)).length
 	const orgNameCoordLabel = (rec: SourceRecord) => (npiPrimary.has(rec.id) ? findC(rec.id) : rec.id)
 
+	// --- ORG-NAME-H3 entity-truth (Task 4, #109). The same building-grain co-location, but keyed on an
+	// H3 CELL (the geocode-first "cell" the issue suggested) instead of a pairwise 50 m haversine: assign
+	// each NPI's coordinate to an H3 cell at building-block resolution, then union same-org (Jaccard ≥
+	// ORG_TAU) NPIs that share a cell. A robustness check on the haversine coord-grain — if the F1
+	// matches, the number isn't an artifact of the 50 m threshold, and cell-blocking is O(n) not O(n²).
+	// Caveat: a hard cell boundary can split a same-building pair into adjacent cells (a slight
+	// under-count vs the radius); res 10 (~65 m edge) absorbs most of it. ---
+	const H3_RES = Number(arg("h3-res", "11")) // res 11 ≈ 25 m edge; res 10 ≈ 65 m (block scale)
+	const parentH = new Map<string, string>()
+	const findH = (x: string): string => {
+		if (!parentH.has(x)) parentH.set(x, x)
+		let root = x
+		while (parentH.get(root)! !== root) root = parentH.get(root)!
+		while (parentH.get(x)! !== root) {
+			const next = parentH.get(x)!
+			parentH.set(x, root)
+			x = next
+		}
+		return root
+	}
+	const unionH = (a: string, b: string) => {
+		const ra = findH(a)
+		const rb = findH(b)
+		if (ra !== rb) parentH.set(ra, rb)
+	}
+	{
+		const byCell = new Map<string, string[]>()
+		for (const n of npiPrimary.keys()) {
+			findH(n) // seed every NPI (un-geocoded ones stay singletons)
+			const c = npiCoord.get(n)
+			if (!c) continue
+			const cell = latLngToCell(c.latitude, c.longitude, H3_RES)
+			if (!byCell.has(cell)) byCell.set(cell, [])
+			byCell.get(cell)!.push(n)
+		}
+		for (const group of byCell.values()) {
+			for (let i = 0; i < group.length; i++) {
+				for (let j = i + 1; j < group.length; j++) {
+					if (orgJaccard(npiPrimary.get(group[i]!)!.tokens, npiPrimary.get(group[j]!)!.tokens) >= ORG_TAU)
+						unionH(group[i]!, group[j]!)
+				}
+			}
+		}
+	}
+	const orgNameH3Label = (rec: SourceRecord) => (npiPrimary.has(rec.id) ? findH(rec.id) : rec.id)
+
 	// --- Phase D: the comparison-model lever progression — toggle each lever ON in turn at the default
 	// threshold to isolate its marginal effect, then sweep the link threshold on the best config (geocode
 	// once, resolve many — config is cheap). ---
@@ -506,6 +553,9 @@ async function main(): Promise<void> {
 	const orgCoordCount = new Set(records.map((r) => orgNameCoordLabel(r))).size
 	const fsOrgCoord = scoreEntities(bestLever.res.entities, orgNameCoordLabel)
 	const gbtOrgCoord = scoreEntities(gbtRes.entities, orgNameCoordLabel)
+	// Task 4 (#109): the H3-cell co-location truth — a robustness check on the haversine coord-grain.
+	const orgH3Count = new Set(records.map((r) => orgNameH3Label(r))).size
+	const gbtOrgH3 = scoreEntities(gbtRes.entities, orgNameH3Label)
 
 	// Optional candidate A/B (--candidate): score a trained GBT module at both levels, at its own
 	// recommendedThreshold, alongside the shipped GBT — grades a new model (e.g. corroboration features).
@@ -533,7 +583,7 @@ async function main(): Promise<void> {
 		)
 	}
 	console.error(
-		`    truth-grains — GBT NPI ${(100 * gbtNpi.f1).toFixed(1)}% → site ${(100 * gbtEntity.f1).toFixed(1)}% → org-name ${(100 * gbtOrg.f1).toFixed(1)}% → org-name-coord ${(100 * gbtOrgCoord.f1).toFixed(1)}%; ` +
+		`    truth-grains — GBT NPI ${(100 * gbtNpi.f1).toFixed(1)}% → site ${(100 * gbtEntity.f1).toFixed(1)}% → org-name ${(100 * gbtOrg.f1).toFixed(1)}% → org-name-coord ${(100 * gbtOrgCoord.f1).toFixed(1)}% → org-name-h3 ${(100 * gbtOrgH3.f1).toFixed(1)}% (res ${H3_RES}); ` +
 			`FS: NPI ${(100 * fsNpi.f1).toFixed(1)}% / entity ${(100 * fsEntity.f1).toFixed(1)}% / org-coord ${(100 * fsOrgCoord.f1).toFixed(1)}%`
 	)
 
@@ -655,6 +705,7 @@ async function main(): Promise<void> {
 	dualRow("GBT (shipped default)", "site", gbtEntity, gbtEntity.f1 - gbtNpi.f1)
 	dualRow("GBT (shipped default)", "**org-name**", gbtOrg, gbtOrg.f1 - gbtNpi.f1)
 	dualRow("GBT (shipped default)", "**org-name (coord)**", gbtOrgCoord, gbtOrgCoord.f1 - gbtNpi.f1)
+	dualRow("GBT (shipped default)", `org-name (H3 res ${H3_RES})`, gbtOrgH3, gbtOrgH3.f1 - gbtNpi.f1)
 	if (cand) {
 		dualRow(cand.label, "NPI", cand.npi)
 		dualRow(cand.label, "**entity**", cand.entity, cand.entity.f1 - cand.npi.f1)
@@ -677,6 +728,21 @@ async function main(): Promise<void> {
 			`(${signed(100 * (gbtOrgCoord.f1 - gbtOrg.f1))}), ${orgCount} → ${orgCoordCount} classes, over ${geocodedNpis}/${kept.size} ` +
 			`geocoded NPIs. The string org-name F1 is a conservative LOWER bound; the coordinate one is tighter (the Jaccard gate ` +
 			`still blocks distinct co-located orgs). Both are honest — the coordinate is the geocode-first key.`
+	)
+	lines.push("")
+	lines.push(
+		`**Task 4 (#109) — H3-cell robustness check.** Re-keying the same building-grain co-location on an H3 cell ` +
+			`(res ${H3_RES}) instead of the 50 m haversine radius — the deterministic, O(n) "geocode-first cell" the issue ` +
+			`suggested — gives GBT **org-name-h3 ${pct(gbtOrgH3.f1)}%** (${orgH3Count} classes), vs the haversine ` +
+			`${pct(gbtOrgCoord.f1)}% (${orgCoordCount}). ${
+				Math.abs(gbtOrgH3.f1 - gbtOrgCoord.f1) < 0.015
+					? "Within noise of the haversine grain — the ~" +
+						pct(gbtOrgCoord.f1) +
+						"% coord-grain F1 is robust to the co-location method, not an artifact of the 50 m threshold."
+					: "The two co-location methods differ by " +
+						signed(100 * (gbtOrgH3.f1 - gbtOrgCoord.f1)) +
+						" — the cell-vs-radius boundary handling shifts the count (a hard H3 boundary can split a same-building pair into adjacent cells)."
+			}`
 	)
 	lines.push("")
 	lines.push(


### PR DESCRIPTION
Task 4: confirm the org-name coord-grain dedup F1 (68.1%) isn't an artifact of the 50m haversine threshold.

**Result:** re-keying the building-grain co-location on an **H3 cell** (res 11 — the geocode-first "cell" #109 suggested) instead of the 50m radius gives GBT **org-name-h3 = 68.1%** (928 classes, over-merge 76) — **identical** to the haversine coord-grain (68.1%, 928). The number is robust to the co-location method, and the cell key is O(n) blocking vs O(n²) pairwise.

Baseline reproduced exactly (53.6/55.3/60.7/68.1), so the run is clean + deterministic. Adds the H3 grain (`--h3-res`, default 11) to the benchmark + a robustness row/paragraph to the dual-level report. Eval-only; no production code touched.

Closes the #109 / Tier-2D follow-up — the yardstick arc is now fully nailed down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)