### PR TITLE
chore: fix the diagnostic-scripts gitignore path (sort stray WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,9 +149,12 @@ HANDOFF-*.md
 
 # Diagnostic scripts — one-off investigation scripts that aren't part of the shipped
 # toolchain. Keepers cited by docs/memories stay tracked; this only hides untracked
-# new diag scripts (#379).
+# new diag scripts (#379). The scripts live under scripts/diagnostic/ (and one-off
+# residual probes under scripts/eval/); the old scripts/diag-*.ts glob never matched.
 scripts/diag-*.ts
 scripts/diag-*.sh
+scripts/diagnostic/
+scripts/eval/*-residual.ts
 
 # Coarse-placer (#244) training data + model artifacts — regenerable, not committed
 data/coarse-placer/


### PR DESCRIPTION
The diagnostic-ignore rule was `scripts/diag-*.ts`, but session diagnostics live under `scripts/diagnostic/` — the glob never matched, so 23 one-off scratch scripts (portland-833 panels, ny-trace, coverage-266-validate, …) leaked into `git status`. Points the rule at the real location + `scripts/eval/*-residual.ts`.

Keepers already tracked stay tracked (gitignore doesn't untrack); only new untracked diagnostics are hidden, as the rule's comment always intended (#379).

Part of sorting the day's stray working-tree WIP: the tracked-file changes were cosmetic churn (oxfmt blank-line padding) + a couple of garbage edits, stashed as `stray-wip-cosmetic` (recoverable); this fix clears the untracked clutter so the tree is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)