### PR TITLE
feat(#478): wire arbitration into runPipeline + arena gate (increment 3)

### DIFF
--- a/core/decoder/proposals-to-tree.test.ts
+++ b/core/decoder/proposals-to-tree.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `treeToProposals` (#478 inc 3) — the inverse of `proposalsToTree`, used to bring the whole-text
+ *   neural parse into the arbitration layer's proposal currency.
+ */
+
+import { describe, expect, it } from "vitest"
+import type { ComponentTag } from "../types/index.js"
+import { proposalsToTree, treeToProposals } from "./proposals-to-tree.js"
+import type { AddressTree } from "./types.js"
+
+describe("treeToProposals", () => {
+	it("walks nodes depth-first (incl. children) into proposals with the given source/sourceId", () => {
+		const tree: AddressTree = {
+			raw: "x",
+			roots: [
+				{
+					tag: "street",
+					value: "Main",
+					start: 0,
+					end: 4,
+					confidence: 0.9,
+					children: [{ tag: "house_number", value: "350", start: 5, end: 8, confidence: 0.8, children: [] }],
+				},
+			],
+		}
+		const props = treeToProposals(tree, "neural", { sourceId: "n1" })
+		expect(props.map((p) => p.component)).toEqual(["street", "house_number"])
+		expect(props.every((p) => p.source === "neural" && p.source_id === "n1")).toBe(true)
+		expect(props[1]).toMatchObject({ confidence: 0.8 })
+		expect(props[1]!.span.start).toBe(5)
+		expect(props[1]!.span.end).toBe(8)
+	})
+
+	it("emits filter restricts which tags become proposals", () => {
+		const tree: AddressTree = {
+			raw: "x",
+			roots: [
+				{ tag: "street", value: "Main", start: 0, end: 4, confidence: 0.9, children: [] },
+				{ tag: "locality", value: "NYC", start: 5, end: 8, confidence: 0.9, children: [] },
+			],
+		}
+		const props = treeToProposals(tree, "neural", { emits: new Set<ComponentTag>(["street"]) })
+		expect(props.map((p) => p.component)).toEqual(["street"])
+	})
+
+	it("round-trips through proposalsToTree preserving tag/value/span (flat)", () => {
+		const tree: AddressTree = {
+			raw: "350 Main",
+			roots: [
+				{ tag: "house_number", value: "350", start: 0, end: 3, confidence: 0.9, children: [] },
+				{ tag: "street", value: "Main", start: 4, end: 8, confidence: 0.9, children: [] },
+			],
+		}
+		const project = (t: AddressTree) =>
+			t.roots.map((r) => ({ tag: r.tag, value: r.value, start: r.start, end: r.end }))
+		const rebuilt = proposalsToTree(tree.raw, treeToProposals(tree, "neural"))
+		expect(project(rebuilt)).toEqual(project(tree))
+	})
+})

--- a/core/decoder/proposals-to-tree.ts
+++ b/core/decoder/proposals-to-tree.ts
@@ -14,7 +14,8 @@
  *   pipeline.
  */
 
-import type { ClassificationProposal, ComponentTag } from "../types/index.js"
+import type { Span } from "../tokenization/index.js"
+import type { ClassificationProposal, ClassificationProposalSource, ComponentTag } from "../types/index.js"
 import type { AddressNode, AddressTree } from "./types.js"
 
 export function proposalsToTree(raw: string, proposals: readonly ClassificationProposal[]): AddressTree {
@@ -30,4 +31,46 @@ export function proposalsToTree(raw: string, proposals: readonly ClassificationP
 	}))
 	roots.sort((a, b) => a.start - b.start)
 	return { raw, roots }
+}
+
+/**
+ * The inverse of {@link proposalsToTree}: walk an `AddressTree` into a flat list of
+ * `ClassificationProposal`s (one per node, depth-first), tagged with the given `source` (#478
+ * increment 3). Used to bring the whole-text neural parse into the arbitration layer's proposal
+ * currency so it can be unioned with rule proposals and filtered by the policy registry.
+ *
+ * The spans are structural (`{ start, end, body }`) — we intentionally avoid `Span.from(...)` (which
+ * forces the tokenization module's filesystem-bound init); downstream proposal consumers read only
+ * `start` / `end` / `body`. Same convention as the neural proposal-classifier adapter.
+ *
+ * @param tree The parsed tree (e.g. the neural argmax tree).
+ * @param source Provenance stamped on every emitted proposal (`"neural"` here).
+ * @param opts.sourceId Optional stable id surfaced as `source_id`.
+ * @param opts.emits Optional tag allow-list; when set, only nodes with these tags are emitted.
+ */
+export function treeToProposals(
+	tree: AddressTree,
+	source: ClassificationProposalSource,
+	opts: { sourceId?: string; emits?: ReadonlySet<ComponentTag> } = {}
+): ClassificationProposal[] {
+	const proposals: ClassificationProposal[] = []
+	const { sourceId, emits } = opts
+
+	const visit = (node: AddressNode): void => {
+		if (!emits || emits.has(node.tag)) {
+			const span = { start: node.start, end: node.end, body: node.value } as unknown as Span
+			proposals.push({
+				span,
+				component: node.tag,
+				confidence: node.confidence,
+				source,
+				source_id: sourceId ?? node.sourceId ?? source,
+				penalty: 0,
+			})
+		}
+		for (const child of node.children) visit(child)
+	}
+
+	for (const root of tree.roots) visit(root)
+	return proposals
 }

