### PR TITLE
#370: span-rescore — falsify then build (lifts 53% of the EU no-result tail to right-place @25km, default-off)

### DIFF
--- a/docs/articles/evals/2026-06-23-370-span-rescore.mdx
+++ b/docs/articles/evals/2026-06-23-370-span-rescore.mdx
@@ -1,0 +1,82 @@
+---
+sidebar_position: 1
+title: "#370 — recovering the EU no-result tail with a span-rescore"
+tags:
+  - eval
+  - resolver
+  - multi-locale
+---
+
+# #370 — recovering the EU no-result tail with a span-rescore
+
+The competitive benchmark (the vs-Nominatim/Pelias scorecard, PR #775) put a number on where we lose to Nominatim and Pelias in Europe, and it wasn't precision. When mailwoman resolves an EU address its centroid is tight (p50 1–3 km). The gap is **no-result** — on the messy multi-order EU panel, mailwoman returns nothing for ~45% of addresses where the competitors return something. So the question for closing the gap isn't "place it more accurately." It's "place it at all."
+
+This is the story of one lever against that tail: a post-hoc **span-rescore** (#370). Falsify first, then build — and let the coordinate, not the label, decide.
+
+## Where the tail comes from
+
+Run the shipped v4.13.0 model over a 7-locale coordinate-golden panel (IT/PT/PL/AT/CZ/FR/AU, real OpenAddresses points) and 259 of 972 rows come back unresolved. Bucket each one by _why_:
+
+| bucket | meaning | count |
+| --- | --- | ---: |
+| **swap** | gold locality IS in the gazetteer, but the model emitted a different/fragmented token | 116 |
+| **needsK** | gold in gazetteer, model emitted no locality at all | 34 |
+| **coverage-gap** | gold NOT in the gazetteer — nothing to recover | 104 |
+| emitted-but-unresolved | model emitted the gold locality, resolver still missed | 5 |
+
+The 116 swaps are the prize. A representative one: `86-300 Grudziądz, Daliowa 4`. The gold locality is **Grudziądz**, which is in the gazetteer — but the model splits it into `Grudzi` + `dz` on the `ą` combining mark (the #555 fragmentation), so neither fragment resolves. The full word sits right there in the raw text, intact. The model's subword tokenizer mangled it; a whitespace tokenizer wouldn't.
+
+## Falsify before building
+
+Before writing a line of the rescore, the question that could kill it: when the gold locality _does_ resolve, does it land anywhere near the truth — or is "Grudziądz" one of five Grudziądzes and we'd be swapping in a coin flip? That's the #566 trap in a new costume: a label that matches gold but a coordinate that's 300 km off — grade the assembled coordinate, never the label.
+
+So for all 116 swaps, resolve the gold locality with the row's postcode as the disambiguator and measure great-circle to truth:
+
+```
+top-1 (resolver-ranked, postcode-disambiguated): p50 1.8 km · p90 12 km
+best-of-5 (ceiling if disambiguation is perfect):  p50 1.4 km · p90  5 km
+```
+
+p50 1.8 km. The swap is real coordinate-recall, not a same-name mirage. Build it. (And note the division of labor the buckets already imply: PL/CZ/AT own the swap tail; IT and FR have **zero** swaps — their unresolved rows are pure coverage gap, a job for more gazetteer, not a rescore.)
+
+## The build, and the knob that was backwards
+
+The rescore enumerates contiguous raw-token spans (diacritics intact, unlike the model's subwords), skips any span overlapping a confident street / house-number / postcode constituent, and exact-matches each against the same-country gazetteer. The open question the falsifier _couldn't_ answer: with no gold to point at, can enumeration find the right span on its own?
+
+First cut, shortest-span-wins (the textbook over-merge guard — prefer "Santa Maria" over "Santa Maria da Feira"): 68% of the tail recovered, but only **49%** of recoveries were the right locality, and p90 blew out to 359 km. Dumping the wrong ones showed the heuristic was backwards for this data:
+
+```
+gold "Tomaszów Mazowiecki"   → recovered "Tomaszów"  (135 km away — a different Tomaszów)
+gold "Nogueira Do Cravo Ohp" → recovered "Nogueira"  (139 km)
+gold "Póvoa De Rio De Moinhos" → recovered "Póvoa"   (207 km)
+```
+
+On real OpenAddresses the gold locality is the _longer, more specific_ name, and shortest-wins kept grabbing its ambiguous prefix. Flip it to **longest exact match wins** and the specific name beats its own prefix:
+
+| metric | shortest-wins | longest-wins |
+| --- | ---: | ---: |
+| right locality (gold string) | 49% | **71%** |
+| coord p50 | 5.7 km | **3.0 km** |
+| coord p90 | 359 km | 206 km |
+
+PL — the biggest swap locale — goes to **56 of 56 recovered, all gold, p50 1.8 km, p90 8 km**. Solved.
+
+## Grade the coordinate, not the string
+
+71% "right" by gold-string undersells it, because the string metric counts `Santa Eulália` against a gold of `Santa Eulália Viz` as a miss — when it's a 1 km miss. The honest read is the coordinate, at the benchmark's right-place bar:
+
+```
+coordinate quality of the 175 recoveries:
+  ≤10 km   128  (73%)
+  ≤25 km   136  (78%)
+  ≤100 km  142  (81%)
+  >100 km   33  (19%)
+```
+
+**The rescore lifts 136 of 259 unresolved EU rows — 53% of the entire no-result tail — to a right-place coordinate (@25 km).** That's a direct dent in the one number the benchmark said we lose on. The cost is 33 mis-fires past 100 km, and they aren't spread evenly: they're the coverage-gap locales (IT, AU) where the gold locality isn't in the gazetteer at all, so the rescore latches onto some other token that happens to name a far-off town. AU adds its own wrinkle — same-name towns across states (Springfield QLD/NSW/VIC) that need state agreement, not just country.
+
+## What's next, and what stays off
+
+The mis-fires share a cause: nothing checks that the recovered locality is _geographically consistent_ with the rest of the address. A postcode-region gate — reject a recovery whose coordinate is nowhere near where the postcode says — would reject most of the 33 without touching the 136. It needs the postcode→point lookup that lives in the postcode-locality shard, not the admin gazetteer this panel ran against (the admin DB returns nothing for an EU postcode), so it's the next build, not this one.
+
+Until that gate exists, the rescore stays **default-off**. The lever is real and the path to default-on is concrete: add the consistency gate, re-measure the >100 km mis-fires, then wire it into the resolver behind a flag. The probe (`scripts/eval/rescore-ceiling-probe.ts`, with the falsifier) and the validator (`scripts/eval/span-rescore-validate.ts`, the buildable `spanRescore`) are the harness that will grade it.

--- a/docs/articles/evals/2026-06-23-370-span-rescore.mdx
+++ b/docs/articles/evals/2026-06-23-370-span-rescore.mdx
@@ -102,7 +102,16 @@ EU coord panel (n=972, @25km right-place), spanRescore off → on:
   ~17% of new resolutions land >25km — the mis-fire rate, trimmed by the gate where postcodes resolve.
 ```
 
-The strategic read: #775 ran Nominatim on these _same_ panels at ~79% EU @25km, so with the flag on mailwoman reaches **near-parity with Nominatim on EU** — the benchmark's EU weakness is largely a default-off flag away from closed, not a model deficiency. (Honest caveat: the e2e and #775 harnesses' mailwoman _baselines_ differ ~4 pp — 63.2 vs 59 — so it's near-parity pending a single-harness confirm; the **+16 pp lift itself is a clean A/B** and not subject to that caveat.) One process note: the first e2e run reported **+0.0 pp** because `@mailwoman/core` resolves to the _compiled_ `out/` (stale, pre-#780) while the unit tests alias to _source_ — `yarn compile`, then the real +16. Grade the wired path on compiled code, not only source unit tests.
+The strategic read, stated precisely (a trade-show claim has to survive a hostile check). The **clean, defensible result is the +16 pp lift** — a flag-only A/B that substantially narrows the EU no-result tail. What it does to the standing-vs-Nominatim is more nuanced than "parity," and the per-locale picture is the honest version. Against #775's Nominatim on the same panels:
+
+| | IT | PT | FR | PL | AT | CZ | AU |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| mailwoman + lever | 99 | 73 | 81 | 85 | 85 | 71 | 42 |
+| Nominatim (#775) | 75 | 47 | 59 | 96 | 97 | 88 | 97 |
+
+So with the lever on, mailwoman **leads** on IT/PT/FR and still **trails** on PL/AT/CZ (narrowed, not closed) and AU (the cross-state problem the country gate can't touch). The aggregates land ~79% each — but that's a _mix_ (the IT/PT/FR leads offset the Slavic/German/AU trails), **not** a uniform catch-up. And it's a **cross-harness** comparison: the e2e grades mailwoman more leniently than #775 did (e2e IT 99 vs #775's 92), so a same-harness run could put mailwoman-with-lever _below_ 79%. **The honest claim: the lever makes mailwoman competitive on EU aggregate and ahead on several countries — not "matches Nominatim across EU."** Confirm the aggregate standing with a single-harness mailwoman-vs-Nominatim run before claiming parity.
+
+One process note: the first e2e run reported **+0.0 pp** because `@mailwoman/core` resolves to the _compiled_ `out/` (stale, pre-#780) while the unit tests alias to _source_ — `yarn compile`, then the real +16. Grade the wired path on compiled code, not only source unit tests.
 
 ## What stays off
 

--- a/docs/articles/evals/2026-06-23-370-span-rescore.mdx
+++ b/docs/articles/evals/2026-06-23-370-span-rescore.mdx
@@ -90,6 +90,20 @@ With the gate on, the IT story flips cleanly: from 4 recoveries all wrong (p50 2
 
 The gate's reach is bounded by where the candidate gazetteer has postcodes: IT resolves 97% of them, so its false-positives get caught; CZ and AU resolve ~none, so their mis-fires survive (AU's are the cross-state same-name problem — Springfield in three states — that needs state agreement the country gate can't supply). That's a coverage limit, not a design flaw: the gate's reach grows automatically as the postcode gazetteer fills in, with no code change.
 
+## Production wiring + the end-to-end result (#780)
+
+The wiring is now done (#780): `spanRescore` lives in `resolveTree` behind a default-off `ResolveOpts.spanRescore` — the idiomatic twin of the `addressPoints`/`interpolation` tiers, injecting the recovered locality via the same `decorateNode` path, gated on `hasResolvedPlace` (the #685 brake). And the wired path is graded end-to-end (`scripts/eval/span-rescore-e2e.ts`): parse → `resolveTree` with the flag off vs on, same model + candidate backend, the flag the only variable.
+
+```
+EU coord panel (n=972, @25km right-place), spanRescore off → on:
+  resolved:          76.0% → 95.2%   (+19.2pp)
+  right-place @25km: 63.2% → 79.2%   (+16.0pp)
+  PL 43→85 · CZ 29→71 · PT 62→73 · AT 79→85 · AU 35→42 · IT/FR flat
+  ~17% of new resolutions land >25km — the mis-fire rate, trimmed by the gate where postcodes resolve.
+```
+
+The strategic read: #775 ran Nominatim on these _same_ panels at ~79% EU @25km, so with the flag on mailwoman reaches **near-parity with Nominatim on EU** — the benchmark's EU weakness is largely a default-off flag away from closed, not a model deficiency. (Honest caveat: the e2e and #775 harnesses' mailwoman _baselines_ differ ~4 pp — 63.2 vs 59 — so it's near-parity pending a single-harness confirm; the **+16 pp lift itself is a clean A/B** and not subject to that caveat.) One process note: the first e2e run reported **+0.0 pp** because `@mailwoman/core` resolves to the _compiled_ `out/` (stale, pre-#780) while the unit tests alias to _source_ — `yarn compile`, then the real +16. Grade the wired path on compiled code, not only source unit tests.
+
 ## What stays off
 
-The rescore stays **default-off**. The lever is proven and the gate is built and measured; what remains before default-on is the resolver wiring (the gate lives in the eval validator today, not the production `resolveTree`) and widening postcode coverage so the gate reaches CZ/AU. The probe (`scripts/eval/rescore-ceiling-probe.ts`, with the falsifier) and the validator (`scripts/eval/span-rescore-validate.ts`, the buildable gated `spanRescore`) are the harness that will grade the wire-up.
+The rescore stays **default-off**. What remains before default-**on** is a decision, not a build: flip `ResolveOpts.spanRescore` (the +16 pp recall against the ~17% >25 km mis-fire is the trade), and widen postcode coverage so the gate reaches CZ/AU (IT today). The harness — `rescore-ceiling-probe.ts` (falsifier), `span-rescore-validate.ts` (standalone), `span-rescore-e2e.ts` (wired) — regrades any of those changes.

--- a/docs/articles/evals/2026-06-23-370-span-rescore.mdx
+++ b/docs/articles/evals/2026-06-23-370-span-rescore.mdx
@@ -75,8 +75,21 @@ coordinate quality of the 175 recoveries:
 
 **The rescore lifts 136 of 259 unresolved EU rows — 53% of the entire no-result tail — to a right-place coordinate (@25 km).** That's a direct dent in the one number the benchmark said we lose on. The cost is 33 mis-fires past 100 km, and they aren't spread evenly: they're the coverage-gap locales (IT, AU) where the gold locality isn't in the gazetteer at all, so the rescore latches onto some other token that happens to name a far-off town. AU adds its own wrinkle — same-name towns across states (Springfield QLD/NSW/VIC) that need state agreement, not just country.
 
-## What's next, and what stays off
+## The consistency gate
 
-The mis-fires share a cause: nothing checks that the recovered locality is _geographically consistent_ with the rest of the address. A postcode-region gate — reject a recovery whose coordinate is nowhere near where the postcode says — would reject most of the 33 without touching the 136. It needs the postcode→point lookup that lives in the postcode-locality shard, not the admin gazetteer this panel ran against (the admin DB returns nothing for an EU postcode), so it's the next build, not this one.
+The mis-fires share a cause: nothing checks that the recovered locality is _geographically consistent_ with the rest of the address. So the validator carries a postcode-region gate — resolve the row's postcode to a point and reject any candidate match that lands more than 50 km from it. The postcode→point lookup the admin gazetteer can't do (it returns nothing for an EU postcode) the **candidate gazetteer** can: it folds postcodes in as queryable rows. The gate is conditional by construction — when the postcode doesn't resolve, it can't fire and the rescore falls through unchanged, so it never _hurts_ a locale it can't help.
 
-Until that gate exists, the rescore stays **default-off**. The lever is real and the path to default-on is concrete: add the consistency gate, re-measure the >100 km mis-fires, then wire it into the resolver behind a flag. The probe (`scripts/eval/rescore-ceiling-probe.ts`, with the falsifier) and the validator (`scripts/eval/span-rescore-validate.ts`, the buildable `spanRescore`) are the harness that will grade it.
+With the gate on, the IT story flips cleanly: from 4 recoveries all wrong (p50 207 km) to 2 recoveries both near (p50 22 km) — it killed the far false-positives and kept the near matches. Aggregate p90 drops 206 → 145 km; the >100 km mis-fires fall 33 → 29; the right-place count holds (136 → 137).
+
+| metric (175→172 recovered) | gate off | gate on (50 km) |
+| --- | ---: | ---: |
+| right-place @25 km | 136 | 137 |
+| coord p50 | 3.0 km | 2.9 km |
+| coord p90 | 206 km | **145 km** |
+| >100 km mis-fires | 33 | **29** |
+
+The gate's reach is bounded by where the candidate gazetteer has postcodes: IT resolves 97% of them, so its false-positives get caught; CZ and AU resolve ~none, so their mis-fires survive (AU's are the cross-state same-name problem — Springfield in three states — that needs state agreement the country gate can't supply). That's a coverage limit, not a design flaw: the gate's reach grows automatically as the postcode gazetteer fills in, with no code change.
+
+## What stays off
+
+The rescore stays **default-off**. The lever is proven and the gate is built and measured; what remains before default-on is the resolver wiring (the gate lives in the eval validator today, not the production `resolveTree`) and widening postcode coverage so the gate reaches CZ/AU. The probe (`scripts/eval/rescore-ceiling-probe.ts`, with the falsifier) and the validator (`scripts/eval/span-rescore-validate.ts`, the buildable gated `spanRescore`) are the harness that will grade the wire-up.

--- a/scripts/eval/rescore-ceiling-probe.ts
+++ b/scripts/eval/rescore-ceiling-probe.ts
@@ -1,0 +1,159 @@
+/**
+ * @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+ *
+ *   #370 RESCORE-CEILING probe — sizes how much of the unresolved tail a parse<->resolve rescoring
+ *   loop could recover, vs a true gazetteer coverage gap. For each coord-golden row: parse (the shipped
+ *   v4.13.0 model) -> resolveTree -> resolved? For each UNRESOLVED row, ask whether the GOLD locality is
+ *   in the gazetteer (findPlace) and what the model emitted, and bucket the failure:
+ *     - swap     : gold IS in the gazetteer AND the model emitted a DIFFERENT (wrong) locality token
+ *                  -> a constrained rescore that swaps in the gold token recovers it. The clearest #370 win.
+ *     - needsK   : gold IS in the gazetteer AND the model emitted NO locality -> only a K-best decode
+ *                  that surfaces the gold token could recover it (harder).
+ *     - emitUnres: model emitted the gold locality but resolveTree still didn't resolve -> a resolver
+ *                  ranking/country-filter issue, NOT a rescore opportunity.
+ *     - covGap   : gold NOT in the gazetteer -> rescoring can't help; it's a coverage gap.
+ *   recoverable = swap + needsK = #370's CEILING. Same resolver for baseline + gold-check (consistent).
+ *
+ *   Run: node --experimental-strip-types scripts/eval/rescore-ceiling-probe.ts [--model out/v191/model.onnx] [--n 150]
+ */
+import { decodeAsJson } from "@mailwoman/core/decoder"
+import { createWofResolver } from "@mailwoman/core/resolver"
+import { existsSync, readFileSync } from "node:fs"
+
+const arg = (k: string, d = "") => {
+	const i = process.argv.indexOf(`--${k}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : d
+}
+const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const CARD = "neural-weights-en-us/model-card.json"
+const ANCHOR = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
+const WOF = "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+const MODEL = arg("model", "out/v191/model.onnx")
+const N = Number(arg("n", "150"))
+const LOCALES: [string, string][] = [
+	["IT", "data/eval/external/oa-it-coord-150.jsonl"],
+	["PT", "data/eval/external/oa-pt-coord-150.jsonl"],
+	["PL", "data/eval/external/oa-pl-coord-150.jsonl"],
+	["AT", "data/eval/external/oa-at-coord-150.jsonl"],
+	["CZ", "data/eval/external/oa-cz-coord-150.jsonl"],
+	["FR", "data/eval/external/oa-fr-coord-150.jsonl"],
+	["AU", "data/eval/external/oa-au-coord-150.jsonl"],
+]
+
+type N9 = { placeId?: string; children?: unknown[] }
+const hasWof = (n: N9): boolean => !!n.placeId?.startsWith("wof:") || ((n.children as N9[]) ?? []).some(hasWof)
+
+const haversineKm = (aLat: number, aLon: number, bLat: number, bLon: number): number => {
+	const R = 6371
+	const dLat = ((bLat - aLat) * Math.PI) / 180
+	const dLon = ((bLon - aLon) * Math.PI) / 180
+	const la1 = (aLat * Math.PI) / 180
+	const la2 = (bLat * Math.PI) / 180
+	const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2
+	return 2 * R * Math.asin(Math.sqrt(h))
+}
+const pctile = (xs: number[], p: number): number => {
+	if (!xs.length) return NaN
+	const s = [...xs].sort((a, b) => a - b)
+	return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))]!
+}
+
+async function main() {
+	const { createScorer } = await import("@mailwoman/neural/scorer")
+	const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
+	const lookup = new WofSqlitePlaceLookup({ databasePath: WOF })
+	const resolver = createWofResolver(lookup as never)
+	const model = await createScorer({ modelPath: MODEL, tokenizerPath: TOK, modelCardPath: CARD, anchorLookupPath: ANCHOR, strict: true, tier: "server" })
+
+	console.log(`loc | n   res  unres | swap needsK emitUnres covGap | swapKm p50/p90 (top1·best5)`)
+	const T = { n: 0, res: 0, unres: 0, swap: 0, needsK: 0, emitUn: 0, cov: 0 }
+	// FALSIFIER accumulators: great-circle error (km) from the postcode-disambiguated gold-locality
+	// resolution to truth, over the swap cases. top1 = resolver's ranked choice; best5 = the ceiling
+	// if same-name disambiguation picks the right candidate from the top 5.
+	const swapTop1: number[] = []
+	const swapBest5: number[] = []
+	for (const [cc, file] of LOCALES) {
+		if (!existsSync(file)) {
+			console.log(`${cc}: golden missing — skipped`)
+			continue
+		}
+		const rows = readFileSync(file, "utf8").trim().split("\n").slice(0, N).map((l) => JSON.parse(l))
+		const s = { n: 0, res: 0, unres: 0, swap: 0, needsK: 0, emitUn: 0, cov: 0 }
+		const sT1: number[] = []
+		const sB5: number[] = []
+		for (const row of rows) {
+			s.n++
+			const tree = await model.parse(row.raw, { postcodeRepair: true })
+			const r = await resolver.resolveTree(tree as never, { defaultCountry: cc })
+			if ((r.roots as N9[]).some(hasWof)) {
+				s.res++
+				continue
+			}
+			s.unres++
+			const emitted = ((decodeAsJson(tree) as Record<string, string>).locality ?? "").toString().trim()
+			const gold = ((row.components?.locality as string) ?? "").toString().trim()
+			const goldCands = gold ? await lookup.findPlace({ text: gold, country: cc, limit: 5 }) : []
+			if (goldCands.length === 0) s.cov++
+			else if (emitted && emitted.toLowerCase() !== gold.toLowerCase()) {
+				s.swap++
+				// FALSIFIER: resolve the gold locality with the row's postcode (what the rescore keeps as
+				// an anchor) and measure great-circle to truth. p50 < 10km → the swap recovers a REAL
+				// coordinate; scatter → the gold name resolves to a same-name collision (a label-F1 mirage,
+				// the #685 trap). (0,0) placeholders are dropped — WOF ships them on some rows.
+				const tLat = Number(row.lat),
+					tLon = Number(row.lon)
+				if (Number.isFinite(tLat) && Number.isFinite(tLon)) {
+					const pc = ((row.components?.postcode ?? row.components?.postal_code ?? "") as string).toString().trim()
+					const dis = pc ? await lookup.findPlace({ text: gold, country: cc, postcode: pc, limit: 5 }) : goldCands
+					// findPlace candidates carry lat/lon (NOT the ResolvedPlace latitude/longitude).
+					const dists = (dis as unknown as { lat: number; lon: number }[])
+						.filter((c) => Number.isFinite(c.lat) && Number.isFinite(c.lon) && (c.lat !== 0 || c.lon !== 0))
+						.map((c) => haversineKm(tLat, tLon, c.lat, c.lon))
+					if (dists.length) {
+						sT1.push(dists[0]!)
+						sB5.push(Math.min(...dists))
+					}
+				}
+			} else if (!emitted) s.needsK++
+			else s.emitUn++
+		}
+		const swapKm =
+			sT1.length > 0
+				? `${pctile(sT1, 50).toFixed(1)}/${pctile(sT1, 90).toFixed(0)} · ${pctile(sB5, 50).toFixed(1)}/${pctile(sB5, 90).toFixed(0)} (n${sT1.length})`
+				: "—"
+		console.log(
+			`${cc.padEnd(3)} | ${String(s.n).padEnd(3)} ${String(s.res).padEnd(3)}  ${String(s.unres).padEnd(4)} | ${String(s.swap).padEnd(3)}  ${String(s.needsK).padEnd(5)}  ${String(s.emitUn).padEnd(8)}  ${String(s.cov).padEnd(2)} | ${swapKm}`
+		)
+		for (const k of Object.keys(s) as (keyof typeof s)[]) T[k] += s[k]
+		swapTop1.push(...sT1)
+		swapBest5.push(...sB5)
+	}
+	const recoverable = T.swap + T.needsK
+	console.log(`ALL | n=${T.n} res=${T.res} unres=${T.unres}`)
+	console.log(
+		`\n#370 CEILING: of ${T.unres} unresolved → recoverable (gold-in-gazetteer) = ${recoverable} ` +
+			`(${((100 * recoverable) / Math.max(T.unres, 1)).toFixed(0)}% of the tail) [swap=${T.swap}, needsK=${T.needsK}]\n` +
+			`              emitted-but-unresolved (resolver-side) = ${T.emitUn}\n` +
+			`              coverage-gap (rescore can't help)      = ${T.cov} (${((100 * T.cov) / Math.max(T.unres, 1)).toFixed(0)}%)`,
+	)
+	// FALSIFIER VERDICT (DeepSeek-specified): does the gold-locality swap recover a REAL coordinate?
+	const t1p50 = pctile(swapTop1, 50),
+		t1p90 = pctile(swapTop1, 90),
+		b5p50 = pctile(swapBest5, 50),
+		b5p90 = pctile(swapBest5, 90)
+	const verdict =
+		swapTop1.length === 0
+			? "INCONCLUSIVE — no swap cases with a truth coord + resolvable gold"
+			: t1p50 < 10
+				? "PASS (top-1) — the postcode-disambiguated gold locality lands <10 km p50; build the span-rescore"
+				: b5p50 < 10
+					? "PASS (best-5 only) — the right candidate is in the top 5 but ranking misses it; the rescore NEEDS the postcode-anchor disambiguation, not just the name swap"
+					: "FAIL — gold name resolves far from truth (same-name-collision mirage / #685 trap); a bare span-rescore would chase label-F1, not coordinates"
+	console.log(
+		`\n#370 FALSIFIER (swap-case gold→truth great-circle, n=${swapTop1.length}):\n` +
+			`   top-1 (resolver-ranked, postcode-disambiguated): p50 ${t1p50.toFixed(1)} km · p90 ${t1p90.toFixed(0)} km\n` +
+			`   best-of-5 (ceiling if disambiguation is perfect):  p50 ${b5p50.toFixed(1)} km · p90 ${b5p90.toFixed(0)} km\n` +
+			`   → ${verdict}`,
+	)
+}
+await main()

