### PR TITLE
feat(coverage): global "work to do" map — civilization-holes layer + coverage-v5

### DIFF
--- a/cartographer/coverage/index.ts
+++ b/cartographer/coverage/index.ts
@@ -3,10 +3,11 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   The "fog of war" address-COVERAGE overlay. An H3 hexbin tileset (built by
- *   `scripts/build-coverage-tiles.ts`) shades each area by how much address-point data we hold:
- *   covered → clear (the basemap shows through), empty → opaque gray fog. Answers "where do we need
- *   more data" at a glance, and reveals the "looks covered until you zoom in, then it goes gray" gaps.
+ *   The "fog of war" address-COVERAGE overlay. An H3 hexbin tileset (built by `mailwoman coverage
+ *   build`) shading "where do we need data" at a glance. Two layers in one tileset: the US rooftop
+ *   fine map (address-point density, street/block detail) and a GLOBAL "work to do" layer — populated
+ *   places (WOF, importance-weighted) we can't geocode yet show as gray-fog holes, and postcode/rooftop
+ *   coverage clears them. Covered → clear (basemap shows through), uncovered civilization → gray fog.
  *
  *   Each cell carries TWO baked fog values in [0,1] (0 = covered, 1 = empty), so the same tiles drive
  *   either reading without a rebuild:
@@ -16,8 +17,8 @@
  *   We expose each as its OWN default-off fill layer (`coverage-opt-fog`, `coverage-honest-fog`) so the
  *   demo's LayerToggleControl gives each its own checkbox — pick the reading you want, no extra UI.
  *
- *   Served as XYZ vector tiles by the tile worker from `nexus-assets/tiles/coverage-us-v4.pmtiles` (same
- *   as `basemap-v4`); the consumer passes its TileJSON URL (`tiles.sister.software/coverage-us-v4.json`)
+ *   Served as XYZ vector tiles by the tile worker from `nexus-assets/tiles/coverage-v5.pmtiles` (same
+ *   as `basemap-v4`); the consumer passes its TileJSON URL (`tiles.sister.software/coverage-v5.json`)
  *   to `createCoverageSource`.
  */
 
@@ -27,7 +28,7 @@ import type {
 } from "@maplibre/maplibre-gl-style-spec"
 import { TileSetSourceID } from "../styles/sources.js"
 
