### PR TITLE
refactor(sql): migrate the build-script DDL to Kysely builders

### DIFF
--- a/corpus/scripts/ingest-csv.ts
+++ b/corpus/scripts/ingest-csv.ts
@@ -239,6 +239,8 @@ async function ingestCSV(opts: IngestOptions): Promise<void> {
 
 	// --- Generate SQL ---
 	const colDefs = columns.map((c) => `"${c.name}" ${c.type}`).join(",\n  ")
+	// Raw DDL by design: the column set + types are INFERRED from the CSV at runtime (colDefs above),
+	// so a Kysely builder loop would just wrap the same dynamic strings with ceremony and no type safety.
 	const createTableSQL = `CREATE TABLE IF NOT EXISTS "${opts.tableName}" (\n  ${colDefs}\n);`
 
 	const tempCols = columns.map((c) => `"${c.name}"`).join(", ")

--- a/scripts/backfill-postcode-centroids.ts
+++ b/scripts/backfill-postcode-centroids.ts
@@ -32,6 +32,7 @@
  *   /mnt/playpen/mailwoman-data/wof/repos
  */
 
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 import { DatabaseSync } from "node:sqlite"
@@ -71,10 +72,12 @@ function parseArgs(): Args {
  * centroid. Matched by the postcode string only — the WOF id is untouched, so the eval keys stay
  * WOF's.
  */
-function geonamesFill(db: DatabaseSync, geonamesDir: string): number {
+async function geonamesFill(db: DatabaseSync, geonamesDir: string): Promise<number> {
 	// The GeoNames UPDATE matches on (country, name); the build only indexes placetype/country/parent,
-	// so without this the per-postcode UPDATEs scan each country's rows (minutes on 400k+ rows).
-	db.exec(`CREATE INDEX IF NOT EXISTS spr_by_country_name ON spr (country, name)`)
+	// so without this the per-postcode UPDATEs scan each country's rows (minutes on 400k+ rows). `kdb`
+	// wraps `db` for the DDL; main() owns `db`'s lifecycle, so we don't destroy it here.
+	const kdb = new DatabaseClient({ database: db })
+	await kdb.schema.createIndex("spr_by_country_name").ifNotExists().on("spr").columns(["country", "name"]).execute()
 
 	const countries = (
 		db
@@ -176,7 +179,7 @@ function ancestorFallback(db: DatabaseSync, reposDir: string): number {
 	return fixed
 }
 
-function main(): void {
+async function main(): Promise<void> {
 	const { dbPath, adminPath, reposDir, geonamesDir } = parseArgs()
 	for (const p of [dbPath, adminPath]) {
 		if (!existsSync(p)) {
@@ -197,7 +200,7 @@ function main(): void {
 	let geonamesFixed = 0
 	if (geonamesDir) {
 		if (!existsSync(geonamesDir)) console.error(`Missing geonames dir, skipping: ${geonamesDir}`)
-		else geonamesFixed = geonamesFill(db, geonamesDir)
+		else geonamesFixed = await geonamesFill(db, geonamesDir)
 	}
 
 	// Priority 3: borrow the parent locality's centroid for every coordinate-less postcode whose parent
@@ -262,4 +265,4 @@ function main(): void {
 	}
 }
 
-main()
+await main()

--- a/scripts/build-conventions.ts
+++ b/scripts/build-conventions.ts
@@ -21,6 +21,7 @@
  *   --src data/conventions/conventions.json\
  *   --output /mnt/playpen/mailwoman-data/wof/conventions.db
  */
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 import { readFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
 
@@ -69,23 +70,33 @@ function validate(rows: AuthoredConvention[]): void {
 	if (errors.length) throw new Error(`convention validation failed:\n  - ${errors.join("\n  - ")}`)
 }
 
-function build(src: string, output: string): void {
+async function build(src: string, output: string): Promise<void> {
 	const rows = JSON.parse(readFileSync(src, "utf8")) as AuthoredConvention[]
 	if (!Array.isArray(rows)) throw new Error(`${src} must be a JSON array of authored conventions`)
 	validate(rows)
 
 	const db = new DatabaseSync(output)
-	db.exec("DROP TABLE IF EXISTS address_convention; DROP TABLE IF EXISTS meta")
-	db.exec(`CREATE TABLE address_convention (
-		wof_id INTEGER PRIMARY KEY,   -- the WOF admin polygon this profile attaches to
-		convention TEXT NOT NULL,     -- the Convention JSON
-		source TEXT NOT NULL          -- provenance: why this row exists / where it came from
-	)`)
+	// DDL via the Kysely schema-builder; the row INSERTs below stay on the raw `db` handle.
+	const kdb = new DatabaseClient({ database: db })
+	await kdb.schema.dropTable("address_convention").ifExists().execute()
+	await kdb.schema.dropTable("meta").ifExists().execute()
+	await kdb.schema
+		.createTable("address_convention")
+		// wof_id: the WOF admin polygon this profile attaches to. convention: the Convention JSON.
+		// source: provenance — why this row exists / where it came from.
+		.addColumn("wof_id", "integer", (c) => c.primaryKey())
+		.addColumn("convention", "text", (c) => c.notNull())
+		.addColumn("source", "text", (c) => c.notNull())
+		.execute()
 	const ins = db.prepare("INSERT INTO address_convention (wof_id, convention, source) VALUES (?, ?, ?)")
 	for (const r of rows) ins.run(r.wof_id, JSON.stringify(r.convention), r.source)
 
 	// Freeze into the read-only distributable asset — same discipline as our other WOF tables.
-	db.exec("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+	await kdb.schema
+		.createTable("meta")
+		.addColumn("key", "text", (c) => c.primaryKey())
+		.addColumn("value", "text")
+		.execute()
 	const meta: Record<string, string> = {
 		name: "mailwoman-conventions",
 		description: "Geographic Rule Engine convention profiles, keyed by WOF polygon id (Direction E)",
@@ -103,8 +114,8 @@ function build(src: string, output: string): void {
 	const ok = (db.prepare("PRAGMA integrity_check").get() as { integrity_check: string }).integrity_check
 	if (ok !== "ok") throw new Error(`integrity_check failed: ${ok}`)
 	db.exec("VACUUM")
-	db.close()
+	await kdb.destroy() // closes the underlying `db` handle
 	console.log(`built ${output}: ${rows.length} convention(s), integrity=ok`)
 }
 
-build(argval("--src", "data/conventions/conventions.json"), argval("--output"))
+await build(argval("--src", "data/conventions/conventions.json"), argval("--output"))

--- a/scripts/build-importance.ts
+++ b/scripts/build-importance.ts
@@ -11,6 +11,7 @@
  *   scripts/build-importance.ts --db /path/to/wof.db --tsv /path/to/wikimedia-importance.csv.gz
  */
 
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 import { createReadStream, existsSync, writeFileSync } from "node:fs"
 import { get as httpsGet } from "node:https"
 import { tmpdir } from "node:os"
@@ -101,6 +102,8 @@ async function main() {
 	}
 
 	const db = new DatabaseSync(dbPath, { open: true })
+	// DDL via the Kysely schema-builder; the hot INSERT loop below stays on the raw `db` handle.
+	const kdb = new DatabaseClient({ database: db })
 
 	// Step 1: Load Wikidata concordances from WOF
 	console.error("Loading Wikidata concordances from WOF...")
@@ -164,8 +167,12 @@ async function main() {
 
 	// Step 4: Build place_importance table
 	console.error("Building place_importance table...")
-	db.exec("DROP TABLE IF EXISTS place_importance")
-	db.exec("CREATE TABLE place_importance (id INTEGER PRIMARY KEY, importance REAL NOT NULL)")
+	await kdb.schema.dropTable("place_importance").ifExists().execute()
+	await kdb.schema
+		.createTable("place_importance")
+		.addColumn("id", "integer", (c) => c.primaryKey())
+		.addColumn("importance", "real", (c) => c.notNull())
+		.execute()
 
 	const insertStmt = db.prepare("INSERT INTO place_importance (id, importance) VALUES (?, ?)")
 	let importanceCount = 0
@@ -201,7 +208,7 @@ async function main() {
 		console.error("  No place_population table — skipping fallback")
 	}
 
-	db.close()
+	await kdb.destroy() // closes the underlying `db` handle
 
 	const elapsed = ((performance.now() - t0) / 1000).toFixed(1)
 	console.error(`\nDone in ${elapsed}s:`)

--- a/scripts/build-wof-polygons.mjs
+++ b/scripts/build-wof-polygons.mjs
@@ -31,6 +31,7 @@
  *   actually live (VT: 255/255 localadmin have real polygons, 0 reached the demo sidecar).
  */
 
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 import { existsSync, readFileSync, rmSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
 
@@ -132,7 +133,13 @@ const rows = src
 src.close()
 
 const out = new DatabaseSync(opts.output)
-out.exec(`CREATE TABLE polygons (id INTEGER PRIMARY KEY, geom TEXT NOT NULL);`)
+// DDL via the Kysely schema-builder; the hot INSERT loop below stays on the raw `out` handle.
+const kdb = new DatabaseClient({ database: out })
+await kdb.schema
+	.createTable("polygons")
+	.addColumn("id", "integer", (c) => c.primaryKey())
+	.addColumn("geom", "text", (c) => c.notNull())
+	.execute()
 const insert = out.prepare(`INSERT OR IGNORE INTO polygons (id, geom) VALUES (?, ?)`)
 
 let done = 0
@@ -163,7 +170,7 @@ for (const r of rows) {
 out.exec("COMMIT")
 out.exec("VACUUM")
 const bytes = out.prepare(`SELECT count(*) n, sum(length(geom)) b FROM polygons`).get()
-out.close()
+await kdb.destroy() // closes the underlying `out` handle
 console.error(
 	`✓ ${opts.output}: ${done} polygons (${missing} no-geometry, ${dropped} dropped), ~${Math.round((bytes.b || 0) / 1024 / 1024)} MB geom`
 )

--- a/scripts/zcta-centroids.ts
+++ b/scripts/zcta-centroids.ts
@@ -75,6 +75,8 @@ export function fillPlaceholderCentroids(
 	zcta: ReadonlyMap<string, ZctaCentroid>,
 	source: string = ZCTA_SOURCE
 ): number {
+	// Raw DDL by design: this is a sync helper that borrows `db` and is exercised by a sync, heavily-
+	// asserted test, so routing one IF-NOT-EXISTS provenance table through async Kysely isn't worth it.
 	db.exec(`CREATE TABLE IF NOT EXISTS centroid_source (id INTEGER PRIMARY KEY, source TEXT NOT NULL)`)
 
 	const placeholders = db
@@ -155,6 +157,8 @@ export function fillGeonamesPlaceholders(
 	geonames: ReadonlyMap<string, ZctaCentroid>,
 	source: string = GEONAMES_US_SOURCE
 ): number {
+	// Raw DDL by design: this is a sync helper that borrows `db` and is exercised by a sync, heavily-
+	// asserted test, so routing one IF-NOT-EXISTS provenance table through async Kysely isn't worth it.
 	db.exec(`CREATE TABLE IF NOT EXISTS centroid_source (id INTEGER PRIMARY KEY, source TEXT NOT NULL)`)
 
 	const placeholders = db


### PR DESCRIPTION
Fourth step of the inline-SQL → Kysely cleanup — the build/eval script batch. Same #745 idiom, with an **untyped** `DatabaseClient` for the DDL (these are ad-hoc, script-local tables with no shared typed reader; inserts stay raw, so no `Database` interface is needed).

## Migrated

| Script | DDL |
| --- | --- |
| `build-importance.ts` | `DROP`/`CREATE place_importance` |
| `build-conventions.ts` | `DROP`×2 + `CREATE address_convention` + `CREATE meta` |
| `build-wof-polygons.mjs` | `CREATE polygons` (plain JS — `@mailwoman/core`'s `./kysley/client` export resolves cleanly from node ESM) |
| `backfill-postcode-centroids.ts` | the one `CREATE INDEX spr_by_country_name` |

Each keeps its hot positional INSERTs, `BEGIN`/`COMMIT`, `PRAGMA`, `VACUUM`, and `ATTACH` raw; `db.close()` → `await kdb.destroy()`. Functions touching DDL went `async`, call sites awaited.

## Left raw, with an inline rationale comment

- **`corpus/scripts/ingest-csv.ts`** — the table's columns + types are *inferred from the CSV at runtime*. A builder loop would wrap the same dynamic strings with ceremony and zero added type safety.
- **`zcta-centroids.ts`** (2 sites) — `centroid_source` is created inside *sync* helpers that borrow a `db` and are exercised by a sync, heavily-asserted test. One `IF NOT EXISTS` provenance table isn't worth an async rewrite of the API + its assertions.

`add-ancestors.ts` is skipped here — it delegates to `createUnifiedSchema()`, so it rides with the **#185** unified-schema batch.

## Verification

`yarn compile` (tsc -b) clean · prettier clean, no jsdoc mangle · `zcta-centroids` test 7/7 · in-memory smoke of all 4 migrated tables/index passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)