### PR TITLE
docs(recipes): privacy, batch, display-on-a-map (#818)

### DIFF
--- a/docs/articles/recipes/batch-geocoding.md
+++ b/docs/articles/recipes/batch-geocoding.md
@@ -1,0 +1,58 @@
+---
+title: Batch Geocoding
+id: batch-geocoding
+---
+
+You have a spreadsheet — ten thousand addresses, a CSV a colleague dropped in Slack, a nightly export from your CRM — and you want a coordinate for every row. Firing ten thousand individual requests works, but you'll spend most of the wall-clock time on HTTP overhead and you'll have to write the concurrency control yourself. The Mailwoman server has a bulk endpoint for exactly this.
+
+## The endpoint
+
+`POST /api/batch` takes a JSON body of `{ addresses: string[] }` and returns `{ results }` in the **same order you sent them**:
+
+```bash
+curl -s localhost:3000/api/batch \
+  -H 'content-type: application/json' \
+  -d '{"addresses": ["350 5th Ave, New York, NY 10118", "Vienna, Austria", ""]}'
+```
+
+```json
+{
+	"results": [
+		{ "input": "350 5th Ave, New York, NY 10118", "lat": 40.7484, "lon": -73.9857, "resolution_tier": "interpolated", "...": "..." },
+		{ "input": "Vienna, Austria", "lat": 48.2083, "lon": 16.3725, "resolution_tier": "admin", "...": "..." },
+		{ "input": "", "error": "..." }
+	]
+}
+```
+
+Order is the contract that makes the bulk path usable: zip the `results` array straight back onto your input rows by index, no join key required.
+
+## One bad row never fails the batch
+
+The third address above was empty, so its slot carries an `{ input, error }` instead of a coordinate. That's the whole isolation model — a row that throws is caught and parked in its own slot, and the other 9 999 rows still come back. So the one check you can't skip is per-row:
+
+```ts
+const res = await fetch("http://localhost:3000/api/batch", {
+	method: "POST",
+	headers: { "content-type": "application/json" },
+	body: JSON.stringify({ addresses }),
+})
+const { results } = await res.json()
+
+for (const [i, row] of results.entries()) {
+	if ("error" in row) {
+		console.warn(`row ${i} (${row.input}): ${row.error}`)
+		continue
+	}
+	upsert(addresses[i], row.lat, row.lon, row.resolution_tier)
+}
+```
+
+## Two limits to size your chunks around
+
+The server bounds two things so a single request can't run away with it:
+
+- **Batch size** caps at 1 000 addresses (`MAILWOMAN_BATCH_MAX`); send more in one body and you get a `413`. Chunk your ten thousand into ten requests.
+- **Concurrency** inside a batch defaults to 8 workers (`MAILWOMAN_BATCH_CONCURRENCY`). The first address in a given US state warms that state's shard cache, so a batch sorted to keep same-state rows together resolves the tail of them almost for free. If your data is already grouped by region, you're getting that win without doing anything.
+
+Both are environment overrides, so you tune them to your box rather than recompiling. Start with the defaults; raise concurrency only once you've confirmed the machine has the cores and the shard I/O to feed them.

--- a/docs/articles/recipes/display-on-a-map.md
+++ b/docs/articles/recipes/display-on-a-map.md
@@ -1,0 +1,46 @@
+---
+title: Displaying Results on a Map
+id: display-on-a-map
+---
+
+Coordinates in a JSON array tell you the geocoder worked. They don't tell you whether the _answers_ are right — that a cluster of clinics really sits where you'd expect, that the three records you merged into one entity actually share a building. For that you need to see them on a map, and you'd rather not stand up a tile server and a frontend to glance at a few hundred points.
+
+`@mailwoman/registry` renders a self-contained map for you. You hand it resolved entities; it hands back a single HTML file you open in a browser.
+
+## From records to a map
+
+The path is three calls. Resolve your source records into canonical entities, turn those into GeoJSON, and render the GeoJSON to HTML:
+
+```ts
+import { resolveEntities, toGeoJSON, toMapHTML } from "@mailwoman/registry"
+import { writeFileSync } from "node:fs"
+
+const { entities } = resolveEntities(records)
+const html = toMapHTML(toGeoJSON(entities), { title: "Clinics — resolved" })
+
+writeFileSync("map.html", html)
+```
+
+`toGeoJSON` is also the export your analysts want — the same FeatureCollection drops straight into QGIS — so you're not rendering to a dead end. The HTML is just the quick-look view over the same data.
+
+## What you're looking at
+
+The page renders on the house stack: MapLibre GL over a Protomaps vector basemap, the same one the demo map uses. The markers carry the resolution story, not just the point. By default the colour tells you how many source datasets agreed on an entity — a point that ≥2 datasets pinned stands out from a single-source one, which is the cross-dataset confirmation you're usually scanning for. If your reconciliation output tags each entity with a `bucket`, the map colours by that instead. You can force either with the `colorBy` option, and pick a basemap with `flavor`:
+
+```ts
+toMapHTML(fc, { title: "Funded sites", flavor: "dark", colorBy: "sources" })
+```
+
+The flavors are the Protomaps stock set — `light` (the default, data reads cleanly over it), `dark`, `white`, `grayscale`, `black`.
+
+## The one gotcha: tiles need an origin
+
+The basemap tiles come from R2, and they're CORS-restricted to `localhost` and the docs domains. Open `map.html` straight off your disk as a `file://` page and your data points render perfectly while the basemap underneath them stays blank — the tile fetches get refused. The page notices it's running from `file://` and shows a banner saying so, so you're not left guessing.
+
+Serve the file over localhost and the basemap fills in:
+
+```bash
+npx serve .   # then open http://localhost:3000/map.html
+```
+
+Your points are accurate either way; it's only the map _under_ them that wants the origin.

--- a/docs/articles/recipes/privacy-coordinate-rounding.md
+++ b/docs/articles/recipes/privacy-coordinate-rounding.md
@@ -1,0 +1,56 @@
+---
+title: Coarsening a Coordinate for Privacy
+id: privacy-coordinate-rounding
+---
+
+You geocoded a customer's address and got a rooftop coordinate back — accurate to a few metres. That precision is the whole point when you're routing a driver to the door. It's a liability when you're about to store the point in an analytics table, share it with a partner, or plot a thousand customers on a public dashboard. A rooftop point _is_ the house; you usually want the neighbourhood.
+
+So coarsen it on purpose. You have two ways to do it, and the only real decision is how much accuracy you're willing to give up.
+
+## Round the decimal degrees
+
+The cheapest coarsening is to drop decimal places. Each one you keep is worth roughly 10× the precision:
+
+| Decimals | Cell size | What it pins |
+| -------- | --------- | ------------ |
+| 5 | ~1 m | the doormat |
+| 4 | ~11 m | the building |
+| 3 | ~110 m | the block |
+| 2 | ~1.1 km | the neighbourhood |
+| 1 | ~11 km | the city |
+
+```ts
+const round = (n: number, decimals: number) => {
+	const f = 10 ** decimals
+	return Math.round(n * f) / f
+}
+
+// A rooftop point coarsened to the neighbourhood.
+const coarse = { lat: round(result.lat, 2), lon: round(result.lon, 2) }
+// { lat: 40.75, lon: -73.99 }
+```
+
+The catch with rounding is that the cell it lands in depends on where the point sits relative to the grid — two houses on the same street can round into different 0.01° cells. If you need every point in a region to collapse to the _same_ coarse location, reach for a geohash instead.
+
+## Truncate a geohash
+
+A geohash encodes a coordinate as a string where every character you drop widens the cell it names. `@mailwoman/spatial` ships the encoder, so you pick a precision and hand back the cell:
+
+```ts
+import { toGeohash } from "@mailwoman/spatial"
+
+toGeohash(40.7484, -73.9857) // precision 9 ≈ 4.8 m: "dr5ru7p4n"
+toGeohash(40.7484, -73.9857, 5) // ≈ 4.9 km: "dr5ru"
+```
+
+| Precision | Cell size |
+| --------- | --------- |
+| 9 (default) | ~4.8 m |
+| 7 | ~153 m |
+| 6 | ~1.2 km |
+| 5 | ~4.9 km |
+| 4 | ~39 km |
+
+Because the cell boundaries are fixed, every address inside `dr5ru` shares the prefix — you can group, join, or count by the truncated string and know that two records in the same cell really are neighbours. Store the geohash, not the point, and the precision you didn't keep is precision you can't leak.
+
+One thing to name plainly: coarsening is one-way by design, but it is not anonymity. A precision-6 cell over a rural address can still hold exactly one house. If the guarantee you need is "this point cannot be traced to a person," coarsening is a layer, not the whole answer — pair it with aggregation thresholds (suppress any cell with fewer than _k_ records) before anything goes public.


### PR DESCRIPTION
Three of the four remaining OpenCage-style developer recipes for #818, each verified against the real API + builds green (`docusaurus build`):

- **Privacy / coordinate-rounding** — decimal-degree rounding + `toGeohash` truncation (`@mailwoman/spatial`), with precision↔cell-size tables and the "coarsening is not anonymity" caveat (pair with k-anonymity thresholds).
- **Batch geocoding** — `POST /api/batch` (`{ addresses: string[] }`, input-order results, per-row `{ input, error }` isolation, the 1000-cap + `MAILWOMAN_BATCH_CONCURRENCY`/`MAILWOMAN_BATCH_MAX` knobs, the same-state shard-cache win).
- **Display on a map** — `resolveEntities → toGeoJSON → toMapHTML` (`@mailwoman/registry`), MapLibre + Protomaps house stack, the localhost-CORS / `file://` banner gotcha.

House voice (developer 2nd-person, name the cost). The **multi-service / cost-first** recipe is deliberately left for the operator's voice pass — it frames Mailwoman against paid APIs, which wants the gracious-not-vengeful positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)