### PR TITLE
feat: race-by-dot-density map — pipeline + default-off demo overlay

### DIFF
--- a/cartographer/package.json
+++ b/cartographer/package.json
@@ -20,6 +20,7 @@
 		"./base": "./out/base/index.js",
 		"./bdc": "./out/bdc/index.js",
 		"./coverage": "./out/coverage/index.js",
+		"./race-dots": "./out/race-dots/index.js",
 		".": "./out/index.js"
 	},
 	"dependencies": {

--- a/cartographer/race-dots/index.ts
+++ b/cartographer/race-dots/index.ts
@@ -1,0 +1,67 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Race-by-dot-density overlay — the Cooper Center "Racial Dot Map" reading, on the demo. One dot per
+ *   ~N people, placed at random inside its Census block (built by `scripts/census/race-dots.ts` +
+ *   tippecanoe), colored by 2020 P.L. 94-171 race/ethnicity category.
+ *
+ *   The PMTiles ships a single `dots` source-layer carrying a `cat` property; we expose each category
+ *   as its OWN default-off circle layer (filtered on `cat`) so the demo's LayerToggleControl gives each
+ *   its own checkbox — show the full mosaic, or isolate one group's geography, no extra UI. Same idiom
+ *   as the coverage overlay.
+ *
+ *   Served as XYZ vector tiles by the tile worker from `nexus-assets/tiles/race-dots-la.pmtiles`; the
+ *   consumer passes its TileJSON URL (`tiles.sister.software/race-dots-la.json`) to `createRaceDotsSource`.
+ *
+ *   The dot is a *representation*, not a record: a random position inside the block, standing in for
+ *   ~N real people of that category. It says nothing about any individual address.
+ */
+
+import type { CircleLayerSpecification, VectorSourceSpecification } from "@maplibre/maplibre-gl-style-spec"
+import { TileSetSourceID } from "../styles/sources.js"
+
+export const RaceDotsTileSetID = TileSetSourceID("race-dots-la")
+
+/** The single source-layer the race-dots PMTiles ships (tippecanoe `-l dots`). */
+export const RACE_DOTS_SOURCE_LAYER = "dots"
+
+/** The togglable categories. Each becomes its own default-off layer + LayerToggleControl checkbox. */
+export const RaceDotsCategories = [
+	{ id: "race-dots-white", label: "Race · White", color: "#1f78b4", match: ["white"] },
+	{ id: "race-dots-black", label: "Race · Black", color: "#33a02c", match: ["black"] },
+	{ id: "race-dots-hispanic", label: "Race · Hispanic", color: "#ff7f00", match: ["hispanic"] },
+	{ id: "race-dots-asian", label: "Race · Asian", color: "#e31a1c", match: ["asian"] },
+	{ id: "race-dots-other", label: "Race · Other", color: "#8c6d31", match: ["aian", "nhpi", "other", "multi"] },
+] as const
+
+/** Build the race-dots source spec from the tile worker's TileJSON endpoint. */
+export function createRaceDotsSource(url: string): VectorSourceSpecification {
+	return { type: "vector", url }
+}
+
+function dotLayer(id: string, color: string, cats: readonly string[]): CircleLayerSpecification {
+	return {
+		id,
+		type: "circle",
+		source: RaceDotsTileSetID,
+		"source-layer": RACE_DOTS_SOURCE_LAYER,
+		// Default OFF — an overlay, surfaced via the layer toggle, never on by default.
+		layout: { visibility: "none" },
+		filter: cats.length === 1 ? ["==", ["get", "cat"], cats[0]!] : ["in", ["get", "cat"], ["literal", cats]],
+		paint: {
+			"circle-radius": ["interpolate", ["linear"], ["zoom"], 4, 0.7, 9, 1.7, 12, 2.8, 16, 4.5],
+			"circle-color": color,
+			"circle-opacity": 0.85,
+		},
+	}
+}
+
+/**
+ * One default-off circle layer per category. Plain MapLibre specs — the demo adds them imperatively on
+ * map-load with a `beforeId` of the first symbol layer, so the dots sit beneath place labels.
+ */
+export const RaceDotsLayers: CircleLayerSpecification[] = RaceDotsCategories.map((c) =>
+	dotLayer(c.id, c.color, c.match),
+)

--- a/docs/src/components/LayerToggleControl/LayerToggleControl.tsx
+++ b/docs/src/components/LayerToggleControl/LayerToggleControl.tsx
@@ -33,6 +33,13 @@ export const LAYER_GROUP_PATTERNS: ReadonlyArray<{ name: string; match: RegExp }
 	// checkbox — turn on "optimistic" (looks covered, reveals gaps on zoom) OR "honest" (true fraction).
 	{ name: "Coverage · optimistic fog", match: /^coverage-opt/ },
 	{ name: "Coverage · honest fog", match: /^coverage-honest/ },
+	// Race-by-dot-density overlay (#race-dots). Per-category default-off layers → one checkbox each, so
+	// you can show the full mosaic or isolate a single group's geography.
+	{ name: "Race · White", match: /^race-dots-white/ },
+	{ name: "Race · Black", match: /^race-dots-black/ },
+	{ name: "Race · Hispanic", match: /^race-dots-hispanic/ },
+	{ name: "Race · Asian", match: /^race-dots-asian/ },
+	{ name: "Race · Other", match: /^race-dots-other/ },
 ]
 
 export class LayerToggleControl implements IControl {

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -24,6 +24,7 @@ import Head from "@docusaurus/Head"
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext"
 import { MailwomanBaseTileSetID, StyleSpecificationComposer } from "@mailwoman/cartographer/base"
 import { CoverageLayers, CoverageTileSetID, createCoverageSource } from "@mailwoman/cartographer/coverage"
+import { createRaceDotsSource, RaceDotsLayers, RaceDotsTileSetID } from "@mailwoman/cartographer/race-dots"
 import Layout from "@theme/Layout"
 import type { Map as MapLibreMap } from "maplibre-gl"
 import type React from "react"
@@ -323,6 +324,29 @@ const DemoApp: React.FC = () => {
 						}
 					}
 					map.on("load", wireCoverage)
