### PR TITLE
#743/#193: bilingual alt-name fold — proven copy + durable build-unified-wof phase

### DIFF
--- a/scripts/build-candidate-geonames-aliases.ts
+++ b/scripts/build-candidate-geonames-aliases.ts
@@ -1,0 +1,107 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #743/#193 — fold GeoNames bilingual / alternate place-names into a candidate gazetteer as
+ *   ALIASES. The candidate table's hard-filter recall gap on bilingual countries (Finland: hard FI
+ *   resolves only 69.5%) is NOT missing places — it's missing alt-language NAMES. The place is
+ *   present under one language (Swedish "Karis") but the address uses the other (Finnish "Karjaa"),
+ *   and the unified-WOF `names` only carried the primary, so the candidate alias path had nothing
+ *   to explode. GeoNames' per-country dump carries the variants inline (the Karis row's
+ *   `alternatenames` includes "Karjaa").
+ *
+ *   This reads a GeoNames country dump (`FI.txt`-style TSV), and for every POPULATED place (feature
+ *   class `P`) inserts each Latin alt-name not already present as a `locality` candidate pointing
+ *   at that place's own coordinate/population — so a query in either language resolves to the same
+ *   point. Operates on a COPY to prove the resolve-rate lift via `oa-resolver-eval --candidate-db
+ *   <copy> --place-country-hard-all` BEFORE any canonical rebuild; the durable fix is to fold the
+ *   same alt-names into the unified-WOF `names` upstream.
+ *
+ *   Usage: node --experimental-strip-types scripts/build-candidate-geonames-aliases.ts\
+ *   --src /mnt/playpen/mailwoman-data/wof/candidate-global-intl.db\
+ *   --out /mnt/playpen/mailwoman-data/wof/candidate-aug-193.db\
+ *   --geonames /mnt/playpen/mailwoman-data/geonames/FI.txt --country FI
+ */
+import { normalizeLocalityForKey } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+import { copyFileSync, readFileSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+const { values: a } = parseArgs({
+	options: {
+		src: { type: "string", default: "/mnt/playpen/mailwoman-data/wof/candidate-global-intl.db" },
+		out: { type: "string", default: "/mnt/playpen/mailwoman-data/wof/candidate-aug-193.db" },
+		geonames: { type: "string" },
+		country: { type: "string", default: "FI" },
+		"min-pop": { type: "string", default: "0" },
+	},
+})
+if (!a.geonames) throw new Error("--geonames <country dump TSV> is required")
+const cc = a.country!.toUpperCase()
+const minPop = Number(a["min-pop"])
+
+// Latin-only, no bracket/paren noise (GeoNames packs things like "(( Karis Landskommun ))" + airport
+// codes into alternatenames), 2–60 chars, not a postcode/number.
+const LATIN_NAME = /^[\p{Script=Latin}\p{M}\s\-'.]{2,60}$/u
+const cleanName = (s: string): string | null => {
+	const t = s.trim()
+	if (!t || !LATIN_NAME.test(t)) return null
+	if (!/\p{L}/u.test(t)) return null
+	return t
+}
+
+copyFileSync(a.src!, a.out!)
+const db = new DatabaseSync(a.out!)
+const ccRow = db.prepare("SELECT id FROM country_codes WHERE code = ?").get(cc) as { id: number } | undefined
+if (!ccRow) throw new Error(`candidate DB has no country code ${cc}`)
+const cid = ccRow.id
+const localityPt = (db.prepare("SELECT id FROM placetype_codes WHERE placetype = 'locality'").get() as { id: number })
+	.id
+const exists = db.prepare("SELECT 1 FROM candidate WHERE name_key = ? AND country_id = ? LIMIT 1")
+const ins = db.prepare(
+	`INSERT INTO candidate (name_key, country_id, region_id, placetype_id, neg_rank, spr_id, name,
+		latitude, longitude, min_lat, min_lon, max_lat, max_lon, population, is_primary)
+	 VALUES (?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`
+)
+
+let sprBase = 9_600_000_000_000
+let nIns = 0
+let nSkip = 0
+let nPlaces = 0
+const insertedKeys = new Set<string>() // de-dupe within this run too
+
+db.exec("BEGIN")
+for (const line of readFileSync(a.geonames!, "utf8").split("\n")) {
+	if (!line) continue
+	// GeoNames dump columns: 1 name, 2 asciiname, 3 alternatenames, 4 lat, 5 lon, 6 feature_class, 14 pop
+	const f = line.split("\t")
+	if (f[6] !== "P") continue // populated places only
+	const lat = Number(f[4])
+	const lon = Number(f[5])
+	if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue
+	const pop = Number(f[14]) || 0
+	if (pop < minPop) continue
+	nPlaces++
+	const names = [f[1], f[2], ...(f[3] ? f[3].split(",") : [])]
+	const neg = -Math.log10(pop + 1)
+	for (const raw of names) {
+		const name = cleanName(raw)
+		if (!name) continue
+		const key = normalizeLocalityForKey(name)
+		if (!key || insertedKeys.has(key) || exists.get(key, cid)) {
+			if (key && exists.get(key, cid)) nSkip++
+			continue
+		}
+		insertedKeys.add(key)
+		ins.run(key, cid, localityPt, neg, sprBase++, name, lat, lon, lat, lon, lat, lon, pop)
+		nIns++
+	}
+}
+db.exec("COMMIT")
+db.exec("ANALYZE candidate")
+db.close()
+console.log(
+	`${cc}: scanned ${nPlaces} populated places; +${nIns} alias localities inserted, ${nSkip} names already present`
+)
+console.log(`→ ${a.out}: validate with  --candidate-db ${a.out} --place-country-hard-all`)

--- a/scripts/build-candidate-locality-augment.ts
+++ b/scripts/build-candidate-locality-augment.ts
@@ -1,0 +1,141 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #743/#193 — augment a candidate gazetteer with POSTAL LOCALITIES from the Overture addresses
+ *   theme. The candidate table sources its localities from Overture DIVISIONS (formal admin units),
+ *   but real addresses use postal localities. This was the first hypothesis for the FI hard-filter
+ *   recall gap (#194/#762) — but it proved MARGINAL: with the correct key normalizer most postal
+ *   localities are already present (FI coverage 74.4%, not the 52% a naïve `.lower()` suggested), and
+ *   this fold added +141 FI localities with ZERO resolve-rate lift. The real FI gap was bilingual
+ *   ALT-NAMES (see build-candidate-geonames-aliases.ts). This companion stays useful where a
+ *   country's gap genuinely IS missing postal localities rather than alt-names.
+ *
+ *   This extracts the distinct deepest-`address_levels` value per country from the per-country
+ *   Overture addresses parquet (the SAME source build-eu-eval-set.ts uses), with the address
+ *   centroid + bbox + an address-count population proxy, and inserts the ones not already present
+ *   as `locality` candidates. Operates on a COPY (never the canonical) so the gain can be measured
+ *   via `oa-resolver-eval --candidate-db <copy> --place-country-hard-all` before any rebuild. Once
+ *   the lift is confirmed the same fold belongs upstream in the unified-WOF build (spr rows) so the
+ *   canonical candidate rebuild carries it.
+ *
+ *   Usage: node --experimental-strip-types scripts/build-candidate-locality-augment.ts\
+ *   --src /mnt/playpen/mailwoman-data/wof/candidate-global-intl.db\
+ *   --out /mnt/playpen/mailwoman-data/wof/candidate-aug-193.db\
+ *   --overture-dir /mnt/playpen/mailwoman-data/overture/2026-06-17.0\
+ *   --countries FI,PL [--min-addresses 3]
+ */
+import { DuckDBInstance } from "@duckdb/node-api"
+import { normalizeLocalityForKey } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+import { copyFileSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+const { values: a } = parseArgs({
+	options: {
+		src: { type: "string", default: "/mnt/playpen/mailwoman-data/wof/candidate-global-intl.db" },
+		out: { type: "string", default: "/mnt/playpen/mailwoman-data/wof/candidate-aug-193.db" },
+		"overture-dir": { type: "string", default: "/mnt/playpen/mailwoman-data/overture/2026-06-17.0" },
+		countries: { type: "string", default: "FI,PL" },
+		"min-addresses": { type: "string", default: "3" },
+	},
+})
+const countries = a.countries!.split(",").map((c) => c.trim().toUpperCase())
+const minAddr = Number(a["min-addresses"])
+
+// Work on a COPY — never mutate the canonical gazetteer.
+copyFileSync(a.src!, a.out!)
+const db = new DatabaseSync(a.out!)
+
+// Resolve the code-dict ids the candidate rows reference.
+const ccId = new Map<string, number>()
+for (const r of db.prepare("SELECT id, code FROM country_codes").all() as { id: number; code: string }[])
+	ccId.set(r.code, r.id)
+const ptRow = db.prepare("SELECT id FROM placetype_codes WHERE placetype = 'locality'").get() as
+	| { id: number }
+	| undefined
+if (!ptRow) throw new Error("candidate DB has no 'locality' placetype code")
+const localityPt = ptRow.id
+
+const exists = db.prepare("SELECT 1 FROM candidate WHERE name_key = ? AND country_id = ? LIMIT 1")
+// Column order MUST match CANDIDATE_COLUMNS (candidate-schema.ts).
+const ins = db.prepare(
+	`INSERT INTO candidate (name_key, country_id, region_id, placetype_id, neg_rank, spr_id, name,
+		latitude, longitude, min_lat, min_lon, max_lat, max_lon, population, is_primary)
+	 VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`
+)
+
+const duck = await (await DuckDBInstance.create()).connect()
+await duck.run("SET memory_limit='4GB'; SET threads=4;")
+
+// Synthetic spr ids well above any real WOF/Overture id so the placeId never collides.
+let sprBase = 9_500_000_000_000
+let totalIns = 0
+let totalSkip = 0
+
+for (const cc of countries) {
+	const cid = ccId.get(cc)
+	if (cid === undefined) {
+		console.error(`  ${cc}: not in candidate country_codes — skipped`)
+		continue
+	}
+	const parquet = `${a["overture-dir"]}/addresses-${cc.toLowerCase()}.parquet`
+	// Distinct postal locality (deepest address_levels, postal_city fallback) with centroid + bbox + count.
+	const q = `
+		WITH src AS (
+			SELECT COALESCE(NULLIF(trim(postal_city), ''), address_levels[len(address_levels)].value) AS loc, lat, lon
+			FROM read_parquet('${parquet}')
+			WHERE lat IS NOT NULL AND lon IS NOT NULL
+		)
+		SELECT loc, avg(lat) AS clat, avg(lon) AS clon,
+			min(lat) AS mnlat, min(lon) AS mnlon, max(lat) AS mxlat, max(lon) AS mxlon, count(*) AS n
+		FROM src WHERE loc IS NOT NULL AND trim(loc) <> ''
+		GROUP BY loc HAVING count(*) >= ${minAddr}`
+	let rows
+	try {
+		rows = (await duck.runAndReadAll(q)).getRowObjects()
+	} catch (e) {
+		console.error(`  ${cc}: FAILED — ${(e as Error).message}`)
+		continue
+	}
+	let nIns = 0
+	let nSkip = 0
+	db.exec("BEGIN")
+	for (const r of rows) {
+		const name = String(r.loc)
+		const key = normalizeLocalityForKey(name)
+		if (!key) continue
+		if (exists.get(key, cid)) {
+			nSkip++
+			continue
+		}
+		const n = Number(r.n)
+		const neg = -Math.log10(n + 1)
+		ins.run(
+			key,
+			cid,
+			neg,
+			sprBase++,
+			name,
+			Number(r.clat),
+			Number(r.clon),
+			Number(r.mnlat),
+			Number(r.mnlon),
+			Number(r.mxlat),
+			Number(r.mxlon),
+			n
+		)
+		nIns++
+	}
+	db.exec("COMMIT")
+	console.log(`  ${cc}: +${nIns} localities inserted, ${nSkip} already present (${rows.length} distinct in Overture)`)
+	totalIns += nIns
+	totalSkip += nSkip
+}
+duck.closeSync()
+db.exec("ANALYZE candidate")
+db.close()
+console.log(
+	`\n→ ${a.out}: +${totalIns} localities (${totalSkip} already present). Validate with --candidate-db ${a.out}`
+)

--- a/scripts/build-unified-wof.ts
+++ b/scripts/build-unified-wof.ts
@@ -33,8 +33,9 @@ import {
 	populateAncestors,
 } from "@mailwoman/resolver-wof-sqlite/unified-schema"
 import FastGlob from "fast-glob"
-import { existsSync, statSync, unlinkSync } from "node:fs"
+import { existsSync, readFileSync, statSync, unlinkSync } from "node:fs"
 import { readFile } from "node:fs/promises"
+import { join } from "node:path"
 import { DatabaseSync } from "node:sqlite"
 import { asyncParallelIterator } from "spliterator"
 
@@ -46,6 +47,13 @@ import { asyncParallelIterator } from "spliterator"
 const OVERTURE_ID_BASE = 8_000_000_000_000
 /** Overture division subtypes that map to the resolver's admin placetypes. */
 const OVERTURE_DIVISION_SUBTYPES = ["locality", "region", "county", "localadmin"]
+/**
+ * Synthetic id base for GeoNames-sourced alias rows (#743/#193) — above Overture's 8e12 so the
+ * three sources (WOF real ids, Overture, GeoNames) never collide in a combined DB.
+ */
+const GEONAMES_ID_BASE = 9_000_000_000_000
+/** Default GeoNames per-country dump directory (`<CC>.txt`, from download.geonames.org/export/dump). */
+const DEFAULT_GEONAMES_DIR = "/mnt/playpen/mailwoman-data/geonames"
 /** Pinned Overture release for the divisions theme (the release the EU coverage was validated on). */
 const DEFAULT_OVERTURE_RELEASE = "2026-06-17.0"
 
@@ -69,6 +77,14 @@ interface Args {
 	overtureCountries?: string[]
 	/** Overture release for `--overture-countries` (the divisions theme is pinned per release). */
 	overtureRelease: string
+	/**
+	 * #743/#193: comma-separated ISO codes to backfill GeoNames place ALIASES (the bilingual / alt-name
+	 * class — Karjaa↔Karis) AFTER the WOF + Overture ingest. Reads `<CC>.txt` from {@link geonamesDir}.
+	 * Off unless provided.
+	 */
+	geonamesCountries?: string[]
+	/** Directory of GeoNames per-country dumps (`<CC>.txt`). Default {@link DEFAULT_GEONAMES_DIR}. */
+	geonamesDir: string
 }
 
 function parseArgs(): Args {
@@ -80,6 +96,8 @@ function parseArgs(): Args {
 	let placetypes: string[] | undefined
 	let overtureCountries: string[] | undefined
 	let overtureRelease = DEFAULT_OVERTURE_RELEASE
+	let geonamesCountries: string[] | undefined
+	let geonamesDir = DEFAULT_GEONAMES_DIR
 
 	for (let i = 0; i < args.length; i++) {
 		if (args[i] === "--data" && args[i + 1]) dataDir = args[++i]
@@ -95,16 +113,31 @@ function parseArgs(): Args {
 				.map((s) => s.trim().toUpperCase())
 				.filter(Boolean)
 		else if (args[i] === "--overture-release" && args[i + 1]) overtureRelease = args[++i]!
+		else if (args[i] === "--geonames-countries" && args[i + 1])
+			geonamesCountries = args[++i]!.split(",")
+				.map((s) => s.trim().toUpperCase())
+				.filter(Boolean)
+		else if (args[i] === "--geonames-dir" && args[i + 1]) geonamesDir = args[++i]!
 	}
 
 	if (!dataDir || !outputPath) {
 		console.error(
-			"Usage: node scripts/build-unified-wof.js --data <wof-repos-dir> --output <output.db> [--concurrency 64] [--batch 500] [--placetypes postalcode] [--overture-countries PT,PL,CZ] [--overture-release 2026-06-17.0]"
+			"Usage: node scripts/build-unified-wof.js --data <wof-repos-dir> --output <output.db> [--concurrency 64] [--batch 500] [--placetypes postalcode] [--overture-countries PT,PL,CZ] [--overture-release 2026-06-17.0] [--geonames-countries FI,EE,LV] [--geonames-dir <dir>]"
 		)
 		process.exit(1)
 	}
 
-	return { dataDir, outputPath, concurrency, batchCommitSize, placetypes, overtureCountries, overtureRelease }
+	return {
+		dataDir,
+		outputPath,
+		concurrency,
+		batchCommitSize,
+		placetypes,
+		overtureCountries,
+		overtureRelease,
+		geonamesCountries,
+		geonamesDir,
+	}
 }
 
 const ADMIN_PLACETYPES = new Set([
@@ -337,9 +370,102 @@ export async function ingestOvertureDivisions(
 	return n
 }
 
+/**
+ * Backfill GeoNames per-country place ALIASES (#743/#193) into an already-open unified ingest DB.
+ * The candidate gazetteer's hard-filter recall gap on BILINGUAL countries (Finland: the address
+ * says "Karjaa" but the table holds the Swedish "Karis") is missing alt-LANGUAGE names, not missing
+ * places: the WOF/Overture `names` carried only the primary, so the candidate build's Latin-alias
+ * explode (build-candidate pass 2) had nothing to widen. GeoNames' per-country dump carries the
+ * variants inline (the Karis row's `alternatenames` includes "Karjaa").
+ *
+ * For each POPULATED place (feature class `P`) this writes an spr row + names rows (primary + Latin
+ * alt-names) + population into the SAME tables the WOF/Overture paths use — synthetic ids based at
+ * {@link GEONAMES_ID_BASE} so the three sources never collide — so the Freeze phase
+ * (place_search/FTS/indexes) treats them uniformly and the candidate rebuild carries Karjaa↔Karis.
+ * Proven on a copy first (scripts/build-candidate-geonames-aliases.ts): FI hard-resolve 69.5 →
+ * 85.8%, coverage 74.4 → 94.0%, coords still tight. Duplicating a place already held under another
+ * source is benign — the extra rows share the same name_key+coord and the candidate ranking dedupes
+ * by score.
+ *
+ * GeoNames dump = `download.geonames.org/export/dump/<CC>.zip` → `<CC>.txt` (TSV). Plain text, so
+ * no DuckDB — a streamed read. Country-scoped (`--geonames-countries`) like the Overture backfill.
+ *
+ * @returns The number of GeoNames places ingested.
+ */
+export function ingestGeonamesAliases(db: DatabaseSync, countries: string[], geonamesDir: string): number {
+	// Latin-only, no bracket/paren noise GeoNames packs into `alternatenames` ("(( Karis Landskommun ))",
+	// airport codes), 2–60 chars, at least one letter (drops bare postcodes/numbers).
+	const LATIN_NAME = /^[\p{Script=Latin}\p{M}\s\-'.]{2,60}$/u
+	const clean = (s: string): string | null => {
+		const t = s.trim()
+		return t && LATIN_NAME.test(t) && /\p{L}/u.test(t) ? t : null
+	}
+	const sprInsert = db.prepare(
+		`INSERT OR REPLACE INTO spr (id, parent_id, name, placetype, country, latitude, longitude, min_latitude, min_longitude, max_latitude, max_longitude, is_current, is_deprecated, is_ceased, is_superseded, is_superseding, lastmodified) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	)
+	const namesInsert = db.prepare(
+		`INSERT INTO names (id, name, placetype, country, language, lastmodified) VALUES (?, ?, ?, ?, ?, ?)`
+	)
+	const populationInsert = db.prepare(`INSERT OR REPLACE INTO place_population (id, population) VALUES (?, ?)`)
+
+	let id = GEONAMES_ID_BASE
+	let total = 0
+	db.exec("BEGIN")
+	for (const cc of countries) {
+		const file = join(geonamesDir, `${cc}.txt`)
+		if (!existsSync(file)) {
+			console.error(
+				`  GeoNames ${cc}: ${file} missing — download from download.geonames.org/export/dump/${cc}.zip; skipped`
+			)
+			continue
+		}
+		let nc = 0
+		// GeoNames dump columns: 1 name, 2 asciiname, 3 alternatenames, 4 lat, 5 lon, 6 feature_class, 14 pop.
+		for (const line of readFileSync(file, "utf8").split("\n")) {
+			if (!line) continue
+			const f = line.split("\t")
+			if (f[6] !== "P") continue // populated places only
+			const lat = Number(f[4])
+			const lon = Number(f[5])
+			if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue
+			const name = clean(f[1] ?? "")
+			if (!name) continue
+			const nid = id++
+			// Point bbox — a GeoNames row is a centroid; the candidate's region-bbox disambiguation just
+			// sees it as contained in itself, fine for a locality.
+			sprInsert.run(nid, -1, name, "locality", cc, lat, lon, lat, lon, lat, lon, 1, 0, 0, 0, 0, 0)
+			namesInsert.run(nid, name, "locality", cc, "", 0)
+			const seen = new Set([name])
+			for (const raw of [f[2] ?? "", ...(f[3] ? f[3].split(",") : [])]) {
+				const alt = clean(raw)
+				if (alt && !seen.has(alt)) {
+					seen.add(alt)
+					namesInsert.run(nid, alt, "locality", cc, "", 0)
+				}
+			}
+			const pop = Number(f[14]) || 0
+			if (pop > 0) populationInsert.run(nid, pop)
+			nc++
+		}
+		console.error(`  GeoNames ${cc}: ${nc.toLocaleString()} populated places (+ Latin alt-names)`)
+		total += nc
+	}
+	db.exec("COMMIT")
+	return total
+}
+
 async function main() {
-	const { dataDir, outputPath, concurrency, batchCommitSize, placetypes, overtureCountries, overtureRelease } =
-		parseArgs()
+	const {
+		dataDir,
+		outputPath,
+		concurrency,
+		batchCommitSize,
+		placetypes,
+		overtureCountries,
+		overtureRelease,
+		geonamesCountries,
+		geonamesDir,
+	} = parseArgs()
 	const activePlacetypes = placetypes ? new Set(placetypes) : ADMIN_PLACETYPES
 	console.error(`Ingesting placetypes: ${[...activePlacetypes].join(", ")}`)
 	const t0 = performance.now()
@@ -474,6 +600,16 @@ async function main() {
 		console.error(`Backfilling Overture divisions for ${overtureCountries.join(",")}...`)
 		overtureIngested = await ingestOvertureDivisions(db, overtureCountries, overtureRelease)
 		console.error(`  Overture divisions ingested: ${overtureIngested.toLocaleString()}`)
+	}
+
+	// -----------------------------------------------------------------------
+	// Phase 2c: GeoNames bilingual / alt-name backfill (#743/#193 — the Karjaa↔Karis class)
+	// -----------------------------------------------------------------------
+	let geonamesIngested = 0
+	if (geonamesCountries && geonamesCountries.length > 0) {
+		console.error(`Backfilling GeoNames aliases for ${geonamesCountries.join(",")} from ${geonamesDir}...`)
+		geonamesIngested = ingestGeonamesAliases(db, geonamesCountries, geonamesDir)
+		console.error(`  GeoNames places ingested: ${geonamesIngested.toLocaleString()}`)
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
The complete #193 fix: the candidate hard-filter recall gap on bilingual countries is missing alt-LANGUAGE names (FI address "Karjaa" vs the table's Swedish "Karis"), not missing places. Proven on a copy, then folded durably into the canonical builder.

## Proven (FI, candidate-copy, `--place-country-hard-all`, limit 400)

| metric | before | after |
|---|--:|--:|
| eval-locality coverage | 74.4% | **94.0%** |
| hard-resolve rate | 69.5% | **85.8%** (+16.3pp) |
| locality-match | 69.0% | **82.5%** (+13.5pp) |
| coord p90/p99 | 18/229 | 20.5/279 (tight) |

(Verify-before-verdict: real FI coverage is 74.4%, not the 52% a naïve `.lower()` showed; the address-locality fold added +141 with **zero** lift — the gap was aliases.)

## What ships

1. **Durable fix** — `build-unified-wof.ts` Phase 2c `ingestGeonamesAliases` (mirrors the Overture backfill): `--geonames-countries FI,EE,LV,…` writes each GeoNames populated place as spr + names (primary + Latin alt-names), synthetic ids at 9e12. The Freeze phase + candidate rebuild then carry Karjaa↔Karis canonically via the existing alias-explode. **Verified on a fresh unified-schema DB**: 29,235 FI places, "Karjaa" attached to the "Karis" spr, 50,556 FI names (~21k aliases).
2. **Proof tooling** (operate on copies, never canonical): `build-candidate-geonames-aliases.ts` (the copy-prover above) + `build-candidate-locality-augment.ts` (address-locality companion — for countries whose gap genuinely IS missing postal localities).

## Rebuild (operator-gated)

Add `--geonames-countries FI,…` to the `build-unified-wof` invocation (dumps from `download.geonames.org/export/dump/<CC>.zip`), then the candidate rebuild. Moves the bilingual tail toward the 95% `HARD_PLACE_COUNTRY_SAFELIST` bar (#762) so those countries also get the hard-filter coord win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)