--- a/core/parser/index.ts
+++ b/core/parser/index.ts
@@ -6,3 +6,4 @@
 
 export * from "./AddressParser.js"
 export * from "./proposal-pipeline.js"
+export * from "./solution-to-proposals.js"

--- a/core/parser/solution-to-proposals.test.ts
+++ b/core/parser/solution-to-proposals.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `solutionToProposals` (#478 inc 3) — projects a solved v0 solution's matches into rule proposals,
+ *   dropping matches whose legacy classification has no `ComponentTag` mapping.
+ */
+
+import { describe, expect, it } from "vitest"
+import type { SerializedSolution } from "../solver/index.js"
+import { solutionToProposals } from "./solution-to-proposals.js"
+
+function match(classification: string, value: string, start: number, confidence: number) {
+	return { classification, value, start, end: start + value.length, confidence }
+}
+
+function solution(matches: ReturnType<typeof match>[]): SerializedSolution {
+	return { score: 1, penalty: 0, classifications: {}, formatted_address: "", matches } as unknown as SerializedSolution
+}
+
+describe("solutionToProposals", () => {
+	it("projects mapped matches into rule proposals, skipping unmapped legacy tags", () => {
+		const props = solutionToProposals(
+			solution([
+				match("house_number", "350", 0, 0.9),
+				match("street", "Main St", 4, 0.8),
+				match("stop_word", "of", 12, 0.5), // unmapped → dropped
+			]),
+			"v0"
+		)
+		expect(props.map((p) => p.component)).toEqual(["house_number", "street"])
+		expect(props.every((p) => p.source === "rule" && p.source_id === "v0")).toBe(true)
+		expect(props[0]).toMatchObject({ confidence: 0.9 })
+		expect(props[0]!.span.start).toBe(0)
+		expect(props[0]!.span.end).toBe(3)
+	})
+
+	it("defaults source_id to 'rule' and returns [] for an empty solution", () => {
+		expect(solutionToProposals(solution([]))).toEqual([])
+		const [p] = solutionToProposals(solution([match("country", "US", 0, 1)]))
+		expect(p?.source_id).toBe("rule")
+	})
+})

--- a/core/parser/solution-to-proposals.ts
+++ b/core/parser/solution-to-proposals.ts
@@ -1,0 +1,48 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Convert a solved v0 (rule) parser solution into `ClassificationProposal`s (#478 increment 3).
+ *
+ *   The arbitration layer's "rule source" is NOT the raw firings of individual legacy classifiers —
+ *   those are uncoordinated (every classifier fires on every span) and only become a coherent parse
+ *   after the v0 solver chain (filters, penalties, declassifiers) runs. So the rule proposals fed to
+ *   arbitration are derived from a *solved* `SerializedSolution` (the v0 parser's actual output), one
+ *   proposal per surviving match — preserving the span offsets and confidence the solver settled on.
+ *
+ *   Spans are structural (`{ start, end, body }`) to avoid forcing the tokenization module's
+ *   filesystem-bound init; downstream proposal consumers read only `start` / `end` / `body`.
+ */
+
+import type { SerializedSolution } from "../solver/index.js"
+import type { Span } from "../tokenization/index.js"
+import { type ClassificationProposal, legacyClassificationToComponentTag } from "../types/index.js"
+
+/**
+ * Project a solved v0 solution's matches into `rule`-sourced proposals. Matches whose legacy
+ * classification has no `ComponentTag` mapping (e.g. structural-only tags) are skipped.
+ *
+ * @param solution A `SerializedSolution` from `AddressParser.parse()` (typically the top solution).
+ * @param sourceId Stable id surfaced as `source_id` (default `"rule"`).
+ */
+export function solutionToProposals(solution: SerializedSolution, sourceId = "rule"): ClassificationProposal[] {
+	const proposals: ClassificationProposal[] = []
+
+	for (const match of solution.matches) {
+		const component = legacyClassificationToComponentTag(match.classification)
+		if (!component) continue
+
+		const span = { start: match.start, end: match.end, body: match.value } as unknown as Span
+		proposals.push({
+			span,
+			component,
+			confidence: match.confidence,
+			source: "rule",
+			source_id: sourceId,
+			penalty: 0,
+		})
+	}
+
+	return proposals
+}

--- a/core/pipeline/runtime-pipeline.test.ts
+++ b/core/pipeline/runtime-pipeline.test.ts
@@ -10,6 +10,8 @@
 import { describe, expect, it, vi } from "vitest"
 import type { AddressNode, AddressTree } from "../decoder/types.js"
 import type { Resolver } from "../resolver/types.js"
+import type { Span } from "../tokenization/index.js"
+import type { ClassificationProposal, ComponentTag } from "../types/index.js"
 import { runPipeline } from "./runtime-pipeline.js"
 import type {
 	AddressClassifier,
@@ -599,5 +601,100 @@ describe("runPipeline — coarse-placer soft prior (#244)", () => {
 		})
 		expect(result.path).toBe("fast-path")
 		expect(seen[0]).toMatchObject({ anchorPosterior: { US: 0.96 }, anchorWeight: 1.0 })
+	})
+})
+
+describe("runPipeline — arbitration (#478 inc 3)", () => {
+	function ruleProp(component: ComponentTag, body: string, start: number, confidence: number): ClassificationProposal {
+		return {
+			span: { start, end: start + body.length, body } as unknown as Span,
+			component,
+			confidence,
+			source: "rule",
+			source_id: "v0-test",
+			penalty: 0,
+		}
+	}
+
+	const cleanKind: QueryKindResult = { kind: "structured_address", confidence: 0.9, alternatives: [] }
+	const alphaShape = (): QueryShapeLite => ({ knownFormats: [], characterClass: "alpha" })
+
+	it("arbitrate unset → neural tree unchanged, ruleProposer never called (byte-stable)", async () => {
+		const neuralRoots: AddressNode[] = [
+			{ tag: "street", value: "Main Street", start: 0, end: 11, confidence: 0.8, children: [] },
+		]
+		const ruleProposer = vi.fn(async () => [ruleProp("street", "Main", 0, 0.9)])
+		const result = await runPipeline("Main Street", {
+			computeQueryShape: alphaShape,
+			classifyKind: async () => cleanKind,
+			classifier: fakeClassifier(fakeTree("Main Street", neuralRoots)),
+			ruleProposer,
+		})
+		expect(ruleProposer).not.toHaveBeenCalled()
+		expect(result.tree.roots).toEqual(neuralRoots)
+		expect(result.timing["arbitrate"]).toBeUndefined()
+	})
+
+	it("rule_preferred route: rule decomposition replaces the coarse neural span", async () => {
+		// clean structured + alpha + no placer → rule_preferred. Rule proposes house_number[0,3] +
+		// street[4,15]; the neural coarse street[0,15] overlaps both → rule preference + coherence win.
+		const ruleProposer = vi.fn(async () => [ruleProp("house_number", "350", 0, 0.9), ruleProp("street", "Main Street", 4, 0.9)])
+		const result = await runPipeline(
+			"350 Main Street",
+			{
+				computeQueryShape: alphaShape,
+				classifyKind: async () => cleanKind,
+				classifier: fakeClassifier(
+					fakeTree("350 Main Street", [
+						{ tag: "street", value: "350 Main Street", start: 0, end: 15, confidence: 0.8, children: [] },
+					])
+				),
+				ruleProposer,
+			},
+			{ arbitrate: true }
+		)
+		expect(ruleProposer).toHaveBeenCalled()
+		expect(result.tree.roots.map((r) => r.tag)).toContain("house_number")
+		expect(result.tree.roots.every((r) => r.source === "rule")).toBe(true)
+		expect(result.timing["arbitrate"]).toBeGreaterThanOrEqual(0)
+	})
+
+	it("neural_preferred (OOD script) keeps the neural span over an overlapping rule span", async () => {
+		const ruleProposer = vi.fn(async () => [ruleProp("street", "abc", 0, 0.95)])
+		const result = await runPipeline(
+			"abc",
+			{
+				computeQueryShape: () => ({ knownFormats: [], characterClass: "cjk" }),
+				classifyKind: async () => cleanKind,
+				classifier: fakeClassifier(
+					fakeTree("abc", [{ tag: "street", value: "abc", start: 0, end: 3, confidence: 0.5, children: [] }])
+				),
+				ruleProposer,
+			},
+			{ arbitrate: true }
+		)
+		expect(result.tree.roots).toHaveLength(1)
+		expect(result.tree.roots[0]?.source).toBe("neural")
+	})
+
+	it("flat round-trip: arbitrate with no rule proposals preserves every neural node (no-op guard)", async () => {
+		const tree = fakeTree("350 Main", [
+			{ tag: "house_number", value: "350", start: 0, end: 3, confidence: 0.9, children: [] },
+			{ tag: "street", value: "Main", start: 4, end: 8, confidence: 0.9, children: [] },
+		])
+		const result = await runPipeline(
+			"350 Main",
+			{
+				computeQueryShape: alphaShape,
+				classifyKind: async () => cleanKind,
+				classifier: fakeClassifier(tree),
+				ruleProposer: async () => [],
+			},
+			{ arbitrate: true }
+		)
+		expect(result.tree.roots.map((r) => ({ tag: r.tag, value: r.value, start: r.start, end: r.end }))).toEqual([
+			{ tag: "house_number", value: "350", start: 0, end: 3 },
+			{ tag: "street", value: "Main", start: 4, end: 8 },
+		])
 	})
 })

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -12,7 +12,11 @@
  *   Implementation contract per `docs/articles/plan/reference/STAGES.md`.
  */
 