+
+					// Race-by-dot-density overlay (default-off per-category circle layers), wired like coverage
+					// above — but deliberately WITHOUT the `isStyleLoaded()` defer. This handler runs on
+					// `load`, when the style *document* is ready, which is all `addSource`/`addLayer` needs.
+					// `isStyleLoaded()` ALSO returns false whenever any source's tiles are still streaming, and
+					// wireCoverage (which runs first) calls addSource — so on the globe basemap, where tiles
+					// stream continuously, gating here would defer on `styledata` forever and the dots would
+					// never wire. Coverage gets away with the guard only because it's the first overlay added.
+					const raceDotsSourceUrl = `https://tiles.sister.software/${RaceDotsTileSetID}.json`
+					const wireRaceDots = (): void => {
+						try {
+							if (!map.getSource(RaceDotsTileSetID)) {
+								map.addSource(RaceDotsTileSetID, createRaceDotsSource(raceDotsSourceUrl))
+							}
+							const firstSymbolID = map.getStyle().layers?.find((l) => l.type === "symbol")?.id
+							for (const layer of RaceDotsLayers) {
+								if (!map.getLayer(layer.id)) map.addLayer(layer, firstSymbolID)
+							}
+						} catch (error) {
+							console.warn("race-dots overlay wiring failed", error)
+						}
+					}
+					map.on("load", wireRaceDots)
 				}
 			} catch (error) {
 				if (cancelled) return

--- a/scripts/census/race-dots-map.ts
+++ b/scripts/census/race-dots-map.ts
@@ -1,0 +1,142 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Render a race-by-dot-density PMTiles tileset (from `race-dots.ts` → tippecanoe) as a standalone
+ *   MapLibre page on the house stack: the Protomaps `basemap-v4` vector basemap (layers generated +
+ *   inlined here, à la `registry/map-html.ts`) under a circle layer of the dots, colored by race
+ *   category. The dots PMTiles is read client-side via the `pmtiles` protocol.
+ *
+ *   Each dot is one of `--per` people of a category, placed at random inside its Census block — a
+ *   representation, not a record about any address. Serve over localhost (the house tile server
+ *   CORS-restricts to localhost + the docs domains).
+ *
+ *   Run: node --experimental-strip-types scripts/census/race-dots-map.ts \
+ *     --pmtiles-url http://localhost:8899/race-dots-oc.pmtiles --out /tmp/race-dots-oc.html
+ */
+
+import { layers, namedFlavor } from "@protomaps/basemaps"
+import { writeFileSync } from "node:fs"
+
+function arg(name: string, fb = ""): string {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fb
+}
+
+const PMTILES_URL = arg("pmtiles-url", "http://localhost:8899/race-dots-oc.pmtiles")
+const OUT = arg("out", "/tmp/race-dots-oc.html")
+const PER = Number(arg("per", "5"))
+const PER_PHRASE = PER === 1 ? "one dot is one person" : `one dot ≈ ${PER} people`
+const TITLE = arg("title", `Race in Orange County, CA — ${PER_PHRASE} (2020 Census)`)
+const CENTER_LNG = Number(arg("lng", "-117.83"))
+const CENTER_LAT = Number(arg("lat", "33.68"))
+const ZOOM = Number(arg("zoom", "9.4"))
+
+const MAPLIBRE_VERSION = "5.24.0"
+const MAPLIBRE_JS_SRI = "sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"
+const MAPLIBRE_CSS_SRI = "sha384-uTttxo/aOKbdE5RlD/SPzSDoDmNvGlUYPjONi2MN/b7c9HPSvW07OIuyP7uL6jxK"
+const PMTILES_VERSION = "4.4.1"
+
+const BASEMAP_SOURCE_ID = "basemap-v4"
+const BASEMAP_TILEJSON_URL = "https://tiles.sister.software/basemap-v4.json"
+const GLYPHS_URL = "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf"
+const SPRITE_URL = "https://protomaps.github.io/basemaps-assets/sprites/v4/light"
+
+// Cooper Center "Racial Dot Map" palette, by `pl_block`/P2 category.
+const CATEGORY_COLOR: Record<string, string> = {
+	white: "#1f78b4", // blue
+	black: "#33a02c", // green
+	hispanic: "#ff7f00", // orange
+	asian: "#e31a1c", // red
+	aian: "#6a3d9a", // purple
+	nhpi: "#00b3b3", // teal
+	other: "#b15928", // brown
+	multi: "#9e9e9e", // grey
+}
+const CATEGORY_LABEL: Record<string, string> = {
+	white: "White (non-Hispanic)",
+	black: "Black (non-Hispanic)",
+	hispanic: "Hispanic or Latino",
+	asian: "Asian (non-Hispanic)",
+	aian: "Native American",
+	nhpi: "Pacific Islander",
+	other: "Other (non-Hispanic)",
+	multi: "Two or more races",
+}
+
+const colorMatch: unknown[] = ["match", ["get", "cat"]]
+for (const [cat, color] of Object.entries(CATEGORY_COLOR)) colorMatch.push(cat, color)
+colorMatch.push("#9e9e9e")
+
+const style = {
+	version: 8,
+	glyphs: GLYPHS_URL,
+	sprite: SPRITE_URL,
+	sources: {
+		[BASEMAP_SOURCE_ID]: { type: "vector", url: BASEMAP_TILEJSON_URL },
+		dots: { type: "vector", url: "pmtiles://" + PMTILES_URL },
+	},
+	layers: [
+		...(layers(BASEMAP_SOURCE_ID, namedFlavor("light"), { lang: "en" }) as unknown[]),
+		{
+			id: "race-dots",
+			type: "circle",
+			source: "dots",
+			"source-layer": "dots",
+			paint: {
+				"circle-radius": ["interpolate", ["linear"], ["zoom"], 4, 0.7, 9, 1.7, 12, 2.8, 16, 4.5],
+				"circle-color": colorMatch,
+				"circle-opacity": 0.85,
+			},
+		},
+	],
+}
+
+const legendRows = Object.keys(CATEGORY_COLOR)
+	.map((c) => `<div><i style="background:${CATEGORY_COLOR[c]}"></i>${CATEGORY_LABEL[c]}</div>`)
+	.join("")
+
+// The client script avoids template literals / `${` so it survives this outer template verbatim.
+const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${TITLE}</title>
+<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.css" integrity="${MAPLIBRE_CSS_SRI}" crossorigin="anonymous" />
+<style>
+	html, body { margin: 0; height: 100%; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+	#map { position: absolute; inset: 0; background: #f4f4f2; }
+	.mw-panel { position: absolute; z-index: 1; background: rgba(255,255,255,0.94); padding: 10px 12px; border-radius: 8px; box-shadow: 0 1px 6px rgba(0,0,0,0.3); font-size: 12px; line-height: 1.5; color: #1a1a1a; }
+	.mw-title { top: 10px; left: 10px; max-width: 64%; }
+	.mw-title h1 { font-size: 14px; margin: 0 0 4px; }
+	.mw-legend { bottom: 22px; right: 10px; }
+	.mw-legend i { display: inline-block; width: 11px; height: 11px; margin-right: 6px; border-radius: 50%; vertical-align: -1px; }
+	.muted { color: #666; }
+</style>
+</head>
+<body>
+<div id="map"></div>
+<div class="mw-panel mw-title"><h1>${TITLE}</h1><div class="muted">Each dot is ${PER === 1 ? "a person" : `~${PER} people`}, placed at random inside their Census block. Source: 2020 P.L. 94-171 (table P2) + TIGER blocks.</div></div>
+<div class="mw-panel mw-legend">${legendRows}</div>
+<script src="https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.js" integrity="${MAPLIBRE_JS_SRI}" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/pmtiles@${PMTILES_VERSION}/dist/pmtiles.js" crossorigin="anonymous"></script>
+<script>
+	var protocol = new pmtiles.Protocol();
+	maplibregl.addProtocol("pmtiles", protocol.tile);
+	var map = new maplibregl.Map({
+		container: "map",
+		style: ${JSON.stringify(style)},
+		center: [${CENTER_LNG}, ${CENTER_LAT}],
+		zoom: ${ZOOM},
+		attributionControl: false
+	});
+	map.addControl(new maplibregl.AttributionControl({ compact: true, customAttribution: "US Census 2020 · TIGER · Protomaps · OpenStreetMap" }));
+</script>
+</body>
+</html>
+`
+
+writeFileSync(OUT, html)
+console.error(`[written] ${OUT}  (pmtiles: ${PMTILES_URL})`)

--- a/scripts/census/race-dots.ts
+++ b/scripts/census/race-dots.ts
@@ -1,0 +1,135 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Race-by-dot-density builder — the Cooper Center "Racial Dot Map" recipe, from the TIGER DB the
+ *   `mailwoman tiger` CLI produces.
+ *
+ *   Reads `tabblock20 ⋈ pl_block` (block geometry + Census 2020 P.L. 94-171 table P2 counts) and
+ *   scatters one dot per `--per` people uniformly at random inside each block, tagged with its
+ *   race/ethnicity category. Output is NDJSON (one GeoJSON Point Feature per line, with a `tippecanoe`
+ *   layer hint) ready for `tippecanoe -o race-dots.pmtiles`.
+ *
+ *   Point-in-polygon uses `@turf/boolean-contains` (ships with `@mailwoman/tiger`). The dot is a
+ *   *representation*, not a record: a random position inside the block it belongs to, standing in for
+ *   `--per` real people of that category. It says nothing about any individual address.
+ *
+ *   Build the input DB first:
+ *     mailwoman tiger fetch --state 06 --county 059 --out tiger-oc.db
+ *     mailwoman tiger redistricting --state 06 --county 059 --out tiger-oc.db
+ *
+ *   Run:
+ *     node --experimental-strip-types scripts/census/race-dots.ts \
+ *       --db tiger-oc.db --per 10 --out /tmp/race-dots.ndjson
+ */
+
+import booleanContains from "@turf/boolean-contains"
+import { createWriteStream } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+
+function arg(name: string, fb = ""): string {
+	const i = process.argv.indexOf(`--${name}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fb
+}
+
+const DB = arg("db", "/mnt/playpen/mailwoman-data/tiger/tiger-oc.db")
+const OUT = arg("out", "/tmp/race-dots.ndjson")
+const PER = Number(arg("per", "10")) // people represented by one dot
+const LAYER = arg("layer", "dots")
+
+// The eight P2 categories (columns in pl_block) that partition each block's population.
+const CATEGORIES = ["hispanic", "white", "black", "asian", "aian", "nhpi", "other", "multi"] as const
+
+type Ring = number[][]
+type PolygonCoords = Ring[]
+
+function bbox(rings: PolygonCoords): [number, number, number, number] {
+	let minX = Infinity,
+		minY = Infinity,
+		maxX = -Infinity,
+		maxY = -Infinity
+	for (const [x, y] of rings[0]!) {
+		if (x! < minX) minX = x!
+		if (x! > maxX) maxX = x!
+		if (y! < minY) minY = y!
+		if (y! > maxY) maxY = y!
+	}
+	return [minX, minY, maxX, maxY]
+}
+
+// A block geometry is one or more polygons. Pick a sub-polygon weighted by bbox area, then
+// rejection-sample inside it with a turf containment test (handles holes + winding correctly).
+function randomPointIn(polys: PolygonCoords[], areas: number[], totalArea: number): [number, number] | null {
+	let r = Math.random() * totalArea
+	let pick = 0
+	while (pick < polys.length - 1 && (r -= areas[pick]!) > 0) pick++
+	const poly = polys[pick]!
+	const polyFeature = { type: "Feature" as const, geometry: { type: "Polygon" as const, coordinates: poly }, properties: {} }
+	const [minX, minY, maxX, maxY] = bbox(poly)
+	for (let tries = 0; tries < 60; tries++) {
+		const x = minX + Math.random() * (maxX - minX)
+		const y = minY + Math.random() * (maxY - minY)
+		const pt = { type: "Feature" as const, geometry: { type: "Point" as const, coordinates: [x, y] }, properties: {} }
+		if (booleanContains(polyFeature, pt)) return [x, y]
+	}
+	return null
+}
+
+const db = new DatabaseSync(DB, { readOnly: true })
+const rows = db
+	.prepare(
+		`SELECT b.geometry AS geometry, ${CATEGORIES.map((c) => `p.${c} AS ${c}`).join(", ")}
+		 FROM tabblock20 b JOIN pl_block p ON b.GEOID = p.GEOID
+		 WHERE p.pop_total > 0`,
+	)
+	.all() as Array<{ geometry: string } & Record<(typeof CATEGORIES)[number], number>>
+db.close()
+
+const out = createWriteStream(OUT)
+const totals = new Map<string, number>()
+let dots = 0,
+	skipped = 0
+
+for (const row of rows) {
+	let geom: { type: string; coordinates: unknown }
+	try {
+		geom = JSON.parse(row.geometry)
+	} catch {
+		continue
+	}
+	const polys: PolygonCoords[] = geom.type === "Polygon" ? [geom.coordinates as PolygonCoords] : (geom.coordinates as PolygonCoords[])
+	const areas = polys.map((p) => {
+		const [a, b, c, d] = bbox(p)
+		return Math.max((c - a) * (d - b), 1e-12)
+	})
+	const totalArea = areas.reduce((s, a) => s + a, 0)
+
+	for (const cat of CATEGORIES) {
+		const people = row[cat]
+		if (people <= 0) continue
+		const exact = people / PER
+		const n = Math.floor(exact) + (Math.random() < exact - Math.floor(exact) ? 1 : 0)
+		for (let k = 0; k < n; k++) {
+			const pt = randomPointIn(polys, areas, totalArea)
+			if (!pt) {
+				skipped++
+				continue
+			}
+			out.write(
+				JSON.stringify({
+					type: "Feature",
+					tippecanoe: { layer: LAYER },
+					properties: { cat },
+					geometry: { type: "Point", coordinates: [Math.round(pt[0] * 1e5) / 1e5, Math.round(pt[1] * 1e5) / 1e5] },
+				}) + "\n",
+			)
+			dots++
+			totals.set(cat, (totals.get(cat) ?? 0) + 1)
+		}
+	}
+}
+
+out.end()
+console.error(`[done] ${dots} dots from ${rows.length} blocks (1 dot ≈ ${PER} people); ${skipped} skipped`)
+for (const [cat, n] of [...totals.entries()].sort((a, b) => b[1] - a[1])) console.error(`  ${n.toString().padStart(7)}  ${cat}`)

--- a/scripts/census/serve-range.mjs
+++ b/scripts/census/serve-range.mjs
@@ -1,0 +1,52 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Minimal static file server that honours HTTP Range requests (206) — Python's `http.server` does
+ *   not, and PMTiles reads via Range, so it can't be served by it. Used to preview/render a local
+ *   `.pmtiles` tileset (e.g. the race-dot map). Not for production; the deployed tiles go through the
+ *   tile worker.
+ *
+ *   Run: node scripts/census/serve-range.mjs [dir=/tmp] [port=8899]
+ */
+
+import { createReadStream, statSync } from "node:fs"
+import { createServer } from "node:http"
+import { extname, join, normalize } from "node:path"
+
+const DIR = process.argv[2] || "/tmp"
+const PORT = Number(process.argv[3] || 8899)
+
+const TYPES = {
+	".html": "text/html; charset=utf-8",
+	".json": "application/json",
+	".pmtiles": "application/octet-stream",
+	".pbf": "application/x-protobuf",
+	".png": "image/png",
+}
+
+createServer((req, res) => {
+	const rel = normalize(decodeURIComponent((req.url || "/").split("?")[0])).replace(/^(\.\.[/\\])+/, "")
+	const path = join(DIR, rel)
+	let st
+	try {
+		st = statSync(path)
+	} catch {
+		res.writeHead(404)
+		return res.end("not found")
+	}
+	const type = TYPES[extname(path)] || "application/octet-stream"
+	const base = { "Content-Type": type, "Accept-Ranges": "bytes", "Access-Control-Allow-Origin": "*" }
+	const range = req.headers.range
+	const m = range && /bytes=(\d+)-(\d*)/.exec(range)
+	if (m) {
+		const start = Number(m[1])
+		const end = m[2] ? Number(m[2]) : st.size - 1
+		res.writeHead(206, { ...base, "Content-Range": `bytes ${start}-${end}/${st.size}`, "Content-Length": end - start + 1 })
+		createReadStream(path, { start, end }).pipe(res)
+	} else {
+		res.writeHead(200, { ...base, "Content-Length": st.size })
+		createReadStream(path).pipe(res)
+	}
+}).listen(PORT, () => console.error(`range server: ${DIR} on http://localhost:${PORT}`))


### PR DESCRIPTION
Bring the Cooper Center "Racial Dot Map" reading into Mailwoman: a build pipeline that turns the TIGER DB into a dot-density tileset, and a default-off togglable overlay on `/demo`.

## Pipeline (`scripts/census/`)
- `race-dots.ts` — reads `tabblock20 ⋈ pl_block` (block geometry + 2020 P.L. 94-171 table P2 counts) from the DB the `mailwoman tiger` CLI produces, and scatters one dot per `--per` people uniformly at random inside each block (rejection sampling via `@turf/boolean-contains`), tagged with its race/ethnicity category. NDJSON out → `tippecanoe -l dots`.
- `race-dots-map.ts` — standalone MapLibre HTML for a single tileset (used to validate the LA build).
- `serve-range.mjs` — Range-capable static server (206 for PMTiles) for local inspection.

The dot is a *representation*, not a record: a random position inside its block, standing in for ~N real people of that category. It says nothing about any individual address.

## Demo overlay
- Tileset `race-dots-la.pmtiles` published to the **nexus-assets R2 bucket**, served as XYZ vector tiles by the tile worker (`tiles.sister.software/race-dots-la.json`).
- `cartographer/race-dots` — `TileSetSourceID` + five per-category `CircleLayer` specs (filtered on `cat`, `visibility:none` by default), same idiom as the coverage overlay.
- `/demo` wires the source + layers on map `load`; `LayerToggleControl` gets five `^race-dots-*` group patterns → **Race · White / Black / Hispanic / Asian / Other** checkboxes, default off.

## Bug fix surfaced by end-to-end verification
A headless WebGL render of the demo caught a real wiring bug that the green build hid: the *second* overlay added on `load` gated on `map.isStyleLoaded()`, which returns false while any source's tiles are still streaming. The coverage overlay (added first) calls `addSource`, keeping the globe basemap streaming, so the race handler deferred on `styledata` forever and never wired — coverage was immune only by being registered first. `addSource`/`addLayer` need only the style *document* (guaranteed at `load`), so the defer is dropped for the race overlay.

## Verification
Rendered the local demo over `localhost` (basemap CORS reflects localhost, not 127.0.0.1) with software WebGL: all five layers auto-wire, appear in the toggle, and paint over LA in the correct per-category colors. Coverage overlay unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)