### PR TITLE
feat(#267): fold GeoNames admin hierarchy + ancestry for coverage gap countries

### DIFF
--- a/docs/articles/evals/2026-06-29-day-postmortem.md
+++ b/docs/articles/evals/2026-06-29-day-postmortem.md
@@ -1,0 +1,47 @@
+# 2026-06-29 day shift — the constraint-graph arc
+
+_A collaborative day that started as three namesake bugs and turned into an architecture. The throughline: stop guessing a country and let the gazetteer's own geometry decide where an address is — and when geometry ties, let the parser's recognition, not a hardcoded list, break it._
+
+## What shipped
+
+- **#832 — NYC, London, and the marquee-city namesake bug.** "New York, NY" was resolving to New York Mills (pop 3,190) over NYC (8.8M). The root cause was not the FTS ranking — NYC was in the window. It was NYC's WOF `parent_id = -4` (the multi-parent sentinel for a city straddling five boroughs), which left it only-self in the `ancestors` table, so the region hard-filter excluded it. The #441 `wof:hierarchy` backfill that fixes exactly this had never been wired into the rebuild pipeline, so the 2026-06-27 rebuild re-orphaned it. Fixed by wiring the backfill into `build-unified-wof` (PR #835) and swapping the repaired canonical DB. (PR #836 locked the gauntlet case to a gated pass.)
+
+- **#833 — Portland, ME → Messina, Italy.** First diagnosed as a coarse-placer mis-prediction (GB 0.79), and a β-weighted posterior damp was built to correct it. Then the operator pushed back: a country safelist or a deterministic country-pin "borders on Pelias." That reframed the whole problem. The real fix is **joint geographic consistency** — resolve the (region, locality) pair where the locality descends from a same-named region candidate, because a "Portland" sits under Maine and not under Messina. No country prior, no list, and it generalizes to every country. Shipped as `opts.adminCoherence` (PR #837); the β-fusion was shelved on a spike branch. The two-consistent-pairs residual it can't reach (Augusta exists under *both* Maine and Messina) is closed by a **derived** forward signal: `recognizeUsRegions` stamps `country_hint: "US"` on a 2-letter state abbreviation, and the resolver constrains that lookup to US (PR #838). Abbreviations only — a full "Georgia" stays ambiguous and is never pinned.
+
+- **#266 — international coverage.** The #265 measurement found the off-map gap was coverage, not routing: the server gazetteer had **zero localities for ~147 countries** (Skopje, Tbilisi, Yerevan all absent). The night-2026-06-28 GeoNames `cities15000` fold had been staged but never promoted, and it predated #832. Reconciled the two (re-applied the ancestry backfill to the staged coverage DB), validated, and swapped it in: **97 → 244 countries, 2.97M → 3.74M localities**. Romanized off-map resolution went from 0% to ~80% (MK 84%, GE 79%, AM 90%, CY 64%), with the US path untouched.
+
+## The decision that mattered: not building a model
+
+#265 asked whether a supplementary forward address-system model was worth building. The measurement said no, and saying no was the win:
+
+- The US two-pairs residual (Augusta) is small and rule-shaped — a derived `country_hint` closes it.
+- The off-map international "0%" was a coverage hole, and a model cannot route to a place that isn't in the gazetteer.
+- Covered international (JP/KR) already resolves 11/12 romanized.
+
+No measured residual justified a learned model. The international lever was coverage (#266), which moved the number from 0% to 80% with data, not parameters.
+
+## Disciplines that earned their keep
+
+- **Verify before verdict** fired repeatedly: the #832 FTS hypothesis was wrong (it was ancestry); the β-fusion's "fixed 4/6" hid an arithmetic hole; the #265 off-map "0%" was coverage, not routing, and the spot-check caught it before a wrong conclusion shipped.
+- **Test the numbers** caught two arithmetic holes in the DeepSeek-proposed β-fusion formula — discounting the argmax only trades Italy for England, and multiplying non-US mass by β can't lift US from zero. The structural advice held; the specific numbers needed a probe. (4-turn pro consult; structural 4/4, quantitative corrected twice.)
+- **Diagnostic before fix** killed the forward model and redirected the effort to coverage.
+
+## Numbers
+
+| | |
+|---|---|
+| PRs merged | #835, #836, #837 (+ #838 in flight) |
+| Canonical DB swaps | 2 (ancestry #832, coverage #266), both build-on-copy + validated |
+| Coverage | 97 → 244 countries; 2.97M → 3.74M localities |
+| Off-map romanized | 0% → ~80% |
+| Gauntlet | regression 9/9 gated, metamorphic unchanged, 0 new violations |
+| Models trained | 0 (the day's one model question was answered "don't") |
+
+## Open / next
+
+- **#838** merges to close the #833 family completely.
+- **R2 deploy + B3 (#260):** the staged coverage *candidate* table makes the win demo-visible in the browser, but the candidate path is denormalized (no `parentId` scoping), so adminCoherence needs a candidate-table change to reach the browser. `country_hint` already works there (the candidate lookup honors a country filter). An R2 deploy is operator-gated.
+- **"Tbilisi, Georgia" (full-name country)** still mis-routes to US Georgia — the reverse namesake plus the coverage-added intl localities lacking parent ancestry. A #266 data-quality follow-up.
+- **#261** (case-aug retrain, gate-failed) and **#259** (the dev-symlink that made the #261 gate baseline unfaithful) remain operator calls.
+
+Design reference: [`plan/2026-06-29-joint-consistency-resolution.mdx`](../plan/2026-06-29-joint-consistency-resolution.mdx).

--- a/mailwoman/gazetteer-pipeline.ts
+++ b/mailwoman/gazetteer-pipeline.ts
@@ -109,8 +109,15 @@ export interface FoldOptions {
 	adminOut: string
 	/** ISO 3166-1 alpha-2 codes whose GeoNames dumps to fold (default {@link DEFAULT_FOLD_COUNTRIES}). */
 	countries?: readonly string[]
-	/** Dir holding `<CC>.txt` GeoNames dumps (default `<data-root>/geonames`). */
+	/** Dir holding `<CC>.txt` GeoNames dumps (default {@link DEFAULT_FOLD_COUNTRIES}). */
 	geonamesDir?: string
+	/**
+	 * #267: the countries to ALSO fold A-class admin (PCLI + ADM1) for, linking the locality→region→country ancestry.
+	 * ZERO-COVERAGE gap countries only (the coverage-expansion targets) — a country that already has WOF admin would
+	 * double up, so the EU alias set is left off. Without it the gap localities are orphans and "Tbilisi, GE" can't
+	 * resolve.
+	 */
+	adminForCountries?: ReadonlySet<string>
 	onCountry?: (event: GeonamesIngestProgress) => void
 	onPhase?: (phase: string, detail?: string) => void
 }
@@ -143,7 +150,8 @@ export async function foldGeonamesIntoAdmin(opts: FoldOptions): Promise<FoldResu
 		db,
 		[...(opts.countries ?? DEFAULT_FOLD_COUNTRIES)],
 		opts.geonamesDir ?? geonamesDir(),
-		opts.onCountry
+		opts.onCountry,
+		opts.adminForCountries ? { adminForCountries: opts.adminForCountries } : undefined
 	)
 	opts.onPhase?.("place_search", "rebuilding place_search + place_bbox from the updated names")
 	const res = buildPlaceSearchFts(db, { drop: true, onProgress: (phase, detail) => opts.onPhase?.(phase, detail) })

--- a/resolver-wof-sqlite/geonames-admin.test.ts
+++ b/resolver-wof-sqlite/geonames-admin.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #267 — `ingestGeonamesAliases({ includeAdmin: true })` folds the GeoNames A-class admin (PCLI country
+ *   + ADM1 regions) alongside the P-class localities and links the locality→region→country ancestry, so
+ *   `parentId` scoping and adminCoherence reach the gap countries ("Tbilisi, GE" can resolve).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { afterAll, beforeAll, expect, test } from "vitest"
+
+import { ingestGeonamesAliases } from "./geonames-aliases.js"
+
+let dir: string
+let db: DatabaseSync
+
+// One GeoNames row: 19 tab-separated columns (id, name, ascii, alt, lat, lon, fclass, fcode, country, cc2,
+// admin1, admin2, admin3, admin4, pop, elev, dem, tz, mod).
+function row(over: Record<number, string>): string {
+	const f = Array(19).fill("")
+	for (const [i, v] of Object.entries(over)) f[Number(i)] = v
+	return f.join("\t")
+}
+
+beforeAll(() => {
+	dir = mkdtempSync(join(tmpdir(), "geonames-admin-"))
+	const lines = [
+		// PCLI country: Georgia
+		row({ 0: "614540", 1: "Georgia", 2: "Georgia", 4: "42.0", 5: "43.5", 6: "A", 7: "PCLI", 8: "GE" }),
+		// ADM1 region: T'bilisi (admin1 code 51)
+		row({ 0: "611716", 1: "Tbilisi", 2: "Tbilisi", 4: "41.7", 5: "44.8", 6: "A", 7: "ADM1", 8: "GE", 10: "51" }),
+		// PPLC locality: Tbilisi (in admin1 51)
+		row({
+			0: "611717",
+			1: "Tbilisi",
+			2: "Tbilisi",
+			4: "41.69",
+			5: "44.83",
+			6: "P",
+			7: "PPLC",
+			8: "GE",
+			10: "51",
+			14: "1049498",
+		}),
+	].join("\n")
+	writeFileSync(join(dir, "GE.txt"), lines)
+
+	db = new DatabaseSync(":memory:")
+	db.exec(
+		`CREATE TABLE spr (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+		 latitude REAL, longitude REAL, min_latitude REAL, min_longitude REAL, max_latitude REAL, max_longitude REAL,
+		 is_current INTEGER, is_deprecated INTEGER, is_ceased INTEGER, is_superseded INTEGER, is_superseding INTEGER, lastmodified INTEGER)`
+	)
+	db.exec(
+		`CREATE TABLE names (id INTEGER, name TEXT, placetype TEXT, country TEXT, language TEXT, lastmodified INTEGER)`
+	)
+	db.exec(`CREATE TABLE ancestors (id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT, lastmodified INTEGER)`)
+	db.exec(`CREATE TABLE place_population (id INTEGER PRIMARY KEY, population INTEGER)`)
+
+	ingestGeonamesAliases(db, ["GE"], dir, () => {}, { adminForCountries: new Set(["GE"]) })
+})
+
+afterAll(() => {
+	db.close()
+	rmSync(dir, { recursive: true, force: true })
+})
+
+test("folds the country (PCLI) and region (ADM1) as admin spr rows", () => {
+	const country = db
+		.prepare("SELECT name, placetype, country FROM spr WHERE placetype='country' AND country='GE'")
+		.get() as any
+	const region = db.prepare("SELECT name, placetype FROM spr WHERE placetype='region' AND country='GE'").get() as any
+
+	expect(country?.name).toBe("Georgia")
+	expect(region?.name).toBe("Tbilisi")
+})
+
+test("links the locality → region → country ancestry so parentId scoping reaches it", () => {
+	const loc = db.prepare("SELECT id, parent_id FROM spr WHERE placetype='locality' AND country='GE'").get() as any
+	const region = db.prepare("SELECT id FROM spr WHERE placetype='region' AND country='GE'").get() as any
+	const country = db.prepare("SELECT id FROM spr WHERE placetype='country' AND country='GE'").get() as any
+
+	// Locality is parented to its region; the ancestor chain carries both region and country.
+	expect(loc.parent_id).toBe(region.id)
+	const ancestorIds = db
+		.prepare("SELECT ancestor_id FROM ancestors WHERE id = ? ORDER BY ancestor_id")
+		.all(loc.id)
+		.map((r: any) => r.ancestor_id)
+	expect(ancestorIds).toContain(region.id)
+	expect(ancestorIds).toContain(country.id)
+	// The region itself ancestors to the country (so a region→country query works too).
+	const regionAnc = db
+		.prepare("SELECT ancestor_id FROM ancestors WHERE id = ?")
+		.all(region.id)
+		.map((r: any) => r.ancestor_id)
+	expect(regionAnc).toContain(country.id)
+})
+
+test("default (no includeAdmin) stays localities-only with no admin rows — byte-stable", () => {
+	const db2 = new DatabaseSync(":memory:")
+	db2.exec(`CREATE TABLE spr (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+		 latitude REAL, longitude REAL, min_latitude REAL, min_longitude REAL, max_latitude REAL, max_longitude REAL,
+		 is_current INTEGER, is_deprecated INTEGER, is_ceased INTEGER, is_superseded INTEGER, is_superseding INTEGER, lastmodified INTEGER)`)
+	db2.exec(
+		`CREATE TABLE names (id INTEGER, name TEXT, placetype TEXT, country TEXT, language TEXT, lastmodified INTEGER)`
+	)
+	db2.exec(`CREATE TABLE ancestors (id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT, lastmodified INTEGER)`)
+	db2.exec(`CREATE TABLE place_population (id INTEGER PRIMARY KEY, population INTEGER)`)
+	ingestGeonamesAliases(db2, ["GE"], dir, () => {})
+
+	expect((db2.prepare("SELECT COUNT(*) n FROM spr WHERE placetype IN ('country','region')").get() as any).n).toBe(0)
+	expect((db2.prepare("SELECT COUNT(*) n FROM ancestors").get() as any).n).toBe(0)
+	expect((db2.prepare("SELECT parent_id FROM spr WHERE placetype='locality'").get() as any).parent_id).toBe(-1)
+	db2.close()
+})

--- a/resolver-wof-sqlite/geonames-aliases.ts
+++ b/resolver-wof-sqlite/geonames-aliases.ts
@@ -56,7 +56,17 @@ export function ingestGeonamesAliases(
 	db: DatabaseSync,
 	countries: string[],
 	geonamesDir: string,
-	onProgress?: (event: GeonamesIngestProgress) => void
+	onProgress?: (event: GeonamesIngestProgress) => void,
+	opts?: {
+		/**
+		 * #267: the countries for which to ALSO fold the GeoNames A-class admin (PCLI country + ADM1 regions) and link each
+		 * locality's `parent_id` + ancestry chain (locality → region → country). PER-COUNTRY because a country that already
+		 * carries WOF admin would double up — pass only the ZERO-COVERAGE gap countries (the coverage-expansion targets),
+		 * never the EU alias set. Without admin, a gap country's localities are orphans (`parent_id=-1`, no ancestors), so
+		 * `parentId` scoping and adminCoherence can't reach them and "Tbilisi, GE" can't resolve.
+		 */
+		adminForCountries?: ReadonlySet<string>
+	}
 ): number {
 	// Latin-only, no bracket/paren noise GeoNames packs into `alternatenames` ("(( Karis Landskommun ))",
 	// airport codes), 2–60 chars, at least one letter (drops bare postcodes/numbers).
@@ -73,6 +83,11 @@ export function ingestGeonamesAliases(
 		`INSERT INTO names (id, name, placetype, country, language, lastmodified) VALUES (?, ?, ?, ?, ?, ?)`
 	)
 	const populationInsert = db.prepare(`INSERT OR REPLACE INTO place_population (id, population) VALUES (?, ?)`)
+	// #267 admin linkage: ancestor rows (locality→region→country) so parentId scoping + adminCoherence reach
+	// the gap countries. Only used for a country in opts.adminForCountries.
+	const ancestorInsert = db.prepare(
+		`INSERT INTO ancestors (id, ancestor_id, ancestor_placetype, lastmodified) VALUES (?, ?, ?, 0)`
+	)
 
 	const report = (event: GeonamesIngestProgress, missingFile?: string): void => {
 		if (onProgress) {
@@ -100,9 +115,52 @@ export function ingestGeonamesAliases(
 			continue
 		}
 		let nc = 0
+		// #267: add A-class admin + ancestry only for the gap countries this country is in (never the EU set).
+		const addAdmin = opts?.adminForCountries?.has(cc) ?? false
+		// GeoNames dump columns (0-indexed): 1 name, 2 asciiname, 3 alternatenames, 4 lat, 5 lon, 6 feature_class,
+		// 7 feature_code, 10 admin1 code, 14 pop.
+		const lines = readFileSync(file, "utf8").split("\n")
 
-		// GeoNames dump columns: 1 name, 2 asciiname, 3 alternatenames, 4 lat, 5 lon, 6 feature_class, 14 pop.
-		for (const line of readFileSync(file, "utf8").split("\n")) {
+		// #267 admin pre-pass (gap countries): fold the country (PCLI) + regions (ADM1), self+ancestry them, and
+		// build the admin1→region map the localities link through. Point bbox (GeoNames gives a centroid only).
+		let countryId = -1
+		const adminMap = new Map<string, number>()
+
+		if (addAdmin) {
+			for (const line of lines) {
+				const f = line.split("\t")
+
+				if (f[6] !== "A") continue
+				const aname = clean(f[2] ?? "") ?? clean(f[1] ?? "")
+
+				if (!aname) continue
+				const lat = Number(f[4]) || 0
+				const lon = Number(f[5]) || 0
+
+				if (f[7] === "PCLI" || f[7] === "PCLIX") {
+					if (countryId >= 0) continue // one country row
+					countryId = id++
+					sprInsert.run(countryId, -1, aname, "country", cc, lat, lon, lat, lon, lat, lon, 1, 0, 0, 0, 0, 0)
+					namesInsert.run(countryId, aname, "country", cc, "", 0)
+					ancestorInsert.run(countryId, countryId, "country")
+				} else if (f[7] === "ADM1" && f[10]) {
+					const rid = id++
+					sprInsert.run(rid, -1, aname, "region", cc, lat, lon, lat, lon, lat, lon, 1, 0, 0, 0, 0, 0)
+					namesInsert.run(rid, aname, "region", cc, "", 0)
+					ancestorInsert.run(rid, rid, "region")
+					adminMap.set(f[10], rid)
+				}
+			}
+			// Re-parent regions + ancestor them to the (now-known) country.
+			if (countryId >= 0) {
+				for (const rid of adminMap.values()) {
+					db.prepare("UPDATE spr SET parent_id = ? WHERE id = ?").run(countryId, rid)
+					ancestorInsert.run(rid, countryId, "country")
+				}
+			}
+		}
+
+		for (const line of lines) {
 			if (!line) continue
 			const f = line.split("\t")
 
@@ -115,10 +173,19 @@ export function ingestGeonamesAliases(
 
 			if (!name) continue
 			const nid = id++
+			// #267: link to the locality's region (else country) for gap countries; -1 (orphan) otherwise.
+			const regionId = addAdmin ? (adminMap.get(f[10] ?? "") ?? -1) : -1
+			const parentId = regionId >= 0 ? regionId : addAdmin && countryId >= 0 ? countryId : -1
 			// Point bbox — a GeoNames row is a centroid; the candidate's region-bbox disambiguation just
 			// sees it as contained in itself, fine for a locality.
-			sprInsert.run(nid, -1, name, "locality", cc, lat, lon, lat, lon, lat, lon, 1, 0, 0, 0, 0, 0)
+			sprInsert.run(nid, parentId, name, "locality", cc, lat, lon, lat, lon, lat, lon, 1, 0, 0, 0, 0, 0)
 			namesInsert.run(nid, name, "locality", cc, "", 0)
+
+			if (addAdmin) {
+				ancestorInsert.run(nid, nid, "locality")
+				if (regionId >= 0) ancestorInsert.run(nid, regionId, "region")
+				if (countryId >= 0) ancestorInsert.run(nid, countryId, "country")
+			}
 			const seen = new Set([name])
 
 			for (const raw of [f[2] ?? "", ...(f[3] ? f[3].split(",") : [])]) {

--- a/resolver/admin-coherence.test.ts
+++ b/resolver/admin-coherence.test.ts
@@ -150,4 +150,72 @@ describe("resolveTree + adminCoherence (#263)", () => {
 
 		expect(loc?.metadata?.["admin_coherence_repicked"]).toBeUndefined()
 	})
+
+	it("falls through to a same-named COUNTRY when no region holds the locality (#267 — Tbilisi, Georgia)", async () => {
+		// "Georgia" the US state vs Georgia the country. Tbilisi descends from the COUNTRY, Atlanta from the state.
+		const usGeorgia = {
+			id: 40,
+			name: "Georgia",
+			placetype: "region",
+			country: "US",
+			lat: 32.6,
+			lon: -83.4,
+			score: 9,
+			exactMatch: true,
+		}
+		const georgiaCountry = {
+			id: 50,
+			name: "Georgia",
+			placetype: "country",
+			country: "GE",
+			lat: 42.0,
+			lon: 43.5,
+			score: 8,
+			exactMatch: true,
+		}
+		const tbilisi: ResolvedPlace = {
+			id: 51,
+			name: "Tbilisi",
+			placetype: "locality",
+			country: "GE",
+			parent_id: 50,
+			lat: 41.69,
+			lon: 44.83,
+			score: 7,
+			exactMatch: true,
+		}
+		const atlanta: ResolvedPlace = {
+			id: 41,
+			name: "Atlanta",
+			placetype: "locality",
+			country: "US",
+			parent_id: 40,
+			lat: 33.76,
+			lon: -84.42,
+			score: 9,
+			exactMatch: true,
+		}
+		const tree = (city: string): AddressTree => ({
+			raw: `${city}, Georgia`,
+			roots: [
+				node({
+					tag: "region",
+					value: "Georgia",
+					start: city.length + 2,
+					end: city.length + 9,
+					children: [node({ tag: "locality", value: city, start: 0, end: city.length })],
+				}),
+			],
+		})
+		const resolver = createWofResolver(makeBackend([usGeorgia, georgiaCountry, tbilisi, atlanta]))
+
+		// Tbilisi has no descendant under the US state → fall through to Georgia the country.
+		const tb = localityOf(await resolver.resolveTree(tree("Tbilisi"), { adminCoherence: true }))
+		expect(tb?.lat).toBeCloseTo(41.69, 2)
+		expect(tb?.metadata?.["admin_coherence_repicked"]).toBe(true)
+
+		// Atlanta IS under the US state → it resolves in the walk; no country fall-through.
+		const at = localityOf(await resolver.resolveTree(tree("Atlanta"), { adminCoherence: true }))
+		expect(at?.lat).toBeCloseTo(33.76, 2)
+	})
 })

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -484,6 +484,38 @@ async function reconcileAdminPair(
 			return
 		}
 	}
+
+	// #267 follow-up: the token may name a COUNTRY whose namesake is a more-populous foreign region — "Tbilisi,
+	// Georgia" parses region("Georgia") → the US state, but Tbilisi descends from Georgia the COUNTRY. When no
+	// region candidate holds the locality, try same-named country candidates: a foreign capital under its
+	// country out-votes the state namesake. Needs the country + the locality's ancestry in the gazetteer (the
+	// #267 admin fold). The re-picked region node then carries the country place; the locality coordinate wins.
+	const countryCands = (await backend.findPlace({ text: regionNode.value, placetype: "country", limit: 3 })).filter(
+		(c) => c.exactMatch
+	)
+
+	for (const country of countryCands) {
+		const scoped = await backend.findPlace({
+			text: localityNode.value,
+			placetype: "locality",
+			parentId: country.id,
+			limit: 3,
+		})
+		const lc = scoped.find((l) => l.exactMatch && !(l.lat === 0 && l.lon === 0))
+
+		if (lc) {
+			decorateNode(regionNode, country, regionCands)
+			regionNode.metadata = { ...regionNode.metadata, admin_coherence_repicked: true }
+			decorateNode(
+				localityNode,
+				lc,
+				scoped.filter((l) => l !== lc)
+			)
+			localityNode.metadata = { ...localityNode.metadata, admin_coherence_repicked: true }
+
+			return
+		}
+	}
 }
 
 class WofResolver implements Resolver {

--- a/scripts/build-coverage-expansion.ts
+++ b/scripts/build-coverage-expansion.ts
@@ -124,6 +124,8 @@ const fold = await foldGeonamesIntoAdmin({
 	adminIn: ADMIN_IN,
 	adminOut: STAGED_ADMIN,
 	countries,
+	// #267: add A-class admin + ancestry for the GAP targets only (the EU default set already has WOF admin).
+	adminForCountries: new Set(targets),
 	geonamesDir: MERGE,
 	onCountry: (e) => {
 		if (!e.skipped && e.places > 0) process.stderr.write(`\r[fold] ${e.country}: ${e.places}      `)


### PR DESCRIPTION
Closes the #266 follow-up: the coverage fold added localities for ~147 gap countries but **not their admin hierarchy**, so Tbilisi (GE) is an orphan and `Tbilisi, GE` mis-routes to US Georgia. `ingestGeonamesAliases` gains a per-country `adminForCountries` set that folds the GeoNames A-class admin (PCLI country + ADM1 regions) and links the locality→region→country ancestry, so `parentId` scoping + adminCoherence reach the gap countries. Per-country (only the zero-coverage targets — a WOF-admin country would double up); the MERGE dir already prefers full dumps (which carry A-class). 3 unit tests; byte-stable default.

Remaining (separate): the rebuild + gated canonical swap, and the resolver-side "Tbilisi, Georgia" full-name country-vs-state disambiguation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)