### PR TITLE
feat(#833): admin descendant-consistency — the joint-consistency resolve (replaces the country-prior band-aid)

### DIFF
--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -291,8 +291,8 @@ export interface ResolveOpts {
 	/**
 	 * Pass the resolved locality's BBOX to the address-point lookup as a final scope (#247). For shards whose points
 	 * carry no postcode/locality of their own (OSM addr nodes often don't), the postcode/locality probes miss and the
-	 * lookup falls through to a `(street, number)` probe within the box. OFF by default — US situs never sets it, so
-	 * the bbox arg is simply never supplied and its postcode/locality probes are byte-identical.
+	 * lookup falls through to a `(street, number)` probe within the box. OFF by default — US situs never sets it, so the
+	 * bbox arg is simply never supplied and its postcode/locality probes are byte-identical.
 	 */
 	addressPointBboxFallback?: boolean
 	/**
@@ -346,6 +346,17 @@ export interface ResolveOpts {
 	 * re-picked or demoted. Default 50.
 	 */
 	postcodeConsistencyGateKm?: number
+	/**
+	 * Admin descendant-consistency (#263). When a region resolved but its child locality did NOT — the greedy region pick
+	 * (name + population) chose a foreign namesake whose descendants hold no such locality ("Portland, ME" → Messina IT;
+	 * "Portland" then finds nothing beneath it and falls back to the region centroid) — re-pick the (region, locality)
+	 * pair JOINTLY against the gazetteer's containment graph: the best same-named locality that descends from one of the
+	 * region's same-named candidates. "Portland" descends from Maine, not Messina, so the pair resolves to (Maine,
+	 * Portland-Maine). Generalizes to every country with no country prior and no list. Costs ONE unscoped locality lookup
+	 * per triggering admin pair; only fires where a locality fell through, so the well-resolved path is byte-identical.
+	 * Needs {@link ResolverBackend.ancestors}; no-op without it. Default-off + byte-stable when unset.
+	 */
+	adminCoherence?: boolean
 	hierarchyCompletion?: boolean
 	/** @deprecated Renamed to {@link hierarchyCompletion} (#405 generalized #387). Still honored. */
 	cityStateFallback?: boolean

--- a/docs/articles/plan/2026-06-29-joint-consistency-resolution.mdx
+++ b/docs/articles/plan/2026-06-29-joint-consistency-resolution.mdx
@@ -102,6 +102,13 @@ most-populous one. Anything that looks like a curated list of famous places must
 from the gazetteer's own structure and provenance-tracked — the moment a hand-list can override where
 the gazetteer says an address actually is, we have rebuilt Pelias in a nicer font. (#264.)
 
+The MVP shipped on this branch (`opts.adminCoherence`, default-on for the geocode path). It fixes the
+clean class — a region whose child locality fell through — and the build surfaced exactly the residual
+this document predicted. "Augusta, ME" stays at Augusta, Sicily: "Augusta" resolves to a real town
+_under_ Messina, so the locality is not unresolved, and both Messina **and** Maine genuinely contain an
+Augusta. Two consistent pairs, and geography alone cannot break the tie. That is the forward
+address-system prior's job (US-format ⇒ prefer the US state), and it is the next section.
+
 ## Future work, gated on a measured residual
 
 Build to a measured gap, not to a good idea. Once descendant-consistency lands (#263), measure where it
@@ -129,7 +136,8 @@ scopes two things we do not have today (#265):
 
 ## Status
 
-Design only. Build order: #263 (descendant-consistency) → #264 (quick-cache role) → measure → #265
-(residual-scoped model + linkage). Companion reading: `concepts/synonymy-and-homonymy.mdx` (the
+MVP landed (#263, `opts.adminCoherence`). Remaining: #264 (quick-cache role) → measure the residual →
+#265 (residual-scoped forward model + the address-system→country linkage; "Augusta, ME" is the first
+case in that bucket). Companion reading: `concepts/synonymy-and-homonymy.mdx` (the
 tag-vs-referent split this extends), `concepts/joint-decoding-walkthrough.mdx` (the retired Stage 5
 veto), `plan/2026-06-14-coarse-placer-soft-signal-spec.md` (the prior that becomes the gap-filler).

--- a/docs/articles/plan/2026-06-29-joint-consistency-resolution.mdx
+++ b/docs/articles/plan/2026-06-29-joint-consistency-resolution.mdx
@@ -1,0 +1,135 @@
+---
+sidebar_position: 60
+title: Joint-consistency resolution — reading an address through the hermeneutic circle
+tags:
+  - plan
+  - architecture
+  - resolver
+  - design
+---
+
+# Joint-consistency resolution — reading an address through the hermeneutic circle
+
+_The target this document sets: an address should resolve to wherever its spans are **jointly
+consistent** in the gazetteer's containment graph, not to wherever a whole-string country guess
+points. "Portland, ME" is Portland, Maine because a Portland sits under Maine and none sits under
+Messina or Medway. Geography decides; the country prior only fills the silences. This is the design
+the #832 / #833 / VT failures asked for; it is not yet built._
+
+## What the failures told us
+
+Three bugs in late June 2026 share one root. "New York, NY" resolved to New York Mills (#832).
+"Portland, ME" resolved to Messina, Italy; "Portland, OR" to Ourense, Spain (#833). "Portland, VT"
+resolves to Viterbo and refuses to move even when you pin the country prior to the US at near-certainty.
+
+The shape underneath all three: the resolver works **greedily**. It resolves the region token "ME" on
+its own — by name match, population, and the soft country prior — and Messina wins on population before
+anything checks whether a "Portland" actually sits beneath it. Then it scopes the locality into the
+region it already picked. The one question that would have saved it — _which "ME" has a "Portland"
+under it?_ — never gets asked.
+
+We did once ask it. Stage 5 (the cross-component reconcile, see `plan/reference/STAGES.mdx`) scored
+whole assignments and vetoed an impossible parent chain (`Houston → New York` earns `-Infinity`
+because Who's On First says Houston descends from Texas). That reconcile was retired to argmax in #566
+because, bundled as it was, it broke the street/house-number precondition on the majority of US
+addresses. The admin-coherence check went out with the bathwater. The greedy fallback that replaced it
+is what produces #833.
+
+## The frame: a hermeneutic circle
+
+You cannot read the parts of an address without a guess at the whole, and you cannot fix the whole
+without the parts. "ME" is only Maine once you suspect the address is American; you only suspect it is
+American once you have read "ME", "Portland", and the shape of the string. Interpretation spirals: a
+provisional whole conditions the parts, the parts revise the whole, until the two cohere. This is the
+hermeneutic circle, and an address is a small, tractable instance of it.
+
+The system already runs a faint version of this loop inside the parser — `neural/anchor-inference.ts`
+infers a soft locale posterior and conditions its own labeling on it, with token-dropout so it never
+becomes dependent. What is missing is the **outer** loop, between the parse and the atlas, run over
+geography rather than over token features.
+
+The circle has two halves, and they are complementary:
+
+- **Forward** — format and script propose a system. A CJK script implies CJK address systems; a UK
+  alphanumeric postcode implies GB; a bare five-digit implies one of a small set. Today this is
+  rule-based (`query-shape`, `locale-gate`'s script-class scorer), and deliberately so — it reads
+  character classes and known postcode formats, never place-name dictionaries.
+- **Backward** — the resolved place confirms the system. Once "Portland, ME" lands in Maine, "US"
+  falls out of the result. You did not guess the country; you derived it.
+
+The coarse placer (#244) is a forward signal that skips the format and guesses the whole string at
+once. It is useful, but it is a guess, and on "Portland, ME" it guesses GB at 0.79 and routes the
+address to Italy. The backward half — geographic consistency — is the half we under-built.
+
+## What we build now: scoped admin descendant-consistency
+
+The minimum viable form of the backward half, using machinery that already exists. When resolving a
+region and a locality together, prefer the assignment in which the locality is a **descendant of the
+region** in the `ancestors` table (the same table #832 repaired):
+
+- "Portland, ME" → candidate regions `{Maine/US, Messina/IT, Medway/GB}`; only Maine has a "Portland"
+  descendant; resolve there.
+- "Portland, VT" → Vermont, because a Portland/Burlington descends from Vermont and not from Viterbo.
+
+This generalizes to every country with no country list and no placer in the loop. It needs no new
+data — `Portland (43.647, -70.168)` already records Maine as an ancestor in the swapped gazetteer. The
+hard constraint is **scope**: the check applies to the admin assignment only, so it cannot re-break the
+street/house-number path that retired the #566 reconcile. We are reintroducing the admin-coherence
+veto in isolation, not the whole beam.
+
+Tracking issue: **#263**. The deterministic country-prior patch we prototyped first (a β-weighted damp
+of the foreign posterior when a US state is recognized) is **shelved** on `spike/833-beta-fusion-shelved`
+— it fixed four of six targets but it is a US-only rule that never reaches the VT cases, and it leans on
+exactly the country-pin reflex this document is trying to retire.
+
+## The placer demotes to gap-filler
+
+This is the part to hold onto. The coarse placer does not disappear; it changes job. Where the
+gazetteer is rich, geography disambiguates and the placer is silent. Where the gazetteer is thin — a
+locality missing under any candidate parent — joint consistency returns nothing, and the placer's prior
+is what keeps a sparsely-covered country from resolving to "no answer." Primary signal: the graph.
+Fallback: the prior. The `HARD_PLACE_COUNTRY_SAFELIST` is the piece this most directly undercuts; its
+job shrinks as the graph's grows, and the docs already half-disown it (the 2026-06-26 postmortem
+measured that widening it changes nothing, because the placer abstains and it never gates).
+
+## The quick cache is the substrate, not a list
+
+There is room for a "well-known place" fast path, and we already have its substrate: the candidate-table
+byte-range gazetteer (`WofCandidateTableLookup`, `candidate-schema.ts`) — a `WITHOUT ROWID` B-tree keyed
+by `name_key`, denormalized so a resolve is a single probe, population-ranked. The constraint graph does
+not replace it; it **re-ranks within it**, choosing the joint-consistent candidate over the merely
+most-populous one. Anything that looks like a curated list of famous places must instead be derived
+from the gazetteer's own structure and provenance-tracked — the moment a hand-list can override where
+the gazetteer says an address actually is, we have rebuilt Pelias in a nicer font. (#264.)
+
+## Future work, gated on a measured residual
+
+Build to a measured gap, not to a good idea. Once descendant-consistency lands (#263), measure where it
+still fails, bucketed by why — romanized or transliterated input, mixed script, ambiguous field
+ordering, sparse-coverage countries where geography stays silent. That residual, and only that residual,
+scopes two things we do not have today (#265):
+
+- A **supplementary address-system model**. The "don't memorize" rule is task-scoped: the open-world job
+  (which Portland, of thousands) must generalize and retrieve; address-_system_ identification is a
+  closed, small taxonomy where densely encoding the format-to-system structure is learning the real
+  distribution, not overfitting. Such a model earns its keep on the fuzzy tier the rules and the graph
+  both miss. It stays **advisory** — it proposes a system, it never vetoes where geography lands an
+  address. Its larger payoff may be routing (which normalizer, which abbreviations, which field order,
+  which gazetteer slice), not disambiguation.
+- An **address-system → country-set** linkage. "Parses like a US address" makes US _and_ Canada
+  candidate postal systems, and floats their regions up — a derived prior, softer and more honest than a
+  whole-string guess. Not built.
+
+## Non-goals
+
+- No hand-curated country list, safe-list, or famous-place list as a source of truth. Derived and
+  provenance-tracked, or it does not ship.
+- No re-enabling of the full #566 beam reconcile. The admin-coherence check returns scoped and alone.
+- No supplementary model built ahead of the residual that justifies it.
+
+## Status
+
+Design only. Build order: #263 (descendant-consistency) → #264 (quick-cache role) → measure → #265
+(residual-scoped model + linkage). Companion reading: `concepts/synonymy-and-homonymy.mdx` (the
+tag-vs-referent split this extends), `concepts/joint-decoding-walkthrough.mdx` (the retired Stage 5
+veto), `plan/2026-06-14-coarse-placer-soft-signal-spec.md` (the prior that becomes the gap-filler).

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -129,6 +129,13 @@ export interface GeocodeDeps {
 	hardPlaceCountry?: boolean
 	/** #743/#194: override the coverage safelist gating {@link hardPlaceCountry}. Undefined → built-in. */
 	hardCountrySafelist?: ReadonlySet<string>
+	/**
+	 * Admin descendant-consistency (#263, `ResolveOpts.adminCoherence`) — re-pick a (region, locality) pair so the
+	 * locality descends from the region ("Portland, ME" → Maine, not Messina). **Default-on** for the geocode path; only
+	 * fires when a region's child locality fell through, so the well-resolved path is byte-identical. Pass `false` to opt
+	 * out.
+	 */
+	adminCoherence?: boolean
 }
 
 /**
@@ -308,6 +315,12 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	const interpolation = usShards.interpolation
 
 	const opts: ResolveOpts = {}
+
+	// Admin descendant-consistency (#263) — joint-consistency resolve over the gazetteer's containment graph.
+	// Default-on for the geocode path (byte-stable on the well-resolved cases — only fires when a region's
+	// child locality fell through); `adminCoherence: false` opts out. Fixes the "Portland, ME → Messina IT"
+	// class structurally, without a country prior or safelist.
+	if (deps.adminCoherence !== false) opts.adminCoherence = true
 
 	if (deps.defaultCountry) opts.defaultCountry = deps.defaultCountry
 	// Coarse country router (#244, soft prior) — DEFAULT-ON (#244 M2). undefined → the bundled placer;

--- a/resolver/admin-coherence.test.ts
+++ b/resolver/admin-coherence.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for #263 admin descendant-consistency (`opts.adminCoherence`). When a region resolves to a
+ *   foreign namesake (greedy by population — "ME" → Messina, IT) and its child locality then finds
+ *   nothing beneath it, re-pick the (region, locality) pair so the locality descends from a same-named
+ *   region candidate ("Portland" → Maine, not Messina). Joint over the containment graph; no country
+ *   prior, no list. Byte-stable when the flag is unset and when no consistent pair exists.
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import type { ResolvedPlace, ResolverBackend } from "@mailwoman/core/resolver"
+import { describe, expect, it } from "vitest"
+
+import { createWofResolver } from "./resolve.js"
+
+// "ME" → Messina (IT, greedy top by population) and Maine (US) — both exact abbrev matches.
+const MESSINA = {
+	id: 10,
+	name: "Messina",
+	placetype: "region",
+	country: "IT",
+	lat: 38.0,
+	lon: 14.9,
+	score: 9,
+	exactMatch: true,
+}
+const MAINE = {
+	id: 20,
+	name: "Maine",
+	placetype: "region",
+	country: "US",
+	lat: 45.3,
+	lon: -69.0,
+	score: 7,
+	exactMatch: true,
+}
+// A loose fuzzy runner-up ("ME" surfaces M-states) — must be ignored (not an exact match).
+const MISSOURI = {
+	id: 30,
+	name: "Missouri",
+	placetype: "region",
+	country: "US",
+	lat: 38.4,
+	lon: -92.5,
+	score: 6,
+	exactMatch: false,
+}
+// Portland lives under Maine (parent_id 20), not under Messina.
+const PORTLAND_ME: ResolvedPlace = {
+	id: 21,
+	name: "Portland",
+	placetype: "locality",
+	country: "US",
+	parent_id: 20,
+	lat: 43.66,
+	lon: -70.25,
+	score: 8,
+	exactMatch: true,
+}
+
+/** Backend filtered by name-substring + placetype + country + `parentId` (descendant scope via parent_id). */
+function makeBackend(places: ResolvedPlace[]): ResolverBackend {
+	return {
+		async findPlace(query) {
+			const text = query.text.toLowerCase()
+			const types = Array.isArray(query.placetype) ? query.placetype : query.placetype ? [query.placetype] : null
+
+			return places
+				.filter((p) => p.name.toLowerCase() === text || (p.placetype === "region" && text.length === 2)) // 2-letter abbrev matches its region candidates
+				.filter((p) => !types || types.includes(p.placetype))
+				.filter((p) => !query.country || p.country === query.country)
+				.filter((p) => query.parentId === undefined || p.parent_id === query.parentId)
+				.slice(0, query.limit ?? 5)
+		},
+	}
+}
+
+const node = (over: Partial<AddressNode> & Pick<AddressNode, "tag" | "value" | "start" | "end">): AddressNode => ({
+	confidence: 0.95,
+	children: [],
+	...over,
+})
+// region(ME) → locality(Portland), the shape recognizeUsRegions produces for "Portland, ME".
+const portlandMeTree = (): AddressTree => ({
+	raw: "Portland, ME",
+	roots: [
+		node({
+			tag: "region",
+			value: "ME",
+			start: 9,
+			end: 11,
+			children: [node({ tag: "locality", value: "Portland", start: 0, end: 8 })],
+		}),
+	],
+})
+
+function localityOf(tree: AddressTree): AddressNode | undefined {
+	const stack = [...tree.roots]
+
+	while (stack.length) {
+		const n = stack.pop()!
+
+		if (n.tag === "locality") return n
+		stack.push(...n.children)
+	}
+
+	return undefined
+}
+
+describe("resolveTree + adminCoherence (#263)", () => {
+	it("re-picks (region, locality) so the locality descends from the region", async () => {
+		const resolver = createWofResolver(makeBackend([MESSINA, MAINE, MISSOURI, PORTLAND_ME]))
+		const out = await resolver.resolveTree(portlandMeTree(), { adminCoherence: true })
+		const loc = localityOf(out)
+
+		expect(loc?.lat).toBeCloseTo(43.66, 2)
+		expect(loc?.lon).toBeCloseTo(-70.25, 2)
+		expect(loc?.metadata?.["admin_coherence_repicked"]).toBe(true)
+	})
+
+	it("is byte-stable when adminCoherence is unset (locality stays unresolved under the greedy region)", async () => {
+		const resolver = createWofResolver(makeBackend([MESSINA, MAINE, MISSOURI, PORTLAND_ME]))
+		const out = await resolver.resolveTree(portlandMeTree(), {})
+		const loc = localityOf(out)
+
+		// Greedy walk scoped Portland to Messina (parent 10) → nothing → unresolved; no re-pick.
+		expect(loc?.lat == null || (loc.lat === 0 && loc.lon === 0)).toBe(true)
+		expect(loc?.metadata?.["admin_coherence_repicked"]).toBeUndefined()
+	})
+
+	it("does not re-pick when no same-named locality descends from any region candidate", async () => {
+		// No Portland anywhere → the pass finds no consistent pair and leaves the tree alone.
+		const resolver = createWofResolver(makeBackend([MESSINA, MAINE, MISSOURI]))
+		const out = await resolver.resolveTree(portlandMeTree(), { adminCoherence: true })
+		const loc = localityOf(out)
+
+		expect(loc?.metadata?.["admin_coherence_repicked"]).toBeUndefined()
+	})
+
+	it("ignores fuzzy (non-exact) region candidates — a Portland under Missouri must NOT match the token 'ME'", async () => {
+		// Place a Portland under Missouri (the fuzzy runner-up). Since MISSOURI.exactMatch is false, the
+		// pass must not consider it, so no re-pick to Missouri.
+		const PORTLAND_MO: ResolvedPlace = { ...PORTLAND_ME, id: 31, parent_id: 30, lat: 37.0, lon: -93.0 }
+		const resolver = createWofResolver(makeBackend([MESSINA, MISSOURI, PORTLAND_MO]))
+		const out = await resolver.resolveTree(portlandMeTree(), { adminCoherence: true })
+		const loc = localityOf(out)
+
+		expect(loc?.metadata?.["admin_coherence_repicked"]).toBeUndefined()
+	})
+})

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -157,10 +157,10 @@ const isDirectionalUnit = (value: string): boolean => isStreetDirectionalToken(v
  * admin resolution is never altered.
  */
 /**
- * Half-width (degrees) of the bbox derived from a resolved locality centroid for the #247 OSM bbox fall-through.
- * ~0.25° ≈ 28 km N–S — generous enough for a large metro whose centroid sits off the queried point, while the EXACT
- * `(street, number)` match keeps a cross-commune collision rare. The proper fix is per-point scope backfill (the OSM
- * association / point-in-polygon pass, #250); this is the coverage stopgap until then.
+ * Half-width (degrees) of the bbox derived from a resolved locality centroid for the #247 OSM bbox fall-through. ~0.25°
+ * ≈ 28 km N–S — generous enough for a large metro whose centroid sits off the queried point, while the EXACT `(street,
+ * number)` match keeps a cross-commune collision rare. The proper fix is per-point scope backfill (the OSM association
+ * / point-in-polygon pass, #250); this is the coverage stopgap until then.
  */
 const LOCALITY_BBOX_RADIUS_DEG = 0.25
 
@@ -404,6 +404,88 @@ function applyPostcodeConsistency(roots: readonly AddressNode[], gateKm: number)
 	}
 }
 
+/**
+ * Admin descendant-consistency (#263) — the joint-consistency resolve, scoped to the admin assignment. The greedy walk
+ * resolves a region on its own (name + population), so "ME" picks Messina (IT) over Maine, then scopes "Portland" to
+ * Messina's descendants, finds nothing, and the result falls back to the region centroid (Sicily). The region's
+ * same-named runner-ups (Maine, Missouri, …) were already captured as `alternatives`; this pass asks the question the
+ * greedy order skipped — _which "ME" has a "Portland" under it?_ — and re-picks the (region, locality) pair where a
+ * same-named locality descends from a same-named region candidate. Geography decides; no country prior, no list.
+ *
+ * Fires ONLY for a resolved region whose child locality fell through (the unresolved-locality signal), so a
+ * well-resolved tree ("Springfield, IL" → Illinois, Springfield) is byte-identical. Costs one unscoped locality lookup
+ * per triggering pair. Needs {@link ResolverBackend.ancestors}; no-op without it. See `ResolveOpts.adminCoherence`.
+ */
+async function applyAdminCoherence(roots: readonly AddressNode[], backend: ResolverBackend): Promise<void> {
+	const visit = async (node: AddressNode, regionAncestor: AddressNode | null): Promise<void> => {
+		const regionHere = node.tag === "region" && isResolvedWithCoord(node) ? node : regionAncestor
+
+		if (
+			regionHere &&
+			(node.tag === "locality" || node.tag === "dependent_locality") &&
+			!isResolvedWithCoord(node) &&
+			node.value.trim().length > 0
+		) {
+			await reconcileAdminPair(regionHere, node, backend)
+		}
+
+		for (const child of node.children) await visit(child, regionHere)
+	}
+
+	for (const root of roots) await visit(root, null)
+}
+
+/**
+ * Re-pick a (region, locality) pair so the locality descends from the region. `alternatives` on the node are the
+ * `ResolvedPlace` runner-ups `decorateNode` attached (typed `unknown[]` in the decoder, which can't import resolver
+ * types — the cast is sound). Picks the FIRST same-named locality (already score-ordered) that descends from a
+ * same-named region candidate, then swaps both nodes. Leaves both untouched when no consistent pair exists (a genuinely
+ * un-gazetteered locality — "Portland, VT" with no Portland in Vermont — stays as the region centroid, not a foreign
+ * namesake).
+ */
+async function reconcileAdminPair(
+	regionNode: AddressNode,
+	localityNode: AddressNode,
+	backend: ResolverBackend
+): Promise<void> {
+	// EXACT region matches only: the alternatives for a 2-letter token are loose ("ME" also surfaces
+	// Missouri/Michigan/Mississippi as fuzzy M-state runner-ups). Restricting to exact name/alias matches
+	// (Maine/Messina/Medway for "ME") keeps the join honest. `exactMatch` is stamped by exactMatchTiering.
+	const regionCands = ((regionNode.alternatives as ResolvedPlace[] | undefined) ?? []).filter((r) => r.exactMatch)
+
+	// For each exact region candidate, ask the gazetteer directly: is there a same-named locality UNDER it?
+	// The `parentId` scope is the descendant test (over the #832-repaired ancestors table), and it finds the
+	// instance regardless of its global population rank — "Springfield, ME" reaches the small Springfield in
+	// Maine that an unscoped top-N window would drop. First region with an exact-named descendant wins; the
+	// region candidates are score-ordered, so a tie breaks toward the more prominent place.
+	for (const region of regionCands) {
+		const scoped = await backend.findPlace({
+			text: localityNode.value,
+			placetype: "locality",
+			parentId: region.id,
+			limit: 3,
+		})
+		const lc = scoped.find((l) => l.exactMatch && !(l.lat === 0 && l.lon === 0))
+
+		if (lc) {
+			decorateNode(
+				regionNode,
+				region,
+				regionCands.filter((r) => r !== region)
+			)
+			regionNode.metadata = { ...regionNode.metadata, admin_coherence_repicked: true }
+			decorateNode(
+				localityNode,
+				lc,
+				scoped.filter((l) => l !== lc)
+			)
+			localityNode.metadata = { ...localityNode.metadata, admin_coherence_repicked: true }
+
+			return
+		}
+	}
+}
+
 class WofResolver implements Resolver {
 	readonly #backend: ResolverBackend
 
@@ -448,6 +530,14 @@ class WofResolver implements Resolver {
 		// one span, two roles — no synthesized sibling. See ResolveOpts.hierarchyCompletion.
 		if (state.hierarchyCompletion && state.resolvedRegion && state.resolvedRegionNode && !state.localityNodePresent) {
 			this.#completeRegionRole(state.resolvedRegion, state.resolvedRegionNode)
+		}
+
+		// Admin descendant-consistency (#263): opt-in. Re-pick a (region, locality) pair so the locality
+		// descends from the region — runs BEFORE postcode-consistency (it resolves the locality the postcode
+		// pass may then refine) and before the street tiers (which key off the postcode/street, not the admin
+		// coordinate this adjusts). Byte-stable when `adminCoherence` is unset.
+		if (opts.adminCoherence) {
+			await applyAdminCoherence(newRoots, this.#backend)
 		}
 
 		// Postcode-consistency (#370 "Lever A"): opt-in. After the admin walk (needs both the locality

--- a/scripts/eval/gauntlet/cases/regression.ts
+++ b/scripts/eval/gauntlet/cases/regression.ts
@@ -117,21 +117,40 @@ export const REGRESSION_CASES: SeedCase[] = [
 		note: "Bare 'New York, NY' resolves to New York Mills (upstate, 43.10) instead of NYC. The placer is correct (US 0.92); this is the FTS ranking.",
 	},
 	{
-		// #833 — the placer mis-predicts Portland/ME → GB (Portland Dorset + 'ME' Medway), and the soft prior
-		// can't stop the IT 'ME'=Messina province match. Tracked until the placer + #194 hard-filter land.
+		// #833 — RESOLVED by admin descendant-consistency (#263). The greedy walk resolved region "ME" to
+		// Messina (IT, by population), "Portland" found nothing under it, and the result fell back to the
+		// Sicilian centroid. The fix re-picks the (region, locality) pair where the locality descends from a
+		// same-named region candidate — Portland descends from Maine, not Messina. No country prior, no list.
 		id: "us-portland-me",
 		input: "Portland, ME",
 		source: "bug:#833",
 		addressKind: "us_city_state",
 		country: "US",
-		status: "improvement_target",
+		status: "pass",
 		expectComponents: { region: "ME", locality: "Portland" },
 		expectLat: 43.647,
 		expectLon: -70.168,
 		expectToleranceM: 25000,
 		addedAt: "2026-06-29",
 		bugRef: "#833",
-		note: "Bare 'Portland, ME' resolves to Messina, Italy. The placer predicts GB 0.79 for it; works with the full state name ('Portland, Maine').",
+		note: "Was Messina, Italy. Fixed by joint-consistency (adminCoherence) — Portland descends from Maine, not Messina. Earlier deterministic country-prior patch shelved; this is the structural fix.",
+	},
+	{
+		// #833 sibling — a different namesake collision (region "OR" → Ourense, Spain), guards that the fix
+		// generalizes across countries (IT for ME, ES for OR), not just one province.
+		id: "us-portland-or",
+		input: "Portland, OR",
+		source: "bug:#833",
+		addressKind: "us_city_state",
+		country: "US",
+		status: "pass",
+		expectComponents: { region: "OR", locality: "Portland" },
+		expectLat: 45.537,
+		expectLon: -122.65,
+		expectToleranceM: 25000,
+		addedAt: "2026-06-29",
+		bugRef: "#833",
+		note: "Was Ourense, Spain ('OR' province). Fixed by adminCoherence — Portland descends from Oregon. Guards the country-agnostic generalization of the joint-consistency fix.",
 	},
 	{
 		// A clean US 'City, ST' that resolves correctly — guards the working path so a placer/ranking change


### PR DESCRIPTION
## What & why

"Portland, ME" resolved to **Messina, Italy**; "Portland, OR" to **Ourense, Spain**; "Portland, VT" to Viterbo and wouldn't move even with the country prior pinned (#833). One root cause: the resolver works **greedily** — it resolves the region token "ME" on its own (name + population), Messina wins before anything checks whether a "Portland" sits beneath it, then scopes the locality into the region it already picked. The one question that would save it — *which "ME" has a "Portland" under it?* — never gets asked. (Stage 5 once asked it; it was retired to argmax in #566 for breaking the street path.)

This is the **structural** fix, agreed after a 4-turn DeepSeek-pro consult and an architecture discussion with the operator: resolve the admin assignment by **joint geographic consistency** in the WOF containment graph, not by a country guess. Design doc: `docs/articles/plan/2026-06-29-joint-consistency-resolution.mdx`.

It **replaces** the deterministic country-prior patch first prototyped (a β-weighted damp of the foreign posterior when a US state is recognized) — that fixed 4/6 targets but was a US-only rule that couldn't reach VT and leaned on the country-pin reflex the operator flagged as the Pelias road. It's preserved on `spike/833-beta-fusion-shelved`.

## The change

- **`resolver`**: `applyAdminCoherence` (`opts.adminCoherence`) — a scoped post-walk pass (sibling to #370's postcode-consistency). It fires **only** for a resolved region whose child locality fell through, so a well-resolved tree is byte-identical. For each **exact** same-token region candidate (Maine/Messina/Medway for "ME", not the fuzzy Missouri/Michigan), it asks the gazetteer — scoped by `parentId` over the #832-repaired `ancestors` table — whether a same-named locality sits under it. First match wins; both nodes re-pick. No country prior, no safelist, no list.
- **`geocode-core`**: default-on for the geocode path (`adminCoherence: false` opts out).

## Results

| query | before | after |
|---|---|---|
| Portland, ME | Messina, IT | **Maine** ✅ |
| Portland, OR | Ourense, ES | **Oregon** ✅ |
| Burlington, VT | Viterbo, IT | **Vermont** ✅ |
| Springfield, ME | Messina, IT | **Maine** ✅ (reaches the tiny Springfield via scoped lookup) |
| Springfield IL / Chicago / NYC / Cambridge MA | correct | unchanged (byte-stable) |
| Berlin DE / Toronto CA / Mumbai IN (placer-wrong) | wrong | unchanged (not regressed) |

- **Gauntlet**: `us-portland-me` + `us-portland-or` promoted to gated `pass`; regression + metamorphic **PASS, zero new violations**.
- 4 resolver unit tests; `tsc -b` clean across the repo; 73/73 resolver tests pass.

## Known residual (scopes #265)

"Augusta, ME → Augusta, Sicily" is **not** fixed and shouldn't be here: "Augusta" resolves to a real town *under* Messina (so the locality isn't unresolved), and both Messina and Maine genuinely contain an Augusta. Two consistent pairs — geography can't break the tie. That's the forward address-system prior's job (US-format ⇒ prefer the US state), tracked as #265.

## Generalizes

No US-specific logic — the same join fixes any "City, ST" namesake collision in any country, and its job shrinks the `HARD_PLACE_COUNTRY_SAFELIST`'s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)