### PR TITLE
eval(#619): geocoder vs provided coords — TX HHSC facilities (+ #690 all-caps finding)

### DIFF
--- a/docs/articles/evals/2026-06-17-geocoder-vs-provided-coords.md
+++ b/docs/articles/evals/2026-06-17-geocoder-vs-provided-coords.md
@@ -1,0 +1,56 @@
+# Geocoder vs provided coordinates — TX HHSC nursing facilities (#619)
+
+_2026-06-17. A free, real-world geocoder accuracy check: the TX HHSC nursing-facilities registry ships
+an authoritative `Geo Location` (`lat,lon`) per facility, so we can geocode each facility's street
+address with our own pipeline and measure the great-circle delta. 1172 facilities with a usable
+address + in-state coordinate (3 skipped). Neutral scope: this measures GEOCODER ACCURACY on real
+public addresses — it makes no claim about the facilities._
+
+Reproduce: `scripts/record-matcher/txhhsc-to-oarow.ts` → `scripts/eval/oa-resolver-eval.ts
+--eval <jsonl> --address-points address-points-us-tx.db --interpolation interpolation-us-tx.db`.
+
+## Geocoder accuracy by tier (our pipeline: neural parse → resolver)
+
+| tier | coord p50 | coord p90 | coord p99 | tier hit rate |
+| --- | --: | --: | --: | --: |
+| admin-centroid (city) | 3.4 km | 27.2 km | 741.6 km | 100% (always) |
+| **+ address-point (rooftop)** | **0.7 km** | 13.5 km | 486.8 km | **47.0%** (551/1172) |
+| **+ interpolation (street)** | **0.1 km** | 8.2 km | 476.7 km | **12.5%** (146/1172) |
+
+**The finer tiers are the story.** The admin-centroid tier lands a facility in the right city — p50
+3.4 km, which is just "the city's middle is a few km from the facility." Switch in the **address-point**
+tier where we have a rooftop for the parsed street + number, and p50 collapses to **0.7 km**; the
+**interpolation** tier (no exact point, interpolated along the street segment) lands p50 **0.1 km** —
+100 m, street-accurate. The honest caveat is **coverage**: the rooftop tier fires on 47% of these
+facilities and interpolation on a further 12.5%, so ~40% still fall back to the city centroid. The tail
+(p99 ~470–740 km) is wrong-place resolutions, not tier imprecision — a handful of facilities whose
+parse resolves to the wrong locality entirely.
+
+## The honest surprise — v0 out-parses neural on this distribution
+
+Graded through the same resolver, **the rules parser (v0) beats neural on locality-match here: 96.8% vs
+90.1%** (and coord p50 3.0 vs 3.4 km). That is the **inverse** of the clean-OpenAddresses result, where
+neural leads 84.0% vs 82.1% (`2026-06-17-per-type-headtohead.md`).
+
+The cause, **confirmed** by a direct probe (`scripts/eval/case-check.ts`): these are **ALL-CAPS
+facility records** (`214 JONES RD, ELKHART, TX 75839`), and the neural model — trained predominantly on
+mixed-case text — degrades on them. On a 5-address spot-check, locality is correct **3/5 in all-caps vs
+5/5 in title-case**, and the failure is a clean tokenization-boundary artifact: `PALESTINE` parses to a
+locality of **`ALESTINE`** (the leading `P` is dropped) in all-caps, but `Palestine` parses correctly.
+v0's dictionaries are case-folded by construction, so on a SHOUTING dataset that robustness wins.
+
+This is a real "where we lose," with a **near-free fix**: title-case (or otherwise case-normalize) an
+all-caps input before the model — it recovered 5/5 in the probe — and/or a case-augmentation training
+shard for durability. Filed as a follow-up.
+
+## Reading
+
+- **The geocoder works where it has data.** On real TX facility addresses, the address-point + street
+  tiers put p50 error at 0.1–0.7 km — rooftop-to-street accuracy, not city-centroid. The pre-geocoded
+  seed (#619's other half) lets us skip re-geocoding where the source already carries an authoritative
+  point; this validation is what justifies trusting our own coordinate where it doesn't.
+- **Coverage, not precision, is the frontier.** ~40% of these facilities fall back to the city centroid
+  for lack of a TX rooftop/interp hit on the parsed street — the address-point shard coverage is the
+  lever, not the tier math.
+- **Case robustness is a measurable neural gap.** All-caps compliance/registry data is common, and we
+  lose 6.7pp of locality there vs the rules parser. Cheap to fix, worth fixing.

--- a/scripts/eval/case-check.ts
+++ b/scripts/eval/case-check.ts
@@ -1,0 +1,45 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #619 follow-up probe: does the neural parser degrade on ALL-CAPS input (the TX HHSC facility
+ *   distribution) vs the same address in title case? Confirms/refutes the case-robustness gap.
+ *   Run: node --experimental-strip-types scripts/eval/case-check.ts
+ */
+
+import { decodeAsJson } from "@mailwoman/core/decoder"
+import { readFileSync } from "node:fs"
+
+const { NeuralAddressClassifier } = await import("@mailwoman/neural")
+const { OnnxRunner } = await import("@mailwoman/neural/onnx-runner")
+const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
+const card = JSON.parse(readFileSync("neural-weights-en-us/model-card.json", "utf8"))
+const [tokenizer, runner] = await Promise.all([
+	MailwomanTokenizer.loadFromFile("/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"),
+	OnnxRunner.create("/mnt/playpen/mailwoman-data/models/quantized/model-v140-step-40000-int8.onnx"),
+])
+const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: card.labels })
+
+const title = (s: string) => s.replace(/\b\w+/g, (w) => w[0]!.toUpperCase() + w.slice(1).toLowerCase())
+const samples = [
+	"214 JONES RD, ELKHART, TX 75839",
+	"1816 TILE FACTORY RD, PALESTINE, TX 75801",
+	"2212 W REAGAN ST, PALESTINE, TX 75801",
+	"4501 W CYPRESS ST, GRAND PRAIRIE, TX 75052",
+	"100 N MAIN ST, FORT WORTH, TX 76102",
+]
+let capsLoc = 0
+let titleLoc = 0
+for (const caps of samples) {
+	const tc = title(caps)
+	const recCaps = decodeAsJson(await neural.parse(caps, { postcodeRepair: true })) as Record<string, string>
+	const recTitle = decodeAsJson(await neural.parse(tc, { postcodeRepair: true })) as Record<string, string>
+	const wantLoc = caps.split(",")[1]!.trim()
+	const capsOk = (recCaps.locality ?? "").toUpperCase() === wantLoc
+	const titleOk = (recTitle.locality ?? "").toUpperCase() === wantLoc
+	if (capsOk) capsLoc++
+	if (titleOk) titleLoc++
+	console.log(`CAPS  loc=${recCaps.locality ?? "—"}  | TITLE loc=${recTitle.locality ?? "—"}  (want ${wantLoc})  ${capsOk ? "" : "CAPS-MISS"}${titleOk ? "" : " TITLE-MISS"}`)
+}
+console.log(`\nlocality correct: ALL-CAPS ${capsLoc}/${samples.length}  vs  TITLE-CASE ${titleLoc}/${samples.length}`)

