### PR TITLE
eval(#375): boundary-instability baseline — the current model's gap quantified

### DIFF
--- a/docs/articles/evals/2026-06-17-boundary-stress-baseline.md
+++ b/docs/articles/evals/2026-06-17-boundary-stress-baseline.md
@@ -1,0 +1,39 @@
+# Boundary-instability: the current model's gap, quantified (#375)
+
+The failure taxonomy named boundary instability the #1 parser lever and the within-token decomposition
+(#702) showed it surfacing under many names. The boundary-stress shard (#703) is the training-data fix.
+This is the **"before" baseline** — how badly today's model places these boundaries, on the exact
+synthetic shapes the shard teaches (`scripts/eval/boundary-stress-baseline.ts`, 300 rows/shape through
+the current neural model, exact-match per tag).
+
+| stress shape | stress tag | stress-tag accuracy | street accuracy |
+| --- | --- | --: | --: |
+| street-eats-affix | street_suffix | **48.0%** | 42% |
+| comma-less City STATE | region | **66.3%** | **34%** |
+| fr-prefix | street_prefix | **70.3%** | 70% |
+| house-number-after-street | house_number | **47.3%** | 44% |
+
+(house_number, locality, postcode read ~100% on the delimited shapes — the failures are concentrated on
+the contested boundary, exactly as designed.)
+
+## Reading
+
+- The model is **42–70%** on the boundary-stress cases vs ~95%+ on clean canonical addresses — the gap
+  is large and real, not a measurement artifact. These are the rows the #1 lever is about.
+- **Comma-less is the worst** (street **34%**, locality 59%): stripping the delimiter cue collapses the
+  segmentation — the same #694 finding (concatenated input loses the boundary), now measured on the
+  parser side, not just the geocoder.
+- **The street boundary is the common casualty** (42% / 34% / 44% across three shapes): when an adjacent
+  component is ambiguous, the street span absorbs or surrenders tokens. One failure, many faces.
+- **house-number-after-street 47%** is the fr.house_number plateau in miniature (the FR/DE
+  number-follows-street order) — confirming the shipped ~87% there degrades further on stress positions,
+  and that this shard's `house-number-after-street` shape targets that lever too.
+
+## So what
+
+The shard (#703) puts the gold boundary on diverse realizations of exactly these shapes. The retrain's
+success criterion is moving these four numbers up without regressing the clean canonical per-locale F1
+(the US/FR/DE tripwire) — one variable, gated, per `CONTRIBUTING_MODEL_WORK`. This table is what the
+retrain is measured against.
+
+_Source: `scripts/eval/boundary-stress-baseline.ts` over `corpus/src/synthesize-boundary-stress.ts`._

--- a/scripts/eval/boundary-stress-baseline.ts
+++ b/scripts/eval/boundary-stress-baseline.ts
@@ -1,0 +1,73 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #375: the "before" baseline for the boundary-instability stress shard (#703). Generates rows from
+ *   each stress shape and parses them through the CURRENT neural model — how badly does today's model
+ *   place these boundaries? Quantifies the #1-lever gap the shard targets + the lift a retrain should
+ *   show. Per-shape, per-stress-tag exact-match accuracy (case-insensitive). Read-only.
+ *   Run: node --experimental-strip-types scripts/eval/boundary-stress-baseline.ts [--n 300]
+ */
+
+import { decodeAsJson } from "@mailwoman/core/decoder"
+import { NeuralAddressClassifier } from "@mailwoman/neural"
+
+import {
+	type BoundaryStressTemplate,
+	synthesizeBoundaryStressRow,
+} from "../../corpus/src/synthesize-boundary-stress.ts"
+
+const N = Number(process.argv[process.argv.indexOf("--n") + 1] || "300")
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0
+	return () => {
+		a |= 0
+		a = (a + 0x6d2b79f5) | 0
+		let t = Math.imul(a ^ (a >>> 15), 1 | a)
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+	}
+}
+
+// The stress tag each shape is built to teach (the boundary the model wobbles on).
+const STRESS_TAG: Record<BoundaryStressTemplate, string> = {
+	"street-eats-affix": "street_suffix",
+	"comma-less-city-state": "region",
+	"fr-prefix": "street_prefix",
+	"house-number-after-street": "house_number",
+}
+
+const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+const random = mulberry32(20260617)
+
+for (const template of Object.keys(STRESS_TAG) as BoundaryStressTemplate[]) {
+	const tag = STRESS_TAG[template]
+	let stressHit = 0
+	const allKeys: Record<string, { hit: number; n: number }> = {}
+	for (let i = 0; i < N; i++) {
+		const row = synthesizeBoundaryStressRow(undefined, { random, forceTemplate: template })
+		const json = decodeAsJson(await classifier.parse(row.raw, { postcodeRepair: true })) as Record<string, unknown>
+		const got: Record<string, string> = {}
+		const collect = (o: Record<string, unknown>): void => {
+			for (const [k, v] of Object.entries(o)) {
+				if (typeof v === "string") got[k] = v
+				else if (v && typeof v === "object") collect(v as Record<string, unknown>)
+			}
+		}
+		collect(json)
+		for (const [k, gold] of Object.entries(row.components)) {
+			const a = (allKeys[k] ??= { hit: 0, n: 0 })
+			a.n++
+			if ((got[k] ?? "").toLowerCase().trim() === String(gold).toLowerCase().trim()) a.hit++
+		}
+		if ((got[tag] ?? "").toLowerCase().trim() === String(row.components[tag as keyof typeof row.components] ?? "").toLowerCase().trim())
+			stressHit++
+	}
+	console.log(`\n## ${template} (stress tag: ${tag})`)
+	console.log(`  stress-tag exact: ${stressHit}/${N} (${((100 * stressHit) / N).toFixed(1)}%)`)
+	const perKey = Object.entries(allKeys)
+		.map(([k, a]) => `${k} ${((100 * a.hit) / a.n).toFixed(0)}%`)
+		.join("  ")
+	console.log(`  all tags: ${perKey}`)
+}


### PR DESCRIPTION
The **'before' baseline** for the #703 boundary-stress shard: today's model on the exact shapes the shard teaches (300 rows/shape). street-eats-affix street_suffix **48%**, comma-less region **66%** / street **34%**, fr-prefix street_prefix **70%**, house-number-after-street house_number **47%** — the model is **42–70%** on these boundaries vs ~95%+ clean. Comma-less is worst (the #694 delimiter-stripping, parser-side); the street boundary is the common casualty across shapes. This is what the retrain (#703 shard, gated, one-variable) is measured against. Eval artifact. 🤖 Generated with [Claude Code](https://claude.com/claude-code)