### PR TITLE
#743/#194: coverage-guarded HARD country filter (default-ON)

### DIFF
--- a/core/pipeline/index.ts
+++ b/core/pipeline/index.ts
@@ -16,7 +16,7 @@ export type {
 	ResolverCandidatesLookup,
 	ScoreBreakdown,
 } from "./reconcile.js"
-export { runPipeline } from "./runtime-pipeline.js"
+export { HARD_PLACE_COUNTRY_SAFELIST, hardCountryFor, runPipeline } from "./runtime-pipeline.js"
 export { aggregateSpanLogits } from "./span-logit-aggregation.js"
 export type { SpanBounds, TokenPiece } from "./span-logit-aggregation.js"
 export { EMPTY_SPAN_PROPOSER_LEXICON, proposeSpans } from "./span-proposer.js"

--- a/core/pipeline/runtime-pipeline.test.ts
+++ b/core/pipeline/runtime-pipeline.test.ts
@@ -12,7 +12,7 @@ import type { AddressNode, AddressTree } from "../decoder/types.js"
 import type { Resolver } from "../resolver/types.js"
 import type { Span } from "../tokenization/index.js"
 import type { ClassificationProposal, ComponentTag } from "../types/index.js"
-import { runPipeline } from "./runtime-pipeline.js"
+import { HARD_PLACE_COUNTRY_SAFELIST, hardCountryFor, runPipeline } from "./runtime-pipeline.js"
 import type {
 	AddressClassifier,
 	LocaleHint,
@@ -33,6 +33,33 @@ function fakeClassifier(tree: AddressTree): AddressClassifier {
 function fakeResolver(decorator: (tree: AddressTree) => AddressTree): Resolver {
 	return { resolveTree: vi.fn(async (tree: AddressTree) => decorator(tree)) }
 }
+
+describe("hardCountryFor — #743/#194 coverage-guarded hard country filter", () => {
+	const ON = true
+	it("returns the country when confident AND safelisted (the pure-win case)", () => {
+		expect(hardCountryFor("ES", 0.99, {}, ON, undefined)).toBe("ES")
+		expect(HARD_PLACE_COUNTRY_SAFELIST.has("ES")).toBe(true)
+	})
+	it("stays SOFT (undefined) for a confident but NON-safelisted country — the low-coverage tail", () => {
+		expect(HARD_PLACE_COUNTRY_SAFELIST.has("FI")).toBe(false)
+		expect(hardCountryFor("FI", 1.0, {}, ON, undefined)).toBeUndefined()
+	})
+	it("stays SOFT below the confidence bar even when safelisted", () => {
+		expect(hardCountryFor("ES", 0.5, {}, ON, undefined)).toBeUndefined()
+	})
+	it("is OFF when hardPlaceCountry is false/undefined", () => {
+		expect(hardCountryFor("ES", 0.99, {}, false, undefined)).toBeUndefined()
+		expect(hardCountryFor("ES", 0.99, {}, undefined, undefined)).toBeUndefined()
+	})
+	it("never overwrites a caller's own hardCountry / defaultCountry", () => {
+		expect(hardCountryFor("ES", 0.99, { defaultCountry: "US" }, ON, undefined)).toBeUndefined()
+		expect(hardCountryFor("ES", 0.99, { hardCountry: "US" }, ON, undefined)).toBeUndefined()
+	})
+	it("honours a safelist override (how the eval measures ungated to grow the list)", () => {
+		expect(hardCountryFor("FI", 0.99, {}, ON, new Set(["FI"]))).toBe("FI")
+		expect(hardCountryFor("ES", 0.99, {}, ON, new Set(["FI"]))).toBeUndefined()
+	})
+})
 
 describe("runPipeline — defaults", () => {
 	it("runs with all stages absent — empty result, no throw", async () => {

--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -60,12 +60,44 @@ function isPostcodeFormat(format: string): boolean {
  */
 const COARSE_PLACER_ANCHOR_WEIGHT = 1.0
 
-// #194: minimum placer confidence to promote the soft country prior to a HARD filter (with fallback).
+// #194: minimum placer confidence to promote the soft country prior to a HARD filter (empty→unresolved).
 // The placer already abstains below 0.9 in-map MASS (open-set rule), but the per-country argmax prob
 // can still be split across neighbours (DK↔NO, EE↔LT↔LV); requiring a high argmax confidence keeps the
 // hard filter to the cases the model is sure of (FI/PL routinely score ~1.0) and leaves the ambiguous
 // ones on the soft path. Deliberately strict — a wrong hard country is the #244 M2 misroute failure.
 const HARD_PLACE_COUNTRY_MIN_CONF = 0.9
+
+// #743/#194 coverage guard: countries whose candidate gazetteer is complete enough that hard-filtering
+// is a PURE WIN — measured hard-resolve-rate ≥ 95% on held-out OpenAddresses points, so a hard-filter
+// "miss → unresolved" is rare and almost always a genuine non-match, not a coverage gap. A confident
+// placement OUTSIDE this set stays on the SOFT prior, so the low-coverage tail (FI/PL/…) keeps its
+// recall until its gazetteer is filled (#193) — the win for covered countries, no recall regression
+// for the rest (DeepSeek-advised, 2026-06-22). Measured resolve-rate under hard: US 100, FR 100, DE
+// 100, ES 99.8, NL 97.3, IT 96.8 (in); FI 69.5, PL 77.8 (out). Grow as more countries clear the bar.
+// Override per-call with `PipelineOpts.hardCountrySafelist` (the eval measures ungated to grow it).
+export const HARD_PLACE_COUNTRY_SAFELIST: ReadonlySet<string> = new Set(["US", "ES", "IT", "NL", "DE", "FR"])
+
+/**
+ * #743/#194: the shared coverage-guard gate — decide whether a confident coarse-placer country
+ * should become a HARD candidate filter. Exported so the two production placeCountry call sites
+ * (the runtime pipeline AND `geocodeAddress`) apply the SAME three gates and can't drift:
+ * confidence ≥ {@link HARD_PLACE_COUNTRY_MIN_CONF}, country in the safelist (override or the default
+ * {@link HARD_PLACE_COUNTRY_SAFELIST}), and no caller-set hard/default country to respect. Returns
+ * the country to hard-filter, or `undefined` to stay on the soft prior.
+ */
+export function hardCountryFor(
+	placedCountry: string,
+	placedConfidence: number,
+	existing: { hardCountry?: string; defaultCountry?: string },
+	hardPlaceCountry: boolean | undefined,
+	safelist: ReadonlySet<string> | undefined
+): string | undefined {
+	if (!hardPlaceCountry) return undefined
+	if (placedConfidence < HARD_PLACE_COUNTRY_MIN_CONF) return undefined
+	if (!(safelist ?? HARD_PLACE_COUNTRY_SAFELIST).has(placedCountry)) return undefined
+	if (existing.hardCountry || existing.defaultCountry) return undefined
+	return placedCountry
+}
 
 function isPostcodeFormatHit(hit: { format: string }): boolean {
 	return isPostcodeFormat(hit.format)
@@ -214,16 +246,21 @@ export async function runPipeline(
 		placedPrediction = placed
 		timing["place-country"] = performance.now() - tPlace
 		if (placed.country && placed.country !== "OTHER" && !opts?.resolveOpts?.anchorPosterior) {
-			// #194: promote a CONFIDENT placement to a HARD country filter (with empty→global fallback) when
-			// the caller opts in AND the confidence clears the bar. The soft posterior alone can't move a
-			// LOW-population place (a FI town loses to a high-pop namesake even when FI is pinned); the hard
-			// filter does. Gated on confidence so ambiguous neighbour placements (DK↔NO) stay soft. The
-			// caller's own `hardCountry`/`defaultCountry` is never overwritten.
-			const hard =
-				opts?.hardPlaceCountry &&
-				placed.confidence >= HARD_PLACE_COUNTRY_MIN_CONF &&
-				!opts?.resolveOpts?.hardCountry &&
-				!opts?.resolveOpts?.defaultCountry
+			// #194/#743: promote a CONFIDENT placement to a HARD country filter (empty→unresolved) when the
+			// caller opts in, the confidence clears the bar, AND the country is in the coverage SAFELIST. The
+			// soft posterior alone can't move a LOW-population place (a FI town loses to a high-pop namesake
+			// even when FI is pinned); the hard filter does. Three gates: confidence (ambiguous DK↔NO stay
+			// soft), the safelist (only well-covered countries — where a miss is a genuine non-match, not a
+			// coverage gap — hard-filter; the low-coverage tail keeps its recall on the soft path), and the
+			// caller's own hardCountry/defaultCountry is never overwritten. Pass `hardCountrySafelist` to
+			// override the default set (the eval measures ungated to grow it).
+			const hardCountry = hardCountryFor(
+				placed.country,
+				placed.confidence,
+				opts?.resolveOpts ?? {},
+				opts?.hardPlaceCountry,
+				opts?.hardCountrySafelist
+			)
 			effectiveOpts = {
 				...opts,
 				resolveOpts: {
@@ -232,7 +269,7 @@ export async function runPipeline(
 					// one-hot argmax (the M2 behavior).
 					anchorPosterior: placed.posterior ?? { [placed.country]: placed.confidence },
 					anchorWeight: opts?.resolveOpts?.anchorWeight ?? COARSE_PLACER_ANCHOR_WEIGHT,
-					...(hard ? { hardCountry: placed.country } : {}),
+					...(hardCountry ? { hardCountry } : {}),
 				},
 			}
 		}

--- a/core/pipeline/types.ts
+++ b/core/pipeline/types.ts
@@ -64,15 +64,22 @@ export interface PipelineOpts {
 	normalizeCase?: boolean
 	/**
 	 * #743/#194: promote a CONFIDENT coarse-placer guess from the soft `anchorPosterior` boost to a
-	 * HARD country filter (empty→unresolved) — see {@link ResolveOpts.hardCountry}. Only fires when
-	 * the placer's confidence clears `HARD_PLACE_COUNTRY_MIN_CONF`, so ambiguous neighbour cases
-	 * (DK↔NO) stay soft. Off by default → byte-stable (the soft prior alone). The lever for the
-	 * low-population EU tail (FI/PL) the soft prior can't move — it trades the off-continent guess
-	 * for "in-region or unresolved", so enabling it IS the precision/recall choice (tail collapse at
-	 * a coverage-bounded recall cost). Pairs with the widened placer (#759), which is what lets the
-	 * placer emit FI/PL confidently.
+	 * HARD country filter (empty→unresolved) — see {@link ResolveOpts.hardCountry}. Gated three ways:
+	 * the placer's confidence ≥ `HARD_PLACE_COUNTRY_MIN_CONF` (ambiguous DK↔NO stay soft), the
+	 * country is in the coverage `HARD_PLACE_COUNTRY_SAFELIST` (or a {@link hardCountrySafelist}
+	 * override), and no caller `hardCountry`/`defaultCountry` is already set. **Default-ON** in the
+	 * shipped `createRuntimePipeline`/`geocodeAddress` (#743, 2026-06-22) — but the safelist confines
+	 * the hard filter to well-covered countries, so the low-coverage tail (FI/PL) keeps its recall on
+	 * the soft path with no regression. Pass `false` to force the pre-#194 soft-only behavior.
 	 */
 	hardPlaceCountry?: boolean
+	/**
+	 * #743/#194: override the coverage safelist that gates {@link hardPlaceCountry}. Undefined → the
+	 * built-in `HARD_PLACE_COUNTRY_SAFELIST` (production). Supply a set to test/measure a different
+	 * coverage frontier — the resolver eval passes the full in-map country set to measure ungated
+	 * hard-resolve-rates (which is how the production safelist is grown).
+	 */
+	hardCountrySafelist?: ReadonlySet<string>
 	signal?: AbortSignal
 }
 

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -23,6 +23,7 @@
  */
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { hardCountryFor } from "@mailwoman/core/pipeline"
 import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } from "@mailwoman/core/resolver"
 import { existsSync } from "node:fs"
 
@@ -108,6 +109,15 @@ export interface GeocodeDeps {
 	 * - `false` → disabled (no prior; the pre-M2 byte-stable behavior).
 	 */
 	placeCountry?: PlaceCountryFn | false
+	/**
+	 * #743/#194: promote a CONFIDENT placer guess to a HARD country filter (empty→unresolved) for
+	 * coverage-safelisted countries — see {@link hardCountryFor}. **DEFAULT-ON** (#743): a pure win on
+	 * well-covered countries (US/ES/IT/NL/DE/FR), soft (no-op) for the rest. Pass `false` to opt
+	 * out.
+	 */
+	hardPlaceCountry?: boolean
+	/** #743/#194: override the coverage safelist gating {@link hardPlaceCountry}. Undefined → built-in. */
+	hardCountrySafelist?: ReadonlySet<string>
 }
 
 /**
@@ -280,6 +290,16 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 			// The full in-map distribution when supplied (resolver breaks ties); else the one-hot argmax.
 			opts.anchorPosterior = placed.posterior ?? { [placed.country]: placed.confidence }
 			opts.anchorWeight = COARSE_PLACER_ANCHOR_WEIGHT
+			// #743/#194: default-on coverage-guarded HARD country filter (same gate as the runtime pipeline,
+			// via the shared helper so the two production paths can't drift).
+			const hardCountry = hardCountryFor(
+				placed.country,
+				placed.confidence,
+				opts,
+				deps.hardPlaceCountry ?? true,
+				deps.hardCountrySafelist
+			)
+			if (hardCountry) opts.hardCountry = hardCountry
 		}
 	}
 	if (addressPoints) opts.addressPoints = addressPoints

--- a/mailwoman/runtime-pipeline.ts
+++ b/mailwoman/runtime-pipeline.ts
@@ -91,12 +91,21 @@ export interface CreateRuntimePipelineOpts {
 	normalizeCase?: boolean
 	/**
 	 * #743/#194: default for `PipelineOpts.hardPlaceCountry` on every call — promote a CONFIDENT
-	 * coarse-placer guess from the soft prior to a HARD country filter (empty→unresolved), the lever
-	 * for the low-population EU tail (FI/PL) the soft prior can't move. Off by default → byte-stable.
-	 * A per-call `runOpts.hardPlaceCountry` overrides this. Best paired with the widened placer (#759),
-	 * which is what lets the placer emit FI/PL confidently in the first place.
+	 * coarse-placer guess from the soft prior to a HARD country filter (empty→unresolved).
+	 * **DEFAULT-ON** (#743, 2026-06-22): the built-in coverage safelist
+	 * (`HARD_PLACE_COUNTRY_SAFELIST`) confines the hard filter to well-covered countries
+	 * (US/ES/IT/NL/DE/FR), so it's a pure win there and a no-op (soft prior) for the low-coverage
+	 * tail (FI/PL) — no recall regression. Pass `false` to opt out entirely; a per-call
+	 * `runOpts.hardPlaceCountry` overrides this.
 	 */
 	hardPlaceCountry?: boolean
+	/**
+	 * #743/#194: default for `PipelineOpts.hardCountrySafelist` — override the coverage safelist that
+	 * gates the hard country filter. Undefined → the built-in `HARD_PLACE_COUNTRY_SAFELIST`. Used by
+	 * the resolver eval to measure ungated hard-resolve-rates (the full in-map set) when growing the
+	 * list.
+	 */
+	hardCountrySafelist?: ReadonlySet<string>
 }
 
 /**
@@ -160,14 +169,20 @@ export function createRuntimePipeline(
 			const fn = await loadDefaultPlaceCountry()
 			if (fn) stages.placeCountry = fn
 		}
-		// Apply factory-level defaults (#690 normalizeCase, #194 hardPlaceCountry); a per-call runOpts
-		// value overrides each.
+		// Apply factory-level defaults (#690 normalizeCase, #743/#194 hardPlaceCountry); a per-call
+		// runOpts value overrides each. hardPlaceCountry is DEFAULT-ON (#743, 2026-06-22): the coverage
+		// safelist confines the hard filter to well-covered countries, so this is a pure win there and a
+		// no-op (soft) for the rest. A caller passes `hardPlaceCountry: false` to opt back out entirely.
+		const factoryHardPlaceCountry = opts.hardPlaceCountry ?? true
 		let effectiveRunOpts = runOpts
 		if (opts.normalizeCase && effectiveRunOpts?.normalizeCase === undefined) {
 			effectiveRunOpts = { ...effectiveRunOpts, normalizeCase: true }
 		}
-		if (opts.hardPlaceCountry && effectiveRunOpts?.hardPlaceCountry === undefined) {
+		if (factoryHardPlaceCountry && effectiveRunOpts?.hardPlaceCountry === undefined) {
 			effectiveRunOpts = { ...effectiveRunOpts, hardPlaceCountry: true }
+		}
+		if (opts.hardCountrySafelist && effectiveRunOpts?.hardCountrySafelist === undefined) {
+			effectiveRunOpts = { ...effectiveRunOpts, hardCountrySafelist: opts.hardCountrySafelist }
 		}
 		return runPipeline(raw, stages, effectiveRunOpts)
 	}

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -48,6 +48,7 @@
 
 import { lookupGermanState } from "@mailwoman/codex/de"
 import { lookupFrenchRegion } from "@mailwoman/codex/fr"
+import { COARSE_CLASSES } from "@mailwoman/core/coarse-placer"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { createWofResolver, expandPlacetypeFilter } from "@mailwoman/core/resolver"
 import {
@@ -655,10 +656,14 @@ async function main(): Promise<void> {
 	// #743 EU country-constraint integrity fix: without it the assembled EU coords are not what a real
 	// caller sees (ambiguous EU names without a country constraint land off-continent).
 	const runAssembled = process.argv.includes("--assembled")
-	// `--place-country-hard` (#194) promotes a CONFIDENT placer guess to a HARD country filter (with
-	// empty→global fallback) — the lever for the low-pop EU tail (FI/PL) the soft prior can't move. It
-	// implies the placer is loaded.
-	const useHardCountry = process.argv.includes("--place-country-hard")
+	// `--place-country-hard` (#194/#743) promotes a CONFIDENT placer guess to a HARD country filter
+	// (empty→unresolved) — the lever for the low-pop EU tail the soft prior can't move. Production-
+	// representative: gated by the built-in coverage safelist (only well-covered countries hard-filter).
+	// `--place-country-hard-all` measures UNGATED (every confident country hard-filters, via a safelist
+	// override of the full in-map set) — how per-country hard-resolve-rates are measured to GROW the
+	// safelist. Both imply the placer is loaded.
+	const useHardCountryAll = process.argv.includes("--place-country-hard-all")
+	const useHardCountry = process.argv.includes("--place-country-hard") || useHardCountryAll
 	const usePlaceCountry = process.argv.includes("--place-country") || useHardCountry
 	const evalPlacer = runAssembled && usePlaceCountry ? await loadDefaultPlaceCountry() : null
 	if (usePlaceCountry && !evalPlacer) {
@@ -689,6 +694,12 @@ async function main(): Promise<void> {
 				resolver: resolver as never,
 				placeCountry: evalPlacer ?? false,
 				hardPlaceCountry: useHardCountry && !!evalPlacer,
+				// `--place-country-hard-all` overrides the production coverage safelist with the full in-map
+				// set, so EVERY confident country hard-filters (ungated measurement). Plain `--place-country-hard`
+				// leaves it undefined → the built-in safelist (production-representative).
+				...(useHardCountryAll
+					? { hardCountrySafelist: new Set(COARSE_CLASSES.filter((c) => c !== "OTHER")) as ReadonlySet<string> }
+					: {}),
 			})
 		: null
 


### PR DESCRIPTION
Flips `hardPlaceCountry` to **default-ON**, but confined to a coverage **safelist** so it's a pure win where the gazetteer is complete and a no-op (soft prior) everywhere else. DeepSeek-advised (2026-06-22, 2-turn consult): the soft prior alone can't move low-pop FI/PL, but pure-hard-everywhere costs −29pp recall on partial-coverage countries; gating on coverage gets the win with no recall regression.

## The guard

`hardCountryFor` (shared by BOTH production placeCountry sites — `createRuntimePipeline` AND `geocodeAddress` — so they can't drift): hard-filter iff the placer is confident (≥0.9), the country is in `HARD_PLACE_COUNTRY_SAFELIST`, and no caller hard/defaultCountry is set.

**Safelist = {US, ES, IT, NL, DE, FR}**, anchored on measured hard-resolve-rate ≥ 95%:

| in (≥95%) | US 100 · FR 100 · DE 100 · ES 99.8 · NL 97.3 · IT 96.8 |
|---|---|
| **out** | **FI 69.5 · PL 77.8** (stay soft) |

`hardCountrySafelist` overrides it (the eval measures ungated to grow the list).

## Validated (assembled coord, candidate-global-intl.db, limit 400)

| case | result |
|---|---|
| ES gated (safelisted) | p90 15.0 → **6.8**, resolved 99.8% unchanged — win |
| FI gated (NOT safelisted) | p90 **3050 (soft, unchanged)** — no recall regression |
| FI `--place-country-hard-all` (ungated override) | p90 3050 → 18 — measurement path works |
| US | byte-identical |

158 resolver/pipeline/geocode tests pass + 6 new for the guard.

## Eval flags

`--place-country-hard` is now production-representative (safelist-gated); `--place-country-hard-all` measures **ungated** (full in-map set) to grow the safelist as more countries' coverage is confirmed (#193).

## Follow-up (DeepSeek-named, non-blocking)

A misroute eval on the safelisted countries + cross-border ambiguous names (the named worst case: a confident-wrong country that has a same-name commune). The guard limits blast radius to full-coverage countries, so this runs in parallel, not as a merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)