### PR TITLE
chore: pin dev-weights to v4.16.0 (#259) + shelve v1.9.6 retrain (#261)

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v1.9.6-surface-aug-full.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v1.9.6-surface-aug-full.yaml
@@ -1,0 +1,191 @@
+# === SHELVED 2026-06-30 (#261) ===========================================================
+# The v1.9.6 surface-augmentation retrain (case robustness, #829-class) is NOT promoted.
+# Gate-failed: the metamorphic layer introduced 2 casing/whitespace regressions
+# (DC-zip-lowercase, Damrak-whitespace). The #834 drop-in normalize fix already covers most
+# of the case-robustness gap, so the retrain isn't worth the GPU + the regressions. Kept as
+# the recipe record; revisit only with a recipe that clears the metamorphic gate.
+# See docs/articles/evals/2026-06-29-night-postmortem.md.
+# =========================================================================================
+#
+# === v1.9.4-fr-bare-street (#251/#148 — teach the FR street→locality boundary WITHOUT a postcode anchor) ===
+# FULL RUN (probe GREEN: 2k-step step-082000 gave bare-FR street-intact 89→92%, demo "Rue du Chevaleret,
+# Paris" FIXED, US 4/4 tag-identical → imbalance confirmed, not modeling deficit). Continue from the probe's
+# step-082000 (--resume auto) to step-092000 (+10k); eval every 2k → gate each checkpoint (US per-tag floors)
+# and ship the FR-up/US-held sweet spot. SAME single variable (the fr-bare-street shard) — clean attribution.
+# v1.9.3a3 (shipped v4.16.x) is verbatim below EXCEPT: corpus_dir → the v0.9.4 overlay, and ONE new
+# source_weight (synth-fr-bare-street). Everything else — model, anchor knobs, class_weights, country_weights,
+# the other source_weights, LR/schedule — is IDENTICAL to v193a3, so the SINGLE variable is the new shard
+# (clean attribution).
+#
+# ROOT MECHANISM (DeepSeek Pro 019f1097 + libpostal's own documented practice, both independent): every
+# comprehensive FR source (BAN, OSM) is postcode-COMPLETE, so the decoder learned the FR street→locality
+# boundary as "the token after the 5-digit postcode," NEVER as "comma + city." Strip the postcode and proper-
+# noun street tokens leak into the following locality ("Rue René Cassin, Paris" → street="Rue Ren",
+# locality="Cassin"). Measured: 90% FR streets intact, a ~10% bare-no-postcode tail that owns the demo
+# address. NOT data absence (BAN is in the corpus) — postcode-anchoring DISTRIBUTION imbalance.
+#
+# THE CHANGE (ONE variable): the synth-fr-bare-street shard — 10.8k real BAN (street, number, city) tuples
+# rendered as the MISSING distribution: bare comma form "<n> Rue <proper-noun name>, <City>", NO postcode.
+# BAN-sourced (Licence Ouverte / permissive) on purpose — the model must stay clean of the ODbL OSM data
+# (that is quarantined to the opt-in rooftop shards). Weight 6.0 = the targeted-fix precedent
+# (synth-german / synth-fr-admin-split / gnaf all 6.0).
+#
+# GATE (the probe — falsifies coverage-imbalance vs modeling-deficit, per DeepSeek): re-run
+# scripts/diagnostic/fr-parse-recall.ts (bare FR street-intact rate, target the 90%→tail) AND US/intl
+# no-regression (the per-tag floors). MOVES → imbalance confirmed → scale to a full run within the $20 cap.
+# FLAT → modeling deficit (comma-boundary feature / decoder), a different fix. conventions-loss-mask is OFF
+# in this lineage already (v193a3), and FR street_prefix is taught by synth-fr-admin-split today, so the
+# v1.6.0 ~7M-loss mask blow-up does NOT apply here. NOT promoted without operator GO + the gate.
+# Launch: modal run -d scripts/modal/train_remote.py --config v1.9.4-fr-bare-street.yaml --resume auto
+data:
+  # v0.9.4 overlay = v0.9.3a3's 694 shards VERBATIM (re-rooted to /data) + the 1 fr-bare-street shard.
+  corpus_dir: /data/corpus/versioned/v0.9.4-fr-bare-street/corpus-v0.9.4-fr-bare-street
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-a0
+  max_length: 128
+  country_weights: # VERBATIM from v1.9.3a3 (22 countries) — no new locales (surgical).
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+    ES: 1.0
+    IT: 1.0
+    NL: 1.0
+    PT: 1.0
+    BE: 1.0
+    PL: 1.0
+    AT: 1.0
+    CH: 1.0
+    CZ: 1.0
+    DK: 1.0
+    NO: 1.0
+    SE: 1.0
+    FI: 1.0
+    IE: 1.0
+    GB: 1.0
+    SK: 1.0
+    SI: 1.0
+    HR: 1.0
+    HU: 1.0
+    AU: 1.0
+  source_weights: # VERBATIM from v1.9.3a3 + the one new fr-bare-street shard.
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 3.0
+    synth-fr-admin-split: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    overture: 3.0
+    gnaf: 6.0
+    synth-anchor-absorption: 6.0
+    # #251 NEW: the bare-no-postcode FR street shard. 6.0 = targeted-fix precedent.
+    synth-fr-bare-street: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  augment_case_prob: 0.3  # case robustness (#829/#261, DeepSeek-backed): lowercased copies
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+  anchor_paint_mode: shaped
+  anchor_value_mode: posterior_latlon
+
+model: # VERBATIM from v1.9.3a3.
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train: # VERBATIM from v1.9.3a3 except output_dir + run_name + max_steps. RESUME from v193a3 step-080000.
+  output_dir: /data/output-v195-surface-aug-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  # FULL RUN: --resume auto picks the probe's step-082000 (latest in output_dir); max_steps 92000 → +10k.
+  # Constant LR 1.5e-4; anchor-dropout curriculum at full strength. Eval every 2k → gate 84/86/88/90/92k and
+  # ship the best (FR street-intact up, US floors held).
+  max_steps: 102000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v1.9.6-surface-aug-full-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/neural-weights-en-us/scripts/link-dev-weights.ts
+++ b/neural-weights-en-us/scripts/link-dev-weights.ts
@@ -45,16 +45,15 @@ import { fileURLToPath } from "node:url"
 
 import { dataRootPath } from "@mailwoman/core/utils"
 
-// --- current default (releases.json defaultVersion = v4.15.0) --------------
-// v4.15.0 en-us ships the v1.9.3a3 anchor-absorption model (step 80000). These md5s
-// are the authoritative bytes the demo serves at .../mailwoman/en-us/v4.15.0/{model,
-// tokenizer} and match `neural-weights-en-us/model-card.json` `files_md5.model.onnx`,
-// so the capability-gate certifies the SHIPPED model. (2026-06-28: this default had
-// drifted to the stale v180 step-40000 bytes while the card moved to v4.15.0 — every
-// `loadFromWeights` eval was silently grading the old model. Bump these two lines on
-// each ship; the #397 guard below only checks self-consistency, not vs the card.)
-const DEFAULT_MODEL = dataRootPath("models", "quantized", "model-v193a3-step-80000-int8.onnx")
-const DEFAULT_MODEL_MD5 = "4dec4f460a934949580d8e7b43adae7e"
+// --- current default (releases.json defaultVersion = v4.16.0) --------------
+// v4.16.0 en-us ships the v1.9.4-fr-bare-street model (step 92000 — v1.9.3a3 resumed
+// with the FR-bare-street shard). These md5s are the authoritative bytes the demo
+// serves at .../mailwoman/en-us/v4.16.0/{model,tokenizer}, so the capability-gate
+// certifies the SHIPPED model. (2026-06-30 #259: pinned off the stale v1.9.3a3
+// step-80000 default, which kept grading v4.15.0's model after v4.16.0 shipped. Bump
+// these two lines on each ship; the #397 guard below only checks self-consistency.)
+const DEFAULT_MODEL = dataRootPath("models", "quantized", "model-v194-step-92000-int8.onnx")
+const DEFAULT_MODEL_MD5 = "eb76ae49adab7dc7ca412b306cc1aab6"
 const DEFAULT_TOKENIZER = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 const DEFAULT_TOKENIZER_MD5 = "b6137e8c52914c9715374268ecaa4bc6"
 

--- a/neural-weights-fr-fr/scripts/link-dev-weights.ts
+++ b/neural-weights-fr-fr/scripts/link-dev-weights.ts
@@ -10,7 +10,7 @@
  *   A single multilingual model serves both en-us and fr-fr (byte-identical artifact;
  *   fr-fr just carries its own calibration). Re-symlinks the SAME files as en-us until
  *   per-locale training lands. Keep these defaults in lockstep with en-us's DEFAULT_*
- *   on every defaultVersion bump (currently v4.1.0 = v0.9.7-unit-v3, tokenizer 0.6.0-a0).
+ *   on every defaultVersion bump (currently v4.16.0 = v1.9.4-fr-bare-street, tokenizer 0.6.0-a0).
  */
 
 import { existsSync, symlinkSync, unlinkSync } from "node:fs"
@@ -20,10 +20,10 @@ import { fileURLToPath } from "node:url"
 import { dataRootPath } from "@mailwoman/core/utils"
 
 const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
-// In lockstep with en-us's DEFAULT_MODEL (one multilingual artifact serves both). 2026-06-28: this had
-// drifted to the stale v097 step-20000 bytes; bumped to the v4.15.0 / v1.9.3a3 shipped model.
+// In lockstep with en-us's DEFAULT_MODEL (one multilingual artifact serves both). 2026-06-30 #259: pinned
+// to the v4.16.0 / v1.9.4-fr-bare-street shipped model (was the stale v1.9.3a3 step-80000 / v4.15.0 default).
 const SRC_MODEL =
-	process.env.MAILWOMAN_DEV_MODEL || dataRootPath("models", "quantized", "model-v193a3-step-80000-int8.onnx")
+	process.env.MAILWOMAN_DEV_MODEL || dataRootPath("models", "quantized", "model-v194-step-92000-int8.onnx")
 const SRC_TOKENIZER =
 	process.env.MAILWOMAN_DEV_TOKENIZER || dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 


### PR DESCRIPTION
Two bookkeeping items from today's backlog.

## #259 — pin dev-weights default to shipped v4.16.0
`link-dev-weights.ts` (en-us + fr-fr) still defaulted to `model-v193a3-step-80000` (v4.15.0's model) after **v4.16.0** shipped, so every local `loadFromWeights` eval was grading the stale model (the exact drift the #397 guard exists to catch).

- Both scripts → `model-v194-step-92000-int8.onnx` (v1.9.4-fr-bare-street, the v4.16.0 default).
- en-us `DEFAULT_MODEL_MD5` → `eb76ae49…` — the bytes R2 serves at `en-us/v4.16.0/model.onnx` (the authoritative source).
- **Verified:** ran the en-us script; the #397 drift guard passes against the new default (model + tokenizer md5s assert-match the shipped bytes). Tokenizer unchanged (`v0.6.0-a0`).
- The v4.16.0 model is pulled into `$MAILWOMAN_DATA_ROOT/models/quantized/` (a data-root artifact, not committed).
- **CI-safe:** `weights.test.ts` uses `skipIf(!haveModel)`, and the test job doesn't provision the dev model, so the guard + model-dependent tests skip where the model is absent — no redness.

## #261 — shelve the v1.9.6 surface-aug retrain
The case-robustness retrain (#829-class) gate-failed: the metamorphic layer introduced 2 casing/whitespace regressions (DC-zip-lowercase, Damrak-whitespace), and #834's drop-in normalize fix already covers most of the gap. Not worth the GPU + the regressions.

Commits the config (was untracked) with a **SHELVED** banner as the recipe record — revisit only with a recipe that clears the metamorphic gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)