### PR TITLE
feat(#375): boundary-instability synthetic stress shard — the #1-lever groundwork

### DIFF
--- a/corpus/src/synthesize-boundary-stress.test.ts
+++ b/corpus/src/synthesize-boundary-stress.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Verifies the boundary-stress synthesizer (#375) aligns cleanly through the REAL `alignRow` aligner —
+ *   the gold boundary the model should learn must survive tokenization + BIO labeling. Each shape
+ *   asserts the stress-relevant tags land in order; the bulk run confirms the overwhelming majority
+ *   align (no quarantine).
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { alignRow } from "./align.js"
+import {
+	type BoundaryStressTemplate,
+	synthesizeBoundaryStressRow,
+	type SynthesizedBoundaryStressRow,
+} from "./synthesize-boundary-stress.js"
+import type { CanonicalRow } from "./types.js"
+
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0
+	return () => {
+		a |= 0
+		a = (a + 0x6d2b79f5) | 0
+		let t = Math.imul(a ^ (a >>> 15), 1 | a)
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+	}
+}
+
+function asCanonical(r: SynthesizedBoundaryStressRow): CanonicalRow {
+	return { ...r, source: "synth-boundary-stress", source_id: "synth-boundary-stress:test" } as CanonicalRow
+}
+
+const labelsFor = (template: BoundaryStressTemplate, seed: number): readonly string[] => {
+	const row = synthesizeBoundaryStressRow(undefined, { random: mulberry32(seed), forceTemplate: template })
+	const result = alignRow(asCanonical(row))
+	expect(result.kind, `${template} should align, raw=${row.raw}`).toBe("labeled")
+	if (result.kind !== "labeled") return []
+	return result.row.labels
+}
+
+describe("synthesizeBoundaryStressRow", () => {
+	it("street-eats-affix: street and street_suffix are SEPARATE spans, in order", () => {
+		const labels = labelsFor("street-eats-affix", 1)
+		expect(labels).toContain("B-street")
+		expect(labels).toContain("B-street_suffix")
+		expect(labels.indexOf("B-street")).toBeLessThan(labels.indexOf("B-street_suffix"))
+	})
+
+	it("comma-less-city-state: locality + region + postcode still label without comma cues", () => {
+		const row = synthesizeBoundaryStressRow(undefined, {
+			random: mulberry32(2),
+			forceTemplate: "comma-less-city-state",
+		})
+		expect(row.raw).not.toContain(",") // the whole point — no delimiter cue
+		const result = alignRow(asCanonical(row))
+		expect(result.kind, `raw=${row.raw}`).toBe("labeled")
+		if (result.kind !== "labeled") return
+		expect(result.row.labels).toContain("B-locality")
+		expect(result.row.labels).toContain("B-region")
+		expect(result.row.labels).toContain("B-postcode")
+	})
+
+	it("fr-prefix: street_prefix split from street, prefix first", () => {
+		const labels = labelsFor("fr-prefix", 3)
+		expect(labels).toContain("B-street_prefix")
+		expect(labels).toContain("B-street")
+		expect(labels.indexOf("B-street_prefix")).toBeLessThan(labels.indexOf("B-street"))
+	})
+
+	it("house-number-after-street: street before the trailing house_number", () => {
+		const labels = labelsFor("house-number-after-street", 4)
+		expect(labels).toContain("B-street")
+		expect(labels).toContain("B-house_number")
+		expect(labels.indexOf("B-street")).toBeLessThan(labels.indexOf("B-house_number"))
+	})
+
+	it("is deterministic under a fixed seed", () => {
+		const a = synthesizeBoundaryStressRow(undefined, { random: mulberry32(42) })
+		const b = synthesizeBoundaryStressRow(undefined, { random: mulberry32(42) })
+		expect(a.raw).toBe(b.raw)
+	})
+
+	it("bulk: ≥97% of 400 rows align cleanly, each carrying its stress tag", () => {
+		const rng = mulberry32(123)
+		let labeled = 0
+		for (let i = 0; i < 400; i++) {
+			const row = synthesizeBoundaryStressRow(undefined, { random: rng })
+			const result = alignRow(asCanonical(row))
+			if (result.kind !== "labeled") continue
+			labeled++
+		}
+		expect(labeled).toBeGreaterThanOrEqual(388) // 97%
+	})
+})

--- a/corpus/src/synthesize-boundary-stress.ts
+++ b/corpus/src/synthesize-boundary-stress.ts
@@ -1,0 +1,215 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Boundary-instability synthesizer (#375 — the highest-leverage parser lever). The failure taxonomy +
+ *   the within-token-punctuation decomposition (#702) found one failure FAMILY surfacing under many
+ *   names: the model mis-places token boundaries between adjacent components when the boundary is
+ *   ambiguous or unmarked. This generator emits diverse BIO-labeled rows that put the gold boundary
+ *   exactly where the model wobbles, so a retrain learns the boundary from context, not the lexeme.
+ *
+ *   The five token-aligned stress shapes (each component is a whitespace-separated token run, so
+ *   `alignRow` labels them cleanly):
+ *
+ *   1. `street-eats-affix` — multi-word street + suffix (`Country Club Rd` → street + street_suffix),
+ *        the #1 wobble: the model keeps the suffix in the street.
+ *   2. `comma-less-city-state` — no comma between street / locality / region (`… North Sydney NSW
+ *        2060`), the #694 family: concatenated input loses the segmentation cue.
+ *   3. `fr-prefix` — FR street-type prefix split from the name (`Rue Jean-Baptiste Lebas` → street_prefix
+ *        + street), postcode-first order.
+ *   4. `house-number-after-street` — FR/DE number-follows-street (`Neuve-des-Capucines 5` → street +
+ *        house_number), the model absorbs the number into the street.
+ *
+ *   The sub-token shapes (region+postcode glue `NY14201`, the AU/UK slash unit-convention `4/2A`) are
+ *   deliberately EXCLUDED — they put two components inside one whitespace token, which the token-BIO
+ *   path can't label (the within-token-punctuation note flags them as a tokenizer/char-offset concern,
+ *   not a clean BIO shard case). See `synthesize-boundary-stress.test.ts` for the alignment proof.
+ */
+
+import type { CanonicalRow } from "./types.js"
+
+export type BoundaryStressTemplate =
+	| "street-eats-affix"
+	| "comma-less-city-state"
+	| "fr-prefix"
+	| "house-number-after-street"
+
+export interface BoundaryStressBaseTuple {
+	locality: string
+	region: string
+	postcode: string
+	country: string
+}
+
+export interface BoundaryStressSynthesisOpts {
+	random?: () => number
+	/** Force a specific shape (tests + balanced shard composition). */
+	forceTemplate?: BoundaryStressTemplate
+}
+
+export interface SynthesizedBoundaryStressRow {
+	raw: string
+	components: CanonicalRow["components"]
+	locale: string
+	template: BoundaryStressTemplate
+}
+
+function pick<T>(arr: ReadonlyArray<T>, random: () => number): T {
+	return arr[Math.floor(random() * arr.length)]!
+}
+
+// Multi-word street names — the suffix boundary only bites when "Club" could be read as part of the
+// name. Single-word names alone teach nothing about the suffix edge.
+const MULTIWORD_STREETS = [
+	"Country Club",
+	"Martin Luther King",
+	"Forest Hill",
+	"Lake View",
+	"Spring Valley",
+	"Cedar Ridge",
+	"Old Mill",
+	"Sunset Park",
+	"Maple Grove",
+	"Stone Creek",
+	"Glen Cove",
+	"Pine Bluff",
+	"Fox Hollow",
+	"Briar Patch",
+	"West End",
+	"College Station",
+] as const
+const SINGLE_STREETS = ["Main", "Oak", "Maple", "Park", "Washington", "Lincoln", "Church", "River"] as const
+const SUFFIXES = ["St", "Street", "Ave", "Avenue", "Rd", "Road", "Blvd", "Ln", "Dr", "Pkwy", "Way", "Ct", "Pl", "Cir", "Ter"] as const
+const DIRECTIONALS = ["N", "S", "E", "W", "NE", "NW", "SE", "SW"] as const
+
+// FR street-type prefixes + hyphenated honorific street names (the hyphen is incidental; the boundary
+// stress is the prefix↔name split + the number-after-street order).
+const FR_PREFIXES = ["Rue", "Avenue", "Boulevard", "Place", "Impasse", "Chemin", "Quai", "Cours", "Allée"] as const
+const FR_NAMES = [
+	"Jean-Baptiste Lebas",
+	"Neuve-des-Capucines",
+	"Charles-de-Gaulle",
+	"du Général-Leclerc",
+	"de la République",
+	"des Trois-Frères",
+	"Victor-Hugo",
+	"Jean-Jaurès",
+	"de l'Abreuvoir",
+] as const
+const DE_NAMES = [
+	"Konrad-Adenauer-Ufer",
+	"Müller-Breslau-Straße",
+	"Ernst-Reuter-Platz",
+	"Hans-Dietrich-Genscher-Platz",
+	"Friedrich-Ebert-Straße",
+	"Rosa-Luxemburg-Straße",
+] as const
+
+const US_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
+	{ locality: "Springfield", region: "IL", postcode: "62701", country: "US" },
+	{ locality: "Winston-Salem", region: "NC", postcode: "27101", country: "US" },
+	{ locality: "Ann Arbor", region: "MI", postcode: "48104", country: "US" },
+	{ locality: "Beverly Hills", region: "CA", postcode: "90210", country: "US" },
+	{ locality: "Fort Worth", region: "TX", postcode: "76102", country: "US" },
+	{ locality: "Grand Prairie", region: "TX", postcode: "75052", country: "US" },
+	{ locality: "Coeur d'Alene", region: "ID", postcode: "83814", country: "US" },
+]
+const AU_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
+	{ locality: "North Sydney", region: "NSW", postcode: "2060", country: "AU" },
+	{ locality: "Melbourne", region: "VIC", postcode: "3000", country: "AU" },
+	{ locality: "Brisbane", region: "QLD", postcode: "4000", country: "AU" },
+	{ locality: "Mosman Park", region: "WA", postcode: "6012", country: "AU" },
+	{ locality: "Wollongong", region: "NSW", postcode: "2500", country: "AU" },
+]
+const FR_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
+	{ locality: "Roubaix", region: "Hauts-de-France", postcode: "59100", country: "FR" },
+	{ locality: "Paris", region: "Île-de-France", postcode: "75014", country: "FR" },
+	{ locality: "Toulouse", region: "Occitanie", postcode: "31000", country: "FR" },
+	{ locality: "Strasbourg", region: "Grand Est", postcode: "67000", country: "FR" },
+]
+const DE_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
+	{ locality: "Berlin", region: "Berlin", postcode: "10623", country: "DE" },
+	{ locality: "Köln", region: "Nordrhein-Westfalen", postcode: "50668", country: "DE" },
+	{ locality: "Heidelberg", region: "Baden-Württemberg", postcode: "69117", country: "DE" },
+]
+
+const houseNumber = (random: () => number): string => String(1 + Math.floor(random() * 4999))
+const localeFor: Record<string, string> = { US: "en-US", AU: "en-AU", FR: "fr-FR", DE: "de-DE" }
+
+const ALL_TEMPLATES: readonly BoundaryStressTemplate[] = [
+	"street-eats-affix",
+	"comma-less-city-state",
+	"fr-prefix",
+	"house-number-after-street",
+]
+
+/**
+ * Synthesize one boundary-stress row. `base` is optional — when omitted, a locale-appropriate tuple is
+ * drawn from the internal pools (so the generator is self-contained; a build script can pass real
+ * tuples for scale + diversity). Every component value is a verbatim substring of `raw`, so `alignRow`
+ * locates + BIO-labels it.
+ */
+export function synthesizeBoundaryStressRow(
+	base: BoundaryStressBaseTuple | undefined,
+	opts: BoundaryStressSynthesisOpts = {}
+): SynthesizedBoundaryStressRow {
+	const random = opts.random ?? Math.random
+	const template = opts.forceTemplate ?? pick(ALL_TEMPLATES, random)
+
+	if (template === "fr-prefix" || template === "house-number-after-street") {
+		const useDe = template === "house-number-after-street" && random() < 0.4
+		const b = base ?? pick(useDe ? DE_TUPLES : FR_TUPLES, random)
+		const name = useDe ? pick(DE_NAMES, random) : pick(FR_NAMES, random)
+		const hn = houseNumber(random)
+		if (template === "fr-prefix") {
+			const prefix = pick(FR_PREFIXES, random)
+			// "{hn} {prefix} {name}, {postcode} {locality}" — postcode-first, prefix split from the name.
+			const raw = `${hn} ${prefix} ${name}, ${b.postcode} ${b.locality}`
+			return {
+				raw,
+				components: {
+					house_number: hn,
+					street_prefix: prefix,
+					street: name,
+					postcode: b.postcode,
+					locality: b.locality,
+				},
+				locale: localeFor[b.country] ?? "fr-FR",
+				template,
+			}
+		}
+		// house-number-after-street: "{name} {hn}, {postcode} {locality}" — number FOLLOWS the street.
+		const raw = `${name} ${hn}, ${b.postcode} ${b.locality}`
+		return {
+			raw,
+			components: { street: name, house_number: hn, postcode: b.postcode, locality: b.locality },
+			locale: localeFor[b.country] ?? "fr-FR",
+			template,
+		}
+	}
+
+	// en-US / en-AU street shapes.
+	const b = base ?? pick(template === "comma-less-city-state" ? [...US_TUPLES, ...AU_TUPLES] : US_TUPLES, random)
+	const hn = houseNumber(random)
+	const dir = random() < 0.4 ? pick(DIRECTIONALS, random) : ""
+	const name = random() < 0.7 ? pick(MULTIWORD_STREETS, random) : pick(SINGLE_STREETS, random)
+	const suffix = pick(SUFFIXES, random)
+	const streetCore = `${dir ? `${dir} ` : ""}${name} ${suffix}`
+	const components: CanonicalRow["components"] = {
+		house_number: hn,
+		...(dir ? { street_prefix: dir } : {}),
+		street: name,
+		street_suffix: suffix,
+		locality: b.locality,
+		region: b.region,
+		postcode: b.postcode,
+	}
+	const raw =
+		template === "comma-less-city-state"
+			? // no commas anywhere — the segmentation cue is gone
+				`${hn} ${streetCore} ${b.locality} ${b.region} ${b.postcode}`
+			: // standard delimited, multi-word street stresses the suffix boundary
+				`${hn} ${streetCore}, ${b.locality}, ${b.region} ${b.postcode}`
+	return { raw, components, locale: localeFor[b.country] ?? "en-US", template }
+}

