### PR TITLE
feat(#478): input-shape router — the arbitration prior (increment 2)

### DIFF
--- a/core/parser/proposal-pipeline.ts
+++ b/core/parser/proposal-pipeline.ts
@@ -15,6 +15,8 @@
  *   Pure module: no resource imports, no top-level await. Safe to import from anywhere.
  */
 
+import { policyRegistryFromRoute } from "../policy/from-config.js"
+import type { InputShapeRoute } from "../policy/input-shape-router.js"
 import type { PolicyRegistry } from "../policy/policy.js"
 import type { Span, TokenContext } from "../tokenization/index.js"
 import {
@@ -53,16 +55,28 @@ export async function collectProposals(
 }
 
 /**
- * Optional policy filter. Returns the input unchanged when `policy` is undefined, otherwise
- * delegates to `PolicyRegistry.apply`.
+ * Optional policy filter.
+ *
+ * Resolution order:
+ *
+ * 1. An explicit `policy` registry is authoritative (the operator's config wins entirely).
+ * 2. Otherwise, when an input-shape `routerPrior` is supplied (#478 increment 2), build a registry
+ *    whose default mode is the routed prior and apply that.
+ * 3. Otherwise return the input unchanged.
+ *
+ * Increment 2 ships with no production caller passing `routerPrior` (the production `runPipeline`
+ * does not yet feed live signals — that is increment 3), so this stays byte-stable by default. The
+ * seam is exercised by the router/proposal-pipeline tests.
  */
 export function filterByPolicy(
 	proposals: readonly ClassificationProposal[],
 	policy: PolicyRegistry | undefined,
-	locale: string | undefined
+	locale: string | undefined,
+	routerPrior?: InputShapeRoute
 ): ClassificationProposal[] {
-	if (!policy) return [...proposals]
-	return policy.apply(proposals, locale)
+	const effective = policy ?? (routerPrior ? policyRegistryFromRoute(routerPrior) : undefined)
+	if (!effective) return [...proposals]
+	return effective.apply(proposals, locale)
 }
 
 /**
@@ -150,10 +164,16 @@ export function writeProposalsToContext(
 export async function runProposalPipeline(
 	context: TokenContext,
 	classifiers: readonly ProposalClassifier[],
-	options: { policy?: PolicyRegistry; locale?: string; classifierContext?: ClassifierContext } = {}
+	options: {
+		policy?: PolicyRegistry
+		locale?: string
+		classifierContext?: ClassifierContext
+		/** Input-shape routed prior (#478 increment 2). Applied only when `policy` is absent. */
+		routerPrior?: InputShapeRoute
+	} = {}
 ): Promise<{ proposals: ClassificationProposal[]; writeback: WritebackResult }> {
 	const raw = await collectProposals(context.sections, classifiers, options.classifierContext ?? {})
-	const filtered = filterByPolicy(raw, options.policy, options.locale)
+	const filtered = filterByPolicy(raw, options.policy, options.locale, options.routerPrior)
 	const writeback = writeProposalsToContext(filtered, context)
 	return { proposals: filtered, writeback }
 }

--- a/core/policy/defaults.ts
+++ b/core/policy/defaults.ts
@@ -9,22 +9,27 @@
  */
 
 import { COMPONENT_TAGS, type ComponentTag } from "@mailwoman/core/types"
-import type { ClassifierPolicy } from "./policy.js"
+import type { ClassifierPolicy, PolicyMode } from "./policy.js"
 
 /**
- * Build a fresh array of `rule_only` policies — one per `ComponentTag`. Returns a new array on each
- * call; callers may mutate it freely.
+ * Build a fresh array of policies — one per `ComponentTag`, all in `mode`. Returns a new array on
+ * each call; callers may mutate it freely.
+ *
+ * `mode` defaults to `rule_only` (the historical default — every component rule-sourced until a
+ * per-tag migration). The input-shape router (#478 increment 2) passes a shape-derived default
+ * (e.g. `neural_preferred` for OOD-script input) so the whole table starts from the routed prior
+ * before per-tag config overlays.
  */
