### PR TITLE
feat(osm,neural): FR rooftop precision — OSM tier + bare-street parse fix

### DIFF
--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -146,7 +146,18 @@ export interface AddressPointHit {
  * contract.
  */
 export interface AddressPointLookup {
-	find(query: { street: string; number: string; postcode?: string; locality?: string }): AddressPointHit | null
+	find(query: {
+		street: string
+		number: string
+		postcode?: string
+		locality?: string
+		/**
+		 * Optional bbox scope (`minLat`/`maxLat`/`minLon`/`maxLon`), tried AFTER postcode/locality. For shards whose points
+		 * carry no postcode/locality of their own (OSM addr nodes often don't) but DO carry a coordinate — the resolved
+		 * locality's bounding box scopes the `(street, number)` probe instead. US situs never passes it (byte-stable).
+		 */
+		bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
+	}): AddressPointHit | null
 }
 
 /**
@@ -277,6 +288,13 @@ export interface ResolveOpts {
 	 * "address_point"`). Opt-in; absent = byte-stable.
 	 */
 	addressPoints?: AddressPointLookup
+	/**
+	 * Pass the resolved locality's BBOX to the address-point lookup as a final scope (#247). For shards whose points
+	 * carry no postcode/locality of their own (OSM addr nodes often don't), the postcode/locality probes miss and the
+	 * lookup falls through to a `(street, number)` probe within the box. OFF by default — US situs never sets it, so
+	 * the bbox arg is simply never supplied and its postcode/locality probes are byte-identical.
+	 */
+	addressPointBboxFallback?: boolean
 	/**
 	 * House-number interpolation tier (#483): consulted ONLY when the exact address-point tier ({@link addressPoints})
 	 * did NOT stamp the street node — the "after the exact-point fall-through" semantics. On hit, stamps the estimate

--- a/corpus-python/src/mailwoman_train/configs/v1.9.4-fr-bare-street.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v1.9.4-fr-bare-street.yaml
@@ -1,0 +1,181 @@
+# === v1.9.4-fr-bare-street (#251/#148 — teach the FR street→locality boundary WITHOUT a postcode anchor) ===
+# FULL RUN (probe GREEN: 2k-step step-082000 gave bare-FR street-intact 89→92%, demo "Rue du Chevaleret,
+# Paris" FIXED, US 4/4 tag-identical → imbalance confirmed, not modeling deficit). Continue from the probe's
+# step-082000 (--resume auto) to step-092000 (+10k); eval every 2k → gate each checkpoint (US per-tag floors)
+# and ship the FR-up/US-held sweet spot. SAME single variable (the fr-bare-street shard) — clean attribution.
+# v1.9.3a3 (shipped v4.16.x) is verbatim below EXCEPT: corpus_dir → the v0.9.4 overlay, and ONE new
+# source_weight (synth-fr-bare-street). Everything else — model, anchor knobs, class_weights, country_weights,
+# the other source_weights, LR/schedule — is IDENTICAL to v193a3, so the SINGLE variable is the new shard
+# (clean attribution).
+#
+# ROOT MECHANISM (DeepSeek Pro 019f1097 + libpostal's own documented practice, both independent): every
+# comprehensive FR source (BAN, OSM) is postcode-COMPLETE, so the decoder learned the FR street→locality
+# boundary as "the token after the 5-digit postcode," NEVER as "comma + city." Strip the postcode and proper-
+# noun street tokens leak into the following locality ("Rue René Cassin, Paris" → street="Rue Ren",
+# locality="Cassin"). Measured: 90% FR streets intact, a ~10% bare-no-postcode tail that owns the demo
+# address. NOT data absence (BAN is in the corpus) — postcode-anchoring DISTRIBUTION imbalance.
+#
+# THE CHANGE (ONE variable): the synth-fr-bare-street shard — 10.8k real BAN (street, number, city) tuples
+# rendered as the MISSING distribution: bare comma form "<n> Rue <proper-noun name>, <City>", NO postcode.
+# BAN-sourced (Licence Ouverte / permissive) on purpose — the model must stay clean of the ODbL OSM data
+# (that is quarantined to the opt-in rooftop shards). Weight 6.0 = the targeted-fix precedent
+# (synth-german / synth-fr-admin-split / gnaf all 6.0).
+#
+# GATE (the probe — falsifies coverage-imbalance vs modeling-deficit, per DeepSeek): re-run
+# scripts/diagnostic/fr-parse-recall.ts (bare FR street-intact rate, target the 90%→tail) AND US/intl
+# no-regression (the per-tag floors). MOVES → imbalance confirmed → scale to a full run within the $20 cap.
+# FLAT → modeling deficit (comma-boundary feature / decoder), a different fix. conventions-loss-mask is OFF
+# in this lineage already (v193a3), and FR street_prefix is taught by synth-fr-admin-split today, so the
+# v1.6.0 ~7M-loss mask blow-up does NOT apply here. NOT promoted without operator GO + the gate.
+# Launch: modal run -d scripts/modal/train_remote.py --config v1.9.4-fr-bare-street.yaml --resume auto
+data:
+  # v0.9.4 overlay = v0.9.3a3's 694 shards VERBATIM (re-rooted to /data) + the 1 fr-bare-street shard.
+  corpus_dir: /data/corpus/versioned/v0.9.4-fr-bare-street/corpus-v0.9.4-fr-bare-street
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights: # VERBATIM from v1.9.3a3 (22 countries) — no new locales (surgical).
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+    ES: 1.0
+    IT: 1.0
+    NL: 1.0
+    PT: 1.0
+    BE: 1.0
+    PL: 1.0
+    AT: 1.0
+    CH: 1.0
+    CZ: 1.0
+    DK: 1.0
+    NO: 1.0
+    SE: 1.0
+    FI: 1.0
+    IE: 1.0
+    GB: 1.0
+    SK: 1.0
+    SI: 1.0
+    HR: 1.0
+    HU: 1.0
+    AU: 1.0
+  source_weights: # VERBATIM from v1.9.3a3 + the one new fr-bare-street shard.
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 3.0
+    synth-fr-admin-split: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    overture: 3.0
+    gnaf: 6.0
+    synth-anchor-absorption: 6.0
+    # #251 NEW: the bare-no-postcode FR street shard. 6.0 = targeted-fix precedent.
+    synth-fr-bare-street: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+  anchor_paint_mode: shaped
+  anchor_value_mode: posterior_latlon
+
+model: # VERBATIM from v1.9.3a3.
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train: # VERBATIM from v1.9.3a3 except output_dir + run_name + max_steps. RESUME from v193a3 step-080000.
+  output_dir: /data/output-v194-fr-bare-street-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  # FULL RUN: --resume auto picks the probe's step-082000 (latest in output_dir); max_steps 92000 → +10k.
+  # Constant LR 1.5e-4; anchor-dropout curriculum at full strength. Eval every 2k → gate 84/86/88/90/92k and
+  # ship the best (FR street-intact up, US floors held).
+  max_steps: 92000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v1.9.4-fr-bare-street-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus/src/shard-recipes/fr-bare-street.ts
+++ b/corpus/src/shard-recipes/fr-bare-street.ts
@@ -1,0 +1,80 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `fr-bare-street` shard recipe (#251) — the postcode-anchoring-imbalance lever. BAN (and every
+ *   other comprehensive FR source) is postcode-COMPLETE, so the model learned the French
+ *   street→locality boundary as "the token after the 5-digit postcode," never as "comma + city." Strip
+ *   the postcode and it leaks the street's proper-noun tokens into the following locality ("Rue René
+ *   Cassin, Paris" → street="Rue Ren", locality="Cassin"). This recipe mints the MISSING distribution:
+ *   the BARE comma form, NO postcode, real `(street, number, city)` tuples from BAN (Licence Ouverte —
+ *   permissive; the model stays clean of ODbL, unlike the opt-in OSM rooftop shards).
+ *
+ *   Each tuple → `<n> <Rue/Avenue/…> <proper-noun name>, <City>` with the FR prefix split
+ *   ({@link decomposeFrStreet}: "Rue" → street_prefix, the rest → street). Tuples whose street carries
+ *   no recognized FR type word are skipped — the failing class is precisely the prefix-led street.
+ *
+ *   ⚠ Convention loss-mask: this recipe TEACHES FR `street_prefix`. The conventions loss-mask forbids it
+ *   for FR and will `-inf` these gold labels (the v1.6.0 ~7M-loss blow-up). Disable that mask for any
+ *   run including this shard.
+ */
+
+import { decomposeFrStreet } from "../adapters/ban/street-decompose.js"
+import { alignAndWrite, makeMulberry32, readTuples, type ShardRecipe, shardSourceId } from "./scaffold.js"
+
+export const frBareStreetRecipe: ShardRecipe = {
+	name: "fr-bare-street",
+	description: "FR bare comma-form street+city, NO postcode (#251): '<n> Rue <name>, <City>' — the postcode-anchoring lever",
+	mode: "tuples",
+	async run(opts, write) {
+		// Seeded for parity with the other recipes; unused beyond reproducibility (the tuples drive the content).
+		makeMulberry32(opts.seed)
+		let read = 0
+		let emitted = 0
+		let skipped = 0
+
+		for await (const t of readTuples(opts.input!)) {
+			read++
+			const fullStreet = String(t.street ?? "").trim()
+			const number = String(t.number ?? "").trim()
+			const locality = String(t.locality ?? "").trim()
+
+			if (!fullStreet || !number || !locality) {
+				skipped++
+				continue
+			}
+			const { prefix, street } = decomposeFrStreet(fullStreet)
+
+			// The failing class is the prefix-led FR street; a no-prefix nom_voie ("La Ville Mois") isn't it.
+			if (!prefix || !street) {
+				skipped++
+				continue
+			}
+			const components: Record<string, string> = {
+				house_number: number,
+				street_prefix: prefix,
+				street,
+				locality,
+			}
+			// BARE comma form, number-before (FR's dominant order), NO postcode — the whole point.
+			const raw = `${number} ${prefix} ${street}, ${locality}`
+			const source_id = shardSourceId("synth-fr-bare-street", { ...components, v: String(read) })
+			const canonical = {
+				raw,
+				components,
+				country: "FR",
+				locale: "fr-FR",
+				source: "synth-fr-bare-street",
+				source_id,
+				corpus_version: "0.9.4",
+				license: "Synthetic — fr-bare-street; (street, number, city) from BAN (Base Adresse Nationale, Licence Ouverte)",
+			}
+
+			if (alignAndWrite(write, canonical, "fr-bare-street")) emitted++
+			else skipped++
+		}
+
+		return { read, emitted, skipped }
+	},
+}

--- a/corpus/src/shard-recipes/index.ts
+++ b/corpus/src/shard-recipes/index.ts
@@ -12,6 +12,7 @@ import { anchorAbsorptionRecipe } from "./anchor-absorption.js"
 import { boundaryStressRecipe } from "./boundary-stress.js"
 import { countryBalancedRecipe } from "./country-balanced.js"
 import { frAdminSplitRecipe } from "./fr-admin-split.js"
+import { frBareStreetRecipe } from "./fr-bare-street.js"
 import { frOrderRecipe } from "./fr-order.js"
 import { germanRecipe } from "./german.js"
 import { houseVenueRecipe } from "./house-venue.js"
@@ -43,6 +44,7 @@ const RECIPES: readonly ShardRecipe[] = [
 	localeRecipe,
 	frOrderRecipe,
 	frAdminSplitRecipe,
+	frBareStreetRecipe,
 	countryBalancedRecipe,
 	boundaryStressRecipe,
 	anchorAbsorptionRecipe,

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -77,6 +77,12 @@ export interface GeocodeDeps {
 	resolver: Resolver
 	/** Per-state shard resolver. Omit for admin-only geocoding. */
 	shards?: ShardResolver
+	/**
+	 * OSM rooftop shards keyed by ISO-3166 alpha-2 country (#247) — the opt-in international precision tier. Consulted
+	 * ONLY when no US per-state situs shard matched (a non-US parse), so the US path is untouched. Inject from
+	 * `@mailwoman/osm`'s `OsmShardProvider`; absent = no OSM tier. ODbL — see `osm/README.md`.
+	 */
+	osmShards?: (country: string) => StateShards
 	/** Country constraint passed to the resolver (e.g. `"US"`). */
 	defaultCountry?: string
 	/**
@@ -285,7 +291,9 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 		await deps.classifier.parse(input, { postcodeRepair: true, normalizeCase: deps.normalizeCase ?? true })
 	)
 	const stateSlug = regionSlugFromTree(tree)
-	const { addressPoints, interpolation } = deps.shards?.(stateSlug) ?? {}
+	const usShards = deps.shards?.(stateSlug) ?? {}
+	let addressPoints = usShards.addressPoints
+	const interpolation = usShards.interpolation
 
 	const opts: ResolveOpts = {}
 
@@ -296,8 +304,12 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	const placeCountry: PlaceCountryFn | null =
 		deps.placeCountry === false ? null : (deps.placeCountry ?? (await loadDefaultPlaceCountry()))
 
+	// The placer's country (in-map, non-OTHER) — reused below to select an OSM rooftop shard for a non-US parse.
+	let placedCountry: string | null = null
+
 	if (placeCountry) {
 		const placed = placeCountry(input)
+		placedCountry = placed.country && placed.country !== "OTHER" ? placed.country : null
 
 		if (placed.country && placed.country !== "OTHER" && !opts.anchorPosterior) {
 			// The full in-map distribution when supplied (resolver breaks ties); else the one-hot argmax.
@@ -314,6 +326,22 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 			)
 
 			if (hardCountry) opts.hardCountry = hardCountry
+		}
+	}
+
+	// OSM international rooftop tier (#247): only when no US situs shard matched (a non-US parse). An explicit
+	// defaultCountry wins; otherwise the coarse placer's country. Bbox fall-through is ON for OSM — its points
+	// often carry no postcode/locality tag, so the resolved locality's box scopes the (street, number) probe.
+	if (!addressPoints) {
+		const country = (deps.defaultCountry ?? placedCountry)?.toLowerCase()
+
+		if (country && country !== "us") {
+			const osm = deps.osmShards?.(country)
+
+			if (osm?.addressPoints) {
+				addressPoints = osm.addressPoints
+				opts.addressPointBboxFallback = true
+			}
 		}
 	}
 

--- a/osm/README.md
+++ b/osm/README.md
@@ -1,0 +1,60 @@
+# @mailwoman/osm
+
+OpenStreetMap rooftop ingestion. This package reads a Geofabrik `.osm.pbf` extract and builds a
+per-country **address-point shard** on the same situs schema the US rooftop tier already uses — so the
+existing `AddressPointSqliteLookup` reads it with zero changes, and the resolver gains street/rooftop
+precision in countries the permissive gazetteer only covers at the admin level.
+
+It is **address-point-first**: we write the exact `addr:housenumber` coordinate (a node, or a building
+polygon's centroid). Interpolation is a separate, confidence-gated tier built only from OSM's explicit
+`addr:interpolation` ways — we never synthesise a house-number line from scattered points, because that
+produces confident wrong answers worse than the admin centroid.
+
+## The licensing boundary — read this first
+
+OpenStreetMap data is licensed under the **ODbL**, which is share-alike on a Derived Database. Mailwoman's
+core gazetteer is built from permissive sources (Who's On First, Overture, OpenAddresses, GeoNames) and we
+keep it that way. So the OSM precision tier is quarantined:
+
+- **This package is code, and code only.** It contains no OSM bytes. You can depend on it, read it, and
+  ship it under the same terms as the rest of Mailwoman.
+- **The ODbL obligation rides on the built shard.** Each `address-points-<cc>-<slug>.db` this package
+  produces is an OSM Derived Database. It is a separately-distributed, opt-in data artifact — you download
+  the countries you want, and you take the share-alike obligation only on those.
+- **The permissive core never touches an OSM byte.** OSM points are not folded into the WOF-keyed
+  gazetteer; they live in their own shards beside it. The `source` on every OSM point is
+  `openstreetmap:<cc>`, so attribution and licence are attributable per-row, and the resolver surfaces
+  "© OpenStreetMap contributors (ODbL)" on any result that resolved through one.
+
+### ⚠ Lawyer sign-off gate
+
+No OSM shard ships to npm, R2, or the public demo until counsel has reviewed how ODbL share-alike applies
+to our distribution model (the opt-in-per-country shard, the attribution surface, and whether serving a
+resolved coordinate from one constitutes a Produced Work or a Derived Database hand-off). The build and the
+local benchmark below are fine to run now; **publishing is blocked on that review.**
+
+## Building a shard
+
+You need GDAL (`ogr2ogr`) on the path — the same dependency `@mailwoman/tiger` uses. GDAL's OSM driver
+resolves node and way/polygon geometries for us, so building-tagged addresses (the dominant German shape)
+aren't lost.
+
+```bash
+# 1. Pull a Geofabrik extract (per-country, or a sub-region to smoke a build):
+#    https://download.geofabrik.de/europe/france/ile-de-france-latest.osm.pbf
+#    → $MAILWOMAN_DATA_ROOT/osm/geofabrik/
+
+# 2. Build the shard (writes $MAILWOMAN_DATA_ROOT/osm/address-points-fr-idf.db):
+node osm/out/scripts/build-rooftop-shard.js \
+  --country fr --slug idf --release 260627 \
+  --pbf $MAILWOMAN_DATA_ROOT/osm/geofabrik/ile-de-france-260627.osm.pbf
+```
+
+The build reports an **association gap** — the share of `addr:housenumber` points it had to skip because
+they carry no `addr:street`. A point with no street is unqueryable, so we count it rather than guess. When
+that gap is large for a country, the fix is a street-association recovery pass (`associatedStreet` relations
+→ enclosing-polygon `addr:street` → point-in-polygon), sized to the measured gap — not built blind.
+
+Supported countries are a deliberately small set (see `streetLocaleForCountry`): each needs a matching
+branch in the locale street normalizer, so adding one is two edits in lockstep, never a silent fold with
+the wrong rules.

--- a/osm/index.ts
+++ b/osm/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `@mailwoman/osm` — OpenStreetMap rooftop address-point ingestion. Permissive code; the ODbL
+ *   obligation rides on the BUILT per-country shards, never on this package. See `./sdk` for the
+ *   ingestion surface and `./scripts/build-rooftop-shard` for the build CLI.
+ */
+
+export * from "./sdk/index.js"

--- a/osm/package.json
+++ b/osm/package.json
@@ -35,7 +35,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "node --test ./out/sdk/street-locale.test.js"
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@mailwoman/core": "workspace:*",

--- a/osm/package.json
+++ b/osm/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@mailwoman/osm",
+	"version": "4.16.2",
+	"description": "OpenStreetMap rooftop address-point ingestion — builds per-country ODbL precision shards on the situs address-point schema.",
+	"keywords": [
+		"openstreetmap",
+		"geospatial",
+		"geocoding",
+		"address-point"
+	],
+	"homepage": "https://github.com/sister-software/mailwoman",
+	"bugs": {
+		"url": "https://github.com/sister-software/mailwoman/issues"
+	},
+	"license": "AGPL-3.0-only",
+	"contributors": [
+		{
+			"name": "Teffen Ellis",
+			"email": "teffen@sister.software"
+		}
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "osm"
+	},
+	"type": "module",
+	"exports": {
+		"./package.json": "./package.json",
+		"./scripts/*": "./out/scripts/*.js",
+		"./sdk": "./out/sdk/index.js",
+		".": "./out/index.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"test": "node --test ./out/sdk/street-locale.test.js"
+	},
+	"dependencies": {
+		"@mailwoman/core": "workspace:*",
+		"@mailwoman/resolver-wof-sqlite": "workspace:*",
+		"@mailwoman/spatial": "workspace:*",
+		"kysely": "^0.29.2"
+	},
+	"engines": {
+		"node": ">=24.18.0"
+	}
+}

--- a/osm/scripts/build-rooftop-shard.ts
+++ b/osm/scripts/build-rooftop-shard.ts
@@ -1,0 +1,171 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build a per-country OSM ROOFTOP address-point shard from a Geofabrik `.osm.pbf` extract, on the
+ *   SHARED situs schema (`@mailwoman/resolver-wof-sqlite/address-point-schema`) so the existing
+ *   `AddressPointSqliteLookup` reads it with zero changes. Address-POINT-first by design: we write the
+ *   exact `addr:housenumber` coordinate (node, or building-polygon centroid). Points with no
+ *   `addr:street` are COUNTED and skipped (the association gap DeepSeek flagged) — we size that gap
+ *   before deciding whether to build the `associatedStreet` / point-in-polygon recovery pass.
+ *
+ *   ⚠ ODbL: the OUTPUT shard is an OpenStreetMap Derived Database (share-alike). This code carries no
+ *   OSM bytes; the obligation rides on the built `.db`. Source = `openstreetmap:<cc>`. See
+ *   `osm/README.md` for the licensing boundary + the lawyer sign-off gate before any shard ships.
+ *
+ *   Usage:
+ *     node --experimental-strip-types osm/scripts/build-rooftop-shard.ts \
+ *       --country fr --slug idf --release 260627 \
+ *       --pbf $MAILWOMAN_DATA_ROOT/osm/geofabrik/ile-de-france-260627.osm.pbf
+ */
+
+import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs"
+import { dirname } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { dataRootPath } from "@mailwoman/core/utils"
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
+import {
+	ADDRESS_POINT_COLUMNS,
+	type AddressPointDatabase,
+	createAddressPointIndexes,
+	createAddressPointTable,
+} from "@mailwoman/resolver-wof-sqlite/address-point-schema"
+import { canonicalizeRouteKey, normalizeLocalityForKey } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+
+import { extractAddrPoints } from "../sdk/extract.js"
+import { normalizeStreetForKeyLocale, streetLocaleForCountry } from "../sdk/street-locale.js"
+
+interface BuildArgs {
+	country: string
+	slug: string
+	pbf: string
+	release: string
+	output: string
+}
+
+function parse(): BuildArgs {
+	const { values } = parseArgs({
+		options: {
+			country: { type: "string" },
+			slug: { type: "string" },
+			pbf: { type: "string" },
+			release: { type: "string" },
+			out: { type: "string" },
+		},
+	})
+
+	const country = values.country?.toLowerCase()
+	const pbf = values.pbf
+
+	if (!country || !pbf) {
+		throw new Error("required: --country <cc> --pbf <path.osm.pbf> [--slug <slug>] [--release <tag>] [--out <path>]")
+	}
+
+	if (!existsSync(pbf)) throw new Error(`PBF not found: ${pbf}`)
+	// Throws for an unsupported country — fail loud, never key with the wrong normalizer.
+	streetLocaleForCountry(country)
+	const slug = values.slug?.toLowerCase() || country
+	const release = values.release || "unknown"
+	const output = values.out || dataRootPath("osm", `address-points-${country}-${slug}.db`)
+
+	return { country, slug, pbf, release, output }
+}
+
+async function main(): Promise<void> {
+	const args = parse()
+	const locale = streetLocaleForCountry(args.country)
+	const source = `openstreetmap:${args.country}`
+	const tmp = `${args.output}.tmp-${process.pid}`
+
+	mkdirSync(dirname(args.output), { recursive: true })
+
+	if (existsSync(tmp)) rmSync(tmp)
+
+	const out = new DatabaseSync(tmp)
+	out.exec("PRAGMA page_size=8192; PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF; PRAGMA cache_size=-2000000;")
+	const kdb = new DatabaseClient<AddressPointDatabase>({ database: out })
+	await createAddressPointTable(kdb)
+
+	const insert = out.prepare(`INSERT INTO address_point VALUES (${ADDRESS_POINT_COLUMNS.map(() => "?").join(", ")})`)
+
+	let total = 0
+	let written = 0
+	let noStreet = 0
+	let badCoord = 0
+	const BATCH = 50_000
+
+	console.error(`[osm] building ${args.country}/${args.slug} rooftop shard from ${args.pbf}`)
+	out.exec("BEGIN")
+
+	for await (const rec of extractAddrPoints(args.pbf)) {
+		total++
+
+		if (rec.street == null) {
+			noStreet++
+			continue
+		}
+		const streetNorm = normalizeStreetForKeyLocale(rec.street, locale)
+		const number = rec.housenumber.trim().toLowerCase()
+
+		if (!streetNorm || !number) {
+			noStreet++
+			continue
+		}
+
+		if (!Number.isFinite(rec.lat) || !Number.isFinite(rec.lon)) {
+			badCoord++
+			continue
+		}
+		// Positional, in ADDRESS_POINT_COLUMNS order: street_norm, street_key, number, unit, postcode,
+		// locality_norm, street_raw, lat, lon, source, release.
+		insert.run(
+			streetNorm,
+			canonicalizeRouteKey(streetNorm),
+			number,
+			null,
+			rec.postcode?.trim() || null,
+			rec.city ? normalizeLocalityForKey(rec.city) : null,
+			rec.street,
+			rec.lat,
+			rec.lon,
+			source,
+			args.release
+		)
+		written++
+
+		if (written % BATCH === 0) {
+			out.exec("COMMIT")
+			out.exec("BEGIN")
+
+			if (written % 500_000 === 0) console.error(`[osm]   ${written.toLocaleString()} written…`)
+		}
+	}
+	out.exec("COMMIT")
+
+	console.error(`[osm] indexing…`)
+	await createAddressPointIndexes(kdb)
+	out.exec("ANALYZE")
+	await kdb.destroy()
+
+	// Build-on-copy: only now swap the freshly-built shard into place (move any prior aside first).
+	if (existsSync(args.output)) renameSync(args.output, `${args.output}.prev`)
+	renameSync(tmp, args.output)
+
+	if (existsSync(`${args.output}.prev`)) rmSync(`${args.output}.prev`)
+
+	const gap = total > 0 ? ((noStreet / total) * 100).toFixed(1) : "0.0"
+
+	console.error(
+		`[osm] DONE ${args.output}\n` +
+			`      total addr:housenumber features : ${total.toLocaleString()}\n` +
+			`      written (had addr:street)        : ${written.toLocaleString()}\n` +
+			`      skipped (no addr:street)         : ${noStreet.toLocaleString()}  (${gap}% association gap)\n` +
+			`      skipped (bad coord)              : ${badCoord.toLocaleString()}\n` +
+			`      source                           : ${source}  release=${args.release}`
+	)
+}
+
+await main()

--- a/osm/sdk/extract.ts
+++ b/osm/sdk/extract.ts
@@ -1,0 +1,150 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Stream rooftop address records out of a Geofabrik `.osm.pbf` extract via GDAL/ogr2ogr — the same
+ *   external-geo-CLI pattern `@mailwoman/tiger` uses for shapefiles. GDAL's OSM driver resolves node
+ *   AND way/polygon geometries for us, so a building tagged with `addr:housenumber` (the dominant DE
+ *   shape) becomes a point via its centroid — we don't hit the pure-JS "ways need a node-location
+ *   cache" wall.
+ *
+ *   Address tags live in the driver's `other_tags` hstore; we pull them with OGRSQL `hstore_get_value`
+ *   over the `points` (nodes) and `multipolygons` (building ways/relations) layers. `addr:interpolation`
+ *   ways are intentionally NOT read here — the rooftop tier is point-first; explicit interpolation is a
+ *   separate, confidence-gated tier (never synthesize a number line from scattered points).
+ */
+
+import { spawn } from "node:child_process"
+import { createInterface } from "node:readline"
+
+/** One OSM address feature, geometry already reduced to a single representative coordinate. */
+export interface OsmAddrRecord {
+	/** `addr:housenumber` — always present (the extract filters on it). */
+	housenumber: string
+	/** `addr:street` — null when the point carries no street tag (the association gap; counted, not written). */
+	street: string | null
+	postcode: string | null
+	city: string | null
+	lon: number
+	lat: number
+}
+
+/** The OSM driver layers that can carry `addr:housenumber`: nodes and building ways/relations. */
+const ADDR_LAYERS = ["points", "multipolygons"] as const
+
+/** OGRSQL projecting the four `addr:*` tags out of the `other_tags` hstore, filtered to rows that have a house number. */
+function addrSql(layer: string): string {
+	return (
+		`SELECT hstore_get_value(other_tags,'addr:housenumber') AS housenumber, ` +
+		`hstore_get_value(other_tags,'addr:street') AS street, ` +
+		`hstore_get_value(other_tags,'addr:postcode') AS postcode, ` +
+		`hstore_get_value(other_tags,'addr:city') AS city ` +
+		`FROM ${layer} WHERE other_tags LIKE '%addr:housenumber%'`
+	)
+}
+
+const isFinitePair = (lon: unknown, lat: unknown): boolean =>
+	typeof lon === "number" && typeof lat === "number" && Number.isFinite(lon) && Number.isFinite(lat)
+
+/** Reduce a GeoJSON geometry to one representative coordinate: the point itself, or a ring-vertex average for a polygon. */
+function representativePoint(geom: { type?: string; coordinates?: unknown } | null | undefined): [number, number] | null {
+	if (!geom) return null
+
+	if (geom.type === "Point") {
+		const c = geom.coordinates as [number, number]
+
+		return isFinitePair(c?.[0], c?.[1]) ? [c[0], c[1]] : null
+	}
+
+	const ring = (
+		geom.type === "Polygon"
+			? (geom.coordinates as number[][][])?.[0]
+			: geom.type === "MultiPolygon"
+				? (geom.coordinates as number[][][][])?.[0]?.[0]
+				: null
+	) as number[][] | null
+
+	if (!ring || ring.length === 0) return null
+
+	// Average the exterior-ring vertices (dropping the duplicated closing vertex). For a single
+	// building footprint this lands a few metres inside the roof — fine for the rooftop tier.
+	let n = ring.length
+
+	if (n > 1 && ring[0]![0] === ring[n - 1]![0] && ring[0]![1] === ring[n - 1]![1]) n--
+	let sx = 0
+	let sy = 0
+
+	for (let i = 0; i < n; i++) {
+		sx += ring[i]![0]!
+		sy += ring[i]![1]!
+	}
+	const lon = sx / n
+	const lat = sy / n
+
+	return isFinitePair(lon, lat) ? [lon, lat] : null
+}
+
+function toRecord(feature: { properties?: Record<string, unknown>; geometry?: { type?: string; coordinates?: unknown } }): OsmAddrRecord | null {
+	const p = feature.properties ?? {}
+	const housenumber = p["housenumber"]
+
+	if (housenumber == null || housenumber === "") return null
+	const pt = representativePoint(feature.geometry)
+
+	if (!pt) return null
+
+	return {
+		housenumber: String(housenumber),
+		street: p["street"] != null && p["street"] !== "" ? String(p["street"]) : null,
+		postcode: p["postcode"] != null && p["postcode"] !== "" ? String(p["postcode"]) : null,
+		city: p["city"] != null && p["city"] !== "" ? String(p["city"]) : null,
+		lon: pt[0],
+		lat: pt[1],
+	}
+}
+
+/** Run ogr2ogr against one layer, yielding parsed records from its GeoJSONSeq stdout. */
+async function* runLayer(pbfPath: string, layer: string): AsyncGenerator<OsmAddrRecord> {
+	const args = ["-f", "GeoJSONSeq", "/vsistdout/", "-dialect", "OGRSQL", "-sql", addrSql(layer), pbfPath]
+	const proc = spawn("ogr2ogr", args, { stdio: ["ignore", "pipe", "pipe"] })
+	let stderr = ""
+
+	proc.stderr.on("data", (d: Buffer) => {
+		stderr += d.toString()
+	})
+	const exit = new Promise<number>((resolve, reject) => {
+		proc.on("error", reject)
+		proc.on("close", resolve)
+	})
+	const rl = createInterface({ input: proc.stdout!, crlfDelay: Infinity })
+
+	for await (const raw of rl) {
+		// GeoJSONSeq is newline-delimited; some GDAL builds prefix each record with an RS (0x1e).
+		const line = raw.replace(/^/, "").trim()
+
+		if (!line) continue
+		let feature: { properties?: Record<string, unknown>; geometry?: { type?: string; coordinates?: unknown } }
+
+		try {
+			feature = JSON.parse(line)
+		} catch {
+			continue
+		}
+		const rec = toRecord(feature)
+
+		if (rec) yield rec
+	}
+	const code = await exit
+
+	if (code !== 0) throw new Error(`ogr2ogr (${layer}) exited ${code}: ${stderr.slice(-800)}`)
+}
+
+/**
+ * Stream every `addr:housenumber`-bearing feature from a PBF extract (nodes + building polygons),
+ * geometry reduced to a representative coordinate. Records with no `addr:street` are still yielded
+ * (street === null) so the caller can COUNT the association gap before deciding to write them.
+ */
+export async function* extractAddrPoints(pbfPath: string): AsyncGenerator<OsmAddrRecord> {
+	for (const layer of ADDR_LAYERS) yield* runLayer(pbfPath, layer)
+}

--- a/osm/sdk/fetch.ts
+++ b/osm/sdk/fetch.ts
@@ -1,0 +1,51 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Geofabrik extract URLs + a streaming downloader. Geofabrik is the OSM ecosystem's de-facto
+ *   regional-extract host: a cascade of continent → country → sub-region `.osm.pbf` files
+ *   (`europe/france/ile-de-france-latest.osm.pbf`). We pull per-COUNTRY extracts (the ecosystem's
+ *   default shard unit — matching Photon's per-country dumps and our own per-locale weights), and a
+ *   smaller sub-region extract when we only need to smoke a build (Île-de-France for the Paris
+ *   acceptance). The bytes are ODbL OpenStreetMap data — see `osm/README.md`.
+ */
+
+import { createWriteStream } from "node:fs"
+import { Readable } from "node:stream"
+import { pipeline } from "node:stream/promises"
+
+const GEOFABRIK_BASE = "https://download.geofabrik.de"
+
+/**
+ * The URL of a Geofabrik `-latest.osm.pbf` extract for a region path like `europe/france/ile-de-france`
+ * or `europe/germany`. Pass the path WITHOUT the `-latest.osm.pbf` suffix.
+ */
+export function geofabrikUrl(regionPath: string): string {
+	const clean = regionPath.replace(/^\/+|\/+$/g, "")
+
+	return `${GEOFABRIK_BASE}/${clean}-latest.osm.pbf`
+}
+
+/**
+ * Download a Geofabrik extract to `destPath`, streaming (these run to several GB for a whole country).
+ * Returns the byte count written. The caller owns where the file lands (typically
+ * `$MAILWOMAN_DATA_ROOT/osm/geofabrik/`).
+ */
+export async function downloadExtract(regionPath: string, destPath: string): Promise<number> {
+	const url = geofabrikUrl(regionPath)
+	const res = await fetch(url)
+
+	if (!res.ok || !res.body) throw new Error(`Geofabrik download failed (${res.status}) for ${url}`)
+	let bytes = 0
+	const counter = new TransformStream<Uint8Array, Uint8Array>({
+		transform(chunk, controller) {
+			bytes += chunk.byteLength
+			controller.enqueue(chunk)
+		},
+	})
+
+	await pipeline(Readable.fromWeb(res.body.pipeThrough(counter)), createWriteStream(destPath))
+
+	return bytes
+}

--- a/osm/sdk/index.ts
+++ b/osm/sdk/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `@mailwoman/osm` SDK — the OpenStreetMap rooftop ingestion surface. PERMISSIVE CODE ONLY: this
+ *   workspace contains no OSM data bytes. It reads a Geofabrik `.osm.pbf` extract (the ODbL source)
+ *   and writes a per-country rooftop address-point shard on the SHARED situs schema
+ *   (`@mailwoman/resolver-wof-sqlite/address-point-schema`). The ODbL obligation rides on the BUILT
+ *   shard (a Derived Database), never on this code. See `osm/README.md` for the licensing boundary.
+ */
+
+export * from "./fetch.js"
+export * from "./extract.js"
+export * from "./street-locale.js"
+export * from "./shard-provider.js"

--- a/osm/sdk/shard-provider.ts
+++ b/osm/sdk/shard-provider.ts
@@ -1,0 +1,68 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The OSM rooftop shard provider — the injection point the geocode cascade consults for the opt-in
+ *   international precision tier (#247). Given a data root, it opens `osm/address-points-<cc>-<cc>.db`
+ *   with the country's street-normalization locale (so probe-side keying matches the shard the builder
+ *   wrote) and caches the open handle per country. Wire its bound `for` into `GeocodeDeps.osmShards`.
+ *
+ *   ⚠ The shards it opens are ODbL OpenStreetMap Derived Databases — see `osm/README.md` for the
+ *   distribution boundary and the lawyer sign-off gate before shipping any of them.
+ */
+
+import { existsSync } from "node:fs"
+
+import { AddressPointSqliteLookup } from "@mailwoman/resolver-wof-sqlite"
+
+import { streetLocaleForCountry, supportedOsmCountries } from "./street-locale.js"
+
+/** What the cascade needs from an OSM shard — structurally a subset of mailwoman's `StateShards`. */
+export interface OsmShards {
+	addressPoints?: AddressPointSqliteLookup
+}
+
+/**
+ * Opens + caches per-country OSM rooftop lookups. A non-US geocode consults `for(country)`; the first hit
+ * for a country opens its shard (with the matching street locale) once, subsequent calls reuse it.
+ */
+export class OsmShardProvider {
+	readonly #dataRoot: string
+	readonly #cache = new Map<string, OsmShards>()
+
+	constructor(dataRoot: string) {
+		this.#dataRoot = dataRoot
+	}
+
+	#shardPath(countryCode: string): string {
+		return `${this.#dataRoot}/osm/address-points-${countryCode}-${countryCode}.db`
+	}
+
+	/** Resolve the OSM shards for an ISO-3166 alpha-2 country, or `{}` when none is shipped/registered. */
+	readonly for = (country: string): OsmShards => {
+		const cc = country.toLowerCase()
+		const cached = this.#cache.get(cc)
+
+		if (cached) return cached
+
+		let entry: OsmShards = {}
+
+		// Only countries with a registered street locale AND an on-disk shard — never key with the wrong rules.
+		if (supportedOsmCountries().includes(cc)) {
+			const path = this.#shardPath(cc)
+
+			if (existsSync(path)) {
+				entry = { addressPoints: new AddressPointSqliteLookup(path, { streetLocale: streetLocaleForCountry(cc) }) }
+			}
+		}
+		this.#cache.set(cc, entry)
+
+		return entry
+	}
+
+	close(): void {
+		for (const entry of this.#cache.values()) entry.addressPoints?.close()
+		this.#cache.clear()
+	}
+}

--- a/osm/sdk/street-locale.test.ts
+++ b/osm/sdk/street-locale.test.ts
@@ -8,8 +8,7 @@
  *   folding (and the Paris acceptance key) so a future tweak can't silently desync the two sides.
  */
 
-import assert from "node:assert/strict"
-import { test } from "node:test"
+import { expect, test } from "vitest"
 
 import { normalizeStreetForKeyLocale } from "@mailwoman/resolver-wof-sqlite/street-normalize"
 
@@ -17,38 +16,38 @@ import { streetLocaleForCountry, supportedOsmCountries } from "./street-locale.j
 
 test("fr: the Paris acceptance address keys consistently", () => {
 	const key = normalizeStreetForKeyLocale("Rue du Chevaleret", "fr")
-	assert.equal(key, "rue du chevaleret")
+	expect(key).toBe("rue du chevaleret")
 	// however a downstream source spells it, it folds to the same key
-	assert.equal(normalizeStreetForKeyLocale("rue du chevaleret", "fr"), key)
+	expect(normalizeStreetForKeyLocale("rue du chevaleret", "fr")).toBe(key)
 })
 
 test("fr: leading type abbreviations + Saint expand", () => {
-	assert.equal(normalizeStreetForKeyLocale("Av. des Champs-Élysées", "fr"), "avenue des champs elysees")
-	assert.equal(normalizeStreetForKeyLocale("Bd Saint-Germain", "fr"), "boulevard saint germain")
-	assert.equal(normalizeStreetForKeyLocale("Rue St-Honoré", "fr"), "rue saint honore")
-	assert.equal(normalizeStreetForKeyLocale("Pl. de la République", "fr"), "place de la republique")
+	expect(normalizeStreetForKeyLocale("Av. des Champs-Élysées", "fr")).toBe("avenue des champs elysees")
+	expect(normalizeStreetForKeyLocale("Bd Saint-Germain", "fr")).toBe("boulevard saint germain")
+	expect(normalizeStreetForKeyLocale("Rue St-Honoré", "fr")).toBe("rue saint honore")
+	expect(normalizeStreetForKeyLocale("Pl. de la République", "fr")).toBe("place de la republique")
 })
 
 test("de: glued -str(.) / -straße all fold to -strasse", () => {
 	const k = "lindenstrasse"
-	assert.equal(normalizeStreetForKeyLocale("Lindenstraße", "de"), k)
-	assert.equal(normalizeStreetForKeyLocale("Lindenstr.", "de"), k)
-	assert.equal(normalizeStreetForKeyLocale("Lindenstr", "de"), k)
-	assert.equal(normalizeStreetForKeyLocale("lindenstrasse", "de"), k)
+	expect(normalizeStreetForKeyLocale("Lindenstraße", "de")).toBe(k)
+	expect(normalizeStreetForKeyLocale("Lindenstr.", "de")).toBe(k)
+	expect(normalizeStreetForKeyLocale("Lindenstr", "de")).toBe(k)
+	expect(normalizeStreetForKeyLocale("lindenstrasse", "de")).toBe(k)
 	// a non-str name is untouched
-	assert.equal(normalizeStreetForKeyLocale("Marienplatz", "de"), "marienplatz")
+	expect(normalizeStreetForKeyLocale("Marienplatz", "de")).toBe("marienplatz")
 })
 
 test("nl: glued -str folds to -straat", () => {
-	assert.equal(normalizeStreetForKeyLocale("Kerkstraat", "nl"), "kerkstraat")
-	assert.equal(normalizeStreetForKeyLocale("Kerkstr.", "nl"), "kerkstraat")
-	assert.equal(normalizeStreetForKeyLocale("Kerkstr", "nl"), "kerkstraat")
+	expect(normalizeStreetForKeyLocale("Kerkstraat", "nl")).toBe("kerkstraat")
+	expect(normalizeStreetForKeyLocale("Kerkstr.", "nl")).toBe("kerkstraat")
+	expect(normalizeStreetForKeyLocale("Kerkstr", "nl")).toBe("kerkstraat")
 })
 
 test("streetLocaleForCountry: maps the shipped countries, throws otherwise", () => {
-	assert.equal(streetLocaleForCountry("FR"), "fr")
-	assert.equal(streetLocaleForCountry("de"), "de")
-	assert.equal(streetLocaleForCountry("nl"), "nl")
-	assert.deepEqual(supportedOsmCountries().sort(), ["de", "fr", "nl"])
-	assert.throws(() => streetLocaleForCountry("xx"), /No street-normalization locale/)
+	expect(streetLocaleForCountry("FR")).toBe("fr")
+	expect(streetLocaleForCountry("de")).toBe("de")
+	expect(streetLocaleForCountry("nl")).toBe("nl")
+	expect(supportedOsmCountries().sort()).toEqual(["de", "fr", "nl"])
+	expect(() => streetLocaleForCountry("xx")).toThrow(/No street-normalization locale/)
 })

--- a/osm/sdk/street-locale.test.ts
+++ b/osm/sdk/street-locale.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build/probe CONSISTENCY is the only contract the locale normalizer must hold: the OSM `addr:street`
+ *   tag and the parser's `street` constituent must fold to the same key. These cases lock the FR/DE/NL
+ *   folding (and the Paris acceptance key) so a future tweak can't silently desync the two sides.
+ */
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { normalizeStreetForKeyLocale } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+
+import { streetLocaleForCountry, supportedOsmCountries } from "./street-locale.js"
+
+test("fr: the Paris acceptance address keys consistently", () => {
+	const key = normalizeStreetForKeyLocale("Rue du Chevaleret", "fr")
+	assert.equal(key, "rue du chevaleret")
+	// however a downstream source spells it, it folds to the same key
+	assert.equal(normalizeStreetForKeyLocale("rue du chevaleret", "fr"), key)
+})
+
+test("fr: leading type abbreviations + Saint expand", () => {
+	assert.equal(normalizeStreetForKeyLocale("Av. des Champs-Élysées", "fr"), "avenue des champs elysees")
+	assert.equal(normalizeStreetForKeyLocale("Bd Saint-Germain", "fr"), "boulevard saint germain")
+	assert.equal(normalizeStreetForKeyLocale("Rue St-Honoré", "fr"), "rue saint honore")
+	assert.equal(normalizeStreetForKeyLocale("Pl. de la République", "fr"), "place de la republique")
+})
+
+test("de: glued -str(.) / -straße all fold to -strasse", () => {
+	const k = "lindenstrasse"
+	assert.equal(normalizeStreetForKeyLocale("Lindenstraße", "de"), k)
+	assert.equal(normalizeStreetForKeyLocale("Lindenstr.", "de"), k)
+	assert.equal(normalizeStreetForKeyLocale("Lindenstr", "de"), k)
+	assert.equal(normalizeStreetForKeyLocale("lindenstrasse", "de"), k)
+	// a non-str name is untouched
+	assert.equal(normalizeStreetForKeyLocale("Marienplatz", "de"), "marienplatz")
+})
+
+test("nl: glued -str folds to -straat", () => {
+	assert.equal(normalizeStreetForKeyLocale("Kerkstraat", "nl"), "kerkstraat")
+	assert.equal(normalizeStreetForKeyLocale("Kerkstr.", "nl"), "kerkstraat")
+	assert.equal(normalizeStreetForKeyLocale("Kerkstr", "nl"), "kerkstraat")
+})
+
+test("streetLocaleForCountry: maps the shipped countries, throws otherwise", () => {
+	assert.equal(streetLocaleForCountry("FR"), "fr")
+	assert.equal(streetLocaleForCountry("de"), "de")
+	assert.equal(streetLocaleForCountry("nl"), "nl")
+	assert.deepEqual(supportedOsmCountries().sort(), ["de", "fr", "nl"])
+	assert.throws(() => streetLocaleForCountry("xx"), /No street-normalization locale/)
+})

--- a/osm/sdk/street-locale.ts
+++ b/osm/sdk/street-locale.ts
@@ -1,0 +1,50 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Country → street-normalization-locale routing for the OSM rooftop build. The NORMALIZER itself
+ *   lives in `@mailwoman/resolver-wof-sqlite/street-normalize` (the one-function discipline — the
+ *   reader on the resolver side and the builder here must call the identical function). This module
+ *   only maps an ISO-3166 country code to the locale that selects the right per-locale rules, and
+ *   re-exports the normalizer so the OSM SDK is a self-contained surface.
+ */
+
+import { normalizeStreetForKeyLocale, type StreetLocale } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+
+export { normalizeStreetForKeyLocale, type StreetLocale }
+
+/**
+ * ISO-3166 alpha-2 (lowercase) → the street-normalization locale. Deliberately small: only the
+ * countries we actually ship an OSM rooftop shard for. Adding a country is a one-line entry PLUS the
+ * matching per-locale branch in `normalizeStreetForKeyLocale` — keep them in lockstep.
+ */
+const COUNTRY_TO_STREET_LOCALE = new Map<string, StreetLocale>([
+	["fr", "fr"],
+	["de", "de"],
+	["nl", "nl"],
+])
+
+/**
+ * Resolve the street-normalization locale for a country. Throws for an unsupported country rather than
+ * silently folding with the wrong rules — a shard built with the wrong normalizer keys every street
+ * incorrectly and looks fine until a probe misses. Add the country to {@link COUNTRY_TO_STREET_LOCALE}
+ * (and a branch in `normalizeStreetForKeyLocale`) before building its shard.
+ */
+export function streetLocaleForCountry(countryCode: string): StreetLocale {
+	const locale = COUNTRY_TO_STREET_LOCALE.get(countryCode.toLowerCase())
+
+	if (!locale) {
+		throw new Error(
+			`No street-normalization locale registered for country "${countryCode}". ` +
+				`Add it to COUNTRY_TO_STREET_LOCALE and add the matching branch in normalizeStreetForKeyLocale before building its OSM rooftop shard.`
+		)
+	}
+
+	return locale
+}
+
+/** The countries with a registered OSM rooftop street locale (for CLI validation / help text). */
+export function supportedOsmCountries(): string[] {
+	return [...COUNTRY_TO_STREET_LOCALE.keys()]
+}

--- a/osm/tsconfig.json
+++ b/osm/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "@sister.software/tsconfig",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"emitDeclarationOnly": false,
+		"allowImportingTsExtensions": false
+	},
+	"exclude": ["./out/**/*"],
+	"references": [
+		// ---
+		{ "path": "../core" },
+		{ "path": "../spatial" },
+		{ "path": "../resolver-wof-sqlite" }
+	]
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"resolver",
 		"spatial",
 		"tiger",
+		"osm",
 		"cartographer",
 		"codex",
 		"classifiers",

--- a/resolver-wof-sqlite/address-point-schema.ts
+++ b/resolver-wof-sqlite/address-point-schema.ts
@@ -99,4 +99,9 @@ export async function createAddressPointIndexes(db: Kysely<AddressPointDatabase>
 		.columns(["locality_norm", "street_norm", "number"])
 		.execute()
 	await db.schema.createIndex("idx_ap_streetkey").on("address_point").columns(["postcode", "street_key"]).execute()
+	// Street-first index for the BBOX scope (#247): OSM points often carry no postcode/locality, so the
+	// reader scopes a `(street_norm, number)` probe by the resolved locality's bbox (lat/lon BETWEEN). The
+	// postcode/locality indexes lead with their scope column and can't serve this; US situs never probes by
+	// bbox so it simply carries one extra (cheap) index on a future rebuild.
+	await db.schema.createIndex("idx_ap_street").on("address_point").columns(["street_norm", "number"]).execute()
 }

--- a/resolver-wof-sqlite/address-point.ts
+++ b/resolver-wof-sqlite/address-point.ts
@@ -4,15 +4,15 @@
  * @author Teffen Ellis, et al.
  *
  *   SQLite implementation of core's `AddressPointLookup` (#476): exact `(street, number)` within a
- *   postcode (preferred) or locality scope, against a per-state shard built by
- *   `scripts/build-address-point-shard.ts`. Query-side normalization is THE shared normalizer
- *   (`street-normalize.ts`) — identical to build-side, by construction.
+ *   postcode (preferred), locality, or — for shards whose points carry no scope tag (OSM, #247) —
+ *   the resolved locality's BBOX. Query-side normalization is THE shared normalizer
+ *   (`street-normalize.ts`), selected per the shard's `streetLocale` so build-side and probe-side
+ *   stay identical by construction (US delegates to the USPS pipeline; FR/DE/NL use the locale rules).
  *
  *   Matching is exact-after-normalization only — no fuzzy street matching in this tier (measure how
- *   far exact gets first; fuzz is a later, separate decision). Postcode scope is attempted first
- *   (cheapest, most selective); locality scope is the fallback. Multiple hits (same number,
- *   units/duplicates) return the first by rowid — coordinates of unit siblings are the same
- *   building for tier purposes.
+ *   far exact gets first; fuzz is a later, separate decision). Scope order is most-selective first:
+ *   postcode, then locality, then the bbox fall-through (only when a bbox is supplied AND the prior
+ *   scopes missed). Multiple hits return the first by rowid — unit siblings share the building coord.
  */
 
 import { DatabaseSync } from "node:sqlite"
@@ -21,7 +21,7 @@ import type { AddressPointHit, AddressPointLookup } from "@mailwoman/resolver"
 
 import type { AddressPointTable } from "./address-point-schema.js"
 import { hasTable } from "./sqlite-utils.js"
-import { normalizeLocalityForKey, normalizeStreetForKey } from "./street-normalize.js"
+import { normalizeLocalityForKey, normalizeStreetForKeyLocale, type StreetLocale } from "./street-normalize.js"
 
 /**
  * The columns this lookup projects — a typed slice of the SHARED {@link AddressPointTable}, so a column rename in
@@ -37,11 +37,19 @@ const SELECT_COLS = "lat, lon, source, release"
 
 export class AddressPointSqliteLookup implements AddressPointLookup {
 	readonly #db: DatabaseSync
+	readonly #locale: StreetLocale
 	readonly #byPostcode: ReturnType<DatabaseSync["prepare"]> | undefined
 	readonly #byLocality: ReturnType<DatabaseSync["prepare"]> | undefined
+	readonly #byBbox: ReturnType<DatabaseSync["prepare"]> | undefined
 
-	constructor(dbPath: string) {
+	/**
+	 * @param dbPath shard path.
+	 * @param opts.streetLocale the street-normalization locale this shard was BUILT with — must match, or every key
+	 *   misses. Defaults to `"us"` (the situs tier), so existing callers are unchanged.
+	 */
+	constructor(dbPath: string, opts: { streetLocale?: StreetLocale } = {}) {
 		this.#db = new DatabaseSync(dbPath, { readOnly: true })
+		this.#locale = opts.streetLocale ?? "us"
 
 		// Degrade gracefully on an empty/tableless shard (interrupted build, stray 0-byte file): with no
 		// `address_point` table this lookup is a no-op miss, not a crash that loses the whole state (#568).
@@ -54,12 +62,22 @@ export class AddressPointSqliteLookup implements AddressPointLookup {
 				`SELECT ${SELECT_COLS} FROM address_point
 				 WHERE locality_norm = ? AND street_norm = ? AND number = ? LIMIT 1`
 			)
+			this.#byBbox = this.#db.prepare(
+				`SELECT ${SELECT_COLS} FROM address_point
+				 WHERE street_norm = ? AND number = ? AND lat BETWEEN ? AND ? AND lon BETWEEN ? AND ? LIMIT 1`
+			)
 		}
 	}
 
