### PR TITLE
docs(evals): #822 frontier-gap before/after (54%→78% bare, CPU)

### DIFF
--- a/docs/articles/evals/2026-06-30-822-frontier-gap.md
+++ b/docs/articles/evals/2026-06-30-822-frontier-gap.md
@@ -1,0 +1,65 @@
+---
+title: "#822 explicit-country coherence — frontier-gap before/after"
+description: Quantifying the #822 resolver fix against the placer-frontier diagnostic — bare "City, Country" resolution lifted 54% → 78% on CPU, with no placer retrain.
+---
+
+# #822 explicit-country coherence — frontier-gap before/after
+
+The #822 fix (`applyExplicitCountryCoherence`, PR #852) re-picks a namesake locality to the country the
+address explicitly names — `Vienna, Austria` → Vienna AT, not Vienna WV. This measures it against the
+`frontier-gap` diagnostic (`scripts/eval/frontier-gap.ts`): forward-geocode the top-3 cities by population
+for every country as a bare `"City, Country"` query (no country constraint — what the drop-in `/search`
+sends), scored by coordinate error (within 50 km of the city's true GeoNames coordinate).
+
+**Config:** the default drop-in path (`admin-global-priority.db`, no `MAILWOMAN_CANDIDATE_DB`) — the path the
+fix touches and the path the nominatim/photon drop-ins use. 506 cities across 187 countries, pop ≥ 50 000.
+
+## Result
+
+| Metric | Before (pre-#822) | After (#822) | Δ |
+|---|---:|---:|---:|
+| Bare resolve-rate | 54.2% | **77.9%** | **+23.7 pp** |
+| +hint ceiling | 82.8% | 83.0% | +0.2 pp (flat) |
+| Bare US-namesake misroutes | 10.5% (53/506) | **4.3% (22/506)** | **−6.2 pp** |
+| Bare-supported countries (≥50%) | 112 | **157** | **+45** |
+| Placer-recoverable (#822) countries | 57 | **12** | **−45** |
+| Residual (exonym + coverage) countries | 18 | 18 | unchanged |
+
+The fix recovered **45 of the 57 placer-recoverable countries** — the ones that resolved only once the
+country was known. It did so **on CPU, with no placer retrain**: the country code comes from the parser's own
+`country` emission (normalized via codex's ISO-3166 table), so the explicit token in the query does what a
+grown coarse-placer would have. The **+hint ceiling barely moved** (82.8 → 83.0), which is the tell that the
+fix closed the bare↔hint gap structurally rather than lifting raw capability — exactly the shape a
+joint-consistency reconcile should have.
+
+This is notable against the prior expectation: the drop-in memo and #822's own framing read the namesake
+miss as a **placer-emission gap needing a GPU retrain**. It was a resolver-logic gap; the model was already
+tagging the country correctly (the A0 parser probe confirmed it), the greedy walk was just ignoring it.
+
+## What the fix does NOT touch — the residual (→ #826)
+
+18 countries fail even **with** a country hint, so neither the placer nor #822 can reach them. This is the
+parallel exonym + coverage lever already tracked on **#826** (the #823 residual split). The post-#822
+breakdown:
+
+- **Residual A — name-not-found / exonym (5):** Kuwait, Réunion, Greece, Hungary, Iraq. The English query
+  name matches no in-country record because the record carries the local name (the `Warsaw`/`Warszawa`
+  class). Where the place exists under a local name, alt-name surface indexing fixes it; otherwise it is a
+  coverage absence. Note these are mostly the **2nd/3rd-population cities** — the capitals (Warsaw, Athens,
+  Budapest, Baghdad) already resolve; the long tail does not.
+- **Residual B — gazetteer coverage / disambiguation (13):** Brazil, Belize, Honduras, Madagascar, São Tomé,
+  Afghanistan, Albania, Burkina Faso, Liberia, Mali, Mozambique, Paraguay, Sweden. Wrong place even with the
+  hint — within-country coverage or disambiguation, not a name-match problem.
+
+The 12 remaining **placer-recoverable** countries (Bahrain, Poland, Serbia, Slovakia, Iceland, Singapore,
+Puerto Rico, …) are the cases where a 2nd/3rd city resolves with a hint but not bare — the smaller residual
+that growing the #244 coarse placer would still capture.
+
+## Reproduce
+
+```bash
+node --expose-gc scripts/eval/frontier-gap.ts --per-country 3 --min-pop 50000 --out <report.md>
+```
+
+The before/after A/B was run by checking out the pre-#822 `resolver/resolve.ts` (commit `84dcbe44`),
+recompiling, running, then restoring `HEAD`.

--- a/docs/articles/evals/2026-07-01-night-postmortem.md
+++ b/docs/articles/evals/2026-07-01-night-postmortem.md
@@ -58,7 +58,7 @@ Updated (kept open) **#822** and **#829** with live evidence (below).
 - **#818** — four OpenCage-style recipes remain; the multi-service one wants a voice review.
 - **#260 (B3)** — still gated on #249 ODbL counsel sign-off (from the day shift).
 
-## Numbers
+## Numbers (Part 1 — cleanup)
 
 | | |
 |---|---|
@@ -70,3 +70,95 @@ Updated (kept open) **#822** and **#829** with live evidence (below).
 | GPU | none |
 | Regressions shipped | 0 |
 | Open issues: before → after | ~45 → 30 |
+
+---
+
+# Part 2 — substantive shift (resolver/parser levers)
+
+The cleanup above was the warm-up. After the operator handed the conn (`/night-shift`, ~05:00 UTC), the
+plan (`nightshift/2026-06-30-NIGHT-SHIFT-PLAN.md`) drives the rest: A (#822) → D → C → B → E + stretch F–I.
+
+## Lever A — #822 named-foreign-country namesake (PR #852)
+
+`Vienna, Austria` → Vienna **WV**. The plan called for a probe-gated fix (the #265 discipline); the probes
+re-shaped it twice before a line of resolver code was written:
+
+- **A0 (parser probe).** Every unambiguous foreign name (`Austria`/`Australia`/`Switzerland`/`Canada`) is
+  tagged `country` by the model. `Georgia` tags as `region` in *both* readings (`Tbilisi, Georgia` and
+  `Atlanta, Georgia`) — so it self-disambiguates; the `{Georgia,GE}` skip-set the plan hedged on is dead
+  code. Fork (i): the bug is resolver-side.
+- **Backend probe (the pivot).** The first read was "coverage gap" — the unscoped `Vienna` lookup returns
+  only US Viennas and there's no `country` row for Austria. Querying the DB directly corrected it: Vienna AT
+  **does** exist (an exonym-folded row), just *outranked* by the populous US namesakes; and well-covered WOF
+  countries carry no `country`-placetype row (only the #267 gap countries do), so the re-pick must filter by
+  the `country` ISO **column**, not a `parentId` descendant scope.
+- **Salvage-first.** `@mailwoman/codex/country` already carries the ISO-3166 base + address surface forms
+  (`matchCountry`, salvaged from isp-nexus). No new table written.
+
+The fix (`applyExplicitCountryCoherence` in `resolve.ts`) is the joint-consistency family's inverse trigger:
+fires when the explicit country is the locality's nearest admin context (region-guarded), regardless of the
+locality's resolution state (so it pre-empts the span-rescore back-fill), and re-picks the locality to its
+same-named in-country place via `matchCountry` → `findPlace({ country })`. No list, no pin — the country
+code is a normalization of the model's own `country` emission.
+
+**Result:** Vienna/Sydney/Toronto/Zurich all land in-country; Tbilisi/GE, Portland/Augusta ME→Maine,
+Springfield IL, NYC, Paris all held. Gauntlet PASS (regression 15/15 with 5 new anti-rot guards). PR #852,
+default-on, awaiting CI.
+
+**verify-before-verdict fired (again):** the first gauntlet run failed Sydney "7532km off." Instead of
+assuming the fix broke, I dug in — the resolver was right (−33.87,151.21); my *expected* value had a dropped
+minus sign (`33.8696` not `−33.8696`). My typo, caught by the gate, not a regression.
+
+## Lever D — resolver/parser backlog (#305, #435, #456): triaged, none a clean CPU PR
+
+The diagnostic-first discipline earned its keep — all three are GPU/schema/coverage-dependent, not the
+"CPU-doable subset" the plan hoped. The realistic output was a correct re-scope of each (which saves the
+next cycle), not three implementations:
+
+- **#305** (proximity-gate the exact-name tier) — the gate needs the postcode anchor's *coordinate*, which
+  lives at the resolver layer; the JP/EU postcode shards exist on disk but aren't wired into the default
+  geocode path; and `applyPostcodeConsistency` (#370, shipped *after* #305) already does this proximity test
+  post-walk but isn't wired into `geocode-core`. Re-scoped to: wire the non-US postcode shards, then fold the
+  exact-tier demote into the existing #370 pass — no second gate on the hot per-keystroke path.
+- **#435** (number-after-street mis-tag) — re-probed the shipped model: **quirk 2 (street-prefix dropped) is
+  FIXED** by v4.16.0 (`Rue` now tags `street_prefix`); **quirk 1 still broken** (+ a `ß` tokenization split).
+  A decode-time relabel would re-classify a token, which #723's repair-discipline forbids → rides the #825
+  retrain eval. Narrowed the issue.
+- **#456** (unit_designator/unit_id split) — schema change (ComponentTag + BIO + retrain). Infra is ready
+  (`codex/us/unit-designator.ts` + `build-unit-shard`); the open fork is `unit`-subsplit vs `locator[]`
+  (#295). Assess-only, deferred to the unit-recognition retrain.
+
+## Lever F — quantify the coverage win (the #822 before/after)
+
+Ran `frontier-gap.ts` (the #822 placer-frontier diagnostic itself) before and after the fix, default drop-in
+config, 506 cities / 187 countries:
+
+| | Before | After |
+|---|---:|---:|
+| Bare `"City, Country"` resolve-rate | 54.2% | **77.9%** (+23.7pp) |
+| +hint ceiling | 82.8% | 83.0% (flat) |
+| US-namesake misroutes | 10.5% (53) | 4.3% (22) |
+| Bare-supported countries | 112 | **157** (+45) |
+| Placer-recoverable (#822) | 57 | **12** (−45 closed) |
+
+**#822 recovered 45 of 57 placer-recoverable countries on CPU** — what the issue (and the drop-in memo)
+expected a GPU placer retrain to do. The flat +hint ceiling confirms it closed the placer↔resolver gap
+structurally. Artifact: `2026-06-30-822-frontier-gap.md`.
+
+The 18-country residual (exonym + coverage, fails even with a hint) is unchanged — it's the parallel #826
+lever, not #822's job. Updated #826 with the post-fix split (5 exonym / 13 coverage), with the nuance that
+**the capitals already resolve — the misses are 2nd/3rd-tier cities** (so the exonym lever's ceiling is the
+long tail). Verify-before-verdict fired: my first exonym probe tested the capitals (which resolve) before I
+realized the failures were the smaller cities.
+
+## Numbers (Part 2 — running)
+
+| | |
+|---|---|
+| Levers shipped | A (#822/#852, merged + measured) |
+| Levers triaged/measured | D (#305/#435/#456 re-scoped), F (frontier A/B + #826 update) |
+| PRs merged | 1 (#852) |
+| #822 bare resolve-rate | 54.2% → 77.9% (+23.7pp, CPU, no retrain) |
+| Modal $ | ~0 |
+| GPU | none |
+| Regressions shipped | 0 |


### PR DESCRIPTION
Records the #822 fix (#852) impact + the night's lever-D triage.

**Headline:** `frontier-gap.ts` before/after the #822 fix, default drop-in config (506 cities / 187 countries):

| | Before | After |
|---|---:|---:|
| Bare `City, Country` resolve-rate | 54.2% | **77.9%** (+23.7pp) |
| Placer-recoverable (#822) countries | 57 | **12** (−45 closed) |
| Bare-supported countries | 112 | **157** |
| +hint ceiling | 82.8% | 83.0% (flat) |

#822 recovered 45 of 57 placer-recoverable countries **on CPU, no placer retrain** — what the issue expected a GPU run to do. The flat +hint ceiling is the tell that it closed the placer↔resolver gap structurally.

The 18-country exonym+coverage residual is unchanged (it's the parallel #826 lever) — updated #826 with the post-fix split + the nuance that the capitals already resolve, so the misses are 2nd/3rd-tier cities.

Also: postmortem Part-2 records the lever-D re-scope (#305 anchor-dependency, #435 quirk-2-fixed/quirk-1-GPU, #456 schema-deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)