### PR TITLE
docs: drop duplicate record-matching tag key (fix broken docs build)

### DIFF
--- a/docs/research/tags.yml
+++ b/docs/research/tags.yml
@@ -40,10 +40,6 @@ geocoder:
   label: Geocoder
   description: Articles about Mailwoman as a calibrated street-level geocoder — resolving a messy address line to a coordinate, a resolution tier, and a calibrated uncertainty.
 
-record-matching:
-  label: Record matching
-  description: Articles about geocode-first entity resolution — correlating and deduplicating fragmented records by the resolved place rather than the address string.
-
 infrastructure:
   label: Infrastructure
   description: Articles about the training-data pipeline, model training, tokenization, and other non-model components.


### PR DESCRIPTION
## Hotfix: duplicate `record-matching` tag key breaks the docs build

`docs/research/tags.yml` ended up with **two** `record-matching:` keys, which fails the Docusaurus build:

```
[ERROR] YAMLException: duplicated mapping key (63:1)
```

### How it happened (merge race)

PR #680 (publish the matcher story) was branched off main *before* two commits landed there: the `docs/blog` → `docs/research` rename and a pre-existing `record-matching` tag definition (`26093451`). My branch added its own `record-matching` def (next to a new `geocoder` def). When #680 squash-merged, git's rename detection correctly relocated my edit into `docs/research/tags.yml` — but that placed my `record-matching` block alongside the pre-existing one, producing the duplicate key. My local pre-merge build was green because neither the rename nor the pre-existing def existed at my branch point.

### Fix

Drop the duplicate I introduced; keep the pre-existing `record-matching:` definition (it's the one the older live posts already rely on) and the new `geocoder:` definition (no duplicate, needed by the matcher blog).

Verified: `grep` shows exactly one `record-matching:` and one `geocoder:` key, and `yarn workspace @mailwoman/docs build` (full production build, `onBrokenLinks: "throw"`) passes clean — the matcher blog + concept docs emit correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
