### PR TITLE
feat(#478): fix-v1 containment-preserving arbitration — regression fixed, not promoted

### DIFF
--- a/core/decoder/arbitrate-tree.test.ts
+++ b/core/decoder/arbitrate-tree.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #478 inc 3 fix-v1: containment-preserving arbitration. Verifies the edit rules (relabel same-span
+ *   tag disagreements, add rule-only non-overlapping missing tags) and — the load-bearing case — that
+ *   neural's street decomposition survives a coarser rule street (the leg-2 precondition bug).
+ */
+
+import { Span } from "@mailwoman/core/tokenization"
+import type { ClassificationProposal, ComponentTag } from "@mailwoman/core/types"
+import { describe, expect, it } from "vitest"
+import { applyRuleArbitration } from "./arbitrate-tree.js"
+import type { AddressNode, AddressTree } from "./types.js"
+
+function rp(component: ComponentTag, body: string, start: number, confidence = 1): ClassificationProposal {
+	return { span: new Span(body, start), component, confidence, source: "rule", source_id: "v0", penalty: 0 } as ClassificationProposal
+}
+function node(tag: ComponentTag, value: string, start: number, end: number, children: AddressNode[] = []): AddressNode {
+	return { tag, value, start, end, confidence: 0.9, children, source: "neural" }
+}
+function tree(...roots: AddressNode[]): AddressTree {
+	return { raw: "x", roots }
+}
+
+describe("applyRuleArbitration — relabel (same span, different tag)", () => {
+	it("relabels a neural node toward the rule's tag", () => {
+		const out = applyRuleArbitration(tree(node("locality", "NYC", 0, 3)), [rp("region", "NYC", 0)])
+		expect(out.roots).toHaveLength(1)
+		expect(out.roots[0]).toMatchObject({ tag: "region", source: "rule", value: "NYC" })
+	})
+
+	it("leaves a same-span same-tag node untouched", () => {
+		const out = applyRuleArbitration(tree(node("region", "NYC", 0, 3)), [rp("region", "NYC", 0)])
+		expect(out.roots[0]).toMatchObject({ tag: "region", source: "neural" })
+	})
+
+	it("relabels nested children too (walks the whole tree)", () => {
+		const out = applyRuleArbitration(tree(node("venue", "Foo", 0, 3, [node("locality", "Bar", 5, 8)])), [rp("region", "Bar", 5)])
+		expect(out.roots[0]!.children[0]).toMatchObject({ tag: "region", source: "rule" })
+	})
+})
+
+describe("applyRuleArbitration — preserves neural structure (the precondition fix)", () => {
+	it("keeps neural street + street_suffix; ignores the coarser rule street that subsumes them", () => {
+		const out = applyRuleArbitration(
+			tree(node("street", "Seminary", 4, 12), node("street_suffix", "Dr", 13, 15)),
+			[rp("street", "Seminary Dr", 4, 0.82)]
+		)
+		const tags = out.roots.map((r) => r.tag)
+		expect(tags).toContain("street")
+		expect(tags).toContain("street_suffix") // not evicted
+		expect(out.roots.find((r) => r.tag === "street")).toMatchObject({ value: "Seminary", start: 4, end: 12 })
+		expect(out.roots).toHaveLength(2) // no coarse rule street added
+	})
+
+	it("a fully-agreeing parse is a no-op", () => {
+		const original = tree(node("locality", "Paris", 0, 5), node("region", "TX", 7, 9))
+		const out = applyRuleArbitration(original, [rp("locality", "Paris", 0), rp("region", "TX", 7)])
+		expect(out.roots.map((r) => ({ tag: r.tag, value: r.value, source: r.source }))).toEqual([
+			{ tag: "locality", value: "Paris", source: "neural" },
+			{ tag: "region", value: "TX", source: "neural" },
+		])
+	})
+})
+
+describe("applyRuleArbitration — add rule-only missing tags", () => {
+	it("adds a rule tag absent from neural on a non-overlapping span", () => {
+		const out = applyRuleArbitration(tree(node("street", "Main", 0, 4)), [rp("country", "USA", 10)])
+		const country = out.roots.find((r) => r.tag === "country")
+		expect(country).toMatchObject({ value: "USA", source: "rule", start: 10, end: 13 })
+	})
+
+	it("does NOT add a rule tag whose span overlaps a neural node", () => {
+		const out = applyRuleArbitration(tree(node("street", "Main", 0, 4)), [rp("country", "Mai", 0)])
+		expect(out.roots).toHaveLength(1)
+		expect(out.roots[0]!.tag).toBe("street")
+	})
+
+	it("adds a rule-only tag at most once and keeps roots in span order", () => {
+		const out = applyRuleArbitration(tree(node("street", "Main", 4, 8)), [rp("house_number", "12", 0), rp("house_number", "12", 0)])
+		expect(out.roots.map((r) => r.tag)).toEqual(["house_number", "street"])
+	})
+})