--- a/scripts/record-matcher/txhhsc-to-oarow.ts
+++ b/scripts/record-matcher/txhhsc-to-oarow.ts
@@ -1,0 +1,71 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #619: convert the TX HHSC nursing-facilities source (which ships an authoritative `Geo Location`
+ *   = `lat,lon` per facility) into the OaRow JSONL the resolver eval consumes — so our geocoder can be
+ *   graded against the provided coordinates on real facility addresses (great-circle delta, tier
+ *   breakdown via `oa-resolver-eval --address-points`).
+ *
+ *   Neutral scope: this measures GEOCODER ACCURACY on real public addresses; it makes no claim about
+ *   the facilities themselves.
+ *
+ *   Run: node --experimental-strip-types scripts/record-matcher/txhhsc-to-oarow.ts \
+ *          --src <tsv> --out /tmp/txhhsc-oarow.jsonl
+ */
+
+import { readFileSync, writeFileSync } from "node:fs"
+
+const arg = (name: string, fallback = "") => {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+}
+
+const src = arg("src", "/mnt/playpen/mailwoman-data/record-matcher/sources/txhhsc_nursing-facilities_20260611.tsv")
+const out = arg("out", "/tmp/txhhsc-oarow.jsonl")
+
+const lines = readFileSync(src, "utf8").split("\n").filter((l) => l.trim())
+const header = lines[0]!.split("\t")
+const col = (name: string) => header.indexOf(name)
+const cAddr = col("Physical Address")
+const cCity = col("Physical Address CITY")
+const cState = col("Physical Address State")
+const cZip = col("Physical Address Zipcode")
+const cGeo = col("Geo Location")
+
+const GEO = /^\s*(-?\d+\.\d+)\s*,\s*(-?\d+\.\d+)\s*$/
+
+const records: string[] = []
+let skipped = 0
+for (const line of lines.slice(1)) {
+	const f = line.split("\t")
+	const addr = (f[cAddr] ?? "").trim()
+	const city = (f[cCity] ?? "").trim()
+	const zip = (f[cZip] ?? "").trim()
+	const m = GEO.exec(f[cGeo] ?? "")
+	if (!addr || !city || !m) {
+		skipped++
+		continue
+	}
+	const lat = Number(m[1])
+	const lon = Number(m[2])
+	// Sanity: TX bounding box (rejects swapped/garbage coords).
+	if (lat < 25 || lat > 37 || lon > -93 || lon < -107) {
+		skipped++
+		continue
+	}
+	records.push(
+		JSON.stringify({
+			input: `${addr}, ${city}, TX ${zip}`,
+			lat,
+			lon,
+			expected: { locality: city, region: "TX", postcode: zip },
+			state: "TX",
+			source: "txhhsc:nursing-facilities",
+		})
+	)
+}
+
+writeFileSync(out, records.join("\n") + "\n")
+console.error(`wrote ${records.length} rows (skipped ${skipped}) → ${out}`)


