### PR TITLE
eval(#474): Overture ES postcode centroids vs GeoNames — gap already closed

### DIFF
--- a/docs/articles/evals/2026-06-17-overture-es-postcode-anchor.md
+++ b/docs/articles/evals/2026-06-17-overture-es-postcode-anchor.md
@@ -1,0 +1,51 @@
+# Overture ES postcode centroids vs the GeoNames baseline (#474)
+
+#474 asked to close the postcode-anchor's **ES/IT coverage gaps** from Overture postcode centroids. The
+measurement says the gap is **mostly already closed** (a GeoNames backfill got there first), Overture
+adds a **marginal +1.5% ES coverage at equivalent accuracy**, and **IT is Overture-blocked**. Net: the
+anchor's ES/IT coverage is effectively solved; Overture is a complementary source, not a needed fix.
+
+## What was measured
+
+The shipped `postalcode-intl.db` already carries GeoNames-backfilled ES/IT postcode centroids (ES 11,331
+postcodes / IT 4,936). From the local Overture release (`addresses-es.parquet`, ES postcode fill 100% /
+15.7M points) I aggregated per-postcode centroids (mean after dropping points >3σ from the per-postcode
+mean — `scripts/eval/overture-es-postcode-centroids.ts`, 10,850 ES postcodes) into a `spr`-table DB, and
+ran the existing harness (`scripts/eval/postcode-anchor-accuracy.ts`) on the 3,000-row ES eval
+(`openaddresses-es-sample.jsonl`) for each source.
+
+| source | postcodes | placed (eval) | p50 km | p90 km | p99 km | within 10 km | within 25 km |
+| --- | --: | --: | --: | --: | --: | --: | --: |
+| GeoNames (shipped) | 11,331 | **98.5%** | 1.0 | 6.3 | 27.9 | 95.2% | 98.6% |
+| Overture | 10,850 | **100.0%** | 1.0 | 6.3 | 27.9 | 95.2% | 98.7% |
+
+## Reading
+
+- **Coverage:** Overture places 100% of the eval postcodes vs GeoNames' 98.5% — it covers the 45 (1.5%)
+  ES postcodes GeoNames missed. But GeoNames carries ~481 more postcodes overall (11,331 vs 10,850), so
+  the two are **complementary**: the union (GeoNames ∪ Overture) is strictly ≥ either alone.
+- **Accuracy: a tie.** The distance distributions are identical (p50 1.0 km, p90 6.3 km). The metric
+  reflects the **postcode's spatial extent** (a random address sits ~1 km from the postcode centroid),
+  not centroid error — both methods place the centroid near the postcode's true center, so Overture's
+  15.7M-point density buys no accuracy edge here. The anchor only needs centre-of-postcode; it has it.
+- **IT is blocked.** Overture's IT postcode fill is **0%** (the #474 ingest gate "≥80% else renegotiate"
+  fails for IT) — GeoNames stays IT's source. Documented as an Overture gap alongside GB (Overture has no
+  GB either — Ordnance Survey licensing).
+
+## Recommendation
+
+The ES/IT postcode-anchor coverage gap is **effectively closed by GeoNames** (98.5% / 90% placed). The
+honest call:
+
+1. **ES** — optionally merge Overture into the canonical (`postalcode-intl.db`) as a **union** to pick up
+   the residual ~1.5% at equal accuracy, with `source` provenance. This is a **canonical-DB change** →
+   the operator's call; the validated Overture ES centroids are staged at
+   `postcode-es-overture.db` + the reusable extractor is committed. Marginal value — not urgent.
+2. **IT** — keep GeoNames; Overture can't help (0% postcode fill).
+3. **GB** — permanent external gap (no open licensed source).
+
+No model retrain, no posterior re-weighting (the #474 scope guard) — this is a data-layer measurement.
+The takeaway for the anchor coverage docs: **es/it are no longer gaps; gb is the only permanent one.**
+
+_Source: `scripts/eval/overture-es-postcode-centroids.ts` (Overture → centroids → spr DB);
+`scripts/eval/postcode-anchor-accuracy.ts` (the before/after on `openaddresses-es-sample.jsonl`)._

--- a/scripts/eval/overture-es-postcode-centroids.ts
+++ b/scripts/eval/overture-es-postcode-centroids.ts
@@ -1,0 +1,88 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #474: build ES postcode centroids from the local Overture addresses parquet (ES postcode fill =
+ *   100%, 15.7M points) and emit a `spr`-table SQLite DB the existing postcode-anchor harness consumes
+ *   (`WofPostcodeLookup` / `postcode-anchor-accuracy.ts`). Per-postcode centroid = mean after dropping
+ *   points >3σ from the per-postcode mean (agency data carries geocoding errors). Lets us measure
+ *   Overture-derived centroids vs the shipped GeoNames-backfilled ones (postalcode-intl.db) on the
+ *   ES eval rows — does Overture's 15.7M-point density beat GeoNames on anchor accuracy?
+ *
+ *   IT is OUT: Overture IT postcode fill = 0% (the #474 ingest gate "≥80% else renegotiate" fails) —
+ *   GeoNames stays IT's source; documented as an Overture gap.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/overture-es-postcode-centroids.ts
+ *        [--parquet <path>] [--out <db>] [--country ES]
+ */
+
+import { DuckDBInstance } from "@duckdb/node-api"
+import { DatabaseSync } from "node:sqlite"
+
+const arg = (n: string, d: string): string => {
+	const i = process.argv.indexOf(`--${n}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : d
+}
+const CC = arg("country", "ES")
+const PARQUET = arg("parquet", `/mnt/playpen/mailwoman-data/overture/2026-05-20.0/addresses-${CC.toLowerCase()}.parquet`)
+const OUT_DB = arg("out", `/mnt/playpen/mailwoman-data/wof/postcode-${CC.toLowerCase()}-overture.db`)
+
+const instance = await DuckDBInstance.create()
+const conn = await instance.connect()
+
+// Confirm the parquet columns first (the ingest output extracts ST_X/ST_Y → lat/lon).
+const desc = await conn.runAndReadAll(`DESCRIBE SELECT * FROM read_parquet('${PARQUET}') LIMIT 1`)
+console.error("columns:", desc.getRowObjects().map((r) => String(r["column_name"])).join(", "))
+
+// Per-postcode centroid: mean of points within 3σ of the per-postcode mean (population stddev).
+// ES postcodes are 5-digit; left-pad numeric codes so leading zeros survive (eval truth uses "01001").
+const sql = `
+WITH base AS (
+  SELECT
+    CASE WHEN regexp_full_match(trim(CAST(postcode AS VARCHAR)), '[0-9]{1,5}')
+         THEN lpad(trim(CAST(postcode AS VARCHAR)), 5, '0')
+         ELSE trim(CAST(postcode AS VARCHAR)) END AS pc,
+    lat, lon
+  FROM read_parquet('${PARQUET}')
+  WHERE postcode IS NOT NULL AND trim(CAST(postcode AS VARCHAR)) != '' AND lat IS NOT NULL AND lon IS NOT NULL
+),
+stats AS (
+  SELECT pc, avg(lat) ml, coalesce(stddev_pop(lat), 0) sl, avg(lon) mo, coalesce(stddev_pop(lon), 0) so
+  FROM base GROUP BY pc
+)
+SELECT b.pc AS postcode, avg(b.lat) AS lat, avg(b.lon) AS lon, count(*) AS n
+FROM base b JOIN stats s ON b.pc = s.pc
+WHERE (s.sl = 0 OR abs(b.lat - s.ml) <= 3 * s.sl) AND (s.so = 0 OR abs(b.lon - s.mo) <= 3 * s.so)
+GROUP BY b.pc
+`
+const res = await conn.runAndReadAll(sql)
+const rows = res.getRowObjects() as Array<{ postcode: string; lat: number; lon: number; n: bigint }>
+console.error(`extracted ${rows.length} ${CC} postcode centroids from Overture`)
+
+// Emit the spr table the WofPostcodeLookup query consumes:
+//   SELECT country, latitude, longitude FROM spr WHERE name=? AND placetype='postalcode' AND is_current!=0
+const out = new DatabaseSync(OUT_DB)
+out.exec(`
+DROP TABLE IF EXISTS spr;
+CREATE TABLE spr (
+  id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL DEFAULT -1, name TEXT NOT NULL DEFAULT '',
+  placetype TEXT NOT NULL DEFAULT '', country TEXT NOT NULL DEFAULT '',
+  latitude REAL NOT NULL DEFAULT 0, longitude REAL NOT NULL DEFAULT 0,
+  min_latitude REAL NOT NULL DEFAULT 0, min_longitude REAL NOT NULL DEFAULT 0,
+  max_latitude REAL NOT NULL DEFAULT 0, max_longitude REAL NOT NULL DEFAULT 0,
+  is_current INTEGER NOT NULL DEFAULT 1, is_deprecated INTEGER NOT NULL DEFAULT 0,
+  is_ceased INTEGER NOT NULL DEFAULT 0, is_superseded INTEGER NOT NULL DEFAULT 0,
+  is_superseding INTEGER NOT NULL DEFAULT 0, lastmodified INTEGER NOT NULL DEFAULT 0,
+  source TEXT DEFAULT NULL, point_count INTEGER DEFAULT 0
+);
+`)
+const ins = out.prepare(
+	`INSERT INTO spr (id, name, placetype, country, latitude, longitude, is_current, source, point_count)
+	 VALUES (?, ?, 'postalcode', ?, ?, ?, 1, 'overture:2026-05-20.0', ?)`
+)
+let id = 1
+for (const r of rows) ins.run(id++, String(r.postcode), CC, Number(r.lat), Number(r.lon), Number(r.n))
+out.exec(`CREATE INDEX spr_by_name ON spr(name); CREATE INDEX spr_by_country ON spr(country);`)
+out.close()
+console.error(`wrote ${rows.length} rows → ${OUT_DB}`)


### PR DESCRIPTION
Measures #474 (close ES/IT postcode-anchor gaps from Overture). **Finding: the gap is largely OBE** — GeoNames already backfilled ES/IT to 98.5%/90% placed. Overture ES closes the residual **1.5%** (100% vs 98.5% on the 3000-row eval) at **equivalent accuracy** (p50 1.0km both — the metric is postcode extent, not centroid error). **IT is Overture-blocked** (0% postcode fill, confirmed). GB permanent gap.

Recommendation: es/it are no longer anchor gaps; gb is the only permanent one. Optional ES union-merge for the +1.5% is a **canonical-DB change → operator's call**; validated Overture ES centroids staged + the reusable extractor committed. No retrain/posterior change (#474 scope guard). Eval artifact. 🤖 Generated with [Claude Code](https://claude.com/claude-code)