### PR TITLE
eval(#478): diagnose the precondition drop — loss of containment + fix plan

### DIFF
--- a/docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md
+++ b/docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md
@@ -83,11 +83,39 @@ close.
 both gate instruments are merged; no default changes. The methodology did its job — it caught a
 catastrophic coordinate regression that the label-match arena scored as a +122 win.
 
-## Next (the path to a promotable arbitration)
+## Diagnosis — one root cause: loss of containment
 
-The failure is concentrated in the precondition drop (48%) and wrong-place resolution. Two suspects,
-separable with a follow-up probe: (a) the **flat `proposalsToTree` rebuild** losing structure the
-resolver needs (DeepSeek's flagged risk — the resolver-output no-op was never asserted, only tree
-shape); (b) the **arbitration/coherence dropping anchor components** (street/house_number/locality) when
-rule and neural spans overlap. Diagnosing which — likely both — is the prerequisite to any future
-promotion. Until then arbitration is a measured-negative behind a default-off flag, not a shipped path.
+`scripts/eval/probe-arbitration.ts` traces the arbitration stages on real US addresses. The aggregate
+over 60 clean rows is decisive — **both** failure modes are the same root cause: the flat
+proposal/tree representation has no containment.
+
+- **Precondition (street dropped 42%, all by overlap eviction).** Neural emits `street` + a separate
+  `street_suffix`/`street_prefix` (e.g. `street[4,12]"Seminary"` + `street_suffix[13,15]"Dr"`); the
+  solved v0 parse emits the combined `street[4,15]"Seminary Dr"`. Under `rule_preferred` both survive
+  arbitration (v0 has no `street_suffix`), then the coherence pass — which only knows intervals, not
+  that a suffix is *part of* a street — sees `street_suffix` (conf 0.94) overlapping `street` (conf
+  0.82) and **evicts the street**, leaving a dangling suffix and no street. Measured: 25/60 rows drop
+  street, **25/25 by this overlap eviction**. (When v0's street outranks the neural suffix, it
+  survives — the ~50/50.)
+- **Coordinate (locality resolves to a wrong-state namesake).** The probe shows locality/region
+  *values* are byte-identical to neural (**0/60** changed) — yet they resolve to the wrong place. The
+  only difference is the tree: the nested neural argmax tree vs the **flat** `proposalsToTree`. The
+  resolver loses the region→locality containment constraint and resolves the same `"Mill Valley"`
+  string globally to a wrong-state namesake. (DeepSeek's flagged flat-tree risk — the resolver-output
+  no-op was never asserted, only tree shape.)
+
+## Fix plan (DeepSeek-coordinated) — edit the neural tree, don't rebuild flat
+
+Apply arbitration as **edits on the nested neural argmax tree** instead of flatten → arbitrate →
+`proposalsToTree`. This preserves containment by construction, so the coherence pass becomes
+unnecessary and the resolver keeps its structure. The v1 edit algorithm:
+
+- `neural_preferred` / `abstain` routes → pass the neural tree **unchanged**.
+- `rule_preferred` → **override a neural node's value only** when a same-tag rule proposal overlaps it
+  with a different value; **add rule-only missing tags** as nodes; **never restructure** (no dropping
+  neural's sub-component decomposition, no flattening).
+
+This makes clean-address arbitration a **no-op** (killing both regressions), captures the high-value
+wins (value disagreements + tags neural missed entirely), and accepts losing the low-value
+pure-decomposition wins. Then **re-run the coordinate gate (leg 2)** before any promotion. Until that
+lands and clears, arbitration stays a measured-negative behind the default-off flag.

--- a/scripts/eval/probe-arbitration.ts
+++ b/scripts/eval/probe-arbitration.ts
@@ -1,0 +1,119 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #478 leg-2 diagnosis: trace the arbitration path stage-by-stage on a handful of clean US addresses
+ *   to find WHERE street/house_number is dropped (the precondition 100→48% regression). Replicates
+ *   exactly what `runPipeline`'s `arbitrate` block does: route → neural proposals ∪ solved-v0 proposals
+ *   → policy registry → coherence pass → (would-be) proposalsToTree.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/probe-arbitration.ts
+ */
+
+import { proposalsToTree, resolveProposalOverlaps, treeToProposals } from "@mailwoman/core/decoder"
+import { solutionToProposals } from "@mailwoman/core/parser"
+import { policyRegistryFromRoute, routeInputShape } from "@mailwoman/core/policy"
+import type { ClassificationProposal } from "@mailwoman/core/types"
+import { classifyKind } from "@mailwoman/kind-classifier"
+import { detectLocale } from "@mailwoman/locale-gate"
+import { normalize } from "@mailwoman/normalize"
+import { computeQueryShape } from "@mailwoman/query-shape"
+import { createAddressParser } from "mailwoman"
+import { readFileSync } from "node:fs"
+
+const MODEL = "/mnt/playpen/mailwoman-data/models/quantized/model-v140-step-40000-int8.onnx"
+const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const CARD = "neural-weights-en-us/model-card.json"
+
+const { NeuralAddressClassifier } = await import("@mailwoman/neural")
+const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+const card = JSON.parse(readFileSync(CARD, "utf8"))
+const [tokenizer, runner] = await Promise.all([MailwomanTokenizer.loadFromFile(TOK), OnnxRunner.create(MODEL)])
+const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: card.labels })
+const v0 = createAddressParser()
+
+const N = Number(process.env.PROBE_N ?? "0")
+const inputs = N
+	? readFileSync("data/eval/external/openaddresses-us-sample.jsonl", "utf8")
+			.split("\n")
+			.filter((l) => l.trim())
+			.slice(0, N)
+			.map((l) => JSON.parse(l).input as string)
+	: [
+			"109 Seminary Dr, Mill Valley, CA 94941",
+			"5210 South Ingleside Avenue, Chicago, IL 60615",
+			"2631 Moreland Place Nw, Washington, DC 20015",
+			"350 5th Ave, New York, NY 10118",
+		]
+
+let nStreetDropped = 0
+let nLocChanged = 0
+let nRegChanged = 0
+let nStreetDroppedBySuffix = 0
+const verbose = !N
+
+const fmt = (ps: readonly ClassificationProposal[]): string =>
+	ps.length === 0
+		? "(none)"
+		: ps
+				.map((p) => `${p.component}[${p.span.start},${p.span.end}]"${p.span.body}"·${p.source}·${p.confidence.toFixed(2)}`)
+				.join("  ")
+
+for (const input of inputs) {
+	const norm = normalize(input)
+	const shape = computeQueryShape(norm)
+	const locale = await detectLocale(norm, shape, { hint: "en-US" })
+	const kind = await classifyKind(norm, shape, locale)
+	const route = routeInputShape(
+		{ kind: kind.kind, confidence: kind.confidence },
+		{ characterClass: shape.characterClass },
+		null
+	)
+
+	const nTree = await neural.parse(norm.normalized, { queryShape: shape as never, postcodeRepair: true })
+	const nProps = treeToProposals(nTree, "neural")
+	const sols = await v0.parse(norm.normalized)
+	const rProps = sols[0] ? solutionToProposals(sols[0]!, "v0-rules") : []
+
+	const arbitrated = policyRegistryFromRoute(route).apply([...nProps, ...rProps], locale.locale)
+	const coherent = resolveProposalOverlaps(arbitrated)
+	const finalTree = proposalsToTree(norm.normalized, coherent)
+
+	const has = (ps: readonly ClassificationProposal[], tag: string) => ps.some((p) => p.component === tag)
+	const val = (ps: readonly ClassificationProposal[], tag: string) => ps.find((p) => p.component === tag)?.span.body
+
+	// Did arbitration drop street that the neural parse HAD? And was it evicted by an overlapping suffix/prefix?
+	const neuralHadStreet = has(nProps, "street")
+	const finalHasStreet = has(coherent, "street")
+	const arbHadStreet = has(arbitrated, "street")
+	if (neuralHadStreet && !finalHasStreet) {
+		nStreetDropped++
+		if (arbHadStreet) nStreetDroppedBySuffix++ // present after arbitration, gone after coherence = overlap eviction
+	}
+	if (val(nProps, "locality") !== val(coherent, "locality")) nLocChanged++
+	if (val(nProps, "region") !== val(coherent, "region")) nRegChanged++
+
+	if (verbose) {
+		console.log(`\n=== ${input}`)
+		console.log(`route:  ${route.defaultMode} (${route.reason}) | kind=${kind.kind}@${kind.confidence.toFixed(2)} cc=${shape.characterClass}`)
+		console.log(`neural: ${fmt(nProps)}`)
+		console.log(`rule:   ${fmt(rProps)}`)
+		console.log(`arb:    ${fmt(arbitrated)}`)
+		console.log(`cohere: ${fmt(coherent)}`)
+		console.log(
+			`FINAL precond: street=${finalHasStreet} house_number=${has(coherent, "house_number")} | locality=${has(coherent, "locality")} region=${has(coherent, "region")} | roots=${finalTree.roots.length}`
+		)
+	} else if (neuralHadStreet && !finalHasStreet) {
+		console.log(`STREET DROPPED: "${input}" — arb-had-street=${arbHadStreet} | cohere: ${fmt(coherent)}`)
+	}
+}
+
+if (N) {
+	console.log(`\n=== AGGREGATE over ${inputs.length} rows ===`)
+	console.log(`street dropped (neural had, final lacks): ${nStreetDropped}/${inputs.length}`)
+	console.log(`  └ of which evicted by overlap in coherence pass: ${nStreetDroppedBySuffix}`)
+	console.log(`locality value changed vs neural: ${nLocChanged}/${inputs.length}`)
+	console.log(`region value changed vs neural: ${nRegChanged}/${inputs.length}`)
+}