--- a/core/decoder/arbitrate-tree.ts
+++ b/core/decoder/arbitrate-tree.ts
@@ -1,0 +1,104 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Containment-preserving arbitration (#478 inc 3, fix-v1).
+ *
+ *   The first arbitration implementation flattened the neural parse to proposals, unioned the solved
+ *   v0 proposals, filtered per-component, resolved span overlaps, and rebuilt a FLAT tree. That lost
+ *   containment two ways (diagnosed in `2026-06-17-478-arbitration-arena-gate.md`): the overlap pass
+ *   evicted a `street` for the `street_suffix` sitting inside it (street dropped on 42% of rows), and
+ *   the flat tree lost the region→locality structure the resolver needs (wrong-state namesakes,
+ *   coord p50 3.3 km → 1069 km).
+ *
+ *   This applies arbitration as **edits on the nested neural argmax tree** — never flattening, never
+ *   restructuring — so the neural tree's containment is preserved by construction. Used only on the
+ *   `rule_preferred` route; `neural_preferred` / `abstain` pass the neural tree through untouched.
+ *
+ *   The edits (DeepSeek-coordinated, 2026-06-17):
+ *
+ *   1. **Relabel** — when a rule proposal covers the EXACT span of a neural node but assigns a
+ *      different tag, take the rule's tag (the genuine same-span disagreement; rule wins under
+ *      `rule_preferred`). Structure unchanged — only the node's tag/provenance.
+ *   2. **Add missing tags** — a rule proposal whose tag is absent from the neural tree AND whose span
+ *      doesn't overlap any neural node is added as a new root (a component neural missed entirely).
+ *
+ *   What it deliberately does NOT do: replace a neural node with a differently-spanned rule node, drop
+ *   neural's sub-component decomposition (`street_suffix`/`street_prefix`), or add an overlapping rule
+ *   node. So a clean address — where neural and v0 agree on tags+spans and differ only in street
+ *   decomposition — is a **no-op**. The cost is losing pure-decomposition wins (low value); the gate
+ *   re-run is the arbiter.
+ */
+
+import type { ClassificationProposal } from "../types/index.js"
+import type { AddressNode, AddressTree } from "./types.js"
+
+function cloneNode(node: AddressNode): AddressNode {
+	return { ...node, children: node.children.map(cloneNode) }
+}
+
+function spansOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+	return aStart < bEnd && bStart < aEnd
+}
+
+/**
+ * Edit the nested neural argmax tree with the solved v0 (rule) parse under the `rule_preferred` route
+ * — relabel same-span tag disagreements toward rule, add rule-only non-overlapping missing tags.
+ * Containment-preserving (no flatten, no restructure). Input is not mutated.
+ *
+ * @param tree The neural argmax `AddressTree`.
+ * @param ruleProposals Proposals from the solved v0 parse (`solutionToProposals`).
+ */
+export function applyRuleArbitration(
+	tree: AddressTree,
+	ruleProposals: readonly ClassificationProposal[]
+): AddressTree {
+	const roots = tree.roots.map(cloneNode)
+
+	// 1. Relabel: a rule proposal on the EXACT span of a neural node, but a different tag → rule's tag.
+	const relabel = (node: AddressNode): void => {
+		const hit = ruleProposals.find(
+			(p) => p.span.start === node.start && p.span.end === node.end && p.component !== node.tag
+		)
+		if (hit) {
+			node.tag = hit.component
+			node.source = "rule"
+			node.confidence = hit.confidence
+			node.sourceId = hit.source_id
+		}
+		for (const child of node.children) relabel(child)
+	}
+	for (const root of roots) relabel(root)
+
+	// Post-relabel inventory: which tags exist, and every node span (for the overlap guard).
+	const neuralTags = new Set<string>()
+	const neuralSpans: Array<{ start: number; end: number }> = []
+	const collect = (node: AddressNode): void => {
+		neuralTags.add(node.tag)
+		neuralSpans.push({ start: node.start, end: node.end })
+		for (const child of node.children) collect(child)
+	}
+	for (const root of roots) collect(root)
+
+	// 2. Add: a rule tag the neural tree lacks entirely, on a span that overlaps no neural node.
+	for (const p of ruleProposals) {
+		if (neuralTags.has(p.component)) continue
+		if (neuralSpans.some((s) => spansOverlap(s.start, s.end, p.span.start, p.span.end))) continue
+		roots.push({
+			tag: p.component,
+			value: p.span.body,
+			start: p.span.start,
+			end: p.span.end,
+			confidence: p.confidence,
+			children: [],
+			source: p.source,
+			sourceId: p.source_id,
+		})
+		neuralTags.add(p.component) // a tag is added at most once
+		neuralSpans.push({ start: p.span.start, end: p.span.end })
+	}
+
+	roots.sort((a, b) => a.start - b.start)
+	return { ...tree, roots }
+}

