### PR TITLE
feat(gauntlet): Phase-1 — full-pipeline integration-test harness

### DIFF
--- a/scripts/eval/gauntlet/build-regression-db.ts
+++ b/scripts/eval/gauntlet/build-regression-db.ts
@@ -1,0 +1,66 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build the curated regression Gauntlet (`$MAILWOMAN_DATA_ROOT/gauntlet/regression.db`) from the
+ *   committed seed (`cases/regression.ts`). Build-on-copy: write a temp DB, then swap it into place.
+ *
+ *   Run: node scripts/eval/gauntlet/build-regression-db.ts
+ */
+
+import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs"
+import { dirname } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
+import { dataRootPath } from "@mailwoman/core/utils"
+
+import { REGRESSION_CASES } from "./cases/regression.ts"
+import { createGauntletTable, GAUNTLET_CASE_COLUMNS, type GauntletDatabase } from "./schema.ts"
+
+const output = dataRootPath("gauntlet", "regression.db")
+const tmp = `${output}.tmp-${process.pid}`
+
+mkdirSync(dirname(output), { recursive: true })
+
+if (existsSync(tmp)) rmSync(tmp)
+
+const db = new DatabaseSync(tmp)
+const kdb = new DatabaseClient<GauntletDatabase>({ database: db })
+await createGauntletTable(kdb)
+
+const insert = db.prepare(`INSERT INTO gauntlet_case VALUES (${GAUNTLET_CASE_COLUMNS.map(() => "?").join(", ")})`)
+
+for (const c of REGRESSION_CASES) {
+	// Positional, in GAUNTLET_CASE_COLUMNS order.
+	insert.run(
+		c.id,
+		c.input,
+		c.source,
+		c.addressKind,
+		c.country,
+		c.status,
+		c.expectComponents ? JSON.stringify(c.expectComponents) : null,
+		c.expectPlaceId ?? null,
+		c.expectPlaceName ?? null,
+		c.expectLat ?? null,
+		c.expectLon ?? null,
+		c.expectToleranceM ?? null,
+		c.expectTier ?? null,
+		c.addedAt,
+		c.bugRef ?? null,
+		c.note ?? null
+	)
+}
+await kdb.destroy()
+
+if (existsSync(output)) renameSync(output, `${output}.prev`)
+renameSync(tmp, output)
+
+if (existsSync(`${output}.prev`)) rmSync(`${output}.prev`)
+
+console.log(`[gauntlet] built ${output} — ${REGRESSION_CASES.length} cases`)
+const kinds = new Map<string, number>()
+for (const c of REGRESSION_CASES) kinds.set(`${c.country}/${c.addressKind}`, (kinds.get(`${c.country}/${c.addressKind}`) ?? 0) + 1)
+console.log(`[gauntlet] coverage by kind: ${[...kinds].map(([k, n]) => `${k}=${n}`).join("  ")}`)

