### PR TITLE
fix(demo): bind #370 findRescoreCandidate via @mailwoman/resolver/span-rescore subpath

### DIFF
--- a/docs/plugins/demo-assets/resolve.mjs
+++ b/docs/plugins/demo-assets/resolve.mjs
@@ -176,12 +176,25 @@ export function buildWorkspaceAliases() {
 		// imports from this barrel is `expandPlacetypeFilter` (the resolver-wof-* lookups + this demo);
 		// `createWofResolver` is never bundled. This alias is webpack-only — `tsc` still resolves the
 		// package barrel, so type-only imports (`CoincidentLocality`, `Ancestor`) keep working.
-		aliases["@mailwoman/resolver"] = resolveWorkspaceFile(coreDir, "resolver/types")
+		// EXACT match (`$`): the bare `@mailwoman/resolver` import resolves to core's types module, but a
+		// SUBPATH like `@mailwoman/resolver/span-rescore` must NOT — it has to reach the real package
+		// (aliased just below). Without the `$` this prefix-matched the subpath too, sending it to
+		// `core/resolver/types/span-rescore` → "Can't resolve" / `findRescoreCandidate is not a function`.
+		aliases["@mailwoman/resolver$"] = resolveWorkspaceFile(coreDir, "resolver/types")
 		// `objects` is a SINGLE-file entry (`core/objects.ts`, exports `./out/objects.js`), so it needs the
 		// flat-file resolver, not the dir-style loop above. Same staleness rationale as `pipeline`/`errors`.
 		aliases["@mailwoman/core/objects"] = resolveWorkspaceFile(coreDir, "objects")
 		aliases["@mailwoman/core/environment/load"] = resolveWorkspaceFile(coreDir, "environment/load")
 		aliases["@mailwoman/core/kysley/dialect"] = resolveWorkspaceFile(coreDir, "kysley/dialect")
+	}
+
+	// @mailwoman/resolver/span-rescore — the #370 rescue. The bare-barrel alias above points at CORE's
+	// types module (for `expandPlacetypeFilter`), which has no `findRescoreCandidate`; so the demo
+	// imports the rescue from this SUBPATH, aliased straight to the real resolver package's source
+	// (browser-safe: span-rescore.ts pulls only `@mailwoman/spatial` haversine + type-only core imports).
+	const resolverDir = resolveWorkspaceDir("@mailwoman/resolver")
+	if (resolverDir) {
+		aliases["@mailwoman/resolver/span-rescore"] = resolveWorkspaceFile(resolverDir, "span-rescore")
 	}
 
 	return aliases

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -64,7 +64,12 @@ import {
 	runCascade,
 } from "../../shared/demo-helpers.ts"
 
-import { findRescoreCandidate } from "@mailwoman/resolver"
+// Imported from the `./span-rescore` SUBPATH, not the `@mailwoman/resolver` barrel: the barrel mixes
+// `export * from "@mailwoman/core/resolver"` with this re-export, and the demo also imports
+// `@mailwoman/core/*` subpaths elsewhere — the bare-barrel + subpath interleave (#481) leaves this
+// re-export unbound at runtime (`findRescoreCandidate is not a function`). The direct subpath gives it
+// its own binding, untouched by the barrel cycle.
+import { findRescoreCandidate } from "@mailwoman/resolver/span-rescore"
 
 import type { HttpvfsAddressPointLookup, HttpvfsInterpolator } from "../../shared/httpvfs-street.ts"
 import { pruneDbRangeCache, registerRangeCacheServiceWorker } from "../../shared/register-range-sw.ts"

--- a/docs/test/browser/200-demo-resolve.spec.ts
+++ b/docs/test/browser/200-demo-resolve.spec.ts
@@ -106,6 +106,31 @@ test.describe("Demo — resolution cascade", () => {
 		demo.console.assertNoFailEvents()
 	})
 
