### PR TITLE
feat(resolver): #370 span-rescore — production wiring (default-off, 8 tests + byte-stable)

### DIFF
--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -265,7 +265,11 @@ async function applySpanRescore(roots: AddressNode[], raw: string, backend: Reso
 		children: [],
 	}
 	decorateNode(node, hit.place, [])
-	node.metadata = { ...(node.metadata ?? {}), span_rescore: true }
+	// `rescore_gated` carries the gate's precision signal as an EXPLICIT handle — NOT folded into the
+	// calibrated `confidence`, which would break the isotonic guarantee (a true calibrated 0.83 must not
+	// be confused with a rescore plug-in estimate; DeepSeek 2026-06-23). true = postcode gate fired
+	// (high-precision); false = ungated (no postcode→point coverage for this country, ~83%-precision).
+	node.metadata = { ...(node.metadata ?? {}), span_rescore: true, rescore_gated: hit.gated }
 	roots.push(node)
 }
 

--- a/core/resolver/resolve.ts
+++ b/core/resolver/resolve.ts
@@ -13,6 +13,7 @@
  */
 
 import type { AddressNode, AddressTree, ComponentTag, Interpretation } from "../decoder/types.js"
+import { findRescoreCandidate, hasResolvedPlace } from "./span-rescore.js"
 import {
 	type AddressPointLookup,
 	type CoincidentLocality,
@@ -239,6 +240,35 @@ function applyInterpolation(roots: AddressNode[], lookup: InterpolationLookup, r
 	}
 }
 
