### PR TITLE
eval: competitive benchmark + scorecard (vs Nominatim/Pelias) — US win, EU trail, metric correction

### DIFF
--- a/data/eval/external/oa-us-coord-150.jsonl
+++ b/data/eval/external/oa-us-coord-150.jsonl
@@ -1,0 +1,150 @@
+{"raw":"109 Seminary Dr, Mill Valley, CA 94941","lat":37.8896183,"lon":-122.5121047,"country":"US","components":{}}
+{"raw":"5210 South Ingleside Avenue, Chicago, IL 60615","lat":41.8004427,"lon":-87.6031768,"country":"US","components":{}}
+{"raw":"2631 Moreland Place Nw, Washington, DC 20015","lat":38.9665826,"lon":-77.0559593,"country":"US","components":{}}
+{"raw":"4106 Avenue B, Council Bluffs, IA 51501","lat":41.2638119,"lon":-95.9154218,"country":"US","components":{}}
+{"raw":"1903 Mount Ellis Lane, Bozeman, MT 59715","lat":45.6343497,"lon":-110.9605771,"country":"US","components":{}}
+{"raw":"226 Bridge Rd, North Hero, VT 05474","lat":44.8865676,"lon":-73.270166,"country":"US","components":{}}
+{"raw":"222 8th St, Burke, SD 57523","lat":43.182674,"lon":-99.2942925,"country":"US","components":{}}
+{"raw":"1332 Neilson St, Berkeley, CA 94702","lat":37.8804115,"lon":-122.2897944,"country":"US","components":{}}
+{"raw":"256 Juniper Circle, Streamwood, IL 60107","lat":42.0292782,"lon":-88.1546018,"country":"US","components":{}}
+{"raw":"1532 Taylor Street Ne, Washington, DC 20017","lat":38.9409863,"lon":-76.9834057,"country":"US","components":{}}
+{"raw":"1833 W 3rd St, Davenport, IA 52802","lat":41.5220842,"lon":-90.6044994,"country":"US","components":{}}
+{"raw":"106 Railroad Avenue East, Scobey, MT 59263","lat":48.7936878,"lon":-105.4195326,"country":"US","components":{}}
+{"raw":"344 East Sheldon Rd, Sheldon, VT 05450","lat":44.8927257,"lon":-72.9269602,"country":"US","components":{}}
+{"raw":"325 Lisa Cir, Tea, SD 57064","lat":43.4510468,"lon":-96.8325577,"country":"US","components":{}}
+{"raw":"167 Via La Paz, Greenbrae, CA 94904","lat":37.9504971,"lon":-122.5200245,"country":"US","components":{}}
+{"raw":"2923 North Oak Park Avenue, Chicago, IL 60634","lat":41.9334134,"lon":-87.7952423,"country":"US","components":{}}
+{"raw":"2924 Cortland Place Nw, Washington, DC 20008","lat":38.9295243,"lon":-77.0595364,"country":"US","components":{}}
+{"raw":"2450 Old Hospital Rd, Coralville, IA 52241","lat":41.7056036,"lon":-91.6017331,"country":"US","components":{}}
+{"raw":"337 Future Circle, Billings, MT 59102","lat":45.7637248,"lon":-108.5934783,"country":"US","components":{}}
+{"raw":"0 Thomas Hill Rd, Halifax, VT 05301","lat":42.8250744,"lon":-72.7079151,"country":"US","components":{}}
+{"raw":"7505 W Boysenberry St, Sioux Falls, SD 57106","lat":43.5386412,"lon":-96.8189495,"country":"US","components":{}}
+{"raw":"10 Calico Ct, Novato, CA 94947","lat":38.1065711,"lon":-122.5986622,"country":"US","components":{}}
+{"raw":"10341 South Torrence Avenue, Chicago, IL 60617","lat":41.7069714,"lon":-87.5593708,"country":"US","components":{}}
+{"raw":"1949 Valley Terrace Se, Washington, DC 20032","lat":38.8411529,"lon":-76.9766507,"country":"US","components":{}}
+{"raw":"209 3rd STREET, West Des Moines, IA 50265","lat":41.5714788,"lon":-93.7058098,"country":"US","components":{}}
+{"raw":"1301 9th Avenue South, Great Falls, MT 59405","lat":47.4954662,"lon":-111.2849445,"country":"US","components":{}}
+{"raw":"880 S Hill Rd, Moretown, VT 05660","lat":44.2358488,"lon":-72.7528928,"country":"US","components":{}}
+{"raw":"2128 Russet Ln, Rapid City, SD 57703","lat":44.0646888,"lon":-103.1504521,"country":"US","components":{}}
+{"raw":"15 Lower Alcatraz Pl, Mill Valley, CA 94941","lat":37.9085971,"lon":-122.5492118,"country":"US","components":{}}
+{"raw":"1503 West Nelson Street, Chicago, IL 60657","lat":41.9367679,"lon":-87.666407,"country":"US","components":{}}
+{"raw":"619 1/2 I Street Se, Washington, DC 20003","lat":38.8799897,"lon":-76.9976919,"country":"US","components":{}}
+{"raw":"135 Bluff Dr, Fairfax, IA 52228","lat":41.9288945,"lon":-91.7649404,"country":"US","components":{}}
+{"raw":"1840 Reynolds Avenue, Butte, MT 59701","lat":45.9954605,"lon":-112.5046688,"country":"US","components":{}}
+{"raw":"308 Ridge Rd, Shaftsbury, VT 05262","lat":42.9794513,"lon":-73.2480559,"country":"US","components":{}}
+{"raw":"304 W 3rd St, Oacoma, SD 57365","lat":43.7993151,"lon":-99.3993277,"country":"US","components":{}}
+{"raw":"2125 Hearst Ave, Berkeley, CA 94709","lat":37.8742614,"lon":-122.2678788,"country":"US","components":{}}
+{"raw":"2020 Valley Lo Lane, Glenview, IL 60025","lat":42.0912216,"lon":-87.8038223,"country":"US","components":{}}
+{"raw":"720 Decatur Place Ne, Washington, DC 20017","lat":38.9489963,"lon":-76.9962395,"country":"US","components":{}}
+{"raw":"119 South 7th Street, Estherville, IA 51334","lat":43.4002874,"lon":-94.8356131,"country":"US","components":{}}
+{"raw":"1017 Cooper Street, Missoula, MT 59802","lat":46.878776,"lon":-114.0053609,"country":"US","components":{}}
+{"raw":"17 Upper Highlands Loop, Dover, VT 05356","lat":42.9769279,"lon":-72.8920645,"country":"US","components":{}}
+{"raw":"6711 W 41st St, Sioux Falls, SD 57106","lat":43.5147649,"lon":-96.8097125,"country":"US","components":{}}
+{"raw":"539 San Geronimo Valley Dr, San Geronimo, CA 94963","lat":38.0130926,"lon":-122.6653122,"country":"US","components":{}}
+{"raw":"8542 South Wallace Street, Chicago, IL 60620","lat":41.7383284,"lon":-87.6390715,"country":"US","components":{}}
+{"raw":"1600 Webster Street Ne, Washington, DC 20017","lat":38.9446477,"lon":-76.9826294,"country":"US","components":{}}
+{"raw":"1315 Summer Street, Grinnell, IA 50112","lat":41.7496748,"lon":-92.714811,"country":"US","components":{}}
+{"raw":"254 Lozeau Crossover Road, Superior, MT 59872","lat":47.1090197,"lon":-114.7829543,"country":"US","components":{}}
+{"raw":"9 Dump Rd, Warren, VT 05674","lat":44.1129753,"lon":-72.8502861,"country":"US","components":{}}
+{"raw":"232 St Patrick St, Rapid City, SD 57701","lat":44.0678302,"lon":-103.2233545,"country":"US","components":{}}
+{"raw":"2212 San Pablo Ave, Berkeley, CA 94702","lat":37.8657997,"lon":-122.2914679,"country":"US","components":{}}
+{"raw":"8726 South Troy Avenue, Evergreen Park, IL 60805","lat":41.7343866,"lon":-87.701318,"country":"US","components":{}}
+{"raw":"3927 Ames Street Ne, Washington, DC 20019","lat":38.8907073,"lon":-76.9493385,"country":"US","components":{}}
+{"raw":"115 Clinton Street, Muscatine, IA 52761","lat":41.4148197,"lon":-91.0662763,"country":"US","components":{}}
+{"raw":"212 South 5th Avenue East, Malta, MT 59538","lat":48.3582908,"lon":-107.8668964,"country":"US","components":{}}
+{"raw":"167 Obrien Mdws, Hinesburg, VT 05461","lat":44.3129548,"lon":-73.0793565,"country":"US","components":{}}
+{"raw":"2625 Maverick Ct, Spearfish, SD 57783","lat":44.4476511,"lon":-103.7863396,"country":"US","components":{}}
+{"raw":"4060 Paradise Dr, Tiburon, CA 94920","lat":37.902757,"lon":-122.4721656,"country":"US","components":{}}
+{"raw":"924 West Oakdale Avenue, Chicago, IL 60657","lat":41.9357863,"lon":-87.6525446,"country":"US","components":{}}
+{"raw":"1762 E Street Ne, Washington, DC 20002","lat":38.8962701,"lon":-76.9787879,"country":"US","components":{}}
+{"raw":"1325 6th Street, Hull, IA 51239","lat":43.1942997,"lon":-96.1279215,"country":"US","components":{}}
+{"raw":"209 4th Avenue Northeast, Browning, MT 59417","lat":48.5597427,"lon":-113.0107791,"country":"US","components":{}}
+{"raw":"59 Elm St, Winooski, VT 05404","lat":44.4953858,"lon":-73.1959331,"country":"US","components":{}}
+{"raw":"118 S Progress St, Lake City, SD 57247","lat":45.724603,"lon":-97.4111968,"country":"US","components":{}}
+{"raw":"1517 Addison St, Berkeley, CA 94703","lat":37.8697874,"lon":-122.2812201,"country":"US","components":{}}
+{"raw":"11024 South Avenue L, Chicago, IL 60617","lat":41.6947195,"lon":-87.5367797,"country":"US","components":{}}
+{"raw":"1832 9th Street Nw, Washington, DC 20001","lat":38.915273,"lon":-77.0242005,"country":"US","components":{}}
+{"raw":"1301 E Linden St, Algona, IA 50511","lat":43.0730015,"lon":-94.2214438,"country":"US","components":{}}
+{"raw":"6853 Sa 2 Drive, Wolf Point, MT 59201","lat":48.1031154,"lon":-105.5289859,"country":"US","components":{}}
+{"raw":"1791 Vt Route 58 E, Irasburg, VT 05860","lat":44.8040748,"lon":-72.2452785,"country":"US","components":{}}
+{"raw":"18095 450th Ave, Hayti, SD 57241","lat":44.7613254,"lon":-97.2103409,"country":"US","components":{}}
+{"raw":"1603 Mcgee Ave, Berkeley, CA 94703","lat":37.8770231,"lon":-122.2779286,"country":"US","components":{}}
+{"raw":"4019 Scoville Avenue, Stickney, IL 60402","lat":41.8189119,"lon":-87.7860372,"country":"US","components":{}}
+{"raw":"735 Morton Street Nw, Washington, DC 20010","lat":38.932093,"lon":-77.0248123,"country":"US","components":{}}
+{"raw":"4333 Benton St Ne, Cedar Rapids, IA 52402","lat":42.0230949,"lon":-91.6594035,"country":"US","components":{}}
+{"raw":"130 Oberlin Loop, Kalispell, MT 59901","lat":48.2137463,"lon":-114.3669323,"country":"US","components":{}}
+{"raw":"740 Pleasant St, Brighton, VT 05846","lat":44.7991114,"lon":-71.8789468,"country":"US","components":{}}
+{"raw":"6209 W 60th St, Sioux Falls, SD 57106","lat":43.4978881,"lon":-96.8029259,"country":"US","components":{}}
+{"raw":"409 Alameda De La Loma, Novato, CA 94949","lat":38.0656508,"lon":-122.5470182,"country":"US","components":{}}
+{"raw":"114 Forest Avenue, River Forest, IL 60305","lat":41.8817521,"lon":-87.8215357,"country":"US","components":{}}
+{"raw":"2837 Myrtle Avenue Ne, Washington, DC 20018","lat":38.931505,"lon":-76.9652984,"country":"US","components":{}}
+{"raw":"301 Armour Street, West Union, IA 52175","lat":42.952546,"lon":-91.8018988,"country":"US","components":{}}
+{"raw":"136 East Street, Fort Smith, MT 59035","lat":45.309885,"lon":-107.9166432,"country":"US","components":{}}
+{"raw":"445 Vt Route 15 E, Morristown, VT 05661","lat":44.5715395,"lon":-72.5852898,"country":"US","components":{}}
+{"raw":"3123 Iris Dr, Rapid City, SD 57702","lat":44.0550532,"lon":-103.2833552,"country":"US","components":{}}
+{"raw":"91 Larkspur St, San Rafael, CA 94901","lat":37.9640039,"lon":-122.5049996,"country":"US","components":{}}
+{"raw":"16324 Halsted Street, Harvey, IL 60426","lat":41.5926848,"lon":-87.6367731,"country":"US","components":{}}
+{"raw":"2622 University Place Nw, Washington, DC 20009","lat":38.9243297,"lon":-77.034396,"country":"US","components":{}}
+{"raw":"717 16th Street, Perry, IA 50220","lat":41.8357804,"lon":-94.0872748,"country":"US","components":{}}
+{"raw":"309 North Lincoln Avenue, Broadus, MT 59317","lat":45.4462972,"lon":-105.4071861,"country":"US","components":{}}
+{"raw":"29 Charles Drake Ln, Putney, VT 05346","lat":42.9755118,"lon":-72.5116151,"country":"US","components":{}}
+{"raw":"12716 Beaver Creek Rd, Custer, SD 57730","lat":43.613631,"lon":-103.5165782,"country":"US","components":{}}
+{"raw":"505 Panoramic Hwy, Mill Valley, CA 94941","lat":37.9010877,"lon":-122.5685658,"country":"US","components":{}}
+{"raw":"7751 Kingsbury Drive, Hanover Park, IL 60133","lat":42.0105961,"lon":-88.1409616,"country":"US","components":{}}
+{"raw":"3530 10th Street Nw, Washington, DC 20010","lat":38.9338789,"lon":-77.0275303,"country":"US","components":{}}
+{"raw":"1045 Evans Avenue, West Liberty, IA 52776","lat":41.5912765,"lon":-91.2690378,"country":"US","components":{}}
+{"raw":"995 Bigfork Stage, Bigfork, MT 59911","lat":48.069988,"lon":-114.0691213,"country":"US","components":{}}
+{"raw":"1320 Sheffield Rd, Sutton, VT 05867","lat":44.6373725,"lon":-72.0517055,"country":"US","components":{}}
+{"raw":"1113 Cherry Dr Ne, Watertown, SD 57201","lat":44.9144492,"lon":-97.0804323,"country":"US","components":{}}
+{"raw":"983 Overlook Rd, Berkeley, CA 94708","lat":37.8956161,"lon":-122.2574062,"country":"US","components":{}}
+{"raw":"10019 South Oakley Avenue, Chicago, IL 60643","lat":41.7112649,"lon":-87.6790446,"country":"US","components":{}}
+{"raw":"5509 4th Street Ne, Washington, DC 20011","lat":38.9563498,"lon":-76.999838,"country":"US","components":{}}
+{"raw":"4109 Bowdoin STREET, Des Moines, IA 50313","lat":41.6353913,"lon":-93.6124014,"country":"US","components":{}}
+{"raw":"4522 Cascade Street, Bozeman, MT 59718","lat":45.6804045,"lon":-111.100929,"country":"US","components":{}}
+{"raw":"39 Charles St, Hartford, VT 05001","lat":43.6500704,"lon":-72.3280452,"country":"US","components":{}}
+{"raw":"37585 274th St, Harrison, SD 57344","lat":43.4133256,"lon":-98.6704086,"country":"US","components":{}}
+{"raw":"46 Lincoln Park, San Anselmo, CA 94960","lat":37.9745482,"lon":-122.5609486,"country":"US","components":{}}
+{"raw":"1032 North Ashland Avenue, Chicago, IL 60622","lat":41.9006763,"lon":-87.6677403,"country":"US","components":{}}
+{"raw":"3129 Robinson Street Se, Washington, DC 20020","lat":38.8499278,"lon":-76.9842033,"country":"US","components":{}}
+{"raw":"222 Marshall St, Boone, IA 50036","lat":42.058252,"lon":-93.8780545,"country":"US","components":{}}
+{"raw":"4136 Morgan Avenue, Billings, MT 59101","lat":45.7601719,"lon":-108.5167287,"country":"US","components":{}}
+{"raw":"162 Chittenden Dr, Arlington, VT 05250","lat":43.071931,"lon":-73.1515898,"country":"US","components":{}}
+{"raw":"115 S 3rd St, Beresford, SD 57004","lat":43.0798738,"lon":-96.7742939,"country":"US","components":{}}
+{"raw":"3215 Idaho St, Berkeley, CA 94702","lat":37.8491321,"lon":-122.2814981,"country":"US","components":{}}
+{"raw":"9754 South Yale Avenue, Chicago, IL 60628","lat":41.7163952,"lon":-87.6300039,"country":"US","components":{}}
+{"raw":"5327 4th Street Nw, Washington, DC 20011","lat":38.9551977,"lon":-77.0175201,"country":"US","components":{}}
+{"raw":"8138 Chain Lakes Rd, Monroe Twp, IA 52411","lat":42.0568763,"lon":-91.762626,"country":"US","components":{}}
+{"raw":"385 Eagle Cliff Meadows Road, Billings, MT 59101","lat":45.8003501,"lon":-108.3774674,"country":"US","components":{}}
+{"raw":"392 Meadow Ln, Warren, VT 05674","lat":44.1337383,"lon":-72.8656306,"country":"US","components":{}}
+{"raw":"24588 Outback Trl, Hermosa, SD 57744","lat":43.8411971,"lon":-103.3025103,"country":"US","components":{}}
+{"raw":"57 Granada Dr, Corte Madera, CA 94925","lat":37.9156809,"lon":-122.5060422,"country":"US","components":{}}
+{"raw":"7008 Plymouth Court, Tinley Park, IL 60477","lat":41.5971649,"lon":-87.7904764,"country":"US","components":{}}
+{"raw":"423 12th Street Se, Washington, DC 20003","lat":38.8835876,"lon":-76.9905108,"country":"US","components":{}}
+{"raw":"1833 Spicer Ave, Wilton, IA 52778","lat":41.6796912,"lon":-91.0159094,"country":"US","components":{}}
+{"raw":"802 Adirondac Avenue, Hamilton, MT 59840","lat":46.2551706,"lon":-114.1680623,"country":"US","components":{}}
+{"raw":"2 Vt Route 106, Weathersfield, VT 05151","lat":43.3447697,"lon":-72.5315706,"country":"US","components":{}}
+{"raw":"915 S Penn St, Aberdeen, SD 57401","lat":45.4558088,"lon":-98.4761872,"country":"US","components":{}}
+{"raw":"2806 Grant St, Berkeley, CA 94703","lat":37.8574185,"lon":-122.2733558,"country":"US","components":{}}
+{"raw":"1873 White Street, Des Plaines, IL 60018","lat":42.0193291,"lon":-87.8842281,"country":"US","components":{}}
+{"raw":"1215 Oates Street Ne, Washington, DC 20002","lat":38.9050867,"lon":-76.9878582,"country":"US","components":{}}
+{"raw":"4016 Patricia DRIVE, Urbandale, IA 50322","lat":41.6336296,"lon":-93.753267,"country":"US","components":{}}
+{"raw":"1633 Flowerree Street, Helena, MT 59601","lat":46.5990458,"lon":-112.0636137,"country":"US","components":{}}
+{"raw":"316 Buck Hill Rd E, Hinesburg, VT 05461","lat":44.3292218,"lon":-73.0809017,"country":"US","components":{}}
+{"raw":"5007 Landenberg Ct, Rapid City, SD 57702","lat":44.0054842,"lon":-103.3037491,"country":"US","components":{}}
+{"raw":"3115 Lewiston Ave, Berkeley, CA 94705","lat":37.8534226,"lon":-122.2514001,"country":"US","components":{}}
+{"raw":"3428 South Ashland Avenue, Chicago, IL 60608","lat":41.8315359,"lon":-87.6658913,"country":"US","components":{}}
+{"raw":"2006 Mississippi Avenue Se, Washington, DC 20020","lat":38.8441298,"lon":-76.9747554,"country":"US","components":{}}
+{"raw":"700 Main St, Ida Grove, IA 51445","lat":42.3389733,"lon":-95.4717081,"country":"US","components":{}}
+{"raw":"1760 West Central Avenue, Missoula, MT 59801","lat":46.8508783,"lon":-114.0240426,"country":"US","components":{}}
+{"raw":"43 Catherine St, Burlington, VT 05401","lat":44.4661331,"lon":-73.2113897,"country":"US","components":{}}
+{"raw":"1836 Northridge Dr, Watertown, SD 57201","lat":44.924926,"lon":-97.103284,"country":"US","components":{}}
+{"raw":"50 Edgemont Way, Inverness, CA 94937","lat":38.0985443,"lon":-122.8537571,"country":"US","components":{}}
+{"raw":"4854 West Winnemac Avenue, Chicago, IL 60630","lat":41.9727633,"lon":-87.7500732,"country":"US","components":{}}
+{"raw":"5416 9th Street Nw, Washington, DC 20011","lat":38.9559432,"lon":-77.0259731,"country":"US","components":{}}
+{"raw":"6818 Brookview DRIVE, Urbandale, IA 50322","lat":41.6504823,"lon":-93.7109466,"country":"US","components":{}}
+{"raw":"2345 Ramers Court, Missoula, MT 59801","lat":46.8698249,"lon":-114.035182,"country":"US","components":{}}
+{"raw":"208 Broadlake Rd, Colchester, VT 05446","lat":44.5432116,"lon":-73.2860032,"country":"US","components":{}}
+{"raw":"24761 487th Ave, Sherman, SD 57030","lat":43.7582194,"lon":-96.4712258,"country":"US","components":{}}
+{"raw":"359 Tennessee Ave, Mill Valley, CA 94941","lat":37.8801309,"lon":-122.5324386,"country":"US","components":{}}
+{"raw":"6730 North East Prairie Road, Lincolnwood, IL 60712","lat":42.0036173,"lon":-87.7262733,"country":"US","components":{}}
+{"raw":"2218 Douglas Street Ne, Washington, DC 20018","lat":38.9236565,"lon":-76.9727834,"country":"US","components":{}}

