### PR TITLE
feat(#690): thread normalizeCase through the runtime pipeline

### DIFF
--- a/core/pipeline/runtime-pipeline.test.ts
+++ b/core/pipeline/runtime-pipeline.test.ts
@@ -113,6 +113,12 @@ describe("runPipeline — stage composition", () => {
 		expect(classifier.parse).toHaveBeenCalledWith("10118", { queryShape: shape, postcodeRepair: true })
 	})
 
+	it("threads PipelineOpts.normalizeCase to classifier.parse (#690)", async () => {
+		const classifier: AddressClassifier = { parse: vi.fn(async () => fakeTree("214 JONES RD")) }
+		await runPipeline("214 JONES RD", { classifier }, { normalizeCase: true })
+		expect(classifier.parse).toHaveBeenCalledWith("214 JONES RD", expect.objectContaining({ normalizeCase: true }))
+	})
+
 	it("skips resolver when not wired", async () => {
 		const classifier = fakeClassifier(fakeTree("hello"))
 		const result = await runPipeline("hello", { classifier })

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -358,7 +358,7 @@ export async function runPipeline(
 	} else if (stages.classifier) {
 		throwIfAborted(opts)
 		const tClassify = performance.now()
-		tree = await safeClassify(stages.classifier, normalized.normalized, queryShape, stages.fst)
+		tree = await safeClassify(stages.classifier, normalized.normalized, queryShape, stages.fst, opts?.normalizeCase)
 		timing["token-classify"] = performance.now() - tClassify
 	}
 
@@ -435,11 +435,12 @@ async function safeClassify(
 	classifier: AddressClassifier,
 	text: string,
 	queryShape: QueryShapeLite,
-	fst?: FstMatcherLike
+	fst?: FstMatcherLike,
+	normalizeCase?: boolean
 ): Promise<AddressTree> {
 	try {
-		// Postcode regex repair on by default (v0.7 #35, operator-signed).
-		return await classifier.parse(text, { queryShape, fst, postcodeRepair: true })
+		// Postcode regex repair on by default (v0.7 #35, operator-signed). #690 normalizeCase off by default.
+		return await classifier.parse(text, { queryShape, fst, postcodeRepair: true, normalizeCase })
 	} catch {
 		return { raw: text, roots: [] }
 	}

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -55,6 +55,12 @@ export interface PipelineOpts {
 	 * argmax tree is used unchanged (byte-stable). Behind a flag pending the assembled gate.
 	 */
 	arbitrate?: boolean
+	/**
+	 * #690: title-case detected all-caps ASCII input before the Stage 3 classifier (helps on
+	 * all-caps registry/compliance data). Threaded to `ClassifierOpts.normalizeCase`. Detection-gated
+	 * + off by default → byte-stable for mixed-case input.
+	 */
+	normalizeCase?: boolean
 	signal?: AbortSignal
 }
 
@@ -173,6 +179,11 @@ export interface ClassifierOpts {
 	fstBiasScale?: number
 	/** Run the deterministic postcode regex repair pass (v0.7 #35) on the decoded labels. */
 	postcodeRepair?: boolean
+	/**
+	 * #690: title-case a detected all-caps ASCII input before the model (all-caps registry/compliance
+	 * data is partly OOD). Detection-gated — mixed-case + non-ASCII input is untouched. Off by default.
+	 */
+	normalizeCase?: boolean
 }
 
 export interface AddressClassifier {

--- a/mailwoman/runtime-pipeline.ts
+++ b/mailwoman/runtime-pipeline.ts
@@ -83,6 +83,12 @@ export interface CreateRuntimePipelineOpts {
 	 * @see RuntimePipelineStages.ruleProposer
 	 */
 	ruleProposer?: RuntimePipelineStages["ruleProposer"]
+	/**
+	 * #690: default for `PipelineOpts.normalizeCase` on every call — title-case detected all-caps ASCII
+	 * input before the model (helps on all-caps registry/compliance data; detection-gated, mixed-case
+	 * untouched). Off by default. A per-call `runOpts.normalizeCase` overrides this.
+	 */
+	normalizeCase?: boolean
 }
 
 /**
@@ -149,7 +155,10 @@ export function createRuntimePipeline(
 			const fn = await loadDefaultPlaceCountry()
 			if (fn) stages.placeCountry = fn
 		}
-		return runPipeline(raw, stages, runOpts)
+		// #690: apply the factory-level normalizeCase default; a per-call runOpts value overrides it.
+		const effectiveRunOpts =
+			opts.normalizeCase && runOpts?.normalizeCase === undefined ? { ...runOpts, normalizeCase: true } : runOpts
+		return runPipeline(raw, stages, effectiveRunOpts)
 	}
 }
 


### PR DESCRIPTION
## #690 follow-on: thread `normalizeCase` through the pipeline

#692 added the `normalizeCase` opt to the neural parser + proved the recovery (all-caps TX locality 90.1→99.7%). This makes it reachable through the runtime pipeline so consumers — notably the record-matcher, which geocodes all-caps compliance data — can enable it without calling the classifier directly.

- `ClassifierOpts.normalizeCase` + `PipelineOpts.normalizeCase` (core) — threaded `safeClassify` → `classifier.parse`.
- `CreateRuntimePipelineOpts.normalizeCase` (mailwoman) — a factory-level default applied per call; a per-call `runOpts.normalizeCase` overrides it.

**Default-OFF at every layer** (detection-gated underneath, so even when ON, mixed-case + non-ASCII input is untouched). The `arbitrate`-style plumbing pattern.

Tests: `runtime-pipeline.test.ts` asserts the opt reaches `classifier.parse`; existing pipeline tests unchanged (the new opt is `undefined` by default and ignored by the equality check). `tsc -b` clean (full project), 72 pipeline/case tests pass.

Not a default decision: the geocoder/record-matcher opting `normalizeCase` ON (and the region-2pp state-code refinement) is the follow-up — this PR just makes the capability reachable. Night-shift #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
