### PR TITLE
eval(#478): coordinate gate (leg 2) FAILS — arbitration not promoted

### DIFF
--- a/docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md
+++ b/docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md
@@ -1,10 +1,14 @@
-# Arbitration layer (#478 inc 3) — arena capability gate
+# Arbitration layer (#478 inc 3) — the two-leg gate (arena PASS, coordinate FAIL → not promoted)
 
 _2026-06-17. Increment 3 wires per-component rule-vs-neural arbitration into the assembled
-`runPipeline` (default-OFF, behind `arbitrate`). This records the first of the two pre-registered gate
-legs — the arena capability gate, graded on the ASSEMBLED pipeline (the #566-lesson instrument inc 1
-added), not raw neural. The second leg (precondition + coordinate, on the non-circular holdouts) is the
-promotion gate and is run separately before any mode flips to default-on._
+`runPipeline` (default-OFF, behind `arbitrate`). The two pre-registered gate legs split decisively:
+**leg 1 (arena label-match) passes strongly** — arbitration nearly halves the `v0-only` gap; **leg 2
+(precondition + coordinate) FAILS catastrophically** — it drops locality-match 26pp, blows coord p50
+from 3.3 km to 1069 km, and loses the street+house_number precondition on half the rows. Arbitration is
+**not promoted**; it stays default-OFF. This is the #566 lesson reproduced in real time: a layer that
+"can't score below v0 by construction" is only true if you grade the ASSEMBLED COORDINATE output — the
+arena's loose label-match made arbitration look like a clean win it isn't. Leg 2 is exactly why the gate
+runs before any flip to default-on._
 
 ## What ran
 
@@ -42,14 +46,48 @@ parse). The run is clean across all 376 assertions, no errors.
   leg below is what confirms these don't translate into a street+house_number precondition or
   coordinate regression — the gate that the original #427 re-promotion skipped.
 
-## Gate status
+## Leg 2 — the coordinate gate (FAILS)
 
-- **Leg 1 (arena capability): CLEARS.** `v0-only vs ASSEMBLED` halved (56.4 → 27.1%), `neural-only`
-  retained (0 lost in that column), no `both-fail` added; +122/−10 vs raw neural.
-- **Leg 2 (precondition + coordinate): the promotion gate, run separately.** `oa-resolver-eval` on the
-  non-circular holdouts (Travis E-911 + OpenAddresses) — street+house_number+postcode precondition must
-  not regress vs argmax and coord-error percentiles must hold. Per-component modes promote to default
-  ONLY where both legs clear.
+`scripts/eval/oa-resolver-eval.ts --assembled` routes each row through `createRuntimePipeline` (same
+neural classifier with postcodeRepair, `placeCountry` OFF for comparability, same resolver) — without
+(`assembled`) and with (`assembled + arb`) arbitration. 300 OpenAddresses US rows, admin-centroid tier:
 
