### PR TITLE
feat(#694): IngestOptions.addressSeparator — opt-in delimited address join

### DIFF
--- a/registry/ingest.test.ts
+++ b/registry/ingest.test.ts
@@ -111,6 +111,13 @@ describe("ingestRows", () => {
 		expect(b!.phone).toBeUndefined()
 	})
 
+	it("joins a multi-column address with addressSeparator when set, space otherwise (#694)", async () => {
+		const [dflt] = await ingestRows(parseCsv(CSV), mapping, { geocodeAddress: stubGeocode })
+		expect(dflt!.address?.formatted).toBe("123 Main St Portland OR 97201") // default: space (byte-stable)
+		const [comma] = await ingestRows(parseCsv(CSV), mapping, { geocodeAddress: stubGeocode, addressSeparator: ", " })
+		expect(comma!.address?.formatted).toBe("123 Main St, Portland, OR, 97201") // delimited for the parser
+	})
+
 	it("falls back to the row index when no id column maps", async () => {
 		const [first] = await ingestRows(parseCsv(CSV), { name: "name" })
 		expect(first!.id).toBe("0")

--- a/registry/ingest.ts
+++ b/registry/ingest.ts
@@ -172,6 +172,15 @@ export function inferMapping(header: readonly string[]): ColumnMapping {
 export interface IngestOptions {
 	/** The geocoding seam. Without it, records carry name/org but no resolved address. */
 	geocodeAddress?: GeocodeAddress
+	/**
+	 * Separator for joining a multi-column ADDRESS mapping (name/org always join with a space). Default
+	 * `" "`. Pass `", "` to give the parser delimited input (`"214 Main St, Austin, TX 78701"`) instead
+	 * of a concatenated run (`"214 Main St Austin TX 78701"`) — the latter strips the parser's
+	 * segmentation boundaries and is partly OOD (it also breaks all-caps case-normalization; #694).
+	 * Default-OFF (`" "`) so existing callers + the space-trained dedup GBT stay byte-stable; opt into
+	 * `", "` for new geocode/record-matcher flows after validating the parse shift.
+	 */
+	addressSeparator?: string
 }
 
 /** Parse a CSV string (with a header row) into row objects keyed by column name. */
@@ -180,13 +189,13 @@ export function parseCsv(text: string): Record<string, string>[] {
 }
 
 /** Join the named column(s) of a row into a single trimmed string, or undefined if empty. */
-function pick(row: Record<string, string>, columns?: string | string[]): string | undefined {
+function pick(row: Record<string, string>, columns?: string | string[], separator = " "): string | undefined {
 	if (!columns) return undefined
 	const list = Array.isArray(columns) ? columns : [columns]
 	const value = list
 		.map((c) => row[c]?.trim())
 		.filter(Boolean)
-		.join(" ")
+		.join(separator)
 		.trim()
 	return value || undefined
 }
@@ -208,7 +217,7 @@ export async function ingestRows(
 		const id = (mapping.id ? row[mapping.id]?.trim() : "") || String(index)
 		const nameValue = pick(row, mapping.name)
 		const orgValue = pick(row, mapping.organization)
-		const addressValue = pick(row, mapping.address)
+		const addressValue = pick(row, mapping.address, opts.addressSeparator ?? " ")
 
 		let attributes: Record<string, string> | undefined
 		if (mapping.attributes) {


### PR DESCRIPTION
The #694 fix CAPABILITY (default-OFF, byte-stable). `ingestRows` space-joins multi-column addresses (`"214 JONES RD ELKHART TX 75839"`); the new `addressSeparator` opt lets a caller use `", "` for delimited parser input.

**Why:** root-caused on #694 — concatenated (comma-less) input strips the parser's only segmentation signal: `geocode-case-diag` shows comma-less TX HHSC title-cased craters **150→17** while delimited holds **150/150** (and title-case *improves* tiers there, address_point 104→141). Delimited is the better parser input generally + the unlock for #690-in-geocoder.

**Default-OFF** (`" "`) so existing `ingestRows` callers + the space-trained dedup GBT + eval baselines are byte-stable. Flipping the geocoder/record-matcher callers to `", "` is the separate validated migration tracked in #694 (cross-dataset link re-validation + possible GBT re-train). 16 ingest tests pass (default space-join pinned; `", "` → `"123 Main St, Portland, OR, 97201"`).

Night-shift. Same default-OFF capability+proof pattern as #692/#693. 🤖 Generated with [Claude Code](https://claude.com/claude-code)