### PR TITLE
refactor(sql): migrate unified-schema.ts DDL to Kysely builders

### DIFF
--- a/resolver-wof-sqlite/unified-schema.ts
+++ b/resolver-wof-sqlite/unified-schema.ts
@@ -12,76 +12,83 @@
  *   `place_search` FTS5 + `place_bbox` R*Tree are built separately by `build-fts` (fts.ts).
  */
 
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 import { DatabaseSync } from "node:sqlite"
+import type { WofDatabase } from "./schema.js"
 
-export function createUnifiedSchema(db: DatabaseSync): void {
+export async function createUnifiedSchema(db: DatabaseSync): Promise<void> {
+	// PRAGMAs stay raw — not Kysely-modelled, and these tune the bulk build.
 	db.exec("PRAGMA journal_mode = WAL")
 	db.exec("PRAGMA busy_timeout = 10000")
 	db.exec("PRAGMA synchronous = OFF")
 
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS spr (
-			id INTEGER PRIMARY KEY,
-			parent_id INTEGER NOT NULL DEFAULT -1,
-			name TEXT NOT NULL DEFAULT '',
-			placetype TEXT NOT NULL DEFAULT '',
-			country TEXT NOT NULL DEFAULT '',
-			latitude REAL NOT NULL DEFAULT 0,
-			longitude REAL NOT NULL DEFAULT 0,
-			min_latitude REAL NOT NULL DEFAULT 0,
-			min_longitude REAL NOT NULL DEFAULT 0,
-			max_latitude REAL NOT NULL DEFAULT 0,
-			max_longitude REAL NOT NULL DEFAULT 0,
-			is_current INTEGER NOT NULL DEFAULT 1,
-			is_deprecated INTEGER NOT NULL DEFAULT 0,
-			is_ceased INTEGER NOT NULL DEFAULT 0,
-			is_superseded INTEGER NOT NULL DEFAULT 0,
-			is_superseding INTEGER NOT NULL DEFAULT 0,
-			lastmodified INTEGER NOT NULL DEFAULT 0
-		)
-	`)
+	// `kdb` wraps `db` for the DDL (the house idiom); the caller owns `db`'s lifecycle, so we don't
+	// destroy it here. The bulk INSERTs (populateAncestors + build-unified-wof) stay on the raw handle.
+	const kdb = new DatabaseClient<WofDatabase>({ database: db })
 
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS names (
-			id INTEGER NOT NULL,
-			name TEXT NOT NULL,
-			placetype TEXT NOT NULL DEFAULT '',
-			country TEXT NOT NULL DEFAULT '',
-			language TEXT NOT NULL DEFAULT '',
-			privateuse TEXT NOT NULL DEFAULT '',
-			lastmodified INTEGER NOT NULL DEFAULT 0
-		)
-	`)
+	await kdb.schema
+		.createTable("spr")
+		.ifNotExists()
+		.addColumn("id", "integer", (c) => c.primaryKey())
+		.addColumn("parent_id", "integer", (c) => c.notNull().defaultTo(-1))
+		.addColumn("name", "text", (c) => c.notNull().defaultTo(""))
+		.addColumn("placetype", "text", (c) => c.notNull().defaultTo(""))
+		.addColumn("country", "text", (c) => c.notNull().defaultTo(""))
+		.addColumn("latitude", "real", (c) => c.notNull().defaultTo(0))
+		.addColumn("longitude", "real", (c) => c.notNull().defaultTo(0))
+		.addColumn("min_latitude", "real", (c) => c.notNull().defaultTo(0))
+		.addColumn("min_longitude", "real", (c) => c.notNull().defaultTo(0))
+		.addColumn("max_latitude", "real", (c) => c.notNull().defaultTo(0))
+		.addColumn("max_longitude", "real", (c) => c.notNull().defaultTo(0))
+		.addColumn("is_current", "integer", (c) => c.notNull().defaultTo(1))
+		.addColumn("is_deprecated", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("is_ceased", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("is_superseded", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("is_superseding", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("lastmodified", "integer", (c) => c.notNull().defaultTo(0))
+		.execute()
 
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS concordances (
-			id INTEGER NOT NULL,
-			other_id TEXT NOT NULL,
-			other_source TEXT NOT NULL,
-			lastmodified INTEGER NOT NULL DEFAULT 0
-		)
-	`)
+	await kdb.schema
+		.createTable("names")
+		.ifNotExists()
+		.addColumn("id", "integer", (c) => c.notNull())
+		.addColumn("name", "text", (c) => c.notNull())
+		.addColumn("placetype", "text", (c) => c.notNull().defaultTo(""))
+		.addColumn("country", "text", (c) => c.notNull().defaultTo(""))
+		.addColumn("language", "text", (c) => c.notNull().defaultTo(""))
+		.addColumn("privateuse", "text", (c) => c.notNull().defaultTo(""))
+		.addColumn("lastmodified", "integer", (c) => c.notNull().defaultTo(0))
+		.execute()
 
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS place_population (
-			id INTEGER PRIMARY KEY,
-			population INTEGER NOT NULL DEFAULT 0
-		)
-	`)
+	await kdb.schema
+		.createTable("concordances")
+		.ifNotExists()
+		.addColumn("id", "integer", (c) => c.notNull())
+		.addColumn("other_id", "text", (c) => c.notNull())
+		.addColumn("other_source", "text", (c) => c.notNull())
+		.addColumn("lastmodified", "integer", (c) => c.notNull().defaultTo(0))
+		.execute()
+
+	await kdb.schema
+		.createTable("place_population")
+		.ifNotExists()
+		.addColumn("id", "integer", (c) => c.primaryKey())
+		.addColumn("population", "integer", (c) => c.notNull().defaultTo(0))
+		.execute()
 
 	// `ancestors` maps each place to every place above it in the hierarchy (and itself). The
 	// resolver's parent-constraint scopes a child lookup to a parent's descendants via
 	// `spr.id IN (SELECT id FROM ancestors WHERE ancestor_id = ?)`. The off-the-shelf WOF dumps
 	// ship this table; our build derives it from the parent_id chain (see populateAncestors) since
 	// we don't capture `wof:hierarchy`.
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS ancestors (
-			id INTEGER NOT NULL,
-			ancestor_id INTEGER NOT NULL,
-			ancestor_placetype TEXT NOT NULL DEFAULT '',
-			lastmodified INTEGER NOT NULL DEFAULT 0
-		)
-	`)
+	await kdb.schema
+		.createTable("ancestors")
+		.ifNotExists()
+		.addColumn("id", "integer", (c) => c.notNull())
+		.addColumn("ancestor_id", "integer", (c) => c.notNull())
+		.addColumn("ancestor_placetype", "text", (c) => c.notNull().defaultTo(""))
+		.addColumn("lastmodified", "integer", (c) => c.notNull().defaultTo(0))
+		.execute()
 }
 
 /**
@@ -122,16 +129,27 @@ export function populateAncestors(db: DatabaseSync): number {
 	return count
 }
 
-export function createUnifiedIndexes(db: DatabaseSync): void {
-	db.exec("CREATE INDEX IF NOT EXISTS spr_by_placetype ON spr (placetype)")
-	db.exec("CREATE INDEX IF NOT EXISTS spr_by_country ON spr (country)")
-	db.exec("CREATE INDEX IF NOT EXISTS spr_by_parent ON spr (parent_id)")
-	db.exec("CREATE INDEX IF NOT EXISTS names_by_id ON names (id)")
-	db.exec("CREATE INDEX IF NOT EXISTS names_by_name ON names (name)")
-	db.exec("CREATE INDEX IF NOT EXISTS concordances_by_id ON concordances (id, lastmodified)")
-	db.exec("CREATE INDEX IF NOT EXISTS concordances_by_other_id ON concordances (other_source, other_id)")
+export async function createUnifiedIndexes(db: DatabaseSync): Promise<void> {
+	const kdb = new DatabaseClient<WofDatabase>({ database: db })
+	await kdb.schema.createIndex("spr_by_placetype").ifNotExists().on("spr").column("placetype").execute()
+	await kdb.schema.createIndex("spr_by_country").ifNotExists().on("spr").column("country").execute()
+	await kdb.schema.createIndex("spr_by_parent").ifNotExists().on("spr").column("parent_id").execute()
+	await kdb.schema.createIndex("names_by_id").ifNotExists().on("names").column("id").execute()
+	await kdb.schema.createIndex("names_by_name").ifNotExists().on("names").column("name").execute()
+	await kdb.schema
+		.createIndex("concordances_by_id")
+		.ifNotExists()
+		.on("concordances")
+		.columns(["id", "lastmodified"])
+		.execute()
+	await kdb.schema
+		.createIndex("concordances_by_other_id")
+		.ifNotExists()
+		.on("concordances")
+		.columns(["other_source", "other_id"])
+		.execute()
 	// ancestor_id is the hot column (parent-constraint queries `WHERE ancestor_id = ?`); id supports
 	// the reverse lookup.
-	db.exec("CREATE INDEX IF NOT EXISTS ancestors_by_ancestor ON ancestors (ancestor_id)")
-	db.exec("CREATE INDEX IF NOT EXISTS ancestors_by_id ON ancestors (id)")
+	await kdb.schema.createIndex("ancestors_by_ancestor").ifNotExists().on("ancestors").column("ancestor_id").execute()
+	await kdb.schema.createIndex("ancestors_by_id").ifNotExists().on("ancestors").column("id").execute()
 }

--- a/scripts/add-ancestors.ts
+++ b/scripts/add-ancestors.ts
@@ -25,10 +25,10 @@ import { DatabaseSync } from "node:sqlite"
 const dbPath = process.argv[2] ?? "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
 console.error(`Adding ancestors to ${dbPath} ...`)
 const db = new DatabaseSync(dbPath)
-createUnifiedSchema(db) // CREATE TABLE IF NOT EXISTS — adds `ancestors`, leaves existing tables intact
+await createUnifiedSchema(db) // CREATE TABLE IF NOT EXISTS — adds `ancestors`, leaves existing tables intact
 const t0 = performance.now()
 const rows = populateAncestors(db)
-createUnifiedIndexes(db)
+await createUnifiedIndexes(db)
 db.exec("ANALYZE")
 // Restore the frozen single-file state (createUnifiedSchema put us in WAL).
 db.exec("PRAGMA wal_checkpoint(TRUNCATE)")

--- a/scripts/augment-admin-overture.ts
+++ b/scripts/augment-admin-overture.ts
@@ -140,7 +140,7 @@ populateAncestors(db)
 console.error("  coincident_roles ...")
 buildCoincidentRoles(db)
 console.error("  indexes ...")
-createUnifiedIndexes(db)
+await createUnifiedIndexes(db)
 // Rebuild the place_search FTS from the names table — the candidate's alias pass reads
 // place_search.alt_names, so without this the augmented places' aliases (incl. the multilingual
 // English names) never reach the candidate, and a non-Latin city resolves only by its local-script

--- a/scripts/build-unified-wof.ts
+++ b/scripts/build-unified-wof.ts
@@ -371,7 +371,7 @@ async function main() {
 		PRAGMA temp_store = MEMORY;
 		PRAGMA cache_size = -200000;
 	`)
-	createUnifiedSchema(db)
+	await createUnifiedSchema(db)
 
 	const sprInsert = db.prepare(
 		`INSERT OR REPLACE INTO spr (id, parent_id, name, placetype, country, latitude, longitude, min_latitude, min_longitude, max_latitude, max_longitude, is_current, is_deprecated, is_ceased, is_superseded, is_superseding, lastmodified) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -509,7 +509,7 @@ async function main() {
 	console.error(`  coincident_roles: ${roles.rowCount} rows`)
 
 	console.error("  Creating indexes...")
-	createUnifiedIndexes(db)
+	await createUnifiedIndexes(db)
 
 	console.error("  ANALYZE...")
 	db.exec("ANALYZE")


### PR DESCRIPTION
Fifth step of the inline-SQL → Kysely cleanup — the **canonical gazetteer schema**. `createUnifiedSchema` (the 5 core WOF tables — `spr`, `names`, `concordances`, `place_population`, `ancestors`) and `createUnifiedIndexes` (9 indexes) move from raw `db.exec` strings to `db.schema` builders via a `DatabaseClient<WofDatabase>`.

- PRAGMAs stay raw (not Kysely-modelled); `populateAncestors`' bulk insert loop stays raw.
- Both functions went `async` (Kysely `.execute()` is async); their three script consumers (`build-unified-wof`, `add-ancestors`, `augment-admin-overture`) gained `await`.
- Verified in-memory: 5 tables + 9 indexes, and **every `DEFAULT` renders + applies correctly** (`parent_id` → -1, text → `''`, `is_current` → 1, …) on a defaults-only insert.

## Deliberately left raw (documented exceptions)

These hit real walls, not laziness — same discipline as the FTS5 / ogr2ogr / hot-insert set:

- **`coincident-roles.ts`** — `buildCoincidentRoles` is a **sync, heavily-tested** function (6 unit tests + a `beforeEach` + a sync CLI `buildOne` that returns an exit code). Routing one table + one index through async Kysely would cascade `async` through the whole sync call graph and rewrite the tests for no real gain. (Same judgment the #748 batch applied to `zcta-centroids`.)
- **`build-slim.ts`** — fundamentally an **introspect-and-replay** builder: it `exec`s the *source* DB's own `CREATE TABLE` strings read from `sqlite_master`. A static builder can't express a runtime-copied schema, and it's the retiring slim path.
- **`PlacetypeDataSource.ts`** — its DDL runs in a **synchronous class constructor**; Kysely's schema-builder is async, so migrating would force an async-factory refactor across every consumer.

## Verification

`yarn compile` (tsc -b) clean · prettier clean, no jsdoc mangle · `coincident-roles` + `coincident-localities-lookup` tests 12/12 (confirming the revert) · in-memory DDL + defaults check passes.

That leaves the DuckDB side (`@oorabona/kysely-duckdb`), the raw query sites, and the closing leave-as-raw documentation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)