### PR DESCRIPTION
## #478 leg-2 diagnosis — the precondition drop is loss of containment (fix plan inside)

Diagnoses the catastrophic coordinate-gate failure from #685 (street dropped 42%, locality resolves to wrong-state namesakes). Adds the diagnostic probe + records the root cause and the DeepSeek-coordinated fix plan. **No production code change** — diagnosis only.

### Root cause: ONE — the flat proposal/tree representation has no containment

`scripts/eval/probe-arbitration.ts` traces the arbitration stages on real US addresses (aggregate over 60 clean rows):

- **Precondition (street dropped 25/60, all by overlap eviction).** Neural emits `street` + a separate `street_suffix`/`street_prefix`; v0 emits the combined `street`. Under `rule_preferred` both survive arbitration, then the coherence pass — interval-only, blind to "suffix is *part of* street" — evicts the lower-confidence `street` for the overlapping `street_suffix`. **25/25 street drops are this eviction.**
- **Coordinate (wrong-place resolution).** locality/region *values* are byte-identical to neural (**0/60** changed) — but the **flat `proposalsToTree`** loses the region→locality containment the resolver needs, so the same `"Mill Valley"` resolves to a wrong-state namesake. (DeepSeek's flagged flat-tree risk; the resolver-output no-op was never asserted.)

Both bugs = the same root cause: flatten→rebuild discards the nested structure.

### Fix plan (DeepSeek, 2 turns) — edit the neural tree, don't rebuild flat

Apply arbitration as **edits on the nested neural argmax tree**: `neural_preferred`/`abstain` pass unchanged; `rule_preferred` **overrides a neural node's value** only on same-tag overlapping disagreement + **adds rule-only missing tags**, **never restructuring**. Clean-address arbitration becomes a no-op (kills both regressions), captures value + missing-tag wins, accepts losing low-value decomposition wins. Then re-run the coordinate gate before promotion.

### What's here

- `scripts/eval/probe-arbitration.ts` — the stage tracer (`PROBE_N=<n>` aggregates over OA rows; hardcoded dev model paths).
- Eval doc updated with the diagnosis + fix plan.

Arbitration stays default-OFF; this is the path-to-promotable record, not a promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