-Arbitration ships **default-OFF** (`opts.arbitrate`); this report is the capability evidence, not a
-promotion. The machinery + this gate instrument land together; the promotion decision rides leg 2.
+| arm | locality-match | region-match | coord p50 km | coord p90 km | street+hn precondition |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| neural | 83.0% | 99.7% | 3.3 | 12.5 | 100.0% |
+| assembled (no arb) | 83.0% | 99.7% | 3.3 | 12.5 | 100.0% |
+| **assembled + arb** | **57.0%** | 100.0% | **1069.4** | **3182.5** | **48.0%** |
+
+The `assembled (no arb)` arm reproduces `neural` to the decimal — the **instrument is sound**, so the
+regression is fully attributable to arbitration (the only delta is `arbitrate: true`). Arbitration:
+
+- **drops locality-match 83.0% → 57.0%** (−26pp) — it produces locality/region values that resolve to
+  the wrong place (a namesake city in another state), which is what blows the coord p50 from **3.3 km to
+  1069 km**;
+- **loses the street+house_number precondition on half the rows** (100% → 48%) — the #566 failure mode
+  directly: components that anchor the street-level geocode are dropped in the union → arbitration →
+  coherence → flat-rebuild path.
+
+This is invisible to leg 1 because the arena scores loose top-1 label-match (does the parse name the
+same components as v0), not the resolved coordinate. Arbitration makes the labels look more v0-like
+(+122) while wrecking the geocode — the exact gap the #566 reconcile-retirement warned the gate must
+close.
+
+## Gate status — NOT PROMOTED
+
+- **Leg 1 (arena label-match): clears.** `v0-only vs ASSEMBLED` 56.4 → 27.1%, +122/−10 vs raw neural.
+- **Leg 2 (precondition + coordinate): FAILS decisively.** locality −26pp, coord p50 3.3 → 1069 km,
+  precondition 100% → 48%.
+
+**Both legs must clear to promote; leg 2 fails, so arbitration stays default-OFF.** The machinery and
+both gate instruments are merged; no default changes. The methodology did its job — it caught a
+catastrophic coordinate regression that the label-match arena scored as a +122 win.
+
+## Next (the path to a promotable arbitration)
+
+The failure is concentrated in the precondition drop (48%) and wrong-place resolution. Two suspects,
+separable with a follow-up probe: (a) the **flat `proposalsToTree` rebuild** losing structure the
+resolver needs (DeepSeek's flagged risk — the resolver-output no-op was never asserted, only tree
+shape); (b) the **arbitration/coherence dropping anchor components** (street/house_number/locality) when
+rule and neural spans overlap. Diagnosing which — likely both — is the prerequisite to any future
+promotion. Until then arbitration is a measured-negative behind a default-off flag, not a shipped path.

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -50,7 +50,7 @@ import { lookupGermanState } from "@mailwoman/codex/de"
 import { lookupFrenchRegion } from "@mailwoman/codex/fr"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { createWofResolver } from "@mailwoman/core/resolver"
