### PR TITLE
#743 Step 1: production-representative placeCountry mode in oa-resolver-eval

### DIFF
--- a/mailwoman/index.ts
+++ b/mailwoman/index.ts
@@ -12,4 +12,5 @@
 export * from "@mailwoman/core"
 export * from "@mailwoman/classifiers"
 export * from "./runtime-pipeline.js"
+export * from "./default-placer.js"
 export * from "./utils/index.js"

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -50,7 +50,12 @@ import { lookupGermanState } from "@mailwoman/codex/de"
 import { lookupFrenchRegion } from "@mailwoman/codex/fr"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { createWofResolver, expandPlacetypeFilter } from "@mailwoman/core/resolver"
-import { type ClassificationRecord, createAddressParser, createRuntimePipeline } from "mailwoman"
+import {
+	type ClassificationRecord,
+	createAddressParser,
+	createRuntimePipeline,
+	loadDefaultPlaceCountry,
+} from "mailwoman"
 import { readFileSync, writeFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
 import { v0RecordToTree } from "./v0-tree-adapter.ts"
@@ -638,11 +643,23 @@ async function main(): Promise<void> {
 	const diagMisses: string[] = []
 
 	// #478 inc 3 leg 2 — the ASSEMBLED arms. Route each row through `createRuntimePipeline` using the
-	// SAME neural classifier (postcodeRepair on, for comparability with the neural arm), placeCountry
-	// OFF (so we isolate arbitration from the #244 coarse prior), and the SAME resolver — without
-	// (`assembled`) and with (`assembled+arb`) per-component arbitration. The street+house_number
-	// precondition (the thing #566 broke) is counted per arm so a regression is visible directly.
+	// SAME neural classifier (postcodeRepair on, for comparability with the neural arm) and the SAME
+	// resolver — without (`assembled`) and with (`assembled+arb`) per-component arbitration. The
+	// street+house_number precondition (the thing #566 broke) is counted per arm so a regression is
+	// visible directly.
+	//
+	// placeCountry default is OFF here (`false`) so the assembled arm isolates arbitration from the
+	// #244 coarse prior. But the SHIPPED `createRuntimePipeline`/`geocodeAddress` default IS the
+	// bundled placer (on, open-set @ 0.9). `--place-country` flips this eval to the production-
+	// representative config — load the same bundled placer and feed it to the pipeline — which is the
+	// #743 EU country-constraint integrity fix: without it the assembled EU coords are not what a real
+	// caller sees (ambiguous EU names without a country constraint land off-continent).
 	const runAssembled = process.argv.includes("--assembled")
+	const usePlaceCountry = process.argv.includes("--place-country")
+	const evalPlacer = runAssembled && usePlaceCountry ? await loadDefaultPlaceCountry() : null
+	if (usePlaceCountry && !evalPlacer) {
+		console.warn("--place-country requested but the bundled coarse-placer failed to load; running placeCountry OFF.")
+	}
 	const assembledAgg = { overall: newAgg(), byState: new Map<string, Agg>() }
 	const assembledArbAgg = { overall: newAgg(), byState: new Map<string, Agg>() }
 	let neuralPrecond = 0
@@ -666,7 +683,7 @@ async function main(): Promise<void> {
 					parse: (text: string, o?: object) => neural.parse(text, { ...o, postcodeRepair: true }),
 				} as never,
 				resolver: resolver as never,
-				placeCountry: false,
+				placeCountry: evalPlacer ?? false,
 			})
 		: null
 


### PR DESCRIPTION
## What

The assembled arms of `oa-resolver-eval` ran with `placeCountry: false`, but the **shipped** `createRuntimePipeline`/`geocodeAddress` default IS the bundled coarse-placer (on, open-set @ 0.9). So the eval's EU assembled coords were not what a real caller sees — ambiguous EU names with no country constraint land off-continent in the population-first candidate gazetteer.

Adds `--place-country`: load the same bundled placer (`loadDefaultPlaceCountry`, now re-exported from `mailwoman`) and feed it to the assembled pipeline. **Default stays OFF** so existing invocations are byte-stable and the #478-leg-2 arbitration-isolation purpose is preserved.

This is #743 Step 1 — the eval-integrity prerequisite for Step 2 (the postcode→country hard constraint). It makes the EU numbers production-representative so Step 2 is measured against an honest baseline.

## Validated

`--candidate-db candidate-global-intl.db --default-country none --assembled`, no-arb arm, 600 rows (FI 400):

| locale | baseline p90 | `--place-country` p90 | loc | note |
|---|--:|--:|--:|---|
| **ES** (in-map, collision-prone) | 2099.0 km | **26.5 km** | 77.0→77.8% | −98.7% tail collapse — the headline case |
| IT (mostly in-country) | 17.0 km | 33.8 (p99 1020→805) | 88.7% flat | marginal |
| NL (already clean) | 2.9 km | 2.9 km | 92.5% flat | no off-continent tail to fix |
| FI / PL (out-of-map) | 3050 km | 3050 km | flat | placer can't emit FI/PL |

The placer's class set is `US,FR,GB,CN,NL,IT,DE,JP,ES,KR,TW,OTHER` — **FI/PL are outside it**, so the soft prior structurally cannot help them. That is the #743 caveat (#193) and the motivation for Step 2: the postcode→country *hard* constraint covers the out-of-map locales the soft placer cannot.

Mechanism: `placeCountry` → `query.country` → candidate country-filter (`candidate-lookup.ts:157`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)