--- a/scripts/eval/gauntlet/cases/regression.ts
+++ b/scripts/eval/gauntlet/cases/regression.ts
@@ -1,0 +1,83 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The curated regression corpus, as committed/reviewable source (built into `gauntlet/regression.db` by
+ *   `build-regression-db.ts`). DELIBERATELY SMALL — this is the executable bug log, NOT a comprehensive
+ *   corpus. Every entry pins a real failure we fixed; the runner gates REGRESSION-ONLY against `status`.
+ *   Add an entry whenever a bug is fixed; never pad it to feel "thorough" (that's curated-set capture).
+ */
+
+import type { AddressKind, CaseStatus, ResolutionTier } from "../schema.ts"
+
+export interface SeedCase {
+	id: string
+	input: string
+	source: string
+	addressKind: AddressKind
+	country: string
+	status: CaseStatus
+	/** Asserted admin/parse fields, when relevant — `{ country?, region?, locality? }` (matched case-insensitively). */
+	expectComponents?: Record<string, string>
+	expectPlaceId?: string
+	expectPlaceName?: string
+	expectLat?: number
+	expectLon?: number
+	/** Great-circle tolerance (m). Defaults at runtime when absent. */
+	expectToleranceM?: number
+	expectTier?: ResolutionTier
+	addedAt: string
+	bugRef?: string
+	note?: string
+}
+
+export const REGRESSION_CASES: SeedCase[] = [
+	{
+		// Entry #1 — the bare French street the model fragmented + the OSM rooftop tier. Was admin 3.19km.
+		id: "fr-bare-chevaleret",
+		input: "181 Rue du Chevaleret, Paris",
+		source: "bug:#828",
+		addressKind: "fr_street_bare",
+		country: "FR",
+		status: "pass",
+		expectLat: 48.8335023,
+		expectLon: 2.3686051,
+		expectToleranceM: 80,
+		expectTier: "address_point",
+		addedAt: "2026-06-29",
+		bugRef: "#251 / #828",
+		note: "Bare FR street, NO postcode. v1.9.4 parse fix (postcode-anchoring) + OSM FR rooftop tier. Pre-fix: street fragmented to 'Rue du', resolved to the arrondissement centroid (3.19km).",
+	},
+	{
+		// A US landmark anchor — guards the US admin/street path doesn't drift while we touch intl.
+		id: "us-dc-pennsylvania",
+		input: "1600 Pennsylvania Ave NW, Washington DC",
+		source: "golden",
+		addressKind: "us_landmark",
+		country: "US",
+		status: "pass",
+		expectComponents: { country: "US", region: "DC", locality: "Washington" },
+		expectLat: 38.8977,
+		expectLon: -77.0365,
+		expectToleranceM: 1500,
+		addedAt: "2026-06-29",
+		note: "Well-known US address; anchors that the US path stays put across intl changes.",
+	},
+	{
+		// The 'Ave recovered as a French locality' span-rescore bug (66ff2e68). Assertion: resolves in NY/US, NOT France.
+		id: "us-5th-ave-ny-rescore",
+		input: "350 5th Ave, New York, NY",
+		source: "bug:span-rescore",
+		addressKind: "us_street_ambiguous",
+		country: "US",
+		status: "pass",
+		expectComponents: { country: "US", region: "NY", locality: "New York" },
+		expectLat: 40.74858,
+		expectLon: -73.98526,
+		expectToleranceM: 20000,
+		addedAt: "2026-06-29",
+		bugRef: "span-rescore confidentRanges (street affix)",
+		note: "Pre-fix the span-rescore recovered 'Ave' as a same-named French locality (48.57,0.28). Must resolve in NY, not France.",
+	},
+]

--- a/scripts/eval/gauntlet/harness.ts
+++ b/scripts/eval/gauntlet/harness.ts
@@ -1,0 +1,63 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Shared Gauntlet harness: build the full-pipeline geocode deps (optionally with a CANDIDATE model, so a
+ *   gate can compare candidate-vs-production on the same inputs) and run one address end-to-end. The
+ *   Gauntlet grades the ASSEMBLED output — coordinate + tier — not raw parse F1, the lesson this project
+ *   paid for once (#566 / reconcile-retirement).
+ */
+
+import { existsSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { NeuralAddressClassifier } from "@mailwoman/neural"
+import { OsmShardProvider } from "@mailwoman/osm/sdk"
+import { createWofResolver } from "@mailwoman/resolver"
+import { type GeocodeResult, geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
+import { createResolverBackend, mailwomanDataRoot, wofShardPaths } from "mailwoman/resolver-backend"
+
+export interface GauntletDeps {
+	geocode(input: string): Promise<GeocodeResult>
+	close(): void
+}
+
+/**
+ * Build the geocode deps. `modelPath` swaps ONLY the ONNX (same tokenizer/card/anchor/gazetteer soft-feed),
+ * so the held-out gate can grade a candidate against production fairly; omit it for the shipped default.
+ */
+export async function buildGauntletDeps(opts: { modelPath?: string } = {}): Promise<GauntletDeps> {
+	const resolverMod = await import("@mailwoman/resolver-wof-sqlite")
+	const classifier = opts.modelPath
+		? await NeuralAddressClassifier.loadFromWeights({ locale: "en-US", modelPath: resolve(opts.modelPath) })
+		: await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+	const resolver = createWofResolver(createResolverBackend(resolverMod, { wofPaths: wofShardPaths().filter(existsSync) }))
+	const shardProvider = new ShardProvider(resolverMod, mailwomanDataRoot())
+	const osmProvider = new OsmShardProvider(mailwomanDataRoot())
+
+	return {
+		geocode: (input: string) =>
+			geocodeAddress(input, { classifier, resolver, shards: shardProvider.for, osmShards: osmProvider.for }),
+		close: () => {
+			shardProvider.close()
+			osmProvider.close()
+		},
+	}
+}
+
+/** The slice of the assembled result the Gauntlet asserts on. */
+export interface GauntletResult {
+	lat: number | null
+	lon: number | null
+	tier: GeocodeResult["resolution_tier"]
+	locality: string | null
+	region: string | null
+	postcode: string | null
+}
+
+export async function runOne(input: string, deps: GauntletDeps): Promise<GauntletResult> {
+	const g = await deps.geocode(input)
+
+	return { lat: g.lat, lon: g.lon, tier: g.resolution_tier, locality: g.locality, region: g.region, postcode: g.postcode }
+}

--- a/scripts/eval/gauntlet/holdout.ts
+++ b/scripts/eval/gauntlet/holdout.ts
@@ -1,0 +1,129 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Held-out fresh-draw Gauntlet — THE generalization gate (DeepSeek 019f1144: "the only layer that
+ *   measures the tail; when it conflicts with the curated suite, it wins"). Each run draws a FRESH random
+ *   sample with truth coordinates (BAN for FR), so the model can't memorize it, and runs BOTH the candidate
+ *   and the current production model on the SAME draw. It gates on a two-proportion z-test: ship only if the
+ *   candidate is NOT statistically worse than production at the locality tolerance. Absolute accuracy is not
+ *   the gate — the candidate-vs-prod DELTA is (this controls for data drift + coverage gaps).
+ *
+ *   Run: node scripts/eval/gauntlet/holdout.ts --candidate ./out/v194-final/model.onnx [--n 300]
+ */
+
+import { createReadStream } from "node:fs"
+import { createInterface } from "node:readline"
+
+import { haversineKm } from "@mailwoman/spatial"
+import { mailwomanDataRoot } from "mailwoman/resolver-backend"
+
+import { arg } from "../../lib/cli-args.ts"
+import { buildGauntletDeps, type GauntletDeps } from "./harness.ts"
+
+const N = Number(arg("n", "300"))
+const CANDIDATE = arg("candidate", "")
+const BAN = `${mailwomanDataRoot()}/corpus/staging/ban-france.csv`
+// BAN columns: numero(2) rep(3) nom_voie(4) nom_commune(7) lon(12) lat(13)
+const C = { numero: 2, rep: 3, voie: 4, commune: 7, lon: 12, lat: 13 }
+const TOLS = [0.1, 0.5, 5] as const // rooftop / street / locality (km)
+const GATE_TOL = 5 // the z-test runs at the locality bucket (the dominant resolvable tier)
+
+interface Sample {
+	query: string
+	lat: number
+	lon: number
+}
+
+/** Reservoir-sample N rows with truth coords from the (streamed) BAN csv — a genuinely fresh draw each run. */
+async function draw(n: number): Promise<Sample[]> {
+	const rl = createInterface({ input: createReadStream(BAN, { encoding: "utf8" }), crlfDelay: Infinity })
+	const res: Sample[] = []
+	let seen = 0
+	let line = 0
+
+	for await (const raw of rl) {
+		if (line++ === 0) continue // header
+		const c = raw.split(";")
+		const voie = (c[C.voie] ?? "").trim()
+		const numero = (c[C.numero] ?? "").trim()
+		const commune = (c[C.commune] ?? "").trim()
+		const lat = Number(c[C.lat])
+		const lon = Number(c[C.lon])
+
+		if (!voie || !numero || !commune || !voie.includes(" ") || !Number.isFinite(lat) || !Number.isFinite(lon)) continue
+		// BARE form, no postcode — the hard case the tail actually exercises.
+		const s: Sample = { query: `${numero} ${voie}, ${commune}`, lat, lon }
+		seen++
+
+		if (res.length < n) res.push(s)
+		else {
+			const j = Math.floor(Math.random() * seen)
+
+			if (j < n) res[j] = s
+		}
+	}
+
+	return res
+}
+
+async function score(deps: GauntletDeps, sample: Sample[]): Promise<{ hits: number[]; resolved: number }> {
+	const hits = TOLS.map(() => 0)
+	let resolved = 0
+
+	for (const s of sample) {
+		const g = await deps.geocode(s.query)
+
+		if (g.lat == null || g.lon == null) continue
+		resolved++
+		const km = haversineKm(g.lat, g.lon, s.lat, s.lon)
+		TOLS.forEach((t, i) => {
+			if (km <= t) hits[i]++
+		})
+	}
+
+	return { hits, resolved }
+}
+
+/** Two-proportion z (candidate − prod). z < −1.96 → candidate significantly WORSE (block). */
+function zStat(cand: number, prod: number, n: number): number {
+	const pc = cand / n
+	const pp = prod / n
+	const pool = (cand + prod) / (2 * n)
+	const se = Math.sqrt(pool * (1 - pool) * (2 / n))
+
+	return se === 0 ? 0 : (pc - pp) / se
+}
+
+if (!CANDIDATE) {
+	console.error("Usage: holdout.ts --candidate <model.onnx> [--n 300]")
+	process.exit(2)
+}
+console.error(`[gauntlet/holdout] drawing ${N} fresh BAN addresses…`)
+const sample = await draw(N)
+console.error(`[gauntlet/holdout] scoring production vs candidate on the SAME ${sample.length} addresses…`)
+
+const prodDeps = await buildGauntletDeps({})
+const prod = await score(prodDeps, sample)
+prodDeps.close()
+
+const candDeps = await buildGauntletDeps({ modelPath: CANDIDATE })
+const cand = await score(candDeps, sample)
+candDeps.close()
+
+const n = sample.length
+const gateIdx = TOLS.indexOf(GATE_TOL as (typeof TOLS)[number])
+const z = zStat(cand.hits[gateIdx]!, prod.hits[gateIdx]!, n)
+
+console.log(`\n=== Gauntlet · held-out fresh draw (FR/BAN, n=${n}) ===`)
+console.log(`  tolerance     production   candidate`)
+TOLS.forEach((t, i) => {
+	console.log(`  ≤${String(t).padEnd(5)}km   ${String(prod.hits[i]).padStart(8)}     ${String(cand.hits[i]).padStart(8)}`)
+})
+console.log(`  resolved      ${String(prod.resolved).padStart(8)}     ${String(cand.resolved).padStart(8)}`)
+console.log(`\n  z (candidate − production) @ ≤${GATE_TOL}km: ${z.toFixed(2)}`)
+// Block ONLY on a significant regression. Candidate ahead or within noise → pass.
+const pass = z >= -1.96
+console.log(`  verdict: ${pass ? "PASS (candidate not significantly worse)" : "FAIL (candidate significantly worse — do not ship)"}`)
+process.exit(pass ? 0 : 1)

--- a/scripts/eval/gauntlet/holdout.ts
+++ b/scripts/eval/gauntlet/holdout.ts
@@ -79,7 +79,7 @@ async function score(deps: GauntletDeps, sample: Sample[]): Promise<{ hits: numb
 		resolved++
 		const km = haversineKm(g.lat, g.lon, s.lat, s.lon)
 		TOLS.forEach((t, i) => {
-			if (km <= t) hits[i]++
+			if (km <= t) hits[i] = (hits[i] ?? 0) + 1
 		})
 	}
 

--- a/scripts/eval/gauntlet/metamorphic.ts
+++ b/scripts/eval/gauntlet/metamorphic.ts
@@ -1,0 +1,99 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Metamorphic Gauntlet (CheckList INV/DIR) — the un-gameable layer. It asserts RELATIONS between outputs,
+ *   not stored expected values, so a curated corpus can't breed false trust here.
+ *
+ *   - INV (invariance): a label-preserving perturbation (casing, whitespace, trailing punctuation) must NOT
+ *       move the assembled coordinate or tier. A drift is a surface-form robustness bug.
+ *   - DIR (directional): dropping the postcode must NOT break resolution — the result must still land near
+ *       the with-postcode coordinate. This is exactly the #251 failure class, frozen as a standing property.
+ *
+ *   GATE: any INV violation, or a DIR that fails to resolve near the anchor, fails the run. Run:
+ *     node scripts/eval/gauntlet/metamorphic.ts [--model <candidate.onnx>]
+ */
+
+import { haversineKm } from "@mailwoman/spatial"
+
+import { arg } from "../../lib/cli-args.ts"
+import { buildGauntletDeps, runOne } from "./harness.ts"
+
+const INV_EPSILON_KM = 0.001 // 1m — same address, identical resolution expected.
+const DIR_NEAR_KM = 5 // dropping the postcode may lose the rooftop, but must still land in the right area.
+
+/** Base inputs. The postcode'd ones drive the DIR (drop-postcode) test; all drive INV. */
+const BASES = [
+	{ input: "181 Rue du Chevaleret, Paris", postcode: false },
+	{ input: "181 Rue du Chevaleret, 75013 Paris", postcode: true },
+	{ input: "1600 Pennsylvania Ave NW, Washington DC", postcode: false },
+	{ input: "1600 Pennsylvania Ave NW, Washington DC 20500", postcode: true },
+	{ input: "350 5th Ave, New York, NY", postcode: false },
+]
+
+/** Label-preserving perturbations — the output must be invariant to these. */
+const INV = [
+	{ name: "lower", f: (s: string) => s.toLowerCase() },
+	{ name: "upper", f: (s: string) => s.toUpperCase() },
+	{ name: "ws", f: (s: string) => s.replace(/ /g, "  ") },
+	{ name: "trail-dot", f: (s: string) => `${s}.` },
+]
+
+/** Strip a 5-digit (US/FR) postcode token for the DIR test. */
+const dropPostcode = (s: string) => s.replace(/\b\d{5}\b/, "").replace(/\s*,\s*,/g, ",").replace(/\s+/g, " ").trim()
+
+const deps = await buildGauntletDeps(arg("model", "") ? { modelPath: arg("model", "") } : {})
+
+let invChecks = 0
+let invFails = 0
+let dirChecks = 0
+let dirFails = 0
+const fails: string[] = []
+
+for (const base of BASES) {
+	const canon = await runOne(base.input, deps)
+
+	// INV: every label-preserving perturbation must reproduce the canonical coordinate + tier.
+	for (const p of INV) {
+		invChecks++
+		const r = await runOne(p.f(base.input), deps)
+		const moved =
+			r.tier !== canon.tier ||
+			(canon.lat != null && r.lat != null && haversineKm(canon.lat, canon.lon!, r.lat, r.lon!) > INV_EPSILON_KM) ||
+			(canon.lat == null) !== (r.lat == null)
+
+		if (moved) {
+			invFails++
+			fails.push(`  ✗ INV[${p.name}] "${base.input}" → tier ${canon.tier}→${r.tier}, coord ${canon.lat},${canon.lon} → ${r.lat},${r.lon}`)
+		}
+	}
+
+	// DIR: dropping the postcode must still resolve near the with-postcode anchor.
+	if (base.postcode) {
+		dirChecks++
+		const dropped = await runOne(dropPostcode(base.input), deps)
+		const ok =
+			dropped.lat != null &&
+			canon.lat != null &&
+			haversineKm(canon.lat, canon.lon!, dropped.lat, dropped.lon!) <= DIR_NEAR_KM
+
+		if (!ok) {
+			dirFails++
+			fails.push(`  ✗ DIR[drop-postcode] "${base.input}" → "${dropPostcode(base.input)}" landed ${dropped.lat},${dropped.lon} (anchor ${canon.lat},${canon.lon})`)
+		}
+	}
+}
+deps.close()
+
+console.log(`\n=== Gauntlet · metamorphic ===`)
+console.log(`  INV (label-preserving invariance): ${invChecks - invFails}/${invChecks} held`)
+console.log(`  DIR (drop-postcode still resolves): ${dirChecks - dirFails}/${dirChecks} held`)
+
+if (fails.length) {
+	console.log(`\nviolations:`)
+	for (const f of fails) console.log(f)
+}
+const pass = invFails === 0 && dirFails === 0
+console.log(`\nverdict: ${pass ? "PASS" : "FAIL"}`)
+process.exit(pass ? 0 : 1)

--- a/scripts/eval/gauntlet/schema.ts
+++ b/scripts/eval/gauntlet/schema.ts
@@ -1,0 +1,115 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The Gauntlet — a full-pipeline integration-test corpus (`input → expected assembled output`). This is
+ *   the CURATED REGRESSION layer (DeepSeek 019f1144): the executable memory of fixed bugs. Its gate is
+ *   REGRESSION-ONLY — "must not break what already passed" — and its pass-RATE is NEVER a ship gauge (that
+ *   would re-invent the Pelias acceptance-test false-trust pass-list). Generalization is gated elsewhere:
+ *   the held-out fresh-draw runner (`holdout.ts`) and the metamorphic invariants (`metamorphic.ts`), which
+ *   need no stored expected values and so can't be over-fit.
+ *
+ *   The `source` + `address_kind` columns are load-bearing: coverage is tracked BY KIND (po-box nonprofits,
+ *   suite-heavy clinics, rural-route facilities, bare intl streets…), so "we tested 10k addresses" can never
+ *   hide "…all suburban-US residential." That is CheckList's capability matrix applied to addresses.
+ */
+
+import type { Kysely } from "kysely"
+
+/**
+ * The address KIND a case exercises — a free string, deliberately extensible (the taxonomy grows with the
+ * corpus). Seed examples: `fr_street_bare`, `fr_street_postcode`, `us_residential`, `us_business_suite`,
+ * `us_po_box`, `us_rural_route`, `us_intersection`, `de_street`, `nl_street`, `intl_multitoken_street`.
+ */
+export type AddressKind = string
+
+/** Pelias-style status: tracked as a DELTA (regression / improvement), never as a raw pass-rate gauge. */
+export type CaseStatus = "pass" | "known_fail" | "improvement_target"
+
+export type ResolutionTier = "address_point" | "interpolated" | "admin"
+
+/** One Gauntlet case: a raw input and its expected ASSEMBLED output (parse + place + coordinate + tier). */
+export interface GauntletCaseTable {
+	/** Stable case id, e.g. `fr-bare-chevaleret`. */
+	id: string
+	/** The raw address string fed to the pipeline. */
+	input: string
+	/** Provenance: where this case came from — `bug:#828`, `demo`, `nppes`, `golden`, `manual`. */
+	source: string
+	/** The address KIND this case exercises (coverage is tracked by this). */
+	address_kind: AddressKind
+	/** ISO-3166 alpha-2 country. */
+	country: string
+	/** Expected status — the baseline the runner diffs against to report regressions vs improvements. */
+	status: CaseStatus
+	/** Expected parse components as JSON `{ tag: value }` (null = parse not asserted for this case). */
+	expect_components: string | null
+	/** Expected resolved place id (null = place not asserted). */
+	expect_place_id: string | null
+	/** Expected resolved place canonical name (null = not asserted). */
+	expect_place_name: string | null
+	/** Expected coordinate (null = coordinate not asserted — e.g. a parse-only case). */
+	expect_lat: number | null
+	expect_lon: number | null
+	/** Accepted great-circle tolerance in METERS (Pelias's distanceThresh; null defaults at runtime). */
+	expect_tolerance_m: number | null
+	/** Expected resolution tier — a result that drifts `address_point`→`admin` is a regression even within tolerance. */
+	expect_tier: ResolutionTier | null
+	/** When the case entered the corpus (ISO date). */
+	added_at: string
+	/** Linked bug / PR / issue, when the case is a fixed regression. */
+	bug_ref: string | null
+	/** Human note — what failure this case pins. */
+	note: string | null
+}
+
+/** The Gauntlet DB schema for `new DatabaseClient<GauntletDatabase>(...)`. */
+export interface GauntletDatabase {
+	gauntlet_case: GauntletCaseTable
+}
+
+/** Column order for the positional INSERT — derived once so the builder + writer can't drift. */
+export const GAUNTLET_CASE_COLUMNS = [
+	"id",
+	"input",
+	"source",
+	"address_kind",
+	"country",
+	"status",
+	"expect_components",
+	"expect_place_id",
+	"expect_place_name",
+	"expect_lat",
+	"expect_lon",
+	"expect_tolerance_m",
+	"expect_tier",
+	"added_at",
+	"bug_ref",
+	"note",
+] as const
+
+/** Create the `gauntlet_case` table (the curated regression corpus). */
+export async function createGauntletTable(db: Kysely<GauntletDatabase>): Promise<void> {
+	await db.schema
+		.createTable("gauntlet_case")
+		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("input", "text", (c) => c.notNull())
+		.addColumn("source", "text", (c) => c.notNull())
+		.addColumn("address_kind", "text", (c) => c.notNull())
+		.addColumn("country", "text", (c) => c.notNull())
+		.addColumn("status", "text", (c) => c.notNull())
+		.addColumn("expect_components", "text")
+		.addColumn("expect_place_id", "text")
+		.addColumn("expect_place_name", "text")
+		.addColumn("expect_lat", "real")
+		.addColumn("expect_lon", "real")
+		.addColumn("expect_tolerance_m", "integer")
+		.addColumn("expect_tier", "text")
+		.addColumn("added_at", "text", (c) => c.notNull())
+		.addColumn("bug_ref", "text")
+		.addColumn("note", "text")
+		.execute()
+	// Coverage-by-kind is a first-class query: "how many kinds does the corpus cover, and which are thin?"
+	await db.schema.createIndex("idx_gauntlet_kind").on("gauntlet_case").columns(["country", "address_kind"]).execute()
+}


### PR DESCRIPTION
Layered integration net that grades the **assembled** output (coordinate + tier) — the gap our per-tag F1 gates were blind to. Designed with DeepSeek (019f1144).

## Three layers
- **Regression** (`regression.db`, Kysely schema) — executable bug-log, gated regression-only, never a pass-rate gauge (avoids Pelias's curated-pass-list false-trust). Tracks coverage **by kind** (source + address_kind).
- **Metamorphic** (INV/DIR) — un-gameable; no stored expected values. **Caught #252 (casing-invariance) on its first run.**
- **Held-out** (fresh BAN draw, candidate-vs-prod z-test) — the generalization gate; gave v4.16.0 its held-out cover (n=400, z=0.21).

## Already paid for itself
- Found #252 (casing bug, now fixed on main) + filed #829 (lowercase model-sensitivity).
- Gave the v4.16.0 promote its generalization evidence.

## Phase-2 (tracked in the night-shift plan)
Held-out verified-coord source expansion (NCES/FDIC), faster draw, wire into the promote gate, grow the regression + metamorphic corpora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)