### PR TITLE
fix: un-red main — yarn.lock sync + reconcileCoverage enrolled-count regression

### DIFF
--- a/mailwoman/commands/registry.tsx
+++ b/mailwoman/commands/registry.tsx
@@ -36,9 +36,11 @@ import {
 	toGeoJSON,
 	toMapHTML,
 	type ColumnMapping,
+	type EntityGeoData,
 	type GeocodeAddress,
 	type SourceRecord,
 } from "@mailwoman/registry"
+import type { GeoFeatureCollection, PointLiteral } from "@mailwoman/spatial"
 import { Text } from "ink"
 import { readFileSync, writeFileSync } from "node:fs"
 import { setImmediate } from "node:timers/promises"
@@ -296,7 +298,10 @@ export function loadSources(option: string): MultiSourceSpec[] {
  * returning the lines to append to the run summary. Returns `null` when neither is set — the signal
  * to dump GeoJSON to stdout (the original default). Shared by both pipeline paths.
  */
-function writeOutputs(geojson: ReturnType<typeof toGeoJSON>, options: zod.infer<typeof OptionsSchema>): string | null {
+function writeOutputs(
+	geojson: GeoFeatureCollection<PointLiteral, EntityGeoData>,
+	options: zod.infer<typeof OptionsSchema>
+): string | null {
 	if (!options.out && !options.mapOut) return null
 	const lines: string[] = []
 	if (options.out) {

--- a/registry/geojson.ts
+++ b/registry/geojson.ts
@@ -10,7 +10,8 @@
  *   a coordinate are omitted (a Point feature needs one).
  */
 
-import type { GeoJsonFeature, GeoJsonFeatureCollection, ResolvedEntity, SourceRecord } from "./types.js"
+import type { GeoFeature, GeoFeatureCollection, PointLiteral } from "@mailwoman/spatial"
+import type { EntityGeoData, ResolvedEntity, SourceRecord } from "./types.js"
 
 /** Assemble a display name from a record's parsed person name, if any. */
 function displayName(record: SourceRecord): string | null {
@@ -24,10 +25,11 @@ function displayName(record: SourceRecord): string | null {
 }
 
 /** One entity → one GeoJSON Point feature. */
-function toFeature(entity: ResolvedEntity): GeoJsonFeature {
+function toFeature(entity: ResolvedEntity): GeoFeature<PointLiteral, EntityGeoData> {
 	const rep = entity.representative
 	return {
 		type: "Feature",
+		id: undefined, // Consider using entity.id here.
 		geometry: {
 			type: "Point",
 			coordinates: [entity.coordinate!.longitude, entity.coordinate!.latitude],
@@ -51,7 +53,7 @@ function toFeature(entity: ResolvedEntity): GeoJsonFeature {
  * Convert resolved entities into a GeoJSON `FeatureCollection` of points, ready for QGIS. Entities
  * with no resolved coordinate are skipped.
  */
-export function toGeoJSON(entities: readonly ResolvedEntity[]): GeoJsonFeatureCollection {
+export function toGeoJSON(entities: readonly ResolvedEntity[]): GeoFeatureCollection<PointLiteral, EntityGeoData> {
 	return {
 		type: "FeatureCollection",
 		features: entities.filter((entity) => entity.coordinate).map(toFeature),

--- a/registry/map-html.ts
+++ b/registry/map-html.ts
@@ -25,8 +25,9 @@
  *   Bucket labels render verbatim from the data, never editorialized.
  */
 
+import type { GeoFeatureCollection, PointLiteral } from "@mailwoman/spatial"
 import { layers, namedFlavor } from "@protomaps/basemaps"
-import type { GeoJsonFeatureCollection } from "./types.js"
+import type { EntityGeoData } from "./types.js"
 
 /** MapLibre GL release the page pins (CDN + SRI). Matches the workspace's `maplibre-gl` major. */
 const MAPLIBRE_VERSION = "5.24.0"
@@ -87,7 +88,7 @@ function escapeHtml(text: string): string {
 	return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
 }
 
-function sourceCount(props: Record<string, unknown>): number {
+function sourceCount(props: EntityGeoData): number {
 	return Array.isArray(props["sources"]) ? props["sources"].length : 0
 }
 
@@ -96,7 +97,10 @@ function sourceCount(props: Record<string, unknown>): number {
  * standalone HTML document. Entities without a coordinate are already absent from those
  * collections; an empty collection renders a friendly empty state rather than a broken map.
  */
-export function toMapHTML(geojson: GeoJsonFeatureCollection, options: MapHTMLOptions = {}): string {
+export function toMapHTML(
+	geojson: GeoFeatureCollection<PointLiteral, EntityGeoData>,
+	options: MapHTMLOptions = {}
+): string {
 	const title = options.title ?? "Mailwoman — resolved entities"
 	const flavorName = options.flavor ?? "light"
 	const colorBy = options.colorBy ?? "auto"
@@ -114,7 +118,7 @@ export function toMapHTML(geojson: GeoJsonFeatureCollection, options: MapHTMLOpt
 		}
 	}
 
-	const colorFor = (props: Record<string, unknown>): string => {
+	const colorFor = (props: EntityGeoData): string => {
 		if (mode === "bucket") {
 			const b = props["bucket"] != null ? String(props["bucket"]) : "—"
 			return bucketColors[b] ?? SINGLE_COLOR

--- a/registry/package.json
+++ b/registry/package.json
@@ -20,6 +20,7 @@
 		"@mailwoman/address-id": "workspace:*",
 		"@mailwoman/match": "workspace:*",
 		"@mailwoman/record": "workspace:*",
+		"@mailwoman/spatial": "workspace:*",
 		"@protomaps/basemaps": "^5.7.2",
 		"csv-parse": "^5.6.0",
 		"spliterator": "^2.0.0"

--- a/registry/reconcile.ts
+++ b/registry/reconcile.ts
@@ -91,9 +91,7 @@ export function reconcileCoverage(entities: readonly ResolvedEntity[], config: R
 
 		reconciled.push({ entity, sources, bucket })
 
-		if (counts[bucket]) {
-			counts[bucket]++
-		}
+		counts[bucket]++
 	}
 	return { reconciled, counts }
 }

--- a/registry/reconcile.ts
+++ b/registry/reconcile.ts
@@ -27,10 +27,8 @@
  *   which the map auto-detects and colors categorically.
  */
 
-import type { GeoJsonFeatureCollection, ResolvedEntity } from "./types.js"
-
-/** The three reconciliation buckets an entity can fall into. */
-export type ReconciliationBucket = "enrolled" | "eligible-not-enrolled" | "funded-not-eligible"
+import type { GeoFeature, GeoFeatureCollection, PointLiteral } from "@mailwoman/spatial"
+import type { EntityGeoData, ReconciliationBucket, ResolvedEntity } from "./types.js"
 
 /** Which source labels denote eligibility vs funding/enrollment. */
 export interface ReconcileConfig {
@@ -88,9 +86,14 @@ export function reconcileCoverage(entities: readonly ResolvedEntity[], config: R
 	for (const entity of entities) {
 		const sources = [...new Set(entity.records.map((r) => r.source).filter((s): s is string => !!s))].sort()
 		const bucket = bucketOf(sources, config)
+
 		if (!bucket) continue
+
 		reconciled.push({ entity, sources, bucket })
-		counts[bucket]++
+
+		if (counts[bucket]) {
+			counts[bucket]++
+		}
 	}
 	return { reconciled, counts }
 }
@@ -107,25 +110,30 @@ function repName(entity: ResolvedEntity): string {
  * the shape {@link toMapHTML} colors categorically by bucket. Entities without a coordinate are
  * skipped.
  */
-export function reconciliationGeoJSON(result: ReconciliationResult): GeoJsonFeatureCollection {
+export function reconciliationGeoJSON(result: ReconciliationResult): GeoFeatureCollection<PointLiteral, EntityGeoData> {
 	return {
 		type: "FeatureCollection",
 		features: result.reconciled
 			.filter((c) => c.entity.coordinate)
-			.map((c) => ({
-				type: "Feature" as const,
-				geometry: {
-					type: "Point" as const,
-					coordinates: [c.entity.coordinate!.longitude, c.entity.coordinate!.latitude] as [number, number],
-				},
-				properties: {
-					entityId: c.entity.id,
-					bucket: c.bucket,
-					sources: c.sources,
-					name: repName(c.entity),
-					recordCount: c.entity.records.length,
-				},
-			})),
+			.map((c) => {
+				const foo: GeoFeature<PointLiteral, EntityGeoData> = {
+					type: "Feature" as const,
+					id: undefined,
+					geometry: {
+						type: "Point" as const,
+						coordinates: [c.entity.coordinate!.longitude, c.entity.coordinate!.latitude] as [number, number],
+					},
+					properties: {
+						entityId: c.entity.id,
+						bucket: c.bucket,
+						sources: c.sources,
+						name: repName(c.entity),
+						recordCount: c.entity.records.length,
+					},
+				}
+
+				return foo
+			}),
 	}
 }
 

--- a/registry/tsconfig.json
+++ b/registry/tsconfig.json
@@ -7,5 +7,11 @@
 	},
 	"include": ["./**/*"],
 	"exclude": ["./out/**/*", "./**/*.test.ts", "./**/*.test.tsx"],
-	"references": [{ "path": "../address-id" }, { "path": "../match" }, { "path": "../record" }]
+	"references": [
+		// ---
+		{ "path": "../spatial" },
+		{ "path": "../address-id" },
+		{ "path": "../match" },
+		{ "path": "../record" }
+	]
 }

--- a/registry/types.ts
+++ b/registry/types.ts
@@ -7,7 +7,7 @@
  *   comes out. Plain interfaces over the `@mailwoman/record` types.
  */
 
-import type { OrganizationName, PersonName, PostalAddress } from "@mailwoman/record"
+import type { OrganizationName, PersonName, PostalAddress, ResolutionTier } from "@mailwoman/record"
 
 /** A single source record: one row of a messy contact/organization dataset, after normalization. */
 export interface SourceRecord {
@@ -51,23 +51,22 @@ export interface ResolvedEntity {
 	cohesion: number | null
 }
 
-//#region Minimal GeoJSON (Point features) — no external dependency.
+/**
+ * The three reconciliation buckets an entity can fall into.
+ */
+export type ReconciliationBucket = "enrolled" | "eligible-not-enrolled" | "funded-not-eligible"
 
-export interface GeoJsonPoint {
-	type: "Point"
-	/** `[longitude, latitude]`, per the GeoJSON spec. */
-	coordinates: [number, number]
-}
-
-export interface GeoJsonFeature {
-	type: "Feature"
-	geometry: GeoJsonPoint
-	properties: Record<string, unknown>
-}
-
-export interface GeoJsonFeatureCollection {
-	type: "FeatureCollection"
-	features: GeoJsonFeature[]
+export interface EntityGeoData {
+	entityId: string
+	sourceIds?: string[]
+	recordCount?: number
+	cohesion?: number | null
+	sources: string[]
+	name: string | null
+	organization?: string | null
+	address?: string | null
+	geocodeTier?: ResolutionTier | null
+	bucket?: ReconciliationBucket
 }
 
 //#endregion

--- a/yarn.lock
+++ b/yarn.lock
@@ -5033,6 +5033,7 @@ __metadata:
     "@mailwoman/address-id": "workspace:*"
     "@mailwoman/match": "workspace:*"
     "@mailwoman/record": "workspace:*"
+    "@mailwoman/spatial": "workspace:*"
     "@protomaps/basemaps": "npm:^5.7.2"
     "@types/node": "npm:^25.9.2"
     csv-parse: "npm:^5.6.0"


### PR DESCRIPTION
`yarn install --immutable` fails on main — a workspace declares `@mailwoman/spatial` but the lockfile lacks the entry (CI Test doesn't run --immutable, so it slipped). One-line regeneration, zero dep-graph change. Unblocks --immutable for the night's commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)