### PR TITLE
feat(#833): close the two-pairs residual with the forward country_hint linkage

### DIFF
--- a/mailwoman/region-recognition.ts
+++ b/mailwoman/region-recognition.ts
@@ -195,12 +195,32 @@ function correctNode(node: AddressNode): AddressNode {
 }
 
 /**
+ * Stamp `country_hint: "US"` on a region node whose value is a 2-letter US state ABBREVIATION (the ones the parser
+ * produced directly — "Augusta, ME" → region(ME) — as well as the ones we re-tagged). The forward
+ * address-system→country linkage: the resolver constrains a hinted region's lookup to US, so a two-consistent-pairs
+ * collision ("Augusta" under both Maine and Messina) resolves the US state.
+ *
+ * ABBREVIATIONS ONLY, deliberately. A 2-letter "ME"/"OR"/"GA" in `City, ST` position is unambiguously the US state
+ * (foreign collisions like Messina/Ourense lose in US-format context, and Georgia-the-country is "GE", not "GA"). A
+ * full NAME is genuinely ambiguous — "Tbilisi, Georgia" is the country, "Atlanta, Georgia" the state — so full names
+ * are left to resolve on their own name-match evidence, never pinned.
+ */
+function annotateUsRegions(node: AddressNode): void {
+	if (node.tag === "region" && /^[A-Za-z]{2}$/.test(node.value.trim()) && usStateSlug(node.value)) {
+		node.metadata = { ...node.metadata, country_hint: "US" }
+	}
+
+	for (const child of node.children) annotateUsRegions(child)
+}
+
+/**
  * Recognize US regions the parser missed and restructure `"City, State"` into `region → locality` nesting so the
  * resolver scopes the locality to its state (#642). Mutates + returns the tree. A no-op when no US state token is found
  * mis-tagged — byte-stable for already-correct parses.
  */
 export function recognizeUsRegions(tree: AddressTree): AddressTree {
 	tree.roots = correctSiblings(tree.roots).map(correctNode)
+	for (const root of tree.roots) annotateUsRegions(root)
 
 	return tree
 }

--- a/resolver/country-hint.test.ts
+++ b/resolver/country-hint.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the #833 forward `country_hint` linkage. A region node carrying `metadata.country_hint`
+ *   (an address-system recognizer's derived country — `recognizeUsRegions` stamps "US" on a 2-letter US
+ *   state abbrev) constrains THAT node's lookup to the hinted country, below a resolved parent's country
+ *   but above the global defaults. It breaks the two-consistent-pairs tie ("Augusta, ME" → Maine, not
+ *   the more-populous Augusta under Messina) that geographic consistency alone cannot.
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import type { ResolvedPlace, ResolverBackend } from "@mailwoman/core/resolver"
+import { describe, expect, it } from "vitest"
+
+import { createWofResolver } from "./resolve.js"
+
+const MESSINA = {
+	id: 10,
+	name: "Messina",
+	placetype: "region",
+	country: "IT",
+	lat: 38.0,
+	lon: 14.9,
+	score: 9,
+	exactMatch: true,
+}
+const MAINE = {
+	id: 20,
+	name: "Maine",
+	placetype: "region",
+	country: "US",
+	lat: 45.3,
+	lon: -69.0,
+	score: 7,
+	exactMatch: true,
+}
+const AUGUSTA_ME: ResolvedPlace = {
+	id: 21,
+	name: "Augusta",
+	placetype: "locality",
+	country: "US",
+	parent_id: 20,
+	lat: 44.31,
+	lon: -69.78,
+	score: 8,
+	exactMatch: true,
+}
+const AUGUSTA_IT: ResolvedPlace = {
+	id: 11,
+	name: "Augusta",
+	placetype: "locality",
+	country: "IT",
+	parent_id: 10,
+	lat: 37.2,
+	lon: 15.2,
+	score: 9,
+	exactMatch: true,
+}
+
+/** Backend filtered by name + placetype + country + parentId. Regions match any 2-letter token (abbrev). */
+function makeBackend(places: ResolvedPlace[]): ResolverBackend {
+	return {
+		async findPlace(query) {
+			const text = query.text.toLowerCase()
+			const types = Array.isArray(query.placetype) ? query.placetype : query.placetype ? [query.placetype] : null
+
+			return places
+				.filter((p) => p.name.toLowerCase() === text || (p.placetype === "region" && text.length === 2))
+				.filter((p) => !types || types.includes(p.placetype))
+				.filter((p) => !query.country || p.country === query.country)
+				.filter((p) => query.parentId === undefined || p.parent_id === query.parentId)
+				.slice(0, query.limit ?? 5)
+		},
+	}
+}
+
+const node = (over: Partial<AddressNode> & Pick<AddressNode, "tag" | "value" | "start" | "end">): AddressNode => ({
+	confidence: 0.95,
+	children: [],
+	...over,
+})
+// region(ME) → locality(Augusta), with the hint set or not.
+const augustaMeTree = (hint: boolean): AddressTree => ({
+	raw: "Augusta, ME",
+	roots: [
+		node({
+			tag: "region",
+			value: "ME",
+			start: 9,
+			end: 11,
+			...(hint ? { metadata: { country_hint: "US" } } : {}),
+			children: [node({ tag: "locality", value: "Augusta", start: 0, end: 7 })],
+		}),
+	],
+})
+
+function localityOf(tree: AddressTree): AddressNode | undefined {
+	const stack = [...tree.roots]
+
+	while (stack.length) {
+		const n = stack.pop()!
+
+		if (n.tag === "locality") return n
+		stack.push(...n.children)
+	}
+
+	return undefined
+}
+
+describe("resolveTree + country_hint (#833 forward linkage)", () => {
+	it("pins a hinted region to its country → the US locality wins the two-pairs tie", async () => {
+		const resolver = createWofResolver(makeBackend([MESSINA, MAINE, AUGUSTA_ME, AUGUSTA_IT]))
+		const out = await resolver.resolveTree(augustaMeTree(true), {})
+		const loc = localityOf(out)
+
+		// region "ME" constrained to US → Maine; Augusta scopes to Maine → Augusta, Maine (not Sicily).
+		expect(loc?.lat).toBeCloseTo(44.31, 2)
+		expect(loc?.lon).toBeCloseTo(-69.78, 2)
+	})
+
+	it("without the hint, the greedy region (more-populous Messina) wins and Augusta lands in Sicily", async () => {
+		const resolver = createWofResolver(makeBackend([MESSINA, MAINE, AUGUSTA_ME, AUGUSTA_IT]))
+		const out = await resolver.resolveTree(augustaMeTree(false), {})
+		const loc = localityOf(out)
+
+		expect(loc?.lat).toBeCloseTo(37.2, 1)
+		expect(loc?.lon).toBeCloseTo(15.2, 1)
+	})
+})

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -668,7 +668,16 @@ class WofResolver implements Resolver {
 		// wrong-continent guess the hard filter exists to drop ("in-region or unresolved"). Measured: a
 		// global fallback collapses back to the soft-prior baseline (FI p90 3050, PL p90 1078); pure-hard
 		// collapses the tail (FI 18 km, PL p99 8172→494) at a coverage-bounded recall cost.
-		const country = parentResolved?.country ?? state.defaultCountry ?? state.hardCountry
+		// #833 forward linkage: a node's own `country_hint` (an address-system recognizer's derived country —
+		// today `recognizeUsRegions` stamping "US" on a recognized closed-set US state) constrains THIS node's
+		// lookup, below a resolved parent's country but above the global defaults. It breaks the two-consistent-
+		// pairs tie ("Augusta, ME" → Maine, not Augusta/Messina) that pure geographic consistency cannot.
+		const countryHint = node.metadata?.["country_hint"]
+		const country =
+			parentResolved?.country ??
+			(typeof countryHint === "string" ? countryHint : undefined) ??
+			state.defaultCountry ??
+			state.hardCountry
 
 		if (country) query.country = country
 

--- a/scripts/eval/gauntlet/cases/regression.ts
+++ b/scripts/eval/gauntlet/cases/regression.ts
@@ -155,6 +155,24 @@ export const REGRESSION_CASES: SeedCase[] = [
 		note: "Was Ourense, Spain ('OR' province). Fixed by adminCoherence — Portland descends from Oregon. Guards the country-agnostic generalization of the joint-consistency fix.",
 	},
 	{
+		// #833 two-pairs residual — "Augusta" exists under BOTH Maine and Messina (IT), so the locality
+		// resolves under the greedy foreign region and adminCoherence's unresolved-trigger never fires.
+		// Closed by the forward `country_hint` linkage: a 2-letter US-state abbrev pins the region to US.
+		id: "us-augusta-me",
+		input: "Augusta, ME",
+		source: "bug:#833",
+		addressKind: "us_city_state",
+		country: "US",
+		status: "pass",
+		expectComponents: { region: "ME", locality: "Augusta" },
+		expectLat: 44.31,
+		expectLon: -69.78,
+		expectToleranceM: 25000,
+		addedAt: "2026-06-29",
+		bugRef: "#833",
+		note: "Was Augusta, Sicily — the two-consistent-pairs case (Augusta under both Maine and Messina). Fixed by the abbrev-only country_hint forward linkage (recognizeUsRegions → resolver country=US), not the descendant-consistency pass.",
+	},
+	{
 		// A clean US 'City, ST' that resolves correctly — guards the working path so a placer/ranking change
 		// for #832/#833 can't silently regress it. Springfield-IL is also a tuned exact-match case.
 		id: "us-springfield-il",


### PR DESCRIPTION
## What & why

Closes the last #833 residual that the descendant-consistency resolve (#263) couldn't reach. #263 fixes the cases where a region's child locality *falls through* under the greedy foreign pick. It can't break the **two-consistent-pairs** tie: "Augusta, ME" — Augusta exists under *both* Maine and Messina (IT), so the locality resolves under the populous foreign region and #263's unresolved-trigger never fires. Geography alone can't decide; you need the forward signal.

This is the **forward address-system→country linkage** #265 scoped as the right fix (a derived prior, not a model, not a list): `recognizeUsRegions` stamps `country_hint: "US"` on a region whose value is a 2-letter US-state **abbreviation**, and the resolver constrains that node's lookup to the hint (below a resolved parent's country, above the global defaults). "Augusta, ME" → region pinned to US → Maine → Augusta, Maine.

## Abbreviations only — deliberately

A 2-letter "ME"/"OR"/"GA" in `City, ST` position is unambiguously the US state (foreign collisions like Messina/Ourense lose in US-format context; Georgia-the-country is **GE**, not GA). A full **name** is genuinely ambiguous — "Tbilisi, Georgia" is the country, "Atlanta, Georgia" the state — so full names are **never** pinned; they resolve on their own name-match evidence. The hint is *derived* from the recognition, not a hardcoded country list, and any future admin recognizer sets its own.

| query | before | after |
|---|---|---|
| Augusta, ME | Augusta, Sicily | **Maine** ✅ |
| Meda, OR | foreign | **Oregon** ✅ |
| San Gregorio, CA | foreign | **California** ✅ |
| Atlanta, GA / Atlanta, Georgia | US Georgia | unchanged ✅ |
| Tbilisi, Georgia (country) | US Georgia | unchanged (not pinned) |
| Portland ME / Springfield IL / NYC | correct | unchanged |

- **Gauntlet**: `us-augusta-me` added + promoted to gated `pass`; regression **9/9 gated**, metamorphic unchanged.
- 2 resolver unit tests (`country-hint.test.ts`); full `tsc -b` clean; 75/75 resolver tests.

## Known separate follow-up

"Tbilisi, Georgia" (full-name country) still mis-routes to US Georgia — the *reverse* namesake plus the #266 coverage-added international localities lacking parent ancestry (a data-quality item). Not in scope here; full-name "Georgia" is correctly left un-pinned by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)