+import { proposalsToTree, treeToProposals } from "../decoder/proposals-to-tree.js"
+import { resolveProposalOverlaps } from "../decoder/resolve-proposal-overlaps.js"
 import type { AddressNode, AddressTree } from "../decoder/types.js"
+import { policyRegistryFromRoute } from "../policy/from-config.js"
+import { routeInputShape } from "../policy/input-shape-router.js"
 import type { ComponentTag } from "../types/component.js"
 import { prefetchReconcileLookups } from "./reconcile-lookups.js"
 import type { ClassifierCandidate } from "./reconcile.js"
@@ -197,9 +201,12 @@ export async function runPipeline(
 	// caller-supplied posterior (a stronger postcode anchor — never overwrite it). Off (no stage) →
 	// `effectiveOpts === opts` → byte-stable. See the soft-signal wiring spec.
 	let effectiveOpts = opts
+	// Captured for the arbitration router signal (#478 inc 3) as well as the resolver anchor below.
+	let placedPrediction: { country: string | null; confidence: number; posterior?: Record<string, number> } | undefined
 	if (stages.placeCountry) {
 		const tPlace = performance.now()
 		const placed = stages.placeCountry(normalized.normalized)
+		placedPrediction = placed
 		timing["place-country"] = performance.now() - tPlace
 		if (placed.country && placed.country !== "OTHER" && !opts?.resolveOpts?.anchorPosterior) {
 			effectiveOpts = {
@@ -355,6 +362,34 @@ export async function runPipeline(
 		const tClassify = performance.now()
 		tree = await safeClassify(stages.classifier, normalized.normalized, queryShape, stages.fst)
 		timing["token-classify"] = performance.now() - tClassify
+	}
+
+	// #478 increment 3: per-component rule-vs-neural arbitration over the (argmax) neural tree.
+	// Default-OFF (`opts.arbitrate`) and requires a `ruleProposer` stage. Union the WHOLE-TEXT neural
+	// parse (preserves the model's sequence context — deliberately NOT the per-section proposal
+	// fan-out) with the solved v0 rule parse, filter per-component by the input-shape router prior,
+	// drop overlapping survivors (the coherence pass), and rebuild the tree from the survivors.
+	// Reconcile (above) stays the orthogonal opt-in; this operates on whatever `tree` it produced.
+	if (opts?.arbitrate && stages.ruleProposer) {
+		throwIfAborted(opts)
+		const tArb = performance.now()
+		const placerSignal =
+			placedPrediction !== undefined
+				? {
+						country: placedPrediction.country,
+						abstained: placedPrediction.country === null || placedPrediction.country === "OTHER",
+					}
+				: null
+		const route = routeInputShape(
+			{ kind: kind.kind, confidence: kind.confidence },
+			{ characterClass: queryShape.characterClass },
+			placerSignal
+		)
+		const neuralProposals = treeToProposals(tree, "neural")
+		const ruleProposals = await stages.ruleProposer(normalized.normalized, locale.locale)
+		const arbitrated = policyRegistryFromRoute(route).apply([...neuralProposals, ...ruleProposals], locale.locale)
+		tree = proposalsToTree(normalized.normalized, resolveProposalOverlaps(arbitrated))
+		timing["arbitrate"] = performance.now() - tArb
 	}
 
 	if (phraseProposals.length > 0 && tree.roots.length >= 0) {

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -15,7 +15,7 @@
 
 import type { AddressTree } from "../decoder/types.js"
 import type { ResolveOpts, Resolver, ResolverBackend } from "../resolver/types.js"
-import type { Section } from "../types/classifier.js"
+import type { ClassificationProposal, Section } from "../types/classifier.js"
 
 export type LocaleTag = string
 
@@ -47,6 +47,14 @@ export interface PipelineOpts {
 	forceJointReconcile?: boolean
 	/** Hard cap on lookups the resolver may issue; passed through. */
 	resolveOpts?: ResolveOpts
+	/**
+	 * Per-component rule-vs-neural arbitration (#478 increment 3). When `true` AND a `ruleProposer`
+	 * stage is wired, the coordinator unions the whole-text neural parse with the solved v0 rule
+	 * parse (as proposals), filters them per-component via the input-shape router prior, resolves
+	 * span overlaps, and rebuilds the tree from the survivors. Default (unset) ⇒ `false` ⇒ the neural
+	 * argmax tree is used unchanged (byte-stable). Behind a flag pending the assembled gate.
+	 */
+	arbitrate?: boolean
 	signal?: AbortSignal
 }
 
@@ -220,6 +228,13 @@ export interface RuntimePipelineStages {
 	 * behavior, byte-stable).
 	 */
 	resolverBackend?: ResolverBackend
+	/**
+	 * The "rule source" for arbitration (#478 increment 3): `(normalizedText, locale) → rule
+	 * proposals`, derived from the SOLVED v0 parser (its solver-coordinated output, not raw classifier
+	 * firings). Invoked only when `opts.arbitrate` is set. Typically wired by `createRuntimePipeline`
+	 * from `createAddressParser` + `solutionToProposals`. Absent ⇒ arbitration is a no-op.
+	 */
+	ruleProposer?: (normalizedText: string, locale: string) => Promise<ClassificationProposal[]>
 }
 
 export interface PipelineTiming {

--- a/docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md
+++ b/docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md
@@ -1,0 +1,55 @@
+# Arbitration layer (#478 inc 3) — arena capability gate
+
+_2026-06-17. Increment 3 wires per-component rule-vs-neural arbitration into the assembled
+`runPipeline` (default-OFF, behind `arbitrate`). This records the first of the two pre-registered gate
+legs — the arena capability gate, graded on the ASSEMBLED pipeline (the #566-lesson instrument inc 1
+added), not raw neural. The second leg (precondition + coordinate, on the non-circular holdouts) is the
+promotion gate and is run separately before any mode flips to default-on._
+
+## What ran
+
+`scripts/harness-v0-neural.ts --tests mailwoman/test --admin-fst <en-us> --postcode-repair --assembled
+--arbitrate` — the 376-assertion arena, the bundled en-us model, graded three ways: v0 (rules), raw
+neural, and the assembled `runPipeline`. Arbitration unions the whole-text neural parse with the solved
+v0 rule parse (as proposals), filters per-component by the input-shape router prior, resolves span
+overlaps (the coherence pass), and rebuilds the tree.
+
+## Result — arbitration nearly halves the v0-only gap
+
+| graded arm | assembled/parser pass | **v0-only vs ASSEMBLED** (gate target → ~0) |
+| --- | ---: | ---: |
+| v0 (rules) | 100.0% | — |
+| raw neural | 43.1% | 56.9% |
+| assembled, no arbitration (inc 1 baseline) | 43.6% | 56.4% |
+| **assembled + arbitration** | **72.9%** | **27.1%** |
+
+Against raw neural the arbitrated pipeline is **+122 / −10**: it captures 122 parses neural alone drops
+(the v0 wins, kept "by construction" — the router routes clean structured input to the rule source and
+the registry keeps it) and loses 10 (cases where neural was right and arbitration preferred the rule
+parse). The run is clean across all 376 assertions, no errors.
+
+## Reading
+
+- **The thesis holds.** Per-component arbitration closes the arena's `v0-only` column the way #478
+  predicted — the pipeline keeps whichever source is right per component, so it stops scoring below v0
+  on the components v0 wins. `v0-only vs ASSEMBLED` moves **56.4% → 27.1%** with arbitration on.
+- **It is not yet ~0.** The residual 102 cases are where, after the router's mode choice + the
+  coherence pass, neither surviving source matched v0. That is the router/config tuning frontier (which
+  tags route to which source per shape) — deferred, and exactly what the per-tag `from-config` overlay
+  exists to A/B without code edits.
+- **The −10 is the watch item.** Ten cases the arbitrated pipeline loses vs raw neural are the
+  precondition-style risk: a rule parse winning a component where neural was correct. The coordinate
+  leg below is what confirms these don't translate into a street+house_number precondition or
+  coordinate regression — the gate that the original #427 re-promotion skipped.
+
+## Gate status
+
+- **Leg 1 (arena capability): CLEARS.** `v0-only vs ASSEMBLED` halved (56.4 → 27.1%), `neural-only`
+  retained (0 lost in that column), no `both-fail` added; +122/−10 vs raw neural.
+- **Leg 2 (precondition + coordinate): the promotion gate, run separately.** `oa-resolver-eval` on the
+  non-circular holdouts (Travis E-911 + OpenAddresses) — street+house_number+postcode precondition must
+  not regress vs argmax and coord-error percentiles must hold. Per-component modes promote to default
+  ONLY where both legs clear.
+
+Arbitration ships **default-OFF** (`opts.arbitrate`); this report is the capability evidence, not a
+promotion. The machinery + this gate instrument land together; the promotion decision rides leg 2.

--- a/mailwoman/runtime-pipeline.ts
+++ b/mailwoman/runtime-pipeline.ts
@@ -14,18 +14,21 @@
  *   See `docs/articles/plan/reference/STAGES.md` for the full contract.
  */
 
+import { type AddressParser, solutionToProposals } from "@mailwoman/core/parser"
 import {
 	runPipeline,
 	type PipelineOpts,
 	type PipelineResult,
 	type RuntimePipelineStages,
 } from "@mailwoman/core/pipeline"
+import type { ClassificationProposal } from "@mailwoman/core/types"
 import { classifyKind as defaultClassifyKind } from "@mailwoman/kind-classifier"
 import { detectLocale as defaultDetectLocale } from "@mailwoman/locale-gate"
 import { normalize } from "@mailwoman/normalize"
 import { groupPhrases as defaultGroupPhrases } from "@mailwoman/phrase-grouper"
 import { computeQueryShape } from "@mailwoman/query-shape"
 import { loadDefaultPlaceCountry } from "./default-placer.js"
+import { createAddressParser } from "./utils/parser.js"
 
 export interface CreateRuntimePipelineOpts {
 	/** The Stage 3 classifier — typically a `NeuralAddressClassifier`. */
@@ -71,6 +74,15 @@ export interface CreateRuntimePipelineOpts {
 	 * @see RuntimePipelineStages.placeCountry
 	 */
 	placeCountry?: RuntimePipelineStages["placeCountry"] | false
+	/**
+	 * The "rule source" for per-component arbitration (#478 increment 3). Defaults to a lazily-built
+	 * v0 `createAddressParser` whose solved output is projected to proposals via `solutionToProposals`
+	 * — constructed on the first `arbitrate: true` call and never if arbitration is never used.
+	 * Override to inject a custom rule parser or a fake in tests.
+	 *
+	 * @see RuntimePipelineStages.ruleProposer
+	 */
+	ruleProposer?: RuntimePipelineStages["ruleProposer"]
 }
 
 /**
@@ -86,6 +98,20 @@ export interface CreateRuntimePipelineOpts {
 export function createRuntimePipeline(
 	opts: CreateRuntimePipelineOpts = {}
 ): (raw: string, runOpts?: PipelineOpts) => Promise<PipelineResult> {
+	// Lazy v0 rule parser for arbitration (#478 inc 3). Built on first use (only when a caller passes
+	// `arbitrate: true`), so non-arbitrating pipelines pay nothing. The solved v0 output — not raw
+	// classifier firings — is the coherent "rule" source projected to proposals.
+	let v0Parser: AddressParser | undefined
+	const defaultRuleProposer = async (
+		normalizedText: string,
+		locale: string
+	): Promise<ClassificationProposal[]> => {
+		v0Parser ??= createAddressParser()
+		const solutions = await v0Parser.parse(normalizedText, { locale })
+		const top = solutions[0]
+		return top ? solutionToProposals(top, "v0-rules") : []
+	}
+
 	const stages: RuntimePipelineStages = {
 		normalize,
 		computeQueryShape,
@@ -103,6 +129,9 @@ export function createRuntimePipeline(
 		// `undefined` default is lazy-loaded on the first call (below) so the sync factory stays sync;
 		// `false` disables it. A confident in-map guess feeds the resolver's anchorPosterior re-rank.
 		placeCountry: typeof opts.placeCountry === "function" ? opts.placeCountry : undefined,
+		// Rule source for arbitration (#478 inc 3) — the lazy v0 parser above, override-able. Invoked
+		// only when a call passes `arbitrate: true`; otherwise never built.
+		ruleProposer: opts.ruleProposer ?? defaultRuleProposer,
 		// Default locale gate: rule-based from @mailwoman/locale-gate. Derives locale from
 		// QueryShape character class (CJK→ja-JP, Cyrillic→ru-RU, Arabic→ar) + known-format
 		// hits (us_zip→en-US, fr_postcode→fr-FR, uk_postcode→en-GB). Caller-hint wins when set.

--- a/scripts/harness-v0-neural.ts
+++ b/scripts/harness-v0-neural.ts
@@ -77,6 +77,12 @@ interface Args {
 	 * byte-stable.
 	 */
 	assembled: boolean
+	/**
+	 * #478 inc 3: run the assembled arm with per-component arbitration ON (`runPipeline`'s
+	 * `arbitrate: true`). Only meaningful with `--assembled`. Lets the gate compare the arbitrated
+	 * pipeline's `v0-only vs ASSEMBLED` against the non-arbitrated assembled baseline.
+	 */
+	arbitrate: boolean
 }
 
 function parseArgs(): Args {
@@ -87,6 +93,7 @@ function parseArgs(): Args {
 		unitRepair: false,
 		symmetricMatch: false,
 		assembled: false,
+		arbitrate: false,
 	}
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i]
@@ -107,6 +114,7 @@ function parseArgs(): Args {
 		else if (a === "--unit-repair") out.unitRepair = true
 		else if (a === "--symmetric-match") out.symmetricMatch = true
 		else if (a === "--assembled") out.assembled = true
+		else if (a === "--arbitrate") out.arbitrate = true
 	}
 	if (!out.testsDir) {
 		console.error("Usage: scripts/harness-v0-neural.ts --tests <dir> [--out-json <path>] [...]")
@@ -389,7 +397,8 @@ async function runAssertion(
 	neuralClassifier: NeuralAddressClassifier,
 	parseOpts: Parameters<NeuralAddressClassifier["parse"]>[1],
 	symmetricMatch: boolean,
-	pipeline?: ReturnType<typeof createRuntimePipeline>
+	pipeline?: ReturnType<typeof createRuntimePipeline>,
+	arbitrate = false
 ): Promise<AssertionResult> {
 	const solutions = await v0Parser.parse(a.input)
 	const v0Records: ClassificationRecord[] = solutions.map((s) => s.classifications as ClassificationRecord)
@@ -430,7 +439,7 @@ async function runAssertion(
 	let assembledPass: boolean | undefined
 	let assembledRecord: ClassificationRecord | undefined
 	if (pipeline) {
-		const { tree: assembledTree } = await pipeline(a.input)
+		const { tree: assembledTree } = await pipeline(a.input, arbitrate ? { arbitrate: true } : undefined)
 		assembledRecord = neuralTreeToV0Record(decodeAsJson(assembledTree)).record
 		assembledPass = anyExpectedMatches(a.expected, assembledRecord)
 	}
@@ -718,7 +727,10 @@ async function main(): Promise<void> {
 	const pipeline = args.assembled
 		? createRuntimePipeline({ classifier: neural, ...(adminFst ? { fst: adminFst as never } : {}) })
 		: undefined
-	if (pipeline) console.error("Assembled-pipeline arm ON (--assembled): grading runPipeline alongside raw neural.")
+	if (pipeline)
+		console.error(
+			`Assembled-pipeline arm ON (--assembled${args.arbitrate ? " --arbitrate" : ""}): grading runPipeline${args.arbitrate ? " with per-component arbitration" : ""} alongside raw neural.`
+		)
 
 	console.error("Running harness...")
 	const t0 = performance.now()
@@ -727,7 +739,7 @@ async function main(): Promise<void> {
 	for (const a of all) {
 		i++
 		try {
-			results.push(await runAssertion(a, v0Parser, neural, parseOpts, args.symmetricMatch, pipeline))
+			results.push(await runAssertion(a, v0Parser, neural, parseOpts, args.symmetricMatch, pipeline, args.arbitrate))
 		} catch (err) {
 			console.error(`[harness] WARN: error on assertion ${i} (${a.input}): ${(err as Error).message}`)
 		}


### PR DESCRIPTION
## #478 increment 3 — wire arbitration into `runPipeline` + the arena gate

Gives the neural-only `runPipeline` a per-component **rule-vs-neural arbitration** site (default-OFF), and grades it on the assembled-pipeline arena gate. This is the #478 capstone: parity is a *pipeline* property, and arbitration closes the arena's `v0-only` gap "by construction".

Consolidates what was sketched as separate increments (the spec's steps 2–3 + the gate run) into one PR, per request.

### The result (the headline)

`harness-v0-neural --tests mailwoman/test --assembled --arbitrate`, 376 assertions, bundled en-us model:

| graded arm | assembled pass | **v0-only vs ASSEMBLED** (→ ~0) |
| --- | ---: | ---: |
| raw neural | 43.1% | 56.9% |
| assembled, no arbitration (inc 1) | 43.6% | 56.4% |
| **assembled + arbitration** | **72.9%** | **27.1%** |

`+122 / −10` vs raw neural. Arbitration **nearly halves** the v0-only gap. Clean run, no errors. Full write-up: `docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md`.

### The flow (resolved Option A — wiring, no new algorithm)

When `opts.arbitrate` is set and a `ruleProposer` stage is wired, after the argmax tree is built:
1. `treeToProposals(neuralTree, "neural")` — the **whole-text** neural parse → proposals (deliberately NOT the per-section fan-out, which would shred the model's sequence context).
2. the solved v0 parser → `solutionToProposals(...)` — the **rule** source is the v0 parser's *solver-coordinated* output, not raw classifier firings (those would be noise).
3. `policyRegistryFromRoute(routeInputShape(kind, shape, placer)).apply(...)` — per-component arbitration by the inc-2 router prior.
4. `resolveProposalOverlaps(...)` — the inc-3 coherence pass (PR #683) drops cross-tag span overlaps so the flat rebuild is coherent.
5. `proposalsToTree(...)` → grouper-audit → resolver.

`createRuntimePipeline` wires the rule source as a **lazy** v0 parser (built only on the first `arbitrate: true` call). Reconcile stays the orthogonal opt-in and remains retired.

### Default-OFF + byte-stable

No shipped behavior changes: `arbitrate` defaults false, the lazy v0 parser is never built unless used, and the existing assembled (inc 1) arena numbers are unchanged with the flag off. New helpers (`treeToProposals`, `solutionToProposals`) are pure and additive.

### Tests (112 passing)

- `treeToProposals` round-trips an argmax tree through `proposalsToTree`; `solutionToProposals` drops unmapped legacy tags.
- `runPipeline` arbitration: flag-off byte-stable (ruleProposer never called), rule_preferred replaces the coarse neural span with the rule decomposition, neural_preferred (OOD) keeps the neural span, and the **flat no-op guard** (arbitrate + no rule proposals preserves every neural node).
- `tsc -p core/tsconfig.json --noEmit` clean.

### What's deferred (deliberately)

**Leg 2 of the gate — the precondition + coordinate run** (`oa-resolver-eval` on the non-circular holdouts) — is the **promotion** gate. The −10 cases above are exactly the precondition-style risk it must clear. A *comparable* assembled coordinate eval needs careful opt-threading (postcodeRepair/anchors) — rushing it would risk the precise miscomparison #566 warns against. Since promotion (flipping per-component modes default-on) is gated on leg 2 and stays deferred, that run + the promotion decision is the deliberate next step, not this PR. Arbitration ships default-OFF until both legs clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