--- a/core/decoder/index.ts
+++ b/core/decoder/index.ts
@@ -4,6 +4,7 @@
  * @author Teffen Ellis, et al.
  */
 
+export * from "./arbitrate-tree.js"
 export * from "./build-tree.js"
 export * from "./calibration.js"
 export * from "./containment.js"

--- a/core/pipeline/runtime-pipeline.test.ts
+++ b/core/pipeline/runtime-pipeline.test.ts
@@ -635,66 +635,83 @@ describe("runPipeline — arbitration (#478 inc 3)", () => {
 		expect(result.timing["arbitrate"]).toBeUndefined()
 	})
 
-	it("rule_preferred route: rule decomposition replaces the coarse neural span", async () => {
-		// clean structured + alpha + no placer → rule_preferred. Rule proposes house_number[0,3] +
-		// street[4,15]; the neural coarse street[0,15] overlaps both → rule preference + coherence win.
-		const ruleProposer = vi.fn(async () => [ruleProp("house_number", "350", 0, 0.9), ruleProp("street", "Main Street", 4, 0.9)])
+	it("rule_preferred PRESERVES neural's street decomposition (the precondition fix)", async () => {
+		// neural: street[4,12]"Seminary" + street_suffix[13,15]"Dr"; rule: combined street[4,15]. fix-v1
+		// never restructures, so both neural nodes survive and the coarse rule street is ignored — the
+		// suffix is no longer able to evict the street (the leg-2 bug).
+		const ruleProposer = vi.fn(async () => [ruleProp("house_number", "109", 0, 1), ruleProp("street", "Seminary Dr", 4, 0.82)])
 		const result = await runPipeline(
-			"350 Main Street",
+			"109 Seminary Dr",
 			{
 				computeQueryShape: alphaShape,
 				classifyKind: async () => cleanKind,
 				classifier: fakeClassifier(
-					fakeTree("350 Main Street", [
-						{ tag: "street", value: "350 Main Street", start: 0, end: 15, confidence: 0.8, children: [] },
+					fakeTree("109 Seminary Dr", [
+						{ tag: "house_number", value: "109", start: 0, end: 3, confidence: 0.93, children: [] },
+						{ tag: "street", value: "Seminary", start: 4, end: 12, confidence: 0.94, children: [] },
+						{ tag: "street_suffix", value: "Dr", start: 13, end: 15, confidence: 0.94, children: [] },
 					])
 				),
 				ruleProposer,
 			},
 			{ arbitrate: true }
 		)
-		expect(ruleProposer).toHaveBeenCalled()
-		expect(result.tree.roots.map((r) => r.tag)).toContain("house_number")
-		expect(result.tree.roots.every((r) => r.source === "rule")).toBe(true)
+		const tags = result.tree.roots.map((r) => r.tag)
+		expect(tags).toContain("street")
+		expect(tags).toContain("street_suffix") // NOT evicted
+		expect(result.tree.roots.find((r) => r.tag === "street")?.value).toBe("Seminary") // neural decomposition kept
 		expect(result.timing["arbitrate"]).toBeGreaterThanOrEqual(0)
 	})
 
-	it("neural_preferred (OOD script) keeps the neural span over an overlapping rule span", async () => {
-		const ruleProposer = vi.fn(async () => [ruleProp("street", "abc", 0, 0.95)])
+	it("rule_preferred RELABELS a same-span tag disagreement toward rule", async () => {
+		// neural labels [0,3] locality; rule says region — same span, different tag → rule wins.
+		const ruleProposer = vi.fn(async () => [ruleProp("region", "NYC", 0, 1)])
 		const result = await runPipeline(
-			"abc",
+			"NYC",
 			{
-				computeQueryShape: () => ({ knownFormats: [], characterClass: "cjk" }),
+				computeQueryShape: alphaShape,
 				classifyKind: async () => cleanKind,
-				classifier: fakeClassifier(
-					fakeTree("abc", [{ tag: "street", value: "abc", start: 0, end: 3, confidence: 0.5, children: [] }])
-				),
+				classifier: fakeClassifier(fakeTree("NYC", [{ tag: "locality", value: "NYC", start: 0, end: 3, confidence: 0.6, children: [] }])),
 				ruleProposer,
 			},
 			{ arbitrate: true }
 		)
 		expect(result.tree.roots).toHaveLength(1)
-		expect(result.tree.roots[0]?.source).toBe("neural")
+		expect(result.tree.roots[0]?.tag).toBe("region")
+		expect(result.tree.roots[0]?.source).toBe("rule")
 	})
 
-	it("flat round-trip: arbitrate with no rule proposals preserves every neural node (no-op guard)", async () => {
-		const tree = fakeTree("350 Main", [
-			{ tag: "house_number", value: "350", start: 0, end: 3, confidence: 0.9, children: [] },
-			{ tag: "street", value: "Main", start: 4, end: 8, confidence: 0.9, children: [] },
-		])
+	it("rule_preferred ADDS a rule-only missing tag on a non-overlapping span", async () => {
+		const ruleProposer = vi.fn(async () => [ruleProp("country", "USA", 10, 1)])
 		const result = await runPipeline(
-			"350 Main",
+			"Main St   USA",
 			{
 				computeQueryShape: alphaShape,
 				classifyKind: async () => cleanKind,
-				classifier: fakeClassifier(tree),
-				ruleProposer: async () => [],
+				classifier: fakeClassifier(fakeTree("Main St   USA", [{ tag: "street", value: "Main St", start: 0, end: 7, confidence: 0.9, children: [] }])),
+				ruleProposer,
 			},
 			{ arbitrate: true }
 		)
-		expect(result.tree.roots.map((r) => ({ tag: r.tag, value: r.value, start: r.start, end: r.end }))).toEqual([
-			{ tag: "house_number", value: "350", start: 0, end: 3 },
-			{ tag: "street", value: "Main", start: 4, end: 8 },
-		])
+		const country = result.tree.roots.find((r) => r.tag === "country")
+		expect(country?.value).toBe("USA")
+		expect(country?.source).toBe("rule")
+	})
+
+	it("neural_preferred (OOD script) passes the neural tree through unchanged", async () => {
+		const ruleProposer = vi.fn(async () => [ruleProp("street", "abc", 0, 0.95)])
+		const neuralRoots: AddressNode[] = [{ tag: "street", value: "abc", start: 0, end: 3, confidence: 0.5, children: [] }]
+		const result = await runPipeline(
+			"abc",
+			{
+				computeQueryShape: () => ({ knownFormats: [], characterClass: "cjk" }),
+				classifyKind: async () => cleanKind,
+				classifier: fakeClassifier(fakeTree("abc", neuralRoots)),
+				ruleProposer,
+			},
+			{ arbitrate: true }
+		)
+		expect(ruleProposer).not.toHaveBeenCalled()
+		expect(result.tree.roots).toEqual(neuralRoots)
 	})
 })

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -12,10 +12,8 @@
  *   Implementation contract per `docs/articles/plan/reference/STAGES.md`.
  */
 
-import { proposalsToTree, treeToProposals } from "../decoder/proposals-to-tree.js"
-import { resolveProposalOverlaps } from "../decoder/resolve-proposal-overlaps.js"
+import { applyRuleArbitration } from "../decoder/arbitrate-tree.js"
 import type { AddressNode, AddressTree } from "../decoder/types.js"
-import { policyRegistryFromRoute } from "../policy/from-config.js"
 import { routeInputShape } from "../policy/input-shape-router.js"
 import type { ComponentTag } from "../types/component.js"
 import { prefetchReconcileLookups } from "./reconcile-lookups.js"
@@ -364,12 +362,13 @@ export async function runPipeline(
 		timing["token-classify"] = performance.now() - tClassify
 	}
 
-	// #478 increment 3: per-component rule-vs-neural arbitration over the (argmax) neural tree.
-	// Default-OFF (`opts.arbitrate`) and requires a `ruleProposer` stage. Union the WHOLE-TEXT neural
-	// parse (preserves the model's sequence context — deliberately NOT the per-section proposal
-	// fan-out) with the solved v0 rule parse, filter per-component by the input-shape router prior,
-	// drop overlapping survivors (the coherence pass), and rebuild the tree from the survivors.
-	// Reconcile (above) stays the orthogonal opt-in; this operates on whatever `tree` it produced.
+	// #478 increment 3 (fix-v1): per-component rule-vs-neural arbitration as EDITS on the nested neural
+	// argmax tree — never flattening, so the tree's containment survives (the flatten+rebuild v0 dropped
+	// `street` for its own `street_suffix` and lost region→locality structure; see the eval doc). The
+	// input-shape router sets the mode: only `rule_preferred` mutates the tree (relabel same-span tag
+	// disagreements toward the solved v0 parse + add rule-only missing tags); `neural_preferred` /
+	// abstain pass the neural tree through unchanged. Default-OFF (`opts.arbitrate`). Reconcile above
+	// stays the orthogonal opt-in; this operates on whatever `tree` it produced.
 	if (opts?.arbitrate && stages.ruleProposer) {
 		throwIfAborted(opts)
 		const tArb = performance.now()
@@ -385,10 +384,10 @@ export async function runPipeline(
 			{ characterClass: queryShape.characterClass },
 			placerSignal
 		)
-		const neuralProposals = treeToProposals(tree, "neural")
-		const ruleProposals = await stages.ruleProposer(normalized.normalized, locale.locale)
-		const arbitrated = policyRegistryFromRoute(route).apply([...neuralProposals, ...ruleProposals], locale.locale)
-		tree = proposalsToTree(normalized.normalized, resolveProposalOverlaps(arbitrated))
+		if (route.defaultMode === "rule_preferred") {
+			const ruleProposals = await stages.ruleProposer(normalized.normalized, locale.locale)
+			tree = applyRuleArbitration(tree, ruleProposals)
+		}
 		timing["arbitrate"] = performance.now() - tArb
 	}
 

--- a/docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md
+++ b/docs/articles/evals/2026-06-17-478-arbitration-arena-gate.md
@@ -1,14 +1,16 @@
-# Arbitration layer (#478 inc 3) — the two-leg gate (arena PASS, coordinate FAIL → not promoted)
+# Arbitration layer (#478 inc 3) — the two-leg gate, and why arbitration is not promoted
 
-_2026-06-17. Increment 3 wires per-component rule-vs-neural arbitration into the assembled
-`runPipeline` (default-OFF, behind `arbitrate`). The two pre-registered gate legs split decisively:
-**leg 1 (arena label-match) passes strongly** — arbitration nearly halves the `v0-only` gap; **leg 2
-(precondition + coordinate) FAILS catastrophically** — it drops locality-match 26pp, blows coord p50
-from 3.3 km to 1069 km, and loses the street+house_number precondition on half the rows. Arbitration is
-**not promoted**; it stays default-OFF. This is the #566 lesson reproduced in real time: a layer that
-"can't score below v0 by construction" is only true if you grade the ASSEMBLED COORDINATE output — the
-arena's loose label-match made arbitration look like a clean win it isn't. Leg 2 is exactly why the gate
-runs before any flip to default-on._
+_2026-06-17. Per-component rule-vs-neural arbitration in the assembled `runPipeline` (default-OFF,
+behind `arbitrate`). The arc, in three acts: (1) the **flatten+rebuild v1** passed the arena
+label-match (`v0-only` 56.4→27.1%) but **FAILED the coordinate gate catastrophically** — locality −26pp,
+coord p50 3.3→1069 km, street+house_number precondition 100→48%; (2) diagnosis pinned it to **loss of
+containment**; (3) the **containment-preserving fix-v1** (edits on the nested neural tree, no flatten)
+**eliminated the regression** — the coordinate arm now matches neural — **but the arena collapsed to a
+net wash (+21/−21, v0-only unchanged at 56.9%)**. The +122 "win" was entirely label-conformance to v0's
+decomposition, the very thing that wrecked the geocode; removing the harm removed the apparent gain.
+**Verdict: arbitration is not promoted — fix-v1 makes it SAFE but provides no net benefit, while adding
+the full v0-parser cost to every parse.** It stays default-OFF. The #566 lesson, twice over: grade the
+assembled COORDINATE output, and a label-match "win" toward the other parser is not a quality win._
 
 ## What ran
 
@@ -117,5 +119,46 @@ unnecessary and the resolver keeps its structure. The v1 edit algorithm:
 
 This makes clean-address arbitration a **no-op** (killing both regressions), captures the high-value
 wins (value disagreements + tags neural missed entirely), and accepts losing the low-value
-pure-decomposition wins. Then **re-run the coordinate gate (leg 2)** before any promotion. Until that
-lands and clears, arbitration stays a measured-negative behind the default-off flag.
+pure-decomposition wins. Then **re-run the coordinate gate (leg 2)** before any promotion.
+
+## Fix-v1 re-gate — regression gone, but no net benefit
+
+Fix-v1 (`applyRuleArbitration` — edits on the nested neural tree; only `rule_preferred` mutates it,
+relabel same-span tag disagreements + add rule-only non-overlapping missing tags, never restructure).
+
+**Coordinate leg (300 OA US rows) — regression ELIMINATED:**
+
+| arm | locality-match | coord p50 km | coord p90 km | street+hn precondition |
+| --- | ---: | ---: | ---: | ---: |
+| neural | 83.0% | 3.3 | 12.5 | 100.0% |
+| flatten+rebuild v1 (prior) | 57.0% | 1069.4 | 3182.5 | 48.0% |
+| **fix-v1 (edit-in-place)** | **83.0%** | **3.3** | **12.5** | **99.7%** |
+
+Fix-v1's `assembled + arb` matches `neural` to the decimal — the catastrophe is gone, containment holds.
+
+**Arena leg — collapses to a net wash:**
+
+| arena metric | flatten+rebuild v1 | fix-v1 |
+| --- | ---: | ---: |
+| assembled pass | 72.9% | 43.1% (= raw neural) |
+| `v0-only vs ASSEMBLED` | 27.1% | 56.9% (= raw neural) |
+| assembled vs raw-neural | +122 / −10 | **+21 / −21** |
+
+The +122 was almost entirely the harmful decomposition-replacement (taking v0's coarser spans to match
+its labels) — the same edits the coordinate gate proved wreck resolution. The *safe* fix-v1 (no
+restructure) nets nothing on the arena: +21 helpful relabels/adds offset by 21 harmful ones, the
+`v0-only` gap unmoved.
+
+## Final verdict — NOT PROMOTED (no net benefit)
+
+Fix-v1 is the correct, containment-preserving arbitration and removes the catastrophic regression — but
+it provides **no net benefit**: a no-op on the coordinate product metric, a +21/−21 wash on the arena,
+while every arbitrated parse pays the cost of a full v0 rule-parse. There is nothing here worth the
+latency. **Arbitration ships SAFE and default-OFF; it is not promoted.**
+
+The durable findings: (1) the `v0-only` arena column conflates "neural is wrong" with "neural is
+*differently right*" — arbitrating toward v0 captures both, and the second kind is harmful; (2) for a
+model this strong on the addresses we serve, rule-vs-neural arbitration toward v0 is not a quality
+lever. The machinery + the safe fix-v1 are banked behind the flag, with the gate instruments, should a
+weaker model, a new locale, or a per-tag config (where the data shows arbitration nets positive on a
+specific tag) make it worth revisiting.


### PR DESCRIPTION
## #478 inc 3 fix-v1 — containment-preserving arbitration; regression fixed, arbitration NOT promoted

Replaces the flatten+rebuild arbitration (which failed the coordinate gate catastrophically, #685) with a containment-preserving edit-in-place version, re-gates both legs, and records the verdict: **fix-v1 eliminates the regression but arbitration provides no net benefit, so it stays default-OFF and is not promoted.**

### The fix

`applyRuleArbitration(tree, ruleProposals)` — arbitration as **edits on the nested neural argmax tree**, never flattening. Only the `rule_preferred` route mutates it: **relabel** a neural node when a rule proposal covers its exact span with a different tag; **add** rule-only tags neural lacks on non-overlapping spans; **never restructure**. `neural_preferred`/`abstain` pass the neural tree through unchanged. `runPipeline` drops the `treeToProposals → policy filter → coherence → proposalsToTree` path entirely.

### Re-gate — coordinate regression ELIMINATED

| arm | locality | coord p50 | street+hn precond |
| --- | ---: | ---: | ---: |
| neural | 83.0% | 3.3 km | 100% |
| flatten+rebuild v1 (#685) | 57.0% | 1069 km | 48% |
| **fix-v1** | **83.0%** | **3.3 km** | **99.7%** |

Fix-v1 matches neural to the decimal — containment holds, the catastrophe is gone.

### Re-gate — arena collapses to a wash

`v0-only vs ASSEMBLED` returns to 56.9% (= raw neural); assembled-vs-neural is **+21 / −21** (was +122/−10). The +122 was almost entirely the harmful decomposition-replacement that wrecked resolution; the *safe* arbitration nets nothing.

### Verdict: NOT PROMOTED

Fix-v1 is the correct arbitration and removes the regression — but it's a no-op on the coordinate product metric and a wash on the arena, while paying a full v0 rule-parse per arbitrated call. Nothing here justifies the cost. **Arbitration ships SAFE and default-OFF.**

Durable findings (in the eval doc): the arena `v0-only` column conflates "neural wrong" with "neural *differently right*" — arbitrating toward v0 captures both, and the second is harmful; for a model this strong on the addresses we serve, rule-vs-neural arbitration toward v0 isn't a quality lever. Machinery + safe fix-v1 + gate instruments are banked behind the flag for a future weaker model / new locale / per-tag config.

92 tests pass; `tsc` core clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
