### PR TITLE
fix(tiger): add repository field — unblock v4.12.0 provenance publish

### DIFF
--- a/tiger/package.json
+++ b/tiger/package.json
@@ -9,6 +9,15 @@
 			"email": "teffen@sister.software"
 		}
 	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "tiger"
+	},
+	"bugs": {
+		"url": "https://github.com/sister-software/mailwoman/issues"
+	},
+	"homepage": "https://github.com/sister-software/mailwoman",
 	"scripts": {
 		"test": "node ./out/sdk/TIGERService.test.js"
 	},


### PR DESCRIPTION
**Release recovery.** The v4.12.0 publish (run 27911694906) failed on `@mailwoman/tiger` with npm **E422** — provenance verification rejected it because `tiger/package.json` had no `repository.url`:

> Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/sister-software/mailwoman" from provenance

tiger was added in #739 without the field; it only bit now that provenance is on (the repo is public). Exactly the class of #660 (the `spatial` fix at 4.10.0).

All **18 other workspaces published cleanly at 4.12.0**; the `v4.12.0` tag + release commit are already on main. This adds the standard `repository`/`bugs`/`homepage` block (matching every other workspace). Once merged, a `publish_only=true` re-run publishes tiger@4.12.0 (the rest become `--tolerate-republish` no-ops) and the release is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)