### PR TITLE
fix(eval): periodic GC to survive the onnxruntime-node native-tensor leak

### DIFF
--- a/scripts/eval/competitive-benchmark.ts
+++ b/scripts/eval/competitive-benchmark.ts
@@ -199,6 +199,7 @@ async function main() {
 	const tallies: Record<string, Record<string, Tally>> = {} // system -> locale -> tally
 	for (const s of sys) tallies[s] = {}
 
+	let totalParses = 0 // global across locales — the periodic-GC trigger (see the loop body)
 	for (const cc of LOCALES) {
 		const file = `data/eval/external/oa-${cc}-coord-150.jsonl`
 		if (!existsSync(file)) {
@@ -244,6 +245,10 @@ async function main() {
 				record(tallies["pelias"]![cc]!, c ? haversineKm(c.lat, c.lon, truth.lat, truth.lon) : null)
 				await sleep(PELIAS_GRACE_MS) // graceful: stay well under geocode.earth's 10/s + 1000/day
 			}
+			// onnxruntime-node accumulates native tensor memory across runs faster than JS GC reclaims it
+			// (~380-parse SIGKILL on the lab box). Periodic forced GC reclaims it; run with `node
+			// --expose-gc` for long panels. No-op without the flag.
+			if (++totalParses % 50 === 0) (globalThis as { gc?: () => void }).gc?.()
 			if (++i % 10 === 0) console.error(`  ${i}/${rows.length}`)
 		}
 	}

--- a/scripts/eval/confidence-discrimination.ts
+++ b/scripts/eval/confidence-discrimination.ts
@@ -238,6 +238,11 @@ async function collect(): Promise<ScoredRow[]> {
 				console.error(`  ⚠ row failed (${cc} "${input.slice(0, 40)}"): ${(e as Error).message}`)
 				append({ cc, mwAnswered: false, errKm: null, nodeConf: 0, minConf: 0, nomAnswered: false, nomRight: false })
 			}
+			// onnxruntime-node accumulates native tensor memory across runs faster than JS GC reclaims
+			// it (~380-parse SIGKILL on the lab box). A periodic forced GC reclaims it; run the harness
+			// with `node --expose-gc` to enable. No-op without the flag (the checkpoint+resume still
+			// covers a crash). Keyed off the GLOBAL row count, not the per-locale `i`.
+			if (rows.length % 50 === 0) (globalThis as { gc?: () => void }).gc?.()
 			if (i % 20 === 0) {
 				console.error(`  ${i}/${goldens.length}`)
 				writeFileSync(cachePath, JSON.stringify(cache))


### PR DESCRIPTION
The night-shift's biggest friction, diagnosed + fixed.

**Symptom:** long single-process eval harnesses SIGKILL at ~380 parses on the lab box (no JS stack → native OOM). Crashed `confidence-discrimination` twice and tripped me up on the gate tonight.

**Diagnosis:** `OnnxRunner` caches + reuses ONE `InferenceSession` (so not a per-parse session leak). The growth is native memory held by each `run()`'s feed + output `ort.Tensor`s, which JS GC reclaims too slowly across hundreds of runs. It only bites long **batch eval**, never single-parse production — so the shipped hot path is **untouched**.

**Fix:** a periodic forced `global.gc()` (keyed off the global parse count) in the `confidence-discrimination` + `competitive-benchmark` collection loops. No-op unless run with `node --expose-gc`.

**Validated:** a 472-parse run (us/it/pt/pl/fr/au n=80) that previously crashed at ~380 now completes cleanly with `--expose-gc`. The per-row checkpoint+resume still covers a crash if the flag is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)