### PR TITLE
#194 #743 lever B: confident-placer HARD country filter (in-region-or-unresolved)

### DIFF
--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -60,6 +60,13 @@ function isPostcodeFormat(format: string): boolean {
  */
 const COARSE_PLACER_ANCHOR_WEIGHT = 1.0
 
+// #194: minimum placer confidence to promote the soft country prior to a HARD filter (with fallback).
+// The placer already abstains below 0.9 in-map MASS (open-set rule), but the per-country argmax prob
+// can still be split across neighbours (DK↔NO, EE↔LT↔LV); requiring a high argmax confidence keeps the
+// hard filter to the cases the model is sure of (FI/PL routinely score ~1.0) and leaves the ambiguous
+// ones on the soft path. Deliberately strict — a wrong hard country is the #244 M2 misroute failure.
+const HARD_PLACE_COUNTRY_MIN_CONF = 0.9
+
 function isPostcodeFormatHit(hit: { format: string }): boolean {
 	return isPostcodeFormat(hit.format)
 }
@@ -207,6 +214,16 @@ export async function runPipeline(
 		placedPrediction = placed
 		timing["place-country"] = performance.now() - tPlace
 		if (placed.country && placed.country !== "OTHER" && !opts?.resolveOpts?.anchorPosterior) {
+			// #194: promote a CONFIDENT placement to a HARD country filter (with empty→global fallback) when
+			// the caller opts in AND the confidence clears the bar. The soft posterior alone can't move a
+			// LOW-population place (a FI town loses to a high-pop namesake even when FI is pinned); the hard
+			// filter does. Gated on confidence so ambiguous neighbour placements (DK↔NO) stay soft. The
+			// caller's own `hardCountry`/`defaultCountry` is never overwritten.
+			const hard =
+				opts?.hardPlaceCountry &&
+				placed.confidence >= HARD_PLACE_COUNTRY_MIN_CONF &&
+				!opts?.resolveOpts?.hardCountry &&
+				!opts?.resolveOpts?.defaultCountry
 			effectiveOpts = {
 				...opts,
 				resolveOpts: {
@@ -215,6 +232,7 @@ export async function runPipeline(
 					// one-hot argmax (the M2 behavior).
 					anchorPosterior: placed.posterior ?? { [placed.country]: placed.confidence },
 					anchorWeight: opts?.resolveOpts?.anchorWeight ?? COARSE_PLACER_ANCHOR_WEIGHT,
+					...(hard ? { hardCountry: placed.country } : {}),
 				},
 			}
 		}

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -62,6 +62,17 @@ export interface PipelineOpts {
 	 * - Off by default → byte-stable for mixed-case input.
 	 */
 	normalizeCase?: boolean
+	/**
+	 * #743/#194: promote a CONFIDENT coarse-placer guess from the soft `anchorPosterior` boost to a
+	 * HARD country filter (empty→unresolved) — see {@link ResolveOpts.hardCountry}. Only fires when
+	 * the placer's confidence clears `HARD_PLACE_COUNTRY_MIN_CONF`, so ambiguous neighbour cases
+	 * (DK↔NO) stay soft. Off by default → byte-stable (the soft prior alone). The lever for the
+	 * low-population EU tail (FI/PL) the soft prior can't move — it trades the off-continent guess
+	 * for "in-region or unresolved", so enabling it IS the precision/recall choice (tail collapse at
+	 * a coverage-bounded recall cost). Pairs with the widened placer (#759), which is what lets the
+	 * placer emit FI/PL confidently.
+	 */
+	hardPlaceCountry?: boolean
 	signal?: AbortSignal
 }
 

--- a/core/resolver/resolve.test.ts
+++ b/core/resolver/resolve.test.ts
@@ -228,6 +228,44 @@ describe("resolveTree", () => {
 		expect(result.roots[0]?.children[0]?.placeId).toBe("wof:101727113")
 	})
 
+	test("#194 hardCountry: a confident placer country is a HARD filter, winning over a higher-scored foreign namesake", async () => {
+		// Two same-name localities; the foreign one scores higher (the population-first collision #743 is about).
+		const places: ResolvedPlace[] = [
+			{ id: 1, name: "Pori", placetype: "locality", country: "FI", lat: 61.48, lon: 21.79, score: 8 },
+			{ id: 2, name: "Pori", placetype: "locality", country: "US", lat: 40.0, lon: -90.0, score: 9 },
+		]
+		const backend = new FakeResolverBackend(places)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Pori", [node("locality", "Pori", 0, 4)])
+		const result = await resolver.resolveTree(input, { hardCountry: "FI" })
+
+		// The FI Pori wins despite the US one's higher score — the hard country filter excludes it.
+		expect(result.roots[0]).toMatchObject({ placeId: "wof:1", lat: 61.48 })
+		expect(backend.calls).toHaveLength(1)
+		expect(backend.calls[0]).toMatchObject({ country: "FI" })
+	})
+
+	test("#194 hardCountry miss → node left UNRESOLVED, with NO global retry (the in-region-or-unresolved contract)", async () => {
+		// The locality exists only in FR; a hardCountry of FI must NOT fall back to it globally.
+		const places: ResolvedPlace[] = [
+			{ id: 3, name: "Lyon", placetype: "locality", country: "FR", lat: 45.76, lon: 4.84, score: 9 },
+		]
+		const backend = new FakeResolverBackend(places)
+		const resolver = createWofResolver(backend)
+
+		const input = tree("Lyon", [node("locality", "Lyon", 0, 4, [], "neural", "v1")])
+		const result = await resolver.resolveTree(input, { hardCountry: "FI" })
+
+		// Unresolved — the classifier attribution survives, no coordinate, no global fallback to the FR Lyon.
+		expect(result.roots[0]?.placeId).toBeUndefined()
+		expect(result.roots[0]?.lat).toBeUndefined()
+		expect(result.roots[0]?.source).toBe("neural")
+		// Exactly one lookup, and it carried the FI filter — there is no second, country-less retry.
+		expect(backend.calls).toHaveLength(1)
+		expect(backend.calls.every((c) => c.country === "FI")).toBe(true)
+	})
+
 	test("respects maxLookups budget", async () => {
 		const backend = new FakeResolverBackend(FIXTURE_PLACES)
 		const resolver = createWofResolver(backend)

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -51,6 +51,9 @@ interface ResolutionState {
 	anchorPosterior?: Record<string, number>
 	/** Weight on the posterior in the locality re-rank. Only used when `anchorPosterior` is set. */
 	anchorWeight: number
+	/** #743/#194 confident-placer country as a HARD filter (empty→unresolved, no global retry). Off =
+undefined. */
+	hardCountry?: string
 	/** Dual-role hierarchy completion (#405). Off by default → byte-stable. */
 	hierarchyCompletion: boolean
 	/** Attach ancestor lineage to each resolved node (#404). Off by default → byte-stable. */
@@ -254,6 +257,7 @@ class WofResolver implements Resolver {
 			postcode: firstPostcodeValue(tree.roots),
 			anchorPosterior: opts.anchorPosterior,
 			anchorWeight: opts.anchorWeight ?? 2.0,
+			hardCountry: opts.hardCountry,
 			// Default-ON (#402): completion only fires for a dual-role region whose locality the parser
 			// dropped, and no-ops entirely when the backend has no relation (the browser WASM resolver, or
 			// a gazetteer without `coincident_roles`). Pass `hierarchyCompletion: false` to opt out.
@@ -373,7 +377,15 @@ class WofResolver implements Resolver {
 		// multi-country gazetteer fuzzy-matches a foreign place (e.g. a French region) — see the
 		// Direction-C resolver eval.
 		if (parentResolved && typeof parentResolved.id === "number") query.parentId = parentResolved.id
-		const country = parentResolved?.country ?? state.defaultCountry
+		// #194: a resolved parent's country wins, then the caller's `defaultCountry`, then the confident
+		// placer `hardCountry`. All three are a HARD candidate filter. The placer's `hardCountry` is gated
+		// upstream on high confidence (so it only fires when the model is sure), and on a miss the node is
+		// left UNRESOLVED rather than re-resolved globally: the off-continent rows are precisely the ones
+		// whose locality isn't in the country's gazetteer slice, so a global retry would just re-admit the
+		// wrong-continent guess the hard filter exists to drop ("in-region or unresolved"). Measured: a
+		// global fallback collapses back to the soft-prior baseline (FI p90 3050, PL p90 1078); pure-hard
+		// collapses the tail (FI 18 km, PL p99 8172→494) at a coverage-bounded recall cost.
+		const country = parentResolved?.country ?? state.defaultCountry ?? state.hardCountry
 		if (country) query.country = country
 		// Coordinate-first: hand the sibling postcode to locality lookups so the backend can inject
 		// postcode-proximal candidates the name-match would miss. Only for locality (the placetype both

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -256,6 +256,19 @@ export interface ResolveOpts {
 	 */
 	anchorWeight?: number
 	/**
+	 * #743/#194 — a CONFIDENT coarse-placer country applied as a HARD candidate filter
+	 * (`query.country`), not the soft {@link anchorPosterior} boost. This collapses the off-continent
+	 * tail for LOW-population places the soft prior can't move (FI/PL — their towns lose to a
+	 * high-pop namesake in the population-first gazetteer even when the country is pinned). On a miss
+	 * the node is left UNRESOLVED ("in-region or unresolved") rather than re-resolved globally — the
+	 * off-continent rows are precisely the ones whose locality isn't in the country's gazetteer
+	 * slice, so a global fallback just re-admits the wrong-continent guess (measured: it collapses
+	 * back to the soft-prior baseline). The win is coverage-bounded: tail collapse at a recall cost
+	 * set by how complete the country's gazetteer is (PL −9.5pp, FI −32pp). Undefined (default) →
+	 * byte-stable. Ignored when a resolved parent or {@link defaultCountry} already pins the country.
+	 */
+	hardCountry?: string
+	/**
 	 * Recover the dropped locality in a DUAL-ROLE-place address (#405, epic #402). Many places occupy
 	 * multiple admin tiers under one name — city-states (Berlin/Hamburg/Bremen = city == state),
 	 * capital-seat provinces (Milano, Madrid), UK unitary authorities — and in the

--- a/mailwoman/runtime-pipeline.ts
+++ b/mailwoman/runtime-pipeline.ts
@@ -89,6 +89,14 @@ export interface CreateRuntimePipelineOpts {
 	 * mixed-case untouched). Off by default. A per-call `runOpts.normalizeCase` overrides this.
 	 */
 	normalizeCase?: boolean
+	/**
+	 * #743/#194: default for `PipelineOpts.hardPlaceCountry` on every call — promote a CONFIDENT
+	 * coarse-placer guess from the soft prior to a HARD country filter (empty→unresolved), the lever
+	 * for the low-population EU tail (FI/PL) the soft prior can't move. Off by default → byte-stable.
+	 * A per-call `runOpts.hardPlaceCountry` overrides this. Best paired with the widened placer (#759),
+	 * which is what lets the placer emit FI/PL confidently in the first place.
+	 */
+	hardPlaceCountry?: boolean
 }
 
 /**
@@ -152,9 +160,15 @@ export function createRuntimePipeline(
 			const fn = await loadDefaultPlaceCountry()
 			if (fn) stages.placeCountry = fn
 		}
-		// #690: apply the factory-level normalizeCase default; a per-call runOpts value overrides it.
-		const effectiveRunOpts =
-			opts.normalizeCase && runOpts?.normalizeCase === undefined ? { ...runOpts, normalizeCase: true } : runOpts
+		// Apply factory-level defaults (#690 normalizeCase, #194 hardPlaceCountry); a per-call runOpts
+		// value overrides each.
+		let effectiveRunOpts = runOpts
+		if (opts.normalizeCase && effectiveRunOpts?.normalizeCase === undefined) {
+			effectiveRunOpts = { ...effectiveRunOpts, normalizeCase: true }
+		}
+		if (opts.hardPlaceCountry && effectiveRunOpts?.hardPlaceCountry === undefined) {
+			effectiveRunOpts = { ...effectiveRunOpts, hardPlaceCountry: true }
+		}
 		return runPipeline(raw, stages, effectiveRunOpts)
 	}
 }

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -655,7 +655,11 @@ async function main(): Promise<void> {
 	// #743 EU country-constraint integrity fix: without it the assembled EU coords are not what a real
 	// caller sees (ambiguous EU names without a country constraint land off-continent).
 	const runAssembled = process.argv.includes("--assembled")
-	const usePlaceCountry = process.argv.includes("--place-country")
+	// `--place-country-hard` (#194) promotes a CONFIDENT placer guess to a HARD country filter (with
+	// empty→global fallback) — the lever for the low-pop EU tail (FI/PL) the soft prior can't move. It
+	// implies the placer is loaded.
+	const useHardCountry = process.argv.includes("--place-country-hard")
+	const usePlaceCountry = process.argv.includes("--place-country") || useHardCountry
 	const evalPlacer = runAssembled && usePlaceCountry ? await loadDefaultPlaceCountry() : null
 	if (usePlaceCountry && !evalPlacer) {
 		console.warn("--place-country requested but the bundled coarse-placer failed to load; running placeCountry OFF.")
@@ -684,6 +688,7 @@ async function main(): Promise<void> {
 				} as never,
 				resolver: resolver as never,
 				placeCountry: evalPlacer ?? false,
+				hardPlaceCountry: useHardCountry && !!evalPlacer,
 			})
 		: null
 


### PR DESCRIPTION
Re-targets #760 to main (its base branch was auto-deleted when #758 merged, closing #760). Same #194 commit, cherry-picked clean onto current main (#758 + #759 already landed). Default-OFF → byte-stable.

The FI/PL coord lever: a CONFIDENT coarse-placer guess (conf ≥ 0.9) is promoted from the soft `anchorPosterior` boost to a HARD `query.country` filter, because the population-first candidate ranking means a low-pop FI/PL town loses to a high-pop namesake even when the country is pinned. **No global fallback** — on a miss the node is left unresolved ("in-region or unresolved"); a measured global fallback collapsed straight back to the soft baseline.

Measured (assembled coord, candidate-global-intl.db, v743b placer #759, limit 400): ES p90 15.0→6.8 (loc +1.5, res 99.8 unchanged) · US byte-identical · FI p90 3050→18 (res −29pp) · PL p99 8172→494 (loc +1.5, res −9.5pp). Improves high-coverage countries for free; trades off-continent→unresolved on the low-coverage tail (recall cost scales with gazetteer completeness). 97 resolver/pipeline tests + 2 new. Enabling `hardPlaceCountry` is the precision/recall call; default-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)