-export function buildDefaultPolicies(): ClassifierPolicy[] {
+export function buildDefaultPolicies(mode: PolicyMode = "rule_only"): ClassifierPolicy[] {
 	return COMPONENT_TAGS.map<ClassifierPolicy>((component) => ({
 		component,
-		mode: "rule_only",
+		mode,
 	}))
 }
 
 /**
- * Convenience accessor for a single-component default.
+ * Convenience accessor for a single-component default. `mode` defaults to `rule_only`.
  */
-export function defaultPolicyFor(component: ComponentTag): ClassifierPolicy {
-	return { component, mode: "rule_only" }
+export function defaultPolicyFor(component: ComponentTag, mode: PolicyMode = "rule_only"): ClassifierPolicy {
+	return { component, mode }
 }

--- a/core/policy/from-config.ts
+++ b/core/policy/from-config.ts
@@ -27,6 +27,7 @@
  */
 
 import { COMPONENT_TAGS, type ComponentTag } from "../types/component.js"
+import type { InputShapeRoute } from "./input-shape-router.js"
 import type { PolicyMode } from "./policy.js"
 import { InMemoryPolicyRegistry } from "./registry.js"
 
@@ -44,15 +45,20 @@ export interface PolicyConfigEntry {
 export type PolicyConfig = Record<string, Record<string, PolicyConfigEntry>>
 
 /**
- * Build a registry from a parsed policy-config object. Starts from `withDefaults()` (every tag
- * `rule_only`) and overlays the config's entries — so an absent tag behaves exactly as today.
- * Throws on ANY unrecognized key or value; the error names the offending JSON path.
+ * Build a registry from a parsed policy-config object. Starts from `withDefaults(defaultMode)` (every
+ * tag at `defaultMode`, historically `rule_only`) and overlays the config's entries — so an absent
+ * tag falls to `defaultMode`. The input-shape router (#478 increment 2) passes its shape-derived
+ * default as `defaultMode` so config entries still win per-tag while un-configured tags follow the
+ * route. Throws on ANY unrecognized key or value; the error names the offending JSON path.
  */
-export function policyRegistryFromConfig(config: PolicyConfig): InMemoryPolicyRegistry {
+export function policyRegistryFromConfig(
+	config: PolicyConfig,
+	defaultMode: PolicyMode = "rule_only"
+): InMemoryPolicyRegistry {
 	if (typeof config !== "object" || config === null || Array.isArray(config)) {
 		throw new Error("policy config: root must be an object of locale → tag → entry")
 	}
-	const registry = InMemoryPolicyRegistry.withDefaults()
+	const registry = InMemoryPolicyRegistry.withDefaults(defaultMode)
 
 	for (const [localeKey, tags] of Object.entries(config)) {
 		if (typeof tags !== "object" || tags === null || Array.isArray(tags)) {
@@ -95,4 +101,13 @@ export function policyRegistryFromConfig(config: PolicyConfig): InMemoryPolicyRe
 	}
 
 	return registry
+}
+
+/**
+ * Build a registry whose default layer is an input-shape route's `defaultMode` (#478 increment 2),
+ * with optional per-tag `config` overlaid on top — so the routed prior fills every un-configured
+ * tag while explicit policy still wins per-tag. Thin wrapper over {@link policyRegistryFromConfig}.
+ */
+export function policyRegistryFromRoute(route: InputShapeRoute, config: PolicyConfig = {}): InMemoryPolicyRegistry {
+	return policyRegistryFromConfig(config, route.defaultMode)
 }

--- a/core/policy/index.ts
+++ b/core/policy/index.ts
@@ -6,5 +6,6 @@
 
 export * from "./defaults.js"
 export * from "./from-config.js"
+export * from "./input-shape-router.js"
 export * from "./policy.js"
 export * from "./registry.js"

--- a/core/policy/input-shape-router.test.ts
+++ b/core/policy/input-shape-router.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #478 increment 2 acceptance. Three layers:
+ *
+ *   1. `routeInputShape` — exhaustive coverage of the decision tree (every branch + the precedence
+ *      edges: OOD script beats a clean kind; placer abstention beats a clean kind; the 0.8 cutoff).
+ *   2. `policyRegistryFromRoute` — the routed prior becomes the table default; explicit config still
+ *      wins per-tag.
+ *   3. The seam (`filterByPolicy` with `routerPrior`) — the "flag-ON lane": the integration code is
+ *      exercised end-to-end even though production ships it default-off (no caller passes a prior
+ *      until #478 increment 3). Guards against the "default-off ⇒ never exercised" risk.
+ */
+
+import { Span } from "@mailwoman/core/tokenization"
+import type { ClassificationProposal } from "@mailwoman/core/types"
+import { describe, expect, test } from "vitest"
+import { filterByPolicy } from "../parser/proposal-pipeline.js"
+import { policyRegistryFromRoute } from "./from-config.js"
+import {
+	type InputShapeRoute,
+	type RouterKindSignal,
+	type RouterPlacerSignal,
+	type RouterShapeSignal,
+	routeInputShape,
+} from "./input-shape-router.js"
+import { InMemoryPolicyRegistry } from "./registry.js"
+
+function kind(k: string, confidence: number): RouterKindSignal {
+	return { kind: k, confidence }
+}
+function shape(characterClass?: string): RouterShapeSignal {
+	return { characterClass }
+}
+const PLACER_US: RouterPlacerSignal = { country: "US", abstained: false }
+const PLACER_ABSTAINED: RouterPlacerSignal = { country: null, abstained: true }
+const PLACER_OTHER: RouterPlacerSignal = { country: "OTHER", abstained: false }
+
+describe("routeInputShape — clean structured → rule_preferred", () => {
+	test("structured_address, high conf, alpha, confident placer", () => {
+		const r = routeInputShape(kind("structured_address", 0.95), shape("alpha"), PLACER_US)
+		expect(r.defaultMode).toBe("rule_preferred")
+		expect(r.abstain).toBe(false)
+		expect(r.reason).toContain("clean:structured_address")
+	})
+
+	test.each(["intersection", "po_box", "postcode_only"])("clean kind %s buckets with structured", (k) => {
+		expect(routeInputShape(kind(k, 0.85), shape("alphanumeric"), PLACER_US).defaultMode).toBe("rule_preferred")
+	})
+
+	test("confidence at the 0.8 boundary is clean (inclusive)", () => {
+		expect(routeInputShape(kind("structured_address", 0.8), shape("numeric"), PLACER_US).defaultMode).toBe(
+			"rule_preferred"
+		)
+	})
+
+	test("undefined characterClass counts as Latin (clean)", () => {
+		expect(routeInputShape(kind("structured_address", 0.9), shape(undefined), PLACER_US).defaultMode).toBe(
+			"rule_preferred"
+		)
+	})
+
+	test("null placer does not block rule_preferred (no signal ≠ abstention)", () => {
+		expect(routeInputShape(kind("structured_address", 0.9), shape("alpha"), null).defaultMode).toBe("rule_preferred")
+	})
+})
+
+describe("routeInputShape — OOD script → neural_preferred (highest precedence)", () => {
+	test.each(["cjk", "cyrillic", "arabic"])("script %s routes neural even for a clean high-conf kind", (cc) => {
+		const r = routeInputShape(kind("structured_address", 0.99), shape(cc), PLACER_US)
+		expect(r.defaultMode).toBe("neural_preferred")
+		expect(r.reason).toContain(`ood-script:${cc}`)
+	})
+
+	test("OOD script beats abstention too (script checked first)", () => {
+		// low conf + abstained placer would otherwise abstain; OOD wins.
+		expect(routeInputShape(kind("structured_address", 0.3), shape("cjk"), PLACER_ABSTAINED).defaultMode).toBe(
+			"neural_preferred"
+		)
+	})
+})
+
+describe("routeInputShape — both weak → abstain (mode both)", () => {
+	test("clean kind but confidence below 0.8", () => {
+		const r = routeInputShape(kind("structured_address", 0.79), shape("alpha"), PLACER_US)
+		expect(r.defaultMode).toBe("both")
+		expect(r.abstain).toBe(true)
+		expect(r.reason).toContain("weak:")
+	})
+
+	test("clean high-conf kind but placer abstained", () => {
+		const r = routeInputShape(kind("structured_address", 0.95), shape("alpha"), PLACER_ABSTAINED)
+		expect(r.defaultMode).toBe("both")
+		expect(r.abstain).toBe(true)
+	})
+
+	test("clean high-conf kind but placer off-map (OTHER)", () => {
+		expect(routeInputShape(kind("structured_address", 0.95), shape("alpha"), PLACER_OTHER).abstain).toBe(true)
+	})
+
+	test("low-confidence non-clean kind also abstains", () => {
+		expect(routeInputShape(kind("vague", 0.3), shape("alpha"), PLACER_US).abstain).toBe(true)
+	})
+})
+
+describe("routeInputShape — confident non-clean → neural_preferred", () => {
+	test.each(["landmark", "vague", "locality_only"])("kind %s, high conf, Latin, placer OK → neural", (k) => {
+		const r = routeInputShape(kind(k, 0.9), shape("alpha"), PLACER_US)
+		expect(r.defaultMode).toBe("neural_preferred")
+		expect(r.abstain).toBe(false)
+		expect(r.reason).toContain("neural-default")
+	})
+
+	test("mixed-script clean kind is NOT rule_preferred (mixed ∉ Latin) → neural", () => {
+		expect(routeInputShape(kind("structured_address", 0.9), shape("mixed"), PLACER_US).defaultMode).toBe(
+			"neural_preferred"
+		)
+	})
+})
+
+describe("policyRegistryFromRoute — routed default + config overlay", () => {
+	test("the routed defaultMode becomes every tag's default", () => {
+		const route: InputShapeRoute = { defaultMode: "neural_preferred", abstain: false, reason: "x" }
+		const registry = policyRegistryFromRoute(route)
+		expect(registry.lookup("street").mode).toBe("neural_preferred")
+		expect(registry.lookup("postcode", "en-US").mode).toBe("neural_preferred")
+	})
+
+	test("explicit per-tag config wins over the routed default", () => {
+		const route: InputShapeRoute = { defaultMode: "rule_preferred", abstain: false, reason: "x" }
+		const registry = policyRegistryFromRoute(route, { "en-US": { street: { mode: "neural_only" } } })
+		expect(registry.lookup("street", "en-US").mode).toBe("neural_only") // config wins
+		expect(registry.lookup("region", "en-US").mode).toBe("rule_preferred") // route default fills the rest
+	})
+
+	test("abstain route (mode both) defaults every tag to both", () => {
+		const route: InputShapeRoute = { defaultMode: "both", abstain: true, reason: "weak" }
+		expect(policyRegistryFromRoute(route).lookup("country").mode).toBe("both")
+	})
+})
+
+// --- The seam / flag-ON lane: filterByPolicy with a routerPrior -----------------------------------
+
+function makeProposal(
+	overrides: Partial<ClassificationProposal> & Pick<ClassificationProposal, "component" | "source">
+): ClassificationProposal {
+	return {
+		span: Span.from("x"),
+		confidence: 1,
+		source_id: `${overrides.source}-test`,
+		penalty: 0,
+		...overrides,
+	} as ClassificationProposal
+}
+
+describe("filterByPolicy — routerPrior seam (#478 increment 2)", () => {
+	const proposals: ClassificationProposal[] = [
+		makeProposal({ component: "region", source: "rule", confidence: 0.9 }),
+		makeProposal({ component: "region", source: "neural", confidence: 0.8 }),
+	]
+
+	test("no policy and no router prior → unchanged (default-off, byte-stable)", () => {
+		const out = filterByPolicy(proposals, undefined, "en-US")
+		expect(out).toHaveLength(2)
+	})
+
+	test("router prior neural_preferred drops the rule proposal", () => {
+		const route: InputShapeRoute = { defaultMode: "neural_preferred", abstain: false, reason: "x" }
+		const out = filterByPolicy(proposals, undefined, "en-US", route)
+		expect(out.map((p) => p.source)).toEqual(["neural"])
+	})
+
+	test("router prior rule_preferred drops the neural proposal", () => {
+		const route: InputShapeRoute = { defaultMode: "rule_preferred", abstain: false, reason: "x" }
+		const out = filterByPolicy(proposals, undefined, "en-US", route)
+		expect(out.map((p) => p.source)).toEqual(["rule"])
+	})
+
+	test("abstain route (both) keeps every source", () => {
+		const route: InputShapeRoute = { defaultMode: "both", abstain: true, reason: "weak" }
+		const out = filterByPolicy(proposals, undefined, "en-US", route)
+		expect(out).toHaveLength(2)
+	})
+
+	test("an explicit policy is authoritative — the router prior is ignored", () => {
+		// Explicit registry forces rule_only; even a neural_preferred route must not override it.
+		const explicit = InMemoryPolicyRegistry.withDefaults("rule_only")
+		const route: InputShapeRoute = { defaultMode: "neural_preferred", abstain: false, reason: "x" }
+		const out = filterByPolicy(proposals, explicit, "en-US", route)
+		expect(out.map((p) => p.source)).toEqual(["rule"])
+	})
+})

--- a/core/policy/input-shape-router.ts
+++ b/core/policy/input-shape-router.ts
@@ -1,0 +1,147 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Input-shape router (#478 increment 2) — the arbitration *prior*.
+ *
+ *   A pure, deterministic classification of the input's *shape* into a default {@link PolicyMode}
+ *   that seeds the whole per-component policy table before per-tag config overlays. The intuition
+ *   (the parity capstone, #478): the old rules system owns clean structured Latin addresses (the
+ *   arena's `v0-only` column), neural owns noisy / off-map / non-Latin input, and when both signals
+ *   are weak the honest move is to *abstain* rather than emit a confident-wrong parse.
+ *
+ *   This module is the decision logic only. It does NOT wire itself into a pipeline: the consumer
+ *   (`policyRegistryFromRoute` → the proposal pipeline) decides whether to apply it, and the
+ *   production `runPipeline` does not feed it live signals until the two arbitration sites are
+ *   unified (#478 increment 3). Keeping the prior pure and exhaustively unit-tested here de-risks
+ *   that wiring — the prior is proven correct in isolation before any behavior changes.
+ *
+ *   Inputs are deliberately *structural lite* types (not the concrete `QueryKindResult` /
+ *   `QueryShapeLite` / `CoarsePrediction`) so this file has zero imports beyond `PolicyMode` and is
+ *   safe to import from anywhere. The real signals satisfy these shapes by construction.
+ */
+
+import type { PolicyMode } from "./policy.js"
+
+/** Minimal kind-classifier signal. Compatible with `QueryKindResult` (`core/pipeline/types.ts`). */
+export interface RouterKindSignal {
+	/** The classified kind, e.g. `structured_address`, `landmark`, `vague`. */
+	kind: string
+	/** Top-class confidence, 0..1. */
+	confidence: number
+}
+
+/** Minimal query-shape signal. Compatible with `QueryShapeLite` (`core/pipeline/types.ts`). */
+export interface RouterShapeSignal {
+	/** Broad character category: `numeric` | `alpha` | `alphanumeric` | `cjk` | `cyrillic` | `arabic` | `mixed`. */
+	characterClass?: string
+}
+
+/**
+ * Minimal coarse-placer signal (#244). Compatible with `CoarsePrediction`
+ * (`core/coarse-placer/coarse-placer.ts`). `null` means no placer ran — treated as "no OOD signal",
+ * never as an abstention.
+ */
+export interface RouterPlacerSignal {
+	/** The in-map country argmax, `null` when abstained, or `"OTHER"` when off-map. */
+	country: string | null
+	/** Explicit abstention flag (M2 open-set reject). */
+	abstained: boolean
+}
+
+/** The routed prior: a default policy mode for the whole component table, plus an abstain signal. */
+export interface InputShapeRoute {
+	/**
+	 * The default {@link PolicyMode} every component starts from (per-tag config still overrides).
+	 *
+	 * - `rule_preferred` — clean structured Latin address; v0's home turf.
+	 * - `neural_preferred` — noisy / non-Latin / off-map; neural carries it.
+	 * - `both` — weak/ambiguous; keep every source (paired with `abstain: true`).
+	 */
+	defaultMode: PolicyMode
+	/**
+	 * True when both sources are weak (low kind confidence and/or the placer abstained on a
+	 * non-clean shape). A first-class outcome reserved for the resolver/admin honest-radius
+	 * downgrade — but it has NO consumer until #478 increment 3, so for now it is computed and
+	 * reported only. `defaultMode` is `both` when this is set (drop nothing).
+	 */
+	abstain: boolean
+	/** Human-readable trace of which branch fired — for telemetry and test assertions. */
+	reason: string
+}
+
+/** Kinds the rules system handles well when the rest of the shape is clean. */
+const RULE_CLEAN_KINDS: ReadonlySet<string> = new Set([
+	"structured_address",
+	"intersection",
+	"po_box",
+	"postcode_only",
+])
+
+/** Non-Latin scripts where the Latin-centric rules system is weak — hand to neural regardless of kind. */
+const OOD_SCRIPTS: ReadonlySet<string> = new Set(["cjk", "cyrillic", "arabic"])
+
+/** Character classes that count as "Latin / clean" for the `rule_preferred` guard. */
+const LATIN_CLASSES: ReadonlySet<string> = new Set(["numeric", "alpha", "alphanumeric"])
+
+/**
+ * Minimum kind confidence to route a clean kind to `rule_preferred`. Strict by design: below this,
+ * v0's rules are brittle on structured input and a confident wrong preference is worse than keeping
+ * both sources (DeepSeek-coordinated, 2026-06-17 — 0.7 invited false-preference).
+ */
+export const CLEAN_KIND_CONFIDENCE = 0.8
+
+/**
+ * Classify the input's shape into a default policy mode.
+ *
+ * The decision tree (first match wins):
+ *
+ * 0. **OOD script** (`cjk` / `cyrillic` / `arabic`) → `neural_preferred`. Script dominates — rules
+ *    are Latin-centric, so non-Latin input is neural's regardless of kind.
+ * 1. **Clean structured** — a {@link RULE_CLEAN_KINDS} kind at confidence ≥ {@link CLEAN_KIND_CONFIDENCE},
+ *    a Latin/unknown character class, and the placer not abstained → `rule_preferred`. v0's home turf.
+ * 2. **Both weak** — the placer abstained, or kind confidence is below the cutoff → `abstain` (mode
+ *    `both`, drop nothing).
+ * 3. **Otherwise** (confident, Latin, placer-OK, but not a clean kind — `landmark`, `vague`,
+ *    `locality_only`) → `neural_preferred`.
+ *
+ * @param kind Kind-classifier signal.
+ * @param shape Query-shape signal.
+ * @param placer Coarse-placer signal, or `null` when none ran.
+ */
+export function routeInputShape(
+	kind: RouterKindSignal,
+	shape: RouterShapeSignal,
+	placer: RouterPlacerSignal | null
+): InputShapeRoute {
+	const cc = shape.characterClass
+	const placerAbstained = placer !== null && (placer.abstained || placer.country === null || placer.country === "OTHER")
+
+	// 0. Non-Latin script → neural, before any kind-based routing.
+	if (cc !== undefined && OOD_SCRIPTS.has(cc)) {
+		return { defaultMode: "neural_preferred", abstain: false, reason: `ood-script:${cc}` }
+	}
+
+	// 1. Clean structured Latin address with a confident clean kind and no placer abstention → rules.
+	const latinOrUnknown = cc === undefined || LATIN_CLASSES.has(cc)
+	if (RULE_CLEAN_KINDS.has(kind.kind) && kind.confidence >= CLEAN_KIND_CONFIDENCE && latinOrUnknown && !placerAbstained) {
+		return {
+			defaultMode: "rule_preferred",
+			abstain: false,
+			reason: `clean:${kind.kind}@${kind.confidence.toFixed(2)}`,
+		}
+	}
+
+	// 2. Both signals weak → abstain (keep every source; drop nothing).
+	if (placerAbstained || kind.confidence < CLEAN_KIND_CONFIDENCE) {
+		return {
+			defaultMode: "both",
+			abstain: true,
+			reason: `weak:kind=${kind.kind}@${kind.confidence.toFixed(2)},placerAbstained=${placerAbstained}`,
+		}
+	}
+
+	// 3. Confident, Latin, placer-OK, but not a clean kind → neural.
+	return { defaultMode: "neural_preferred", abstain: false, reason: `neural-default:${kind.kind}` }
+}

--- a/core/policy/registry.ts
+++ b/core/policy/registry.ts
@@ -27,10 +27,14 @@ function policyKey(component: ComponentTag, locale: string | undefined): string 
 export class InMemoryPolicyRegistry implements PolicyRegistry {
 	#entries = new Map<string, ClassifierPolicy>()
 
-	/** Build a registry pre-loaded with `rule_only` for every component. */
-	static withDefaults(): InMemoryPolicyRegistry {
+	/**
+	 * Build a registry pre-loaded with `mode` for every component (default `rule_only`). The
+	 * input-shape router (#478) passes a shape-derived default so the whole table starts from the
+	 * routed prior.
+	 */
+	static withDefaults(mode: PolicyMode = "rule_only"): InMemoryPolicyRegistry {
 		const registry = new InMemoryPolicyRegistry()
-		for (const policy of buildDefaultPolicies()) {
+		for (const policy of buildDefaultPolicies(mode)) {
 			registry.set(policy)
 		}
 		return registry


### PR DESCRIPTION
## #478 increment 2 — the input-shape router (the arbitration prior)

Increment 1 (PR #679) gave the arena an assembled-pipeline gate. This adds the **input-shape router**: a pure, deterministic classification of an input's *shape* into a default `PolicyMode` that seeds the per-component policy table before per-tag config overlays.

The parity intuition (#478): the rules system owns clean structured Latin addresses (the arena's `v0-only` column), neural owns noisy / off-map / non-Latin input, and when both signals are weak the honest move is to **abstain** rather than emit a confident-wrong parse.

### What's here

- **`core/policy/input-shape-router.ts`** — `routeInputShape(kind, shape, placer) → { defaultMode, abstain, reason }`. Pure, structural-lite inputs (compatible with `QueryKindResult` / `QueryShapeLite` / the #244 `CoarsePrediction`), zero imports beyond `PolicyMode`. Decision tree, first match wins:
  0. **OOD script** (cjk/cyrillic/arabic) → `neural_preferred` (rules are Latin-centric; script dominates).
  1. **Clean structured** — a clean kind (`structured_address`/`intersection`/`po_box`/`postcode_only`) at confidence **≥ 0.8**, Latin/unknown character class, placer not abstained → `rule_preferred`.
  2. **Both weak** — placer abstained or kind confidence < 0.8 → `abstain` (mode `both`, drop nothing).
  3. **Otherwise** (confident, Latin, placer-OK, non-clean kind) → `neural_preferred`.
- **`policyRegistryFromRoute(route, config?)`** + parametrized `buildDefaultPolicies(mode?)` / `withDefaults(mode?)` / `policyRegistryFromConfig(config, defaultMode?)` — the routed prior becomes the table default; explicit per-tag config still wins. All default to `rule_only`, so existing callers are unchanged.
- **The seam** — `filterByPolicy` / `runProposalPipeline` gain an optional `routerPrior`. Resolution order: an explicit policy registry is authoritative; else a `routerPrior` builds a router-default registry; else no filtering.

### Default-OFF, byte-stable, and *why it's still exercised*

No production caller passes a `routerPrior` — the production `runPipeline` is neural-only and doesn't yet feed live signals (that's **increment 3**: give `runPipeline` an arbitration site, then grade it on the assembled gate + the oa-resolver coordinate leg). So this ships with **zero behavior change**.

The one risk DeepSeek flagged (default-off ⇒ never exercised ⇒ bugs hide until inc 3) is mitigated by a **flag-ON lane**: `input-shape-router.test.ts` drives proposals through `filterByPolicy` *with* a `routerPrior` and asserts the right source wins per mode — so the integration code runs end-to-end in CI even though the default ships off.

### The slice (and why it stops here)

The map surfaced the crux: the arbitration machinery (policy registry + proposal pipeline) lives only in `AddressParser`, while the assembled gate grades `runPipeline` — and neither site can host the router *live* without the unify step. So inc 2 lands the router **proven correct in isolation** (the reviewable substance) and defers the `runPipeline` surgery + the gate run to inc 3. Plan + DeepSeek coordination recorded in the increment-2 plan note.

### Verification

- `vitest --run input-shape-router from-config registry proposal-pipeline` → **74 passed** (27 new + 47 existing; parametrized defaults regress nothing).
- `tsc -p core/tsconfig.json --noEmit` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
