### PR TITLE
fix(ci): add tiger to the publish_only finish-loop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,7 +166,7 @@ jobs:
           set -uo pipefail
           yarn compile
           FAILED=()
-          for ws in core spatial normalize query-shape kind-classifier locale-gate phrase-grouper codex classifiers corpus neural neural-weights-en-us neural-weights-fr-fr formatter record match address-id registry mailwoman; do
+          for ws in core spatial normalize query-shape kind-classifier locale-gate phrase-grouper codex classifiers corpus neural neural-weights-en-us neural-weights-fr-fr formatter record match address-id registry tiger mailwoman; do
             echo "::group::publish ${ws}"
             if RELEASE_IT_WORKSPACES_PATH_TO_WORKSPACE="./${ws}" node scripts/publish-workspace.mjs; then
               echo "  ✓ ${ws}"


### PR DESCRIPTION
Second release-recovery step for v4.12.0. After #754 fixed tiger's missing `repository` field, I re-dispatched `publish_only=true` — but tiger **still** didn't publish (it's `1.0.0` on npm; everything else is `4.12.0`).

Cause: `publish.yml`'s **"Finish publish" step has a separate, hardcoded** `for ws in …` workspace list, and it never had `tiger` added (tiger joined `.release-it` in #739). So the tolerate-republish loop skipped the 19 it knew about and never even attempted tiger. The normal release-it publish path reads the `.release-it` workspaces array (which *does* have tiger — that's why the live run got far enough to hit tiger's E422), so only this finish-loop was stale.

Fix: add `tiger` before `mailwoman`, matching the `.release-it` order. After merge, one more `publish_only=true` dispatch publishes `tiger@4.12.0` and the release is complete.

(Worth a follow-up: derive this loop from `.release-it.json` so it can't drift again.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)