-import { type ClassificationRecord, createAddressParser } from "mailwoman"
+import { type ClassificationRecord, createAddressParser, createRuntimePipeline } from "mailwoman"
 import { readFileSync, writeFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
 import { v0RecordToTree } from "./v0-tree-adapter.ts"
@@ -580,6 +580,38 @@ async function main(): Promise<void> {
 	let interpPrecond = 0 // rows that parsed street+house_number+postcode (interp's precondition)
 	let interpFullParseMiss = 0 // precond met + exact missed + interp null = genuine find() miss
 	const diagMisses: string[] = []
+
+	// #478 inc 3 leg 2 — the ASSEMBLED arms. Route each row through `createRuntimePipeline` using the
+	// SAME neural classifier (postcodeRepair on, for comparability with the neural arm), placeCountry
+	// OFF (so we isolate arbitration from the #244 coarse prior), and the SAME resolver — without
+	// (`assembled`) and with (`assembled+arb`) per-component arbitration. The street+house_number
+	// precondition (the thing #566 broke) is counted per arm so a regression is visible directly.
+	const runAssembled = process.argv.includes("--assembled")
+	const assembledAgg = { overall: newAgg(), byState: new Map<string, Agg>() }
+	const assembledArbAgg = { overall: newAgg(), byState: new Map<string, Agg>() }
+	let neuralPrecond = 0
+	let asmPrecond = 0
+	let arbPrecond = 0
+	const hasStreetHN = (tree: AddressTree | null): boolean => {
+		if (!tree) return false
+		let street = false
+		let hn = false
+		const visit = (n: AddressNode): void => {
+			if (n.tag === "street") street = true
+			if (n.tag === "house_number") hn = true
+			for (const c of n.children) visit(c)
+		}
+		for (const r of tree.roots) visit(r)
+		return street && hn
+	}
+	const assembledPipeline = runAssembled
+		? createRuntimePipeline({
+				classifier: { parse: (text: string, o?: object) => neural.parse(text, { ...o, postcodeRepair: true }) } as never,
+				resolver: resolver as never,
+				placeCountry: false,
+			})
+		: null
+
 	const record = (
 		who: "neural" | "v0",
 		row: OaRow,
@@ -610,16 +642,18 @@ async function main(): Promise<void> {
 		i++
 		if (i % 500 === 0) console.error(`  ${i}/${rows.length}`)
 
+		// Shared resolve opts (hoisted so the assembled arms below resolve identically to neural).
+		const nOpts = {
+			...(anchorRerank ? { ...resolveOpts, anchorPosterior: anchorPosteriorFor(row.input) } : resolveOpts),
+			...(addressPoints ? { addressPoints } : {}),
+			...(interpolation ? { interpolation } : {}),
+		}
+
 		// neural
 		let nResolved: Resolved[] = []
 		let nDecorated: AddressTree | null = null
 		try {
 			const nTree = await neural.parse(row.input, parseOpts)
-			const nOpts = {
-				...(anchorRerank ? { ...resolveOpts, anchorPosterior: anchorPosteriorFor(row.input) } : resolveOpts),
-				...(addressPoints ? { addressPoints } : {}),
-				...(interpolation ? { interpolation } : {}),
-			}
 			nDecorated = await resolver.resolveTree(nTree, nOpts)
 			nResolved = collectResolved(nDecorated)
 		} catch {
@@ -627,6 +661,7 @@ async function main(): Promise<void> {
 		}
 		const ns = scoreTree(row, nResolved)
 		record("neural", row, ns)
+		if (runAssembled && hasStreetHN(nDecorated)) neuralPrecond++
 
 		if (collectResolvedDump) {
 			resolvedRows.push({
@@ -713,6 +748,31 @@ async function main(): Promise<void> {
 		const vs = scoreTree(row, vResolved)
 		record("v0", row, vs)
 
+		// #478 inc 3 leg 2: assembled (no-arb) + assembled+arb, through the same resolver + nOpts.
+		if (assembledPipeline) {
+			const st = row.state || "??"
+			try {
+				const { tree } = await assembledPipeline(row.input, { resolveOpts: nOpts })
+				const s = scoreTree(row, collectResolved(tree))
+				if (!assembledAgg.byState.has(st)) assembledAgg.byState.set(st, newAgg())
+				bump(assembledAgg.byState.get(st)!, s.locMatch, s.regMatch, s.resolved, s.err)
+				bump(assembledAgg.overall, s.locMatch, s.regMatch, s.resolved, s.err)
+				if (hasStreetHN(tree)) asmPrecond++
+			} catch {
+				/* unresolved */
+			}
+			try {
+				const { tree } = await assembledPipeline(row.input, { arbitrate: true, resolveOpts: nOpts })
+				const s = scoreTree(row, collectResolved(tree))
+				if (!assembledArbAgg.byState.has(st)) assembledArbAgg.byState.set(st, newAgg())
+				bump(assembledArbAgg.byState.get(st)!, s.locMatch, s.regMatch, s.resolved, s.err)
+				bump(assembledArbAgg.overall, s.locMatch, s.regMatch, s.resolved, s.err)
+				if (hasStreetHN(tree)) arbPrecond++
+			} catch {
+				/* unresolved */
+			}
+		}
+
 		if (collectErrors && (!ns.locMatch || !vs.locMatch)) {
 			errorRows.push({
 				input: row.input,
@@ -760,6 +820,10 @@ async function main(): Promise<void> {
 		`| ${label} | ${pct(a.localityMatch, a.n)} | ${pct(a.regionMatch, a.n)} | ${pct(a.resolved, a.n)} | ${p(a.errs, 50)} | ${p(a.errs, 90)} | ${p(a.errs, 99)} |`
 	lines.push(overallRow("**neural**", agg.neural.overall))
 	lines.push(overallRow("v0 (Pelias)", agg.v0.overall))
+	if (runAssembled) {
+		lines.push(overallRow("assembled (no arb)", assembledAgg.overall))
+		lines.push(overallRow("**assembled + arb**", assembledArbAgg.overall))
+	}
 	if (useAnchor) lines.push(overallRow("**neural+anchor**", neuralAnchorAgg.overall))
 	if (addressPoints) {
 		lines.push(overallRow("**neural+addrpt**", neuralAddrPtAgg.overall))
@@ -806,6 +870,21 @@ async function main(): Promise<void> {
 				for (const m of diagMisses.slice(0, 12)) lines.push(`  - ${m}`)
 			}
 		}
+	}
+	if (runAssembled) {
+		const N = agg.neural.overall.n
+		lines.push("")
+		lines.push(`### Arbitration coordinate gate (#478 leg 2)`)
+		lines.push("")
+		lines.push(
+			"`assembled (no arb)` is the pipeline through the same neural+resolver (comparability check vs `neural`); `assembled + arb` adds per-component arbitration. The street+house_number **precondition** (parsed both, the thing #566 broke) per arm:"
+		)
+		lines.push("")
+		lines.push(`- neural: ${pct(neuralPrecond, N)} · assembled (no arb): ${pct(asmPrecond, N)} · **assembled + arb: ${pct(arbPrecond, N)}** (of ${N} rows)`)
+		lines.push("")
+		lines.push(
+			"Gate: arbitration PASSES leg 2 iff the precondition does not regress and coord p50/p90 + locality/region Acc@1 hold vs `neural`."
+		)
 	}
 	lines.push("")
 	lines.push(`## Neural per-state (locality-match)`)


### PR DESCRIPTION
## #478 inc 3 leg 2 — the coordinate gate FAILS; arbitration not promoted

Adds the coordinate leg of the arbitration gate (`oa-resolver-eval --assembled`) and runs it. The verdict is decisive: **arbitration catastrophically regresses the geocode output and must NOT be promoted.** No defaults change — this PR is the instrument + the negative result.

### The result (300 OpenAddresses US rows, admin-centroid tier)

| arm | locality-match | coord p50 km | coord p90 km | street+hn precondition |
| --- | ---: | ---: | ---: | ---: |
| neural | 83.0% | 3.3 | 12.5 | 100.0% |
| assembled (no arb) | 83.0% | 3.3 | 12.5 | 100.0% |
| **assembled + arb** | **57.0%** | **1069.4** | **3182.5** | **48.0%** |

`assembled (no arb)` reproduces `neural` to the decimal — the **instrument is sound** (the only delta in the arb arm is `arbitrate: true`). Arbitration drops locality-match **−26pp**, blows coord p50 **3.3 km → 1069 km** (resolving to wrong-state namesakes), and **loses street+house_number on half the rows** (100% → 48%).

### Why leg 1 missed it

Leg 1 (the arena) scored arbitration as a clean **+122** win — but it measures loose top-1 *label*-match (does the parse name v0's components), not the resolved coordinate. Arbitration makes labels look more v0-like while wrecking the geocode. **This is the #566 trap reproduced exactly** — the reason the gate has a coordinate leg at all. The methodology did its job.

### What's in the PR

- **`oa-resolver-eval --assembled`** — routes each row through `createRuntimePipeline` (same neural+postcodeRepair, `placeCountry` off for comparability, same resolver), as two arms (`assembled` and `assembled + arb`), with a per-arm **street+house_number precondition** counter. The `assembled (no arb) ≈ neural` equality is the built-in comparability check.
- **Updated eval doc** (`2026-06-17-478-arbitration-arena-gate.md`) — now records both legs and the NOT-PROMOTED verdict.

### No promotion, no default change

Arbitration stays **default-OFF** (`opts.arbitrate`). The machinery (merged in #684) is a measured-negative behind a flag, not a shipped path.

### The path forward (follow-up, not this PR)

The failure concentrates in the precondition drop + wrong-place resolution. Two separable suspects: (a) the flat `proposalsToTree` rebuild losing structure the resolver needs (DeepSeek's flagged risk — the resolver-output no-op was never asserted, only tree shape); (b) arbitration/coherence dropping anchor components (street/house_number/locality) on rule×neural span overlap. Diagnosing which — likely both — is the prerequisite to any future promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
