### PR TITLE
fix(#375): boundary shard base-locales-only — the #511 lint caught an AU contradiction

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v1.6.0-boundary-stress.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v1.6.0-boundary-stress.yaml
@@ -8,17 +8,18 @@
 # decomposition (#702) showed it surfacing under many names. The "before" baseline
 # (docs/articles/evals/2026-06-17-boundary-stress-baseline.md) measured the current model at 38.7–70%
 # on these boundaries vs ~95%+ on clean canonical:
-#   (diverse-pool baseline — the thin-pool first read inflated street_suffix to 48 / fr-prefix to 70):
-#   street-eats-affix street_suffix 40.7 / street 38 | comma-less region 74.7 / street 44 |
-#   fr-prefix prefix 47.7 / street 43 | house-number-after-street house_number 50.7 |
-#   au-uk-slash-unit house_number 38.7 / unit 39 / region 9 (worst)
+#   (diverse-pool baseline, BASE-LOCALES-ONLY US/FR/DE — the #511 lint flagged an AU-bearing draft as a
+#   real contradiction, so AU/NZ/UK + the slash shape are deferred to a separate AU-coverage shard):
+#   street-eats-affix street_suffix 40.7 / street 38 | comma-less(US) street 46 / locality 91 |
+#   fr-prefix prefix 47.7 / street 43 | house-number-after-street house_number 50.7 / street 49.
+#   The STREET span is the common casualty (38-49% across all four shapes).
 # The shard puts the gold boundary on diverse realizations of exactly these 5 shapes (alignRow-clean,
 # 0% quarantine). It ALSO reinforces fr.house_number (the number-after-street shape).
 #
 # PRE-REGISTERED GATE (DeepSeek-signed targets; per-shape via scripts/eval/boundary-stress-baseline.ts):
-#   - street_suffix 40.7 → ≥55 ; comma-less region 74.7 → ≥85 ; fr-prefix 47.7 → ≥70 ;
-#     house-number-after-street 50.7 → ≥65 ; au-uk-slash-unit 38.7 → ≥60 (anchored to the diverse
-#     baseline; the lifts are larger than the thin-pool first read implied).
+#   - street_suffix 40.7 → ≥55 ; comma-less(US) street 46 → ≥65 ; fr-prefix 47.7 → ≥70 ;
+#     house-number-after-street 50.7 → ≥65 ; AND the shared STREET span ≥65 on all four shapes
+#     (anchored to the diverse base-locale baseline).
 #   NON-REGRESSION FLOORS (must hold, the v4.x ship-gate): US street ≥80.4, locality ≥72.9,
 #     unit ≥90.6, US postcode ≥97 ; affix prefix ≥78 / suffix ≥67 ; FR postcode ≥99.5,
 #     fr.house_number ≥87 (the v4.6.0 re-baseline) ; DE native-order locality ≥83.8 ; country band 83.3.
@@ -29,11 +30,14 @@
 #   DECISION: targets move up + floors hold → ship candidate. Spine regression → STOP, re-audit the
 #     shard's alignment before any weight surgery.
 #
-# CORPUS PREREQUISITE (operator-machine step — NOT done here): synth-boundary-stress must be built into
-# a versioned corpus first. Generate the shard JSONL (scripts/build-boundary-stress-shard.mjs), run the
-# #511 base-consistency lint against the base corpus (lint-corpus-shard.ts — needs base corpus-stats),
-# assemble its overlay manifest (the scripts/assemble-*-overlay-manifest.py pattern), build the new
-# corpus version, then point `corpus_dir` at it. Until then this config references a TODO path.
+# CORPUS PREREQUISITE: the shard JSONL→parquet + the overlay manifest are BUILT (a v0.6.0-boundary-stress
+# corpus is staged at /mnt/playpen/.../corpus/versioned/v0.6.0-boundary-stress/ — assembled via
+# scripts/assemble-boundary-stress-overlay-manifest.py against the v0.5.0 base, schema-matched). Operator
+# steps: (1) `modal volume put` the parquet + manifest, (2) **run the FULL #511 base-consistency lint**
+# (build-corpus-stats over the whole base, not a sample — the night-16 sampled lint flagged distribution
+# outliers, e.g. US/FR locality tokens that read as I-street, that a source-clustered sample can't
+# resolve; if the full lint confirms a locality/street overlap, tune the shard's locality vocabulary to
+# tokens the base labels as localities). DO NOT retrain until that lint is clean. Then `modal run`.
 #
 # Launch (after the corpus build): modal run -d scripts/modal/train_remote.py \
 #   --config v1.6.0-boundary-stress.yaml --resume none

--- a/corpus/src/synthesize-boundary-stress.test.ts
+++ b/corpus/src/synthesize-boundary-stress.test.ts
@@ -78,13 +78,6 @@ describe("synthesizeBoundaryStressRow", () => {
 		expect(labels.indexOf("B-street")).toBeLessThan(labels.indexOf("B-house_number"))
 	})
 
-	it("au-uk-slash-unit: the slash splits into unit then house_number (clean BIO)", () => {
-		const labels = labelsFor("au-uk-slash-unit", 5)
-		expect(labels).toContain("B-unit")
-		expect(labels).toContain("B-house_number")
-		expect(labels.indexOf("B-unit")).toBeLessThan(labels.indexOf("B-house_number"))
-	})
-
 	it("is deterministic under a fixed seed", () => {
 		const a = synthesizeBoundaryStressRow(undefined, { random: mulberry32(42) })
 		const b = synthesizeBoundaryStressRow(undefined, { random: mulberry32(42) })

--- a/corpus/src/synthesize-boundary-stress.ts
+++ b/corpus/src/synthesize-boundary-stress.ts
@@ -9,25 +9,28 @@
  *   ambiguous or unmarked. This generator emits diverse BIO-labeled rows that put the gold boundary
  *   exactly where the model wobbles, so a retrain learns the boundary from context, not the lexeme.
  *
- *   The five token-aligned stress shapes (each component is a whitespace-separated token run, so
- *   `alignRow` labels them cleanly):
+ *   The four token-aligned stress shapes, all in BASE LOCALES (US/FR/DE) so the shard never introduces
+ *   tokens the base corpus lacks (the #511 base-consistency lint flagged an earlier AU-bearing draft:
+ *   AU 4-digit postcodes collide with US house numbers, and AU localities are absent from the US/FR/DE
+ *   base — a real contradiction). Each component is a whitespace-separated token run, so `alignRow`
+ *   labels it cleanly:
  *
  *   1. `street-eats-affix` — multi-word street + suffix (`Country Club Rd` → street + street_suffix),
  *        the #1 wobble: the model keeps the suffix in the street.
- *   2. `comma-less-city-state` — no comma between street / locality / region (`… North Sydney NSW
- *        2060`), the #694 family: concatenated input loses the segmentation cue.
+ *   2. `comma-less-city-state` — no comma between street / locality / region (`100 Main St Springfield
+ *        IL 62701`), the #694 family: concatenated input loses the segmentation cue. US-only (US zips
+ *        are base-consistent; the boundary is locale-agnostic).
  *   3. `fr-prefix` — FR street-type prefix split from the name (`Rue Jean-Baptiste Lebas` → street_prefix
  *        + street), postcode-first order.
  *   4. `house-number-after-street` — FR/DE number-follows-street (`Neuve-des-Capucines 5` → street +
  *        house_number), the model absorbs the number into the street.
- *   5. `au-uk-slash-unit` — the AU/NZ/UK unit/street-number slash (`4/2A` → unit + house_number,
- *        `Unit 11/2` → unit "Unit 11" + house_number 2). The aligner's tokenizer splits on `/`, so this
- *        labels cleanly (verified) — it does NOT collide with US `123 1/2` fractions because those are
- *        US-locale and keep `1/2` in house_number; the convention is locale-disambiguated.
  *
- *   The region+postcode glue shape (`NY14201`) is EXCLUDED — with no punctuation it stays one
- *   whitespace token spanning two components, which the token-BIO path can't label (a tokenizer
- *   concern, not a clean BIO shard case). `synthesize-boundary-stress.test.ts` proves the alignments.
+ *   EXCLUDED: the region+postcode glue (`NY14201` — sub-token, no punctuation to split) and the AU/NZ/UK
+ *   slash unit-convention (`4/2A` → unit+house_number). The slash labels cleanly (the tokenizer splits
+ *   `/`) and is the worst within-token class — but it inherently requires non-base AU/NZ/UK locales,
+ *   which contradict the US/FR/DE base (the lint catch). It belongs in a separately-scoped AU/NZ/UK
+ *   boundary-coverage shard that ALSO adds AU base coverage, not in this base-locale shard.
+ *   `synthesize-boundary-stress.test.ts` proves the alignments.
  */
 
 import type { CanonicalRow } from "./types.js"
@@ -37,7 +40,6 @@ export type BoundaryStressTemplate =
 	| "comma-less-city-state"
 	| "fr-prefix"
 	| "house-number-after-street"
-	| "au-uk-slash-unit"
 
 export interface BoundaryStressBaseTuple {
 	locality: string
@@ -142,22 +144,6 @@ const US_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
 	{ locality: "Dover", region: "DE", postcode: "19901", country: "US" },
 	{ locality: "Bozeman", region: "MT", postcode: "59715", country: "US" },
 ]
-const AU_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
-	{ locality: "North Sydney", region: "NSW", postcode: "2060", country: "AU" },
-	{ locality: "Melbourne", region: "VIC", postcode: "3000", country: "AU" },
-	{ locality: "Brisbane", region: "QLD", postcode: "4000", country: "AU" },
-	{ locality: "Mosman Park", region: "WA", postcode: "6012", country: "AU" },
-	{ locality: "Wollongong", region: "NSW", postcode: "2500", country: "AU" },
-	{ locality: "Newcastle", region: "NSW", postcode: "2300", country: "AU" },
-	{ locality: "Geelong", region: "VIC", postcode: "3220", country: "AU" },
-	{ locality: "Adelaide", region: "SA", postcode: "5000", country: "AU" },
-	{ locality: "Hobart", region: "TAS", postcode: "7000", country: "AU" },
-	{ locality: "Darwin", region: "NT", postcode: "0800", country: "AU" },
-	{ locality: "Cairns", region: "QLD", postcode: "4870", country: "AU" },
-	{ locality: "Ballarat", region: "VIC", postcode: "3350", country: "AU" },
-	{ locality: "Fremantle", region: "WA", postcode: "6160", country: "AU" },
-	{ locality: "Toowoomba", region: "QLD", postcode: "4350", country: "AU" },
-]
 const FR_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
 	{ locality: "Roubaix", region: "Hauts-de-France", postcode: "59100", country: "FR" },
 	{ locality: "Paris", region: "Île-de-France", postcode: "75014", country: "FR" },