+	// -20j (2026-06-24a) adds postcodes for PT/PL/CZ/AU — absent from the prior -20h build, so these
+	// countries had no postcode tier on the demo at all. Each case feeds locality + postcode + country
+	// and grades the resolved coordinate against the city bbox: the cascade country-gates and the new
+	// postcode (or its locality) is reachable. Pairs with the v4.14.0 AU model (postcode-first format).
+	const newPostcodeCases: { name: string; query: string; lat: [number, number]; lon: [number, number] }[] = [
+		{ name: "Portuguese postcode 1000-001 → Lisbon", query: "Lisboa 1000-001, Portugal", lat: [38.6, 38.9], lon: [-9.3, -9.0] },
+		{ name: "Polish postcode 00-002 → Warsaw", query: "Warszawa 00-002, Poland", lat: [52.1, 52.4], lon: [20.9, 21.2] },
+		{ name: "Czech postcode 100 00 → Prague", query: "Praha 100 00, Czechia", lat: [49.9, 50.2], lon: [14.3, 14.6] },
+		{ name: "Australian postcode 2000 → Sydney", query: "Sydney NSW 2000, Australia", lat: [-34.0, -33.7], lon: [151.0, 151.4] },
+	]
+	for (const c of newPostcodeCases) {
+		test(`-20j postcode coverage — ${c.name}`, async ({ demo }) => {
+			await demo.goto(c.query)
+			await demo.submit()
+			const { resolved, markerCount } = await demo.readResult()
+			expect(markerCount).toBeGreaterThan(0)
+			const [lat, lon] = (resolved["coords"] ?? "").split(",").map((s) => Number.parseFloat(s.trim()))
+			expect(lat, `resolved lat ${lat} for "${c.query}"`).toBeGreaterThan(c.lat[0])
+			expect(lat).toBeLessThan(c.lat[1])
+			expect(lon, `resolved lon ${lon} for "${c.query}"`).toBeGreaterThan(c.lon[0])
+			expect(lon).toBeLessThan(c.lon[1])
+			demo.console.assertNoFailEvents()
+		})
+	}
+
 	test("White House default — surfaces no fail-pattern errors even when resolver returns nothing", async ({ demo }) => {
 		// Postcode 20500 has lat=0/lon=0 in WOF; cascade filters it; raw text + locality may also
 		// miss. The test isn't asserting the resolution succeeds — it's asserting that the

--- a/resolver/package.json
+++ b/resolver/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",
-		".": "./out/index.js"
+		".": "./out/index.js",
+		"./span-rescore": "./out/span-rescore.js"
 	},
 	"dependencies": {
 		"@mailwoman/codex": "workspace:*",


### PR DESCRIPTION
## What

The demo's #370 span-rescue threw `findRescoreCandidate is not a function` at runtime for any input whose primary resolve failed (EU coverage-gap postcodes — PT/CZ surfaced it via new e2e cases), **aborting the parse so no result rendered** — worse than no rescue. Live since #780/#215 deployed; **not** caused by the v4.14.0 repoint.

## Root cause (not a stale compile)

The deployed chunk was **byte-identical to a clean local build** (md5 match), ruling out staleness. The demo's webpack alias map (`docs/plugins/demo-assets/resolve.mjs`) aliases bare `@mailwoman/resolver` → **core's** `resolver/types` module (a deliberate barrel-bypass so `expandPlacetypeFilter` binds). That alias had no `$`, so it **prefix-matched `@mailwoman/resolver/...` too**, and `core/resolver/types` doesn't define `findRescoreCandidate` (that lives in the real `@mailwoman/resolver` package, `resolver/span-rescore.ts`). The demo's import resolved to a module without the function → `undefined`.

## Fix

- `@mailwoman/resolver$` (EXACT) keeps the bare import → `core/resolver/types` for `expandPlacetypeFilter` (the only bare consumer, `httpvfs-resolver.ts`).
- New alias `@mailwoman/resolver/span-rescore` → the real package's source (browser-safe: pulls only `@mailwoman/spatial` haversine + type-only core imports).
- `resolver/package.json` gains the `./span-rescore` subpath export (tsc + node).
- `demo/index.tsx` imports `findRescoreCandidate` from the subpath.
- 4 new browser e2e postcode cases (PT/PL/CZ/AU) that surfaced this.

## Verification

Rebuilt bundle now carries the real impl (`hasResolvedPlace` present). Browser e2e local-serve runtime is blocked by cross-origin font/asset CORS (R2 doesn't allow `localhost`), so verified on the production Pages deploy (full resolve e2e). The `$`-exact change is safe: the only bare `@mailwoman/resolver` import is `expandPlacetypeFilter`; no other subpath imports exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)