### PR TITLE
chore(deps): http-proxy-middleware 2.0.9→2.0.10 (medium CVE, #379)

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
 	},
 	"resolutions": {
 		"@dsnp/parquetjs@1.7.0": "patch:@dsnp/parquetjs@npm%3A1.7.0#./.yarn/patches/@dsnp-parquetjs-npm-1.7.0-efe8288b39.patch",
-		"undici": "^6.24.0"
+		"undici": "^6.24.0",
+		"http-proxy-middleware@^2.0.9": "2.0.10"
 	},
 	"engines": {
 		"node": ">=24.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15057,9 +15057,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "http-proxy-middleware@npm:2.0.9"
+"http-proxy-middleware@npm:2.0.10":
+  version: 2.0.10
+  resolution: "http-proxy-middleware@npm:2.0.10"
   dependencies:
     "@types/http-proxy": "npm:^1.17.8"
     http-proxy: "npm:^1.18.1"
@@ -15071,7 +15071,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/express":
       optional: true
-  checksum: 10/4ece416a91d52e96f8136c5f4abfbf7ac2f39becbad21fa8b158a12d7e7d8f808287ff1ae342b903fd1f15f2249dee87fabc09e1f0e73106b83331c496d67660
+  checksum: 10/efa8b5d4dec112fba5f6741df33a926818f87156f44dee425e653284c20844f3a9f2af88042a7d4ef297161479e1549302dea693bce23123fa2da07420fa2214
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The one cleanly-safe dependabot fix from #379's remaining alerts — an in-major patch (webpack-dev-server wants `^2.0.9`; 2.0.10 satisfies), medium severity, **dev-server-only** (not in any shipped tarball). `yarn install --immutable` clean.

**Triage of the other open alerts** (verify-before-verdict — the issue's "high CVE" framing was stale; all remaining are medium):

| Alert | Disposition |
|---|---|
| serialize-javascript | **Not flagged anymore** — on 6.0.2, already patched. |
| js-yaml | All copies are **4.2.0** (> the `< 3.15.0` vuln range) — stale alert, no action. |
| tar 6.2.1 | Fix is **7.5.16** (no 6.x backport). Pulled only by `cacache` + `node-gyp` (install/build tooling, not shipped). Forcing tar 7.x risks their 6.x API use → **left for operator**: a major bump on dev-only tooling, medium severity. |

So #379's "serialize-javascript RCE + tar path-traversal major bumps" turned out to be: serialize-javascript already patched, and the *remaining* tar alert is a different (medium) CVE whose only fix is the 7.x major. This PR ships the genuinely-safe one and documents why the rest aren't autonomous bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)