@@ -184,36 +170,14 @@ const DE_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
 	{ locality: "Bremen", region: "Bremen", postcode: "28195", country: "DE" },
 	{ locality: "Münster", region: "Nordrhein-Westfalen", postcode: "48143", country: "DE" },
 ]
-// AU/NZ/UK — the unit/street-number slash convention lives here (4/2A = unit 4, number 2A).
-const SLASH_TUPLES: ReadonlyArray<BoundaryStressBaseTuple> = [
-	{ locality: "North Sydney", region: "NSW", postcode: "2060", country: "AU" },
-	{ locality: "Wollongong", region: "NSW", postcode: "2500", country: "AU" },
-	{ locality: "Melbourne", region: "VIC", postcode: "3000", country: "AU" },
-	{ locality: "Auckland", region: "", postcode: "1011", country: "NZ" },
-	{ locality: "Edinburgh", region: "", postcode: "EH2 2BY", country: "GB" },
-	{ locality: "Brisbane", region: "QLD", postcode: "4000", country: "AU" },
-	{ locality: "Newcastle", region: "NSW", postcode: "2300", country: "AU" },
-	{ locality: "Perth", region: "WA", postcode: "6000", country: "AU" },
-	{ locality: "Wellington", region: "", postcode: "6011", country: "NZ" },
-	{ locality: "Christchurch", region: "", postcode: "8011", country: "NZ" },
-	{ locality: "Glasgow", region: "", postcode: "G1 1XW", country: "GB" },
-	{ locality: "Manchester", region: "", postcode: "M1 1AE", country: "GB" },
-	{ locality: "Bristol", region: "", postcode: "BS1 4DJ", country: "GB" },
-	{ locality: "Adelaide", region: "SA", postcode: "5000", country: "AU" },
-	{ locality: "Hobart", region: "TAS", postcode: "7000", country: "AU" },
-	{ locality: "Canberra", region: "ACT", postcode: "2600", country: "AU" },
-]
-const UNIT_DESIGNATORS = ["", "", "Unit", "Flat", "Apt", "Suite", "Shop", "Level"] as const
-
 const houseNumber = (random: () => number): string => String(1 + Math.floor(random() * 4999))
