### PR TITLE
docs(recipes): fill the timezone + un-locode lookup recipes (#818)

### DIFF
--- a/docs/articles/recipes/timezones.md
+++ b/docs/articles/recipes/timezones.md
@@ -1,11 +1,47 @@
 ---
 title: Looking up a Timezone
 id: timezone-lookup
-draft: true
 ---
 
-A timezone is a region of the Earth that has the same standard time. The `@mailwoman/timezone-lookup` package provides a simple way to look up timezones for locations around the world.
+You have a coordinate and you want the IANA timezone it lands in — `America/New_York`, `Asia/Tokyo`. The [`@mailwoman/timezone-lookup`](https://www.npmjs.com/package/@mailwoman/timezone-lookup) package does the point-in-polygon for you, over [timezone-boundary-builder](https://github.com/evansiroky/timezone-boundary-builder) polygons in a `node:sqlite` database. The UTC offset comes from `Intl`, so there's no tz-database dependency to keep patched.
 
-## CLI Usage
+Two costs to name up front. It's **server-side** — the polygon test runs over `node:sqlite`, so this is a backend lookup, not a browser one. And you build the database once from the boundary release before the first lookup.
 
-## Programmatic Usage
+## Build the database
+
+Download the `combined-with-oceans.json` release from timezone-boundary-builder, then build the read-only DB you'll ship alongside your service:
+
+```bash
+npx @mailwoman/timezone-lookup build --geojson combined-with-oceans.json --out timezone.db
+```
+
+That's a one-time step. The `.db` is an immutable artifact — build it in CI, ship it with your deploy.
+
+## CLI usage
+
+Hand it a latitude and longitude:
+
+```bash
+npx @mailwoman/timezone-lookup --db timezone.db 40.7128 -74.0060
+# {"timezone":"America/New_York","offsetSec":-18000}
+```
+
+## Programmatic usage
+
+```ts
+import { TimezoneLookup, makeTimezoneAnnotator } from "@mailwoman/timezone-lookup"
+
+const lookup = new TimezoneLookup({ databasePath: "timezone.db" })
+
+lookup.find(35.6762, 139.6503) // "Asia/Tokyo"
+```
+
+Already using the annotations layer? Wrap the lookup as an `Annotator` and it fills `AnnotationSet.timezone` on any resolved result, so a timezone rides along with every geocode:
+
+```ts
+const annotator = makeTimezoneAnnotator(lookup)
+```
+
+## Data and licensing
+
+The boundaries come from timezone-boundary-builder, which is **ODbL**. Attribution and share-alike apply to the database you build and distribute — [Data licensing](../licensing/data-provenance.md) is where that line falls and what you owe. A browser/WASM build is a follow-up; today the lookup is server-side.

--- a/docs/articles/recipes/un-locode-lookup.md
+++ b/docs/articles/recipes/un-locode-lookup.md
@@ -1,7 +1,49 @@
 ---
 title: UN/LOCODE Lookup
 id: un-locode-lookup
-draft: true
 ---
 
-A UN/LOCODE (United Nations Code for Trade and Transport Locations) is a geographic coding scheme developed and maintained by the United Nations Economic Commission for Europe (UNECE). It assigns unique codes to locations used in trade and transport, such as ports, airports, and cities. The `@mailwoman/un-locode-lookup` package provides a simple way to look up UN/LOCODEs for locations around the world.
+A **UN/LOCODE** is the UNECE's code for a trade-and-transport location — `US NYC` for New York, `NL RTM` for Rotterdam. If you're moving freight, filing customs, or matching a shipping record to a place, you need these codes, and you usually have either a place name or a coordinate to start from. The [`@mailwoman/un-locode-lookup`](https://www.npmjs.com/package/@mailwoman/un-locode-lookup) package goes both ways, over the UNECE code list in a `node:sqlite` database.
+
+Like the timezone lookup, it's **server-side** and you build the database once before the first query.
+
+## Build the database
+
+Grab the UNECE code list (`code-list.csv`) and build the read-only DB:
+
+```bash
+npx @mailwoman/un-locode-lookup build --csv code-list.csv --out un-locode.db
+```
+
+## CLI usage
+
+By country and place name, or by nearest coordinate:
+
+```bash
+npx @mailwoman/un-locode-lookup --db un-locode.db --country NL --name "Rotterdam"
+# {"unLocode":"NL RTM"}
+
+npx @mailwoman/un-locode-lookup --db un-locode.db --near 40.7128 -74.0060
+# {"unLocode":"US NYC"}
+```
+
+## Programmatic usage
+
+```ts
+import { UnLocodeLookup, makeUnLocodeAnnotator } from "@mailwoman/un-locode-lookup"
+
+const lookup = new UnLocodeLookup({ databasePath: "un-locode.db" })
+
+lookup.byName("US", "New York") // "US NYC"
+lookup.nearest(51.92, 4.48) // "NL RTM"
+```
+
+`byName` is exact, but the match is diacritic-folded and case-insensitive, so "São Paulo" and "sao paulo" both land. `nearest` covers the roughly 80% of entries that carry coordinates (93k of 116k), which is most of what you'll reach for. Wrap it as an `Annotator` to fill `AnnotationSet.unLocode` on a resolved result:
+
+```ts
+const annotator = makeUnLocodeAnnotator(lookup)
+```
+
+## Data
+
+The UNECE UN/LOCODE code list is public domain, so this one carries no share-alike obligation — see [Data licensing](../licensing/data-provenance.md) for how the sources differ.


### PR DESCRIPTION
Fills the two seeded recipe stubs with **verified** CLI + programmatic usage (house voice), part of #818 / #811 Phase 5.1.

- **timezone-lookup** — coordinate → IANA tz, server-side `node:sqlite` PIP; names the ODbL cost (timezone-boundary-builder is share-alike, links [Data licensing](../blob/docs/818-recipes/docs/articles/licensing/data-provenance.md)).
- **un-locode-lookup** — place ↔ UN/LOCODE both directions, public-domain UNECE.

Both drop `draft: true`. Usage verified against each package's README + exports (`TimezoneLookup.find`, `UnLocodeLookup.byName/nearest`, the `make*Annotator` wrappers).

**Remaining on #818** (kept open): the four new OpenCage-style recipes — privacy/coordinate-rounding, batch, multi-service/cost-first, display-on-a-map. The multi-service one touches competitive positioning and wants an operator voice pass (gracious-not-vengeful), so I left it rather than guess the tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)