### PR TITLE
chore(demo): point browser gazetteer at 2026-06-30a (#266/#267 coverage)

### DIFF
--- a/docs/src/shared/resources.tsx
+++ b/docs/src/shared/resources.tsx
@@ -169,16 +169,17 @@ export function streetShardUrl(slug: string, kind: "situs" | "interp"): string {
  * Cache-Control means a fresh DB needs a fresh URL). See RELEASING.md "Rebuilding + swapping the canonical admin
  * gazetteer".
  */
-export const ADMIN_GAZETTEER_VERSION = "2026-06-28a"
+export const ADMIN_GAZETTEER_VERSION = "2026-06-30a"
 
 /**
- * Byte-ranged global "candidate" gazetteer (`candidate-global.db`, ~1.19 GB; US + intl postcodes incl. PT/PL/CZ/AU +
- * the GeoNames bilingual alt-name fold as of 2026-06-27a) — the single-B-tree-probe lookup that replaces the slim
- * per-model-version `wof-hot.db` AND the full-DB FTS. A resolve touches a handful of contiguous pages (~12 range
- * fetches/session vs 243 on the full DB), with GLOBAL coverage and no `SLIM_COUNTRIES` upkeep. It now also carries a
- * co-located FTS5-trigram fuzzy index, consulted ONLY on an exact-name miss (typo tolerance, e.g. Manchestr→Manchester)
- * so the contiguous fast path is untouched. Resolved by {@link WofCandidateTableLookup} (build-candidate.ts). Hosted at
- * `mailwoman/gazetteer/<date>/candidate.db`, version-independent like the street shards.
+ * Byte-ranged global "candidate" gazetteer (`candidate-global.db`, ~1.39 GB; US + intl postcodes + the GeoNames fold
+ * grown to 244 countries by the #266 village-level + #267 admin-hierarchy coverage expansion as of 2026-06-30a) — the
+ * single-B-tree-probe lookup that replaces the slim per-model-version `wof-hot.db` AND the full-DB FTS. A resolve
+ * touches a handful of contiguous pages (~12 range fetches/session vs 243 on the full DB), with GLOBAL coverage and no
+ * `SLIM_COUNTRIES` upkeep. It now also carries a co-located FTS5-trigram fuzzy index, consulted ONLY on an exact-name
+ * miss (typo tolerance, e.g. Manchestr→Manchester) so the contiguous fast path is untouched. Resolved by
+ * {@link WofCandidateTableLookup} (build-candidate.ts). Hosted at `mailwoman/gazetteer/<date>/candidate.db`,
+ * version-independent like the street shards.
  */
 export function adminGazetteerUrl(): string {
 	return `${ASSET_BASE_URL}gazetteer/${ADMIN_GAZETTEER_VERSION}/candidate.db`


### PR DESCRIPTION
Makes the day's **#266/#267 international coverage** visible in the browser demo.

## What
The demo's byte-range admin gazetteer (`WOFCandidateTableLookup`) was pinned at `2026-06-28a` — built from `admin-global-priority.db` **before** the coverage swap (97 countries). The coverage-complete **#267 candidate** (`candidate-global-coverage-admin.db` — 244 countries, 10.14M rows, FTS baked, 1.39 GB) is now uploaded to R2 at `gazetteer/2026-06-30a/candidate.db`. This bumps `ADMIN_GAZETTEER_VERSION` so the demo requests it.

`serverMode: "full"` discovers the DB size at runtime, so the version string is the only code change (no hardcoded byte-length).

## Already done (the heavy half)
- Uploaded the candidate to R2 `nexus-public` via the proven `publish-demo-assets-to-r2.py` (boto3 + immutable Cache-Control).
- **Verified live:** `HTTP 200`, `content-length: 1389363200` (exact match), range-reads work, SQLite magic intact at byte 0.

## On merge
`docs-build.yml` (push, `paths: docs/**`) auto-deploys the Pages site → the demo loads the 244-country gazetteer. "Tbilisi, Georgia" + off-map romanized localities (Skopje, etc.) resolve in-browser, where before they fell through.

## Not included
The old `2026-06-28a` candidate stays on R2, so nothing breaks before the deploy. The browser **OSM rooftop tier (B3, #260)** is a separate effort — blocked on #249 (ODbL legal sign-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)