### PR TITLE
docs: day postmortem — #148 v1.9.1 shipped as v4.13.0

### DIFF
--- a/docs/articles/evals/2026-06-22-day-148-shipped-v4.13.0-postmortem.md
+++ b/docs/articles/evals/2026-06-22-day-148-shipped-v4.13.0-postmortem.md
@@ -1,0 +1,65 @@
+# Day shift — 2026-06-22→23 (#148 multi-locale: v1.9.0 failed → v1.9.1 fixed → shipped v4.13.0)
+
+_Collaborative day session, picking up where the night's [eval-coverage postmortem](./2026-06-22-night-postmortem.md) left off. The night reframed #148 as a **parse-recall** gap that tracks training representation; the day acted on it — trained the multi-locale model, watched it fail, diagnosed the failure, fixed it with one knob, gated it three ways, and shipped it to npm as **v4.13.0** — the first multi-locale retrain to actually improve EU parse-recall. Closed by codifying the release as the `/mailwoman-release` skill._
+
+## What shipped
+
+- **🎯 v4.13.0 — `@mailwoman/*` at v1.9.1-multilocale-3order, live on npm.** The first model in the arc to lift non-FR/DE EU resolve, at zero US/FR coordinate cost. Bundled int8 verified `0b150efb` in the published tarball, provenance-attested (repo went public). Tag `v4.13.0` + `release: v4.13.0` on main.
+  | locale | v1.8.0 (prod) | v1.9.0 (failed) | **v1.9.1 (shipped)** |
+  | --- | --: | --: | --: |
+  | IT | 79% | 63% | **92.7%** |
+  | PT | 52% | 35% | **82.0%** |
+  | PL | 53% | 39% | **62.0%** |
+  | AT | 50% | 45% | **81.3%** |
+  | CZ | 43% | 31% | **52.0%** |
+
+  Guardrails held on the metric we ship (the assembled coordinate): **US locality-match 83.4→84.1** (+0.7, 44-state holdout; 9 states gained >1pp incl. IN 68→90), **FR resolve flat / p50 1.28→1.22 km**. Three US *label-F1* deltas (country −6.6, locality −2.2, venue −1.2) tripped the ±1pp gate but were confirmed **coordinate-invisible** by grading the coordinate.
+
+- **PR #771** — the model + the prep (model-card + release.config → 4.13.0, build scripts: `rerender-overture-multiorder.mjs`, `locality-emit-diff.ts`, the v1.9.1 recipe, `sync_v091`).
+- **PR #772 + the `/mailwoman-release` skill** — the CI-publish runbook, codified from this cut and its five landmines.
+
+## What went well — patterns worth reusing
+
+- **Dump-and-read beat a plausible-but-wrong diagnosis.** v1.9.0 regressed every in-shard locale. DeepSeek's first call (case-mismatch) and second (locality-*grain* mismatch) were both reasonable — and both wrong. The `locality-emit-diff.ts` per-row dump showed v1.9.0 emitting the **street** in the locality slot (`Alvito→"R Alexandre Herculano"`), and the failing rows were all city-first while the training shard was 100% canonical (town-last). Root cause: **order-overfit** ("locality = last token-group"), not grain. The evidence carried it; the operator's "DeepSeek is myopic — push back if you disagree" was vindicated.
+- **One knob.** The fix re-rendered the *same* 2.4M rows in three orders (canonical / pc-first / city-first), weight unchanged at 3.0 — a clean single-variable A/B. The mechanism mattered: `source_weights` is a multinomial over *sources*, so row count and weight don't change the 5.7% EU mass; only the **rendering** does. DeepSeek's instinct to drop the weight would have starved EU without touching the order bias.
+- **Grade the coordinate, not label-F1 — again.** The US label-F1 said "three regressions, don't ship." The assembled coordinate said "clean, +0.7." The #566 discipline kept the right call; the 44-state holdout confirmed it.
+- **The dry-run earned its keep.** It caught *three* would-be-shipped defects before they went out: 4.12.0 was already taken (a code-only release), `--minor` had silently degraded to a patch (4.12.1), and the materialized workspace `model.onnx` was a stale v180 leftover. None reached npm.
+
+## What could've gone better — named friction
+
+- **The version landmines cost ~an hour of excavation.** "Promote to v4.12.0" was wrong twice over (taken; and `--minor`→patch). The fix was empirical (`npm view` + `git tag` + dry-run), but it should have been a checklist from the start — now it is (`/mailwoman-release` step 0).
+- **The local-vs-CI release confusion.** I prepped a local `yarn release` before learning "we never do it locally" (local npm auth is E401 by design; CI publishes via OIDC). The HF-staging prerequisite (the workflow fetches weights from HF at the card version) surfaced late. Both are now cardinal rules in the skill.
+- **Heat paced the eval.** The lab box spiked to ~91 °C on local ONNX grading; the operator's AC + fans bought the 44-state holdout. Modal-first for full golden evals remains the rule.
+
+## Decisions made
+
+- **Promote on the coordinate, weight stays 3.0.** The 2k diagnostic (under-trained v1.9.1 already beat the fully-trained broken v1.9.0) greenlit the full run; the 40k panel + 44-state US holdout + FR gate cleared promotion.
+- **Shipped two coordinate-invisible label-F1 deltas, stated** (country/locality/venue) — same discipline as v1.8.0's #728, not a silent relaxation.
+- **Sweden (#202) shelved.** Belägenhetsadress is the right source (CC-BY, 3.7M, clean schema) but has **no anonymous download** — a Geotorget account + human-approved purpose review + signed license (days-to-weeks). No honest interim exists (we have SE localities but zero real SE streets/postcodes, and the project re-renders real OA streets, never fabricated ones). Parked on the approval clock; the ingest pipeline is ready (`ogr2ogr` GML→CSV → the 3-order producer).
+
+## Open questions / for the operator
+
+- **#203 — the demo still serves v4.11.0.** The npm ship didn't repoint it (deliberate: `--set-default` + R2 + the demo version constant are a separate step). The win isn't visible to anyone until the demo serves it.
+- **#202 — register Geotorget** when you have a window, to start the SE approval clock.
+- **v1.9.2** — once SE lands, it's the 17th locale in the same 3-order shard; GB/IE/HU remain genuinely gated (commercial / no open feed).
+
+## Concrete next steps
+
+1. **#203** — repoint the demo to v4.13.0 (HF `--set-default` or patch `releases.json`, R2 upload, bump the demo version constant; heed the `hasPolygons=false` warning).
+2. **#202** — operator registers Geotorget → I ingest the GML → render SE as locale 17 → v1.9.2.
+3. Merge **PR #772** (the release skill) at leisure.
+
+## Numbers
+
+| metric | value |
+| --- | --- |
+| session shape | collaborative day (post morning-wrap) |
+| models trained | 2 (v1.9.0 failed, v1.9.1 shipped) |
+| Modal spend | ~$16 (~$8 × 2 A100 40k runs) |
+| released | **v4.13.0** to npm (13 workspaces, synced; provenance-attested) |
+| EU resolve lift (v1.8.0→v1.9.1) | +9 to +31 pp (PT +30, AT +31) |
+| US guardrail (44-state) | 83.4 → 84.1 (+0.7) |
+| FR guardrail | resolve flat, p50 1.28→1.22 km |
+| regressions shipped | 0 (label-F1 deltas confirmed coord-invisible) |
+| version defects caught pre-ship | 3 (taken version, --minor→patch, stale model) |
+| new skills | 1 (`/mailwoman-release`) |


### PR DESCRIPTION
The day's collaborative arc: v1.9.0 (order-overfit) failed → v1.9.1 (3-order fix) won → gated three ways → shipped v4.13.0 to npm via CI → codified `/mailwoman-release`. Chains from the 2026-06-22 night postmortem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)