--- a/scripts/build-boundary-stress-shard.mjs
+++ b/scripts/build-boundary-stress-shard.mjs
@@ -1,0 +1,76 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #375 — build the boundary-instability synthetic shard. Wraps `synthesizeBoundaryStressRow`
+ *   (`corpus/src/synthesize-boundary-stress.ts`) through the real `alignRow` aligner and writes a
+ *   LabeledRow JSONL the corpus build / a Modal training run can ride. Concrete groundwork for the
+ *   taxonomy's #1 parser lever (the boundary-wobble family); no retrain happens here.
+ *
+ *   Imports the COMPILED corpus (`corpus/out/src/*.js`) — `alignRow` has internal `.js` runtime
+ *   imports the strip-types loader can't resolve from source, so `tsc -b` first.
+ *
+ *   Run: node scripts/build-boundary-stress-shard.mjs [--count 20000] [--seed 20260617]
+ *        [--out data/corpus/shards/synth-boundary-stress.jsonl]
+ */
+
+import { createWriteStream, mkdirSync } from "node:fs"
+import { dirname } from "node:path"
+
+import { alignRow } from "../corpus/out/src/align.js"
+import { stableSourceId } from "../corpus/out/src/adapter.js"
+import { synthesizeBoundaryStressRow } from "../corpus/out/src/synthesize-boundary-stress.js"
+
+const arg = (n, d) => {
+	const i = process.argv.indexOf(`--${n}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : d
+}
+const COUNT = Number(arg("count", "20000"))
+const OUT = arg("out", "data/corpus/shards/synth-boundary-stress.jsonl")
+const SEED = Number(arg("seed", "20260617"))
+
+function mulberry32(seed) {
+	let a = seed >>> 0
+	return () => {
+		a |= 0
+		a = (a + 0x6d2b79f5) | 0
+		let t = Math.imul(a ^ (a >>> 15), 1 | a)
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+	}
+}
+const random = mulberry32(SEED)
+
+mkdirSync(dirname(OUT), { recursive: true })
+const out = createWriteStream(OUT)
+let labeled = 0
+let quarantined = 0
+const byTemplate = {}
+for (let i = 0; i < COUNT; i++) {
+	const row = synthesizeBoundaryStressRow(undefined, { random })
+	const country = row.locale.split("-")[1] ?? "US"
+	const source_id = stableSourceId("synth-boundary-stress", { ...row.components, v: String(i) })
+	const canonical = {
+		raw: row.raw,
+		components: row.components,
+		country,
+		locale: row.locale,
+		source: "synth-boundary-stress",
+		source_id,
+		corpus_version: "0.6.0",
+		license: "Synthetic — boundary-stress; derived from public-domain locality/region tuples",
+		synth: { method: `boundary-stress:${row.template}`, base_source_id: source_id },
+	}
+	const r = alignRow(canonical)
+	if (r.kind !== "labeled") {
+		quarantined++
+		continue
+	}
+	labeled++
+	byTemplate[row.template] = (byTemplate[row.template] ?? 0) + 1
+	out.write(JSON.stringify(r.row) + "\n")
+}
+out.end()
+console.error(`wrote ${labeled} labeled rows (${quarantined} quarantined, ${((100 * quarantined) / COUNT).toFixed(1)}%) → ${OUT}`)
+console.error("by template:", JSON.stringify(byTemplate))


### PR DESCRIPTION
Concrete training-data groundwork for the failure taxonomy's **#1 parser lever** (boundary instability), grounded in tonight's within-token decomposition (#702). A new corpus generator + build script producing BIO-labeled boundary-stress rows.

**4 token-aligned stress shapes** (each validated through the real `alignRow`): street-eats-affix (`Country Club Rd` → street + street_suffix), comma-less `City STATE` (the #694 family — no delimiter cue), fr-prefix (`Rue` split from name, postcode-first), house-number-after-street (FR/DE number follows street). Sub-token shapes (`NY14201` glue, AU `4/2A` slash) **excluded** — two components in one whitespace token, a tokenizer/char-offset concern not a clean BIO case (documented).

**Validated:** 6 unit tests pass; the build script generates a 3000-row sample at **0% quarantine**, balanced across shapes, correct BIO by eye (e.g. comma-less `229 Old Mill Avenue North Sydney NSW 2060` → correct locality/region/postcode without commas).

**No retrain here** — this is the tool + data. Integration (lint vs base corpus per the #511 base-consistency check, manifest entry, a gated Modal run, one-variable-per-run) is the operator's call per CONTRIBUTING_MODEL_WORK. DeepSeek-steered (the night's chosen #1-lever groundwork). 🤖 Generated with [Claude Code](https://claude.com/claude-code)