### PR TITLE
eval(#478): grade the assembled runPipeline in the arena harness

### DIFF
--- a/scripts/harness-v0-neural.ts
+++ b/scripts/harness-v0-neural.ts
@@ -38,7 +38,7 @@ import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
 import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
 import { deserializeFst } from "@mailwoman/resolver-wof-sqlite/fst-serialize"
 import { buildStreetMorphologyFst } from "@mailwoman/resolver-wof-sqlite/street-morphology-fst-builder"
-import { type ClassificationRecord, createAddressParser } from "mailwoman"
+import { type ClassificationRecord, createAddressParser, createRuntimePipeline } from "mailwoman"
 import { readdirSync, readFileSync, writeFileSync } from "node:fs"
 import { basename, dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -69,6 +69,13 @@ interface Args {
 	postcodeRepair: boolean
 	unitRepair: boolean
 	symmetricMatch: boolean
+	/**
+	 * #478: also grade the ASSEMBLED runtime pipeline (`createRuntimePipeline` — normalize → kind/
+	 * fast-path → grouper → reconcile → classify), not just the raw neural classifier. This is the
+	 * #566-lesson gate: a pipeline regression (e.g. a reconcile/arbitration change) is invisible when
+	 * the eval grades raw neural. Off by default → the existing v0-vs-raw-neural report is byte-stable.
+	 */
+	assembled: boolean
 }
 
 function parseArgs(): Args {
@@ -78,6 +85,7 @@ function parseArgs(): Args {
 		postcodeRepair: false,
 		unitRepair: false,
 		symmetricMatch: false,
+		assembled: false,
 	}
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i]
@@ -97,6 +105,7 @@ function parseArgs(): Args {
 		else if (a === "--postcode-repair") out.postcodeRepair = true
 		else if (a === "--unit-repair") out.unitRepair = true
 		else if (a === "--symmetric-match") out.symmetricMatch = true
+		else if (a === "--assembled") out.assembled = true
 	}
 	if (!out.testsDir) {
 		console.error("Usage: scripts/harness-v0-neural.ts --tests <dir> [--out-json <path>] [...]")
@@ -348,6 +357,9 @@ interface AssertionResult {
 	neural_dropped: Partial<Record<ComponentTag, string>>
 	neural_tree_valid: boolean
 	neural_tree_violations: TreeViolation[]
+	/** #478 assembled-pipeline arm (only when `--assembled`): the full `runPipeline` parse, graded like neural. */
+	assembled_pass?: boolean
+	assembled_actual?: ClassificationRecord
 }
 
 /**
@@ -374,7 +386,8 @@ async function runAssertion(
 	v0Parser: ReturnType<typeof createAddressParser>,
 	neuralClassifier: NeuralAddressClassifier,
 	parseOpts: Parameters<NeuralAddressClassifier["parse"]>[1],
-	symmetricMatch: boolean
+	symmetricMatch: boolean,
+	pipeline?: ReturnType<typeof createRuntimePipeline>
 ): Promise<AssertionResult> {
 	const solutions = await v0Parser.parse(a.input)
 	const v0Records: ClassificationRecord[] = solutions.map((s) => s.classifications as ClassificationRecord)
@@ -408,6 +421,18 @@ async function runAssertion(
 	const neuralPass = anyExpectedMatches(a.expected, neuralRecord)
 	const treeValidity = validateTree(tree) // #37 — structural coherence of the neural parse
 
+	// #478 assembled-pipeline arm: grade the full `runPipeline` parse (what production runs) — same
+	// loose top-1 semantics + tree→v0-record conversion as neural. Off unless `--assembled` wired the
+	// pipeline. This is the #566-lesson measurement: an assembled-pipeline regression is invisible
+	// against raw-neural F1.
+	let assembledPass: boolean | undefined
+	let assembledRecord: ClassificationRecord | undefined
+	if (pipeline) {
+		const { tree: assembledTree } = await pipeline(a.input)
+		assembledRecord = neuralTreeToV0Record(decodeAsJson(assembledTree)).record
+		assembledPass = anyExpectedMatches(a.expected, assembledRecord)
+	}
+
 	return {
 		file: a.file,
 		locale: a.locale,
@@ -420,6 +445,8 @@ async function runAssertion(
 		neural_dropped: dropped,
 		neural_tree_valid: treeValidity.valid,
 		neural_tree_violations: treeValidity.violations,
+		assembled_pass: assembledPass,
+		assembled_actual: assembledRecord,
 	}
 }
 
@@ -522,6 +549,31 @@ function printReport(results: AssertionResult[]): void {
 	console.log(`| Neural only | ${onlyNeural} | ${((100 * onlyNeural) / total).toFixed(1)}% |`)
 	console.log(`| Both fail | ${bothFail} | ${((100 * bothFail) / total).toFixed(1)}% |`)
 	console.log("")
+
+	// #478 assembled-pipeline arm (only when --assembled). The HEADLINE is `v0-only vs ASSEMBLED` —
+	// the parses v0 gets that the ASSEMBLED pipeline (not just raw neural) drops. Arbitration must
+	// drive this to ~0 "by construction"; comparing it to `v0-only vs raw-neural` shows what the
+	// current pipeline (grouper + reconcile + fast-path, no arbitration yet) already captures or loses.
+	const hasAssembled = results.some((r) => r.assembled_pass !== undefined)
+	if (hasAssembled) {
+		const asmPass = results.filter((r) => r.assembled_pass).length
+		const onlyV0vsAsm = results.filter((r) => r.v0_pass && !r.assembled_pass).length
+		const onlyAsm = results.filter((r) => !r.v0_pass && r.assembled_pass).length
+		const asmGainedVsNeural = results.filter((r) => r.assembled_pass && !r.neural_pass).length
+		const asmLostVsNeural = results.filter((r) => !r.assembled_pass && r.neural_pass).length
+		console.log("## Assembled pipeline (#478 — `runPipeline`, the gate)")
+		console.log("")
+		console.log(`| Metric | Count | Rate |`)
+		console.log(`|--------|-------|------|`)
+		console.log(`| Assembled pass | ${asmPass} | ${((100 * asmPass) / total).toFixed(1)}% |`)
+		console.log(
+			`| **v0-only vs ASSEMBLED** (gate target → ~0) | ${onlyV0vsAsm} | ${((100 * onlyV0vsAsm) / total).toFixed(1)}% |`
+		)
+		console.log(`| v0-only vs raw-neural (for comparison) | ${onlyV0} | ${((100 * onlyV0) / total).toFixed(1)}% |`)
+		console.log(`| Assembled-only (vs v0) | ${onlyAsm} | ${((100 * onlyAsm) / total).toFixed(1)}% |`)
+		console.log(`| Assembled vs raw-neural (gained / lost) | +${asmGainedVsNeural} / -${asmLostVsNeural} | |`)
+		console.log("")
+	}
 
 	console.log("## Per-file")
 	console.log("")
@@ -659,6 +711,13 @@ async function main(): Promise<void> {
 		unitRepair: args.unitRepair,
 	} as Parameters<NeuralAddressClassifier["parse"]>[1]
 
+	// #478: the assembled runtime pipeline (reuses the neural classifier + admin FST). No resolver —
+	// the arena grades COMPONENT parses (Stage 3 / grouper / reconcile), not coordinates.
+	const pipeline = args.assembled
+		? createRuntimePipeline({ classifier: neural, ...(adminFst ? { fst: adminFst as never } : {}) })
+		: undefined
+	if (pipeline) console.error("Assembled-pipeline arm ON (--assembled): grading runPipeline alongside raw neural.")
+
 	console.error("Running harness...")
 	const t0 = performance.now()
 	const results: AssertionResult[] = []
@@ -666,7 +725,7 @@ async function main(): Promise<void> {
 	for (const a of all) {
 		i++
 		try {
-			results.push(await runAssertion(a, v0Parser, neural, parseOpts, args.symmetricMatch))
+			results.push(await runAssertion(a, v0Parser, neural, parseOpts, args.symmetricMatch, pipeline))
 		} catch (err) {
 			console.error(`[harness] WARN: error on assertion ${i} (${a.input}): ${(err as Error).message}`)
 		}


### PR DESCRIPTION
## #478 increment 1 — grade the ASSEMBLED pipeline in the arena harness

The arena harness (`scripts/harness-v0-neural.ts`) has only ever graded the **raw neural classifier** against v0. But production runs `runPipeline` — normalize → kind/fast-path → phrase grouper → reconcile → classify. That gap is the #566 blind spot: a pipeline-stage regression (a reconcile change, an arbitration prior) is **invisible** when the eval grades raw neural. The retired joint-reconcile shipped as default precisely because evals graded raw neural, not the assembled parse.

This is increment 1 of the #478 arbitration-layer work: **add the measurement before changing behavior.** Per the arbitration-layer spec sequencing (`docs/articles/plan/2026-06-14-arbitration-layer-spec.md`), the corrected gate must grade the *assembled* pipeline — so it has to exist first.

### What this changes

- **New `--assembled` flag** (default OFF → the existing v0-vs-raw-neural report is byte-stable). When set, the harness builds `createRuntimePipeline({ classifier: neural, fst })` and runs every assertion through `runPipeline` as a third arm, graded with the same loose top-1 / tree→v0-record semantics as the neural arm.
- **New report block** `## Assembled pipeline (#478 — runPipeline, the gate)` with the headline **`v0-only vs ASSEMBLED`** (the parses v0 gets that the assembled pipeline drops — the gate target arbitration must drive toward ~0), compared side-by-side with the existing `v0-only vs raw-neural` and an `assembled vs raw-neural` gained/lost delta so you can see what the current pipeline (grouper + reconcile + fast-path, no arbitration yet) already captures or loses relative to bare neural.

### No behavior change

Pure measurement. No pipeline stage, default, or shipped artifact is touched. The flag is opt-in; without it the harness output is identical.

### How it was verified

Ran `scripts/harness-v0-neural.ts --tests mailwoman/test --admin-fst <en-us> --postcode-repair --assembled` — the assembled arm runs clean across all arena assertions and produces the `v0-only vs ASSEMBLED` baseline. (Numbers in the PR thread.)

### The gate's second leg

This closes the *component-parse* half of the corrected gate. The other leg — precondition coverage + coordinate metrics on the assembled pipeline (the resolver-facing half, per the spec) — rides the existing `oa-resolver-eval.ts` harness; #478's later increments wire the input-shape router and unify the two arbitration sites against **both** legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
