### PR TITLE
fix(eval): extend GC leak-fix to collect-span-confidences + oa-resolver-eval

### DIFF
--- a/scripts/eval/collect-span-confidences.ts
+++ b/scripts/eval/collect-span-confidences.ts
@@ -168,6 +168,10 @@ async function main(): Promise<void> {
 	for (const row of rows) {
 		i++
 		if (i % 1000 === 0) console.error(`  ${i}/${rows.length}  (${records.length} gradable spans)`)
+		// onnxruntime-node accumulates native tensor memory across runs faster than JS GC reclaims it
+		// (~380-parse SIGKILL on the lab box). Periodic forced GC reclaims it; run with `node
+		// --expose-gc` for full calibration sets (8000 rows). No-op without the flag. (#787 pattern.)
+		if (i % 50 === 0) (globalThis as { gc?: () => void }).gc?.()
 		let tree: AddressTree
 		try {
 			tree = await neural.parse(row.raw, parseOpts)

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -729,6 +729,10 @@ async function main(): Promise<void> {
 	for (const row of rows) {
 		i++
 		if (i % 500 === 0) console.error(`  ${i}/${rows.length}`)
+		// onnxruntime-node accumulates native tensor memory across runs faster than JS GC reclaims it
+		// (~380-parse SIGKILL on the lab box — it crashed the promotion-gate's de-order step tonight).
+		// Periodic forced GC reclaims it; run with `node --expose-gc`. No-op without the flag. (#787 pattern.)
+		if (i % 50 === 0) (globalThis as { gc?: () => void }).gc?.()
 
 		// --cascade: per-row per-state shards (the production geocode cascade); falls back to the
 		// single-state --address-points/--interpolation when --cascade is off (byte-stable default).


### PR DESCRIPTION
Completes #787 across the eval suite. The two remaining heavy parse loops — collect-span-confidences (8000-row calib sets) and oa-resolver-eval (crashed the promotion-gate's de-order step tonight) — get the same validated periodic `global.gc()` (no-op without `--expose-gc`). Prevents the gate-crash recurrence + makes the full calibration re-fit runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)