### PR TITLE
docs: publish the matcher story (geocode-first matching + dedup yardstick)

### DIFF
--- a/docs/research/tags.yml
+++ b/docs/research/tags.yml
@@ -36,6 +36,14 @@ geocoding:
   label: Geocoding
   description: Articles about geocoding — the process of turning parsed addresses into lat/lon coordinates.
 
+geocoder:
+  label: Geocoder
+  description: Articles about Mailwoman as a calibrated street-level geocoder — resolving a messy address line to a coordinate, a resolution tier, and a calibrated uncertainty.
+
+record-matching:
+  label: Record matching
+  description: Articles about geocode-first entity resolution — correlating and deduplicating fragmented records by the resolved place rather than the address string.
+
 infrastructure:
   label: Infrastructure
   description: Articles about the training-data pipeline, model training, tokenization, and other non-model components.


### PR DESCRIPTION
## Publish the matcher story

The geocode-first record-matching narrative has been sitting as `draft: true` — written, reviewed, and merged, but excluded from the production build (the live blog still stops at June 9). This flips the matcher story live.

Also defines the two previously-undeclared blog tags (`geocoder`, `record-matching`) in `blog/tags.yml` so the build is warning-clean.

### What goes live (4 files, `draft: true` removed)

- **Blog** — `2026-06-16-match-where-it-is-not-how-its-spelled.mdx` (the entry point: match where it *is*, not how it's spelled)
- **Concept** — `geocode-first-record-matching.mdx` (the full strategy: the FS spine without labels, the geocode-first blocking bet, block/match/cluster)
- **Concept** — `dedup-entity-truth.mdx` (choosing the dedup yardstick — why org-name, not NPI; the four-grain climb 53.6% → 68.1%)
- **Concept** — `spatial-expectation-and-density.mdx` (the Winkler/term-frequency bridge — the same expected-vs-observed engine at the value level and the regional level)

### Link closure verified

Every outbound link from these docs resolves to a page that is **already live or in this set**:
- concept targets `eval-discipline`, `importance-vs-population`, `confidence-calibration` — all live
- eval-doc targets `2026-06-16-dedup-{dual-level-benchmark,gold-set-tx120,ceiling}` — all live
- inter-set link `spatial-expectation → geocode-first-record-matching` — both in this set
- images present: `concepts/img/geocode-first-surface.png`, `evals/charts/dedup-yardstick.svg`, and the blog's static `/img/{geocode-first-surface.png,dedup-yardstick.svg}`

### Verified with the production build, not dev

`yarn workspace @mailwoman/docs build` (full Docusaurus production build, `onBrokenLinks: "throw"` enforced) — passes. This is the gate that `yarn start` silently skips and that broke a prior docs PR (#670); running it before push is the lesson applied.

Neutral framing throughout: entity resolution / correlation of fragmented compliance data — no interpretation of what a match *means* (that's the consumer's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
