### PR TITLE
fix(neural): kill repairLeadingHouseNumber (#723) — decode-time override patching anchor-pollution

### DIFF
--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -30,7 +30,7 @@ import { buildFstEmissionPriors, type FstMatcherLike } from "./fst-prior.js"
 import type { GazetteerLexicon } from "./gazetteer-inference.js"
 import { STAGE2_BIO_LABELS } from "./labels.js"
 import type { InferResult } from "./onnx-runner.js"
-import { repairLeadingHouseNumber, repairPostcodeLabels } from "./postcode-repair.js"
+import { repairPostcodeLabels } from "./postcode-repair.js"
 import { addEmissionMatrix, buildEmissionPriors, type QueryShapeLike } from "./query-shape-prior.js"
 import { buildSoftFeatures } from "./soft-features.js"
 import { bridgePunctuationGaps } from "./span-bridge.js"
@@ -366,8 +366,8 @@ export class NeuralAddressClassifier {
 		// system, or the model's own locale-head detection under a high confidence bar. Null = no
 		// constraints; the parse below is byte-identical to the pre-conventions path.
 		const conventionsOpt = opts?.addressSystemConventions ?? this.cfg.addressSystemConventions
-		// The resolved system code, captured so the US-only leading-house-number repair below can gate on
-		// it (see repairLeadingHouseNumber). null when conventions are off → no system, no repair
+		// The resolved system code drives the conventions row below (the `forbiddenTags` emission mask +
+		// the `postcodePattern` snap-repair). null when conventions are off → no system, no constraints
 		// (byte-stable). "auto" reads the model's locale head; a pinned SystemCode wins.
 		const detectedSystem: SystemCode | null =
 			conventionsOpt === undefined
@@ -477,12 +477,6 @@ export class NeuralAddressClassifier {
 		// snap-only truncation class the pass exists for ("47110" decoded as "4711" + a digit-split).
 		if (opts?.postcodeRepair || conventions?.postcodePattern) {
 			tokens = repairPostcodeLabels(text, tokens).tokens
-		}
-		// US leading-house-number repair (#723): the model labels a big rural house number as a ZIP
-		// ("24588 Outback Trl" → [postcode], no house_number). US-GATED — a leading 5-digit before a
-		// street is a POSTCODE in reversed-order FR (the #560 shard), so only when the detected system is US.
-		if (detectedSystem === "us") {
-			tokens = repairLeadingHouseNumber(text, tokens).tokens
 		}
 		if (opts?.unitRepair) {
 			tokens = repairUnitLabels(text, tokens).tokens

--- a/neural/postcode-repair.test.ts
+++ b/neural/postcode-repair.test.ts
@@ -11,7 +11,7 @@
 
 import type { BioLabel, DecoderToken } from "@mailwoman/core/decoder"
 import { describe, expect, it } from "vitest"
-import { repairLeadingHouseNumber, repairPostcodeLabels } from "./postcode-repair.js"
+import { repairPostcodeLabels } from "./postcode-repair.js"
 
 /** Build a char-aligned token. */
 function tok(piece: string, start: number, end: number, label: BioLabel): DecoderToken {
@@ -146,42 +146,5 @@ describe("repairPostcodeLabels", () => {
 		const { tokens: out, changed } = repairPostcodeLabels(text, tokens)
 		expect(changed).toBe(0)
 		expect(out.map((t) => t.label)).toEqual(tokens.map((t) => t.label))
-	})
-})
-
-describe("repairLeadingHouseNumber (#723, US-gated)", () => {
-	it("relabels a leading 5-digit postcode before a street → house_number (no house_number decoded)", () => {
-		const text = "24588 Outback Trl Hermosa SD"
-		const tokens = [
-			tok("24588", 0, 5, "B-postcode"),
-			tok("Outback", 6, 13, "B-street"),
-			tok("Trl", 14, 17, "I-street"),
-			tok("Hermosa", 18, 25, "B-locality"),
-			tok("SD", 26, 28, "B-region"),
-		]
-		const { tokens: out, changed } = repairLeadingHouseNumber(text, tokens)
-		expect(changed).toBe(1)
-		expect(out[0]!.label).toBe("B-house_number")
-	})
-
-	it("leaves the postcode alone when a house_number was already decoded", () => {
-		const text = "100 Main St 24588"
-		const tokens = [
-			tok("100", 0, 3, "B-house_number"),
-			tok("Main", 4, 8, "B-street"),
-			tok("St", 9, 11, "I-street"),
-			tok("24588", 12, 17, "B-postcode"),
-		]
-		const { tokens: out, changed } = repairLeadingHouseNumber(text, tokens)
-		expect(changed).toBe(0)
-		expect(out[3]!.label).toBe("B-postcode")
-	})
-
-	it("does NOT fire on the postcode-first shape (5-digit + locality, no street) — the FR/DE guard", () => {
-		const text = "08523 Plauen"
-		const tokens = [tok("08523", 0, 5, "B-postcode"), tok("Plauen", 6, 12, "B-locality")]
-		const { tokens: out, changed } = repairLeadingHouseNumber(text, tokens)
-		expect(changed).toBe(0)
-		expect(out[0]!.label).toBe("B-postcode")
 	})
 })

--- a/neural/postcode-repair.ts
+++ b/neural/postcode-repair.ts
@@ -191,46 +191,11 @@ export function repairPostcodeLabels(text: string, input: readonly DecoderToken[
 	return { tokens, changed }
 }
 
-/**
- * US leading-house-number repair (#723, admin-tail diagnostic). The model reads a big rural house
- * number as a ZIP and labels it `postcode` ("24588 Outback Trl, Hermosa SD" → [postcode] "24588",
- * no house_number) — so the situs key loses its number and the row falls back to the admin centroid
- * (~3.8pts of the 12% US admin tail).
- *
- * When a bare 5-digit `postcode` span LEADS the address, no `house_number` was decoded, and a
- * `street` follows it, relabel that span to `house_number`. A trailing postcode (if any) is
- * untouched.
- *
- * **US ONLY — the caller MUST gate this on the detected address system === "us".** A leading
- * 5-digit before a street is a _postcode_ in reversed-order FR ("75008 Rue de la Paix", the #560
- * shard), so applying it outside US would re-break FR reversed-order house numbers. The "a street
- * follows" check is a second guard (FR/DE postcode-first puts a LOCALITY after the leading 5-digit,
- * "08523 Plauen"), but the locale gate is the decisive one.
- */
-export function repairLeadingHouseNumber(text: string, input: readonly DecoderToken[]): RepairResult {
-	const tokens = input.map((t) => ({ ...t }))
-	// The model already placed a house number — leave the postcode alone.
-	if (tokens.some((t) => tagOf(t.label) === "house_number")) return { tokens, changed: 0 }
-	// The first contiguous postcode run.
-	const first = tokens.findIndex((t) => isPostcodeLabel(t.label))
-	if (first === -1) return { tokens, changed: 0 }
-	const run = [first]
-	for (let i = first + 1; i < tokens.length && isPostcodeLabel(tokens[i]!.label); i++) run.push(i)
-	// It must be a bare 5-digit (the rural-house-number-as-ZIP shape) — not ZIP+4 or alphanumeric.
-	const spanEnd = tokens[run[run.length - 1]!]!.end
-	if (!/^\d{5}$/.test(text.slice(tokens[first]!.start, spanEnd).trim())) return { tokens, changed: 0 }
-	// A street must FOLLOW the leading number (the house-number position). Rejects the postcode-first
-	// "5-digit + locality" shape; the US gate already rejects FR reversed-order.
-	const street = tokens.find((t) => tagOf(t.label) === "street")
-	if (!street || street.start < spanEnd) return { tokens, changed: 0 }
-	// Relabel the leading postcode run → house_number.
-	let changed = 0
-	run.forEach((i, k) => {
-		const label = (k === 0 ? "B-house_number" : "I-house_number") as DecoderToken["label"]
-		if (tokens[i]!.label !== label) {
-			tokens[i]!.label = label
-			changed++
-		}
-	})
-	return { tokens, changed }
-}
+// repairLeadingHouseNumber (#723) was removed 2026-06-24. It RELABELLED a leading 5-digit postcode →
+// house_number under conventions=auto (US) — an OVERRIDE that contradicted the model's own label,
+// which the project's repair discipline forbids (a repair may add spans on O-tokens or snap
+// boundaries, never re-classify a token from one entity to another). Net on the US golden set it was
+// −302 postcode / +16 house_number; an anchor-ablation probe showed the model is 100% correct on the
+// target slice once the binary postcode anchor (which fires on a leading number that is a valid ZIP
+// elsewhere) is removed. The disambiguation is being absorbed model-side: a region-congruence anchor
+// upgrade + augmented postcode-leading shards. See the 2026-06-24 postmortem + DeepSeek consult 019ef789.

--- a/scripts/eval/anchor-ablation-probe.ts
+++ b/scripts/eval/anchor-ablation-probe.ts
@@ -1,0 +1,93 @@
+/**
+ * @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+ *
+ *   Anchor-ablation probe (DeepSeek consult 019ef789, turn 2). Hypothesis: the model mislabels a
+ *   leading 5-digit house number as `postcode` because the BINARY postcode anchor FIRES on it (a real
+ *   ZIP elsewhere in the country — "15715" is a PA ZIP), polluting the decision. Test: on rows whose
+ *   gold house_number is a leading 5-digit AND that carry a trailing postcode, parse with the anchor
+ *   feed ON vs OFF (conventions OFF both times, so the #723 repair never runs — we isolate the ANCHOR,
+ *   not the repair). If anchor-OFF flips the leading from postcode→house_number, the binary anchor is
+ *   the culprit → the fix is a richer anchor (region-congruence), not more data.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/anchor-ablation-probe.ts --model out/v192/model.onnx
+ */
+import { type ComponentTag, decodeAsJson } from "@mailwoman/core/decoder"
+import { NeuralAddressClassifier, parseAnchorLookup, parseGazetteerLexicon } from "@mailwoman/neural"
+import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
+import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+import { existsSync, readFileSync } from "node:fs"
+
+const arg = (k: string, d = ""): string => {
+	const i = process.argv.indexOf(`--${k}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : d
+}
+const MODEL = arg("model", "out/v192/model.onnx")
+const TOK = arg("tokenizer", "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model")
+const CARD = arg("model-card", "neural-weights-en-us/model-card.json")
+const ANCHOR = arg("anchor", "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json")
+const GAZ = arg("gazetteer-lexicon", "data/gazetteer/anchor-lexicon-v1.json")
+const FILE = arg("file", "data/eval/golden/v0.1.2/dev/us.jsonl")
+
+interface Row {
+	raw: string
+	components: Record<string, string>
+}
+const norm = (v: string | undefined): string => (v ?? "").trim().toLowerCase()
+const flat = (t: Partial<Record<ComponentTag, string>>) => t as Record<string, string>
+
+async function build(withAnchor: boolean) {
+	const card = JSON.parse(readFileSync(CARD, "utf8"))
+	const [tokenizer, runner] = await Promise.all([MailwomanTokenizer.loadFromFile(TOK), OnnxRunner.create(MODEL)])
+	return new NeuralAddressClassifier({
+		tokenizer,
+		runner,
+		labels: card.labels,
+		postcodeAnchorLookup:
+			withAnchor && existsSync(ANCHOR) ? parseAnchorLookup(JSON.parse(readFileSync(ANCHOR, "utf8"))) : undefined,
+		gazetteerLexicon:
+			withAnchor && existsSync(GAZ) ? parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))) : undefined,
+		suppressGazetteerNearPostcode: true,
+	})
+}
+
+async function main() {
+	const [on, off] = await Promise.all([build(true), build(false)])
+	// Rows where the gold house_number is a leading 5-digit AND a trailing postcode exists — the exact
+	// ambiguous shape the #723 repair was bolted on to handle.
+	const rows = readFileSync(FILE, "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((l) => JSON.parse(l) as Row)
+		.filter((r) => /^\d{5}$/.test(r.components.house_number ?? "") && /^\d{5}$/.test(r.components.postcode ?? ""))
+
+	let n = 0
+	let onHN = 0,
+		offHN = 0 // leading 5-digit correctly labelled house_number
+	let onAsPC = 0,
+		offAsPC = 0 // leading 5-digit MISlabelled postcode
+	const flips: string[] = []
+	for (const row of rows) {
+		const hn = norm(row.components.house_number)
+		n++
+		const pOn = flat(decodeAsJson(await on.parse(row.raw, {})))
+		const pOff = flat(decodeAsJson(await off.parse(row.raw, {})))
+		const onOk = norm(pOn.house_number) === hn
+		const offOk = norm(pOff.house_number) === hn
+		if (onOk) onHN++
+		if (offOk) offHN++
+		if (norm(pOn.postcode) === hn) onAsPC++
+		if (norm(pOff.postcode) === hn) offAsPC++
+		if (!onOk && offOk && flips.length < 12)
+			flips.push(`  raw=${JSON.stringify(row.raw)} gold.hn=${hn} | anchorON.hn=${JSON.stringify(pOn.house_number ?? null)} pc=${JSON.stringify(pOn.postcode ?? null)} → anchorOFF.hn=${JSON.stringify(pOff.house_number ?? null)} pc=${JSON.stringify(pOff.postcode ?? null)}`)
+	}
+	const pct = (x: number) => ((100 * x) / Math.max(n, 1)).toFixed(1)
+	console.log(`\nanchor-ablation probe — ${MODEL}  (n=${n} rows, gold house_number = leading 5-digit + trailing ZIP)`)
+	console.log(`  leading-5-digit correctly = house_number:   anchorON ${pct(onHN)}%   anchorOFF ${pct(offHN)}%`)
+	console.log(`  leading-5-digit MISlabelled = postcode:      anchorON ${pct(onAsPC)}%   anchorOFF ${pct(offAsPC)}%`)
+	console.log(
+		`  → ${offHN > onHN ? "ANCHOR POLLUTES: removing it flips the leading toward house_number (feature-gap confirmed)" : "anchor not the dominant driver — data/capacity gap more likely"}`
+	)
+	console.log(`  --- example flips (anchorON wrong → anchorOFF right) ---`)
+	flips.forEach((f) => console.log(f))
+}
+await main()

--- a/scripts/eval/de-order-eval.sh
+++ b/scripts/eval/de-order-eval.sh
@@ -36,8 +36,10 @@ run() {
   node --experimental-strip-types scripts/eval/oa-resolver-eval.ts \
     --eval "$1" --model "$MODEL" --model-card "$CARD" --tokenizer "$TOK" \
     --model-anchor-lookup "$2" --default-country "$3" \
-    > "$OUT/$4.md" 2> "$OUT/$4.log"
-}
+    > "$OUT/$4.md" 2> "$OUT/$4.log" || true
+} # || true: oa-resolver-eval exits non-zero on its own internal regression signal even when it wrote
+  # a valid report; this is a MEASUREMENT harness (loc() reads the .md), so under `set -e` we must not
+  # let that exit code abort the script before the 2x2 summary prints (it false-failed de.native_locality).
 # Pull the neural locality-match % out of a result .md (the "| **neural** | XX.X% |" row).
 loc() { grep -E '\*\*neural\*\*' "$OUT/$1.md" | grep -oE '[0-9]+\.[0-9]+%' | head -1; }
 

--- a/scripts/eval/digit-count-probe.ts
+++ b/scripts/eval/digit-count-probe.ts
@@ -1,0 +1,110 @@
+/**
+ * @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+ *
+ *   DIGIT-COUNT INTERFERENCE PROBE (DeepSeek-designed, session 019ef737).
+ *
+ *   v1.9.2 added Australia (4-digit, postcode-FIRST) and US postcode label-F1 regressed 98→87 — but
+ *   the signature is a RECALL collapse (precision held, fn 16→318), i.e. the model stops emitting
+ *   `postcode` on ~300 US 5-digit ZIPs. Two hypotheses with different fixes:
+ *     (a) DILUTION   — gnaf weight 6.0 just starved the US signal; a weight cut (→2.5) recovers it.
+ *     (b) INTERFERENCE — the model learned a "4-digit ⇒ postcode" shortcut from AU pc-first rows that
+ *         actively fights the US "leading number=house_number, 5-digit-trailing=postcode" prior; NO
+ *         weight > 0 is safe, the fix is the AU order-mix + anchor change.
+ *
+ *   The discriminator: in US context, does the model label a 4-digit surrogate as postcode MORE than
+ *   the true 5-digit ZIP? Parse each US row twice — real ZIP, then ZIP truncated to 4 digits — and
+ *   read `pred.postcode`. Run BOTH v191 (control, never saw AU) and v192 (max conflict) with the SAME
+ *   production anchor, so any R4 delta is the model's learned representation, not the anchor feature.
+ *
+ *   Read:  R5 = rate the true 5-digit ZIP is labelled postcode (= recall).
+ *          R4 = rate the 4-digit surrogate is labelled postcode in the same US context.
+ *     v192 R4 > R5  → interference (digit-count shortcut dominates) → weight cut alone won't fix.
+ *     v192 R4 ≤ R5  AND R4 ≈ R4_v191 → dilution → gnaf 2.5 suffices.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/digit-count-probe.ts --model out/v192/model.onnx
+ */
+import { type ComponentTag, decodeAsJson } from "@mailwoman/core/decoder"
+import { NeuralAddressClassifier, parseAnchorLookup, parseGazetteerLexicon } from "@mailwoman/neural"
+import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
+import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+import { existsSync, readFileSync } from "node:fs"
+
+const arg = (k: string, d = ""): string => {
+	const i = process.argv.indexOf(`--${k}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : d
+}
+const MODEL = arg("model", "out/v192/model.onnx")
+const TOK = arg("tokenizer", "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model")
+const CARD = arg("model-card", "neural-weights-en-us/model-card.json")
+const ANCHOR = arg("anchor", "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json")
+const GAZ = arg("gazetteer-lexicon", "/mnt/playpen/mailwoman-data/anchor/gazetteer-lexicon.json")
+const FILE = arg("file", "data/eval/golden/v0.1.2/dev/us.jsonl")
+
+interface Row {
+	raw: string
+	components: Record<string, string>
+}
+
+/** Fold neural Stage-3 tags into the golden component vocab (street parts → street). Mirrors per-locale-f1. */
+function foldPostcode(flat: Partial<Record<ComponentTag, string>>): string | undefined {
+	return flat.postcode
+}
+
+const norm = (v: string | undefined): string => (v ?? "").trim().toLowerCase()
+
+async function main() {
+	const card = JSON.parse(readFileSync(CARD, "utf8"))
+	const [tokenizer, runner] = await Promise.all([MailwomanTokenizer.loadFromFile(TOK), OnnxRunner.create(MODEL)])
+	const postcodeAnchorLookup =
+		existsSync(ANCHOR) ? parseAnchorLookup(JSON.parse(readFileSync(ANCHOR, "utf8"))) : undefined
+	const gazetteerLexicon =
+		existsSync(GAZ) ? parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))) : undefined
+	const neural = new NeuralAddressClassifier({
+		tokenizer,
+		runner,
+		labels: card.labels,
+		postcodeAnchorLookup,
+		gazetteerLexicon,
+		suppressGazetteerNearPostcode: true,
+	})
+	console.error(`model=${MODEL} anchor=${postcodeAnchorLookup ? postcodeAnchorLookup.size + " codes" : "none"}`)
+
+	const rows = readFileSync(FILE, "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((l) => JSON.parse(l) as Row)
+		.filter((r) => /^\d{5}$/.test(r.components.postcode ?? ""))
+
+	let n = 0
+	let r5Hit = 0 // true 5-digit ZIP labelled postcode
+	let r4Hit = 0 // 4-digit surrogate labelled postcode (same US context)
+	let r4AsHouse = 0 // 4-digit surrogate mislabelled house_number (the AU collision)
+	for (const row of rows) {
+		const zip5 = row.components.postcode!
+		const zip4 = zip5.slice(0, 4)
+		// Replace ONLY the postcode token (last occurrence, to avoid clobbering a coincident house number).
+		const at = row.raw.lastIndexOf(zip5)
+		if (at < 0) continue
+		const raw4 = row.raw.slice(0, at) + zip4 + row.raw.slice(at + zip5.length)
+		n++
+
+		const p5 = foldPostcode(decodeAsJson(await neural.parse(row.raw, {})))
+		if (norm(p5) === norm(zip5)) r5Hit++
+
+		const flat4 = decodeAsJson(await neural.parse(raw4, {}))
+		const p4 = foldPostcode(flat4)
+		if (norm(p4) === norm(zip4)) r4Hit++
+		else if (norm(flat4.house_number) === norm(zip4)) r4AsHouse++
+	}
+	const pct = (x: number) => ((100 * x) / Math.max(n, 1)).toFixed(1)
+	console.log(`\ndigit-count probe (n=${n} US rows w/ 5-digit ZIP) — ${MODEL}`)
+	console.log(`  R5  true 5-digit ZIP → postcode:       ${pct(r5Hit)}%   (recall)`)
+	console.log(`  R4  4-digit surrogate → postcode:      ${pct(r4Hit)}%`)
+	console.log(`  R4h 4-digit surrogate → house_number:  ${pct(r4AsHouse)}%   (the AU 4-digit collision)`)
+	const verdict =
+		r4Hit > r5Hit
+			? "INTERFERENCE: model labels 4-digit > true 5-digit in US context → weight cut alone won't fix"
+			: "no 4>5 inversion: consistent with DILUTION (weight cut should recover) — compare R4 vs v191 control"
+	console.log(`  → ${verdict}`)
+}
+await main()

--- a/scripts/eval/promotion-gate-verdict.ts
+++ b/scripts/eval/promotion-gate-verdict.ts
@@ -75,7 +75,10 @@ function collect(tag: "fp32" | "int8"): Record<string, number | undefined> {
 	const pobox = maybeRead(`${tag}-pobox.md`)
 	const intersection = maybeRead(`${tag}-intersection.md`)
 	const deorder = read(`${tag}-deorder.md`)
-	const deNative = deorder.match(/native DE\s*\|\s*[\d.]+%\s*\|\s*([\d.]+)%/)
+	// Capture the anchor-ON native-DE locality (the gated value) regardless of the anchor-OFF cell —
+	// the OFF cell is a diagnostic and is empty when the zeroed-anchor run can't satisfy the card's
+	// `anchor.required` strict scorer (`[^|]*` tolerates that empty cell instead of false-failing).
+	const deNative = deorder.match(/native DE\s*\|[^|]*\|\s*([\d.]+)%/)
 	// Locale summary row: `| us | <n> | <macro>% | <micro>% | <exact>% |`
 	const micro = pl.match(/\|\s*us\s*\|\s*\d+\s*\|\s*[\d.]+%\s*\|\s*([\d.]+)%/)
 	return {

--- a/scripts/eval/promotion-gate.sh
+++ b/scripts/eval/promotion-gate.sh
@@ -65,6 +65,24 @@ if [[ -d core/out ]] && [[ -n "$(find core -maxdepth 2 -name '*.ts' -newer core/
 	echo "⚠ core/ sources newer than core/out — run 'yarn compile' or the harness grades stale code" >&2
 fi
 
+# --- lore guard: artifact provenance ----------------------------------------
+# A FAIL is only trustworthy if you know WHICH bytes were graded. v1.9.2's first gate run
+# false-FAILed (us.postcode 86.9) because it graded a stale/mislabeled artifact — the real model
+# scored 97.5 under every config. Record md5 + the dynamic-quant fingerprint (count of
+# DynamicQuantizeLinear nodes; 0 = fp32, >0 = int8) of every graded artifact, and hard-assert the
+# obvious mislabels: --model must be fp32, --int8 must actually be quantized and differ from --model.
+dql() { grep -c -a "DynamicQuantizeLinear" "$1" 2>/dev/null || true; } # grep -c prints 0 + exits 1 on no-match; || true keeps the single "0"
+{
+	echo "graded at $(date -u +%FT%TZ)"
+	echo "MODEL  $(md5sum "$MODEL" | cut -d' ' -f1)  dql=$(dql "$MODEL")  $MODEL"
+	[[ -n "$INT8" ]] && echo "INT8   $(md5sum "$INT8" | cut -d' ' -f1)  dql=$(dql "$INT8")  $INT8"
+} | tee "$OUT_DIR/provenance.txt"
+[[ "$(dql "$MODEL")" == "0" ]] || { echo "✗ --model '$MODEL' carries int8 quant nodes — it is not an fp32 artifact" >&2; exit 2; }
+if [[ -n "$INT8" ]]; then
+	[[ "$(dql "$INT8")" != "0" ]] || { echo "✗ --int8 '$INT8' has no quant nodes — it is not a quantized artifact" >&2; exit 2; }
+	[[ "$(md5sum "$MODEL" | cut -d' ' -f1)" != "$(md5sum "$INT8" | cut -d' ' -f1)" ]] || { echo "✗ --model and --int8 are byte-identical — one is mislabeled" >&2; exit 2; }
+fi
+
 GAZ_ARGS=()
 if [[ "$(node -e "console.log(JSON.parse(require('fs').readFileSync('$GATE','utf8')).requires_gazetteer_lexicon === true)")" == "true" ]]; then
 	GAZ_ARGS=(--gazetteer-lexicon "$GAZ" --suppress-gaz-near-postcode)

--- a/scripts/eval/repair-net-probe.ts
+++ b/scripts/eval/repair-net-probe.ts
@@ -1,0 +1,95 @@
+/**
+ * @copyright Sister Software · @license AGPL-3.0 · @author Teffen Ellis, et al.
+ *
+ *   #723 repairLeadingHouseNumber net-effect probe. The conventions=auto US path runs ONE pass for US
+ *   (repairLeadingHouseNumber; US has no forbiddenTags/postcodePattern), so parsing each US golden row
+ *   with conventions OFF vs AUTO isolates the repair's end-to-end effect. For postcode + house_number
+ *   we classify every row the repair changes:
+ *     HELP — repair-off wrong, repair-on correct (its target: rural leading-HN-as-ZIP, no trailing ZIP)
+ *     HURT — repair-off correct, repair-on wrong (the over-fire: a valid trailing ZIP got clobbered)
+ *   Net = HELP − HURT. The HURT rows reveal the guard the fix needs.
+ *
+ *   Run: node --experimental-strip-types scripts/eval/repair-net-probe.ts --model out/v192/model.onnx
+ */
+import { type ComponentTag, decodeAsJson } from "@mailwoman/core/decoder"
+import { NeuralAddressClassifier, parseAnchorLookup, parseGazetteerLexicon } from "@mailwoman/neural"
+import { OnnxRunner } from "@mailwoman/neural/onnx-runner"
+import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+import { existsSync, readFileSync } from "node:fs"
+
+const arg = (k: string, d = ""): string => {
+	const i = process.argv.indexOf(`--${k}`)
+	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : d
+}
+const MODEL = arg("model", "out/v192/model.onnx")
+const TOK = arg("tokenizer", "/mnt/playpen/mailwoman-data/models/tokenizer/v0.6.0-a0/tokenizer.model")
+const CARD = arg("model-card", "neural-weights-en-us/model-card.json")
+const ANCHOR = arg("anchor", "/mnt/playpen/mailwoman-data/anchor/pilot-anchor-lookup.json")
+const GAZ = arg("gazetteer-lexicon", "data/gazetteer/anchor-lexicon-v1.json")
+const FILE = arg("file", "data/eval/golden/v0.1.2/dev/us.jsonl")
+
+interface Row {
+	raw: string
+	components: Record<string, string>
+}
+const norm = (v: string | undefined): string => (v ?? "").trim().toLowerCase()
+const flat = (t: Partial<Record<ComponentTag, string>>) => t as Record<string, string>
+
+async function main() {
+	const card = JSON.parse(readFileSync(CARD, "utf8"))
+	const [tokenizer, runner] = await Promise.all([MailwomanTokenizer.loadFromFile(TOK), OnnxRunner.create(MODEL)])
+	const neural = new NeuralAddressClassifier({
+		tokenizer,
+		runner,
+		labels: card.labels,
+		postcodeAnchorLookup: existsSync(ANCHOR) ? parseAnchorLookup(JSON.parse(readFileSync(ANCHOR, "utf8"))) : undefined,
+		gazetteerLexicon: existsSync(GAZ) ? parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))) : undefined,
+		suppressGazetteerNearPostcode: true,
+	})
+
+	const rows = readFileSync(FILE, "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((l) => JSON.parse(l) as Row)
+
+	const tags = ["postcode", "house_number"] as const
+	const stat: Record<string, { help: number; hurt: number; helpRows: string[]; hurtRows: string[] }> = {}
+	for (const t of tags) stat[t] = { help: 0, hurt: 0, helpRows: [], hurtRows: [] }
+
+	for (const row of rows) {
+		const off = flat(decodeAsJson(await neural.parse(row.raw, {})))
+		const on = flat(decodeAsJson(await neural.parse(row.raw, { addressSystemConventions: "auto" })))
+		// Only rows the repair actually changed are interesting.
+		if (norm(off.postcode) === norm(on.postcode) && norm(off.house_number) === norm(on.house_number)) continue
+		for (const t of tags) {
+			const gold = norm(row.components[t])
+			if (!gold) continue
+			const offOk = norm(off[t]) === gold
+			const onOk = norm(on[t]) === gold
+			if (offOk && !onOk) {
+				stat[t]!.hurt++
+				if (stat[t]!.hurtRows.length < 18)
+					stat[t]!.hurtRows.push(
+						`  raw=${JSON.stringify(row.raw)} gold.${t}=${JSON.stringify(row.components[t])} off=${JSON.stringify(off[t] ?? null)} on=${JSON.stringify(on[t] ?? null)} | on.hn=${JSON.stringify(on.house_number ?? null)} on.pc=${JSON.stringify(on.postcode ?? null)}`
+					)
+			} else if (!offOk && onOk) {
+				stat[t]!.help++
+				if (stat[t]!.helpRows.length < 12)
+					stat[t]!.helpRows.push(
+						`  raw=${JSON.stringify(row.raw)} gold.${t}=${JSON.stringify(row.components[t])} off=${JSON.stringify(off[t] ?? null)} on=${JSON.stringify(on[t] ?? null)}`
+					)
+			}
+		}
+	}
+
+	console.log(`\n#723 repairLeadingHouseNumber net effect — ${MODEL} (n=${rows.length} US golden rows)`)
+	for (const t of tags) {
+		const s = stat[t]!
+		console.log(`\n[${t}]  HELP ${s.help}  HURT ${s.hurt}  NET ${s.help - s.hurt >= 0 ? "+" : ""}${s.help - s.hurt}`)
+		console.log(`  --- HURT (repair broke a correct ${t}) ---`)
+		s.hurtRows.forEach((r) => console.log(r))
+		console.log(`  --- HELP (repair fixed ${t}) ---`)
+		s.helpRows.forEach((r) => console.log(r))
+	}
+}
+await main()


### PR DESCRIPTION
## What

Deletes `repairLeadingHouseNumber` (#723), a decode-time pass that relabelled a leading 5-digit `postcode` → `house_number` under `conventions=auto` (US).

It's an **override** — it contradicts the model's own label — which the repair discipline forbids. Per `what-mailwoman-is.mdx` ("the accreting patch"): a decode-time repair may *add* a span on `O`-tokens or *snap boundaries*, but must **never re-classify a token from one entity to another**. Overrides are scaffolding-only with a kill-date; this one had grown toward a second guard.

## Why (evidence, all no-GPU)

| signal | result |
|---|---|
| net on US golden | **−302 postcode / +16 house_number** (traded 16 house_number for 314 postcode) |
| anchor-ablation | leading-5-digit labeled correctly **20% → 100%** once the binary postcode anchor is removed |
| net-coord | removing it = **+80pp @25km** on postcode-leading rows, ~0 on rural |

The HURT population is uniform: postcode-leading rows (`05764 Finel Hollow Road, VT`) where the leading 5-digit **is** the real postcode and the repair destroyed it. The model is 100% correct on the target slice once the binary anchor (which fires on a leading number that's a valid ZIP *elsewhere*) stops polluting it — so the repair was papering over a **feature** bug, not a model limit. It was greenlit on a coord/admin-tail metric that never measured the postcode label-F1 it cost.

## Verified

- **mask-regression PASSES** for both current prod and the AU candidate: `us.postcode 97.5→97.5`, `house_number 95.2→95.2` (the conventions mask is benign for US again).
- **Full promotion gate PASSES.**
- This also repairs a **latent regression in shipped v4.13.0**, whose `conventions=auto` path runs this repair today.

The disambiguation is being absorbed model-side (region-congruence anchor upgrade + augmented postcode-leading shards — separate retrain). Design from DeepSeek consult `019ef789`.

## Also folds in two gate-harness fixes (found while verifying)

- `promotion-gate.sh`: artifact-provenance guard (md5 + quant-fingerprint; assert fp32/int8 sanity) so a stale/mislabeled artifact can't silently false-FAIL.
- `de-order-eval.sh` + `promotion-gate-verdict.ts`: the de-order leg's `set -e` aborted before the summary printed (its `oa-resolver-eval` exits non-zero even on a valid report), false-failing `de.native_locality` (real **90.7%** ≥ 83.8).

Probe scripts included as the evidence: `scripts/eval/{repair-net,anchor-ablation,digit-count}-probe.ts`.

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)