### PR TITLE
feat(#375): v1.6.0-boundary-stress retrain recipe (DRAFT, DeepSeek-signed)

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v1.6.0-boundary-stress.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v1.6.0-boundary-stress.yaml
@@ -1,0 +1,160 @@
+# === v1.6.0-boundary-stress (DRAFT — operator/DeepSeek sign-off + GO required) ===================
+# The #375 #1-lever pass: add the boundary-instability synthetic shard (corpus/src/
+# synthesize-boundary-stress.ts, PRs #703/#704/#705). ONE variable vs v1.5.1: + synth-boundary-stress
+# at weight 1.0. DeepSeek-signed approach (2026-06-17): base on v1.5.1 (latest stable FR-order
+# recovery), stack boundary-stress on top, conservative 1.0 weight (tune up next iteration if short).
+#
+# WHY: the failure taxonomy named boundary instability the #1 parser lever, and the within-token
+# decomposition (#702) showed it surfacing under many names. The "before" baseline
+# (docs/articles/evals/2026-06-17-boundary-stress-baseline.md) measured the current model at 38.7–70%
+# on these boundaries vs ~95%+ on clean canonical:
+#   street-eats-affix street_suffix 48.0 | comma-less region 66.3 / street 34 | fr-prefix prefix 70.3
+#   | house-number-after-street house_number 47.3 | au-uk-slash-unit house_number 38.7 (worst)
+# The shard puts the gold boundary on diverse realizations of exactly these 5 shapes (alignRow-clean,
+# 0% quarantine). It ALSO reinforces fr.house_number (the number-after-street shape).
+#
+# PRE-REGISTERED GATE (DeepSeek-signed targets; per-shape via scripts/eval/boundary-stress-baseline.ts):
+#   - street_suffix 48 → ≥55 ; comma-less region 66 → ≥80 ; fr-prefix 70 → ≥80 ;
+#     house-number-after-street 47 → ≥60 ; au-uk-slash-unit 38.7 → ≥60.
+#   NON-REGRESSION FLOORS (must hold, the v4.x ship-gate): US street ≥80.4, locality ≥72.9,
+#     unit ≥90.6, US postcode ≥97 ; affix prefix ≥78 / suffix ≥67 ; FR postcode ≥99.5,
+#     fr.house_number ≥87 (the v4.6.0 re-baseline) ; DE native-order locality ≥83.8 ; country band 83.3.
+#   WATCH (DeepSeek): street_suffix OVER-fire (its gate target vs the floor — a boundary shard can push
+#     suffix onto non-suffix tokens) ; affix CRF transition stability (prefix↔street↔suffix) — a relabel
+#     bug presents as boundary noise, not dilution. If slash/comma-less land short at 1.0, sweep the
+#     weight UP (1.5) — one variable, do not stack other changes.
+#   DECISION: targets move up + floors hold → ship candidate. Spine regression → STOP, re-audit the
+#     shard's alignment before any weight surgery.
+#
+# CORPUS PREREQUISITE (operator-machine step — NOT done here): synth-boundary-stress must be built into
+# a versioned corpus first. Generate the shard JSONL (scripts/build-boundary-stress-shard.mjs), run the
+# #511 base-consistency lint against the base corpus (lint-corpus-shard.ts — needs base corpus-stats),
+# assemble its overlay manifest (the scripts/assemble-*-overlay-manifest.py pattern), build the new
+# corpus version, then point `corpus_dir` at it. Until then this config references a TODO path.
+#
+# Launch (after the corpus build): modal run -d scripts/modal/train_remote.py \
+#   --config v1.6.0-boundary-stress.yaml --resume none
+data:
+  # TODO(operator): rebuild corpus with synth-boundary-stress, then set this to the new version.
+  corpus_dir: /data/corpus/versioned/v0.6.0-boundary-stress/corpus-v0.6.0-boundary-stress
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights:
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+  source_weights:
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    # THE #375 #1-lever variable (DeepSeek-signed 2026-06-17): the boundary-instability stress shard.
+    # Conservative 1.0 start (prevents street_suffix over-fire); sweep to 1.5 if slash/comma-less land
+    # short. ONE change vs v1.5.1 — nothing else moves.
+    synth-boundary-stress: 1.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+
+model:
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train:
+  output_dir: /data/output-v160-boundary-stress-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  max_steps: 40000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v1.6.0-boundary-stress-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""


### PR DESCRIPTION
The one-GO-away integration of the boundary-stress shard (#703–705). **One variable** vs v1.5.1: `+ synth-boundary-stress: 1.0` (DeepSeek-signed 2026-06-17: base on v1.5.1, conservative 1.0, sweep to 1.5 if short).

**Pre-registered gate** (from the #704 baseline): street_suffix 48→55, comma-less region 66→80, fr-prefix 70→80, hn-after-street 47→60, slash 38.7→60; **non-regress floors** US street ≥80.4 / locality ≥72.9 / affix 78/67 / FR-DE tripwire; **watch** street_suffix over-fire + affix CRF stability.

**Corpus prerequisite (operator-machine, NOT here):** build the shard into a versioned corpus (the #511 lint + overlay manifest) → set `corpus_dir` → `modal run`. This is a **draft for sign-off + GO** — no retrain triggered. Completes the #1-lever groundwork to one-review-away. 🤖 Generated with [Claude Code](https://claude.com/claude-code)