### PR TITLE
release: make .release-it.json the single source of truth (#757 guard + #756 finish-loop)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,8 +165,15 @@ jobs:
         run: | # shell
           set -uo pipefail
           yarn compile
+          # #756: derive the workspace set from .release-it.json — the SAME list release-it publishes on a
+          # normal run — so this recovery loop can't drift from it (the v4.12.0 tiger-skip: tiger was in
+          # .release-it.json but missing from the hardcoded list here, so publish_only silently skipped it).
+          # The order (core … mailwoman) is the dependency order release-it already uses. The #757 test
+          # asserts every entry carries a repository field, so a new workspace can't reach release malformed.
+          WORKSPACES=$(node -p "require('./.release-it.json').plugins['@release-it-plugins/workspaces'].workspaces.join(' ')")
+          echo "publish_only workspaces (from .release-it.json): ${WORKSPACES}"
           FAILED=()
-          for ws in core spatial normalize query-shape kind-classifier locale-gate phrase-grouper codex classifiers corpus neural neural-weights-en-us neural-weights-fr-fr formatter record match address-id registry tiger mailwoman; do
+          for ws in ${WORKSPACES}; do
             echo "::group::publish ${ws}"
             if RELEASE_IT_WORKSPACES_PATH_TO_WORKSPACE="./${ws}" node scripts/publish-workspace.mjs; then
               echo "  ✓ ${ws}"

--- a/neural-weights-en-us/package.json
+++ b/neural-weights-en-us/package.json
@@ -5,7 +5,8 @@
 	"license": "AGPL-3.0-only",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sister-software/mailwoman"
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "neural-weights-en-us"
 	},
 	"files": [
 		"model.onnx",

--- a/neural-weights-fr-fr/package.json
+++ b/neural-weights-fr-fr/package.json
@@ -5,7 +5,8 @@
 	"license": "AGPL-3.0-only",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sister-software/mailwoman"
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "neural-weights-fr-fr"
 	},
 	"files": [
 		"model.onnx",

--- a/scripts/release-workspace-repository.test.ts
+++ b/scripts/release-workspace-repository.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #757 — fail-fast guard for the npm-provenance `repository` requirement.
+ *
+ *   Since the repo went public (v4.8.0) every npm publish is provenance-signed, and sigstore
+ *   provenance verification REJECTS (HTTP 422) any workspace whose `package.json` lacks a
+ *   `repository.url` matching the source repo. This is invisible until release, and has bitten twice
+ *   on new/edited workspaces — `spatial` (#660, v4.10.0) and `tiger` (#739, v4.12.0) — each costing a
+ *   recovery cycle. (Writing this test immediately caught a third + fourth: the two `neural-weights-*`
+ *   workspaces had a `.git`-less url and no `directory`.)
+ *
+ *   This asserts EVERY workspace in the `.release-it.json` publish set carries the canonical
+ *   `repository` block, so a drift fails at PR/CI time instead of mid-release.
+ */
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url))
+const CANONICAL_URL = "https://github.com/sister-software/mailwoman.git"
+
+/** The published workspace set — the single source of truth release-it iterates. */
+function releaseWorkspaces(): string[] {
+	const releaseIt = JSON.parse(readFileSync(resolve(repoRoot, ".release-it.json"), "utf8"))
+	const ws = releaseIt?.plugins?.["@release-it-plugins/workspaces"]?.workspaces
+	if (!Array.isArray(ws) || ws.length === 0) {
+		throw new Error("could not read the workspaces array from .release-it.json")
+	}
+	return ws as string[]
+}
+
+describe("#757 release provenance: every published workspace declares its repository", () => {
+	const workspaces = releaseWorkspaces()
+
+	it.each(workspaces)("%s/package.json has the canonical repository block", (ws) => {
+		const pkg = JSON.parse(readFileSync(resolve(repoRoot, ws, "package.json"), "utf8")) as {
+			repository?: { type?: string; url?: string; directory?: string }
+		}
+		const repo = pkg.repository
+		// A missing/empty repository.url is exactly what npm provenance rejects with E422.
+		expect(repo, `${ws}/package.json is missing "repository"`).toBeTypeOf("object")
+		expect(repo!.type, `${ws}: repository.type must be "git"`).toBe("git")
+		expect(repo!.url, `${ws}: repository.url must be the canonical source repo (with .git)`).toBe(CANONICAL_URL)
+		// `directory` lets npm resolve the per-workspace source path under the monorepo.
+		expect(repo!.directory, `${ws}: repository.directory must be the workspace path`).toBe(ws)
+	})
+})


### PR DESCRIPTION
Two release-hardening fixes that make `.release-it.json`'s workspace set the **single source of truth**, killing the latent failures that bit v4.10.0 and v4.12.0. Closes #757 and #756.

## #757 — CI guard: every published workspace declares its `repository`

Since the repo went public (v4.8.0), npm provenance **rejects** (HTTP 422) any workspace whose `package.json` lacks a `repository.url` matching the source repo — invisible until release; bit `spatial` (#660) and `tiger` (#739). A `vitest` guard (`scripts/release-workspace-repository.test.ts`) reads the `.release-it.json` publish set and asserts each has the canonical `repository` block (type git, `.git` url, `directory` = workspace path). Runs in `ci:test` → fails at PR time, not mid-release.

**Caught a 3rd + 4th latent E422 on first run:** `neural-weights-en-us` + `neural-weights-fr-fr` had `.git`-less urls and no `directory`. Fixed both; guard green (20/20).

## #756 — derive the `publish_only` finish-loop from `.release-it.json`

The "Finish publish" recovery step hardcoded its own `for ws in core … mailwoman` list, separate from `.release-it.json`. They drifted: at v4.12.0 `tiger` was in `.release-it.json` but missing here, so `publish_only` silently skipped it (needed a 3rd dispatch + #755). Now derived from `.release-it.json` — byte-identical list + order, behaviour unchanged, drift-proof.

Together: the guard validates the list, the finish-loop consumes the same list. A new workspace can't reach release malformed or get skipped on recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)