### PR TITLE
feat(#690): case-normalize all-caps input before the neural parser

### DIFF
--- a/docs/articles/evals/2026-06-17-geocoder-vs-provided-coords.md
+++ b/docs/articles/evals/2026-06-17-geocoder-vs-provided-coords.md
@@ -39,9 +39,25 @@ mixed-case text — degrades on them. On a 5-address spot-check, locality is cor
 locality of **`ALESTINE`** (the leading `P` is dropped) in all-caps, but `Palestine` parses correctly.
 v0's dictionaries are case-folded by construction, so on a SHOUTING dataset that robustness wins.
 
-This is a real "where we lose," with a **near-free fix**: title-case (or otherwise case-normalize) an
-all-caps input before the model — it recovered 5/5 in the probe — and/or a case-augmentation training
-shard for durability. Filed as a follow-up.
+This is a real "where we lose," with a **near-free fix** — and we built it (#690). `parse(…, {
+normalizeCase: true })` title-cases a detected all-caps **ASCII** input before the model (detection is
+strict: mixed-case and non-ASCII/accented input are left untouched, so the path is byte-stable by
+construction). Re-running this eval with `--normalize-case`:
+
+| metric | all-caps (default) | + `normalizeCase` (#690) |
+| --- | --: | --: |
+| neural locality-match | 90.1% | **99.7%** (now > v0's 96.8%) |
+| address-point hit rate | 47.0% | **61.8%** |
+| coord p50 (admin) | 3.4 km | 2.8 km |
+| coord p50 (+address-point) | 0.7 km | **0.1 km** |
+| coord p99 (+address-point) | 486.8 km | **20.7 km** |
+
+The fix doesn't just close the gap — it **overtakes** v0 on locality (99.7 vs 96.8) and collapses the
+catastrophic-miss tail (p99 487 → 21 km), because correct localities resolve to the right place and the
+parsed street/number then hits the rooftop shard more often (47% → 62%). The one cost: region dips
+**100.0% → 98.0%** — title-casing the 2-letter state (`TX`→`Tx`) trips ~2% of region resolutions, a
+small, fixable artifact (preserve all-caps 2-letter state codes) against a large net win. Ships
+**default-OFF** behind the `normalizeCase` opt.
 
 ## Reading
 

--- a/neural/case-normalize.ts
+++ b/neural/case-normalize.ts
@@ -1,0 +1,45 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #690: input case-normalization for the neural parser. ALL-CAPS registry/compliance data
+ *   (`214 JONES RD, ELKHART, TX 75839`) is partly out-of-domain for a model trained on mixed-case
+ *   text — it drops/mis-bounds tokens (`PALESTINE` → locality `ALESTINE`). Title-casing an all-caps
+ *   input before the model recovers it (measured: TX HHSC locality 90.1% → 99.7%,
+ *   `docs/articles/evals/2026-06-17-geocoder-vs-provided-coords.md`).
+ *
+ *   Detection is deliberately STRICT — only a fully-shouting input qualifies — so mixed-case input is
+ *   never touched (the caller's byte-stable path). Distinct from the identifier-casing all-caps idiom
+ *   in `core/identifiers.ts` (`smartSnakeCase`/`smartCamelCase`): those skip *case conversion* when a
+ *   name is already uppercase; this *applies* a title-case to address TEXT for the model.
+ */
+
+/**
+ * True when `text` is PURE-ASCII ALL-CAPS: it has cased ASCII letters and ZERO lowercase, and NO
+ * non-ASCII characters. The pure-ASCII requirement is deliberate — title-casing accented/non-Latin
+ * text is locale-sensitive and can change length (`ß`→`SS`, Turkish dotted/dotless I), which would
+ * break the token-offset invariant the caller relies on. So this fix targets ASCII registry data only;
+ * accented or non-Latin input falls back to the model's current behavior. The 3-letter floor avoids
+ * treating a digit/punctuation-only or tiny-token input as a whole shouting address.
+ */
+export function isAllCapsInput(text: string): boolean {
+	let upper = 0
+	for (let i = 0; i < text.length; i++) {
+		const c = text.charCodeAt(i)
+		if (c > 127) return false // any non-ASCII (accented/non-Latin) → leave it alone
+		if (c >= 97 && c <= 122) return false // any [a-z] → mixed case, leave it alone
+		if (c >= 65 && c <= 90) upper++
+	}
+	return upper >= 3
+}
+
+/** Title-case each ASCII alphabetic run (`PALESTINE` → `Palestine`). Length-preserving — token offsets unchanged. */
+export function titleCaseInput(text: string): string {
+	return text.replace(/[A-Za-z]+/g, (w) => w[0]!.toUpperCase() + w.slice(1).toLowerCase())
+}
+
+/** Title-case the input iff it is all-caps; otherwise return it unchanged. The parser's #690 hook. */
+export function normalizeInputCase(text: string): string {
+	return isAllCapsInput(text) ? titleCaseInput(text) : text
+}

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -25,6 +25,7 @@ import { proposeSpans, type ProposedSpan, type SpanProposerLexicon } from "@mail
 
 import { detectAddressSystem } from "./address-system.js"
 import { buildAnchorFeatures, type AnchorLookup } from "./anchor-inference.js"
+import { normalizeInputCase } from "./case-normalize.js"
 import { buildFstEmissionPriors, type FstMatcherLike } from "./fst-prior.js"
 import { buildGazetteerFeatures, suppressGazetteerNearPostcode, type GazetteerLexicon } from "./gazetteer-inference.js"
 import { STAGE2_BIO_LABELS } from "./labels.js"
@@ -224,8 +225,13 @@ export class NeuralAddressClassifier {
 	/** Tokenize → infer → Viterbi (or argmax) → decoder tree. */
 	async parse(text: string, opts?: ParseOpts): Promise<AddressTree> {
 		if (text.length === 0) return { raw: text, roots: [] }
-		const { tokens } = await this.#decode(text, opts)
-		return buildAddressTree(text, tokens, opts?.calibrate ? { calibrate: opts.calibrate } : undefined)
+		// #690: title-case all-caps ASCII input so the mixed-case-trained model doesn't go OOD.
+		// Detection-gated (mixed-case + non-ASCII untouched), opt-in. ASCII title-case is char-for-char
+		// length-preserving, so token offsets are unaffected; the tree is built from the normalized text
+		// (values come out title-cased — the SHOUTING is gone, the resolver name-matches case-insensitively).
+		const modelText = opts?.normalizeCase ? normalizeInputCase(text) : text
+		const { tokens } = await this.#decode(modelText, opts)
+		return buildAddressTree(modelText, tokens, opts?.calibrate ? { calibrate: opts.calibrate } : undefined)
 	}
 
 	/**
@@ -484,6 +490,16 @@ export interface ParseOpts {
 	 * v0.7.2 arena re-run quantifies its delta. See `./unit-repair.ts`.
 	 */
 	unitRepair?: boolean
+	/**
+	 * When true AND the input is detected ALL-CAPS (registry/compliance data like
+	 * `214 JONES RD, ELKHART, TX 75839`), title-case the input before the model sees it. The model
+	 * trains on mixed-case text, so all-caps is partly OOD — it drops/mis-bounds tokens (#690:
+	 * `PALESTINE` → locality `ALESTINE`; all-caps locality 3/5 vs title-case 5/5). Detection-gated, so
+	 * MIXED-case input is untouched (byte-stable). Off by default. On all-caps input the output values
+	 * are title-cased (the SHOUTING is normalized away — better, and the resolver name-matches
+	 * case-insensitively regardless).
+	 */
+	normalizeCase?: boolean
 	/**
 	 * Optional span-confidence calibrator (task #59). When provided, each decoded span's `conf=` is
 	 * mapped through it (isotonic lookup table → calibrated probability of correctness). OPT-IN —

--- a/neural/test/case-normalize.test.ts
+++ b/neural/test/case-normalize.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #690 input case-normalization — detection + transform. The load-bearing guarantees: mixed-case and
+ *   non-ASCII input are NEVER touched (byte-stable, the no-regression-by-construction), and the
+ *   transform is length-preserving (token offsets survive).
+ */
+
+import { describe, expect, it } from "vitest"
+import { isAllCapsInput, normalizeInputCase, titleCaseInput } from "../case-normalize.js"
+
+describe("isAllCapsInput", () => {
+	it("detects a pure-ASCII all-caps address", () => {
+		expect(isAllCapsInput("214 JONES RD, ELKHART, TX 75839")).toBe(true)
+		expect(isAllCapsInput("ABC")).toBe(true)
+	})
+
+	it("leaves mixed-case alone (one lowercase ⇒ false)", () => {
+		expect(isAllCapsInput("109 Seminary Dr, Mill Valley, CA 94941")).toBe(false)
+		expect(isAllCapsInput("ABc")).toBe(false)
+	})
+
+	it("ignores tiny / letterless inputs (3-letter floor)", () => {
+		expect(isAllCapsInput("TX")).toBe(false)
+		expect(isAllCapsInput("123 456, 90210")).toBe(false)
+	})
+
+	it("BAILS on any non-ASCII letter — accented + non-Latin (DeepSeek's length/locale concern)", () => {
+		expect(isAllCapsInput("CAFÉ DE PARÍS")).toBe(false) // accented all-caps Latin
+		expect(isAllCapsInput("STRASSE GROSSER ZOLLERN ÜBER")).toBe(false) // German Ü
+		expect(isAllCapsInput("МОСКВА УЛИЦА")).toBe(false) // Cyrillic
+		expect(isAllCapsInput("東京都")).toBe(false) // CJK
+	})
+})
+
+describe("titleCaseInput", () => {
+	it("title-cases each ASCII run and preserves length", () => {
+		expect(titleCaseInput("PALESTINE")).toBe("Palestine")
+		expect(titleCaseInput("214 JONES RD")).toBe("214 Jones Rd")
+		const caps = "214 JONES RD, ELKHART, TX 75839"
+		expect(titleCaseInput(caps).length).toBe(caps.length) // offsets survive
+	})
+})
+
+describe("normalizeInputCase — the parser hook", () => {
+	it("title-cases all-caps input", () => {
+		expect(normalizeInputCase("PALESTINE TX")).toBe("Palestine Tx")
+	})
+
+	it("returns mixed-case and non-ASCII input UNCHANGED (no-regression by construction)", () => {
+		const mixed = "109 Seminary Dr, Mill Valley, CA 94941"
+		expect(normalizeInputCase(mixed)).toBe(mixed)
+		const accented = "CAFÉ DE PARÍS"
+		expect(normalizeInputCase(accented)).toBe(accented)
+	})
+})

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -403,7 +403,11 @@ async function main(): Promise<void> {
 		return false
 	}
 
-	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
+	// #690: --normalize-case title-cases all-caps input before the model (detection-gated). Off by default.
+	const normalizeCase = process.argv.includes("--normalize-case")
+	const parseOpts = { postcodeRepair: true, ...(normalizeCase ? { normalizeCase: true } : {}) } as Parameters<
+		typeof neural.parse
+	>[1]
 	// `defaultCountry` is the hard country filter applied to admin lookups when the parse carries no
 	// resolved country node. It MUST match the dataset's locale — hardcoding "US" silently filters a
 	// non-US eval to US places (a German "Berlin" then loses to a tiny US Berlin). Settable via


### PR DESCRIPTION
## #690: case-normalize all-caps input before the neural parser

Surfaced by the #619 TX geocoder validation: on the all-caps TX HHSC facility holdout, neural **lost** to the rules parser on locality (90.1% vs 96.8%) — the inverse of clean OpenAddresses — because the mixed-case-trained model goes OOD on SHOUTING input (`PALESTINE` → locality `ALESTINE`, leading char dropped). This fixes it.

### The fix

`parse(text, { normalizeCase: true })` title-cases a **detected all-caps ASCII** input before the model. New `neural/case-normalize.ts`:
- `isAllCapsInput` — strict: cased ASCII letters, **zero** lowercase, **no non-ASCII**. Mixed-case and non-Latin/accented input are left untouched → the path is **byte-stable by construction**.
- The pure-ASCII restriction (thanks DeepSeek) avoids the length-changing, locale-sensitive casing of accented/non-Latin text (`ß`→`SS`, Turkish İ) — title-case stays char-for-char length-preserving, so token offsets survive.

Default-OFF behind `ParseOpts.normalizeCase`; `--normalize-case` flag on `oa-resolver-eval` to gate it.

### Gated (TX HHSC, 1172 facilities)

| metric | all-caps (default) | + normalizeCase |
| --- | --: | --: |
| neural locality | 90.1% | **99.7%** (now > v0's 96.8%) |
| address-point hit | 47.0% | **61.8%** |
| coord p50 (rooftop) | 0.7 km | **0.1 km** |
| coord p99 (rooftop) | 487 km | **20.7 km** |

It doesn't just close the gap — it **overtakes** v0 and collapses the catastrophic-miss tail. One cost: region dips 100→98% (`TX`→`Tx` trips ~2% of state resolutions) — small, fixable (preserve all-caps state codes), noted in the eval doc.

### Tests
`neural/test/case-normalize.test.ts` (7) — detection (incl. non-Latin/accent bail), length-preservation, the no-regression-by-construction (mixed-case + non-ASCII unchanged). `tsc` neural clean.

### Follow-ups (not this PR)
- Preserve all-caps US state codes during title-case (recover the region 2pp).
- Wire `normalizeCase` into `createRuntimePipeline` + a default decision after a broader case-distribution eval (high value for the record-matcher's all-caps compliance data).

Night-shift #117. Default-OFF — no shipped-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
