### PR TITLE
demo: port #370 span-rescore into the browser cascade — live EU recovery

### DIFF
--- a/core/resolver/index.ts
+++ b/core/resolver/index.ts
@@ -12,6 +12,11 @@ export type {
 	SerializableResolveOpts,
 } from "./remote-resolver.js"
 export { createWofResolver } from "./resolve.js"
+// #370 span-rescore — the pure, backend-agnostic recovery (raw-token enumeration + exact same-country
+// gazetteer match + postcode gate). Exported so consumers off the `resolveTree` path — e.g. the demo's
+// browser httpvfs cascade — can reuse it instead of re-deriving. No node deps; browser-safe.
+export { findRescoreCandidate, hasResolvedPlace } from "./span-rescore.js"
+export type { RescoreCandidate, SpanRescoreOptions } from "./span-rescore.js"
 export { DEFAULT_PLACETYPE_MAP, PLACETYPE_FILTER_GROUPS, expandPlacetypeFilter } from "./types.js"
 export type {
 	AddressPointHit,

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -64,6 +64,8 @@ import {
 	runCascade,
 } from "../../shared/demo-helpers.ts"
 
+import { findRescoreCandidate } from "@mailwoman/core/resolver"
+
 import type { HttpvfsAddressPointLookup, HttpvfsInterpolator } from "../../shared/httpvfs-street.ts"
 import { pruneDbRangeCache, registerRangeCacheServiceWorker } from "../../shared/register-range-sw.ts"
 
@@ -979,6 +981,26 @@ const DemoApp: React.FC = () => {
 				const tBeforeResolve = performance.now()
 				const cascadeHits = await runCascade(wofLookup, postcodeNode, localityNodes, stateNode, text)
 				const tResolve = performance.now()
+				// Span-rescore fallback (#370 — the demo opts the lever ON). When the admin cascade resolved
+				// NOTHING, recover a dropped/fragmented locality from the RAW text — the model splits accented
+				// towns ("Grudziądz" → "Grudzi"+"dz") so they never resolve, but the word is intact in the input.
+				// Tried before the US-postcode anchor fallback: it recovers the actual locality (not just a
+				// postcode centroid) and it's where the EU recovery lives. Recovered places are marked
+				// "(recovered)"; ungated ones (no postcode→point coverage to verify against) say "unverified".
+				if (cascadeHits.length === 0) {
+					const pc = postcodeNode?.value ? String(postcodeNode.value).trim() : undefined
+					const rescued = await findRescoreCandidate(text, tree.roots as never, wofLookup as never, { postcode: pc })
+					if (rescued) {
+						cascadeHits.push({
+							id: rescued.place.id,
+							name: `${rescued.place.name} (recovered${rescued.gated ? "" : ", unverified"})`,
+							placetype: "locality",
+							lat: rescued.place.lat,
+							lon: rescued.place.lon,
+							score: 0,
+						} as (typeof cascadeHits)[number])
+					}
+				}
 				// Anchor-centroid fallback (postcode-only dead ends): WOF ships placeholder (0,0) for
 				// ~22% of US postcodes and the cascade rightly drops those — but postcode-us.bin (the
 				// model's anchor channel, already loaded) carries a real centroid for every US ZIP.


### PR DESCRIPTION
Puts the night's EU lever where the trade show can see it. The demo resolves via its own httpvfs candidate-gazetteer cascade (`runCascade`), not core `resolveTree` — so #780's wiring wasn't in that path. Now, when the cascade resolves **nothing**, the demo recovers a dropped/fragmented locality from the raw text: *type a Polish address the model fragmented → it resolves, live.*

## What
- **`core/resolver` barrel**: export `findRescoreCandidate` + `hasResolvedPlace` (the module is pure/browser-safe — no node deps), so the demo **reuses the same validated logic** instead of re-deriving it (DRY).
- **demo**: on `cascadeHits.length === 0`, call `findRescoreCandidate(raw, tree.roots, wofLookup, {postcode})`, tried **before** the US-postcode anchor fallback (it recovers the actual locality, not a postcode centroid; and it's where EU recovery lives). Recovered hits are labelled **"(recovered)"**; ungated ones (no postcode→point coverage to verify against) say **"unverified"** — the `rescore_gated` signal surfaced honestly, never dressed up as calibrated confidence (per the DeepSeek consult).
- The demo **opts the lever on**; the library default stays off (batch/API-safe). The `cascadeHits.length === 0` guard is the demo's #685 brake.

## Verification
- Docs build clean (client + server compiled, onBrokenLinks pass); core recompiled (barrel export in `out/`).
- Browser `WofCandidateTableLookup.findPlace` confirmed to return `name/lat/lon/exactMatch` — compatible with the rescore filter.
- Reuses #780's `findRescoreCandidate` verbatim (validated +16pp EU @25km end-to-end).
- Live render not e2e-tested locally (R2 CORS blocks the model fetch from localhost, as with the calibration showcase) — confirm on the deploy preview.

Builds on #780 (merged). 🤖 Generated with [Claude Code](https://claude.com/claude-code)