### PR DESCRIPTION
## #619 (validation half): geocoder vs provided coordinates — TX HHSC facilities

A free, real-world geocoder accuracy check. The TX HHSC nursing-facilities registry ships an authoritative `Geo Location` per facility, so we geocode each facility's street address with our pipeline and measure the great-circle delta. 1172 real facility addresses. Neutral scope — geocoder accuracy, no claim about the facilities.

### Geocoder accuracy by tier (neural parse → resolver)

| tier | coord p50 | coord p90 | hit rate |
|---|--:|--:|--:|
| admin-centroid (city) | 3.4 km | 27.2 km | 100% |
| **+ address-point (rooftop)** | **0.7 km** | 13.5 km | 47.0% |
| **+ interpolation (street)** | **0.1 km** | 8.2 km | 12.5% |

**The finer tiers deliver rooftop-to-street accuracy** (p50 0.7 km → 0.1 km) where they have coverage; ~40% still fall back to the city centroid. Coverage, not tier math, is the frontier.

### The honest surprise (+ a confirmed finding → #690)

Through the same resolver, **v0 out-parses neural on locality here: 96.8% vs 90.1%** — the *inverse* of clean OpenAddresses (neural 84 vs 82). Confirmed by `case-check.ts`: it's **ALL-CAPS** input — locality correct 3/5 caps vs 5/5 title-case, with `PALESTINE` → `ALESTINE` (leading char dropped). ALL-CAPS is the record-matcher's whole input domain, so this matters. Near-free fix (case-normalize before the model); filed as **#690**.

### What's here
- `scripts/record-matcher/txhhsc-to-oarow.ts` — TX source → OaRow JSONL (reuses the resolver eval's geocode+delta machinery).
- `scripts/eval/case-check.ts` — the all-caps probe that confirmed #690.
- `docs/articles/evals/2026-06-17-geocoder-vs-provided-coords.md` — the report.

Validation half of #619; the seed half (use provided coord to skip re-geocoding) is a separate registry-ingest change. Night-shift #117. No shipped-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
