### PR TITLE
fix(#267): fold all PCL* country codes (HK/MO/PS territories), not just PCLI

### DIFF
--- a/resolver-wof-sqlite/geonames-admin.test.ts
+++ b/resolver-wof-sqlite/geonames-admin.test.ts
@@ -119,3 +119,41 @@ test("default (no includeAdmin) stays localities-only with no admin rows — byt
 	expect((db2.prepare("SELECT parent_id FROM spr WHERE placetype='locality'").get() as any).parent_id).toBe(-1)
 	db2.close()
 })
+
+test("recognizes a PCLS special-administrative-region as the country (HK/MO/PS)", () => {
+	const d = mkdtempSync(join(tmpdir(), "geonames-pcls-"))
+	writeFileSync(
+		join(d, "HK.txt"),
+		[
+			row({ 0: "1819730", 1: "Hong Kong", 2: "Hong Kong", 4: "22.3", 5: "114.2", 6: "A", 7: "PCLS", 8: "HK" }),
+			row({
+				0: "1819729",
+				1: "Hong Kong",
+				2: "Hong Kong",
+				4: "22.28",
+				5: "114.16",
+				6: "P",
+				7: "PPLC",
+				8: "HK",
+				14: "7012738",
+			}),
+		].join("\n")
+	)
+	const hk = new DatabaseSync(":memory:")
+	hk.exec(`CREATE TABLE spr (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+		 latitude REAL, longitude REAL, min_latitude REAL, min_longitude REAL, max_latitude REAL, max_longitude REAL,
+		 is_current INTEGER, is_deprecated INTEGER, is_ceased INTEGER, is_superseded INTEGER, is_superseding INTEGER, lastmodified INTEGER)`)
+	hk.exec(
+		`CREATE TABLE names (id INTEGER, name TEXT, placetype TEXT, country TEXT, language TEXT, lastmodified INTEGER)`
+	)
+	hk.exec(`CREATE TABLE ancestors (id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT, lastmodified INTEGER)`)
+	hk.exec(`CREATE TABLE place_population (id INTEGER PRIMARY KEY, population INTEGER)`)
+	ingestGeonamesAliases(hk, ["HK"], d, () => {}, { adminForCountries: new Set(["HK"]) })
+
+	// PCLS is a country-level code; the fold must seat Hong Kong as the country (not skip it like pre-PCL*).
+	expect((hk.prepare("SELECT name FROM spr WHERE placetype='country' AND country='HK'").get() as any)?.name).toBe(
+		"Hong Kong"
+	)
+	hk.close()
+	rmSync(d, { recursive: true, force: true })
+})

--- a/resolver-wof-sqlite/geonames-aliases.ts
+++ b/resolver-wof-sqlite/geonames-aliases.ts
@@ -137,7 +137,10 @@ export function ingestGeonamesAliases(
 				const lat = Number(f[4]) || 0
 				const lon = Number(f[5]) || 0
 
-				if (f[7] === "PCLI" || f[7] === "PCLIX") {
+				if (f[7]?.startsWith("PCL")) {
+					// Any country-level political entity — PCLI (independent), PCLD (dependent territory),
+					// PCLF (freely associated), PCLS (special administrative region: HK/MO/PS). All are the
+					// country tier; restricting to PCLI left those ~17 territories without a country row.
 					if (countryId >= 0) continue // one country row
 					countryId = id++
 					sprInsert.run(countryId, -1, aname, "country", cc, lat, lon, lat, lon, lat, lon, 1, 0, 0, 0, 0, 0)


### PR DESCRIPTION
Tail of the #267 coverage work. The dumps were never missing — all 147 gap countries had full GeoNames dumps. The only residual: the admin fold seated the country from `PCLI`/`PCLIX` only, so ~17 territories whose country row is `PCLD` (dependent), `PCLF` (freely associated), or `PCLS` (special administrative region — Hong Kong, Macau, Palestine) got region ancestry but no country row. Accept any `PCL*` political entity. +1 test (PCLS → Hong Kong). Lands on the next coverage rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)