### PR TITLE
refactor(sql): migrate the typed-schema modules' DDL to Kysely builders

### DIFF
--- a/resolver-wof-sqlite/address-point-interpolation.test.ts
+++ b/resolver-wof-sqlite/address-point-interpolation.test.ts
@@ -10,10 +10,11 @@
  *   its cap, route-key folding, and the no-bracket fall-through to the TIGER segment fallback.
  */
 
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 import { DatabaseSync } from "node:sqlite"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { AddressPointInterpolator } from "./address-point-interpolation.js"
-import { ADDRESS_POINT_DDL } from "./address-point-schema.js"
+import { type AddressPointDatabase, createAddressPointTable } from "./address-point-schema.js"
 import { StreetInterpolator } from "./interpolation.js"
 
 interface SeedPoint {
@@ -24,10 +25,12 @@ interface SeedPoint {
 	lon: number
 }
 
-function seedPoints(db: DatabaseSync, points: SeedPoint[]): void {
-	// Shared DDL (the same `scripts/build-address-point-shard.ts` builds) so this fixture can't drift
-	// from the production table shape.
-	db.exec(ADDRESS_POINT_DDL)
+async function seedPoints(db: DatabaseSync, points: SeedPoint[]): Promise<void> {
+	// Shared table builder (the same `scripts/build-address-point-shard.ts` uses) so this fixture can't
+	// drift from the production shape. `kdb` wraps `db` for the DDL; the test owns `db`'s lifecycle
+	// (closed in afterAll), so we don't destroy `kdb`.
+	const kdb = new DatabaseClient<AddressPointDatabase>({ database: db })
+	await createAddressPointTable(kdb)
 	const ins = db.prepare(
 		`INSERT INTO address_point (street_norm, street_key, number, unit, postcode, locality_norm, street_raw, lat, lon, source, release)
 		 VALUES (?, ?, ?, NULL, ?, NULL, ?, ?, ?, 'overture:test', '2026-05-20.0')`
@@ -42,9 +45,9 @@ function seedPoints(db: DatabaseSync, points: SeedPoint[]): void {
 let db: DatabaseSync
 let interpolator: AddressPointInterpolator
 
-beforeAll(() => {
+beforeAll(async () => {
 	db = new DatabaseSync(":memory:")
-	seedPoints(db, [
+	await seedPoints(db, [
 		// Both-sided bracket fixture: known points at 100 and 200.
 		{ street_key: "main street", number: "100", postcode: "05601", lat: 0, lon: 0 },
 		{ street_key: "main street", number: "200", postcode: "05601", lat: 0, lon: 0.001 },

--- a/resolver-wof-sqlite/address-point-schema.ts
+++ b/resolver-wof-sqlite/address-point-schema.ts
@@ -11,10 +11,12 @@
  *
  *   The builder's hot INSERT (tens of millions of rows per state) stays a POSITIONAL prepared
  *   statement for throughput — but its column list is derived from {@link ADDRESS_POINT_COLUMNS}
- *   here, and its DDL is {@link ADDRESS_POINT_DDL}, so the positional order can't silently drift
- *   from what the reader expects. (Same convention as the candidate build: typed schema guards the
- *   contract; positional inserts keep the speed.)
+ *   here, and its table comes from {@link createAddressPointTable}, so the positional order can't
+ *   silently drift from what the reader expects. (Same convention as the candidate build: typed
+ *   schema guards the contract; positional inserts keep the speed.)
  */
+
+import type { Kysely } from "kysely"
 
 /**
  * One rooftop address point. `(street_norm, number)` within a `postcode` (preferred) or
@@ -66,26 +68,36 @@ export const ADDRESS_POINT_COLUMNS = [
 	"release",
 ] as const
 
-/** DDL for the `address_point` table — created before the streaming bulk load. */
-export const ADDRESS_POINT_DDL = /* sql */ `
-CREATE TABLE address_point (
-	street_norm   TEXT NOT NULL,
-	street_key    TEXT NOT NULL, -- canonicalizeRouteKey(street_norm): the route-fold key (#483 Method 2)
-	number        TEXT NOT NULL,
-	unit          TEXT,
-	postcode      TEXT,
-	locality_norm TEXT,
-	street_raw    TEXT NOT NULL,
-	lat           REAL NOT NULL,
-	lon           REAL NOT NULL,
-	source        TEXT NOT NULL,
-	release       TEXT NOT NULL
-);
-`
+/** Create the `address_point` table — called before the streaming bulk load. */
+export async function createAddressPointTable(db: Kysely<AddressPointDatabase>): Promise<void> {
+	await db.schema
+		.createTable("address_point")
+		.addColumn("street_norm", "text", (c) => c.notNull())
+		// `street_key` = canonicalizeRouteKey(street_norm): the route-fold key (#483 Method 2).
+		.addColumn("street_key", "text", (c) => c.notNull())
+		.addColumn("number", "text", (c) => c.notNull())
+		.addColumn("unit", "text")
+		.addColumn("postcode", "text")
+		.addColumn("locality_norm", "text")
+		.addColumn("street_raw", "text", (c) => c.notNull())
+		.addColumn("lat", "real", (c) => c.notNull())
+		.addColumn("lon", "real", (c) => c.notNull())
+		.addColumn("source", "text", (c) => c.notNull())
+		.addColumn("release", "text", (c) => c.notNull())
+		.execute()
+}
 
-/** The three probe indexes the reader relies on (postcode-scope, locality-scope, route-key). */
-export const ADDRESS_POINT_INDEX_DDL = /* sql */ `
-CREATE INDEX idx_ap_postcode ON address_point (postcode, street_norm, number);
-CREATE INDEX idx_ap_locality ON address_point (locality_norm, street_norm, number);
-CREATE INDEX idx_ap_streetkey ON address_point (postcode, street_key);
-`
+/** Create the three probe indexes the reader relies on (postcode-scope, locality-scope, route-key). */
+export async function createAddressPointIndexes(db: Kysely<AddressPointDatabase>): Promise<void> {
+	await db.schema
+		.createIndex("idx_ap_postcode")
+		.on("address_point")
+		.columns(["postcode", "street_norm", "number"])
+		.execute()
+	await db.schema
+		.createIndex("idx_ap_locality")
+		.on("address_point")
+		.columns(["locality_norm", "street_norm", "number"])
+		.execute()
+	await db.schema.createIndex("idx_ap_streetkey").on("address_point").columns(["postcode", "street_key"]).execute()
+}

--- a/resolver-wof-sqlite/build-candidate.ts
+++ b/resolver-wof-sqlite/build-candidate.ts
@@ -33,8 +33,8 @@ import { existsSync, rmSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
 import {
 	CANDIDATE_COLUMNS,
-	CANDIDATE_STAGE_DDL,
-	CANDIDATE_TABLE_DDL,
+	createCandidateStagingTables,
+	createCandidateTable,
 	type CandidateDatabase,
 } from "./candidate-schema.js"
 import { normalizeLocalityForKey } from "./street-normalize.js"
@@ -92,8 +92,8 @@ export async function buildCandidateTable(opts: BuildCandidateOptions): Promise<
 	// Build-tuning pragmas (raw — Kysely doesn't model PRAGMA). The code dictionaries + the transient
 	// staging table come from the SHARED schema DDL, so they can't drift from {@link CandidateDatabase}.
 	out.exec("PRAGMA page_size=8192; PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF; PRAGMA cache_size=-2000000;")
-	out.exec(CANDIDATE_STAGE_DDL)
 	const kdb = new DatabaseClient<CandidateDatabase>({ database: out })
+	await createCandidateStagingTables(kdb)
 
 	// --- compact code maps (country/placetype → small int, shrinks the clustered key). The ids are
 	// assigned here; the rows are bulk-inserted via kdb once the passes have discovered every code. ---
@@ -294,15 +294,15 @@ export async function buildCandidateTable(opts: BuildCandidateOptions): Promise<
 	// --- materialize the clustered WITHOUT ROWID table (sorted insert → contiguous leaves) ---
 	progress("cluster", "building clustered candidate table + VACUUM")
 	// Column list + clustered-key order are sourced from CANDIDATE_COLUMNS (the first 6 ARE the PRIMARY
-	// KEY) so the SELECT, the ORDER BY, and the table can't drift. The DDL is the shared CANDIDATE_TABLE_DDL.
+	// KEY) so the SELECT, the ORDER BY, and the table can't drift. The table comes from the shared
+	// createCandidateTable().
 	const cols = CANDIDATE_COLUMNS.join(", ")
 	const keyOrder = CANDIDATE_COLUMNS.slice(0, 6).join(", ")
-	out.exec(
-		CANDIDATE_TABLE_DDL +
-			// OR IGNORE: an abbrev/alias can normalize to a place's primary key (same place, same rank) → any one row.
-			`INSERT OR IGNORE INTO candidate (${cols}) SELECT ${cols} FROM cand_stage ORDER BY ${keyOrder};` +
-			`DROP TABLE cand_stage;`
-	)
+	await createCandidateTable(kdb)
+	// OR IGNORE: an abbrev/alias can normalize to a place's primary key (same place, same rank) → any one
+	// row. The bulk sorted INSERT…SELECT (clustered materialization) stays raw — a single hot bulk statement.
+	out.exec(`INSERT OR IGNORE INTO candidate (${cols}) SELECT ${cols} FROM cand_stage ORDER BY ${keyOrder};`)
+	await kdb.schema.dropTable("cand_stage").execute()
 	// page_size MUST be set right before VACUUM: node:sqlite initializes the file at the 4096 default on
 	// `new DatabaseSync`, so the creation-time pragma is a no-op — only a VACUUM rebuilds at the new size.
 	// 8192 matches the sql.js-httpvfs 64 KiB request chunk cleanly (8 pages) and shallows the B-tree.

--- a/resolver-wof-sqlite/candidate-schema.ts
+++ b/resolver-wof-sqlite/candidate-schema.ts
@@ -15,6 +15,8 @@
  *   `WITHOUT ROWID` B-tree it's materialized into (same columns). The reader queries `candidate`.
  */
 
+import { sql, type Kysely } from "kysely"
+
 /**
  * One candidate row. `name_key` + the four small int keys + `neg_rank` + `spr_id` form the
  * clustered primary key; the rest is denormalized so a resolve is one probe (no join to `spr`).
@@ -93,24 +95,73 @@ export const CANDIDATE_COLUMNS = [
 	"is_primary",
 ] as const
 
-/** DDL for the code dictionaries + the staging table — created before the build's load passes. */
-export const CANDIDATE_STAGE_DDL = /* sql */ `
-CREATE TABLE country_codes (id INTEGER PRIMARY KEY, code TEXT UNIQUE);
-CREATE TABLE placetype_codes (id INTEGER PRIMARY KEY, placetype TEXT UNIQUE);
-CREATE TABLE cand_stage (
-	name_key TEXT, country_id INTEGER, region_id INTEGER, placetype_id INTEGER,
-	neg_rank REAL, spr_id INTEGER, name TEXT, latitude REAL, longitude REAL,
-	min_lat REAL, min_lon REAL, max_lat REAL, max_lon REAL, population INTEGER, is_primary INTEGER
-);
-`
+/**
+ * Create the code dictionaries + the transient staging table — called before the build's load
+ * passes. `cand_stage` mirrors {@link CandidateTable} but every column is nullable (the loader fills
+ * them positionally). Pass a {@link DatabaseClient} (or any `Kysely`) over the candidate DB.
+ */
+export async function createCandidateStagingTables(db: Kysely<CandidateDatabase>): Promise<void> {
+	await db.schema
+		.createTable("country_codes")
+		.addColumn("id", "integer", (c) => c.primaryKey())
+		.addColumn("code", "text", (c) => c.unique())
+		.execute()
+	await db.schema
+		.createTable("placetype_codes")
+		.addColumn("id", "integer", (c) => c.primaryKey())
+		.addColumn("placetype", "text", (c) => c.unique())
+		.execute()
+	await db.schema
+		.createTable("cand_stage")
+		.addColumn("name_key", "text")
+		.addColumn("country_id", "integer")
+		.addColumn("region_id", "integer")
+		.addColumn("placetype_id", "integer")
+		.addColumn("neg_rank", "real")
+		.addColumn("spr_id", "integer")
+		.addColumn("name", "text")
+		.addColumn("latitude", "real")
+		.addColumn("longitude", "real")
+		.addColumn("min_lat", "real")
+		.addColumn("min_lon", "real")
+		.addColumn("max_lat", "real")
+		.addColumn("max_lon", "real")
+		.addColumn("population", "integer")
+		.addColumn("is_primary", "integer")
+		.execute()
+}
 
-/** DDL for the clustered `WITHOUT ROWID` lookup table — created after staging, before the VACUUM. */
-export const CANDIDATE_TABLE_DDL = /* sql */ `
-CREATE TABLE candidate (
-	name_key TEXT NOT NULL, country_id INTEGER NOT NULL, region_id INTEGER NOT NULL,
-	placetype_id INTEGER NOT NULL, neg_rank REAL NOT NULL, spr_id INTEGER NOT NULL,
-	name TEXT, latitude REAL, longitude REAL, min_lat REAL, min_lon REAL, max_lat REAL, max_lon REAL,
-	population INTEGER, is_primary INTEGER,
-	PRIMARY KEY (name_key, country_id, region_id, placetype_id, neg_rank, spr_id)
-) WITHOUT ROWID;
-`
+/**
+ * Create the clustered `WITHOUT ROWID` lookup table — called after staging, before the VACUUM. The
+ * first six columns form the clustered primary key (population-ranked via `neg_rank`).
+ */
+export async function createCandidateTable(db: Kysely<CandidateDatabase>): Promise<void> {
+	await db.schema
+		.createTable("candidate")
+		.addColumn("name_key", "text", (c) => c.notNull())
+		.addColumn("country_id", "integer", (c) => c.notNull())
+		.addColumn("region_id", "integer", (c) => c.notNull())
+		.addColumn("placetype_id", "integer", (c) => c.notNull())
+		.addColumn("neg_rank", "real", (c) => c.notNull())
+		.addColumn("spr_id", "integer", (c) => c.notNull())
+		.addColumn("name", "text")
+		.addColumn("latitude", "real")
+		.addColumn("longitude", "real")
+		.addColumn("min_lat", "real")
+		.addColumn("min_lon", "real")
+		.addColumn("max_lat", "real")
+		.addColumn("max_lon", "real")
+		.addColumn("population", "integer")
+		.addColumn("is_primary", "integer")
+		.addPrimaryKeyConstraint("candidate_pk", [
+			"name_key",
+			"country_id",
+			"region_id",
+			"placetype_id",
+			"neg_rank",
+			"spr_id",
+		])
+		// `WITHOUT ROWID` has no first-class builder; the raw modifier is the idiomatic escape hatch.
+		.modifyEnd(sql`without rowid`)
+		.execute()
+}

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -23,7 +23,7 @@ export { WofSqlitePlaceLookup, type RankingWeights, type WofSqlitePlaceLookupOpt
 
 export { WofCandidateTableLookup, type WofCandidateTableLookupOpts } from "./candidate-lookup.js"
 
-export { ADDRESS_POINT_COLUMNS, ADDRESS_POINT_DDL, ADDRESS_POINT_INDEX_DDL } from "./address-point-schema.js"
+export { ADDRESS_POINT_COLUMNS, createAddressPointIndexes, createAddressPointTable } from "./address-point-schema.js"
 export type { AddressPointDatabase, AddressPointTable } from "./address-point-schema.js"
 export {
 	WofPostalCityAliasLookup,

--- a/resolver-wof-sqlite/postal-city-alias-lookup.test.ts
+++ b/resolver-wof-sqlite/postal-city-alias-lookup.test.ts
@@ -17,14 +17,18 @@
 import { DatabaseSync } from "node:sqlite"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 import { WofSqlitePlaceLookup } from "./lookup.js"
 import { WofPostalCityAliasLookup } from "./postal-city-alias-lookup.js"
-import { POSTAL_CITY_ALIAS_DDL } from "./postal-city-alias-schema.js"
+import { createPostalCityAliasTable, type PostalCityAliasDatabase } from "./postal-city-alias-schema.js"
 
 /** A `postal_city_alias` fixture DB with the production DDL + a divergent and a non-divergent row. */
-function buildAliasDb(): DatabaseSync {
+async function buildAliasDb(): Promise<DatabaseSync> {
 	const db = new DatabaseSync(":memory:")
-	db.exec(POSTAL_CITY_ALIAS_DDL)
+	// `kdb` wraps `db` for the DDL; the test owns `db`'s lifecycle (reader.close()/aliasDb.close()),
+	// so we don't destroy `kdb`.
+	const kdb = new DatabaseClient<PostalCityAliasDatabase>({ database: db })
+	await createPostalCityAliasTable(kdb)
 	const ins = db.prepare(
 		"INSERT INTO postal_city_alias (postcode, postal_city, geo_locality, n, divergent, source, release) VALUES (?,?,?,?,?,?,?)"
 	)
@@ -64,8 +68,8 @@ function buildMainDb(): DatabaseSync {
 
 describe("WofPostalCityAliasLookup (#475 reader)", () => {
 	let reader: WofPostalCityAliasLookup
-	beforeEach(() => {
-		reader = new WofPostalCityAliasLookup({ database: buildAliasDb() })
+	beforeEach(async () => {
+		reader = new WofPostalCityAliasLookup({ database: await buildAliasDb() })
 	})
 	afterEach(() => reader.close())
 
@@ -102,7 +106,7 @@ describe("postal-city alias coordinate-first wiring (#475)", () => {
 	})
 
 	it("WITH the reader, the postal city resolves to its geographic locality (the fix)", async () => {
-		aliasDb = buildAliasDb()
+		aliasDb = await buildAliasDb()
 		const lookup = new WofSqlitePlaceLookup({
 			database: buildMainDb(),
 			buildFts: true,
@@ -119,7 +123,7 @@ describe("postal-city alias coordinate-first wiring (#475)", () => {
 	it("an unrelated postcode (no alias) is byte-stable with the reader attached", async () => {
 		// Reader attached, but 37013 isn't queried — a postcode with no divergent alias must behave
 		// exactly as without the reader. Here the distractor still wins (no alias rescues Nashville).
-		aliasDb = buildAliasDb()
+		aliasDb = await buildAliasDb()
 		const lookup = new WofSqlitePlaceLookup({
 			database: buildMainDb(),
 			buildFts: true,

--- a/resolver-wof-sqlite/postal-city-alias-schema.ts
+++ b/resolver-wof-sqlite/postal-city-alias-schema.ts
@@ -16,6 +16,8 @@
  *   signal — the only rows the resolver consumes).
  */
 
+import type { Kysely } from "kysely"
+
 /**
  * One observed postal-city aggregate. The natural key is `(postcode, postal_city, geo_locality)`;
  * the builder enforces a `MIN_COUNT` floor on `n`, so every row is a non-trivial usage.
@@ -54,19 +56,21 @@ export const POSTAL_CITY_ALIAS_COLUMNS = [
 ] as const
 
 /**
- * DDL for the `postal_city_alias` table + the two probe indexes. Kept here (not only in the
- * builder) so tests can stand up a fixture DB with the exact production shape.
+ * Create the `postal_city_alias` table + its two probe indexes. Kept here (not only in the builder)
+ * so tests can stand up a fixture DB with the exact production shape. Pass a {@link DatabaseClient}
+ * (or any `Kysely`) over the alias DB.
  */
-export const POSTAL_CITY_ALIAS_DDL = /* sql */ `
-CREATE TABLE postal_city_alias (
-	postcode     TEXT NOT NULL,
-	postal_city  TEXT NOT NULL,
-	geo_locality TEXT NOT NULL,
-	n            INTEGER NOT NULL,
-	divergent    INTEGER NOT NULL,
-	source       TEXT NOT NULL,
-	release      TEXT NOT NULL
-);
-CREATE INDEX idx_pca_postcode ON postal_city_alias (postcode);
-CREATE INDEX idx_pca_pair ON postal_city_alias (postal_city, geo_locality);
-`
+export async function createPostalCityAliasTable(db: Kysely<PostalCityAliasDatabase>): Promise<void> {
+	await db.schema
+		.createTable("postal_city_alias")
+		.addColumn("postcode", "text", (c) => c.notNull())
+		.addColumn("postal_city", "text", (c) => c.notNull())
+		.addColumn("geo_locality", "text", (c) => c.notNull())
+		.addColumn("n", "integer", (c) => c.notNull())
+		.addColumn("divergent", "integer", (c) => c.notNull())
+		.addColumn("source", "text", (c) => c.notNull())
+		.addColumn("release", "text", (c) => c.notNull())
+		.execute()
+	await db.schema.createIndex("idx_pca_postcode").on("postal_city_alias").column("postcode").execute()
+	await db.schema.createIndex("idx_pca_pair").on("postal_city_alias").columns(["postal_city", "geo_locality"]).execute()
+}

--- a/scripts/build-address-point-shard.ts
+++ b/scripts/build-address-point-shard.ts
@@ -30,13 +30,15 @@ import { DatabaseSync } from "node:sqlite"
 import { parseArgs } from "node:util"
 
 import { DuckDBInstance } from "@duckdb/node-api"
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 
 // Cross-tree source import (.ts explicit): this script runs via --experimental-strip-types,
 // not from compiled out/ — the lookup tier imports the same module intra-package.
 import {
 	ADDRESS_POINT_COLUMNS,
-	ADDRESS_POINT_DDL,
-	ADDRESS_POINT_INDEX_DDL,
+	type AddressPointDatabase,
+	createAddressPointIndexes,
+	createAddressPointTable,
 } from "../resolver-wof-sqlite/address-point-schema.ts"
 import {
 	canonicalizeRouteKey,
@@ -121,7 +123,10 @@ const db = new DatabaseSync(OUT)
 // DDL + column order come from the SHARED schema (address-point-schema.ts) so the writer can't drift
 // from AddressPointSqliteLookup (the reader). The INSERT stays a POSITIONAL prepared statement —
 // tens of millions of rows per state — but its column list is derived from ADDRESS_POINT_COLUMNS.
-db.exec(`PRAGMA journal_mode = WAL;${ADDRESS_POINT_DDL}`)
+db.exec("PRAGMA journal_mode = WAL;")
+// DDL via the Kysely schema-builder; the hot positional INSERT below stays on the raw `db` handle.
+const kdb = new DatabaseClient<AddressPointDatabase>({ database: db })
+await createAddressPointTable(kdb)
 
 const insert = db.prepare(
 	`INSERT INTO address_point (${ADDRESS_POINT_COLUMNS.join(", ")})
@@ -203,16 +208,14 @@ for (let chunk = await stream.fetchChunk(); chunk && chunk.rowCount > 0; chunk =
 }
 db.exec("COMMIT")
 console.log(`${totalReturned} ${STATE} rows from ${OA_MODE ? "OpenAddresses" : path.basename(PARQUET)}`)
-db.exec(`${ADDRESS_POINT_INDEX_DDL}
-	PRAGMA wal_checkpoint(TRUNCATE);
-	VACUUM;
-`)
+await createAddressPointIndexes(kdb)
+db.exec("PRAGMA wal_checkpoint(TRUNCATE); VACUUM;")
 const stats = db
 	.prepare(
 		"SELECT count(*) AS n, count(DISTINCT street_norm) AS streets, count(DISTINCT postcode) AS postcodes FROM address_point"
 	)
 	.get() as Record<string, number>
-db.close()
+await kdb.destroy() // closes the underlying `db` handle
 console.log(`${kept} points → ${OUT}`)
 console.log(`distinct streets: ${stats.streets} · postcodes: ${stats.postcodes}`)
 


### PR DESCRIPTION
Second step of the inline-SQL → Kysely cleanup (stacks conceptually on #745's idiom; independent files, no overlap). Migrates the three typed-schema modules' raw DDL strings to co-located `createX(db)` schema-builder functions.

## What moved

| Module | Before | After |
| --- | --- | --- |
| `candidate-schema.ts` | `CANDIDATE_STAGE_DDL`, `CANDIDATE_TABLE_DDL` | `createCandidateStagingTables()`, `createCandidateTable()` |
| `address-point-schema.ts` | `ADDRESS_POINT_DDL`, `ADDRESS_POINT_INDEX_DDL` | `createAddressPointTable()`, `createAddressPointIndexes()` |
| `postal-city-alias-schema.ts` | `POSTAL_CITY_ALIAS_DDL` | `createPostalCityAliasTable()` |

The typed `Table` interfaces + column-list consts are untouched — still the single source of truth. `index.ts` re-exports follow.

## Coexistence held to the #745 rule

`build-candidate.ts` already carried a `DatabaseClient` (its code-dict inserts were Kysely); now its table-create + drop-staging go through it too. `build-address-point-shard.ts` gains a `DatabaseClient` for the DDL. In both, the **hot bulk writes stay raw**: the candidate clustering `INSERT … SELECT … ORDER BY` (one sorted bulk statement) and the address-point tens-of-millions-row positional INSERT. `PRAGMA`/`VACUUM` stay raw too (not Kysely-modelled).

Test fixtures that stood up tables from the raw DDL (`seedPoints`, `buildAliasDb`) now call the builder fns — they became `async`, and their call sites were updated.

## Verification

- `yarn compile` (tsc -b) clean.
- 21/21 tests pass across `build-candidate`, `address-point-interpolation`, and `postal-city-alias-lookup` — including the candidate page_size-8192 clustering test that exercises the `WITHOUT ROWID` materialization end-to-end.

Next batches (separate PRs): `unified-schema.ts` (14 tables), `tiger/sdk/schema.ts`, the build/eval scripts, then DuckDB via `@oorabona/kysely-duckdb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)