### PR TITLE
fix(#832): wire wof:hierarchy ancestry backfill into the unified-WOF build

### DIFF
--- a/resolver-wof-sqlite/ancestry-backfill.test.ts
+++ b/resolver-wof-sqlite/ancestry-backfill.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { afterAll, beforeAll, expect, test } from "vitest"
+
+import { backfillAncestorsFromHierarchy, discoverAdminDataRoots } from "./ancestry-backfill.js"
+
+let root: string
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), "ancestry-backfill-"))
+	// Nested lab layout: <root>/whosonfirst-data/whosonfirst-data-admin-us/data
+	mkdirSync(join(root, "whosonfirst-data", "whosonfirst-data-admin-us", "data"), { recursive: true })
+	// Flat layout: <root>/whosonfirst-data-admin-gb/data
+	mkdirSync(join(root, "whosonfirst-data-admin-gb", "data"), { recursive: true })
+	// A non-WOF sibling dir that must be ignored
+	mkdirSync(join(root, "some-other-repo", "data"), { recursive: true })
+	// A `data` dir buried too deep (depth 3+) that must NOT be discovered
+	mkdirSync(join(root, "whosonfirst-data", "nested", "deeper", "data"), { recursive: true })
+})
+
+afterAll(() => {
+	rmSync(root, { recursive: true, force: true })
+})
+
+test("discoverAdminDataRoots: finds nested + flat whosonfirst data roots, skips non-WOF + too-deep", () => {
+	const roots = discoverAdminDataRoots(root)
+
+	expect(roots).toContain(join(root, "whosonfirst-data", "whosonfirst-data-admin-us", "data"))
+	expect(roots).toContain(join(root, "whosonfirst-data-admin-gb", "data"))
+	// non-WOF sibling is not traversed (its name doesn't start with whosonfirst-data)
+	expect(roots).not.toContain(join(root, "some-other-repo", "data"))
+	// `nested/deeper/data` sits at depth 3 from root — beyond the 2-level cap
+	expect(roots).not.toContain(join(root, "whosonfirst-data", "nested", "deeper", "data"))
+})
+
+test("discoverAdminDataRoots: missing root yields empty list, never throws", () => {
+	expect(discoverAdminDataRoots(join(root, "does-not-exist"))).toEqual([])
+})
+
+test("backfillAncestorsFromHierarchy: inserts wof:hierarchy ancestors for only-self places, idempotent", () => {
+	const db = new DatabaseSync(":memory:")
+	db.exec("CREATE TABLE spr (id INTEGER PRIMARY KEY, placetype TEXT)")
+	db.exec("CREATE TABLE ancestors (id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT, lastmodified INTEGER)")
+
+	// A multi-parent locality (parent_id=-4 in real WOF) — only-self ancestry, must be repaired.
+	const orphanId = 85977539
+	db.prepare("INSERT INTO spr (id, placetype) VALUES (?, 'locality')").run(orphanId)
+	db.prepare("INSERT INTO ancestors VALUES (?, ?, 'locality', 0)").run(orphanId, orphanId) // self only
+	// A country (top-level) with only-self ancestry — must be skipped, not queried for geojson.
+	db.prepare("INSERT INTO spr (id, placetype) VALUES (?, 'country')").run(85633793)
+	db.prepare("INSERT INTO ancestors VALUES (?, ?, 'country', 0)").run(85633793, 85633793)
+
+	// Source geojson with a populated wof:hierarchy (region + country), even though parent_id is -4.
+	const dataRoot = join(root, "whosonfirst-data", "whosonfirst-data-admin-us", "data")
+	mkdirSync(join(dataRoot, "859", "775", "39"), { recursive: true })
+	writeFileSync(
+		join(dataRoot, "859", "775", "39", `${orphanId}.geojson`),
+		JSON.stringify({
+			properties: {
+				"wof:parent_id": -4,
+				"wof:hierarchy": [
+					{ locality_id: orphanId, region_id: 85688543, country_id: 85633793 },
+					{ locality_id: orphanId, region_id: 85688543, county_id: 102081863 },
+				],
+			},
+		})
+	)
+
+	const result = backfillAncestorsFromHierarchy(db, [dataRoot])
+	// region + country + county = 3 distinct ancestors across branches (self/locality excluded).
+	expect(result.placesFixed).toBe(1)
+	expect(result.rowsAdded).toBe(3)
+
+	const ancestorIds = db
+		.prepare("SELECT ancestor_id FROM ancestors WHERE id = ? AND ancestor_id != ? ORDER BY ancestor_id")
+		.all(orphanId, orphanId)
+		.map((r) => (r as { ancestor_id: number }).ancestor_id)
+	expect(ancestorIds).toEqual([85633793, 85688543, 102081863].sort((a, b) => a - b))
+
+	// Re-run: idempotent — already-present rows are not duplicated.
+	const again = backfillAncestorsFromHierarchy(db, [dataRoot])
+	expect(again.rowsAdded).toBe(0)
+	expect(again.placesFixed).toBe(0)
+
+	db.close()
+})