+/**
+ * Span-rescore tier (#370): opt-in last-resort locality recovery. Runs ONLY when the tree resolved
+ * NOTHING (the #685 brake — never disturb a working coordinate). Enumerates raw-token spans, exact-
+ * matches the same-country gazetteer (longest-wins + postcode-consistency gate; see `span-rescore.ts`),
+ * and on a hit INJECTS a resolved `locality` node decorated exactly like a normally-resolved one.
+ * Byte-stable when `opts.spanRescore` is unset. Async (it queries the backend), so it's awaited.
+ */
+async function applySpanRescore(roots: AddressNode[], raw: string, backend: ResolverBackend, opts: ResolveOpts): Promise<void> {
+	if (hasResolvedPlace(roots)) return // already resolved — never second-guess a working coordinate
+	const hit = await findRescoreCandidate(raw, roots, backend, {
+		country: opts.defaultCountry,
+		postcode: firstPostcodeValue(roots),
+		gateKm: opts.spanRescoreGateKm,
+	})
+	if (!hit) return
+	const node: AddressNode = {
+		tag: "locality",
+		value: hit.text,
+		start: hit.start,
+		end: hit.end,
+		// No model confidence for a post-hoc recovery; a mid-tier value marks it as recovered, not asserted.
+		confidence: 0.5,
+		children: [],
+	}
+	decorateNode(node, hit.place, [])
+	node.metadata = { ...(node.metadata ?? {}), span_rescore: true }
+	roots.push(node)
+}
+
 class WofResolver implements Resolver {
 	readonly #backend: ResolverBackend
 
@@ -295,6 +325,11 @@ class WofResolver implements Resolver {
 		// byte-stable when opts.interpolation is absent.
 		if (opts.interpolation) {
 			applyInterpolation(newRoots, opts.interpolation, opts.interpolationRadiusCalibration)
+		}
+		// Span-rescore tier (#370): opt-in, last (so it only fires when every other tier left the tree
+		// unresolved). Byte-stable when opts.spanRescore is unset.
+		if (opts.spanRescore) {
+			await applySpanRescore(newRoots, tree.raw, this.#backend, opts)
 		}
 		return { raw: tree.raw, roots: newRoots }
 	}

--- a/core/resolver/span-rescore.test.ts
+++ b/core/resolver/span-rescore.test.ts
@@ -62,6 +62,8 @@ describe("findRescoreCandidate", () => {
 		const hit = await findRescoreCandidate(raw, roots, makeBackend(), { country: "PL", postcode: "86-300" })
 		expect(hit?.text).toBe("Grudziądz")
 		expect(hit?.place.id).toBe(1)
+		// 86-300 isn't in the fixture → no anchor → ungated (flagged lower-precision).
+		expect(hit?.gated).toBe(false)
 	})
 
 	it("prefers the LONGEST exact match (specific name beats its own prefix)", async () => {
@@ -69,6 +71,18 @@ describe("findRescoreCandidate", () => {
 		const hit = await findRescoreCandidate(raw, [], makeBackend(), { country: "PL", gateKm: 0 })
 		expect(hit?.text).toBe("Tomaszów Mazowiecki")
 		expect(hit?.place.id).toBe(3)
+		expect(hit?.gated).toBe(false) // gate disabled (gateKm 0)
+	})
+
+	it("flags a recovery GATED when the postcode resolves and the match is within range", async () => {
+		// 97-200 resolves (fixture) near Tomaszów Mazowiecki; the longest match lands within 50km → gated.
+		const hit = await findRescoreCandidate("Tomaszów Mazowiecki", [], makeBackend(), {
+			country: "PL",
+			postcode: "97-200",
+			gateKm: 50,
+		})
+		expect(hit?.place.id).toBe(3)
+		expect(hit?.gated).toBe(true)
 	})
 
 	it("postcode gate rejects a match far from where the postcode resolves", async () => {
@@ -112,6 +126,8 @@ describe("resolveTree + spanRescore", () => {
 		expect(injected?.value).toBe("Grudziądz")
 		expect(injected?.lat).toBe(53.48)
 		expect(injected?.metadata?.span_rescore).toBe(true)
+		// No postcode node in this tree → no anchor → ungated, flagged so the consumer can threshold.
+		expect(injected?.metadata?.rescore_gated).toBe(false)
 	})
 
 	it("is byte-stable when spanRescore is unset (no injection)", async () => {

--- a/core/resolver/span-rescore.test.ts
+++ b/core/resolver/span-rescore.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the #370 span-rescore: the pure `findRescoreCandidate` (raw-token enumeration, longest-
+ *   wins, postcode gate) and its `resolveTree` integration (opt-in injection, the #685 brake, byte-
+ *   stability when the flag is unset). A fixture backend stands in for the gazetteer.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import type { AddressNode, AddressTree } from "../decoder/types.js"
+import { createWofResolver } from "./resolve.js"
+import { findRescoreCandidate, hasResolvedPlace } from "./span-rescore.js"
+import type { ResolvedPlace, ResolverBackend } from "./types.js"
+
+const norm = (s: string): string =>
+	s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[^a-z0-9 ]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+
+/** A tiny gazetteer: exact-normalized-name matches only (so the walk can't fuzzy-resolve fragments). */
+const PLACES: ResolvedPlace[] = [
+	{ id: 1, name: "Grudziądz", placetype: "locality", country: "PL", lat: 53.48, lon: 18.75, score: 10, exactMatch: true },
+	// Two same-prefix localities far apart — the longest-wins + gate test.
+	{ id: 2, name: "Tomaszów", placetype: "locality", country: "PL", lat: 50.45, lon: 23.42, score: 30, exactMatch: true },
+	{ id: 3, name: "Tomaszów Mazowiecki", placetype: "locality", country: "PL", lat: 51.53, lon: 20.0, score: 5, exactMatch: true },
+	// A postcode → point, near Tomaszów Mazowiecki (the gate anchor).
+	{ id: 900, name: "97-200", placetype: "postalcode", country: "PL", lat: 51.53, lon: 20.01, score: 1 },
+]
+
+function makeBackend(): ResolverBackend {
+	return {
+		async findPlace(query) {
+			const key = norm(query.text)
+			return PLACES.filter((p) => norm(p.name) === key && (!query.country || p.country === query.country)).map((p) => ({
+				...p,
+			}))
+		},
+	}
+}
+
+const node = (over: Partial<AddressNode> & Pick<AddressNode, "tag" | "value" | "start" | "end">): AddressNode => ({
+	confidence: 0.95,
+	children: [],
+	...over,
+})
+
+describe("findRescoreCandidate", () => {
+	it("recovers a fragmented locality from the raw text", async () => {
+		// The model split "Grudziądz" into "Grudzi" + "dz"; neither resolves. The raw word is intact.
+		const raw = "86-300 Grudziądz, Daliowa 4"
+		const roots: AddressNode[] = [
+			node({ tag: "postcode", value: "86-300", start: 0, end: 6 }),
+			node({ tag: "locality", value: "Grudzi", start: 7, end: 13 }),
+			node({ tag: "locality", value: "dz", start: 14, end: 16, confidence: 0.9 }),
+		]
+		const hit = await findRescoreCandidate(raw, roots, makeBackend(), { country: "PL", postcode: "86-300" })
+		expect(hit?.text).toBe("Grudziądz")
+		expect(hit?.place.id).toBe(1)
+	})
+
+	it("prefers the LONGEST exact match (specific name beats its own prefix)", async () => {
+		const raw = "Tomaszów Mazowiecki" // gold is the longer name; shortest-wins would grab "Tomaszów"
+		const hit = await findRescoreCandidate(raw, [], makeBackend(), { country: "PL", gateKm: 0 })
+		expect(hit?.text).toBe("Tomaszów Mazowiecki")
+		expect(hit?.place.id).toBe(3)
+	})
+
+	it("postcode gate rejects a match far from where the postcode resolves", async () => {
+		// "Tomaszów" alone exact-matches the FAR Tomaszów (id 2); the 97-200 postcode anchors near the
+		// Mazowiecki one (~240 km away), so the gate rejects it → no recovery.
+		const hit = await findRescoreCandidate("Tomaszów", [], makeBackend(), { country: "PL", postcode: "97-200", gateKm: 50 })
+		expect(hit).toBeNull()
+	})
+
+	it("skips a span overlapping a confident street/house_number/postcode constituent", async () => {
+		// "Grudziądz" sits where a confident postcode node is declared → not eligible as a locality span.
+		const raw = "Grudziądz 4"
+		const roots: AddressNode[] = [node({ tag: "postcode", value: "Grudziądz", start: 0, end: 9, confidence: 0.95 })]
+		const hit = await findRescoreCandidate(raw, roots, makeBackend(), { country: "PL", gateKm: 0 })
+		expect(hit).toBeNull()
+	})
+})
+
+describe("hasResolvedPlace", () => {
+	it("detects a resolved node anywhere in the tree", () => {
+		expect(hasResolvedPlace([node({ tag: "locality", value: "x", start: 0, end: 1 })])).toBe(false)
+		const resolved = node({ tag: "locality", value: "x", start: 0, end: 1 })
+		resolved.placeId = "wof:1"
+		expect(hasResolvedPlace([resolved])).toBe(true)
+	})
+})
+
+describe("resolveTree + spanRescore", () => {
+	const tree = (raw: string, roots: AddressNode[]): AddressTree => ({ raw, roots })
+
+	it("injects a resolved locality when the tree resolved nothing (opt-in)", async () => {
+		const resolver = createWofResolver(makeBackend())
+		const input = tree("86-300 Grudziądz, Daliowa 4", [
+			node({ tag: "locality", value: "Grudzi", start: 7, end: 13 }),
+			node({ tag: "locality", value: "dz", start: 14, end: 16 }),
+		])
+		const out = await resolver.resolveTree(input, { defaultCountry: "PL", spanRescore: true })
+		const injected = out.roots.find((n) => n.placeId === "wof:1")
+		expect(injected).toBeDefined()
+		expect(injected?.tag).toBe("locality")
+		expect(injected?.value).toBe("Grudziądz")
+		expect(injected?.lat).toBe(53.48)
+		expect(injected?.metadata?.span_rescore).toBe(true)
+	})
+
+	it("is byte-stable when spanRescore is unset (no injection)", async () => {
+		const resolver = createWofResolver(makeBackend())
+		const roots = [node({ tag: "locality", value: "Grudzi", start: 7, end: 13 })]
+		const out = await resolver.resolveTree(tree("86-300 Grudziądz", roots), { defaultCountry: "PL" })
+		expect(out.roots.some((n) => n.placeId)).toBe(false)
+		expect(out.roots).toHaveLength(1)
+	})
+
+	it("does not fire when the tree already resolved (the #685 brake)", async () => {
+		const resolver = createWofResolver(makeBackend())
+		// "Grudziądz" as a single locality node resolves in the walk → already has a coordinate.
+		const out = await resolver.resolveTree(tree("Grudziądz", [node({ tag: "locality", value: "Grudziądz", start: 0, end: 9 })]), {
+			defaultCountry: "PL",
+			spanRescore: true,
+		})
+		// Exactly one locality node (the resolved original), no injected duplicate.
+		expect(out.roots.filter((n) => n.tag === "locality")).toHaveLength(1)
+	})
+})

--- a/core/resolver/span-rescore.ts
+++ b/core/resolver/span-rescore.ts
@@ -52,6 +52,16 @@ export interface RescoreCandidate {
 	end: number
 	/** The resolved gazetteer place (decorate a node with this). */
 	place: ResolvedPlace
+	/**
+	 * Whether the postcode-consistency gate FIRED for this recovery — i.e. the postcode resolved to a
+	 * point and the match was validated within `gateKm` of it. `true` = high-precision (postcode-
+	 * consistent); `false` = ungated (no postcode→point coverage for this country, so the match wasn't
+	 * geo-validated — the ~83%-precision case). The caller surfaces this as `metadata.rescore_gated` so
+	 * a consumer can threshold on it WITHOUT a hidden per-country coverage map. Deliberately NOT folded
+	 * into the calibrated `confidence` — that would break the isotonic guarantee (a true calibrated 0.83
+	 * must not be confused with a rescore plug-in estimate).
+	 */
+	gated: boolean
 }
 
 const haversineKm = (aLat: number, aLon: number, bLat: number, bLon: number): number => {
@@ -174,7 +184,9 @@ export async function findRescoreCandidate(
 		)
 		for (const h of exact) {
 			if (anchor && gateKm > 0 && haversineKm(anchor.lat, anchor.lon, h.lat, h.lon) > gateKm) continue
-			return { text: sp.text, start: sp.start, end: sp.end, place: h }
+			// gated = the postcode anchor existed AND validated this match (within gateKm). When no anchor
+			// (no postcode→point coverage), the match is ungated — returned, but flagged lower-precision.
+			return { text: sp.text, start: sp.start, end: sp.end, place: h, gated: anchor !== null }
 		}
 	}
 	return null

--- a/core/resolver/span-rescore.ts
+++ b/core/resolver/span-rescore.ts
@@ -1,0 +1,181 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #370 span-rescore — recover a dropped/fragmented locality from the RAW text when a parse fails to
+ *   resolve. The model sometimes fragments an accented or non-ASCII locality token ("Grudziądz" splits
+ *   into "Grudzi" + "dz" on the ą combining mark, #555), so neither fragment resolves and the address
+ *   comes back with no coordinate. But the whole word sits intact in the raw input — a whitespace
+ *   tokenizer sees it where the model's subword tokenizer didn't.
+ *
+ *   This module is the PURE, backend-agnostic core: enumerate contiguous raw-token spans, exact-match
+ *   them against the same-country gazetteer, and return the best locality candidate. The resolver
+ *   (`resolve.ts` → `applySpanRescore`) owns the integration: it runs this ONLY on an unresolved tree
+ *   (the #685 brake — never second-guess a working coordinate) and injects the recovered locality as a
+ *   resolved node. Opt-in via `ResolveOpts.spanRescore`; default-off + byte-stable when unset.
+ *
+ *   The design + thresholds are validated on a 7-locale coordinate panel
+ *   (`scripts/eval/span-rescore-validate.ts`, eval `docs/articles/evals/2026-06-23-370-span-rescore.mdx`):
+ *   longest-exact-match-wins (the gold locality is usually the LONGER, more-specific name — shortest-
+ *   wins grabs the ambiguous prefix "Tomaszów" of "Tomaszów Mazowiecki", 135 km off), and a postcode-
+ *   consistency gate that rejects a match far from where the postcode resolves (kills coverage-gap
+ *   false-positives where the backend has postcode coverage).
+ */
+
+import type { AddressNode } from "../decoder/types.js"
+import type { ResolvedPlace, ResolverBackend } from "./types.js"
+
+export interface SpanRescoreOptions {
+	/** ISO-3166 alpha-2 country to constrain the gazetteer match (the parse's detected/ default country). */
+	country?: string
+	/** Sibling postcode — used both as the backend disambiguation hint AND the consistency-gate anchor. */
+	postcode?: string
+	/**
+	 * Reject a candidate whose coordinate is farther than this (km) from the postcode anchor. The gate
+	 * only fires when the postcode resolves to a point in the backend; otherwise it can't and the match
+	 * is accepted (so it never penalizes a backend without postcode coverage). 0 disables. Default 50.
+	 */
+	gateKm?: number
+	/** Max contiguous raw tokens to treat as one locality span. Default 4. */
+	maxSpanTokens?: number
+	/** Min confidence for a street/house_number/postcode node to count as a span-blocking constituent. Default 0.7. */
+	confidentThreshold?: number
+}
+
+/** The recovered locality: the raw span and the gazetteer place it resolved to. */
+export interface RescoreCandidate {
+	/** The raw text of the winning span. */
+	text: string
+	/** Char offsets of the span in the raw input. */
+	start: number
+	end: number
+	/** The resolved gazetteer place (decorate a node with this). */
+	place: ResolvedPlace
+}
+
+const haversineKm = (aLat: number, aLon: number, bLat: number, bLon: number): number => {
+	const R = 6371
+	const dLat = ((bLat - aLat) * Math.PI) / 180
+	const dLon = ((bLon - aLon) * Math.PI) / 180
+	const la1 = (aLat * Math.PI) / 180
+	const la2 = (bLat * Math.PI) / 180
+	const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2
+	return 2 * R * Math.asin(Math.sqrt(h))
+}
+
+/** Normalize for exact comparison: lowercase, strip diacritics + punctuation, collapse whitespace. */
+const norm = (s: string): string =>
+	s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[^a-z0-9 ]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+
+interface RawTok {
+	text: string
+	start: number
+	end: number
+}
+/** Whitespace/punctuation tokenization of the raw input, char offsets preserved, diacritics intact. */
+function tokenizeRaw(raw: string): RawTok[] {
+	const toks: RawTok[] = []
+	const re = /[^\s,;/]+/g
+	let m: RegExpExecArray | null
+	while ((m = re.exec(raw)) !== null) toks.push({ text: m[0], start: m.index, end: m.index + m[0].length })
+	return toks
+}
+
+/** True if any node in the tree already carries a resolved place id — the #685 brake. */
+export function hasResolvedPlace(roots: readonly AddressNode[]): boolean {
+	const stack: AddressNode[] = [...roots]
+	while (stack.length) {
+		const n = stack.pop()!
+		if (n.placeId) return true
+		if (n.children?.length) stack.push(...n.children)
+	}
+	return false
+}
+
+/** Char ranges of confident street/house_number/postcode constituents — a locality span must not overlap them. */
+function confidentRanges(roots: readonly AddressNode[], threshold: number): Array<[number, number]> {
+	const out: Array<[number, number]> = []
+	const stack: AddressNode[] = [...roots]
+	while (stack.length) {
+		const n = stack.pop()!
+		if (
+			(n.tag === "postcode" || n.tag === "house_number" || n.tag === "street") &&
+			(n.confidence ?? 0) >= threshold &&
+			Number.isFinite(n.start) &&
+			Number.isFinite(n.end)
+		) {
+			out.push([n.start, n.end])
+		}
+		if (n.children?.length) stack.push(...n.children)
+	}
+	return out
+}
+
+/**
+ * Find the best locality the raw text exact-matches in the gazetteer. Returns null when nothing
+ * matches (or the postcode gate rejects every match). Callers gate on `hasResolvedPlace` first.
+ */
+export async function findRescoreCandidate(
+	raw: string,
+	roots: readonly AddressNode[],
+	backend: ResolverBackend,
+	opts: SpanRescoreOptions = {}
+): Promise<RescoreCandidate | null> {
+	const gateKm = opts.gateKm ?? 50
+	const maxSpan = opts.maxSpanTokens ?? 4
+	const threshold = opts.confidentThreshold ?? 0.7
+	const country = opts.country
+	const postcode = opts.postcode?.trim() || undefined
+
+	// Postcode-consistency anchor: where does the postcode itself resolve? (No-op when the backend has
+	// no postcode coverage — findPlace returns nothing → no anchor → gate can't fire → match accepted.)
+	let anchor: { lat: number; lon: number } | null = null
+	if (postcode && gateKm > 0) {
+		const pcHits = await backend.findPlace({ text: postcode, country, limit: 2 })
+		const a = pcHits.find((h) => h.lat !== 0 || h.lon !== 0)
+		if (a) anchor = { lat: a.lat, lon: a.lon }
+	}
+
+	const toks = tokenizeRaw(raw)
+	const avoid = confidentRanges(roots, threshold)
+	const overlapsAvoid = (s: number, e: number) => avoid.some(([as, ae]) => s < ae && as < e)
+
+	// Enumerate contiguous spans, LONGEST first — the gold locality is usually the more-specific
+	// (longer) name; longest-wins lets it beat its own ambiguous prefix.
+	interface Span {
+		text: string
+		start: number
+		end: number
+		len: number
+	}
+	const spans: Span[] = []
+	for (let len = Math.min(maxSpan, toks.length); len >= 1; len--) {
+		for (let i = 0; i + len <= toks.length; i++) {
+			const start = toks[i]!.start
+			const end = toks[i + len - 1]!.end
+			if (overlapsAvoid(start, end)) continue
+			spans.push({ text: raw.slice(start, end), start, end, len })
+		}
+	}
+	spans.sort((a, b) => b.len - a.len)
+
+	for (const sp of spans) {
+		const key = norm(sp.text)
+		if (key.length < 2 || /^\d+$/.test(key)) continue // skip bare numbers / empties
+		const hits = await backend.findPlace({ text: sp.text, country, postcode, placetype: "locality", limit: 5 })
+		const exact = hits.filter(
+			(h) => h.exactMatch && norm(h.name) === key && (h.lat !== 0 || h.lon !== 0)
+		)
+		for (const h of exact) {
+			if (anchor && gateKm > 0 && haversineKm(anchor.lat, anchor.lon, h.lat, h.lon) > gateKm) continue
+			return { text: sp.text, start: sp.start, end: sp.end, place: h }
+		}
+	}
+	return null
+}

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -317,6 +317,21 @@ export interface ResolveOpts {
 	 * Report: docs/articles/evals/2026-06-14-interp-radius-calibration.md.
 	 */
 	interpolationRadiusCalibration?: number
+	/**
+	 * Span-rescore tier (#370). When set, AND the tree resolved nothing, recover a dropped/fragmented
+	 * locality from the raw text: enumerate raw-token spans, exact-match the same-country gazetteer
+	 * (longest-wins + postcode-consistency gate), and inject the recovered locality as a resolved node.
+	 * Targets the EU no-result tail the model leaves when it fragments an accented locality token
+	 * ("Grudziądz" → "Grudzi"+"dz", #555). Default-off + byte-stable when unset; never disturbs a tree
+	 * that already resolved (the #685 brake). Validated in `docs/articles/evals/2026-06-23-370-span-rescore.mdx`.
+	 */
+	spanRescore?: boolean
+	/**
+	 * Postcode-consistency gate radius (km) for the span-rescore tier — reject a recovered locality
+	 * farther than this from where the postcode resolves. Only bites when the backend has postcode
+	 * coverage (else no anchor, no gate). Default 50.
+	 */
+	spanRescoreGateKm?: number
 	hierarchyCompletion?: boolean
 	/** @deprecated Renamed to {@link hierarchyCompletion} (#405 generalized #387). Still honored. */
 	cityStateFallback?: boolean

--- a/scripts/eval/span-rescore-e2e.ts
+++ b/scripts/eval/span-rescore-e2e.ts
@@ -1,0 +1,129 @@
+/**
+ * @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+ *
+ *   #370 span-rescore — END-TO-END production validation (#780).
+ *
+ *   #777's eval graded a STANDALONE `spanRescore` function; #780 wired it into `resolveTree` behind
+ *   `ResolveOpts.spanRescore`. This grades the WIRED path: parse → `resolveTree(spanRescore:false)`
+ *   (baseline) vs `resolveTree(spanRescore:true)` (lever), on the same EU coord panel, coordinate-
+ *   graded (#566). The question this answers that the unit tests can't: does flipping the production
+ *   flag actually move the EU coordinate on real addresses, through the real walk + the real backend?
+ *
+ *   Backend = the demo's candidate gazetteer (EU coverage + the postcodes the gate needs — IT resolves,
+ *   so the gate bites there; PL/PT don't, so the rescore runs ungated there, exactly as in production).
+ *
+ *   Run: node --experimental-strip-types scripts/eval/span-rescore-e2e.ts [--n 150]
+ */
+import { createWofResolver } from "@mailwoman/core/resolver"
+import { existsSync, readFileSync } from "node:fs"
+
+const arg = (k: string, d = "") => {
+	const i = process.argv.indexOf(`--${k}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : d
+}
+const TOK = "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model"
+const CARD = "neural-weights-en-us/model-card.json"
+const ANCHOR = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
+const MODEL = arg("model", "out/v191/model.onnx")
+const CAND = arg("candidate-db", "/mnt/playpen/mailwoman-data/wof/candidate-global-20h.db")
+const N = Number(arg("n", "150"))
+const LOCALES: [string, string][] = [
+	["IT", "data/eval/external/oa-it-coord-150.jsonl"],
+	["PT", "data/eval/external/oa-pt-coord-150.jsonl"],
+	["PL", "data/eval/external/oa-pl-coord-150.jsonl"],
+	["AT", "data/eval/external/oa-at-coord-150.jsonl"],
+	["CZ", "data/eval/external/oa-cz-coord-150.jsonl"],
+	["FR", "data/eval/external/oa-fr-coord-150.jsonl"],
+	["AU", "data/eval/external/oa-au-coord-150.jsonl"],
+]
+
+const haversineKm = (aLat: number, aLon: number, bLat: number, bLon: number): number => {
+	const R = 6371
+	const dLat = ((bLat - aLat) * Math.PI) / 180
+	const dLon = ((bLon - aLon) * Math.PI) / 180
+	const la1 = (aLat * Math.PI) / 180
+	const la2 = (bLat * Math.PI) / 180
+	const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2
+	return 2 * R * Math.asin(Math.sqrt(h))
+}
+
+type N9 = { tag?: string; lat?: number; lon?: number; placeId?: string; children?: N9[] }
+const RANK: Record<string, number> = { house_number: 5, street: 4, locality: 3, city: 3, region: 2, country: 1 }
+/** Most-specific resolved coordinate in the tree (highest placetype rank with a real lat/lon). */
+function bestCoord(roots: N9[]): { lat: number; lon: number } | null {
+	let best: { lat: number; lon: number; rank: number } | null = null
+	const stack = [...roots]
+	while (stack.length) {
+		const n = stack.pop()!
+		if (n.placeId && typeof n.lat === "number" && typeof n.lon === "number" && (n.lat !== 0 || n.lon !== 0)) {
+			const rank = RANK[n.tag ?? ""] ?? 0
+			if (!best || rank > best.rank) best = { lat: n.lat, lon: n.lon, rank }
+		}
+		if (n.children?.length) stack.push(...n.children)
+	}
+	return best ? { lat: best.lat, lon: best.lon } : null
+}
+
+interface Stat {
+	n: number
+	resBase: number
+	res25Base: number
+	resLever: number
+	res25Lever: number
+}
+
+async function main() {
+	const { createScorer } = await import("@mailwoman/neural/scorer")
+	const { WofCandidateTableLookup } = await import("@mailwoman/resolver-wof-sqlite")
+	const backend = new WofCandidateTableLookup({ databasePath: CAND })
+	const resolver = createWofResolver(backend as never)
+	const model = await createScorer({
+		modelPath: MODEL,
+		tokenizerPath: TOK,
+		modelCardPath: CARD,
+		anchorLookupPath: ANCHOR,
+		strict: true,
+		tier: "server",
+	})
+
+	console.log(`loc |  n  | resolved% base→lever | @25km% base→lever`)
+	const T: Stat = { n: 0, resBase: 0, res25Base: 0, resLever: 0, res25Lever: 0 }
+	for (const [cc, file] of LOCALES) {
+		if (!existsSync(file)) continue
+		const rows = readFileSync(file, "utf8").trim().split("\n").slice(0, N).map((l) => JSON.parse(l))
+		const s: Stat = { n: 0, resBase: 0, res25Base: 0, resLever: 0, res25Lever: 0 }
+		for (const row of rows) {
+			const tLat = Number(row.lat),
+				tLon = Number(row.lon)
+			if (!Number.isFinite(tLat) || !Number.isFinite(tLon)) continue
+			s.n++
+			const tree = await model.parse(row.raw, { postcodeRepair: true })
+			// resolveTree decorates nodes in place — clone so the two configs are independent.
+			const base = await resolver.resolveTree(structuredClone(tree) as never, { defaultCountry: cc })
+			const lever = await resolver.resolveTree(structuredClone(tree) as never, { defaultCountry: cc, spanRescore: true })
+			const cB = bestCoord((base.roots as N9[]) ?? [])
+			const cL = bestCoord((lever.roots as N9[]) ?? [])
+			if (cB) {
+				s.resBase++
+				if (haversineKm(tLat, tLon, cB.lat, cB.lon) <= 25) s.res25Base++
+			}
+			if (cL) {
+				s.resLever++
+				if (haversineKm(tLat, tLon, cL.lat, cL.lon) <= 25) s.res25Lever++
+			}
+		}
+		const pct = (x: number) => `${((100 * x) / Math.max(s.n, 1)).toFixed(0)}%`
+		console.log(
+			`${cc.padEnd(3)} | ${String(s.n).padStart(3)} | ${pct(s.resBase).padStart(4)} → ${pct(s.resLever).padStart(4)}        | ${pct(s.res25Base).padStart(4)} → ${pct(s.res25Lever).padStart(4)}`
+		)
+		for (const k of Object.keys(s) as (keyof Stat)[]) T[k] += s[k]
+	}
+	const p = (x: number) => ((100 * x) / Math.max(T.n, 1)).toFixed(1)
+	console.log(
+		`\n#370 span-rescore E2E (wired resolveTree, candidate gazetteer, coord-graded @25km, n=${T.n}):\n` +
+			`   resolved:        baseline ${p(T.resBase)}% → spanRescore ${p(T.resLever)}%  (+${(Number(p(T.resLever)) - Number(p(T.resBase))).toFixed(1)}pp)\n` +
+			`   right-place @25km: baseline ${p(T.res25Base)}% → spanRescore ${p(T.res25Lever)}%  (+${(Number(p(T.res25Lever)) - Number(p(T.res25Base))).toFixed(1)}pp)\n` +
+			`   → the production flag's real EU coordinate lift, end-to-end through resolveTree + the gate.`
+	)
+}
+await main()

--- a/scripts/eval/span-rescore-e2e.ts
+++ b/scripts/eval/span-rescore-e2e.ts
@@ -27,6 +27,27 @@ const ANCHOR = "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json"
 const MODEL = arg("model", "out/v191/model.onnx")
 const CAND = arg("candidate-db", "/mnt/playpen/mailwoman-data/wof/candidate-global-20h.db")
 const N = Number(arg("n", "150"))
+// Same-harness confirm (#780): also grade Nominatim on the same rows + grading, so mailwoman-with-lever
+// vs Nominatim is apples-to-apples (no cross-harness baseline gap). Opt-in — the public API is rate-
+// limited to ~1 req/s, so only run when explicitly confirming. Reuses #775's queryNominatim verbatim.
+const NOM = process.argv.includes("--nominatim")
+const NOMINATIM_UA = "mailwoman-eval/1.0 (https://mailwoman.sister.software)"
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+async function queryNominatim(raw: string, cc: string): Promise<{ lat: number; lon: number } | null> {
+	try {
+		const u = new URL("https://nominatim.openstreetmap.org/search")
+		u.searchParams.set("q", raw)
+		u.searchParams.set("format", "jsonv2")
+		u.searchParams.set("limit", "1")
+		u.searchParams.set("countrycodes", cc.toLowerCase())
+		const r = await fetch(u, { headers: { "User-Agent": NOMINATIM_UA } })
+		if (!r.ok) return null
+		const j = (await r.json()) as Array<{ lat: string; lon: string }>
+		return j[0] ? { lat: Number(j[0].lat), lon: Number(j[0].lon) } : null
+	} catch {
+		return null
+	}
+}
 const LOCALES: [string, string][] = [
 	["IT", "data/eval/external/oa-it-coord-150.jsonl"],
 	["PT", "data/eval/external/oa-pt-coord-150.jsonl"],
@@ -70,6 +91,7 @@ interface Stat {
 	res25Base: number
 	resLever: number
 	res25Lever: number
+	nom25: number
 }
 
 async function main() {
@@ -86,12 +108,12 @@ async function main() {
 		tier: "server",
 	})
 
-	console.log(`loc |  n  | resolved% base→lever | @25km% base→lever`)
-	const T: Stat = { n: 0, resBase: 0, res25Base: 0, resLever: 0, res25Lever: 0 }
+	console.log(`loc |  n  | @25km% base → lever${NOM ? " | nominatim" : ""}`)
+	const T: Stat = { n: 0, resBase: 0, res25Base: 0, resLever: 0, res25Lever: 0, nom25: 0 }
 	for (const [cc, file] of LOCALES) {
 		if (!existsSync(file)) continue
 		const rows = readFileSync(file, "utf8").trim().split("\n").slice(0, N).map((l) => JSON.parse(l))
-		const s: Stat = { n: 0, resBase: 0, res25Base: 0, resLever: 0, res25Lever: 0 }
+		const s: Stat = { n: 0, resBase: 0, res25Base: 0, resLever: 0, res25Lever: 0, nom25: 0 }
 		for (const row of rows) {
 			const tLat = Number(row.lat),
 				tLon = Number(row.lon)
@@ -111,10 +133,15 @@ async function main() {
 				s.resLever++
 				if (haversineKm(tLat, tLon, cL.lat, cL.lon) <= 25) s.res25Lever++
 			}
+			if (NOM) {
+				const cN = await queryNominatim(row.raw, cc)
+				if (cN && haversineKm(tLat, tLon, cN.lat, cN.lon) <= 25) s.nom25++
+				await sleep(1100) // Nominatim ~1 req/s policy
+			}
 		}
 		const pct = (x: number) => `${((100 * x) / Math.max(s.n, 1)).toFixed(0)}%`
 		console.log(
-			`${cc.padEnd(3)} | ${String(s.n).padStart(3)} | ${pct(s.resBase).padStart(4)} → ${pct(s.resLever).padStart(4)}        | ${pct(s.res25Base).padStart(4)} → ${pct(s.res25Lever).padStart(4)}`
+			`${cc.padEnd(3)} | ${String(s.n).padStart(3)} | ${pct(s.res25Base).padStart(4)} → ${pct(s.res25Lever).padStart(4)}${NOM ? ` | ${pct(s.nom25).padStart(4)}` : ""}`
 		)
 		for (const k of Object.keys(s) as (keyof Stat)[]) T[k] += s[k]
 	}
@@ -122,8 +149,11 @@ async function main() {
 	console.log(
 		`\n#370 span-rescore E2E (wired resolveTree, candidate gazetteer, coord-graded @25km, n=${T.n}):\n` +
 			`   resolved:        baseline ${p(T.resBase)}% → spanRescore ${p(T.resLever)}%  (+${(Number(p(T.resLever)) - Number(p(T.resBase))).toFixed(1)}pp)\n` +
-			`   right-place @25km: baseline ${p(T.res25Base)}% → spanRescore ${p(T.res25Lever)}%  (+${(Number(p(T.res25Lever)) - Number(p(T.res25Base))).toFixed(1)}pp)\n` +
-			`   → the production flag's real EU coordinate lift, end-to-end through resolveTree + the gate.`
+			`   right-place @25km: baseline ${p(T.res25Base)}% → spanRescore ${p(T.res25Lever)}%  (+${(Number(p(T.res25Lever)) - Number(p(T.res25Base))).toFixed(1)}pp)` +
+			(NOM
+				? `\n   SAME-HARNESS vs Nominatim @25km: mailwoman+lever ${p(T.res25Lever)}% vs Nominatim ${p(T.nom25)}%  (Δ ${(Number(p(T.res25Lever)) - Number(p(T.nom25))).toFixed(1)}pp)`
+				: "") +
+			`\n   → the production flag's real EU coordinate lift, end-to-end through resolveTree + the gate.`
 	)
 }
 await main()


### PR DESCRIPTION
The production code for the lever #777 validated (lifts 53% of the EU no-result tail to right-place @25km). #777 is eval-only; this wires it into `resolveTree` behind a **default-off** opt-in — the idiomatic twin of the existing `addressPoints` / `interpolation` tiers.

## What
- **`core/resolver/span-rescore.ts`** — pure, backend-agnostic `findRescoreCandidate`: raw-token enumeration (diacritics intact, unlike the model's subwords), **longest-exact-match-wins** (the gold locality is the more-specific name; shortest-wins grabs the ambiguous prefix `Tomaszów` of `Tomaszów Mazowiecki`), + a **postcode-consistency gate** (rejects a match far from where the postcode resolves; no-ops when the backend lacks postcode coverage, so it never penalizes the admin DB).
- **`resolve.ts`** — `applySpanRescore` injects the recovered locality as a resolved node via the same `decorateNode` path, gated on `hasResolvedPlace` (**the #685 brake** — fires only when the tree resolved *nothing*). Hooked last in `resolveTree`.
- **`ResolveOpts.spanRescore`** (boolean) + **`spanRescoreGateKm`** (default 50).

## Verification
- **8 new tests** (recovery of a fragmented locality, longest-wins, the postcode gate, confident-span skip, the #685 brake, injection shape, byte-stable-when-unset) — all green.
- **The 48 existing resolver tests still pass** — default-off changes nothing.
- Typecheck clean.

## Why default-off
The gate bites only where the backend has postcode coverage (the admin DB has none; the candidate gazetteer has IT). Operator enables via `ResolveOpts.spanRescore` once postcode coverage is where they want — and after reviewing the 19% >100km mis-fire rate that the gate trims (see #777's eval). No promote; no behavior change until the flag is set.

Complements #777 (eval + validation) + #778 (the resolver-side qualified-name twin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)