### PR TITLE
chore(demo): repoint admin gazetteer to 2026-06-24a (-20j: PT/PL/CZ/AU postcodes)

### DIFF
--- a/docs/src/shared/resources.tsx
+++ b/docs/src/shared/resources.tsx
@@ -172,11 +172,11 @@ export function streetShardUrl(slug: string, kind: "situs" | "interp"): string {
  * is rebuilt + re-uploaded (the immutable Cache-Control means a fresh DB needs a fresh URL). See
  * RELEASING.md "Rebuilding + swapping the canonical admin gazetteer".
  */
-export const ADMIN_GAZETTEER_VERSION = "2026-06-22a"
+export const ADMIN_GAZETTEER_VERSION = "2026-06-24a"
 
 /**
- * Byte-ranged global "candidate" gazetteer (`candidate-global.db`, ~530 MB incl. US + intl
- * postcodes) — the FTS-free, single-B-tree-probe lookup that replaces the slim per-model-version
+ * Byte-ranged global "candidate" gazetteer (`candidate-global.db`, ~871 MB; US + intl postcodes
+ * incl. PT/PL/CZ/AU as of 2026-06-24a) — the FTS-free, single-B-tree-probe lookup that replaces the slim per-model-version
  * `wof-hot.db` AND the full-DB FTS. A resolve touches a handful of contiguous pages (~12 range
  * fetches/session vs 243 on the full DB), with GLOBAL coverage and no `SLIM_COUNTRIES` upkeep.
  * Resolved by {@link WofCandidateTableLookup} (build-candidate.ts). Hosted at


### PR DESCRIPTION
## What

Repoints the live demo's byte-range admin gazetteer from `2026-06-22a` (the `-20h` build) to `2026-06-24a` (`-20j`).

The live `-20h` build carries **zero** postcodes for PT/PL/CZ/AU. `-20j` adds them as a **strict superset** — every other placetype is byte-identical:

| country | -20h | -20j |
|---|--:|--:|
| PT | 0 | 395,544 |
| PL | 0 | 40,598 |
| CZ | 0 | 5,388 |
| AU | 0 | 3,171 |
| AT | 809 | 3,022 |

Net `+446,914` postalcode rows; locality/region/county/neighbourhood/etc. unchanged.

This is the gazetteer the EU+AU competitive standing-run measured the **86-vs-80 @25km** win on (night 2026-06-24). It was held out of the demo pending this re-stage (task #213).

## Done + verified
- Uploaded `candidate-global-20j.db` (913,498,112 bytes) → `mailwoman/gazetteer/2026-06-24a/candidate.db` on R2 (immutable, octet-stream).
- HEAD confirms content-length match; range fetch returns the `SQLite format 3` magic.
- New postcodes resolve to their cities: PT `1000-001`→Lisbon (38.717, -9.133), PL `00-002`→Warsaw (52.236, 21.010), CZ `100 00`→Prague (50.077, 14.466), AU `2000`→Sydney (-33.864, 151.205), AU `3000`→Melbourne (-37.814, 144.963).
- Regression: US `10001`→NYC (40.751, -73.997) unchanged.

Old `2026-06-22a` path stays on R2 as rollback (immutable). Revert = revert this one-line constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)