### PR TITLE
feat(#375): stage v1.6.0 retrain bundle — conventions loss-mask + expanded gate

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v1.6.0-boundary-stress.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v1.6.0-boundary-stress.yaml
@@ -1,8 +1,23 @@
 # === v1.6.0-boundary-stress (DRAFT — operator/DeepSeek sign-off + GO required) ===================
 # The #375 #1-lever pass: add the boundary-instability synthetic shard (corpus/src/
-# synthesize-boundary-stress.ts, PRs #703/#704/#705). ONE variable vs v1.5.1: + synth-boundary-stress
-# at weight 1.0. DeepSeek-signed approach (2026-06-17): base on v1.5.1 (latest stable FR-order
-# recovery), stack boundary-stress on top, conservative 1.0 weight (tune up next iteration if short).
+# synthesize-boundary-stress.ts, PRs #703/#704/#705) at weight 1.0 on top of v1.5.1 (latest stable
+# FR-order recovery). DeepSeek-signed (2026-06-17): conservative 1.0 weight, tune up next iteration if short.
+#
+# BUNDLE (DeepSeek-validated 2026-06-17 — the rule is "one CONFOUNDING variable per run, each change its
+# own gate row"). The boundary shard is the headline data-mix variable. Riding alongside it, NON-confounding
+# because they don't shift the distribution the shard trains on, three additions, each gated below:
+#   (a) use_conventions_loss_mask ON — a loss-level legality mask (different axis, can't compete for
+#       capacity). READY NOW (built #478, enabled below).
+#   (c) an EXPANDED gate grading the FR/DE composition wins the shard already trains for free
+#       (fr.house_number #564, FR street_prefix, number-after-street #435). READY NOW (gate rows below).
+#   (b) [NOT ride-ready — a focused #517 corpus task, do it first if you want it this run] extend
+#       synth-po-box for NZ + military. It's more than leaders: the synthesizer needs an en-NZ template +
+#       `countryToLocale` NZ→en-NZ + a NEW military template (CMR/PSC/Unit + Box, APO/FPO/DPO + AE/AP/AA —
+#       which the leader-based model doesn't fit), and the shard builder needs NZ/military base tuples +
+#       a rebuild. Low-confounding (additive on the po_box tag) once built, but it isn't built yet.
+# Competing new shards (typo-inject, non-Latin) are deliberately NOT bundled — same-axis capacity
+# competition is the v4.2.0 trap (affix 78→27). DeepSeek also flagged a per-locale CRF transition penalty
+# (street→cedex) as a clean future rider; it needs wiring (crf_loss_weight is 0.0) so it's a later run.
 #
 # WHY: the failure taxonomy named boundary instability the #1 parser lever, and the within-token
 # decomposition (#702) showed it surfacing under many names. The "before" baseline
@@ -13,7 +28,7 @@
 #   street-eats-affix street_suffix 40.7 / street 38 | comma-less(US) street 46 / locality 91 |
 #   fr-prefix prefix 47.7 / street 43 | house-number-after-street house_number 50.7 / street 49.
 #   The STREET span is the common casualty (38-49% across all four shapes).
-# The shard puts the gold boundary on diverse realizations of exactly these 5 shapes (alignRow-clean,
+# The shard puts the gold boundary on diverse realizations of exactly these 4 shapes (alignRow-clean,
 # 0% quarantine). It ALSO reinforces fr.house_number (the number-after-street shape).
 #
 # PRE-REGISTERED GATE (DeepSeek-signed targets; per-shape via scripts/eval/boundary-stress-baseline.ts):
@@ -29,6 +44,16 @@
 #     weight UP (1.5) — one variable, do not stack other changes.
 #   DECISION: targets move up + floors hold → ship candidate. Spine regression → STOP, re-audit the
 #     shard's alignment before any weight surgery.
+#
+#   BUNDLE GATE ROWS (each rider attributable on its own; DeepSeek-validated non-confounding):
+#   - conventions loss-mask: ZERO per-locale impossible-label emissions in the eval (the mask's job), AND
+#     no regression on the non-regression floors above (a legality mask must not cost legal recall).
+#   - po_box NZ + military [ONLY IF rider (b) is built first]: the postal arena po_box class 0/4 → >0 (and
+#     military 0/3 → >0), with NO US/FR/CA po_box regression (existing synth-po-box rows only extended).
+#   - FREE-RIDER MEASURES (the shard trains these — grade as wins, not just floors): fr.house_number holds
+#     ≥87 AND targets the plateau-break >87 (#564) ; FR street_prefix (the fr-prefix shape) up ;
+#     number-after-street house_number (the hn-after shape, #435/#444) up. A lift is a free win; a DROP
+#     means the shard's FR/DE shapes are fighting the native-order shards — STOP and re-audit.
 #
 # CORPUS PREREQUISITE: the shard JSONL→parquet + the overlay manifest are BUILT (a v0.6.0-boundary-stress
 # corpus is staged at /mnt/playpen/.../corpus/versioned/v0.6.0-boundary-stress/ — assembled via
@@ -103,6 +128,11 @@ model:
   label_smoothing: 0.1
   use_locale_conditioning: true
   locale_loss_weight: 0.3
+  # #694-bundle rider (DeepSeek-validated 2026-06-17, NON-confounding): a loss-level legality constraint,
+  # not a data-mix change, so it cannot compete for capacity with the boundary shard. Masks per-locale
+  # IMPOSSIBLE label emissions (e.g. a US address emitting a French CEDEX). Built for #478, dormant until
+  # now. Its own gate row below — enable + watch, attributable independently of the shard.
+  use_conventions_loss_mask: true
   use_postcode_anchor: true
   use_gazetteer_anchor: true
   gazetteer_feature_dim: 5


### PR DESCRIPTION
Stages the DeepSeek-validated, non-confounding riders onto the boundary-shard retrain recipe so one GPU run banks more, attributable, wins. Recipe stays **DRAFT** (operator GO + the full #511 lint still gate it).

Reframe (DeepSeek 2026-06-17): the rule is **"one *confounding* variable per run, each change its own gate row."** A change only confounds the boundary result if it shifts the data distribution the shard trains on.

## Riders (each with its own pre-registered gate row)
- **(a) `use_conventions_loss_mask: true`** — READY. A loss-level per-locale legality mask (US can't emit a French CEDEX), built for #478 and dormant until now. Different axis from the data-mix shards → can't compete for capacity. DeepSeek: *"loss-level constraint, not a data change — enable it."*
- **(c) Expanded gate** — READY. Grades the FR/DE composition wins the boundary shard already trains for free: fr.house_number (#564, target the >87 plateau-break), FR street_prefix, number-after-street (#435/#444). A lift = free win; a drop = the shard fighting the native-order shards → STOP.
- **(b) po_box NZ + military** — **scoped OUT** as a focused #517 corpus task. It's more than leaders (needs an en-NZ template + a new military template for the CMR/Unit/Box + APO/AE shape + base tuples + a rebuild), so it's marked NOT-ride-ready in the recipe.

DeepSeek's per-locale CRF transition-penalty (street→cedex) is noted as a clean future run (needs wiring; `crf_loss_weight` is 0.0). Competing new shards (typo-inject, non-Latin) deliberately NOT bundled — the v4.2.0 capacity trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)