-export const CoverageTileSetID = TileSetSourceID("coverage-us-v4")
+export const CoverageTileSetID = TileSetSourceID("coverage-v5")
 
 /**
  * The single source-layer the coverage PMTiles ships (see `build-coverage-tiles.ts` → tippecanoe `-l`).
@@ -56,7 +57,7 @@ export const CoverageLayerID = {
 
 /**
  * Build the coverage source spec from the tile worker's TileJSON endpoint
- * (`https://tiles.sister.software/coverage-us-v4.json`).
+ * (`https://tiles.sister.software/coverage-v5.json`).
  */
 export function createCoverageSource(url: string): VectorSourceSpecification {
 	return { type: "vector", url }

--- a/docs/articles/plan/reference/coverage-overlay.mdx
+++ b/docs/articles/plan/reference/coverage-overlay.mdx
@@ -8,11 +8,14 @@
 
 ## What it is
 
-A demo-map overlay that shades each area by **how much address-point data we actually hold** — covered → clear (basemap shows through), empty → gray fog. It answers "where do we need more data," and reveals the "looks covered until you zoom in, then the gaps go gray" holes.
+A demo-map overlay that answers **"where do we need data"** at a glance — covered → clear (basemap shows through), uncovered → gray fog. Two layers in one tileset:
 
-- **Live:** `https://tiles.sister.software/coverage-us-v4.json` (XYZ vector tiles via the tile worker).
+1. **US rooftop fine map** — shades each US area by address-point density (street/block detail). The original overlay; reveals the "looks covered until you zoom in, then the gaps go gray" holes.
+2. **Global "work to do" holes** (`fog = salience·(1 − coverage)`) — populated places worldwide that we **can't geocode yet** show as gray-fog holes, weighted by importance (big uncovered cities are darkest). Postcode/rooftop coverage **clears** the hole, so the holes land where civilization exists but our data doesn't — Africa, the Middle East, C/S Asia, South America, and gaps like UK/Ireland (Royal Mail isn't in open GeoNames).
+
+- **Live:** `https://tiles.sister.software/coverage-v5.json` (XYZ vector tiles via the tile worker).
 - **In the demo:** the **Layers** panel (top-right) has two **default-off** toggle groups — _Coverage · optimistic fog_ and _Coverage · honest fog_. The user picks one.
-- **Coverage today:** 48 states + DC + VI (Overture) + HI (OpenAddresses, rooftop) + NH (street-level only). **AK is excluded** (antimeridian hex-wrap). National res-9 archive ≈ 848 MiB, 58.85M features.
+- **Coverage today:** US rooftop = 48 states + DC + VI (Overture) + HI (OpenAddresses) + NH (street-level), **AK excluded** (antimeridian). Global postcode coverage = GeoNames `allCountries` postal (121 countries) clearing the holes; civilization backdrop = WOF settlement places weighted by `place_importance`.
 
 ## Architecture (read this before touching anything)
 
@@ -23,7 +26,9 @@ It is an **H3 hexbin** tileset. Each cell carries **two baked fog values** in `[
 
 The demo's two fill layers (`coverage-opt-fog`, `coverage-honest-fog`) just point `fill-opacity` at one prop or the other — **no rebake needed to switch readings**. Each H3 resolution is baked in its own non-overlapping zoom band; the finest is baked at a single tile-max zoom and MapLibre **overzooms** above it (hexes are identical geometry at every zoom).
 
-**Serving is XYZ via the tile worker — NOT client-side PMTiles.** The `.pmtiles` archive lives at `nexus-assets/tiles/coverage-us-v4.pmtiles` and the `tile-worker/` Cloudflare Worker serves it as `tiles.sister.software/coverage-us-v4/{z}/{x}/{y}.mvt` (exactly like `basemap-v4`). A previous iteration served the PMTiles directly through the `pmtiles://` protocol — **that was wrong and was removed** (`524f78a8`). Don't bring it back.
+**Serving is XYZ via the tile worker — NOT client-side PMTiles.** The `.pmtiles` archive lives at `nexus-assets/tiles/coverage-v5.pmtiles` and the `tile-worker/` Cloudflare Worker serves it as `tiles.sister.software/coverage-v5/{z}/{x}/{y}.mvt` (exactly like `basemap-v4`). A previous iteration served the PMTiles directly through the `pmtiles://` protocol — **that was wrong and was removed** (`524f78a8`). Don't bring it back.
+
+The **global holes layer** is decoupled from the US rooftop pipeline (its own DuckDB stage, US-excluded) but rides the SAME `coverage` source-layer + `fog`/`fog_opt` props, so the demo's two fill layers render it with zero wiring changes. It emits res-domain hexes at `[onset…max]` + a res-4 low-zoom rollup; the US tiers are untouched.
 
 ## Code map
 
@@ -32,21 +37,32 @@ The demo's two fill layers (`coverage-opt-fog`, `coverage-honest-fog`) just poin
 | `mailwoman/coverage-core.ts`                                    | The build pipeline (React-free): DuckDB H3 aggregation → NDJSON → `tippecanoe` → PMTiles. The fog model lives here. |
 | `mailwoman/commands/coverage/build.tsx`                         | `mailwoman coverage build` — thin Ink wrapper over `coverage-core`.                                                 |
 | `mailwoman/commands/tiles/publish.tsx`                          | `mailwoman tiles publish` — rclone upload of a PMTiles to an R2 bucket (multipart).                                 |
-| `cartographer/coverage/index.ts`                                | `CoverageTileSetID` (= `"coverage-us-v4"`), the two fog fill layers, fog color/opacity, `createCoverageSource`.     |
+| `cartographer/coverage/index.ts`                                | `CoverageTileSetID` (= `"coverage-v5"`), the two fog fill layers, fog color/opacity, `createCoverageSource`.        |
+| `scripts/build-importance.ts`                                   | Builds `place_importance` (Wikipedia importance + population fallback) — the holes-layer salience source.           |
 | `docs/src/pages/demo/index.tsx`                                 | Demo wiring — registers the coverage source + adds the default-off layers on map load.                              |
 | `docs/src/components/LayerToggleControl/LayerToggleControl.tsx` | The toggle-group patterns (`coverage-opt`, `coverage-honest`).                                                      |
 | `scripts/build-address-point-shard.ts`                          | Per-state situs shard builder. `--oa-csv` mode reads OpenAddresses for states Overture omits (HI).                  |
 
-Source data (per-state shards, NOT in git): `/mnt/playpen/mailwoman-data/address-points/address-points-us-<st>.db` (124.9M US points) + `…/interpolation/interpolation-us-<st>.db` (TIGER street segments).
+Source data (NOT in git): the per-state US rooftop shards `/mnt/playpen/mailwoman-data/address-points/address-points-us-<st>.db` (124.9M points) + `…/interpolation/interpolation-us-<st>.db` (TIGER segments); the global postcode signal `…/geonames/allCountries-postal.txt` (GeoNames postal, 121 countries); and the civilization backdrop `…/wof/admin-global-priority-importance.db` (WOF `spr` + `place_importance`, built by `scripts/build-importance.ts`).
 
 ## Runbook: rebuild + republish
+
+**0. Refresh the civilization backdrop** (only when WOF or the importance data changes) — `place_importance` keys the holes layer's salience. Build it onto a COPY of the canonical WOF DB so the gazetteer the resolver uses stays untouched:
+
+```bash
+cp /mnt/playpen/mailwoman-data/wof/admin-global-priority.db \
+   /mnt/playpen/mailwoman-data/wof/admin-global-priority-importance.db
+npx tsx scripts/build-importance.ts --db /mnt/playpen/mailwoman-data/wof/admin-global-priority-importance.db
+# Downloads Nominatim's wikimedia-importance.csv.gz (needs a browser User-Agent — it 403s curl's default).
+```
 
 **1. Build the tileset** (maintainer-only — needs the local shards + `tippecanoe` on PATH + the `@duckdb/node-api` dev dep):
 
 ```bash
 mailwoman coverage build --states all --exclude-states AK \
-  --out /mnt/playpen/mailwoman-data/coverage/coverage-us.pmtiles
-# ~minutes; res-9 national ≈ 848 MiB. --keep-ndjson to re-tile without re-aggregating.
+  --out /mnt/playpen/mailwoman-data/coverage/coverage-global-v5.pmtiles
+# ~10–15 min; archive ≈ 1 GiB. The global holes layer is on by default (--no-postcode to skip it).
+# --keep-ndjson to re-tile without re-aggregating.
 ```
 
 **2. Publish to the tile-worker bucket** (`nexus-assets`):
@@ -58,12 +74,12 @@ RCLONE_S3_ACCESS_KEY_ID="$RCLONE_S3_PUBLIC_ACCESS_KEY_ID" \
 RCLONE_S3_SECRET_ACCESS_KEY="$RCLONE_S3_PUBLIC_SECRET_ACCESS_KEY" \
 RCLONE_S3_ENDPOINT="$RCLONE_S3_PUBLIC_ENDPOINT" \
 RCLONE_S3_PROVIDER=Cloudflare RCLONE_S3_REGION=auto \
-mailwoman tiles publish --file /mnt/playpen/mailwoman-data/coverage/coverage-us.pmtiles --tileset coverage-us-v4
+mailwoman tiles publish --file /mnt/playpen/mailwoman-data/coverage/coverage-global-v5.pmtiles --tileset coverage-v5
 ```
 
-**3. Verify:** `curl -s -o /dev/null -w '%{http_code}' https://tiles.sister.software/coverage-us-v4.json` → `200`.
+**3. Verify:** `curl -s -o /dev/null -w '%{http_code}' https://tiles.sister.software/coverage-v5.json` → `200`.
 
-**Re-versioning:** the object is at a versioned path (`coverage-us-v4`). To ship a fresh bake, bump `CoverageTileSetID` in `cartographer/coverage/index.ts` to `coverage-us-v5`, upload to `tiles/coverage-us-v5.pmtiles`, and the demo follows automatically. (Versioning avoids R2 cache-staleness; same pattern as `basemap-v4`.)
+**Re-versioning:** the object is at a versioned path (`coverage-v5`). To ship a fresh bake, bump `CoverageTileSetID` in `cartographer/coverage/index.ts` to `coverage-v6`, upload to `tiles/coverage-v6.pmtiles`, and the demo follows automatically. (Versioning avoids R2 cache-staleness; same pattern as `basemap-v4`.)
 
 ### Credential + upload gotchas (this cost a whole session — read it)
 
@@ -93,6 +109,19 @@ To add an Overture-gap state from OpenAddresses: download the OA conformed CSV(s
 | `--optimistic-gamma`         | 2.0                      | The `fog_opt = fog ** gamma` exponent.                                                          |
 | `--max-zoom`                 | 12                       | Highest baked zoom; overzoom above.                                                             |
 
+**Global holes layer** (`fog = salience·(1 − coverage)`, res-domain hexes, US-excluded):
+
+| Flag                  | Default                                | Effect                                                                                            |
+| --------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `--no-postcode`       | (on)                                   | Disable the global holes layer entirely — US rooftop fine map only.                               |
+| `--geonames-postal`   | `…/geonames/allCountries-postal.txt`   | The postcode COVERAGE signal — a postcode present in a domain cell clears its hole.                |
+| `--wof-db`            | `…/wof/admin-global-priority-importance.db` | The civilization backdrop — `spr` + `place_importance` (settlement salience).                 |
+| `--postcode-ceiling`  | 0.85                                   | How much a postcode cell clears the hole (≤ 1; rooftop is the full 1).                            |
+| `--salience-floor`    | 0.15                                   | Min place importance to flag as a hole — the noise floor (raise to keep only the notable holes).  |
+| `--postcode-exclude`  | `US`                                   | Countries the holes layer skips (handled by the rooftop fine map).                                |
+
+The salience is `sqrt(importance)` — lifts modest uncovered towns to a visible gray while keeping big cities darkest. Holes below 0.05 residual fog (covered or trivial) are dropped, so the layer is just the holes (~290 K res-6 cells); covered + empty stay clear.
+
 **National size by `--fine-res`** (res-9 d6 measured): res-9 ≈ **848 MiB**, res-8 ≈ 364 MiB, res-7 ≈ 55 MiB. Only res-7 fits wrangler's 300 MiB cap — irrelevant now that rclone-multipart works, so we ship the full res-9.
 
 ## Gotchas (learned the hard way)
@@ -100,11 +129,12 @@ To add an Overture-gap state from OpenAddresses: download the OA conformed CSV(s
 - **DuckDB multi-ATTACH mis-binds.** `ATTACH`ing N sqlite DBs and `UNION ALL`-ing structurally-identical _aggregating_ subqueries (`h3_latlng_to_cell(…) … GROUP BY 1` per arm) silently binds every arm to the **first** attached DB (a 49-state build reported 3× CA's points in CA's cells). **Fix:** `UNION ALL` the **raw** columns, aggregate **once** in the outer query. (Already done in `coverage-core.ts` — don't undo it.)
 - **`.gitignore` bare `coverage` rule** (the vitest report dir) matches any dir named `coverage` at any depth — it was silently swallowing `mailwoman/commands/coverage/` and `cartographer/coverage/`. Scoped `!`-negations are in `.gitignore`; keep them or the command + module vanish from git/npm-publish.
 - **Don't serve PMTiles client-side.** XYZ via the tile worker only.
+- **The holes layer is res-domain-coarse on purpose.** Postcode/importance is area-scale; it does NOT subdivide to res-9 (that would multiply the archive ~343×). EU/global reads at ~3.2 km granularity, overzoomed above z12 — honest, since a postcode IS coarse. Don't "finish" it to street level.
 
 ## Follow-ups / open work
 
-1. **NH rooftop points** via NH GRANIT (state address portal) — separate fetch + ingest. NH is street-level only today.
-2. **AK** — needs antimeridian boundary splitting in `coverage-core.ts` before it can be included.
-3. **International coverage** — currently US-only. Overture has intl addresses (FR/DE/etc.); the build is US-shard-shaped, so this is real work.
-4. **Re-bake cadence / versioning** — bump to `coverage-us-v5` on the next data refresh.
-5. **Browser perf** — the 848 MiB / 58M-feature archive serves per-tile (fine in practice), but worth watching dense-metro z12 tile sizes if it feels slow.
+1. **Close real holes with rooftop/postcode data.** The map now NAMES the gaps — biggest wins: UK/Ireland (Royal Mail isn't in open GeoNames; needs Code-Point Open or OA), and the Overture-EU address parquets already on disk (`…/overture/<rel>/addresses-<cc>.parquet`) → real EU **rooftop** shards (would upgrade EU from postcode-coarse to street-level + clear more holes).
+2. **NH rooftop points** via NH GRANIT — NH is street-level only today.
+3. **AK** — the antimeridian guard now DROPS wrapped hexes (so AK partial-renders if its shard is included); a proper fix splits the boundary at ±180 in `coverage-core.ts` instead of dropping.
+4. **Importance refresh cadence** — `place_importance` is built onto a WOF-DB copy; re-run `build-importance` when WOF or the Nominatim importance dump refreshes, then re-bake.
+5. **Browser perf** — the ~1 GiB / 59M-feature archive serves per-tile (fine in practice), but worth watching dense-metro z12 tile sizes if it feels slow.

--- a/mailwoman/commands/coverage/build.tsx
+++ b/mailwoman/commands/coverage/build.tsx
@@ -38,6 +38,20 @@ const OptionsSchema = zod.object({
 	satSeg: zod.coerce.number().positive().optional().default(8).describe("Street-segment count at which the interp signal saturates"),
 	interpWeight: zod.coerce.number().min(0).max(1).optional().default(0.4).describe("Weight of the street-segment signal vs address points"),
 	optimisticGamma: zod.coerce.number().positive().optional().default(2).describe("Exponent for the optimistic fog curve (fog ** gamma)"),
+	postcode: zod.coerce.boolean().optional().default(true).describe("Add the global civilization-holes layer (--no-postcode to disable)"),
+	geonamesPostal: zod
+		.string()
+		.optional()
+		.default("/mnt/playpen/mailwoman-data/geonames/allCountries-postal.txt")
+		.describe("GeoNames postal file (12-col) — the global postcode COVERAGE signal"),
+	wofDb: zod
+		.string()
+		.optional()
+		.default("/mnt/playpen/mailwoman-data/wof/admin-global-priority-importance.db")
+		.describe("WOF DB (spr + place_importance) — the civilization/salience backdrop"),
+	postcodeCeiling: zod.coerce.number().min(0).max(1).optional().default(0.85).describe("Coverage a postcode cell contributes (clears the hole; ≤ 1)"),
+	salienceFloor: zod.coerce.number().min(0).max(1).optional().default(0.15).describe("Min place importance to flag as a hole (noise floor)"),
+	postcodeExclude: zod.string().optional().default("US").describe("Country codes the global holes layer skips (rooftop-covered; comma-separated)"),
 	maxZoom: zod.coerce.number().int().min(0).max(22).optional().default(12).describe("Highest baked zoom (MapLibre overzooms above)"),
 	out: zod
 		.string()
@@ -78,6 +92,11 @@ const CoverageBuild: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 				satSeg: options.satSeg,
 				interpWeight: options.interpWeight,
 				optimisticGamma: options.optimisticGamma,
+				geonamesPostalFile: options.postcode ? options.geonamesPostal : null,
+				wofDb: options.postcode ? options.wofDb : null,
+				postcodeCeiling: options.postcodeCeiling,
+				salienceFloor: options.salienceFloor,
+				postcodeExcludeCountries: options.postcodeExclude.split(",").map((s) => s.trim()).filter(Boolean),
 				tileMaxZoom: options.maxZoom,
 				out: options.out,
 				keepNdjson: options.keepNdjson,
@@ -96,8 +115,8 @@ const CoverageBuild: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 			<Box flexDirection="column">
 				<Text>
 					<Text color="green">✓</Text> {done.features.toLocaleString()} features · {done.domainCells.toLocaleString()} cells (
-					{done.withPoints.toLocaleString()} with points, {done.streetOnly.toLocaleString()} street-only) ·{" "}
-					{(done.pmtilesBytes / 1024 / 1024).toFixed(1)} MB
+					{done.withPoints.toLocaleString()} with points, {done.streetOnly.toLocaleString()} street-only,{" "}
+					{done.postcodeCells.toLocaleString()} postcode) · {(done.pmtilesBytes / 1024 / 1024).toFixed(1)} MB
 				</Text>
 				<Text dimColor>{done.out}</Text>
 			</Box>

--- a/mailwoman/coverage-core.ts
+++ b/mailwoman/coverage-core.ts
@@ -58,6 +58,25 @@ export interface CoverageBuildOptions {
 	interpWeight: number
 	/** Optimistic-mode exponent for `fog_opt = fog ** gamma`. */
 	optimisticGamma: number
+	/**
+	 * GeoNames postal file (12-col tab-separated) — the GLOBAL postcode COVERAGE signal that clears the
+	 * "where do we need data" holes. Null to skip. A postcode is area-scale, so centroids bin at the
+	 * domain resolution and a domain cell holding ≥1 postcode reads as postcode-resolvable (covered).
+	 */
+	geonamesPostalFile: string | null
+	/**
+	 * WOF SQLite DB (the admin gazetteer) holding `spr` (place coords + placetype) + `place_population`
+	 * / `place_importance` — the CIVILIZATION/salience backdrop. Settlement places, weighted by salience,
+	 * mark "where civilization is": a salient place we DON'T cover is a gray hole = work to do. Null to
+	 * skip the global holes layer (US rooftop fine map is independent of it).
+	 */
+	wofDb: string | null
+	/** Coverage a postcode cell contributes (≤ 1) — how much it clears the hole (rooftop is the full 1). */
+	postcodeCeiling: number
+	/** Minimum place importance (∈ [0,1]) to count as civilization worth flagging — the noise floor. */
+	salienceFloor: number
+	/** Country codes the global holes/postcode layer skips (US is handled by the rooftop fine map). */
+	postcodeExcludeCountries: string[]
 	/** Highest zoom baked; MapLibre overzooms above it. */
 	tileMaxZoom: number
 	/** Output `.pmtiles` path. */
@@ -77,6 +96,7 @@ export interface CoverageBuildResult {
 	domainCells: number
 	withPoints: number
 	streetOnly: number
+	postcodeCells: number
 	features: number
 	pmtilesBytes: number
 }
@@ -128,6 +148,26 @@ function buildBands(allRes: number[], tileMaxZoom: number): Map<number, [number,
 	)
 }
 
+/**
+ * True if a GeoJSON polygon's outer ring spans >180° of longitude — the antimeridian-wrap artifact.
+ * `h3_cell_to_boundary_wkt` emits UNWRAPPED lon for cells straddling ±180, smearing a polygon across
+ * the whole map; a normal hex spans a fraction of a degree, so a >180° span is unambiguously a wrap.
+ * Cheaper than round-tripping through the spatial extension; covers AK/RU/FJ/NZ-Chathams.
+ */
+function antimeridianWrapped(geojson: string): boolean {
+	let min = Infinity
+	let max = -Infinity
+	// Each coordinate pair is `[lon,lat]`; capture the lon (first number after a `[`). `[[[` won't
+	// match (no digit follows the inner `[`), so only real vertices are scanned.
+	const re = /\[\s*(-?\d+(?:\.\d+)?)\s*,/g
+	for (let m = re.exec(geojson); m; m = re.exec(geojson)) {
+		const lon = Number(m[1])
+		if (lon < min) min = lon
+		if (lon > max) max = lon
+	}
+	return max - min > 180
+}
+
 export async function buildCoverageTiles(
 	opts: CoverageBuildOptions,
 	onProgress: CoverageProgress = () => {}
@@ -158,6 +198,8 @@ export async function buildCoverageTiles(
 		await duck.run(`ATTACH '${s.file}' AS st${i} (TYPE sqlite, READ_ONLY)`)
 		if (s.interp) await duck.run(`ATTACH '${s.interp}' AS ip${i} (TYPE sqlite, READ_ONLY)`)
 	}
+	// ATTACH the WOF gazetteer read-only for the global civilization/salience backdrop (if requested).
+	if (opts.wofDb) await duck.run(`ATTACH '${opts.wofDb}' AS wof (TYPE sqlite, READ_ONLY)`)
 
 	// data_pt: res-FINE address-point counts. UNION ALL the RAW (lat, lon) across states and bin + count
 	// ONCE in the outer query. Do NOT pre-aggregate per UNION arm: DuckDB mis-binds structurally-identical
@@ -214,6 +256,7 @@ export async function buildCoverageTiles(
 	const domainCells = Number(summary.domain)
 	const withPoints = Number(summary.pt_cov)
 	const streetOnly = Number(summary.seg_only)
+	let postcodeCells = 0
 	onProgress(
 		"domain",
 		`${domainCells.toLocaleString()} cells · ${withPoints.toLocaleString()} with points · ${streetOnly.toLocaleString()} street-only`
@@ -224,20 +267,22 @@ export async function buildCoverageTiles(
 	const ndjsonPath = opts.out.replace(/\.pmtiles$/, "") + ".ndjson"
 	const sink = createWriteStream(ndjsonPath)
 	let featureCount = 0
-	const emitResolution = async (res: number, sql: string): Promise<void> => {
-		const [minzoom, maxzoom] = bands.get(res) ?? [0, opts.tileMaxZoom]
+	const emitResolution = async (res: number, sql: string, bandOverride?: [number, number]): Promise<void> => {
+		const [minzoom, maxzoom] = bandOverride ?? bands.get(res) ?? [0, opts.tileMaxZoom]
 		const prefix = `{"type":"Feature","tippecanoe":{"layer":"coverage","minzoom":${minzoom},"maxzoom":${maxzoom}},"properties":`
 		const stream = await duck.stream(sql)
 		const cols = stream.columnNames()
 		for (let chunk = await stream.fetchChunk(); chunk && chunk.rowCount > 0; chunk = await stream.fetchChunk()) {
 			for (const r of chunk.getRowObjects(cols) as Record<string, unknown>[]) {
 				if (r.geom == null) continue
+				if (antimeridianWrapped(String(r.geom))) continue
 				const fog = Number(r.fog)
 				const props = {
 					fog: Math.round(fog * 1000) / 1000,
 					fog_opt: Math.round(fog ** opts.optimisticGamma * 1000) / 1000,
 					pt: Number(r.pt ?? 0),
 					seg: Number(r.seg ?? 0),
+					pc: Number(r.pc ?? 0),
 					res,
 				}
 				sink.write(`${prefix}${JSON.stringify(props)},"geometry":${String(r.geom)}}\n`)
@@ -260,6 +305,84 @@ export async function buildCoverageTiles(
 			 SELECT pt, seg, 1.0 - cov AS fog, ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cellR))) AS geom FROM agg`
 		)
 	}
+
+	// --- Global "where do we need data" holes layer (civilization − coverage) ---
+	// The map's job worldwide: make it obvious where human civilization is AND whether we cover it. A
+	// SALIENT place we don't cover is a gray hole = work to do. We model it as fog = salience·(1−cov):
+	//   • salience ∈ [0,1] — WOF settlement places weighted by population/importance (a 1-ring halo), so
+	//     a big uncovered city is a dark hole, a hamlet a faint one, the empty steppe nothing.
+	//   • cov ∈ [0,1] — postcode presence (GeoNames) clears the hole (a postcode = we can geocode here).
+	//     US is excluded — the rooftop fine map above already covers it at street level.
+	// Only cells with residual fog (uncovered salient places) are emitted, so the layer is just the
+	// HOLES — covered + empty stay clear (basemap). Same `coverage` layer + fog props as the US tier, so
+	// the demo renders it unchanged, at res-domainRes [onset…max] + a res-4 low-zoom rollup.
+	if (opts.geonamesPostalFile && opts.wofDb) {
+		const exclude = opts.postcodeExcludeCountries.map((c) => `'${c.toUpperCase()}'`).join(", ") || "''"
+		onProgress("holes", "postcode coverage + civilization salience → holes…")
+		// pc_cov: postcode COVERAGE per domain cell — flat presence (postcode ∪ 1-ring), clears the hole.
+		await duck.run(`
+			CREATE TEMP TABLE pc_cov AS
+			WITH data_pc AS (
+				SELECT h3_latlng_to_cell(lat, lon, ${opts.domainRes}) AS cell
+				FROM (
+					SELECT column00 AS cc, TRY_CAST(column09 AS DOUBLE) AS lat, TRY_CAST(column10 AS DOUBLE) AS lon
+					FROM read_csv('${opts.geonamesPostalFile}', delim='\t', header=false, quote='', ignore_errors=true, all_varchar=true)
+				)
+				WHERE lat IS NOT NULL AND lon IS NOT NULL AND lat BETWEEN -90 AND 90 AND lon BETWEEN -180 AND 180
+					AND cc NOT IN (${exclude})
+			)
+			SELECT DISTINCT UNNEST(h3_grid_disk(cell, 1)) AS cell, ${opts.postcodeCeiling}::DOUBLE AS cov FROM data_pc
+		`)
+		// sal: CIVILIZATION salience per domain cell — WOF settlement places weighted by IMPORTANCE
+		// (Wikipedia notability via place_importance, with a population fallback baked in by
+		// build-importance). importance is already ∈ [0,1] with major cities ≈ 0.85–0.99, so it IS the
+		// salience: a big uncovered city → dark hole, a hamlet → faint. Only places carrying a signal
+		// count as "civilization" (the unknown long tail is dropped, not flagged as work-to-do). Each
+		// place spreads to a 1-ring halo; a cell's salience is the strongest place touching it.
+		await duck.run(`
+			CREATE TEMP TABLE sal AS
+			WITH places AS (
+				-- sqrt lifts the mid-range so even modest uncovered towns read as a visible hole while
+				-- keeping the importance ORDER (big cities stay darkest) — "obvious work to do".
+				SELECT s.latitude AS lat, s.longitude AS lon, sqrt(imp.importance) AS sal
+				FROM wof.spr s JOIN wof.place_importance imp ON imp.id = s.id
+				WHERE s.placetype IN ('locality','localadmin','borough','neighbourhood','macrohood','microhood')
+					AND s.is_current = 1 AND s.country NOT IN (${exclude})
+					AND s.latitude BETWEEN -90 AND 90 AND s.longitude BETWEEN -180 AND 180
+					AND imp.importance >= ${opts.salienceFloor}
+			),
+			spread AS (SELECT UNNEST(h3_grid_disk(h3_latlng_to_cell(lat, lon, ${opts.domainRes}), 1)) AS cell, sal FROM places)
+			SELECT cell, max(sal) AS salience FROM spread GROUP BY cell
+		`)
+		// holes: fog = salience·(1−cov). Keep only residual fog > 0.05 (the actual holes); covered +
+		// empty cells are dropped → clear basemap.
+		await duck.run(`
+			CREATE TEMP TABLE pc_cells AS
+			SELECT s.cell AS cell, 0::BIGINT AS pc,
+			       s.salience * (1.0 - COALESCE(c.cov, 0)) AS fog
+			FROM sal s LEFT JOIN pc_cov c USING (cell)
+			WHERE s.salience * (1.0 - COALESCE(c.cov, 0)) > 0.05
+		`)
+		postcodeCells = Number(
+			(await duck.runAndReadAll("SELECT count(*) AS n FROM pc_cells")).getRowObjects()[0]!.n as bigint
+		)
+		const pcOnset = RES_ONSET_ZOOM[opts.domainRes] ?? 5
+		onProgress("holes", `${postcodeCells.toLocaleString()} uncovered-civilization holes → res ${opts.domainRes}`)
+		// res-domainRes holes, visible from their onset zoom up through the tile max (overzoomed above).
+		await emitResolution(
+			opts.domainRes,
+			`SELECT pc, fog, ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geom FROM pc_cells`,
+			[pcOnset, opts.tileMaxZoom]
+		)
+		// res-4 low-zoom rollup (mean child fog) for the world/continent view.
+		await emitResolution(
+			4,
+			`WITH agg AS (SELECT h3_cell_to_parent(cell, 4) AS cellR, avg(fog) AS fog FROM pc_cells GROUP BY 1)
+			 SELECT 0::BIGINT AS pc, fog, ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cellR))) AS geom FROM agg`,
+			[0, pcOnset - 1]
+		)
+	}
+
 	await new Promise<void>((resolve, reject) => sink.end((err?: Error | null) => (err ? reject(err) : resolve())))
 
 	// --- tippecanoe → PMTiles ---
@@ -272,7 +395,7 @@ export async function buildCoverageTiles(
 		"-n",
 		"Mailwoman address coverage",
 		"-A",
-		"© Sister Software · Overture / OpenAddresses / TIGER",
+		"© Sister Software · Overture / OpenAddresses / TIGER / GeoNames",
 		"--minimum-zoom",
 		"0",
 		"--maximum-zoom",
@@ -302,6 +425,7 @@ export async function buildCoverageTiles(
 		domainCells,
 		withPoints,
 		streetOnly,
+		postcodeCells,
 		features: featureCount,
 		pmtilesBytes,
 	}


### PR DESCRIPTION
Turns the demo's address-coverage "fog of war" from a **US-rooftop footprint** into a **global "where do we need data" map**, while leaving the US rooftop fine map untouched. Published live as `coverage-v5`.

## The model

A second layer in the same `coverage` tileset (same `fog`/`fog_opt` props, so the demo's two fill layers + LayerToggleControl render it with zero wiring changes):

```
fog = salience · (1 − coverage)
```

- **coverage** — GeoNames `allCountries` postal centroids (121 countries). A postcode means we can geocode here, so it **clears** the hole. US excluded (rooftop covers it).
- **salience** — WOF settlement places weighted by `place_importance` (Wikipedia notability + population fallback), `sqrt`-curved so modest uncovered towns still read while big cities stay darkest.
- Only residual holes (uncovered, salient places) are drawn — covered + empty stay clear, so the layer is small (~293K res-6 cells). Antimeridian-guarded.

The holes land where **civilization exists but our data doesn't** — Africa, the Middle East, C/S Asia, South America, and real gaps like **UK/Ireland** (Royal Mail isn't in open GeoNames). Covered civilization (US rooftop, EU postcode) reads clear.

## What's in this PR

- `mailwoman/coverage-core.ts` + `commands/coverage/build.tsx` — the holes layer + its flags (`--geonames-postal`, `--wof-db`, `--postcode-ceiling`, `--salience-floor`, `--postcode-exclude`, `--no-postcode`). Decoupled from the (unchanged) US rooftop pipeline.
- `cartographer/coverage/index.ts` — `CoverageTileSetID` → `coverage-v5`; docstrings describe the two-layer tileset. Layer IDs + fill specs unchanged → demo follows automatically.
- `docs/articles/plan/reference/coverage-overlay.mdx` — rewritten for the global map: the build-importance refresh step, the holes tuning flags, the `coverage-v5` publish/verify, refreshed follow-ups.

## Already shipped (operational)

- **`coverage-v5.pmtiles` published** to `nexus-assets/tiles/` (1,042,010,569 bytes; 59.17M features = 57.6M US rooftop + 293K global holes). TileJSON serves 200 with global bounds; real tiles verified over Africa.
- Salience source `place_importance` built (`scripts/build-importance.ts`) onto a **copy** of the WOF DB — the canonical gazetteer the resolver uses is untouched.

## Verification

Rendered the **live** published tileset with the demo's exact Rebecca-Purple fog: global holes show (Africa/ME/Asia/S.America/UK purple), Western/Central Europe clear, and the **US rooftop fine map is fully intact** (city-clear / rural-purple density texture). `yarn compile` clean.

## Follow-ups (the map now names them)

Close real holes with data: UK/Ireland (Code-Point Open / OA), and EU **rooftop** from the Overture address parquets already on disk (upgrades EU from postcode-coarse to street-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)