### PR TITLE
feat(#375): add the AU/UK slash unit-convention shape to the boundary shard

### DIFF
--- a/corpus/src/synthesize-boundary-stress.test.ts
+++ b/corpus/src/synthesize-boundary-stress.test.ts
@@ -78,6 +78,13 @@ describe("synthesizeBoundaryStressRow", () => {
 		expect(labels.indexOf("B-street")).toBeLessThan(labels.indexOf("B-house_number"))
 	})
 
+	it("au-uk-slash-unit: the slash splits into unit then house_number (clean BIO)", () => {
+		const labels = labelsFor("au-uk-slash-unit", 5)
+		expect(labels).toContain("B-unit")
+		expect(labels).toContain("B-house_number")
+		expect(labels.indexOf("B-unit")).toBeLessThan(labels.indexOf("B-house_number"))
+	})
+
 	it("is deterministic under a fixed seed", () => {
 		const a = synthesizeBoundaryStressRow(undefined, { random: mulberry32(42) })
 		const b = synthesizeBoundaryStressRow(undefined, { random: mulberry32(42) })

--- a/corpus/src/synthesize-boundary-stress.ts
+++ b/corpus/src/synthesize-boundary-stress.ts
@@ -20,11 +20,14 @@
  *        + street), postcode-first order.
  *   4. `house-number-after-street` — FR/DE number-follows-street (`Neuve-des-Capucines 5` → street +
  *        house_number), the model absorbs the number into the street.
+ *   5. `au-uk-slash-unit` — the AU/NZ/UK unit/street-number slash (`4/2A` → unit + house_number,
+ *        `Unit 11/2` → unit "Unit 11" + house_number 2). The aligner's tokenizer splits on `/`, so this
+ *        labels cleanly (verified) — it does NOT collide with US `123 1/2` fractions because those are
+ *        US-locale and keep `1/2` in house_number; the convention is locale-disambiguated.
  *
- *   The sub-token shapes (region+postcode glue `NY14201`, the AU/UK slash unit-convention `4/2A`) are
- *   deliberately EXCLUDED — they put two components inside one whitespace token, which the token-BIO
- *   path can't label (the within-token-punctuation note flags them as a tokenizer/char-offset concern,
- *   not a clean BIO shard case). See `synthesize-boundary-stress.test.ts` for the alignment proof.
+ *   The region+postcode glue shape (`NY14201`) is EXCLUDED — with no punctuation it stays one
+ *   whitespace token spanning two components, which the token-BIO path can't label (a tokenizer
+ *   concern, not a clean BIO shard case). `synthesize-boundary-stress.test.ts` proves the alignments.
  */
 
 import type { CanonicalRow } from "./types.js"
@@ -34,6 +37,7 @@ export type BoundaryStressTemplate =
 	| "comma-less-city-state"
 	| "fr-prefix"
 	| "house-number-after-street"
+	| "au-uk-slash-unit"
 
 export interface BoundaryStressBaseTuple {
 	locality: string
@@ -133,15 +137,26 @@ const DE_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
 	{ locality: "Köln", region: "Nordrhein-Westfalen", postcode: "50668", country: "DE" },
 	{ locality: "Heidelberg", region: "Baden-Württemberg", postcode: "69117", country: "DE" },
 ]
+// AU/NZ/UK — the unit/street-number slash convention lives here (4/2A = unit 4, number 2A).
+const SLASH_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
+	{ locality: "North Sydney", region: "NSW", postcode: "2060", country: "AU" },
+	{ locality: "Wollongong", region: "NSW", postcode: "2500", country: "AU" },
+	{ locality: "Melbourne", region: "VIC", postcode: "3000", country: "AU" },
+	{ locality: "Auckland", region: "", postcode: "1011", country: "NZ" },
+	{ locality: "Edinburgh", region: "", postcode: "EH2 2BY", country: "GB" },
+	{ locality: "Brisbane", region: "QLD", postcode: "4000", country: "AU" },
+]
+const UNIT_DESIGNATORS = ["", "", "Unit", "Flat", "Apt", "Suite", "Shop", "Level"] as const
 
 const houseNumber = (random: () => number): string => String(1 + Math.floor(random() * 4999))
