### PR TITLE
feat(#694): flip geocoder ingest to comma-join + normalizeCase (validated, neutral on dedup)

### DIFF
--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -68,7 +68,7 @@ export type ShardResolver = (stateSlug: string | null) => StateShards
 
 /** The minimal classifier surface the cascade needs (a `NeuralAddressClassifier` satisfies it). */
 export interface GeocodeClassifier {
-	parse(text: string, opts?: { postcodeRepair?: boolean }): Promise<AddressTree>
+	parse(text: string, opts?: { postcodeRepair?: boolean; normalizeCase?: boolean }): Promise<AddressTree>
 }
 
 export interface GeocodeDeps {
@@ -78,6 +78,13 @@ export interface GeocodeDeps {
 	shards?: ShardResolver
 	/** Country constraint passed to the resolver (e.g. `"US"`). */
 	defaultCountry?: string
+	/**
+	 * Title-case all-caps ASCII input before the model (#690), detection-gated so mixed-case + non-Latin
+	 * pass through untouched. **Default `true`** — validated-beneficial on this geocode/resolveTree path
+	 * (#619: TX-facility locality 90.1 → 99.7%). The #694 comma-less crater was the space-join, not the
+	 * casing, so on comma-joined input it is a clean win. Set `false` to restore the legacy raw-case parse.
+	 */
+	normalizeCase?: boolean
 	/**
 	 * Interpolation-radius conformal calibration (#374) so reported radii are an honest ~90% bound;
 	 * `1` or `undefined` keeps the raw half-segment heuristic. Accepts either a single multiplier
@@ -253,7 +260,7 @@ export class ShardProvider {
  * parse/resolve error — callers doing batch work should catch per-row.
  */
 export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<GeocodeResult> {
-	const tree = recognizeUsRegions(await deps.classifier.parse(input, { postcodeRepair: true }))
+	const tree = recognizeUsRegions(await deps.classifier.parse(input, { postcodeRepair: true, normalizeCase: deps.normalizeCase ?? true }))
 	const stateSlug = regionSlugFromTree(tree)
 	const { addressPoints, interpolation } = deps.shards?.(stateSlug) ?? {}
 

--- a/registry/ingest.test.ts
+++ b/registry/ingest.test.ts
@@ -103,19 +103,19 @@ describe("ingestRows", () => {
 		expect(a!.phone).toBe("503-555-0100")
 		expect(a!.email).toBe("bob@acme.org") // lowercased
 		expect(a!.address?.geocode?.tier).toBe("address_point")
-		// The address column-join feeds the geocoder.
-		expect(a!.address?.formatted).toBe("123 Main St Portland OR 97201")
+		// The address column-join feeds the geocoder (comma-joined by default; #694 flip).
+		expect(a!.address?.formatted).toBe("123 Main St, Portland, OR, 97201")
 
 		expect(b!.name).toEqual({ given: "Maria", family: "Garcia" })
 		expect(b!.organization).toBeUndefined() // empty org column
 		expect(b!.phone).toBeUndefined()
 	})
 
-	it("joins a multi-column address with addressSeparator when set, space otherwise (#694)", async () => {
+	it("comma-joins a multi-column address by default, space when overridden (#694 flip)", async () => {
 		const [dflt] = await ingestRows(parseCsv(CSV), mapping, { geocodeAddress: stubGeocode })
-		expect(dflt!.address?.formatted).toBe("123 Main St Portland OR 97201") // default: space (byte-stable)
-		const [comma] = await ingestRows(parseCsv(CSV), mapping, { geocodeAddress: stubGeocode, addressSeparator: ", " })
-		expect(comma!.address?.formatted).toBe("123 Main St, Portland, OR, 97201") // delimited for the parser
+		expect(dflt!.address?.formatted).toBe("123 Main St, Portland, OR, 97201") // default: comma-join (#694, validated)
+		const [space] = await ingestRows(parseCsv(CSV), mapping, { geocodeAddress: stubGeocode, addressSeparator: " " })
+		expect(space!.address?.formatted).toBe("123 Main St Portland OR 97201") // override → legacy space-join (byte-stable A/B)
 	})
 
 	it("falls back to the row index when no id column maps", async () => {

--- a/registry/ingest.ts
+++ b/registry/ingest.ts
@@ -177,8 +177,10 @@ export interface IngestOptions {
 	 * `" "`. Pass `", "` to give the parser delimited input (`"214 Main St, Austin, TX 78701"`) instead
 	 * of a concatenated run (`"214 Main St Austin TX 78701"`) — the latter strips the parser's
 	 * segmentation boundaries and is partly OOD (it also breaks all-caps case-normalization; #694).
-	 * Default-OFF (`" "`) so existing callers + the space-trained dedup GBT stay byte-stable; opt into
-	 * `", "` for new geocode/record-matcher flows after validating the parse shift.
+	 * **Default `", "` (#694 flip, validated).** Comma-join is the correct shape for an address built
+	 * from separate columns, and #700 measured it at +15% cross-dataset rooftop (579→667) with no
+	 * comma-less crater. The dedup GBT was trained on the old space-joined coords, so this flip is paired
+	 * with a GBT re-validation (#694). Pass `" "` to restore the legacy space-join for a byte-stable A/B.
 	 */
 	addressSeparator?: string
 }
@@ -217,7 +219,7 @@ export async function ingestRows(
 		const id = (mapping.id ? row[mapping.id]?.trim() : "") || String(index)
 		const nameValue = pick(row, mapping.name)
 		const orgValue = pick(row, mapping.organization)
-		const addressValue = pick(row, mapping.address, opts.addressSeparator ?? " ")
+		const addressValue = pick(row, mapping.address, opts.addressSeparator ?? ", ")
 
 		let attributes: Record<string, string> | undefined
 		if (mapping.attributes) {

--- a/scripts/record-matcher/nppes-dedup-benchmark.ts
+++ b/scripts/record-matcher/nppes-dedup-benchmark.ts
@@ -58,6 +58,10 @@ const WOF = arg("wof", "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db
 const DATA_ROOT = arg("data-root", "/mnt/playpen/mailwoman-data")
 const OUT_MD = arg("out-md", "")
 const TRAIN_EM = !process.argv.includes("--no-train-em")
+// #694 A/B: `--legacy-join` reproduces the pre-flip ingest (space-joined address columns + normalizeCase
+// OFF). Default (no flag) is the validated flip: comma-join (the correct address shape) + #690 all-caps
+// normalization. Same data + GBT, only the flip toggled — so a delta here is attributable to the flip.
+const LEGACY = process.argv.includes("--legacy-join")
 // Optional A/B: a path to a trained dedup-gbt TS module (exports DEDUP_GBT_MODEL + DEDUP_GBT_META) to
 // score alongside the shipped GBT at both truth levels — e.g. grade the #625 corroboration candidate.
 const CANDIDATE = arg("candidate", "")
@@ -238,6 +242,7 @@ async function main(): Promise<void> {
 				shards: shardProvider.for,
 				defaultCountry: "US",
 				placeCountry: false,
+				normalizeCase: !LEGACY,
 			})
 			if (g.lat !== null) geo++
 			return g
@@ -255,7 +260,10 @@ async function main(): Promise<void> {
 		attributes: { authorizedOfficial: "auth", entityTruth: "entityId" },
 		source: "nppes",
 	}
-	const records = await ingestRows(rows as unknown as Record<string, string>[], mapping, { geocodeAddress: seam })
+	const records = await ingestRows(rows as unknown as Record<string, string>[], mapping, {
+		geocodeAddress: seam,
+		addressSeparator: LEGACY ? " " : ", ",
+	})
 	shardProvider.close()
 	lookup.close()
 	console.error(`    geocoded ${geo}/${rows.length} (${((100 * geo) / rows.length).toFixed(1)}%)`)


### PR DESCRIPTION
Graduates the #700-validated config to the defaults. The #694 root-cause: `ingestRows` space-joined address columns (`"214 Main St Austin TX"`), stripping the parser's segmentation cue and breaking the #690 all-caps fix on the comma-less run.

## Changes
- **`registry/ingest.ts`** — `IngestOptions.addressSeparator` default `" "` → `", "` (an address from separate columns is comma-delimited). ingestRows is matcher-only; pass `" "` for a byte-stable legacy A/B.
- **`mailwoman/geocode-core.ts`** — new `GeocodeDeps.normalizeCase`, threaded to `classifier.parse`, **default `true`**. Validated-beneficial on this exact geocode/resolveTree path (#619: TX locality 90.1→99.7%), detection-gated (no-op on mixed-case + non-Latin). **Blast radius includes the CLI/server geocode path** — flagged for your call; set `normalizeCase:false` to opt a caller out.
- **`nppes-dedup-benchmark.ts`** — `--legacy-join` A/B toggle.

## Validation
- **#700 (cross-dataset):** comma-join + #690 = **+15% rooftop** (579→667), cross-source links 23→25, no crater.
- **NPPES dedup A/B at scale (500 TX NPIs, 1366 records, 100% geocoded both) — NEW vs LEGACY:**

  | truth | NEW | LEGACY | Δ |
  |---|---|---|---|
  | NPI F1 (coord-independent) | 61.5% | 61.5% | 0.0 |
  | NPI over-merge | 45 | 45 | 0 |
  | site F1 | 62.7% | 61.7% | +1.0 |
  | org-name F1 | 66.2% | 66.1% | +0.1 |
  | org-name-coord F1 | 68.0% | 69.0% | −1.0* |

  \*within the benchmark's ±2pp noise + confounded (the coord-blocked grain's truth shifts with the coords). The **coord-independent NPI truth and its over-merge are identical** → the space-trained GBT holds on the new comma-coords, **no re-train needed on this evidence**. The +15% rooftop lands at no dedup cost.

Consequential record-matcher behavior change — flagged for your bless, not self-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)