### PR TITLE
docs(#375): correct the #511 finding — locality/street overlap is REAL

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v1.6.0-boundary-stress.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v1.6.0-boundary-stress.yaml
@@ -34,10 +34,13 @@
 # corpus is staged at /mnt/playpen/.../corpus/versioned/v0.6.0-boundary-stress/ — assembled via
 # scripts/assemble-boundary-stress-overlay-manifest.py against the v0.5.0 base, schema-matched). Operator
 # steps: (1) `modal volume put` the parquet + manifest, (2) **run the FULL #511 base-consistency lint**
-# (build-corpus-stats over the whole base, not a sample — the night-16 sampled lint flagged distribution
-# outliers, e.g. US/FR locality tokens that read as I-street, that a source-clustered sample can't
-# resolve; if the full lint confirms a locality/street overlap, tune the shard's locality vocabulary to
-# tokens the base labels as localities). DO NOT retrain until that lint is clean. Then `modal run`.
+# (build-corpus-stats over the whole base). The night-16 sampled lint found a REAL locality/street
+# overlap: common US city names (Paris, Springfield) appear predominantly as STREET tokens in the base
+# (usgov-nad/tiger), so the shard's B-locality is the minority sense (the "5th Avenue Theatre" class).
+# The CRF is context-aware and may resolve it — so WATCH the per-locale F1 for locality-token regression
+# in the retrain; if it regresses, tune the shard's locality vocabulary to distinctive cities the base
+# labels as localities. (The affix-tag flags are train-time-relabel artifacts — safe, lexicon-verified.)
+# DO NOT retrain until the full lint is clean OR the overlap is confirmed context-resolved. Then `modal run`.
 #
 # Launch (after the corpus build): modal run -d scripts/modal/train_remote.py \
 #   --config v1.6.0-boundary-stress.yaml --resume none

--- a/docs/articles/evals/2026-06-17-boundary-stress-baseline.md
+++ b/docs/articles/evals/2026-06-17-boundary-stress-baseline.md
@@ -35,15 +35,19 @@ caught two things, only one of them a true problem:
   flagged it; the shard is now **base-locales-only**, and the AU/UK slash convention (the worst
   within-token class, #702) is deferred to a separately-scoped AU/NZ/UK shard that also adds AU **base
   coverage** — it cannot ride a US/FR/DE shard without contradicting the base.
-- **Residual distribution-outlier flags are likely sampling artifacts.** The lint also flags US/FR
-  localities (`Paris`, `Springfield`, `Toulouse`) as B-locality where the *sampled* base majority is
-  I-street — but the sample (a by-index spread of 20/685 shards) is source-clustered and TIGER-street-
-  heavy, undersampling the WOF/admin shards that carry localities. And the street_suffix/street_prefix
-  flags are train-time-relabel artifacts (the lint compares pre-relabel parquets; the affix-relabel
-  lexicon — verified — maps every one of the shard's suffixes/directionals). **The proper gate is the
-  full-corpus lint on the operator's machine** (the 680M-row base-stats); it will resolve whether the
-  locality/street overlap is real, and if so the shard's locality vocabulary should be tuned to tokens
-  the base labels as localities. The shard must not ship to a retrain until that lint is clean.
+- **The affix-tag flags ARE artifacts; the locality/street overlap is REAL.** Two residual classes:
+  - *street_suffix / street_prefix* flags (`Ave`/`Place`/`NW` → suffix/prefix) are **train-time-relabel
+    artifacts** — the lint compares pre-relabel parquets, and the affix-relabel lexicon (verified) maps
+    every one of the shard's suffixes + directionals. Safe.
+  - *locality/street* flags (`Paris`, `Springfield`, `Toulouse` → B-locality) are **real**. The base
+    shards are source-homogeneous (part-0000–~199 = wof-admin localities; ~342+ = usgov-nad US streets),
+    and across the full base these common city names appear *predominantly as street tokens* (countless
+    "Paris Ave" / "Springfield St"), so the base's token-majority is I-street and the shard's B-locality
+    is the minority sense — the "5th Avenue Theatre" #511 class. The model is context-aware (a token
+    after `street+suffix+comma` is a locality), so the CRF may resolve it, but the retrain MUST watch for
+    locality-token regression, and a safer shard would draw locality names the base labels as localities
+    (distinctive cities), tunable against the full base-stats. **The full-corpus lint is the gate — do
+    not retrain until it's clean OR the overlap is confirmed context-resolved by the per-locale F1.**
 
 ## Reading
 


### PR DESCRIPTION
Checked the base shards' per-row `source` column: they're source-homogeneous + ordered (part-0000–~199 wof-admin localities; ~342+ usgov-nad US streets). This confirms my first-12 sample was all wof-admin (no streets → the street_suffix vacuum flags were artifacts) — **but** reveals the locality/street overlap is **real**: across the full base, common city names (Paris, Springfield) are predominantly **street** tokens, so the shard's B-locality is the minority sense (the '5th Avenue Theatre' #511 class). My earlier doc understated it as 'likely artifact' — corrected. The CRF may resolve it by context, but the retrain must watch locality-token regression / tune the locality vocab. Affix flags remain safe (lexicon-verified). 🤖 Generated with [Claude Code](https://claude.com/claude-code)