--- a/scripts/eval/span-rescore-validate.ts
+++ b/scripts/eval/span-rescore-validate.ts
@@ -1,0 +1,234 @@
+/**
+ * @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+ *
+ *   #370 SPAN-RESCORE validator — the BUILD of the lever the rescore-ceiling-probe greenlit.
+ *
+ *   The probe + its falsifier established two things: (1) 116/259 unresolved EU rows are "swaps" — the
+ *   gold locality IS in the gazetteer but the model emitted a different/fragmented token (e.g. the model
+ *   splits "Grudziądz" into "Grudzi"+"dz" on the ą combining mark, #555, so it never resolves); (2) the
+ *   gold locality, postcode-disambiguated, resolves p50 1.8 km from truth — a REAL coordinate, not a
+ *   same-name mirage. So the open question this script answers is the BUILD's: can a post-hoc span
+ *   relabel RECOVER the right locality span WITHOUT being told the gold — by enumerating the RAW tokens
+ *   (diacritics intact, unlike the model's subwords) and exact-matching the same-country gazetteer?
+ *
+ *   The rescore (DeepSeek-validated design):
+ *     - Fires ONLY when the parse is currently unresolved (the #685 brake — never second-guess a
+ *       working coordinate).
+ *     - Enumerates contiguous RAW-token spans ≤4 tokens, skipping any span that overlaps a CONFIDENT
+ *       street / house_number / postcode node (those are the parse's load-bearing constituents).
+ *     - Exact canonical same-country gazetteer match (normalized: lowercase, strip diacritics/punct).
+ *     - SHORTEST matching span wins (the over-merge guard: "Santa Maria" beats "Santa Maria da Feira").
+ *
+ *   Measures, on the same 7-locale coord panel: recovery rate (how many swaps the enumeration recovers),
+ *   gold-match rate (did it recover the RIGHT locality), and the recovered coord p50/p90 vs truth — the
+ *   honest test of whether the production rescore moves coordinates.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/span-rescore-validate.ts [--n 150]
+ */
+import { decodeAsJson } from "@mailwoman/core/decoder"
+import { createWofResolver } from "@mailwoman/core/resolver"
+import { existsSync, readFileSync } from "node:fs"
+
+const arg = (k: string, d = "") => {
+	const i = process.argv.indexOf(`--${k}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : d
+}
+const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const CARD = "neural-weights-en-us/model-card.json"
+const ANCHOR = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
+const WOF = "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+const MODEL = arg("model", "out/v191/model.onnx")
+const N = Number(arg("n", "150"))
+const LOCALES: [string, string][] = [
+	["IT", "data/eval/external/oa-it-coord-150.jsonl"],
+	["PT", "data/eval/external/oa-pt-coord-150.jsonl"],
+	["PL", "data/eval/external/oa-pl-coord-150.jsonl"],
+	["AT", "data/eval/external/oa-at-coord-150.jsonl"],
+	["CZ", "data/eval/external/oa-cz-coord-150.jsonl"],
+	["FR", "data/eval/external/oa-fr-coord-150.jsonl"],
+	["AU", "data/eval/external/oa-au-coord-150.jsonl"],
+]
+
+type N9 = { placeId?: string; children?: unknown[] }
+const hasWof = (n: N9): boolean => !!n.placeId?.startsWith("wof:") || ((n.children as N9[]) ?? []).some(hasWof)
+
+const haversineKm = (aLat: number, aLon: number, bLat: number, bLon: number): number => {
+	const R = 6371
+	const dLat = ((bLat - aLat) * Math.PI) / 180
+	const dLon = ((bLon - aLon) * Math.PI) / 180
+	const la1 = (aLat * Math.PI) / 180
+	const la2 = (bLat * Math.PI) / 180
+	const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2
+	return 2 * R * Math.asin(Math.sqrt(h))
+}
+const pctile = (xs: number[], p: number): number => {
+	if (!xs.length) return NaN
+	const s = [...xs].sort((a, b) => a - b)
+	return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))]!
+}
+const norm = (s: string): string =>
+	s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[̀-ͯ]/g, "")
+		.replace(/[^a-z0-9 ]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+
+interface RawTok {
+	text: string
+	start: number
+	end: number
+}
+/** Whitespace/punctuation tokenization of the raw, char offsets preserved, diacritics intact. */
+const tokenizeRaw = (raw: string): RawTok[] => {
+	const toks: RawTok[] = []
+	const re = /[^\s,;/]+/g
+	let m: RegExpExecArray | null
+	while ((m = re.exec(raw)) !== null) toks.push({ text: m[0], start: m.index, end: m.index + m[0].length })
+	return toks
+}
+
+type FlatNode = { tag: string; conf: number; start: number; end: number }
+const flatten = (roots: unknown[]): FlatNode[] => {
+	const out: FlatNode[] = []
+	const walk = (ns: unknown[]) => {
+		for (const n of ns as { tag?: string; confidence?: number; start?: number; end?: number; children?: unknown[] }[]) {
+			if (n.tag && n.start != null && n.end != null)
+				out.push({ tag: n.tag, conf: n.confidence ?? 0, start: n.start, end: n.end })
+			if (n.children) walk(n.children)
+		}
+	}
+	walk(roots)
+	return out
+}
+
+interface Lookup {
+	findPlace(q: {
+		text: string
+		country?: string
+		postcode?: string
+		limit?: number
+	}): Promise<{ name: string; lat: number; lon: number; exactMatch?: boolean }[]>
+}
+
+/**
+ * The production span-rescore. Returns the recovered locality {text, span, lat, lon} or null. Pure
+ * post-hoc: it does not touch the existing parse beyond reading it for confident-constituent ranges.
+ */
+async function spanRescore(
+	raw: string,
+	roots: unknown[],
+	lookup: Lookup,
+	country: string,
+	postcode: string | undefined
+): Promise<{ text: string; start: number; end: number; lat: number; lon: number } | null> {
+	const toks = tokenizeRaw(raw)
+	// Confident constituents to never absorb into a locality span (the load-bearing parse parts).
+	const avoid = flatten(roots).filter(
+		(n) => (n.tag === "postcode" || n.tag === "house_number" || n.tag === "street") && n.conf >= 0.7
+	)
+	const overlapsAvoid = (s: number, e: number) => avoid.some((a) => s < a.end && a.start < e)
+
+	// Enumerate contiguous token spans, SHORTEST first (the over-merge guard).
+	type Span = { text: string; start: number; end: number; i: number; j: number }
+	const spans: Span[] = []
+	for (let len = 1; len <= 4; len++) {
+		for (let i = 0; i + len <= toks.length; i++) {
+			const j = i + len - 1
+			const start = toks[i]!.start
+			const end = toks[j]!.end
+			if (overlapsAvoid(start, end)) continue
+			spans.push({ text: raw.slice(start, end), start, end, i, j })
+		}
+	}
+	// LONGEST (most-specific) span first. Diagnostic finding (#370 build): the gold locality is usually
+	// the LONGER multi-token name ("Tomaszów Mazowiecki", "Nogueira Do Cravo"); shortest-wins grabs the
+	// ambiguous prefix ("Tomaszów") which resolves to a DIFFERENT same-name place 100+ km away. Prefer
+	// the longest exact match so the specific name beats its own prefix. (DeepSeek's shortest-wins guard
+	// was aimed at the opposite over-merge; on real OA the disambiguating tail token makes longest right.)
+	spans.sort((a, b) => b.j - b.i - (a.j - a.i))
+
+	for (const sp of spans) {
+		const key = norm(sp.text)
+		if (key.length < 2 || /^\d+$/.test(key)) continue // skip bare numbers / empties
+		const hits = await lookup.findPlace({ text: sp.text, country, postcode, limit: 5 })
+		const exact = hits.filter((h) => h.exactMatch && norm(h.name) === key && (h.lat !== 0 || h.lon !== 0))
+		if (exact.length) {
+			const h = exact[0]!
+			return { text: sp.text, start: sp.start, end: sp.end, lat: h.lat, lon: h.lon }
+		}
+	}
+	return null
+}
+
+async function main() {
+	const { createScorer } = await import("@mailwoman/neural/scorer")
+	const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
+	const lookup = new WofSqlitePlaceLookup({ databasePath: WOF }) as unknown as Lookup & {
+		findPlace: Lookup["findPlace"]
+	}
+	const resolver = createWofResolver(lookup as never)
+	const model = await createScorer({
+		modelPath: MODEL,
+		tokenizerPath: TOK,
+		modelCardPath: CARD,
+		anchorLookupPath: ANCHOR,
+		strict: true,
+		tier: "server",
+	})
+
+	console.log(`loc | unres | recov goldMatch | recovKm p50/p90 | net-resolve-lift`)
+	const G = { unres: 0, recov: 0, gold: 0 }
+	const recovKm: number[] = []
+	for (const [cc, file] of LOCALES) {
+		if (!existsSync(file)) continue
+		const rows = readFileSync(file, "utf8").trim().split("\n").slice(0, N).map((l) => JSON.parse(l))
+		const s = { unres: 0, recov: 0, gold: 0 }
+		const km: number[] = []
+		for (const row of rows) {
+			const tree = await model.parse(row.raw, { postcodeRepair: true })
+			const r = await resolver.resolveTree(tree as never, { defaultCountry: cc })
+			if ((r.roots as N9[]).some(hasWof)) continue
+			s.unres++
+			const pc = ((row.components?.postcode ?? "") as string).toString().trim() || undefined
+			const hit = await spanRescore(row.raw, (tree as { roots: unknown[] }).roots, lookup, cc, pc)
+			if (!hit) continue
+			s.recov++
+			const gold = ((row.components?.locality as string) ?? "").toString().trim()
+			const isGold = norm(hit.text) === norm(gold)
+			if (isGold) s.gold++
+			const tLat = Number(row.lat),
+				tLon = Number(row.lon)
+			const dist = Number.isFinite(tLat) && Number.isFinite(tLon) ? haversineKm(tLat, tLon, hit.lat, hit.lon) : NaN
+			if (Number.isFinite(dist)) km.push(dist)
+			if (process.env.DEBUG && !isGold)
+				console.error(
+					`  [${cc}] WRONG: raw="${row.raw}" gold="${gold}" → recovered="${hit.text}" pc=${pc ?? "-"} dist=${dist.toFixed(0)}km`
+				)
+		}
+		const kmStr = km.length ? `${pctile(km, 50).toFixed(1)}/${pctile(km, 90).toFixed(0)} (n${km.length})` : "—"
+		const lift = s.unres ? `${((100 * s.recov) / s.unres).toFixed(0)}% of unres recovered` : "—"
+		console.log(
+			`${cc.padEnd(3)} | ${String(s.unres).padEnd(5)} | ${String(s.recov).padEnd(5)} ${String(s.gold).padEnd(9)} | ${kmStr.padEnd(15)} | ${lift}`
+		)
+		G.unres += s.unres
+		G.recov += s.recov
+		G.gold += s.gold
+		recovKm.push(...km)
+	}
+	// Coordinate-quality breakdown — the metric that matters (#566): grade the assembled coordinate, not
+	// the gold STRING (a "Santa Eulália" vs gold "Santa Eulália Viz" is 1 km, coordinate-right but
+	// string-wrong). @25 km is the benchmark's right-place bar.
+	const within = (r: number) => recovKm.filter((d) => d <= r).length
+	const n = recovKm.length || 1
+	console.log(
+		`\n#370 SPAN-RESCORE (v4.13.0, raw-token enumeration + longest exact same-country gazetteer match):\n` +
+			`   unresolved tail = ${G.unres} → recovered = ${G.recov} (${((100 * G.recov) / Math.max(G.unres, 1)).toFixed(0)}% of the tail)\n` +
+			`   of recovered, RIGHT locality (== gold STRING) = ${G.gold} (${((100 * G.gold) / Math.max(G.recov, 1)).toFixed(0)}%)\n` +
+			`   recovered coord vs truth: p50 ${pctile(recovKm, 50).toFixed(1)} km · p90 ${pctile(recovKm, 90).toFixed(0)} km (n${recovKm.length})\n` +
+			`   coordinate quality: ≤10km ${within(10)} (${((100 * within(10)) / n).toFixed(0)}%) · ≤25km ${within(25)} (${((100 * within(25)) / n).toFixed(0)}%) · ≤100km ${within(100)} (${((100 * within(100)) / n).toFixed(0)}%) · >100km ${n - within(100)}\n` +
+			`   → NET lift: ${within(25)} of ${G.unres} unresolved EU rows now resolve RIGHT-PLACE (@25km) — ${((100 * within(25)) / Math.max(G.unres, 1)).toFixed(0)}% of the no-result tail, at the cost of ${n - within(100)} >100km mis-fires (the coverage-gap false-positives a postcode-region gate would reject).`
+	)
+}
+await main()

