### PR TITLE
feat(#517): po_box synthesizer — NZ leaders + region-less format + US military class

### DIFF
--- a/corpus/src/synthesize-po-box.test.ts
+++ b/corpus/src/synthesize-po-box.test.ts
@@ -5,13 +5,16 @@
  */
 
 import { describe, expect, it } from "vitest"
+import { alignRow } from "./align.js"
 import {
 	composePoBoxPhrase,
 	countryToLocale,
 	maybeNoisifyBoxNumber,
 	supportedLocales,
+	synthesizeMilitaryPoBoxRow,
 	synthesizePoBoxRow,
 } from "./synthesize-po-box.js"
+import type { CanonicalRow } from "./types.js"
 
 // Deterministic RNG for reproducible tests.
 function seededRandom(seed: number): () => number {
@@ -71,6 +74,18 @@ describe("synthesizePoBoxRow", () => {
 		expect(row!.components.po_box!).toMatch(/^(Casilla|Casilla de Correo|CC) 55$/)
 	})
 
+	it("NZ: Private Bag / Private Box leaders, region-less format (#517)", () => {
+		const row = synthesizePoBoxRow(
+			{ locality: "Auckland", region: "", postcode: "1010", country: "NZ" },
+			{ random: seededRandom(5), pickNumber: () => "12" }
+		)
+		expect(row).not.toBeNull()
+		expect(row!.locale).toBe("en-NZ")
+		expect(row!.components.po_box!).toMatch(/^(PO Box|P\.O\. Box|Post Office Box|Private Bag|Private Box) 12$/)
+		expect(row!.components.region).toBeUndefined() // NZ: no region token between locality and postcode
+		expect(row!.raw).toBe(`${row!.components.po_box}, Auckland 1010`)
+	})
+
 	it("PMB variant: when locale supports it and street is provided", () => {
 		// pmbRatio=1.0 forces PMB path
 		const row = synthesizePoBoxRow(
@@ -126,6 +141,36 @@ describe("synthesizePoBoxRow", () => {
 		)
 		// po_box component is the WHOLE span ("PO Box 5"), not just "5"
 		expect(row!.components.po_box!.split(/\s+/).length).toBeGreaterThanOrEqual(2)
+	})
+})
+
+describe("synthesizeMilitaryPoBoxRow (#517)", () => {
+	it("generates a unit-line po_box + APO/FPO/DPO locality + AA/AE/AP region + theatre ZIP", () => {
+		const row = synthesizeMilitaryPoBoxRow({ random: seededRandom(7) })
+		expect(row.template).toBe("military-po-box")
+		expect(row.locale).toBe("en-US")
+		expect(row.components.po_box!).toMatch(/^(PSC|CMR|Unit) \d+( Box \d+)?$/)
+		expect(["APO", "FPO", "DPO"]).toContain(row.components.locality)
+		expect(["AA", "AE", "AP"]).toContain(row.components.region)
+		expect(row.components.postcode!).toMatch(/^\d{5}$/)
+		// Every component must be a verbatim substring of raw (the BIO aligner needs this).
+		for (const v of [row.components.po_box, row.components.locality, row.components.region, row.components.postcode]) {
+			expect(row.raw).toContain(v!)
+		}
+	})
+
+	it("aligns cleanly through alignRow (po_box + locality + region + postcode, no quarantine)", () => {
+		// Seeds chosen to cover a box-bearing (PSC/CMR) and a bare (Unit) line.
+		for (const seed of [11, 23, 42, 7, 100]) {
+			const row = synthesizeMilitaryPoBoxRow({ random: seededRandom(seed) })
+			const canonical = { ...row, source: "synth-po-box", source_id: `mil:${seed}` } as CanonicalRow
+			const result = alignRow(canonical)
+			expect(result.kind, `should align, raw=${row.raw}`).toBe("labeled")
+			if (result.kind !== "labeled") continue
+			expect(result.row.labels).toContain("B-po_box")
+			expect(result.row.labels).toContain("B-locality")
+			expect(result.row.labels).toContain("B-postcode")
+		}
 	})
 })
 

--- a/corpus/src/synthesize-po-box.ts
+++ b/corpus/src/synthesize-po-box.ts
@@ -66,6 +66,10 @@ export const PO_BOX_LOCALE_TEMPLATES: ReadonlyArray<LocaleTemplate> = [
 		leaders: ["PO Box", "P.O. Box", "Post Office Box", "GPO Box", "Locked Bag"],
 	},
 	{
+		locale: "en-NZ",
+		leaders: ["PO Box", "P.O. Box", "Post Office Box", "Private Bag", "Private Box"],
+	},
+	{
 		locale: "fr-FR",
 		leaders: ["BP", "B.P.", "Boîte Postale", "BP."],
 	},
@@ -121,7 +125,7 @@ export interface SynthesizedPoBoxRow {
 	raw: string
 	components: CanonicalRow["components"]
 	locale: string
-	template: "po-box" | "pmb-with-street"
+	template: "po-box" | "pmb-with-street" | "military-po-box"
 }
 
 export interface PoBoxSynthesisOpts {
@@ -186,19 +190,68 @@ export function synthesizePoBoxRow(
 		}
 	}
 
-	// Standard PO box: replaces the street line entirely.
-	const raw = `${poBoxPhrase}, ${base.locality}, ${base.region} ${base.postcode}`
+	// Standard PO box: replaces the street line entirely. Region-optional — NZ (and other region-less
+	// locales) read "Private Bag 12, Auckland 1010" with no region token between locality and postcode.
+	const hasRegion = Boolean(base.region && base.region.trim())
+	const tail = hasRegion ? `${base.locality}, ${base.region} ${base.postcode}` : `${base.locality} ${base.postcode}`
+	const raw = `${poBoxPhrase}, ${tail}`
 	return {
 		raw,
 		components: {
 			po_box: poBoxPhrase,
 			locality: base.locality,
-			region: base.region,
+			...(hasRegion ? { region: base.region } : {}),
 			postcode: base.postcode,
 			country: base.country,
 		},
 		locale,
 		template: "po-box",
+	}
+}
+
+/**
+ * The US military/diplomatic PO-box class (#517). A distinct shape the leader-based locale templates
+ * can't express: a unit line (`PSC <id> Box <box>`, `CMR <id> Box <box>`, `Unit <id> [Box <box>]`)
+ * tagged `po_box`, then the post-office code (APO/FPO/DPO) as the locality and the armed-forces region
+ * (AA/AE/AP) as the region, with a theatre-specific ZIP. Authoritative reference + citations:
+ * `@mailwoman/codex` `codex/us/military-address.ts`; the small constants are inlined here so the
+ * generator is self-contained.
+ */
+const MIL_UNITS: ReadonlyArray<{ code: string; boxRequired: boolean }> = [
+	{ code: "PSC", boxRequired: true },
+	{ code: "CMR", boxRequired: true },
+	{ code: "Unit", boxRequired: false },
+]
+const MIL_PO_CODES = ["APO", "FPO", "DPO"] as const
+// region → plausible ZIP prefix (AE Europe 09xxx, AP Pacific 962-966xx, AA Americas 340xx).
+const MIL_REGION_ZIP: ReadonlyArray<{ region: string; zip: (r: () => number) => string }> = [
+	{ region: "AE", zip: (r) => `09${String(Math.floor(r() * 1000)).padStart(3, "0")}` },
+	{ region: "AP", zip: (r) => `96${String(200 + Math.floor(r() * 100)).padStart(3, "0")}` },
+	{ region: "AA", zip: (r) => `340${String(Math.floor(r() * 100)).padStart(2, "0")}` },
+]
+
+/** Generate one US military/diplomatic PO-box row (#517). Self-contained — draws no base tuple. */
+export function synthesizeMilitaryPoBoxRow(opts: PoBoxSynthesisOpts = {}): SynthesizedPoBoxRow {
+	const random = opts.random ?? Math.random
+	const unit = MIL_UNITS[Math.floor(random() * MIL_UNITS.length)]!
+	const unitId = String(1 + Math.floor(random() * 9999))
+	const { region, zip } = MIL_REGION_ZIP[Math.floor(random() * MIL_REGION_ZIP.length)]!
+	const zipStr = zip(random)
+	const po = MIL_PO_CODES[Math.floor(random() * MIL_PO_CODES.length)]!
+	const hasBox = unit.boxRequired || random() < 0.5
+	const unitLine = hasBox ? `${unit.code} ${unitId} Box ${1 + Math.floor(random() * 9999)}` : `${unit.code} ${unitId}`
+	const raw = `${unitLine}, ${po} ${region} ${zipStr}`
+	return {
+		raw,
+		components: {
+			po_box: unitLine,
+			locality: po,
+			region,
+			postcode: zipStr,
+			country: "US",
+		},
+		locale: "en-US",
+		template: "military-po-box",
 	}
 }
 
@@ -212,6 +265,7 @@ export function countryToLocale(country: string): string {
 	if (c === "CA" || c === "CAN" || c === "CANADA") return "en-CA"
 	if (c === "GB" || c === "UK" || c === "GBR" || c === "UNITED KINGDOM") return "en-GB"
 	if (c === "AU" || c === "AUS" || c === "AUSTRALIA") return "en-AU"
+	if (c === "NZ" || c === "NZL" || c === "NEW ZEALAND") return "en-NZ"
 	if (c === "FR" || c === "FRA" || c === "FRANCE") return "fr-FR"
 	if (c === "ES" || c === "ESP" || c === "SPAIN") return "es-ES"
 	if (c === "MX" || c === "MEX" || c === "MEXICO") return "es-MX"


### PR DESCRIPTION
The generator half of #517's remaining work (codex recognition + the au/gb/es leaders already shipped in #553/#562). Makes the bundle rider (b) — the deferred po_box piece from #714 — generator-ready.

## Changes (`corpus/src/synthesize-po-box.ts` + test)
- **en-NZ template** (Private Bag / Private Box + PO Box) + `countryToLocale` NZ→en-NZ.
- **Region-optional standard format** — NZ (and any region-less locale) now reads `"Private Bag 12, Auckland 1010"` with no region token. Backward-compatible: a non-empty region is unchanged.
- **`synthesizeMilitaryPoBoxRow`** — the distinct US military/diplomatic shape the leader model can't express: a unit line (`PSC/CMR/UNIT <id> [Box <box>]`) tagged `po_box`, `APO/FPO/DPO` as locality, `AA/AE/AP` as region, theatre ZIP (AE 09xxx / AP 962xx / AA 340xx). Constants inlined from `codex/us/military-address.ts` (the authoritative reference, #553) so the generator is self-contained.

## Tests
18 pass — NZ region-less, military structure, and the military row **aligns cleanly through the real `alignRow`** across 5 seeds (B-po_box / locality / postcode, no quarantine — confirms the multi-token unit-line po_box and the APO/AE locality/region label correctly).

## Remaining (operator, to bank the arena win)
Wire `synthesizeMilitaryPoBoxRow` + NZ base tuples into `build-po-box-cedex-shard.mjs` and rebuild the synth-po-box shard. Then it can ride the v1.6.0 retrain as bundle rider (b), moving the postal arena po_box class 0/4 → >0 and military 0/3 → >0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)