### PR TITLE
refactor(sql): establish the async query-builder pattern (#189 pattern)

### DIFF
--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -861,7 +861,7 @@ export class WofSqlitePlaceLookup implements PlaceLookup, Disposable {
 		// isn't supplied → the scoring loop below is byte-identical to pre-#475.
 		const postalAliasByGeo = new Map<string, string[]>()
 		if (this.#postalCityAliases) {
-			for (const a of this.#postalCityAliases.getDivergentAliases(pc)) {
+			for (const a of await this.#postalCityAliases.getDivergentAliases(pc)) {
 				const key = cfNormalize(a.geoLocality)
 				if (!key) continue
 				const bag = postalAliasByGeo.get(key)

--- a/resolver-wof-sqlite/postal-city-alias-lookup.test.ts
+++ b/resolver-wof-sqlite/postal-city-alias-lookup.test.ts
@@ -73,22 +73,22 @@ describe("WofPostalCityAliasLookup (#475 reader)", () => {
 	})
 	afterEach(() => reader.close())
 
-	it("returns the divergent alias for a known postcode", () => {
-		const aliases = reader.getDivergentAliases("37013")
+	it("returns the divergent alias for a known postcode", async () => {
+		const aliases = await reader.getDivergentAliases("37013")
 		expect(aliases).toHaveLength(1)
 		expect(aliases[0]).toMatchObject({ postalCity: "Antioch", geoLocality: "Nashville", n: 47389 })
 	})
 
-	it("excludes non-divergent rows (postal name == geo name)", () => {
-		expect(reader.getDivergentAliases("90210")).toHaveLength(0)
+	it("excludes non-divergent rows (postal name == geo name)", async () => {
+		expect(await reader.getDivergentAliases("90210")).toHaveLength(0)
 	})
 
-	it("returns [] for a postcode not in the table", () => {
-		expect(reader.getDivergentAliases("00000")).toEqual([])
+	it("returns [] for a postcode not in the table", async () => {
+		expect(await reader.getDivergentAliases("00000")).toEqual([])
 	})
 
-	it("trims the queried postcode", () => {
-		expect(reader.getDivergentAliases("  22191 ")).toHaveLength(1)
+	it("trims the queried postcode", async () => {
+		expect(await reader.getDivergentAliases("  22191 ")).toHaveLength(1)
 	})
 })
 

--- a/resolver-wof-sqlite/postal-city-alias-lookup.ts
+++ b/resolver-wof-sqlite/postal-city-alias-lookup.ts
@@ -16,8 +16,9 @@
  *   uses), keeping one normalizer in one place.
  */
 
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
 import { DatabaseSync } from "node:sqlite"
-import type { PostalCityAliasTable } from "./postal-city-alias-schema.js"
+import type { PostalCityAliasDatabase } from "./postal-city-alias-schema.js"
 
 export interface WofPostalCityAliasLookupOpts {
 	/** Path to a `postal-city-alias-<cc>.db` built by `build-postal-city-alias.ts`. Opened read-only. */
@@ -36,17 +37,15 @@ export interface PostalCityAlias {
 	n: number
 }
 
-/** The columns the reader projects — a typed slice of {@link PostalCityAliasTable} (writer↔reader). */
-type AliasRow = Pick<PostalCityAliasTable, "postal_city" | "geo_locality" | "n">
-
 /**
  * Reader over `postal_city_alias`. The only query is a postcode-scoped probe for DIVERGENT rows
- * (where the postal name differs from the geographic name — the rows that carry alias signal).
+ * (where the postal name differs from the geographic name — the rows that carry alias signal),
+ * issued via the typed Kysely query builder against {@link PostalCityAliasDatabase}.
  */
 export class WofPostalCityAliasLookup {
 	#db: DatabaseSync
+	#kdb: DatabaseClient<PostalCityAliasDatabase>
 	#ownsDb: boolean
-	#stmt: ReturnType<DatabaseSync["prepare"]>
 
 	constructor(opts: WofPostalCityAliasLookupOpts) {
 		if (opts.database) {
@@ -58,9 +57,8 @@ export class WofPostalCityAliasLookup {
 		} else {
 			throw new Error("WofPostalCityAliasLookup needs `databasePath` or `database`")
 		}
-		this.#stmt = this.#db.prepare(
-			"SELECT postal_city, geo_locality, n FROM postal_city_alias WHERE postcode = ? AND divergent = 1"
-		)
+		// `#kdb` wraps `#db` for the typed query; close() owns the raw handle directly (sync).
+		this.#kdb = new DatabaseClient<PostalCityAliasDatabase>({ database: this.#db })
 	}
 
 	/**
@@ -68,10 +66,15 @@ export class WofPostalCityAliasLookup {
 	 * scorer groups these by normalized `geoLocality` and appends the `postalCity` surfaces to the
 	 * matching candidate locality's alias set.
 	 */
-	getDivergentAliases(postcode: string): PostalCityAlias[] {
+	async getDivergentAliases(postcode: string): Promise<PostalCityAlias[]> {
 		const pc = postcode.trim()
 		if (!pc) return []
-		const rows = this.#stmt.all(pc) as unknown as AliasRow[]
+		const rows = await this.#kdb
+			.selectFrom("postal_city_alias")
+			.select(["postal_city", "geo_locality", "n"])
+			.where("postcode", "=", pc)
+			.where("divergent", "=", 1)
+			.execute()
 		return rows.map((r) => ({ postalCity: String(r.postal_city), geoLocality: String(r.geo_locality), n: Number(r.n) }))
 	}
 


### PR DESCRIPTION
First step of #189 (raw `.prepare()` query sites → Kysely query builder) and the **worked example** for the resolver-reader migration — converting a sync, statement-cached reader to a typed async Kysely query and cascading `async` through its caller.

`WofPostalCityAliasLookup.getDivergentAliases` is now `async`: it issues `kdb.selectFrom("postal_city_alias").select([…]).where("postcode","=",pc).where("divergent","=",1)` against the typed `PostalCityAliasDatabase` — the hand-written `Pick<>` projection and the `as unknown as` cast are gone; the row type comes from the schema. The reader keeps the raw `DatabaseSync` for a sync `close()`; a `DatabaseClient` wraps it for the query. The one caller (lookup.ts's coordinate-first scorer, already inside the async `findPlace`) now awaits the alias loop.

## Pattern rules for the fan-out

- **Only plain SELECT/INSERT readers convert.** FTS5 `MATCH` stays raw (Kysely can't express it); hot bulk inserts stay raw.
- Each converted reader cascades `async` to its callers — the cost you accepted for typed read paths.

## Verification

`yarn compile` clean · prettier clean · `postal-city-alias-lookup` 7/7 (covers the reader **and** the lookup.ts cascade via the coordinate-first wiring tests).

This is intentionally one reader — the pattern PR. The rest stages across several PRs (candidate-lookup, address-point, the non-FTS lookup.ts queries, then the build/eval/corpus query sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)