### PR TITLE
chore(release): add 4 remaining publish-intended workspaces (BLOCKED on trusted-publishing)

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -13,6 +13,7 @@
 				"codex",
 				"resolver",
 				"resolver-wof-sqlite",
+				"resolver-wof-wasm",
 				"classifiers",
 				"corpus",
 				"neural",
@@ -24,6 +25,9 @@
 				"address-id",
 				"registry",
 				"tiger",
+				"cartographer",
+				"neural-web",
+				"variant-aliases",
 				"mailwoman"
 			],
 			"publish": true,

--- a/cartographer/package.json
+++ b/cartographer/package.json
@@ -3,6 +3,11 @@
 	"version": "1.0.0",
 	"description": "Mapping utilities for the Mailwoman geo-spatial data pipeline.",
 	"license": "AGPL-3.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "cartographer"
+	},
 	"contributors": [
 		{
 			"name": "Teffen Ellis",


### PR DESCRIPTION
**A publish-gap finding from the night shift.** `cartographer`, `neural-web`, `resolver-wof-wasm`, `variant-aliases` all declare `publishConfig: {access: public}` and are referenced in the **getting-started / api docs as installable** (`npm i @mailwoman/neural-web`), but none are on npm (404) and none were in `.release-it.json` — the same #215-class gap that left resolver/resolver-wof-sqlite unpublished. `cartographer` was also missing its `repository.directory` (#757 guard).

This adds the 4 to the publish list + cartographer's repository field. Their `@mailwoman/*` deps are all published at 4.14.0.

## ⚠ DO NOT MERGE until npm Trusted Publishing is configured for these 4 packages
Never-published → their first OIDC publish from `publish.yml` will 404/permission-fail like `resolver-wof-sqlite` did on 2026-06-24, partial-failing the release. Configure the trusted-publisher for each (repo `sister-software/mailwoman`, workflow `publish.yml`), then merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)