--- a/scripts/eval/span-rescore-validate.ts
+++ b/scripts/eval/span-rescore-validate.ts
@@ -121,7 +121,11 @@ async function spanRescore(
 	roots: unknown[],
 	lookup: Lookup,
 	country: string,
-	postcode: string | undefined
+	postcode: string | undefined,
+	/** Postcode→point anchor for the consistency gate, resolved by the caller (null when unavailable). */
+	anchor: { lat: number; lon: number } | null,
+	/** Reject a candidate match farther than this from the postcode anchor. 0 disables the gate. */
+	gateKm: number
 ): Promise<{ text: string; start: number; end: number; lat: number; lon: number } | null> {
 	const toks = tokenizeRaw(raw)
 	// Confident constituents to never absorb into a locality span (the load-bearing parse parts).
@@ -154,8 +158,12 @@ async function spanRescore(
 		if (key.length < 2 || /^\d+$/.test(key)) continue // skip bare numbers / empties
 		const hits = await lookup.findPlace({ text: sp.text, country, postcode, limit: 5 })
 		const exact = hits.filter((h) => h.exactMatch && norm(h.name) === key && (h.lat !== 0 || h.lon !== 0))
-		if (exact.length) {
-			const h = exact[0]!
+		for (const h of exact) {
+			// Postcode-consistency gate: when the postcode resolves to a point, reject a match that lands
+			// nowhere near it — the coverage-gap false-positive ("Pereiro" 200 km from the postcode is the
+			// wrong Pereiro). When the postcode doesn't resolve (PL/PT/AU here), the gate can't fire and the
+			// rescore falls through to longest-exact-match — so it never HURTS the locales it can't gate.
+			if (anchor && gateKm > 0 && haversineKm(anchor.lat, anchor.lon, h.lat, h.lon) > gateKm) continue
 			return { text: sp.text, start: sp.start, end: sp.end, lat: h.lat, lon: h.lon }
 		}
 	}
@@ -164,10 +172,15 @@ async function spanRescore(
 
 async function main() {
 	const { createScorer } = await import("@mailwoman/neural/scorer")
-	const { WofSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
+	const { WofSqlitePlaceLookup, WofCandidateTableLookup } = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new WofSqlitePlaceLookup({ databasePath: WOF }) as unknown as Lookup & {
 		findPlace: Lookup["findPlace"]
 	}
+	// Postcode→point anchor for the consistency gate. The candidate gazetteer folds postcodes as
+	// queryable rows (the demo's resolver); IT/CZ postcodes resolve here, PL/PT/AU don't (gate no-ops there).
+	const GATE_KM = Number(arg("gate", "50")) // 0 disables the gate
+	const CAND = arg("candidate-db", "/mnt/playpen/mailwoman-data/wof/candidate-global-20h.db")
+	const pcLookup = new WofCandidateTableLookup({ databasePath: CAND }) as unknown as Lookup
 	const resolver = createWofResolver(lookup as never)
 	const model = await createScorer({
 		modelPath: MODEL,
@@ -192,7 +205,14 @@ async function main() {
 			if ((r.roots as N9[]).some(hasWof)) continue
 			s.unres++
 			const pc = ((row.components?.postcode ?? "") as string).toString().trim() || undefined
-			const hit = await spanRescore(row.raw, (tree as { roots: unknown[] }).roots, lookup, cc, pc)
+			// Resolve the postcode anchor for the consistency gate (once per row).
+			let anchor: { lat: number; lon: number } | null = null
+			if (pc && GATE_KM > 0) {
+				const pcHits = await pcLookup.findPlace({ text: pc, country: cc, limit: 2 })
+				const a = pcHits.find((h) => h.lat !== 0 || h.lon !== 0)
+				if (a) anchor = { lat: a.lat, lon: a.lon }
+			}
+			const hit = await spanRescore(row.raw, (tree as { roots: unknown[] }).roots, lookup, cc, pc, anchor, GATE_KM)
 			if (!hit) continue
 			s.recov++
 			const gold = ((row.components?.locality as string) ?? "").toString().trim()


### PR DESCRIPTION
## The arc
The competitive benchmark (#775) localized the EU loss to **no-result, not precision** (~45% no-result vs the centroid being tight when it does resolve). This is one lever against that tail — falsify, then build, graded on the coordinate.

## Falsifier (the gate)
116/259 unresolved EU rows are **swaps**: the gold locality IS in the gazetteer but the model emitted a fragmented/wrong token (it splits `Grudziądz` → `Grudzi`+`dz` on the ą combining mark, #555). The falsifier resolves the gold locality (postcode-disambiguated) → truth: **p50 1.8 km / p90 12 km.** Real coordinate-recall, not a same-name mirage — the #685 brake holds. IT/FR have **0 swaps** (pure coverage-gap; a job for gazetteer, not rescore).

## Build + the knob that was backwards
`spanRescore` enumerates raw-token spans (diacritics intact, unlike the model's subwords), skips confident street/house-number/postcode constituents, exact-matches the same-country gazetteer. Diagnostic-driven fix: **shortest-span-wins was backwards** — it grabbed the ambiguous prefix (`Tomaszów` of gold `Tomaszów Mazowiecki`, 135 km off). **Longest-wins** → gold-match 49→71%, p50 5.7→3.0 km. **PL fully solved: 56/56, p50 1.8 km, p90 8 km.**

## Coordinate-graded verdict (#566 discipline)
Not the gold *string* (`Santa Eulália` vs gold `Santa Eulália Viz` is 1 km, counted string-wrong). The coordinate:

| ≤10 km | ≤25 km | ≤100 km | >100 km |
|---:|---:|---:|---:|
| 73% | **78%** | 81% | 19% |

**NET: lifts 136/259 (53%) of the EU no-result tail to a right-place coordinate (@25 km)**, at a cost of 33 (19%) >100 km mis-fires — the coverage-gap false-positives (IT/AU cross-state).

## Why it stays default-off
The mis-fires need a **postcode-region consistency gate** (reject a recovery far from where the postcode says). The postcode→point lives in the postcode-locality shard, not the admin DB this panel ran — that's the next build, not this one. This PR lands the **proven lever + the harness** (probe with falsifier, validator with the buildable `spanRescore`) + the honest eval writeup. No production wiring; no promote.

Docs build clean (onBrokenLinks + MDX). Full writeup: `docs/articles/evals/2026-06-23-370-span-rescore.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)