-const localeFor: Record<string, string> = { US: "en-US", AU: "en-AU", FR: "fr-FR", DE: "de-DE", NZ: "en-NZ", GB: "en-GB" }
+const localeFor: Record<string, string> = { US: "en-US", FR: "fr-FR", DE: "de-DE" }
 
 const ALL_TEMPLATES: readonly BoundaryStressTemplate[] = [
 	"street-eats-affix",
 	"comma-less-city-state",
 	"fr-prefix",
 	"house-number-after-street",
-	"au-uk-slash-unit",
 ]
 
 /**
@@ -261,36 +225,9 @@ export function synthesizeBoundaryStressRow(
 		}
 	}
 
-	if (template === "au-uk-slash-unit") {
-		const b = base ?? pick(SLASH_TUPLES, random)
-		const designator = pick(UNIT_DESIGNATORS, random)
-		const unitNum = String(1 + Math.floor(random() * 99))
-		const houseNum = String(1 + Math.floor(random() * 99)) + (random() < 0.3 ? pick(["A", "B", "C"], random) : "")
-		const unit = designator ? `${designator} ${unitNum}` : unitNum
-		const name = random() < 0.6 ? pick(SINGLE_STREETS, random) : pick(MULTIWORD_STREETS, random)
-		const suffix = pick(SUFFIXES, random)
-		// "{unit}/{houseNum} {street} {suffix}, {locality} {region?} {postcode}" — the "/" is what the
-		// model must split into unit vs street-number. AU comma-less city/state/postcode tail.
-		const tail = b.region ? `${b.locality} ${b.region} ${b.postcode}` : `${b.locality} ${b.postcode}`
-		const raw = `${unit}/${houseNum} ${name} ${suffix}, ${tail}`
-		return {
-			raw,
-			components: {
-				unit,
-				house_number: houseNum,
-				street: name,
-				street_suffix: suffix,
-				locality: b.locality,
-				...(b.region ? { region: b.region } : {}),
-				postcode: b.postcode,
-			},
-			locale: localeFor[b.country] ?? "en-AU",
-			template,
-		}
-	}
-
-	// en-US / en-AU street shapes.
-	const b = base ?? pick(template === "comma-less-city-state" ? [...US_TUPLES, ...AU_TUPLES] : US_TUPLES, random)
+	// en-US street shapes (street-eats-affix + comma-less). US-only — US zips are base-consistent and
+	// the boundary these teach is locale-agnostic; no need to introduce a non-base locale.
+	const b = base ?? pick(US_TUPLES, random)
 	const hn = houseNumber(random)
 	const dir = random() < 0.4 ? pick(DIRECTIONALS, random) : ""
 	const name = random() < 0.7 ? pick(MULTIWORD_STREETS, random) : pick(SINGLE_STREETS, random)

--- a/docs/articles/evals/2026-06-17-boundary-stress-baseline.md
+++ b/docs/articles/evals/2026-06-17-boundary-stress-baseline.md
@@ -4,49 +4,60 @@ The failure taxonomy named boundary instability the #1 parser lever and the with
 (#702) showed it surfacing under many names. The boundary-stress shard (#703) is the training-data fix.
 This is the **"before" baseline** — how badly today's model places these boundaries, on the exact
 synthetic shapes the shard teaches (`scripts/eval/boundary-stress-baseline.ts`, 300 rows/shape through
-the current neural model, exact-match per tag).
+the current neural model, exact-match per tag). The shard is **base-locales-only (US/FR/DE)** — see the
+base-consistency section for why.
 
-| stress shape | stress tag | stress-tag accuracy | street accuracy |
+| stress shape | stress tag | accuracy | street accuracy |
 | --- | --- | --: | --: |
 | street-eats-affix | street_suffix | **40.7%** | 38% |
-| comma-less City STATE | region | **74.7%** | street 44 / locality 65 |
+| comma-less City ST | street | **46%** | (locality 91, region 100) |
 | fr-prefix | street_prefix | **47.7%** | 43% |
 | house-number-after-street | house_number | **50.7%** | 49% |
-| au-uk-slash-unit (`4/2A`) | house_number | **38.7%** | unit 39 / region 9 |
 
 (On the delimited shapes the uncontested tags read ~100% — the failures concentrate on the contested
-boundary, exactly as designed.)
+boundary, exactly as designed. US comma-less locality/region are easy at 91/100%; the *street* span is
+the casualty there too.)
 
 **Diversity correction (the runbook's point, measured):** an initial thin-pool shard (~16 streets, ~7
-tuples) gave an *inflated* baseline — street_suffix read 48% and fr-prefix 70% because the few lexemes
-were memorizable. Expanding the pools ~3× (≈100 distinct streets, 28 US / 14 AU / 12 FR / 10 DE tuples,
-~100% unique rows) drops those to **40.7% / 47.7%** — the *true* gap on the real distribution. This is
-exactly why CONTRIBUTING_MODEL_WORK gates on diversity ("thin diversity teaches lexical pattern-matching,
-not the boundary"): a thin shard would have taught the lexemes and a thin baseline would have hidden the
-gap. The numbers above are the diverse-pool measurement.
+tuples) gave an *inflated* baseline — street_suffix read 48%, fr-prefix 70% — because the few lexemes
+were memorizable. Expanding the pools ~3× (≈100 distinct streets, 28 US / 12 FR / 10 DE tuples, ~100%
+unique rows) drops those to **40.7% / 47.7%** — the true gap on the real distribution. Exactly why
+CONTRIBUTING_MODEL_WORK gates on diversity: a thin shard teaches lexemes and a thin baseline hides the gap.
+
+## Base-consistency (#511 lint) — the gate caught a real contradiction
+
+Running the #511 base-consistency lint (`lint-corpus-shard.ts` against sampled `v0.5.0` base-stats)
+caught two things, only one of them a true problem:
+
+- **AU content was a real contradiction → FIXED.** An earlier draft used AU/NZ/UK tuples (for an
+  `au-uk-slash-unit` shape + AU comma-less). AU isn't a base locale (the base is US/FR/DE), and **AU
+  4-digit postcodes collide with US house numbers** (`3000` is a common US street number). The lint
+  flagged it; the shard is now **base-locales-only**, and the AU/UK slash convention (the worst
+  within-token class, #702) is deferred to a separately-scoped AU/NZ/UK shard that also adds AU **base
+  coverage** — it cannot ride a US/FR/DE shard without contradicting the base.
+- **Residual distribution-outlier flags are likely sampling artifacts.** The lint also flags US/FR
+  localities (`Paris`, `Springfield`, `Toulouse`) as B-locality where the *sampled* base majority is
+  I-street — but the sample (a by-index spread of 20/685 shards) is source-clustered and TIGER-street-
+  heavy, undersampling the WOF/admin shards that carry localities. And the street_suffix/street_prefix
+  flags are train-time-relabel artifacts (the lint compares pre-relabel parquets; the affix-relabel
+  lexicon — verified — maps every one of the shard's suffixes/directionals). **The proper gate is the
+  full-corpus lint on the operator's machine** (the 680M-row base-stats); it will resolve whether the
+  locality/street overlap is real, and if so the shard's locality vocabulary should be tuned to tokens
+  the base labels as localities. The shard must not ship to a retrain until that lint is clean.
 
 ## Reading
 
-- The model is **42–70%** on the boundary-stress cases vs ~95%+ on clean canonical addresses — the gap
-  is large and real, not a measurement artifact. These are the rows the #1 lever is about.
-- **Comma-less is the worst** (street **34%**, locality 59%): stripping the delimiter cue collapses the
-  segmentation — the same #694 finding (concatenated input loses the boundary), now measured on the
-  parser side, not just the geocoder.
-- **The street boundary is the common casualty** (42% / 34% / 44% across three shapes): when an adjacent
-  component is ambiguous, the street span absorbs or surrenders tokens. One failure, many faces.
-- **house-number-after-street 47%** is the fr.house_number plateau in miniature (the FR/DE
-  number-follows-street order) — confirming the shipped ~87% there degrades further on stress positions,
-  and that this shard's `house-number-after-street` shape targets that lever too.
-- **au-uk-slash-unit is the worst at 38.7%** — the AU/NZ/UK `4/2A` unit/street-number convention, the
-  one genuinely-new case from the #702 decomposition. The aligner's tokenizer splits on `/`, so this
-  labels cleanly (unit then house_number) and is includable in the shard; it does not collide with the
-  US `123 1/2` fraction (locale-disambiguated). This is the clearest single addressable win in the set.
+- The model is **38–51%** on the boundary-stress cases vs ~95%+ on clean canonical — a large, real gap.
+- **The street boundary is the common casualty** (38% / 46% / 43% / 49% across all four shapes): when an
+  adjacent component is ambiguous, the street span absorbs or surrenders tokens. One failure, many faces.
+- **house-number-after-street 51%** is the fr.house_number plateau in miniature (the FR/DE
+  number-follows-street order) — this shard's `house-number-after-street` shape targets that lever too.
 
 ## So what
 
-The shard (#703) puts the gold boundary on diverse realizations of exactly these shapes. The retrain's
-success criterion is moving these four numbers up without regressing the clean canonical per-locale F1
-(the US/FR/DE tripwire) — one variable, gated, per `CONTRIBUTING_MODEL_WORK`. This table is what the
-retrain is measured against.
+The shard puts the gold boundary on diverse realizations of these shapes. The retrain's success
+criterion (the `v1.6.0-boundary-stress` recipe gate): move these four numbers up without regressing the
+clean canonical per-locale F1 (the US/FR/DE tripwire) and the affix floors — one variable, gated, per
+`CONTRIBUTING_MODEL_WORK`, **after the full-corpus #511 lint is clean**.
 
 _Source: `scripts/eval/boundary-stress-baseline.ts` over `corpus/src/synthesize-boundary-stress.ts`._

--- a/scripts/eval/boundary-stress-baseline.ts
+++ b/scripts/eval/boundary-stress-baseline.ts
@@ -33,10 +33,9 @@ function mulberry32(seed: number): () => number {
 // The stress tag each shape is built to teach (the boundary the model wobbles on).
 const STRESS_TAG: Record<BoundaryStressTemplate, string> = {
 	"street-eats-affix": "street_suffix",
-	"comma-less-city-state": "region",
+	"comma-less-city-state": "street",
 	"fr-prefix": "street_prefix",
 	"house-number-after-street": "house_number",
-	"au-uk-slash-unit": "house_number",
 }
 
 const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })


### PR DESCRIPTION
Ran the #511 base-consistency lint on the boundary shard. **It caught a real contradiction:** the AU/NZ/UK content (slash shape + AU comma-less) introduces tokens absent from the US/FR/DE base, and **AU 4-digit postcodes collide with US house numbers** (`3000` is a common US street number) — the #511 trap.

**Fix: base-locales-only (US/FR/DE).** Dropped the slash shape (inherently AU/NZ/UK → deferred to a separately-scoped AU shard with AU base coverage); comma-less → US-only. Lint errors **111→58**; residual = train-time-relabel artifacts (affix, verified vs lexicon) + likely sampling artifacts (a source-clustered 20/685-shard spread reads localities as I-street). The **full-corpus lint (operator machine) is the real gate** — recipe + baseline doc now require it clean before retraining.

4 shapes, 6 tests pass, 0% quarantine. The STREET span is the common casualty (38–49%). The eval gate doing its job (#478/#566-style). 🤖 Generated with [Claude Code](https://claude.com/claude-code)