### PR TITLE
refactor(sql,tiger): migrate TIGER schema to Kysely + schema-correctness fixes

### DIFF
--- a/tiger/package.json
+++ b/tiger/package.json
@@ -24,6 +24,7 @@
 		"@mailwoman/core": "workspace:*",
 		"@mailwoman/spatial": "workspace:*",
 		"@turf/boolean-contains": "^7.3.5",
+		"kysely": "^0.29.2",
 		"shapefile-parser": "^1.0.3",
 		"type-fest": "^5.7.0"
 	},

--- a/tiger/sdk/fetch.ts
+++ b/tiger/sdk/fetch.ts
@@ -34,7 +34,7 @@ import { DatabaseSync } from "node:sqlite"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import type { TIGERBlockTable, TIGERDatabase, TIGERPlaceTable, TIGERStreetTable } from "./schema.js"
-import { TIGER_INITIALIZE_SQL } from "./schema.js"
+import { initializeTIGERSchema, TIGER_PRAGMAS } from "./schema.js"
 
 const CENSUS_HOST = "https://www2.census.gov"
 const DEFAULT_DATA_ROOT = process.env.MAILWOMAN_DATA_ROOT ?? "/mnt/playpen/mailwoman-data"
@@ -92,7 +92,7 @@ function blockSelectSQL(layer: string, county?: string): string {
 	const where = county ? ` WHERE COUNTYFP20 = '${county}'` : ""
 	return (
 		`SELECT GEOID20 AS GEOID, STATEFP20 AS state_code, COUNTYFP20 AS county_code, ` +
-		`SUBSTR(GEOID20, 6, 5) AS county_sub_division_code, SUBSTR(GEOID20, 6, 6) AS tract_code, ` +
+		`SUBSTR(GEOID20, 6, 6) AS tract_code, ` +
 		`SUBSTR(GEOID20, 12, 1) AS block_group_code, BLOCKCE20 AS block_code, ` +
 		`UACE20 AS urbanized_area_code, UR20 AS urban_rural_code, ` +
 		`HOUSING20 AS housing_unit_count, ALAND20 AS land_area_sqm, AWATER20 AS water_area_sqm, ` +
@@ -138,7 +138,6 @@ function buildRow(level: TIGERFetchLevel, p: Record<string, unknown>, geometry: 
 				GEOID: String(p.GEOID),
 				state_code: String(p.state_code),
 				county_code: String(p.county_code),
-				county_sub_division_code: String(p.county_sub_division_code ?? ""),
 				tract_code: String(p.tract_code ?? ""),
 				block_group_code: String(p.block_group_code ?? ""),
 				block_code: String(p.block_code ?? ""),
@@ -223,8 +222,9 @@ export async function* fetchTIGER(options: FetchTIGEROptions): AsyncGenerator<Fe
 	}
 
 	const db = new DatabaseSync(outPath)
-	db.exec(TIGER_INITIALIZE_SQL)
+	db.exec(TIGER_PRAGMAS)
 	const kdb = new DatabaseClient<TIGERDatabase>({ database: db })
+	await initializeTIGERSchema(kdb)
 
 	const insertBatch = async (rows: Row[]): Promise<void> => {
 		if (level === "tabblock20")

--- a/tiger/sdk/redistricting.ts
+++ b/tiger/sdk/redistricting.ts
@@ -26,7 +26,7 @@ import { DatabaseSync } from "node:sqlite"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import { AdminLevel1CodeToAbbreviation, StateName, type AdminLevel1Code } from "../state.js"
-import { TIGER_INITIALIZE_SQL, type PLBlockTable, type TIGERDatabase } from "./schema.js"
+import { initializeTIGERSchema, TIGER_PRAGMAS, type PLBlockTable, type TIGERDatabase } from "./schema.js"
 
 const REDISTRICTING_BASE =
 	"https://www2.census.gov/programs-surveys/decennial/2020/data/01-Redistricting_File--PL_94-171"
@@ -168,8 +168,9 @@ export async function* fetchRedistricting(
 	yield { phase: "header", blocks: total }
 
 	const db = new DatabaseSync(outPath)
-	db.exec(TIGER_INITIALIZE_SQL)
+	db.exec(TIGER_PRAGMAS)
 	const kdb = new DatabaseClient<TIGERDatabase>({ database: db })
+	await initializeTIGERSchema(kdb)
 
 	try {
 		// Idempotent re-run: drop the rows we're about to (re)load.

--- a/tiger/sdk/schema.ts
+++ b/tiger/sdk/schema.ts
@@ -10,14 +10,13 @@
  *   back with `JSON.parse`).
  */
 
-import type { Generated } from "kysely"
+import { sql, type Generated, type Kysely } from "kysely"
 
 /** Kysely row type for `tabblock20`. Geometry is a GeoJSON string. */
 export interface TIGERBlockTable {
 	GEOID: string
 	state_code: string
 	county_code: string
-	county_sub_division_code: string
 	tract_code: string
 	block_group_code: string
 	block_code: string
@@ -78,82 +77,127 @@ export interface TIGERDatabase {
 /** Marker so callers can opt into `Generated` columns later without importing kysely here. */
 export type { Generated }
 
-export const TIGER_INITIALIZE_SQL = /* sql */ `
+/**
+ * Build-tuning PRAGMAs, run raw before any table is created (`page_size`/`auto_vacuum` only take
+ * effect on an empty DB, and PRAGMA has no Kysely builder). The consumer execs this, then calls
+ * {@link initializeTIGERSchema} for the tables + indexes.
+ */
+export const TIGER_PRAGMAS = /* sql */ `
 PRAGMA auto_vacuum = INCREMENTAL;
 PRAGMA page_size = 4096;
 PRAGMA cache_size = 10000;
 PRAGMA journal_mode = WAL;
-
-CREATE TABLE IF NOT EXISTS "us_state" (
-	"state_code" text(2) PRIMARY KEY NOT NULL,
-	"abbreviation" text NOT NULL,
-	"display_name" text NOT NULL,
-	"geometry" text NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS "tract" (
-	"GEOID" text(11) PRIMARY KEY NOT NULL,
-	"state_code" text(2) NOT NULL,
-	"county_code" text(3) NOT NULL,
-	"county_sub_division_code" text(5) NOT NULL,
-	"tract_code" text(6) NOT NULL,
-	"geometry" text NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS "tabblock20" (
-	"GEOID" text(15) PRIMARY KEY NOT NULL,
-	"state_code" text(2) NOT NULL,
-	"county_code" text(3) NOT NULL,
-	"county_sub_division_code" text(5) NOT NULL,
-	"tract_code" text(6) NOT NULL,
-	"block_group_code" text(1) NOT NULL,
-	"block_code" text(4) NOT NULL,
-	"urbanized_area_code" text(5),
-	"urban_rural_code" text(1),
-	"housing_unit_count" integer NOT NULL,
-	"land_area_sqm" integer NOT NULL,
-	"water_area_sqm" integer NOT NULL,
-	"population" integer NOT NULL,
-	"geometry" text NOT NULL
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS "idx_tabblock20_geoid" ON "tabblock20" ("GEOID");
-CREATE INDEX IF NOT EXISTS "idx_tabblock20_state_code" ON "tabblock20" ("state_code");
-CREATE INDEX IF NOT EXISTS "idx_tabblock20_state_county" ON "tabblock20" ("state_code", "county_code");
-CREATE INDEX IF NOT EXISTS "idx_tabblock20_state_county_tract" ON "tabblock20" ("state_code", "county_code", "tract_code");
-CREATE INDEX IF NOT EXISTS "idx_tabblock20_population" ON "tabblock20" ("population");
-
-CREATE TABLE IF NOT EXISTS "pl_block" (
-	"GEOID" text(15) PRIMARY KEY NOT NULL,
-	"pop_total" integer NOT NULL,
-	"hispanic" integer NOT NULL,
-	"white" integer NOT NULL,
-	"black" integer NOT NULL,
-	"aian" integer NOT NULL,
-	"asian" integer NOT NULL,
-	"nhpi" integer NOT NULL,
-	"other" integer NOT NULL,
-	"multi" integer NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS "tiger_streets" (
-	"linearid" text NOT NULL,
-	"fullname" text NOT NULL,
-	"zipl" text,
-	"zipr" text,
-	"statefp" text(2) NOT NULL
-);
-CREATE INDEX IF NOT EXISTS "idx_tiger_streets_statefp" ON "tiger_streets" ("statefp");
-CREATE INDEX IF NOT EXISTS "idx_tiger_streets_linearid" ON "tiger_streets" ("linearid");
-
-CREATE TABLE IF NOT EXISTS "tiger_places" (
-	"geoid" text NOT NULL,
-	"name" text NOT NULL,
-	"statefp" text(2) NOT NULL,
-	"lsad" text,
-	"namelsad" text,
-	"classfp" text
-);
-CREATE INDEX IF NOT EXISTS "idx_tiger_places_statefp" ON "tiger_places" ("statefp");
-CREATE INDEX IF NOT EXISTS "idx_tiger_places_geoid" ON "tiger_places" ("geoid");
 `
+
+/**
+ * Create the TIGER tables + indexes via the Kysely schema-builder (the house idiom). Idempotent
+ * (`IF NOT EXISTS`). Pass a {@link DatabaseClient} (or any `Kysely`) over the TIGER DB; run
+ * {@link TIGER_PRAGMAS} first. `us_state`/`tract` aren't in {@link TIGERDatabase} (created here but
+ * not queried via Kysely) — `createTable` takes any table name, so that's fine.
+ *
+ * The `text(N)` length hints in the prior raw DDL were documentary only (SQLite uses TEXT affinity
+ * regardless); the lengths live on the {@link TIGERBlockTable} interface instead.
+ */
+export async function initializeTIGERSchema(db: Kysely<TIGERDatabase>): Promise<void> {
+	await db.schema
+		.createTable("us_state")
+		.ifNotExists()
+		.addColumn("state_code", "text", (c) => c.primaryKey().notNull())
+		.addColumn("abbreviation", "text", (c) => c.notNull())
+		.addColumn("display_name", "text", (c) => c.notNull())
+		.addColumn("geometry", "text", (c) => c.notNull())
+		.execute()
+
+	await db.schema
+		.createTable("tract")
+		.ifNotExists()
+		.addColumn("GEOID", "text", (c) => c.primaryKey().notNull())
+		.addColumn("state_code", "text", (c) => c.notNull())
+		.addColumn("county_code", "text", (c) => c.notNull())
+		.addColumn("tract_code", "text", (c) => c.notNull())
+		.addColumn("geometry", "text", (c) => c.notNull())
+		.execute()
+
+	await db.schema
+		.createTable("tabblock20")
+		.ifNotExists()
+		.addColumn("GEOID", "text", (c) => c.primaryKey().notNull())
+		.addColumn("state_code", "text", (c) => c.notNull())
+		.addColumn("county_code", "text", (c) => c.notNull())
+		.addColumn("tract_code", "text", (c) => c.notNull())
+		.addColumn("block_group_code", "text", (c) => c.notNull())
+		.addColumn("block_code", "text", (c) => c.notNull())
+		.addColumn("urbanized_area_code", "text")
+		.addColumn("urban_rural_code", "text")
+		.addColumn("housing_unit_count", "integer", (c) => c.notNull())
+		.addColumn("land_area_sqm", "integer", (c) => c.notNull())
+		.addColumn("water_area_sqm", "integer", (c) => c.notNull())
+		.addColumn("population", "integer", (c) => c.notNull())
+		.addColumn("geometry", "text", (c) => c.notNull())
+		.execute()
+
+	// No index on GEOID alone — it's the PRIMARY KEY, which already carries a unique index. The prior
+	// schema's idx_tabblock20_geoid duplicated that for nothing (double insert cost, double footprint).
+	await db.schema.createIndex("idx_tabblock20_state_code").ifNotExists().on("tabblock20").column("state_code").execute()
+	await db.schema
+		.createIndex("idx_tabblock20_state_county")
+		.ifNotExists()
+		.on("tabblock20")
+		.columns(["state_code", "county_code"])
+		.execute()
+	await db.schema
+		.createIndex("idx_tabblock20_state_county_tract")
+		.ifNotExists()
+		.on("tabblock20")
+		.columns(["state_code", "county_code", "tract_code"])
+		.execute()
+	await db.schema.createIndex("idx_tabblock20_population").ifNotExists().on("tabblock20").column("population").execute()
+
+	await db.schema
+		.createTable("pl_block")
+		.ifNotExists()
+		.addColumn("GEOID", "text", (c) => c.primaryKey().notNull())
+		.addColumn("pop_total", "integer", (c) => c.notNull())
+		.addColumn("hispanic", "integer", (c) => c.notNull())
+		.addColumn("white", "integer", (c) => c.notNull())
+		.addColumn("black", "integer", (c) => c.notNull())
+		.addColumn("aian", "integer", (c) => c.notNull())
+		.addColumn("asian", "integer", (c) => c.notNull())
+		.addColumn("nhpi", "integer", (c) => c.notNull())
+		.addColumn("other", "integer", (c) => c.notNull())
+		.addColumn("multi", "integer", (c) => c.notNull())
+		// pl_block is small (no geometry) and always probed by its GEOID PK (1:1 join to tabblock20), so
+		// cluster it WITHOUT ROWID — one B-tree probe per join, no separate rowid + PK-index pair.
+		.modifyEnd(sql`without rowid`)
+		.execute()
+
+	await db.schema
+		.createTable("tiger_streets")
+		.ifNotExists()
+		.addColumn("linearid", "text", (c) => c.notNull())
+		.addColumn("fullname", "text", (c) => c.notNull())
+		.addColumn("zipl", "text")
+		.addColumn("zipr", "text")
+		.addColumn("statefp", "text", (c) => c.notNull())
+		.execute()
+	await db.schema.createIndex("idx_tiger_streets_statefp").ifNotExists().on("tiger_streets").column("statefp").execute()
+	await db.schema
+		.createIndex("idx_tiger_streets_linearid")
+		.ifNotExists()
+		.on("tiger_streets")
+		.column("linearid")
+		.execute()
+
+	await db.schema
+		.createTable("tiger_places")
+		.ifNotExists()
+		.addColumn("geoid", "text", (c) => c.notNull())
+		.addColumn("name", "text", (c) => c.notNull())
+		.addColumn("statefp", "text", (c) => c.notNull())
+		.addColumn("lsad", "text")
+		.addColumn("namelsad", "text")
+		.addColumn("classfp", "text")
+		.execute()
+	await db.schema.createIndex("idx_tiger_places_statefp").ifNotExists().on("tiger_places").column("statefp").execute()
+	await db.schema.createIndex("idx_tiger_places_geoid").ifNotExists().on("tiger_places").column("geoid").execute()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5100,6 +5100,7 @@ __metadata:
     "@mailwoman/core": "workspace:*"
     "@mailwoman/spatial": "workspace:*"
     "@turf/boolean-contains": "npm:^7.3.5"
+    kysely: "npm:^0.29.2"
     shapefile-parser: "npm:^1.0.3"
     type-fest: "npm:^5.7.0"
   languageName: unknown


### PR DESCRIPTION
Migrates `tiger/sdk/schema.ts` off the raw `TIGER_INITIALIZE_SQL` string to a Kysely schema-builder (`initializeTIGERSchema`), per the #745 idiom — the migration target the #739 review flagged. Both consumers (`fetch.ts`, `redistricting.ts`) already constructed a `DatabaseClient`, so they now `exec(TIGER_PRAGMAS)` then `await initializeTIGERSchema(kdb)`.

While in here, folds in three schema-correctness fixes the migration surfaced (per a design discussion on the rowid question):

- **Dropped the phantom `county_sub_division_code` column** (`tabblock20` + `tract`). It was filled by `SUBSTR(GEOID20, 6, 5)` — the first 5 chars of the 6-char tract, i.e. a tract prefix, **not** a county subdivision (a block GEOID has no cousub field). Garbage in, and nothing read it back out. Removed from the SELECT, the row-builder, and the `TIGERBlockTable` interface. (`tiger/geoid.ts`'s real cousub-GEOID parser is a separate, correct thing — untouched.)
- **Dropped the redundant `idx_tabblock20_geoid` unique index** — `GEOID` is already the PRIMARY KEY, which carries its own unique index, so this was double insert cost + double footprint for zero benefit.
- **`pl_block` is now `WITHOUT ROWID`** — it's small (no geometry) and always probed by its `GEOID` PK on the 1:1 join to `tabblock20`, so clustering by `GEOID` saves a B-tree hop plus the rowid/PK-index pair. The geometry-bearing tables (`tabblock20`/`tract`/`us_state`) stay rowid — `WITHOUT ROWID` is contraindicated for KB-scale rows (SQLite wants rows under ~1/20 of a page).

PRAGMAs split into `TIGER_PRAGMAS` (raw — not Kysely-modelled, and `page_size`/`auto_vacuum` must run on the empty DB before any table). `kysely` added as a direct tiger dep (`schema.ts` now imports `sql` for the `WITHOUT ROWID` modifier — previously transitive via core).

## Verification

- `yarn compile` (tsc -b) clean.
- Built the schema in-memory and checked: all 6 tables + 8 indexes present; `pl_block` is `WITHOUT ROWID` and a GEOID-keyed insert+probe works; no `county_sub_division_code` on `tabblock20`/`tract`; no `idx_tabblock20_geoid`.

(No committed tiger unit test exists — the `package.json` `test` script points at a non-existent compiled file; worth a follow-up, noted separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)