### PR TITLE
fix(mailwoman): remove missing sdk repo export

### DIFF
--- a/mailwoman/package.json
+++ b/mailwoman/package.json
@@ -28,7 +28,6 @@
 		"./geocode-core": "./out/geocode-core.js",
 		"./server": "./out/server/index.js",
 		"./sdk/test": "./out/sdk/test/index.js",
-		"./sdk/repo": "./out/sdk/repo.js",
 		"./sdk/cli": "./out/sdk/cli.js"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary
- remove the `mailwoman/sdk/repo` export that points at `./out/sdk/repo.js`

## Why
The published `mailwoman@4.12.0` package advertises `./sdk/repo`, but the npm tarball does not include `out/sdk/repo.js`. The repo also has `mailwoman/sdk/cli.ts` and `mailwoman/sdk/test`, but no `mailwoman/sdk/repo.ts`, so the export appears stale.

Repro from the npm tarball:

```sh
npm pack mailwoman@4.12.0
# tarball contains out/sdk/cli.js and out/sdk/test/index.js, but no out/sdk/repo.js
node --input-type=module -e "import('mailwoman/sdk/repo')"
# ERR_MODULE_NOT_FOUND: Cannot find module .../node_modules/mailwoman/out/sdk/repo.js
```

## Validation
- confirmed `mailwoman@4.12.0` tarball lacks `package/out/sdk/repo.js`
- confirmed current repo has no `mailwoman/sdk/repo.ts`
- parsed `mailwoman/package.json` after the edit