--- a/resolver-wof-sqlite/ancestry-backfill.ts
+++ b/resolver-wof-sqlite/ancestry-backfill.ts
@@ -1,0 +1,189 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Repair the only-self ancestry that {@link populateAncestors} (the parent_id closure in
+ *   unified-schema.ts) leaves for places whose `wof:parent_id` is the WOF `-4` "ambiguous /
+ *   multi-parent" sentinel.
+ *
+ *   Root cause (#440 / #832): a place that straddles multiple parents — New York City spans five
+ *   counties (its boroughs), London 30+ — carries `wof:parent_id = -4`, so the parent_id closure
+ *   dead-ends and the place gets NO region/county/country ancestry. The resolver's region-descendant
+ *   filter then can't reach it: given "New York, NY", NYC (with no NY-state ancestor) is excluded and
+ *   a correctly-parented namesake ("New York Mills", pop 3,190) wins over NYC's 8.8M. The same defect
+ *   orphans London, Singapore, and ~2,850 other localities — the most demo-visible queries.
+ *
+ *   The authoritative hierarchy IS in the source geojson: `wof:hierarchy` is an array of branches,
+ *   each a `<placetype>_id` → id map (region_id, county_id, country_id, …), fully populated even when
+ *   parent_id is -4. This reads it for every only-self place and inserts the missing ancestor rows
+ *   (one per distinct ancestor across branches).
+ *
+ *   MUST run AFTER populateAncestors and BEFORE the build freezes (VACUUM INTO), so the rows land in
+ *   the shipped artifact — `scripts/build-unified-wof.ts` Phase 3 calls it inline. The standalone
+ *   `scripts/backfill-ancestors-from-hierarchy.ts` is a thin CLI over the same function for ad-hoc
+ *   repair of an already-built DB. Idempotent: only touches places with <= 1 ancestor row (self), and
+ *   inserts each (id, ancestor_id) at most once.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import type { DatabaseSync } from "node:sqlite"
+
+/** Genuinely top-level placetypes — they never have (or need) an ancestor, so skip them. */
+const TOP_PLACETYPES = new Set(["country", "continent", "empire", "ocean", "marinearea", "planet"])
+
+export interface AncestryBackfillResult {
+	/** Places that gained at least one ancestor row. */
+	placesFixed: number
+	/** Total ancestor rows inserted. */
+	rowsAdded: number
+	/**
+	 * Only-self candidates whose source geojson could not be found (non-WOF backfilled places, or repos not present
+	 * locally) — skipped, not an error.
+	 */
+	noGeojson: number
+}
+
+/**
+ * Discover the `data` directories under a WOF repos root that hold sharded geojson, e.g.
+ * `<root>/whosonfirst-data/whosonfirst-data-admin-us/data`. Resolves an id to its geojson via these roots. Accepts both
+ * the nested lab layout (a `whosonfirst-data` group dir holding the admin repos) and a flat layout (admin repos
+ * directly under the root); searches at most two directory levels deep.
+ */
+export function discoverAdminDataRoots(reposRoot: string): string[] {
+	const roots: string[] = []
+
+	const visit = (dir: string, depth: number): void => {
+		if (depth > 2) return
+
+		let names: string[]
+
+		try {
+			names = readdirSync(dir, { withFileTypes: true })
+				.filter((e) => e.isDirectory())
+				.map((e) => e.name)
+		} catch {
+			return
+		}
+
+		for (const name of names) {
+			const child = join(dir, name)
+
+			if (name === "data") {
+				roots.push(child)
+			} else if (name.startsWith("whosonfirst-data")) {
+				visit(child, depth + 1)
+			}
+		}
+	}
+
+	visit(reposRoot, 0)
+
+	return roots
+}
+
+/** WOF geojson lives sharded: an id resolves to `<3-char chunks>/<id>.geojson` under each data root. */
+function geojsonForId(id: number, roots: readonly string[]): Record<string, unknown> | null {
+	const s = String(id)
+	const chunks: string[] = []
+
+	for (let i = 0; i < s.length; i += 3) chunks.push(s.slice(i, i + 3))
+	const rel = join(chunks.join("/"), `${s}.geojson`)
+
+	for (const root of roots) {
+		const fp = join(root, rel)
+
+		if (existsSync(fp)) {
+			try {
+				return JSON.parse(readFileSync(fp, "utf8")) as Record<string, unknown>
+			} catch {
+				return null
+			}
+		}
+	}
+
+	return null
+}
+
+// `<placetype>_id` key → ancestor placetype. WOF hierarchy keys are e.g. region_id, county_id. Self
+// is filtered downstream by the `aid === id` check, so we do NOT special-case locality here: for a
+// locality candidate `locality_id` IS self (dropped by aid===id), but for a neighbourhood candidate
+// `locality_id` is its PARENT locality — a real ancestor we must keep.
+function placetypeFromKey(key: string): string | null {
+	if (!key.endsWith("_id")) return null
+
+	return key.slice(0, -3)
+}
+
+/**
+ * Insert missing ancestor rows for only-self places by reading `wof:hierarchy` from their source geojson under
+ * `geojsonRoots` (see {@link discoverAdminDataRoots}). Runs inside a single transaction; caller owns connection
+ * lifecycle (open, WAL checkpoint, close).
+ */
+export function backfillAncestorsFromHierarchy(
+	db: DatabaseSync,
+	geojsonRoots: readonly string[]
+): AncestryBackfillResult {
+	const candidates = db
+		.prepare(
+			`SELECT s.id AS id, s.placetype AS placetype FROM spr s
+			 WHERE (SELECT count(*) FROM ancestors a WHERE a.id = s.id) <= 1`
+		)
+		.all() as Array<{ id: number; placetype: string }>
+
+	const insert = db.prepare(
+		"INSERT INTO ancestors (id, ancestor_id, ancestor_placetype, lastmodified) VALUES (?, ?, ?, 0)"
+	)
+	const hasRow = db.prepare("SELECT 1 FROM ancestors WHERE id = ? AND ancestor_id = ? LIMIT 1")
+
+	let placesFixed = 0
+	let rowsAdded = 0
+	let noGeojson = 0
+	db.exec("BEGIN")
+
+	for (const { id, placetype } of candidates) {
+		if (TOP_PLACETYPES.has(placetype)) continue
+		const gj = geojsonForId(id, geojsonRoots)
+		const props = (gj?.["properties"] ?? null) as Record<string, unknown> | null
+		const hierarchy = (props?.["wof:hierarchy"] ?? null) as Array<Record<string, number>> | null
+
+		if (!hierarchy || hierarchy.length === 0) {
+			if (!gj) noGeojson++
+			continue
+		}
+
+		// Collect distinct (ancestor_id, placetype) across all hierarchy branches, excluding self.
+		const seen = new Map<number, string>()
+
+		for (const branch of hierarchy) {
+			for (const [key, val] of Object.entries(branch)) {
+				const pt = placetypeFromKey(key)
+
+				if (!pt) continue
+				const aid = Number(val)
+
+				if (!Number.isFinite(aid) || aid <= 0 || aid === id) continue
+
+				if (!seen.has(aid)) seen.set(aid, pt)
+			}
+		}
+
+		let added = 0
+
+		for (const [aid, pt] of seen) {
+			if (hasRow.get(id, aid)) continue
+			insert.run(id, aid, pt)
+			added++
+		}
+
+		if (added > 0) {
+			placesFixed++
+			rowsAdded += added
+		}
+	}
+
+	db.exec("COMMIT")
+
+	return { placesFixed, rowsAdded, noGeojson }
+}

--- a/resolver-wof-sqlite/package.json
+++ b/resolver-wof-sqlite/package.json
@@ -35,6 +35,7 @@
 		"./fst-types": "./out/fst-types.js",
 		"./fst-deserialize-web": "./out/fst-deserialize-web.js",
 		"./unified-schema": "./out/unified-schema.js",
+		"./ancestry-backfill": "./out/ancestry-backfill.js",
 		"./coincident-roles": "./out/coincident-roles.js",
 		"./geonames-aliases": "./out/geonames-aliases.js",
 		"./geo": "./out/geo.js",

--- a/scripts/backfill-ancestors-from-hierarchy.ts
+++ b/scripts/backfill-ancestors-from-hierarchy.ts
@@ -3,151 +3,50 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Repair the unified WOF DB's `ancestors` table for places that `populateAncestors`
- *   (build-unified-wof.ts, a parent_id closure) leaves with ONLY-SELF ancestry.
+ *   Thin CLI over {@link backfillAncestorsFromHierarchy} (@mailwoman/resolver-wof-sqlite) for ad-hoc
+ *   repair of an ALREADY-BUILT unified WOF DB. The build pipeline (`scripts/build-unified-wof.ts`,
+ *   Phase 3) now calls the same function inline AFTER populateAncestors and BEFORE the freeze, so a
+ *   fresh rebuild needs no separate step — this CLI exists for repairing a DB built before the wiring
+ *   landed, or for re-running after a manual ancestors edit.
  *
- *   Root cause (#440): a place that spans multiple parents — e.g. New York City, which straddles five
- *   counties (the boroughs) — carries `wof:parent_id = -4` (the WOF "ambiguous / no single parent"
- *   sentinel). The parent_id closure dead-ends there, so the place gets no region/county/country
- *   ancestry. The resolver's region-descendant boost then can't reach it: given "New York, NY", NYC
- *   (no NY-state ancestor) loses the boost to a correctly-parented namesake like "New York Mills",
- *   which wins despite NYC's 8.8M population. The honest-eval harness caught this as a metro
- *   regression once region resolution was fixed (docs/articles/evals/2026-06-08-honest-eval.md).
- *
- *   The authoritative hierarchy IS in the source geojson: `wof:hierarchy` is an array of branches,
- *   each a map of `<placetype>_id` → id (region_id, county_id, country_id, …), fully populated even
- *   when parent_id is -4. This script reads it for every only-self place and inserts the missing
- *   ancestor rows (one per distinct ancestor across branches).
+ *   Repairs only-self ancestry left by the parent_id closure for places whose `wof:parent_id` is the
+ *   WOF `-4` "multi-parent" sentinel (New York City, London, …) — see the function's docstring for the
+ *   root cause (#440 / #832). Idempotent.
  *
  *   Run AFTER build-unified-wof and add-region-abbrevs, BEFORE build-fts (FTS doesn't depend on
- *   ancestors, so order vs FTS is not strict; keep it with the other post-build steps): node
- *   --experimental-strip-types scripts/backfill-ancestors-from-hierarchy.ts <unified.db>
- *   [<repos-root>] Idempotent: only touches places whose current ancestry is <= 1 row (self only),
- *   and inserts each (id, ancestor_id) at most once.
+ *   ancestors, so order vs FTS is not strict):
+ *
+ *     node --experimental-strip-types scripts/backfill-ancestors-from-hierarchy.ts <unified.db> [<repos-root>]
+ *
+ *   <repos-root> defaults to the lab WOF repos dir; its `whosonfirst-data` admin-repo `data` subtrees
+ *   are discovered automatically (no hardcoded admin list).
  */
 
-import { existsSync, readFileSync } from "node:fs"
-import { join } from "node:path"
 import { DatabaseSync } from "node:sqlite"
+
+import {
+	backfillAncestorsFromHierarchy,
+	discoverAdminDataRoots,
+} from "@mailwoman/resolver-wof-sqlite/ancestry-backfill"
 
 const dbPath = process.argv[2] ?? "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
 const reposRoot = process.argv[3] ?? "/mnt/playpen/mailwoman-data/wof/repos"
 
-// WOF geojson lives sharded under several admin repos; an id resolves to <root>/<3-char chunks>/<id>.geojson.
-const adminRoots: string[] = []
+const geojsonRoots = discoverAdminDataRoots(reposRoot)
 
-for (const sub of [
-	"whosonfirst-data/whosonfirst-data-admin-cn",
-	"whosonfirst-data/whosonfirst-data-admin-de",
-	"whosonfirst-data/whosonfirst-data-admin-es",
-	"whosonfirst-data/whosonfirst-data-admin-fr",
-	"whosonfirst-data/whosonfirst-data-admin-gb",
-	"whosonfirst-data/whosonfirst-data-admin-it",
-	"whosonfirst-data/whosonfirst-data-admin-jp",
-	"whosonfirst-data/whosonfirst-data-admin-kr",
-	"whosonfirst-data/whosonfirst-data-admin-nl",
-	"whosonfirst-data/whosonfirst-data-admin-us",
-	"whosonfirst-data-admin-us",
-]) {
-	const p = join(reposRoot, sub, "data")
-
-	if (existsSync(p)) adminRoots.push(p)
+if (geojsonRoots.length === 0) {
+	console.error(`No */data geojson roots found under ${reposRoot} — nothing to read hierarchy from.`)
+	process.exit(1)
 }
 
-function geojsonForId(id: number): Record<string, unknown> | null {
-	const s = String(id)
-	const chunks: string[] = []
-
-	for (let i = 0; i < s.length; i += 3) chunks.push(s.slice(i, i + 3))
-	const rel = join(chunks.join("/"), `${s}.geojson`)
-
-	for (const root of adminRoots) {
-		const fp = join(root, rel)
-
-		if (existsSync(fp)) {
-			try {
-				return JSON.parse(readFileSync(fp, "utf8")) as Record<string, unknown>
-			} catch {
-				return null
-			}
-		}
-	}
-
-	return null
-}
-
-// `<placetype>_id` key → ancestor placetype. WOF hierarchy keys are e.g. region_id, county_id.
-// Self is filtered downstream by the `aid === id` check, so we do NOT special-case locality here:
-// for a locality candidate `locality_id` IS self (dropped by aid===id), but for a neighbourhood
-// candidate `locality_id` is its PARENT locality — a real ancestor we must keep.
-function placetypeFromKey(key: string): string | null {
-	if (!key.endsWith("_id")) return null
-
-	return key.slice(0, -3)
-}
+console.error(`Reading hierarchy from ${geojsonRoots.length} data root(s) under ${reposRoot}`)
 
 const db = new DatabaseSync(dbPath)
+const { placesFixed, rowsAdded, noGeojson } = backfillAncestorsFromHierarchy(db, geojsonRoots)
 
-// Places with only-self (or zero) ancestry, excluding genuinely top-level placetypes.
-const TOP = new Set(["country", "continent", "empire", "ocean", "marinearea", "planet"])
-const candidates = db
-	.prepare(
-		`SELECT s.id AS id, s.placetype AS placetype FROM spr s
-		 WHERE (SELECT count(*) FROM ancestors a WHERE a.id = s.id) <= 1`
-	)
-	.all() as Array<{ id: number; placetype: string }>
-
-const insert = db.prepare(
-	"INSERT INTO ancestors (id, ancestor_id, ancestor_placetype, lastmodified) VALUES (?, ?, ?, 0)"
-)
-const hasRow = db.prepare("SELECT 1 FROM ancestors WHERE id = ? AND ancestor_id = ? LIMIT 1")
-
-let placesFixed = 0
-let rowsAdded = 0
-let noGeojson = 0
-db.exec("BEGIN")
-
-for (const { id, placetype } of candidates) {
-	if (TOP.has(placetype)) continue
-	const gj = geojsonForId(id)
-	const props = (gj?.["properties"] ?? null) as Record<string, unknown> | null
-	const hierarchy = (props?.["wof:hierarchy"] ?? null) as Array<Record<string, number>> | null
-
-	if (!hierarchy || hierarchy.length === 0) {
-		if (!gj) noGeojson++
-		continue
-	}
-	// Collect distinct (ancestor_id, placetype) across all hierarchy branches, excluding self.
-	const seen = new Map<number, string>()
-
-	for (const branch of hierarchy) {
-		for (const [key, val] of Object.entries(branch)) {
-			const pt = placetypeFromKey(key)
-
-			if (!pt) continue
-			const aid = Number(val)
-
-			if (!Number.isFinite(aid) || aid <= 0 || aid === id) continue
-
-			if (!seen.has(aid)) seen.set(aid, pt)
-		}
-	}
-	let added = 0
-
-	for (const [aid, pt] of seen) {
-		if (hasRow.get(id, aid)) continue
-		insert.run(id, aid, pt)
-		added++
-	}
-
-	if (added > 0) {
-		placesFixed++
-		rowsAdded += added
-	}
-}
-db.exec("COMMIT")
 db.exec("PRAGMA wal_checkpoint(TRUNCATE)")
 db.close()
+
 console.error(
 	`backfilled ancestry for ${placesFixed} places (+${rowsAdded} rows); ${noGeojson} candidates had no source geojson`
 )

--- a/scripts/build-unified-wof.ts
+++ b/scripts/build-unified-wof.ts
@@ -30,6 +30,10 @@ import { readFile } from "node:fs/promises"
 import { DatabaseSync } from "node:sqlite"
 
 import { DuckDBInstance } from "@duckdb/node-api"
+import {
+	backfillAncestorsFromHierarchy,
+	discoverAdminDataRoots,
+} from "@mailwoman/resolver-wof-sqlite/ancestry-backfill"
 import { buildCoincidentRoles } from "@mailwoman/resolver-wof-sqlite/coincident-roles"
 import { ingestGeonamesAliases } from "@mailwoman/resolver-wof-sqlite/geonames-aliases"
 import {
@@ -565,6 +569,23 @@ async function main() {
 	console.error("  Building ancestors (parent_id closure)...")
 	const ancestorRows = populateAncestors(db)
 	console.error(`  ancestors: ${ancestorRows} rows`)
+
+	// Repair the multi-parent orphans the closure leaves only-self (#440 / #832): places with
+	// `wof:parent_id = -4` (New York City, London, …) get NO region/county ancestry from the closure,
+	// so the resolver's region-descendant filter excludes them and a small namesake wins. Read the
+	// authoritative `wof:hierarchy` from source geojson and insert the missing rows. MUST run here —
+	// after the closure, before `coincident_roles` (which reads ancestry) and the VACUUM freeze.
+	console.error("  Backfilling ancestry from wof:hierarchy (multi-parent -4 places)...")
+	const geojsonRoots = discoverAdminDataRoots(dataDir)
+
+	if (geojsonRoots.length === 0) {
+		console.error(`    WARNING: no */data geojson roots under ${dataDir}; skipping — orphans like NYC stay unreachable`)
+	} else {
+		const bf = backfillAncestorsFromHierarchy(db, geojsonRoots)
+		console.error(
+			`    +${bf.rowsAdded} rows for ${bf.placesFixed} places (${bf.noGeojson} candidates had no source geojson)`
+		)
+	}
 
 	// Dual-role-place relation (#403, epic #402) — needs `ancestors` + `spr` bbox + `place_population`,
 	// all present by now. Drives the resolver's hierarchy completion (on by default). Tiny (~hundreds of


### PR DESCRIPTION
## What & why

`#832` — "New York, NY" resolves to **New York Mills** (pop 3,190), not **NYC** (8.8M). Same for **London → a GB namesake**, **Singapore**, and ~2,850 other localities. These are the most demo-visible queries.

**Root cause (not the FTS window).** NYC carries `wof:parent_id = -4` — the WOF "ambiguous / multi-parent" sentinel (it straddles its five boroughs). The `ancestors` table is built as a `parent_id` closure (`populateAncestors`), which dead-ends at `-4`, so NYC ends up with **only-self ancestry**. The geocode applies `parentId = NY-state` as a **hard** filter (`parent_id=? OR id IN ancestors`), so NYC is excluded and a correctly-parented small namesake wins. (NYC was rank 22/49 in the FTS window — already present; the drop is purely the ancestry filter.)

**Why it regressed.** The `#441` fix — read the authoritative `wof:hierarchy` from source geojson (fully populated even when `parent_id=-4`) and insert the missing ancestor rows — existed only as a standalone post-build script (`scripts/backfill-ancestors-from-hierarchy.ts`). It was **never wired into the rebuild pipeline**, so the 2026-06-27 rebuild regenerated `ancestors` from scratch and re-orphaned everything.

## Change

- Extract the repair into a shared `backfillAncestorsFromHierarchy` + `discoverAdminDataRoots` (`@mailwoman/resolver-wof-sqlite/ancestry-backfill`).
- `build-unified-wof` **Phase 3** calls it inline, **after `populateAncestors`** and **before `coincident_roles`** (which reads ancestry) and the `VACUUM` freeze — so a fresh rebuild ships the repair and can't re-orphan.
- The standalone CLI becomes a thin wrapper for ad-hoc repair of an already-built DB; its hardcoded 11-repo admin list is replaced by auto-discovery (found 21 roots).
- Tests: `discoverAdminDataRoots` (nested/flat/depth-cap) + a `backfillAncestorsFromHierarchy` unit.

## Validation (staged copy of the live DB, canonical untouched)

Ran the backfill on a 3.5G copy → repaired **47,927 places (+147,875 ancestor rows)**, then geocoded end-to-end against it:

| query | before | after |
|---|---|---|
| `New York, NY` | (43.101) New York Mills | **(40.694) NYC** ✅ |
| `London, GB` | GB namesake | **London 8.8M** ✅ |
| Springfield IL/MA, Chicago, Boston, NYC-explicit | correct | correct (no regression) |

## Operator action — NOT in this PR

This PR fixes the **rebuild pipeline**. Applying the fix to the **running resolver** without a full rebuild is a separate **operator-gated canonical-DB swap**: the validated artifact is staged at `wof/staging-832b/admin-global-priority.db` (run `scripts/backfill-ancestors-from-hierarchy.ts` on a copy, or move the staged copy into place). After the swap, the Gauntlet `us-new-york-nyc` case flips from `improvement_target` → `pass`.

Separate, pre-existing follow-up (not addressed here): bare `New York, US` (no region) still picks a tiny "New York Township" — a bm25-dilution-vs-+4-population-cap quirk in the tuned ranking, identical on canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)