### PR TITLE
docs(perf): #378 WASM cold-path budget + SLO; postmortem part-2

### DIFF
--- a/docs/articles/evals/2026-06-30-378-wasm-cold-path-slo.md
+++ b/docs/articles/evals/2026-06-30-378-wasm-cold-path-slo.md
@@ -1,0 +1,66 @@
+---
+title: "#378 — browser/WASM cold-path budget + SLO proposal"
+description: A cold-path accounting for the browser geocoder (model + candidate.db + WASM), a proposed latency/size SLO, and the one bottleneck the numbers already name.
+---
+
+# #378 — browser/WASM cold-path budget + SLO proposal
+
+We target the browser as a first-class runtime but have never written down a performance budget, so nothing
+tells us which features are even shippable to a mid-range phone. This sets a proposed SLO and accounts for
+the cold path from measured artifact sizes + a node-side compute floor. **What's measured vs estimated is
+marked** — the in-browser P95 still wants a real device/headless trace (see _Open_).
+
+## Two budgets, not one
+
+The browser geocoder has two distinct latency surfaces, and conflating them hides the real costs:
+
+1. **Cold load** — page open → first interactive parse. One-time; network-dominated.
+2. **Per-keystroke** — parse + resolve on each input change. Steady-state; compute + query dominated.
+
+### Proposed SLO
+
+| Surface | Target (Moto-G-class phone, 4G) | Bound by |
+| ------- | ------------------------------- | -------- |
+| Cold load (P95) | **< 6 s** to first interactive | the 29 MB model fetch |
+| Per-keystroke parse (P95) | **< 50 ms** | WASM inference |
+| Per-keystroke resolve (P95) | **< 50 ms** | the candidate-table SQLite probe |
+
+## Cold-path accounting
+
+What the loader (`neural-web/loader.ts`) fetches and runs before the first parse:
+
+| Component | Size / count | Source | Cost driver |
+| --------- | ------------ | ------ | ----------- |
+| int8 ONNX model | **~29 MB** (measured) | HTTP fetch from R2 | the dominant cold cost — ~23 s @ 10 Mbps, ~4.6 s @ 50 Mbps |
+| onnxruntime-web WASM | a few MB (estimated) | HTTP + compile | one-time WASM compile |
+| tokenizer + anchor + postcode bins | ~MB (estimated) | HTTP fetch | small |
+| `candidate.db` warmup | **~12 cold byte-range fetches** (measured, candidate-table spike) | sql.js-httpvfs over a **1.3 GB** R2 DB | NOT a full download — header + B-tree nodes only |
+| model session-init | **126 ms** (measured, node native EP) | local | WASM EP is ~3–5× → est. ~400–600 ms in-browser |
+| first (cold) parse | **219 ms** (measured, node; includes one-time lazy decoder/gazetteer init) | local | amortized after the first parse |
+
+Per-keystroke floor (node native EP, measured): **warm parse 5.7 ms**. The browser WASM EP runs ~3–5× slower,
+so a ~15–30 ms in-browser parse is the realistic estimate — comfortably inside the 50 ms parse budget. The
+resolve half (the candidate-table SQLite probe) is the half we have NOT measured in-browser and is the
+suspected per-keystroke bottleneck (DeepSeek S45).
+
+## The bottleneck the numbers already name
+
+**Cold load is network-bound on the 29 MB model**, not compute. The session-init (126 ms node → ~0.5 s WASM)
+and the ~12 candidate-table byte-range fetches are small beside a 29 MB sequential download. So the cold-load
+SLO is won or lost on **model transfer size**, which points the levers at: a smaller model (distillation /
+structured pruning past int8), HTTP streaming + compile-while-download, and CDN edge-caching — not at the
+SQLite path.
+
+**Per-keystroke is the opposite** — transfer is done, so it's WASM inference (estimated in-budget) + the
+candidate SQLite probe (unmeasured, suspected bottleneck). This is exactly where the **#372 flatbush
+pre-filter** would help — pruning candidates by bbox before the name search. Per the diagnostic-before-fix
+discipline, #372 should be gated on the per-keystroke trace below, not built ahead of it.
+
+## Open — the empirical trace
+
+These numbers bound the cold path from sizes + a compute floor, but the in-browser **P95 on a real device**
+(the SLO's actual gate) needs a browser trace: cold-load waterfall (model/wasm/db fetch overlap), and a
+per-keystroke breakdown (WASM inference vs the SQLite probe). That trace was blocked this shift — **no Chrome
+on the lab box** for the chrome-devtools profiler. Next step: run it against the live `/demo` from a machine
+with Chrome (or a throttled headless run), confirm the model-fetch-dominates-cold hypothesis, and measure the
+resolve-half per-keystroke cost that gates #372.

--- a/docs/articles/evals/2026-07-01-night-postmortem.md
+++ b/docs/articles/evals/2026-07-01-night-postmortem.md
@@ -151,14 +151,61 @@ lever, not #822's job. Updated #826 with the post-fix split (5 exonym / 13 cover
 long tail). Verify-before-verdict fired: my first exonym probe tested the capitals (which resolve) before I
 realized the failures were the smaller cities.
 