-const localeFor: Record<string, string> = { US: "en-US", AU: "en-AU", FR: "fr-FR", DE: "de-DE" }
+const localeFor: Record<string, string> = { US: "en-US", AU: "en-AU", FR: "fr-FR", DE: "de-DE", NZ: "en-NZ", GB: "en-GB" }
 
 const ALL_TEMPLATES: readonly BoundaryStressTemplate[] = [
 	"street-eats-affix",
 	"comma-less-city-state",
 	"fr-prefix",
 	"house-number-after-street",
+	"au-uk-slash-unit",
 ]
 
 /**
@@ -185,6 +200,34 @@ export function synthesizeBoundaryStressRow(
 			raw,
 			components: { street: name, house_number: hn, postcode: b.postcode, locality: b.locality },
 			locale: localeFor[b.country] ?? "fr-FR",
+			template,
+		}
+	}
+
+	if (template === "au-uk-slash-unit") {
+		const b = base ?? pick(SLASH_TUPLES, random)
+		const designator = pick(UNIT_DESIGNATORS, random)
+		const unitNum = String(1 + Math.floor(random() * 99))
+		const houseNum = String(1 + Math.floor(random() * 99)) + (random() < 0.3 ? pick(["A", "B", "C"], random) : "")
+		const unit = designator ? `${designator} ${unitNum}` : unitNum
+		const name = random() < 0.6 ? pick(SINGLE_STREETS, random) : pick(MULTIWORD_STREETS, random)
+		const suffix = pick(SUFFIXES, random)
+		// "{unit}/{houseNum} {street} {suffix}, {locality} {region?} {postcode}" — the "/" is what the
+		// model must split into unit vs street-number. AU comma-less city/state/postcode tail.
+		const tail = b.region ? `${b.locality} ${b.region} ${b.postcode}` : `${b.locality} ${b.postcode}`
+		const raw = `${unit}/${houseNum} ${name} ${suffix}, ${tail}`
+		return {
+			raw,
+			components: {
+				unit,
+				house_number: houseNum,
+				street: name,
+				street_suffix: suffix,
+				locality: b.locality,
+				...(b.region ? { region: b.region } : {}),
+				postcode: b.postcode,
+			},
+			locale: localeFor[b.country] ?? "en-AU",
 			template,
 		}
 	}

--- a/docs/articles/evals/2026-06-17-boundary-stress-baseline.md
+++ b/docs/articles/evals/2026-06-17-boundary-stress-baseline.md
@@ -12,9 +12,10 @@ the current neural model, exact-match per tag).
 | comma-less City STATE | region | **66.3%** | **34%** |
 | fr-prefix | street_prefix | **70.3%** | 70% |
 | house-number-after-street | house_number | **47.3%** | 44% |
+| au-uk-slash-unit (`4/2A`) | house_number | **38.7%** | — |
 
-(house_number, locality, postcode read ~100% on the delimited shapes — the failures are concentrated on
-the contested boundary, exactly as designed.)
+(On the delimited shapes the uncontested tags read ~100% — the failures concentrate on the contested
+boundary, exactly as designed.)
 
 ## Reading
 
@@ -28,6 +29,10 @@ the contested boundary, exactly as designed.)
 - **house-number-after-street 47%** is the fr.house_number plateau in miniature (the FR/DE
   number-follows-street order) — confirming the shipped ~87% there degrades further on stress positions,
   and that this shard's `house-number-after-street` shape targets that lever too.
+- **au-uk-slash-unit is the worst at 38.7%** — the AU/NZ/UK `4/2A` unit/street-number convention, the
+  one genuinely-new case from the #702 decomposition. The aligner's tokenizer splits on `/`, so this
+  labels cleanly (unit then house_number) and is includable in the shard; it does not collide with the
+  US `123 1/2` fraction (locale-disambiguated). This is the clearest single addressable win in the set.
 
 ## So what
 

--- a/scripts/eval/boundary-stress-baseline.ts
+++ b/scripts/eval/boundary-stress-baseline.ts
@@ -36,6 +36,7 @@ const STRESS_TAG: Record<BoundaryStressTemplate, string> = {
 	"comma-less-city-state": "region",
 	"fr-prefix": "street_prefix",
 	"house-number-after-street": "house_number",
+	"au-uk-slash-unit": "house_number",
 }
 
 const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })


### PR DESCRIPTION
Extends the #703 boundary shard with the **AU/NZ/UK slash unit-convention** (`4/2A` → unit + house_number) — correcting #703's exclusion. The aligner's tokenizer **splits on `/`**, so `4/2A` → `4`+`2A` and labels cleanly (B-unit then B-house_number, verified); it's NOT sub-token (only the punctuation-less `NY14201` glue is). Locale-gated (AU/NZ/UK), so no collision with the US `123 1/2` fraction.

This is the **worst within-token class** (#702) and the one genuinely-new addressable case. Baseline: the current model gets the slash house_number right only **38.7%** — worst of the five shapes, now covered. 7 tests pass; 3000-row build 0% quarantine across all 5 shapes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)