-	find(query: { street: string; number: string; postcode?: string; locality?: string }): AddressPointHit | null {
-		if (!this.#byPostcode || !this.#byLocality) return null
-		const streetNorm = normalizeStreetForKey(query.street)
+	find(query: {
+		street: string
+		number: string
+		postcode?: string
+		locality?: string
+		bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
+	}): AddressPointHit | null {
+		if (!this.#byPostcode || !this.#byLocality || !this.#byBbox) return null
+		const streetNorm = normalizeStreetForKeyLocale(query.street, this.#locale)
 		const number = query.number.trim().toLowerCase()
 
 		if (!streetNorm || !number) return null
@@ -72,6 +90,15 @@ export class AddressPointSqliteLookup implements AddressPointLookup {
 
 		if (!row && query.locality) {
 			row = this.#byLocality.get(normalizeLocalityForKey(query.locality), streetNorm, number) as
+				| AddressPointRow
+				| undefined
+		}
+
+		// Bbox fall-through (#247): the point carries no postcode/locality of its own, but its coordinate falls
+		// inside the resolved locality's box. Only reached when the scoped probes missed AND a bbox was supplied.
+		if (!row && query.bbox) {
+			const b = query.bbox
+			row = this.#byBbox.get(streetNorm, number, b.minLat, b.maxLat, b.minLon, b.maxLon) as
 				| AddressPointRow
 				| undefined
 		}

--- a/resolver-wof-sqlite/street-normalize.ts
+++ b/resolver-wof-sqlite/street-normalize.ts
@@ -133,6 +133,88 @@ export function normalizeStreetForKey(street: string): string {
 	return tokens.join(" ")
 }
 
+/**
+ * Street-name locale for the address-point key. The US path is the full USPS pipeline
+ * ({@link normalizeStreetForKey}); the international paths fold + apply a SMALL, consistent per-locale
+ * type-token canonicalization. Same discipline as the US normalizer: build side and probe side call
+ * the identical function, so the key only needs to be CONSISTENT, not linguistically perfect — a
+ * folded "rue du chevaleret" keys the same on both sides whether or not we reorder the article, so no
+ * salient-token / multi-key index is built yet (deferred until probing shows the normalizer can't
+ * absorb the false-negatives).
+ */
+export type StreetLocale = "us" | "fr" | "de" | "nl"
+
+/**
+ * French street-type abbreviations → canonical full form, applied per token after {@link fold}. French
+ * address types LEAD the name ("Av. de…", "Bd …", "Pl. …") and "St"/"Ste" abbreviate Saint/Sainte
+ * inside names ("Rue St-Honoré" → "rue saint honore"). fold() has already stripped the trailing period,
+ * so the keys are point-free ("av", "bd").
+ */
+const FR_STREET_ABBREV = new Map<string, string>([
+	["av", "avenue"],
+	["ave", "avenue"],
+	["bd", "boulevard"],
+	["bld", "boulevard"],
+	["bvd", "boulevard"],
+	["boul", "boulevard"],
+	["pl", "place"],
+	["imp", "impasse"],
+	["all", "allee"],
+	["ch", "chemin"],
+	["che", "chemin"],
+	["sq", "square"],
+	["pas", "passage"],
+	["fg", "faubourg"],
+	["fbg", "faubourg"],
+	["rte", "route"],
+	["st", "saint"],
+	["ste", "sainte"],
+	["sts", "saints"],
+])
+
+/**
+ * Normalize a street name for the address-point key in a non-US locale. Same function build-side and
+ * probe-side (the one-function discipline). US delegates to {@link normalizeStreetForKey}.
+ *
+ * - **fr** — fold + expand leading type abbreviations and Saint/Sainte (token map).
+ * - **de** — fold + ß→ss + canonicalize the GLUED `-str(.)` suffix to `-strasse` ("Lindenstr." →
+ *     "lindenstrasse", "Lindenstraße" → "lindenstrasse"); an already-full "-strasse" is left intact.
+ * - **nl** — fold + canonicalize the glued `-str` suffix to `-straat` ("Kerkstr." → "kerkstraat").
+ */
+export function normalizeStreetForKeyLocale(street: string, locale: StreetLocale): string {
+	if (locale === "us") return normalizeStreetForKey(street)
+
+	// Hyphen → space so a compound name keys the same whether the source or the query writes the
+	// hyphen ("Champs-Élysées", "St-Honoré") or a space — both sides fold identically, so this is pure
+	// robustness. It also splits a hyphenated abbreviation ("St-Honoré" → "st honore") into tokens the
+	// per-locale type/Saint map can see.
+	const tokens = fold(street).replace(/ß/g, "ss").replace(/-/g, " ").split(/\s+/).filter(Boolean)
+
+	if (tokens.length === 0) return ""
+
+	switch (locale) {
+		case "fr":
+			for (let i = 0; i < tokens.length; i++) tokens[i] = FR_STREET_ABBREV.get(tokens[i]!) ?? tokens[i]!
+			break
+		case "de":
+			for (let i = 0; i < tokens.length; i++) {
+				const t = tokens[i]!
+
+				if (/str$/.test(t) && !/strasse$/.test(t)) tokens[i] = t.replace(/str$/, "strasse")
+			}
+			break
+		case "nl":
+			for (let i = 0; i < tokens.length; i++) {
+				const t = tokens[i]!
+
+				if (/str$/.test(t) && !/straat$/.test(t)) tokens[i] = t.replace(/str$/, "straat")
+			}
+			break
+	}
+
+	return tokens.join(" ")
+}
+
 /** Normalize a locality name for address-point keying (fold only — no street semantics). */
 export function normalizeLocalityForKey(locality: string): string {
 	return fold(locality)

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -156,10 +156,19 @@ const isDirectionalUnit = (value: string): boolean => isStreetDirectionalToken(v
  * tree's postcode/locality values, and on an exact hit stamp the point onto the STREET node's metadata. Additive only —
  * admin resolution is never altered.
  */
-function applyAddressPoint(roots: AddressNode[], lookup: AddressPointLookup): void {
+/**
+ * Half-width (degrees) of the bbox derived from a resolved locality centroid for the #247 OSM bbox fall-through.
+ * ~0.25° ≈ 28 km N–S — generous enough for a large metro whose centroid sits off the queried point, while the EXACT
+ * `(street, number)` match keeps a cross-commune collision rare. The proper fix is per-point scope backfill (the OSM
+ * association / point-in-polygon pass, #250); this is the coverage stopgap until then.
+ */
+const LOCALITY_BBOX_RADIUS_DEG = 0.25
+
+function applyAddressPoint(roots: AddressNode[], lookup: AddressPointLookup, bboxFallback?: boolean): void {
 	let street: AddressNode | undefined
 	let houseNumber: AddressNode | undefined
 	let directionalUnit: AddressNode | undefined
+	let localityNode: AddressNode | undefined
 	let locality: string | undefined
 	let postcode: string | undefined
 	const stack = [...roots]
@@ -173,18 +182,37 @@ function applyAddressPoint(roots: AddressNode[], lookup: AddressPointLookup): vo
 
 		if (n.tag === "unit" && !directionalUnit && isDirectionalUnit(n.value)) directionalUnit = n
 
-		if (n.tag === "locality" && !locality && n.value.trim()) locality = n.value.trim()
+		if (n.tag === "locality" && !localityNode && n.value.trim()) {
+			localityNode = n
+			locality = n.value.trim()
+		}
 
 		if (n.tag === "postcode" && !postcode && n.value.trim()) postcode = n.value.trim()
 		stack.push(...n.children)
 	}
 
 	if (!street || !houseNumber) return
+
+	// #247 OSM bbox fall-through: when enabled (an OSM shard is wired) and the locality resolved to a
+	// coordinate, scope a final `(street, number)` probe by the locality's box — recovering OSM points that
+	// carry no postcode/locality tag of their own. US situs never enables it, so its probes are byte-identical.
+	let bbox: { minLat: number; maxLat: number; minLon: number; maxLon: number } | undefined
+
+	if (bboxFallback && localityNode?.lat != null && localityNode.lon != null) {
+		bbox = {
+			minLat: localityNode.lat - LOCALITY_BBOX_RADIUS_DEG,
+			maxLat: localityNode.lat + LOCALITY_BBOX_RADIUS_DEG,
+			minLon: localityNode.lon - LOCALITY_BBOX_RADIUS_DEG,
+			maxLon: localityNode.lon + LOCALITY_BBOX_RADIUS_DEG,
+		}
+	}
+
 	const hit = lookup.find({
 		street: assembleStreetValue(street, directionalUnit),
 		number: houseNumber.value,
 		postcode,
 		locality,
+		bbox,
 	})
 
 	if (!hit) return
@@ -433,7 +461,7 @@ class WofResolver implements Resolver {
 		// tier can never disturb admin attribution — it only ADDS the precise coordinate. Byte-stable
 		// when opts.addressPoints is absent.
 		if (opts.addressPoints) {
-			applyAddressPoint(newRoots, opts.addressPoints)
+			applyAddressPoint(newRoots, opts.addressPoints, opts.addressPointBboxFallback)
 		}
 
 		// Interpolation tier (#483): strictly AFTER the exact-point block so an estimate can never

--- a/scripts/diagnostic/export-fr-bare-tuples.ts
+++ b/scripts/diagnostic/export-fr-bare-tuples.ts
@@ -1,0 +1,67 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Export distinct real French (street, number, city) tuples from **BAN** (Base Adresse Nationale —
+ *   France's official address DB, Licence Ouverte / permissive) for the #251 `fr-bare-street`
+ *   augmentation. BAN, NOT OpenStreetMap, on purpose: the augmentation trains the SHIPPED model, which
+ *   must stay permissive — the ODbL OSM data is quarantined to the opt-in rooftop shards and must not
+ *   contaminate the core model. BAN is also the source DeepSeek identified as postcode-COMPLETE, so the
+ *   bare (postcode-dropped) forms minted here are exactly the distribution the model never saw.
+ *
+ *   Strided sampling spreads the draw across all départements (BAN is sorted by code_insee), one tuple
+ *   per distinct street to keep the set diverse rather than re-teaching the same name.
+ *
+ *   Run: node scripts/diagnostic/export-fr-bare-tuples.ts [--n 12000] [--stride 1200] [--out <jsonl>]
+ */
+
+import { createReadStream, createWriteStream } from "node:fs"
+import { createInterface } from "node:readline"
+
+import { mailwomanDataRoot } from "mailwoman/resolver-backend"
+import { arg } from "../lib/cli-args.ts"
+
+const N = Number(arg("n", "12000"))
+const STRIDE = Number(arg("stride", "1200"))
+const BAN = `${mailwomanDataRoot()}/corpus/staging/ban-france.csv`
+const OUT = arg("out", `${mailwomanDataRoot()}/osm/fr-bare-tuples.jsonl`)
+
+// BAN header: id;id_fantoir;numero;rep;nom_voie;code_postal;code_insee;nom_commune;…
+const NUMERO = 2
+const REP = 3
+const NOM_VOIE = 4
+const NOM_COMMUNE = 7
+
+const seen = new Set<string>()
+const ws = createWriteStream(OUT)
+const rl = createInterface({ input: createReadStream(BAN, { encoding: "utf8" }), crlfDelay: Infinity })
+
+let lineNo = 0
+let written = 0
+
+for await (const line of rl) {
+	lineNo++
+
+	if (lineNo === 1) continue // header
+
+	if (lineNo % STRIDE !== 0) continue // strided sample
+	const c = line.split(";")
+	const street = (c[NOM_VOIE] ?? "").trim()
+	const numero = (c[NUMERO] ?? "").trim()
+	const rep = (c[REP] ?? "").trim()
+	const locality = (c[NOM_COMMUNE] ?? "").trim()
+
+	if (!street || !numero || !locality || !street.includes(" ")) continue
+	const key = street.toLowerCase()
+
+	if (seen.has(key)) continue
+	seen.add(key)
+	const number = rep ? `${numero} ${rep}` : numero
+	ws.write(JSON.stringify({ street, number, locality }) + "\n")
+	written++
+
+	if (written >= N) break
+}
+ws.end()
+console.log(`wrote ${written} distinct FR (street, number, city) tuples from BAN → ${OUT}`)

--- a/scripts/diagnostic/fr-parse-recall-verdict.ts
+++ b/scripts/diagnostic/fr-parse-recall-verdict.ts
@@ -1,0 +1,107 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #251 PROBE VERDICT: does the fr-bare-street shard fix the bare-FR street-segmentation tail? Grade
+ *   the SHIPPED v193a3 (symlink) vs the v194 probe (same tokenizer/card/anchor/gazetteer soft-feed —
+ *   only the ONNX swapped, via loadFromWeights modelPath override) on:
+ *     1. bare-FR street-intact rate, sampled from the OSM-FR shard (a DIFFERENT source than the BAN
+ *        the probe trained on → cross-source held-out pattern test), + the named demo failures.
+ *     2. US no-regression sanity: a few US addresses must parse identically (the lever must not move US).
+ *
+ *   GO = FR street-intact rises materially AND US holds. Run: node scripts/diagnostic/fr-parse-recall-verdict.ts
+ */
+
+import { resolve } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { NeuralAddressClassifier } from "@mailwoman/neural"
+import { normalizeStreetForKeyLocale } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+import { mailwomanDataRoot } from "mailwoman/resolver-backend"
+
+const STREET_TAGS = new Set(["street", "street_prefix", "street_suffix"])
+const PROBE_MODEL = resolve(process.env["PROBE_MODEL"] ?? "./out/v194-final/model.onnx")
+
+const baseline = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+const probe = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US", modelPath: PROBE_MODEL })
+
+function streetKey(tree: { roots: readonly { tag: string; value: string; start: number; children: readonly unknown[] }[] }): string {
+	const parts: Array<{ value: string; start: number }> = []
+	const stack = [...tree.roots]
+
+	while (stack.length) {
+		const n = stack.pop()! as { tag: string; value: string; start: number; children: readonly unknown[] }
+
+		if (STREET_TAGS.has(n.tag) && n.value.trim()) parts.push({ value: n.value.trim(), start: n.start })
+		stack.push(...(n.children as typeof stack))
+	}
+	parts.sort((a, b) => a.start - b.start)
+
+	return normalizeStreetForKeyLocale(parts.map((p) => p.value).join(" "), "fr")
+}
+
+async function streetIntact(c: NeuralAddressClassifier, q: string, want: string): Promise<boolean> {
+	const tree = await c.parse(q, { postcodeRepair: true, normalizeCase: true })
+
+	return streetKey(tree) === want
+}
+
+// --- FR held-out sample from OSM-FR (NOT the BAN training source) + the named demo failures ---
+const db = new DatabaseSync(`${mailwomanDataRoot()}/osm/address-points-fr-fr.db`, { readOnly: true })
+const sample = db
+	.prepare(
+		`SELECT street_raw, number, locality_norm FROM address_point
+		 WHERE locality_norm IS NOT NULL AND street_raw LIKE '% %' GROUP BY street_norm ORDER BY number LIMIT 60`
+	)
+	.all() as Array<{ street_raw: string; number: string; locality_norm: string }>
+
+const demos = [
+	{ street_raw: "Rue du Chevaleret", number: "181", locality_norm: "Paris" },
+	{ street_raw: "Rue René Cassin", number: "181", locality_norm: "Paris" },
+	{ street_raw: "Avenue des Champs-Élysées", number: "10", locality_norm: "Paris" },
+]
+const cases = [...demos, ...sample]
+
+let baseOk = 0
+let probeOk = 0
+const flips: string[] = []
+
+for (const r of cases) {
+	const want = normalizeStreetForKeyLocale(r.street_raw, "fr")
+	const q = `${r.number} ${r.street_raw}, ${r.locality_norm}` // BARE, no postcode
+	const b = await streetIntact(baseline, q, want)
+	const p = await streetIntact(probe, q, want)
+
+	if (b) baseOk++
+
+	if (p) probeOk++
+
+	if (!b && p && flips.length < 8) flips.push(`  ✓ FIXED  "${r.street_raw}, ${r.locality_norm}"`)
+
+	if (b && !p && flips.length < 16) flips.push(`  ✗ BROKE  "${r.street_raw}, ${r.locality_norm}"`)
+}
+
+// --- US no-regression: parses must be identical (the lever must not touch US) ---
+const usCases = [
+	"350 5th Ave, New York, NY",
+	"1600 Pennsylvania Ave NW, Washington DC",
+	"1 Infinite Loop, Cupertino, CA 95014",
+	"233 S Wacker Dr, Chicago, IL",
+]
+let usSame = 0
+
+for (const q of usCases) {
+	const a = JSON.stringify((await baseline.parse(q, { postcodeRepair: true, normalizeCase: true })).roots)
+	const c = JSON.stringify((await probe.parse(q, { postcodeRepair: true, normalizeCase: true })).roots)
+
+	if (a === c) usSame++
+}
+
+const n = cases.length
+console.log(`\n=== #251 fr-bare-street PROBE VERDICT (bare FR, no postcode; ${n} cases incl 3 named demos) ===`)
+console.log(`  SHIPPED v193a3 : ${baseOk}/${n} street-intact  (${((baseOk / n) * 100).toFixed(0)}%)`)
+console.log(`  PROBE   v194   : ${probeOk}/${n} street-intact  (${((probeOk / n) * 100).toFixed(0)}%)   Δ ${(((probeOk - baseOk) / n) * 100).toFixed(0)}pp`)
+console.log(`  US no-regression: ${usSame}/${usCases.length} parses identical to shipped`)
+console.log(`\nflips:`)
+for (const f of flips) console.log(f)

--- a/scripts/diagnostic/fr-parse-recall.ts
+++ b/scripts/diagnostic/fr-parse-recall.ts
@@ -1,0 +1,73 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Diagnose the FR street parse-recall gap (#148): the en-US model fragments a French street when no
+ *   postcode anchors it ("Rue du Chevaleret, Paris" → street="Rue du", locality="Chevaleret"). Sample
+ *   real FR addresses from the OSM shard, parse each BARE ("<n> <street>, <city>") and ANCHORED
+ *   ("<n> <street>, <pc> <city>"), assemble the street key (FR locale) and check it matches the shard's
+ *   street_norm. The bare-vs-anchored match-rate delta IS the gap, and isolates whether the model only
+ *   learned FR structure in the postcode-anchored context.
+ *
+ *   Run: node scripts/diagnostic/fr-parse-recall.ts
+ */
+
+import { DatabaseSync } from "node:sqlite"
+
+import { NeuralAddressClassifier } from "@mailwoman/neural"
+import { normalizeStreetForKeyLocale } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+import { mailwomanDataRoot } from "mailwoman/resolver-backend"
+
+const STREET_TAGS = new Set(["street", "street_prefix", "street_suffix"])
+
+const db = new DatabaseSync(`${mailwomanDataRoot()}/osm/address-points-fr-fr.db`, { readOnly: true })
+// Distinct streets with a city + postcode, sampled across the table (not one street repeated).
+const rows = db
+	.prepare(
+		`SELECT street_raw, number, locality_norm, postcode FROM address_point
+		 WHERE locality_norm IS NOT NULL AND postcode IS NOT NULL AND street_raw LIKE '% %'
+		 GROUP BY street_norm ORDER BY number LIMIT 40`
+	)
+	.all() as Array<{ street_raw: string; number: string; locality_norm: string; postcode: string }>
+
+const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+
+function streetKeyOf(tree: { roots: readonly { tag: string; value: string; start: number; children: readonly unknown[] }[] }): string {
+	const parts: Array<{ value: string; start: number }> = []
+	const stack = [...tree.roots]
+
+	while (stack.length) {
+		const n = stack.pop()! as { tag: string; value: string; start: number; children: readonly unknown[] }
+
+		if (STREET_TAGS.has(n.tag) && n.value.trim()) parts.push({ value: n.value.trim(), start: n.start })
+		stack.push(...(n.children as typeof stack))
+	}
+	parts.sort((a, b) => a.start - b.start)
+
+	return normalizeStreetForKeyLocale(parts.map((p) => p.value).join(" "), "fr")
+}
+
+let bareOk = 0
+let anchoredOk = 0
+const fails: string[] = []
+
+for (const r of rows) {
+	const want = normalizeStreetForKeyLocale(r.street_raw, "fr")
+	const bareQ = `${r.number} ${r.street_raw}, ${r.locality_norm}`
+	const anchQ = `${r.number} ${r.street_raw}, ${r.postcode} ${r.locality_norm}`
+	const bare = streetKeyOf(await classifier.parse(bareQ, { postcodeRepair: true, normalizeCase: true }))
+	const anch = streetKeyOf(await classifier.parse(anchQ, { postcodeRepair: true, normalizeCase: true }))
+
+	if (bare === want) bareOk++
+
+	if (anch === want) anchoredOk++
+
+	if (bare !== want && fails.length < 12) fails.push(`  ✗ bare "${r.street_raw}" → "${bare}" (want "${want}")  | anchored→"${anch}"`)
+}
+
+console.log(`\nFR street parse-recall on ${rows.length} real OSM addresses:`)
+console.log(`  BARE     (no postcode): ${bareOk}/${rows.length} streets intact  (${((bareOk / rows.length) * 100).toFixed(0)}%)`)
+console.log(`  ANCHORED (w/ postcode): ${anchoredOk}/${rows.length} streets intact  (${((anchoredOk / rows.length) * 100).toFixed(0)}%)`)
+console.log(`\nbare failures:`)
+for (const f of fails) console.log(f)

--- a/scripts/eval/osm-rooftop-acceptance.ts
+++ b/scripts/eval/osm-rooftop-acceptance.ts
@@ -1,0 +1,59 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #247 acceptance: geocode FR addresses end-to-end through the drop-in (`geocodeAddress`) with the OSM
+ *   rooftop tier wired (`osmShards`), and check the resolved coordinate + tier. The headline case is the
+ *   demo's `181 Rue du Chevaleret, Paris` — admin-only resolves to the arrondissement centroid; with the
+ *   OSM tier it should resolve `address_point` to the building. Runs with an explicit defaultCountry AND
+ *   via the coarse placer (no country hint) to confirm the placer routes a bare "…Paris" to the FR shard.
+ *
+ *   Run: node scripts/eval/osm-rooftop-acceptance.ts
+ */
+
+import { existsSync } from "node:fs"
+
+import { NeuralAddressClassifier } from "@mailwoman/neural"
+import { OsmShardProvider } from "@mailwoman/osm/sdk"
+import { createWofResolver } from "@mailwoman/resolver"
+import { haversineKm } from "@mailwoman/spatial"
+import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
+import { createResolverBackend, mailwomanDataRoot, wofShardPaths } from "mailwoman/resolver-backend"
+
+const resolverMod = await import("@mailwoman/resolver-wof-sqlite")
+const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+const resolver = createWofResolver(createResolverBackend(resolverMod, { wofPaths: wofShardPaths().filter(existsSync) }))
+const shards = new ShardProvider(resolverMod, mailwomanDataRoot())
+const osm = new OsmShardProvider(mailwomanDataRoot())
+
+interface Case {
+	q: string
+	country?: string
+	expect: [number, number]
+}
+
+const PANEL: Case[] = [
+	{ q: "181 Rue du Chevaleret, Paris", country: "FR", expect: [48.8335023, 2.3686051] },
+	{ q: "181 Rue du Chevaleret, 75013 Paris", country: "FR", expect: [48.8335023, 2.3686051] },
+	// no defaultCountry — the coarse placer must route "…Paris" to FR and pick the OSM shard:
+	{ q: "181 Rue du Chevaleret, Paris", country: undefined, expect: [48.8335023, 2.3686051] },
+]
+
+for (const t of PANEL) {
+	const g = await geocodeAddress(t.q, {
+		classifier,
+		resolver,
+		shards: shards.for,
+		osmShards: osm.for,
+		defaultCountry: t.country,
+	})
+	const errKm = g.lat != null && g.lon != null ? haversineKm(g.lat, g.lon, t.expect[0], t.expect[1]) : null
+	const verdict = g.resolution_tier === "address_point" && (errKm ?? 99) < 0.1 ? "✅ ROOFTOP" : "—"
+
+	console.log(`\n${t.q}   [country=${t.country ?? "placer"}]`)
+	console.log(`   tier=${g.resolution_tier}  lat=${g.lat}  lon=${g.lon}  err=${errKm?.toFixed(3) ?? "n/a"} km  ${verdict}`)
+}
+
+shards.close()
+osm.close()

--- a/scripts/modal/train_remote.py
+++ b/scripts/modal/train_remote.py
@@ -806,6 +806,66 @@ def sync_v193a3():
     secrets=[r2_secret],
     timeout=1800,
 )
+def sync_v094_fr_bare():
+    """#251/#148 fr-bare-street probe. The v0.9.4 overlay = v0.9.3a3's 694 shards VERBATIM (re-rooted to
+    /data) + the 1 fr-bare-street shard (BAN-sourced bare-no-postcode FR streets — the postcode-anchoring
+    lever). Pulls that overlay (small; base shards persist on the volume, referenced by the re-rooted
+    manifest) + code/config, then pre-seeds the v193a3 step-080000 ckpt into the v194 output dir for
+    `--resume auto` (RESUME — continue growing the FR street→locality boundary, NOT init_from)."""
+    import shutil
+    import subprocess
+
+    print("Syncing v0.9.4 fr-bare-street overlay + code+config from R2 + pre-seeding v193a3 step-080000...")
+    vol.reload()
+    R = "--low-level-retries 30 --retries 8 --transfers 12 --checkers 24 --stats 30s --stats-log-level NOTICE"
+    commands = [
+        f"rclone copy :s3:{BUCKET}/corpus-python/src/ {VOL_MOUNT}/corpus-python/src/ {R}",
+        f"rclone copy :s3:{BUCKET}/corpus/v0.9.4-fr-bare-street/corpus-v0.9.4-fr-bare-street/ "
+        f"{VOL_MOUNT}/corpus/versioned/v0.9.4-fr-bare-street/corpus-v0.9.4-fr-bare-street/ {R}",
+    ]
+    for i, cmd in enumerate(commands):
+        print(f"\n[{i+1}/{len(commands)}] {cmd[:90]}...")
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"STDERR: {result.stderr[:800]}")
+            raise RuntimeError(f"rclone failed: {result.stderr[:200]}")
+        if result.stdout:
+            print(result.stdout[-300:])
+
+    src = f"{VOL_MOUNT}/output-v193a3-anchor-absorption-s42/checkpoints/step-080000"
+    dst = f"{VOL_MOUNT}/output-v194-fr-bare-street-s42/checkpoints/step-080000"
+    if not os.path.isdir(src):
+        raise RuntimeError(f"v193a3 step-080000 checkpoint missing at {src} — cannot resume")
+    if os.path.isdir(dst):
+        print("  v194 pre-seed already present (skip copy)")
+    else:
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copytree(src, dst)
+        print(f"  pre-seeded v193a3 step-080000 -> {dst}")
+
+    pyc = f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/__pycache__"
+    if os.path.isdir(pyc):
+        shutil.rmtree(pyc)
+
+    vol.commit()
+    print("\nv0.9.4 fr-bare-street sync + pre-seed complete. Volume committed.")
+
+    cdir = f"{VOL_MOUNT}/corpus/versioned/v0.9.4-fr-bare-street/corpus-v0.9.4-fr-bare-street"
+    cfg = f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/configs/v1.9.4-fr-bare-street.yaml"
+    print("  v1.9.4 config present:", os.path.isfile(cfg))
+    print("  overlay MANIFEST present:", os.path.isfile(f"{cdir}/MANIFEST.json"))
+    print("  fr-bare-street shard present:", os.path.isfile(f"{cdir}/train/part-fr-bare-street-train.parquet"))
+    base05 = f"{VOL_MOUNT}/corpus/versioned/v0.5.0/corpus-v0.5.0/train/part-0001.parquet"
+    print("  base v0.5.0 shard on volume (manifest-referenced):", os.path.isfile(base05))
+    print("  v194 pre-seed ckpt files:", sorted(os.listdir(dst)) if os.path.isdir(dst) else "MISSING")
+
+
+@app.function(
+    image=training_image,
+    volumes={VOL_MOUNT: vol},
+    secrets=[r2_secret],
+    timeout=1800,
+)
 def push_artifact_r2(volume_path: str, r2_subpath: str):
     """Push a volume artifact (e.g. an exported model.onnx) OUT to R2, container-side.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
 		{ "path": "./resolver" },
 		{ "path": "./spatial" },
 		{ "path": "./tiger" },
+		{ "path": "./osm" },
 		{ "path": "./cartographer" },
 		{ "path": "./codex" },
 		{ "path": "./classifiers" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4912,6 +4912,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@mailwoman/osm@workspace:osm":
+  version: 0.0.0-use.local
+  resolution: "@mailwoman/osm@workspace:osm"
+  dependencies:
+    "@mailwoman/core": "workspace:*"
+    "@mailwoman/resolver-wof-sqlite": "workspace:*"
+    "@mailwoman/spatial": "workspace:*"
+    kysely: "npm:^0.29.2"
+  languageName: unknown
+  linkType: soft
+
 "@mailwoman/photon@workspace:photon":
   version: 0.0.0-use.local
   resolution: "@mailwoman/photon@workspace:photon"


### PR DESCRIPTION
## FR rooftop precision: OSM address-point tier + bare-street parse fix

Resolves a **bare** French address to the exact building. Two composing changes:

### 1. `@mailwoman/osm` — optional OSM rooftop tier (FR/DE/NL)
Geofabrik PBF → ogr2ogr extract → locale-normalized address-point shards on the **shared situs schema**, served opt-in via `OsmShardProvider`. Permissive code; the **ODbL** obligation rides on the downloadable per-country shards (`osm/README.md` + the lawyer sign-off gate, #249).

### 2. Resolver wiring (#247)
Locale-aware probe + **resolved-locality bbox fall-through** in `AddressPointSqliteLookup`; country-routed OSM shard selection in `geocodeAddress`. **US byte-stable** — situs tests pass, the `v4.15.0` promotion-gate holds (all floors), US 5/5 tag-identical.

### 3. FR parse fix (#251 / #148)
The `fr-bare-street` corpus recipe (BAN-sourced bare comma-form FR streets, **no postcode**) corrects the **postcode-anchoring imbalance** that fragmented `Rue René Cassin, Paris` → `street="Rue Ren"`. The `v1.9.4` retrain (resume v193a3 + the one shard, single variable) **gates green**:

| | bare-FR street-intact | demo `Rue du Chevaleret, Paris` | US floors |
|---|---|---|---|
| shipped v193a3 | 89% | ✗ admin 3.19km | — |
| **v1.9.4** | **92%** | **✓ rooftop 0.00km** | **all pass, 5/5 tag-identical** |

Diagnosis: DeepSeek Pro (postcode-anchoring distribution skew) + libpostal's own documented practice (format augmentation).

## Ship state
- **Model `v1.9.4`**: gate-green, ready to promote to default (HF stage + model-card bump). Int8 fetched + graded.
- **OSM FR shard**: built (`address-points-fr-fr.db`, 477k points); deploy to R2 for the server drop-ins / demo.
- **Browser-demo rooftop**: follow-on (needs a browser-loadable OSM shard + WASM wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