-## Numbers (Part 2 — running)
+## Lever C — #818 recipes (3 of 4 shipped, PR #854)
+
+Wrote three OpenCage-style developer recipes in house voice, each verified against the real API (not the
+README-fiction trap): **privacy/coordinate-rounding** (`toGeohash` + decimal rounding, with the
+"coarsening is not anonymity" caveat), **batch geocoding** (`POST /api/batch`, input-order results, per-row
+error isolation, the cap + concurrency knobs), **display-on-a-map** (`resolveEntities → toGeoJSON →
+toMapHTML`, the localhost-CORS `file://` gotcha). `docusaurus build` green. The **multi-service/cost-first**
+recipe was left for the operator's voice pass (competitive positioning, gracious-not-vengeful).
+
+## Lever B — #379 deps (PR #855): the "high CVE" framing was stale
+
+Verify-before-verdict on the dependabot alerts: serialize-javascript is no longer flagged (on 6.0.2, patched);
+js-yaml is all 4.2.0 (above the vuln range); the one cleanly-safe fix was **http-proxy-middleware 2.0.9 →
+2.0.10** (in-major patch, dev-server-only) — shipped. The remaining `tar` alert needs the **7.x major** (no
+6.x backport), pulled only by cacache/node-gyp install tooling — left for the operator, not an autonomous force.
+
+## Lever I — #480 reproducibility (PR #856): #4 shipped, the rest already done
+
+Most of #480 was already shipped (verify-before-verdict again): REPRODUCIBILITY.md, the strict shard
+resolution + `test_shard_paths.py` (deliverable 2), the quantize value_info/opset docstring. The open
+deliverable I closed is **#4 — a toolchain pin-consistency verifier** (`verify_toolchain.py`): asserts the
+export/quant pins agree across pyproject ↔ the Modal image ↔ the export opset (the exact drift that broke
+mobile-Safari int8 in 2026-06-09), wired into `lint:python` + a 3-test pytest. Deliverables 3 (curriculum
+stamping) + 5 (snapshot publishing) stay open — both touch the train loop / release machinery.
+
+## Lever H — #378 WASM cold-path SLO (committed artifact)
+
+Couldn't run the live browser trace (**no Chrome on the lab box**), so delivered the measurable half: a
+cold-path budget from real artifact sizes (29 MB int8 model, the 1.3 GB candidate.db byte-range-fetched ~12
+cold chunks) + a node-side compute floor (model session-init 126 ms, warm parse 5.7 ms native EP) + a
+proposed two-surface SLO (cold-load < 6 s / per-keystroke < 50 ms on a Moto-G-class phone). The numbers
+already name the cold bottleneck: **the 29 MB model download**, not compute — so the cold lever is model size
++ streaming + CDN, not the SQLite path. The per-keystroke resolve cost (which gates **#372 flatbush**) is the
+one piece still needing the in-browser trace. Artifact: `2026-06-30-378-wasm-cold-path-slo.md`. **#372 is
+explicitly parked** behind that trace (diagnostic-before-fix — don't build the index before the profile).
+
+## Decisions made autonomously (Part 2)
+
+- **Deferred lever E (the $20 GPU budget).** #825's gate is GO, but no multilocale corpus/config is staged —
+  the retrain needs *new* PT/PL/AU data (a pipeline session), and weight-only up-weighting likely falsifies
+  (the fr.house_number precedent). Burning the $20 on an uninformative probe is worse than preserving it.
+  Flagged for operator override.
+- **#822 fix shape:** resolver-side joint-consistency (extend the reconcile) over a forward country pin —
+  the operator rejected Pelias-style determinism in #833, and DeepSeek's review concurred. Shipped default-on.
+- **Did not force the tar 7.x major bump** — dev-only tooling, no 6.x backport, breakage risk on cacache/node-gyp.
+
+## Numbers (Part 2 — final-ish)
 
 | | |
 |---|---|
-| Levers shipped | A (#822/#852, merged + measured) |
-| Levers triaged/measured | D (#305/#435/#456 re-scoped), F (frontier A/B + #826 update) |
-| PRs merged | 1 (#852) |
-| #822 bare resolve-rate | 54.2% → 77.9% (+23.7pp, CPU, no retrain) |
-| Modal $ | ~0 |
+| Levers shipped | A (#822/#852) + C (#818/#854) + B (#379/#855) + I (#480#4/#856) + F+H artifacts (#853 + SLO doc) |
+| Levers triaged/measured | D (#305/#435/#456 re-scoped), E (deferred w/ reason), F (frontier A/B), H (SLO + cold-path budget) |
+| PRs merged | 5 (#852, #853, #854, #855, #856) |
+| #822 bare resolve-rate | **54.2% → 77.9%** (+23.7pp, CPU, no retrain); 45/57 placer-recoverable countries closed |
+| Modal $ | ~0 (E deferred, budget preserved) |
 | GPU | none |
 | Regressions shipped | 0 |
+| Issues advanced | #822 closed; #305/#379/#435/#456/#480/#818/#826 updated/advanced |


### PR DESCRIPTION
**#378** — a cold-path accounting + proposed SLO for the browser geocoder, grounded in measured numbers (honest about measured vs estimated):

- **Sizes (measured):** int8 model ~29 MB, browser `candidate.db` is the 1.3 GB coverage gazetteer **byte-range fetched** (~12 cold chunks, not a full download).
- **Compute floor (measured, node native EP):** model session-init 126 ms, warm parse 5.7 ms (browser WASM ≈3–5× → ~15–30 ms parse, in-budget).
- **Proposed SLO:** cold-load P95 < 6 s, per-keystroke parse/resolve P95 < 50 ms (Moto-G-class, 4G).
- **The bottleneck the numbers already name:** cold load is **network-bound on the 29 MB model**, not compute → the lever is model size + streaming + CDN, not the SQLite path.
- **#372 flatbush is parked** behind the per-keystroke resolve trace (diagnostic-before-fix — don't build the index before profiling).

The in-browser P95 trace (the SLO's real gate) was blocked this shift: **no Chrome on the lab box** for the chrome-devtools profiler. Scoped as the explicit next step.

Also: postmortem part-2 records levers C/B/I/H + the autonomous decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)