--- a/docs/articles/evals/2026-06-23-vs-nominatim-pelias.md
+++ b/docs/articles/evals/2026-06-23-vs-nominatim-pelias.md
@@ -1,0 +1,86 @@
+# Competitive benchmark — mailwoman vs Nominatim vs Pelias (2026-06-23)
+
+_The honest head-to-head, run for trade-show readiness. Harness: `scripts/eval/competitive-benchmark.ts`._
+_Reproduce: `node --experimental-strip-types scripts/eval/competitive-benchmark.ts --n 150 --locales it,pt,pl,at,cz,fr,au` (Pelias via geocode.earth; Nominatim via the public API at ~1 req/s)._
+
+## Method (and why it's built this way)
+
+Three systems, identical real held-out OpenAddresses rows (truth lat/lon), 150/locale. The systems return structurally different things — mailwoman resolves to a gazetteer **centroid**; Nominatim returns the matched **OSM object** (rooftop when it matches, nothing when it doesn't); Pelias is ES over OSM+OA+WOF — so a raw median-error race flatters whoever returns rooftops on the addresses they match and hides who returns nothing. So we score **resolve-rate @ a coarse km threshold** (within Xkm of truth; **"no result" = a miss**) as the honest denominator, plus conditional accuracy. Coarse thresholds (5/25 km = "right locality area") because mailwoman returns centroids — a km-to-rooftop metric would unfairly reward rooftop-when-it-matches.
+
+## Headline — resolve-rate @ 25 km (clean inputs)
+
+| locale | mailwoman | nominatim | pelias |
+|---|--:|--:|--:|
+| IT | **92%** | 75% | 79% |
+| PT | 57% | 47% | 65% |
+| PL | 42% | **96%** | 92% |
+| AT | 73% | **97%** | 89% |
+| CZ | 33% | **88%** | 68% |
+| FR | 66% | 59% | **94%** |
+| AU | 38% | **97%** | 76% |
+| **ALL** | **59%** | **79%** | **81%** |
+
+| system | n | @1km | @5km | @25km | cond. p50 | no-result |
+|---|--:|--:|--:|--:|--:|--:|
+| mailwoman | 972 | 26% | 52% | 59% | 1.8 km | 27% |
+| nominatim | 972 | 74% | 78% | 79% | 0.0 km | 20% |
+| pelias | 972 | 66% | 77% | 81% | 0.0 km | 1% |
+
+**On clean OpenAddresses, mailwoman trails both** (59 vs 79/81). The losing rows stay in the table.
+
+## What's real and what's confounded (verify-before-verdict)
+
+- **The loss is NOT a resolver-config handicap.** mailwoman is ~44% on the trailing locales across all three resolver configs — admin-only, admin + `postcode-locality-intl`, and the **demo's actual candidate gazetteer** (`candidate-global-20h`). The resolver isn't the cause.
+- **Our internal "resolve-rate" metric OVERSTATES by ~15–22 pp.** Internal panel: PL resolve 62%, CZ 52%, AU 53%. Honest @25 km right-place: PL 42%, CZ 28–33%, AU 32–38%. The gap = resolves that land **>25 km** (region-level fallback / wrong same-name place) — counted as success by resolve-rate, as a miss by right-place. **We have been grading ourselves on a lenient metric.** (mailwoman's centroid is NOT the issue — p50 1.8 km, well inside 25 km; @25 km forgives it.)
+- **The test set favors Pelias.** OpenAddresses is one of Pelias's INDEXED sources — its 81% / p50 0.0 km is partly recall-of-its-own-data, not generalization (home-field advantage). Nominatim (OSM) overlaps less. mailwoman trained on a disjoint held-out split.
+- **The real mailwoman gap is coverage/recall:** ~27% no-result aggregate (worse on EU non-IT) vs Pelias ~1% / Nominatim ~20%. It fails to return a usable coordinate for a quarter of these addresses.
+
+## Messy inputs — the slice that should favor a calibrated parser
+
+_(filled from the `--messy` run: lowercase + dropped commas/dash-postcodes + abbreviations — the "typed in a hurry" case where a search index that leans on exact tokens + structure should degrade more than a learned parser.)_
+
+Messy = lowercase + dropped commas/dash-postcodes + abbreviations (house numbers preserved). 40/locale.
+
+| system | clean @25km | messy @25km | Δ |
+|---|--:|--:|--:|
+| mailwoman | 59% | **49%** | −10 (graceful) |
+| nominatim | 79% | **81%** | +2 (robust free-text) |
+| pelias | 81% | ~~6%~~ | **INVALID — rate-limited** |
+
+⚠ **Pelias's messy "6%" is a geocode.earth RATE-LIMIT artifact, not a finding** — verified by direct query: the API now returns **HTTP 429 on every call**, clean OR messy (the trial key's quota exhausted after ~1.2k calls; the messy run ran later than the clean run, so its Pelias column collapsed to 429→null→"no result"). The clean Pelias 81% (earlier, under quota) is likely valid; the messy Pelias number is **discarded**. _verify-before-verdict caught what would have been a false "Pelias collapses on messy" headline._
+
+Real messy takeaway: **mailwoman degrades gracefully (−10pp); Nominatim's free-text search is robust (doesn't degrade)**. My perturbation didn't break Nominatim — OSM has the addresses and its tokenizer forgives lowercase/no-comma/no-postcode.
+
+## US — the home turf (mailwoman vs Nominatim; Pelias rate-locked)
+
+| locale | mailwoman | nominatim |
+|---|--:|--:|
+| **US** | **99%** | 84% |
+
+| system | n | @1km | @5km | @25km | cond. p50 | no-result |
+|---|--:|--:|--:|--:|--:|--:|
+| mailwoman | 150 | 18% | 67% | **99%** | 3.2 km | **0%** |
+| nominatim | 150 | 82% | 83% | 84% | 0.0 km | 16% |
+
+**On US, mailwoman dominates: 99% vs 84%, and 0% no-result vs Nominatim's 16%.** Nominatim returns rooftops when it matches (p50 0.0 km) but misses 16% of US addresses — OSM's US coverage gaps (rural, new developments). mailwoman (TIGER + national situs + the candidate gazetteer) resolves *every* address to the right locality. The US set is OpenAddresses, which Nominatim (OSM) does NOT index wholesale, so this is genuine coverage superiority, not data overlap.
+
+## Honest verdict
+
+The picture is nuanced — and good, once you stop grading on the lenient metric:
+
+| market | mailwoman | Nominatim | Pelias |
+|---|--:|--:|--:|
+| **US** | **99%** | 84% | _(rate-locked)_ |
+| **EU (clean)** | 59% | 79% | 81%¹ |
+
+1. ¹ EU is OpenAddresses, a Pelias-indexed source — its 81% is partly recall-of-its-own-data.
+
+**Where we win:** US accuracy + coverage (the high-value market) — 99 vs 84, zero misses. Plus two capabilities the competitors structurally lack: **calibrated confidence** (knows when it's wrong) and **deployability** (30 MB, in-browser/offline, no Elasticsearch, no PostgreSQL+OSM-planet).
+
+**Where we trail:** EU coordinate coverage. Nominatim/OSM and Pelias/OA simply have more EU address data than our gazetteer + model do today. This is a **coverage/recall gap** (no-result), not a precision gap (our resolved p50 is 1.8 km) — and it's the active roadmap: the v4.13.0 multi-locale ship, #370 (the rescore that recovers the wrong-place tail), and G-NAF/coverage ingestion all target exactly it.
+
+**The methodology correction (most important internal takeaway):** our internal "resolve-rate" metric overstated EU by ~15–22 pp — it counts region-level / wrong-same-name resolves that land >25 km from truth. **Going forward, grade on right-place resolve-rate (@25 km / PIP-containment), not bare resolve-rate.** This is the #566 "grade the assembled coordinate" discipline, sharpened.
+
+**Trade-show framing:** lead with US dominance + the calibrated-confidence demo + deployability; present EU as the fast-improving frontier (just shipped 16 locales). Do **not** claim "more accurate than Nominatim" globally — it's false on EU and true on US; claim it precisely.
+
+_Caveats: Pelias rate-locked tonight (US Pelias + messy Pelias untested — re-run paced on fresh quota); EU set favors Pelias (OA overlap); n=150/locale._

--- a/scripts/eval/competitive-benchmark.ts
+++ b/scripts/eval/competitive-benchmark.ts
@@ -36,7 +36,13 @@ const arg = (k: string, d = ""): string => {
 const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
 const CARD = "neural-weights-en-us/model-card.json"
 const ANCHOR = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
-const WOF = "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+// Production-representative resolver: admin gazetteer + the intl postcode→locality shard (the
+// oa-resolver-eval default). admin-ONLY handicaps mailwoman — the postcode-coordinate-first path
+// resolves localities the admin gazetteer misses. --wof overrides (comma-separated shard paths).
+const WOF = arg(
+	"wof",
+	"/mnt/playpen/mailwoman-data/wof/admin-global-priority.db,/mnt/playpen/mailwoman-data/wof/postcode-locality-intl.db",
+).split(",")
 const MODEL = arg("model", "out/v191/model.onnx") // v4.13.0 int8
 const N = Number(arg("n", "40"))
 const LOCALES = arg("locales", "it,pt,pl,at,cz,fr,au").split(",")
@@ -44,6 +50,19 @@ const SYSTEMS = arg("systems", "mailwoman,nominatim,pelias").split(",")
 const OUT = arg("out", "")
 const THRESHOLDS = [1, 5, 25] // km — coarse "right-place" tiers
 const NOMINATIM_UA = "mailwoman-benchmark/1.0 (teffen@sister.software)"
+const MESSY = process.argv.includes("--messy")
+// Real-world degradation — the slice where a calibrated parser should beat a search index that leans
+// on exact tokens + the comma structure + the postcode. SAFE: drops commas/dash-postcodes + lowercases
+// + abbreviates common street words; never touches the house number.
+function messify(raw: string): string {
+	let s = raw.toLowerCase()
+	s = s.replace(/\b\d{2,4}-\d{2,3}\b/g, " ") // dash-postcodes (PT 7920-031, PL 59-920) — unambiguously postcodes
+	s = s
+		.replace(/\brua\b/g, "r").replace(/\bavenida\b/g, "av").replace(/\bestrada\b/g, "estr")
+		.replace(/\bstra(?:ss|ß)e\b/g, "str").replace(/\bstreet\b/g, "st").replace(/\bvia\b/g, "v").replace(/\bavenue\b/g, "ave")
+	s = s.replace(/,/g, " ").replace(/\s+/g, " ").trim() // drop the comma structure, collapse spaces
+	return s
+}
 
 const PLACETYPE_RANK: Record<string, number> = {
 	country: 0, region: 1, macrocounty: 2, county: 3, localadmin: 4, locality: 5,
@@ -121,8 +140,12 @@ function record(t: Tally, err: number | null) {
 
 async function main() {
 	const { createScorer } = await import("@mailwoman/neural/scorer")
-	const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
-	const resolver = createWofResolver(new WofSqlitePlaceLookup({ databasePath: WOF }) as never)
+	const { WofSqlitePlaceLookup, WofCandidateTableLookup } = await import("@mailwoman/resolver-wof-sqlite")
+	// --candidate-db <path> uses the DEMO's resolver (the byte-range candidate gazetteer, with the
+	// promoted EU postcode/GeoNames coverage); else the CLI shards (admin + postcode-locality-intl).
+	const CAND = arg("candidate-db", "")
+	const lookup = CAND ? new WofCandidateTableLookup({ databasePath: CAND }) : new WofSqlitePlaceLookup({ databasePath: WOF })
+	const resolver = createWofResolver(lookup as never)
 	const model = SYSTEMS.includes("mailwoman")
 		? await createScorer({ modelPath: MODEL, tokenizerPath: TOK, modelCardPath: CARD, anchorLookupPath: ANCHOR, strict: true, tier: "server" })
 		: null
@@ -145,19 +168,20 @@ async function main() {
 		let i = 0
 		for (const row of rows) {
 			const truth = { lat: row.lat, lon: row.lon }
+			const input = MESSY ? messify(row.raw) : row.raw
 			if (model) {
-				const tree = await model.parse(row.raw, { postcodeRepair: true })
+				const tree = await model.parse(input, { postcodeRepair: true })
 				const r = await resolver.resolveTree(tree as never, { defaultCountry: cc.toUpperCase() })
 				const c = mostSpecificCoord(r as never)
 				record(tallies["mailwoman"]![cc]!, c ? haversineKm(c, truth) : null)
 			}
 			if (sys.includes("nominatim")) {
-				const c = await queryNominatim(row.raw, cc)
+				const c = await queryNominatim(input, cc)
 				record(tallies["nominatim"]![cc]!, c ? haversineKm(c, truth) : null)
 				await sleep(1100) // respect Nominatim's ~1 req/s policy
 			}
 			if (pelias) {
-				const c = await pelias(row.raw)
+				const c = await pelias(input)
 				record(tallies["pelias"]![cc]!, c ? haversineKm(c, truth) : null)
 			}
 			if (++i % 10 === 0) console.error(`  ${i}/${rows.length}`)

--- a/scripts/eval/competitive-benchmark.ts
+++ b/scripts/eval/competitive-benchmark.ts
@@ -1,0 +1,202 @@
+/**
+ * @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+ *
+ *   COMPETITIVE BENCHMARK — mailwoman vs Nominatim vs Pelias on identical real addresses, scored the
+ *   honest way. The three systems return structurally different things (mailwoman: parse→resolve to a
+ *   gazetteer centroid; Nominatim: the matched OSM object; Pelias: ES over mixed sources), so a raw
+ *   median-error comparison flatters whoever returns rooftops on the addresses they DO match and hides
+ *   who returns nothing on the messy tail. Instead we score TWO axes:
+ *
+ *     PRIMARY  — resolve-rate @ a COARSE correctness threshold (within Xkm of truth). "No result"
+ *                counts as a MISS. This is the honest denominator: it surfaces coverage + graceful
+ *                degradation and refuses to let rooftop precision hide a low match rate. We use COARSE
+ *                thresholds (5/25 km = "right locality area") because mailwoman resolves to admin/
+ *                postcode CENTROIDS — a km-to-rooftop metric would unfairly reward Nominatim's
+ *                rooftop-when-it-matches and penalize our centroid. Right-PLACE is the fair test.
+ *     SECONDARY — conditional accuracy (median error among the rows the system DID place), reported at
+ *                a fine + coarse threshold, clearly "conditional on resolve".
+ *
+ *   Same golden rows for all three systems → apples-to-apples on identical inputs. The set is the real,
+ *   held-out OA coordinate goldens (truth lat/lon). Pelias (geocode.earth) rides scripts/diag-geocode-
+ *   earth.ts via a DYNAMIC import, so this committed harness degrades gracefully (Pelias row skipped)
+ *   for anyone without the operator's diag.
+ *
+ *   Run: GEOCODE_EARTH_API_KEY=… node --experimental-strip-types scripts/eval/competitive-benchmark.ts \
+ *          [--n 40] [--locales it,pt,pl,at,cz,fr,au] [--systems mailwoman,nominatim,pelias] [--out <md>]
+ */
+import { createWofResolver } from "@mailwoman/core/resolver"
+import type { AddressNode, AddressTree } from "@mailwoman/core/resolver"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { setTimeout as sleep } from "node:timers/promises"
+
+const arg = (k: string, d = ""): string => {
+	const i = process.argv.indexOf(`--${k}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : d
+}
+const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const CARD = "neural-weights-en-us/model-card.json"
+const ANCHOR = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
+const WOF = "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+const MODEL = arg("model", "out/v191/model.onnx") // v4.13.0 int8
+const N = Number(arg("n", "40"))
+const LOCALES = arg("locales", "it,pt,pl,at,cz,fr,au").split(",")
+const SYSTEMS = arg("systems", "mailwoman,nominatim,pelias").split(",")
+const OUT = arg("out", "")
+const THRESHOLDS = [1, 5, 25] // km — coarse "right-place" tiers
+const NOMINATIM_UA = "mailwoman-benchmark/1.0 (teffen@sister.software)"
+
+const PLACETYPE_RANK: Record<string, number> = {
+	country: 0, region: 1, macrocounty: 2, county: 3, localadmin: 4, locality: 5,
+	borough: 6, macrohood: 6, neighbourhood: 7, microhood: 8, street: 9, address: 10, venue: 10,
+}
+type Resolved = { placetype: string; lat: number; lon: number }
+function mostSpecificCoord(tree: AddressTree): { lat: number; lon: number } | null {
+	let best: Resolved | null = null
+	const visit = (n: AddressNode): void => {
+		if (n.placeId?.startsWith("wof:") && n.lat !== undefined && n.lon !== undefined) {
+			const placetype = String(n.sourceId ?? "").split(":")[0] ?? ""
+			if (!best || (PLACETYPE_RANK[placetype] ?? 5) > (PLACETYPE_RANK[best.placetype] ?? 5)) best = { placetype, lat: n.lat, lon: n.lon }
+		}
+		for (const c of n.children) visit(c)
+	}
+	for (const r of tree.roots) visit(r)
+	return best ? { lat: best.lat, lon: best.lon } : null
+}
+function haversineKm(a: { lat: number; lon: number }, b: { lat: number; lon: number }): number {
+	const R = 6371
+	const dLat = ((b.lat - a.lat) * Math.PI) / 180
+	const dLon = ((b.lon - a.lon) * Math.PI) / 180
+	const h = Math.sin(dLat / 2) ** 2 + Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLon / 2) ** 2
+	return 2 * R * Math.asin(Math.sqrt(h))
+}
+const p50 = (xs: number[]): number => (xs.length ? [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)]! : NaN)
+
+type Coord = { lat: number; lon: number } | null
+async function queryNominatim(raw: string, cc: string): Promise<Coord> {
+	try {
+		const u = new URL("https://nominatim.openstreetmap.org/search")
+		u.searchParams.set("q", raw)
+		u.searchParams.set("format", "jsonv2")
+		u.searchParams.set("limit", "1")
+		u.searchParams.set("countrycodes", cc.toLowerCase())
+		const r = await fetch(u, { headers: { "User-Agent": NOMINATIM_UA } })
+		if (!r.ok) return null
+		const j = (await r.json()) as Array<{ lat: string; lon: string }>
+		return j[0] ? { lat: Number(j[0].lat), lon: Number(j[0].lon) } : null
+	} catch {
+		return null
+	}
+}
+async function loadPelias(): Promise<((q: string) => Promise<Coord>) | null> {
+	if (!process.env.GEOCODE_EARTH_API_KEY) return null
+	try {
+		const mod = await import("../diag-geocode-earth.ts")
+		const fetchGeocodeData = (mod as { fetchGeocodeData?: (q: string) => Promise<{ features?: Array<{ geometry?: { coordinates?: [number, number] } }> }> }).fetchGeocodeData
+		if (!fetchGeocodeData) return null
+		return async (q: string) => {
+			try {
+				const fc = await fetchGeocodeData(q)
+				const c = fc.features?.[0]?.geometry?.coordinates
+				return c ? { lat: c[1], lon: c[0] } : null
+			} catch {
+				return null
+			}
+		}
+	} catch {
+		return null
+	}
+}
+
+type Tally = { n: number; within: Record<number, number>; resolvedErrs: number[]; noResult: number }
+const newTally = (): Tally => ({ n: 0, within: Object.fromEntries(THRESHOLDS.map((t) => [t, 0])), resolvedErrs: [], noResult: 0 })
+function record(t: Tally, err: number | null) {
+	t.n++
+	if (err === null) {
+		t.noResult++
+		return
+	}
+	t.resolvedErrs.push(err)
+	for (const th of THRESHOLDS) if (err <= th) t.within[th]++
+}
+
+async function main() {
+	const { createScorer } = await import("@mailwoman/neural/scorer")
+	const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
+	const resolver = createWofResolver(new WofSqlitePlaceLookup({ databasePath: WOF }) as never)
+	const model = SYSTEMS.includes("mailwoman")
+		? await createScorer({ modelPath: MODEL, tokenizerPath: TOK, modelCardPath: CARD, anchorLookupPath: ANCHOR, strict: true, tier: "server" })
+		: null
+	const pelias = SYSTEMS.includes("pelias") ? await loadPelias() : null
+	if (SYSTEMS.includes("pelias") && !pelias) console.error("⚠ pelias: GEOCODE_EARTH_API_KEY or diag-geocode-earth.ts unavailable — skipping that row")
+	const sys = SYSTEMS.filter((s) => s !== "pelias" || pelias)
+
+	const tallies: Record<string, Record<string, Tally>> = {} // system -> locale -> tally
+	for (const s of sys) tallies[s] = {}
+
+	for (const cc of LOCALES) {
+		const file = `data/eval/external/oa-${cc}-coord-150.jsonl`
+		if (!existsSync(file)) {
+			console.error(`${cc}: golden missing — skipped`)
+			continue
+		}
+		const rows = readFileSync(file, "utf8").trim().split("\n").slice(0, N).map((l) => JSON.parse(l)) as Array<{ raw: string; lat: number; lon: number }>
+		for (const s of sys) tallies[s]![cc] = newTally()
+		console.error(`\n[${cc.toUpperCase()}] ${rows.length} rows…`)
+		let i = 0
+		for (const row of rows) {
+			const truth = { lat: row.lat, lon: row.lon }
+			if (model) {
+				const tree = await model.parse(row.raw, { postcodeRepair: true })
+				const r = await resolver.resolveTree(tree as never, { defaultCountry: cc.toUpperCase() })
+				const c = mostSpecificCoord(r as never)
+				record(tallies["mailwoman"]![cc]!, c ? haversineKm(c, truth) : null)
+			}
+			if (sys.includes("nominatim")) {
+				const c = await queryNominatim(row.raw, cc)
+				record(tallies["nominatim"]![cc]!, c ? haversineKm(c, truth) : null)
+				await sleep(1100) // respect Nominatim's ~1 req/s policy
+			}
+			if (pelias) {
+				const c = await pelias(row.raw)
+				record(tallies["pelias"]![cc]!, c ? haversineKm(c, truth) : null)
+			}
+			if (++i % 10 === 0) console.error(`  ${i}/${rows.length}`)
+		}
+	}
+
+	// ── scorecard ────────────────────────────────────────────────────────────
+	const lines: string[] = []
+	lines.push(`# Competitive benchmark — mailwoman vs Nominatim vs Pelias (${new Date().toISOString().slice(0, 10)})`)
+	lines.push(`\n_Identical real held-out OA addresses (truth lat/lon), ${N} rows/locale. PRIMARY metric: **resolve-rate @ coarse km threshold** (within Xkm of truth; "no result" = miss) — the honest denominator, fair to centroids. SECONDARY: conditional median error (resolved rows only). Systems: ${sys.join(", ")}._\n`)
+	lines.push(`## Resolve-rate @ 25 km (right-locality-area — the headline)\n`)
+	const head = `| locale | ${sys.map((s) => s).join(" | ")} |`
+	lines.push(head, `|${"---|".repeat(sys.length + 1)}`)
+	const agg: Record<string, Tally> = Object.fromEntries(sys.map((s) => [s, newTally()]))
+	for (const cc of LOCALES) {
+		if (!tallies[sys[0]!]?.[cc]) continue
+		const cells = sys.map((s) => {
+			const t = tallies[s]![cc]!
+			for (const th of THRESHOLDS) agg[s]!.within[th]! += t.within[th]!
+			agg[s]!.n += t.n
+			agg[s]!.resolvedErrs.push(...t.resolvedErrs)
+			agg[s]!.noResult += t.noResult
+			return t.n ? `${((100 * t.within[25]!) / t.n).toFixed(0)}%` : "—"
+		})
+		lines.push(`| ${cc.toUpperCase()} | ${cells.join(" | ")} |`)
+	}
+	lines.push(`| **ALL** | ${sys.map((s) => (agg[s]!.n ? `**${((100 * agg[s]!.within[25]!) / agg[s]!.n).toFixed(0)}%**` : "—")).join(" | ")} |`)
+	lines.push(`\n## Full two-axis (aggregate)\n`)
+	lines.push(`| system | n | @1km | @5km | @25km | cond. p50 (km) | no-result |`)
+	lines.push(`|---|--:|--:|--:|--:|--:|--:|`)
+	for (const s of sys) {
+		const t = agg[s]!
+		lines.push(`| ${s} | ${t.n} | ${((100 * t.within[1]!) / t.n).toFixed(0)}% | ${((100 * t.within[5]!) / t.n).toFixed(0)}% | ${((100 * t.within[25]!) / t.n).toFixed(0)}% | ${p50(t.resolvedErrs).toFixed(1)} | ${((100 * t.noResult) / t.n).toFixed(0)}% |`)
+	}
+	const md = lines.join("\n") + "\n"
+	console.log(md)
+	if (OUT) {
+		writeFileSync(OUT, md)
+		console.error(`\nwrote ${OUT}`)
+	}
+}
+await main()


### PR DESCRIPTION
Trade-show prep. Honest two-axis head-to-head (resolve-rate @ right-place threshold, the honest denominator). **US: mailwoman 99% vs Nominatim 84%** (0% vs 16% no-result). **EU clean: 59% vs 79%/81%** (coverage gap; Pelias indexes OA). Messy: we degrade gracefully, Nominatim robust, Pelias number discarded (geocode.earth 429 artifact — caught by verify-before-verdict). **Key internal finding: our resolve-rate metric overstates EU ~15-22pp — grade right-place @25km going forward.** Scorecard: docs/articles/evals/2026-06-23-vs-nominatim-pelias.md. The diag (geocode.earth) stays git-excluded; the harness imports it dynamically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)