### PR TITLE
feat: parallel CSV ingest — normalizeCSV core + threaded geocodeStream

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -78,7 +78,7 @@
 		"pino-pretty": "^13.1.3",
 		"pluralize": "^8.0.0",
 		"regenerate": "^1.4.2",
-		"spliterator": "^2.2.1",
+		"spliterator": "^3.1.0",
 		"table": "^6.9.0"
 	},
 	"devDependencies": {

--- a/corpus/package.json
+++ b/corpus/package.json
@@ -33,7 +33,7 @@
 		"fast-glob": "^3.3.3",
 		"fastest-levenshtein": "^1.0.16",
 		"lru-cache": "^10.4.3",
-		"spliterator": "^2.2.1"
+		"spliterator": "^3.1.0"
 	},
 	"devDependencies": {
 		"@types/node": ">=24.18.0"

--- a/docs/articles/recipes/parallel-csv-ingest.md
+++ b/docs/articles/recipes/parallel-csv-ingest.md
@@ -1,0 +1,98 @@
+---
+title: Ingesting Giant CSVs
+id: parallel-csv-ingest
+---
+
+Someone hands you a national dataset as a single CSV — the NPPES provider registry (millions of rows), an FCC broadband availability drop, a state address export. You need every row normalized into the same shape, and ideally a coordinate on each one. Two things stand in the way: the file won't fit in memory, and geocoding a million addresses one after another takes hours. This recipe is the shape that handles both — a streaming normalize core you can hold in your head, plus an optional threaded geocode stage you bolt on only when the per-row cost earns it.
+
+## Start with a stream, not a file
+
+`normalizeCSV` (from `@mailwoman/registry`) takes a path and a column mapping and hands back an async iterable of `SourceRecord`s. It reads the header, then yields one normalized record per row — it never holds more than a row or two in memory, so the file size doesn't matter.
+
+```ts
+import { normalizeCSV } from "@mailwoman/registry"
+
+const mapping = {
+	id: "NPI",
+	name: "Provider Name",
+	organization: "Provider Organization Name",
+	address: ["Address Line 1", "City", "State", "Postal Code"],
+}
+
+for await (const record of normalizeCSV("nppes.csv", { mapping })) {
+	// record.id, record.name, record.organization, record.raw …
+	sink.write(record)
+}
+```
+
+The `mapping` is the whole interface: each field names the column (or columns) it draws from. A field with several columns — like `address` above — gets them joined in order, so four NPPES columns become `"500 N Hiatus Rd Ste 200, Pembroke Pines, FL, 33026"`. The original row survives verbatim on `record.raw`, so nothing is lost; downstream stages recompute from it rather than trusting a lossy projection.
+
+What you _don't_ get from `normalizeCSV` is a coordinate. `record.address` is undefined here, on purpose — normalizing (column-map, parse the name, canonicalize the org) costs microseconds a row, and that's the cheap, single-threaded core. Geocoding is a different animal.
+
+## Why geocoding is a separate stage
+
+The instinct with a million rows is "throw it on all my cores." That instinct is right for expensive work and actively wrong for cheap work, and the line between them is sharper than it looks.
+
+Dispatching a row to a worker thread and getting the result back costs something fixed — serialize the row out, deserialize the result in, a few microseconds of structured-clone either way. Normalizing a row costs about the same. So threading the normalize step spends a microsecond to save a microsecond: you'd run it across eight cores and watch it get _slower_, because the main thread now spends all its time packing and unpacking messages. We measured exactly this on light CSV work — 0.3–0.9× of single-threaded. Don't thread the cheap stage.
+
+Geocoding is the opposite. Each address runs a neural parse and several lookups against a multi-gigabyte gazetteer — milliseconds, not microseconds, a thousand times the dispatch cost. There the fixed overhead vanishes into the work, and threads pay off. So the split writes itself: **normalize on the main thread, geocode in workers.**
+
+## Compose them, and filter in between
+
+`geocodeStream` (from `mailwoman/geocode-stream`) is the threaded half. It takes the record stream and a geocoder config, runs the addresses across a worker pool, and yields the records back with `address` populated. Because it consumes an async iterable and produces one, it composes directly onto `normalizeCSV` — and the main thread sits between them, which is exactly where you want your filter:
+
+```ts
+import { normalizeCSV } from "@mailwoman/registry"
+import { geocodeStream } from "mailwoman/geocode-stream"
+
+const geocode = {
+	wofDbPath: "/data/wof/admin-global-priority.db",
+	dataRoot: "/data",
+	locale: "en-US",
+	country: "US",
+}
+
+const normalized = normalizeCSV("nppes.csv", { mapping })
+
+// Cheap, on the main thread: drop rows you'll never geocode before paying for a worker.
+async function* onlyWithAddress(records) {
+	for await (const r of records) if (r.raw?.["Address Line 1"]) yield r
+}
+
+for await (const record of geocodeStream(onlyWithAddress(normalized), { mapping, geocode })) {
+	sink.write(record) // record.address is now populated
+}
+```
+
+That filter is the quiet win. Geocoding is the expensive stage, so every row you discard _before_ it is a worker dispatch you never pay for. Normalize a million rows, keep the 300 K with a usable address, and only those reach the pool. Filtering is a microsecond; geocoding is milliseconds — do the cheap rejection first.
+
+## How the workers stay cheap
+
+A worker can't receive your geocoder — a 4 GB SQLite handle and a loaded neural model don't survive a `postMessage`. So they don't cross. `geocodeStream` sends each worker only the serializable `geocode` config (paths, locale), and the worker _rebuilds_ its own classifier, WOF lookup, resolver, and shard provider at startup. After that, only the config went out and only the enriched record comes back.
+
+Two consequences worth holding onto:
+
+- **The DB is opened per worker, read-only.** Each worker opens its own handle to the same gazetteer file; the OS page cache is shared underneath, so you're not paying for N copies of the data, but you _are_ paying for N readers contending on it (more on that next).
+- **Records arrive in completion order, not input order.** A pool finishes rows as workers free up, so don't zip the output back onto your input by position. Re-key by `record.id` — which is why the mapping always carries one.
+
+## Don't reach for all your cores
+
+Here's the part that surprises people, and the reason `geocodeStream` defaults its `concurrency` low instead of to your core count. Geocoding looks CPU-bound, but it isn't — it's latency- and memory-bound. Every row makes random reads into that multi-gigabyte WOF database, and the classifier already spreads each inference across several cores. Stack more workers on top and they don't get more compute; they contend for the same memory bandwidth and the same DB pages.
+
+A sweep over real NPPES addresses on a 16-core box, single 4 GB gazetteer:
+
+| Workers |    Throughput |  Speedup |
+| ------: | ------------: | -------: |
+|       1 |     43 rows/s |       1× |
+|   **2** | **57 rows/s** | **1.4×** |
+|       3 |     51 rows/s |     1.2× |
+|       4 |     47 rows/s |     1.1× |
+|       6 |     43 rows/s |       1× |
+
+Throughput peaks at two workers and _declines_ from there — by six, you're back to single-threaded, having spent six cores to get there. Capping per-worker inference threads didn't move it either; the ceiling is the shared database, not the CPU. So treat `concurrency` as something you sweep for your data and your disk, starting low. The win from threading geocode is real but modest (~1.4×), and the way to lose it is to ask for more.
+
+If your gazetteer fits in RAM, or you've sharded it across disks, your curve will sit higher — measure it. The default (`min(4, cores)`) is deliberately conservative so the out-of-the-box behavior helps rather than thrashes.
+
+## When to stop at `normalize`
+
+Not every ingest needs a coordinate. If you're loading records to dedupe by name and org, or to join on an ID, the address never gets geocoded — so there's no heavy stage to thread, and `normalizeCSV` on its own is the whole job. Reaching for `geocodeStream` there would only add worker overhead to microsecond work, the exact loss from two sections ago. Thread the stage that earns it; leave the cheap one alone.

--- a/mailwoman/geocode-stream.test.ts
+++ b/mailwoman/geocode-stream.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import type { SourceRecord } from "@mailwoman/registry"
+import { describe, expect, it } from "vitest"
+
+import { geocodeStream } from "./geocode-stream.js"
+
+const fakeWorker = join(fileURLToPath(new URL("./test-fixtures/", import.meta.url)), "fake-geocode-worker.js")
+
+async function* records(n: number): AsyncIterableIterator<SourceRecord> {
+	for (let i = 0; i < n; i++) yield { id: String(i), raw: { addr: `addr ${i}` } } as SourceRecord
+}
+
+describe("geocodeStream (wiring, fake worker)", () => {
+	it("passes mapping + config to the worker and streams enriched records back", async () => {
+		const out: SourceRecord[] = []
+
+		for await (const r of geocodeStream(records(50), {
+			mapping: { address: ["addr", "city"] },
+			geocode: { wofDbPath: "/x.db", dataRoot: "/data", locale: "en-US", country: "US" },
+			concurrency: 3,
+			batchSize: 8,
+			worker: fakeWorker,
+		})) {
+			out.push(r)
+		}
+
+		expect(out).toHaveLength(50)
+		// Every record geocoded; config (locale) + mapping (address col count) reached the worker.
+		expect(out.every((r) => (r.address as unknown as { tag: string }).tag === "en-US")).toBe(true)
+		expect((out[0]!.address as unknown as { cols: number }).cols).toBe(2)
+		// Records preserved (set comparison — completion order).
+		expect(out.map((r) => r.id).sort((a, b) => Number(a) - Number(b))).toEqual(
+			Array.from({ length: 50 }, (_, i) => String(i))
+		)
+	})
+})

--- a/mailwoman/geocode-stream.ts
+++ b/mailwoman/geocode-stream.ts
@@ -1,0 +1,85 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ * The heavy, threaded half of the parallel-ingest split: geocode a stream of normalized records across
+ * worker threads (`spliterator.parallelMap`). Compose it after `@mailwoman/registry`'s `normalizeCSV`,
+ * filtering on the main thread first so you only geocode the rows you care about:
+ *
+ * ```ts
+ * import { normalizeCSV } from "@mailwoman/registry"
+ * import { geocodeStream } from "mailwoman/geocode-stream"
+ *
+ * const normalized = normalizeCSV("nppes.csv", { mapping })
+ * for await (const rec of geocodeStream(normalized, { mapping, geocode })) sink.write(rec)
+ * ```
+ *
+ * Each worker rebuilds the classifier / WOF lookup / resolver / shards from {@link GeocodeStreamConfig}
+ * (paths + locale) at startup — nothing but config crosses out, only the enriched record crosses back.
+ * Records arrive in completion order. Worth threading only because geocoding is ms-scale per row
+ * (~23ms measured) — far above the cross-thread cost; for light normalization, stop after normalizeCSV.
+ *
+ * **Concurrency is low on purpose.** Geocoding is latency/memory-bound, not CPU-bound: each row makes
+ * random reads into the multi-GB WOF SQLite, and the classifier already uses several cores per inference.
+ * A measured NPPES sweep (single 4 GB DB, 16-core box) peaked at **2 workers (~1.4×)** and *degraded* from
+ * there — 4 workers ≈ baseline, 6 ≈ no gain — because the shared DB + memory bandwidth is the ceiling, not
+ * the core count. So the default is small, and more is usually worse. Sweep it for your data/box rather
+ * than reaching for `availableParallelism()`.
+ */
+
+import { availableParallelism } from "node:os"
+
+import type { ColumnMapping, SourceRecord } from "@mailwoman/registry"
+import { parallelMap } from "spliterator"
+
+export interface GeocodeStreamConfig {
+	/** Path to the WOF admin SQLite DB. Opened read-only per worker (shared OS page cache). */
+	wofDbPath: string
+	/** Mailwoman data root (geometry shards live under here). */
+	dataRoot: string
+	/** Classifier weights locale, e.g. `"en-US"`. */
+	locale: string
+	/** Default country for resolution, e.g. `"US"`. */
+	country?: string
+}
+
+export interface GeocodeStreamOptions {
+	/** The same {@link ColumnMapping} used to normalize — the worker recomputes the address from it. */
+	mapping: ColumnMapping
+	/** Serializable geocoder config the worker rebuilds its deps from. */
+	geocode: GeocodeStreamConfig
+	/**
+	 * Worker pool size. Keep it small — geocoding is I/O/memory-bound, so throughput peaks at ~2 workers and degrades
+	 * past that (see the module doc). Bounded by RAM too (each worker loads the model + opens the DB).
+	 *
+	 * @default Math.min(4, availableParallelism())
+	 */
+	concurrency?: number
+	/** Records per dispatched batch. @default 32 */
+	batchSize?: number
+	/** Override the worker module — tests inject a fake. Defaults to the real geocode worker. */
+	worker?: string | URL
+}
+
+/** The compiled worker, resolved whether this runs from `out/` (prod) or `.ts` source (tests). */
+const GEOCODE_WORKER_URL = new URL(
+	import.meta.url.includes("/out/") ? "./geocode-worker.js" : "./out/geocode-worker.js",
+	import.meta.url
+)
+
+/**
+ * Geocode `records` across a worker pool, yielding enriched {@link SourceRecord}s (with `address` populated) in
+ * completion order. See the module doc for composition + the in-worker dep rebuild.
+ */
+export function geocodeStream(
+	records: AsyncIterable<SourceRecord> | Iterable<SourceRecord>,
+	opts: GeocodeStreamOptions
+): AsyncIterableIterator<SourceRecord> {
+	return parallelMap<SourceRecord, SourceRecord>(records, {
+		worker: opts.worker ?? GEOCODE_WORKER_URL,
+		concurrency: opts.concurrency ?? Math.min(4, availableParallelism()),
+		batchSize: opts.batchSize ?? 32,
+		workerData: { mapping: opts.mapping, geocode: opts.geocode },
+	})
+}

--- a/mailwoman/geocode-worker.ts
+++ b/mailwoman/geocode-worker.ts
@@ -1,0 +1,46 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ * Runs inside a worker thread (spawned by `geocodeStream` via `spliterator.parallelMap`). Top-level
+ * code is per-worker init: rebuild the classifier, WOF SQLite lookup, resolver, and geometry shards
+ * from the serializable `workerData.userData` config (paths + locale), then assemble the same geocode
+ * seam the CLI builds. Each dispatched record is geocoded by `makeGeocodeHandler`.
+ */
+
+import { workerData } from "node:worker_threads"
+
+import { decodeAsJSON } from "@mailwoman/core/decoder"
+import { NeuralAddressClassifier } from "@mailwoman/neural"
+import { type ColumnMapping, geocodeAddressVia, makeGeocodeHandler } from "@mailwoman/registry"
+import { createWofResolver, type ResolverBackend } from "@mailwoman/resolver"
+
+import { geocodeAddress, ShardProvider } from "./geocode-core.js"
+import type { GeocodeStreamConfig } from "./geocode-stream.js"
+
+const { mapping, geocode: cfg } = (workerData?.userData ?? {}) as {
+	mapping: ColumnMapping
+	geocode: GeocodeStreamConfig
+}
+
+const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: cfg.locale })
+const wof = await import("@mailwoman/resolver-wof-sqlite")
+const lookup = new wof.WofSqlitePlaceLookup({ databasePath: cfg.wofDbPath })
+const resolver = createWofResolver(lookup as unknown as ResolverBackend)
+const shards = new ShardProvider(wof, cfg.dataRoot)
+
+const seam = geocodeAddressVia({
+	parse: async (raw) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),
+	geocode: (raw) =>
+		geocodeAddress(raw, {
+			classifier,
+			resolver,
+			shards: shards.for,
+			defaultCountry: cfg.country ?? "US",
+			placeCountry: false,
+		}),
+	country: cfg.country,
+})
+
+export const handleItem = makeGeocodeHandler(seam, mapping)

--- a/mailwoman/package.json
+++ b/mailwoman/package.json
@@ -88,7 +88,7 @@
 		"pluralize": "^8.0.0",
 		"react": "^19.2.7",
 		"regenerate": "^1.4.2",
-		"spliterator": "^2.2.1",
+		"spliterator": "^3.1.0",
 		"zod": "^4.4.3",
 		"zx": "^8.8.5"
 	},

--- a/mailwoman/package.json
+++ b/mailwoman/package.json
@@ -45,6 +45,7 @@
 		"./package.json": "./package.json",
 		".": "./out/index.js",
 		"./geocode-core": "./out/geocode-core.js",
+		"./geocode-stream": "./out/geocode-stream.js",
 		"./resolver-backend": "./out/resolver-backend.js",
 		"./server": "./out/server/index.js",
 		"./sdk/test": "./out/sdk/test/index.js",

--- a/mailwoman/test-fixtures/fake-geocode-worker.js
+++ b/mailwoman/test-fixtures/fake-geocode-worker.js
@@ -1,0 +1,20 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ * A fake geocode worker (no real model/DB) that proves geocodeStream's wiring: workerData config and
+ * the record both arrive, and results flow back. It tags each record's address with the config locale
+ * and the mapped-address column count.
+ */
+
+import { workerData } from "node:worker_threads"
+
+const { mapping, geocode } = workerData.userData
+
+/** @param {{ raw: Record<string, string> }} record */
+export function handleItem(record) {
+	const cols = Array.isArray(mapping.address) ? mapping.address.length : mapping.address ? 1 : 0
+
+	return { ...record, address: { tag: geocode.locale, cols } }
+}

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"oxlint": "1.71.0",
 		"react": "^19.2.7",
 		"release-it": "^19.2.4",
-		"spliterator": "^2.2.1",
+		"spliterator": "^3.1.0",
 		"tap-difflet": "^0.7.2",
 		"typescript": "^6.0.3",
 		"vitest": "3.2.6",

--- a/registry/geocode-handler.test.ts
+++ b/registry/geocode-handler.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import type { PostalAddress } from "@mailwoman/record"
+import { describe, expect, it } from "vitest"
+
+import { makeGeocodeHandler } from "./geocode-handler.js"
+import type { GeocodeAddress } from "./ingest.js"
+import type { SourceRecord } from "./types.js"
+
+const rec = (raw: Record<string, string>): SourceRecord => ({ id: "x", raw }) as SourceRecord
+
+describe("makeGeocodeHandler", () => {
+	it("recomputes the address from raw+mapping and attaches the geocode", async () => {
+		const seam: GeocodeAddress = async (raw) => ({ formatted: raw.toUpperCase() }) as unknown as PostalAddress
+		const handle = makeGeocodeHandler(seam, { address: ["addr", "city", "state"] })
+
+		const out = await handle(rec({ addr: "1 Main St", city: "Austin", state: "TX" }))
+
+		expect((out.address as unknown as { formatted: string }).formatted).toBe("1 MAIN ST, AUSTIN, TX")
+	})
+
+	it("leaves a record with no mapped address untouched (no geocode call)", async () => {
+		let calls = 0
+		const seam: GeocodeAddress = async () => {
+			calls++
+
+			return null
+		}
+		const handle = makeGeocodeHandler(seam, { address: ["addr"] })
+
+		const out = await handle(rec({ addr: "" }))
+
+		expect(out.address).toBeUndefined()
+		expect(calls).toBe(0)
+	})
+
+	it("maps a null geocode result to undefined", async () => {
+		const seam: GeocodeAddress = async () => null
+		const handle = makeGeocodeHandler(seam, { address: ["addr"] })
+
+		expect((await handle(rec({ addr: "nowhere" }))).address).toBeUndefined()
+	})
+})

--- a/registry/geocode-handler.ts
+++ b/registry/geocode-handler.ts
@@ -1,0 +1,35 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ * The per-record geocode step, factored out of the worker so it unit-tests against a fake seam (no
+ * neural model / SQLite). `geocode-worker.ts` builds the real seam from config and wraps this.
+ */
+
+import { type ColumnMapping, type GeocodeAddress, pick } from "./ingest.js"
+import type { SourceRecord } from "./types.js"
+
+/**
+ * Build the handler `geocodeStream` runs per normalized record: recompute the joined address string from `record.raw` +
+ * `mapping.address` (the worker can't receive the original closure), geocode it via `seam`, and attach the result.
+ * Records with no mapped address pass through untouched (no geocode call). The default separator matches
+ * {@link ingestRow}'s `addressSeparator`.
+ */
+export function makeGeocodeHandler(
+	seam: GeocodeAddress,
+	mapping: ColumnMapping,
+	addressSeparator = ", "
+): (record: SourceRecord) => Promise<SourceRecord> {
+	return async (record) => {
+		if (!record.raw) return record
+
+		const addressValue = pick(record.raw, mapping.address, addressSeparator)
+
+		if (!addressValue) return record
+
+		const address = (await seam(addressValue)) ?? undefined
+
+		return { ...record, address }
+	}
+}

--- a/registry/index.ts
+++ b/registry/index.ts
@@ -14,6 +14,7 @@
 export * from "./address-key.js"
 export * from "./geojson.js"
 export * from "./ingest.js"
+export * from "./geocode-handler.js"
 export * from "./learned-scorer.js"
 export * from "./map-html.js"
 export * from "./models/dedup-gbt-en-us.js"

--- a/registry/ingest.ts
+++ b/registry/ingest.ts
@@ -194,7 +194,7 @@ export function parseCsv(text: string): Record<string, string>[] {
 }
 
 /** Join the named column(s) of a row into a single trimmed string, or undefined if empty. */
-function pick(row: Record<string, string>, columns?: string | string[], separator = " "): string | undefined {
+export function pick(row: Record<string, string>, columns?: string | string[], separator = " "): string | undefined {
 	if (!columns) return undefined
 	const list = Array.isArray(columns) ? columns : [columns]
 	const value = list
@@ -204,6 +204,46 @@ function pick(row: Record<string, string>, columns?: string | string[], separato
 		.trim()
 
 	return value || undefined
+}
+
+/**
+ * Normalize one tabular row into a {@link SourceRecord} under a {@link ColumnMapping}: parse the person name,
+ * canonicalize the org, and (if `opts.geocodeAddress` is provided) geocode the joined address. `id` falls back to the
+ * caller-supplied row index. Pure aside from the optional geocode seam, so the deterministic normalization can run
+ * single-threaded (see {@link normalizeCSV}) while geocoding is offloaded (see `geocodeStream`).
+ */
+export async function ingestRow(
+	row: Record<string, string>,
+	mapping: ColumnMapping,
+	index: number,
+	opts: IngestOptions = {}
+): Promise<SourceRecord> {
+	const id = (mapping.id ? row[mapping.id]?.trim() : "") || String(index)
+	const nameValue = pick(row, mapping.name)
+	const orgValue = pick(row, mapping.organization)
+	const addressValue = pick(row, mapping.address, opts.addressSeparator ?? ", ")
+
+	let attributes: Record<string, string> | undefined
+
+	if (mapping.attributes) {
+		for (const [key, columns] of Object.entries(mapping.attributes)) {
+			const value = pick(row, columns)
+
+			if (value) (attributes ??= {})[key] = value
+		}
+	}
+
+	return {
+		id,
+		source: mapping.source,
+		name: nameValue ? parsePersonName(nameValue) : undefined,
+		organization: orgValue ? canonicalizeOrganizationName(orgValue) : undefined,
+		phone: (mapping.phone && row[mapping.phone]?.trim()) || undefined,
+		email: (mapping.email && row[mapping.email]?.trim()?.toLowerCase()) || undefined,
+		address: addressValue && opts.geocodeAddress ? ((await opts.geocodeAddress(addressValue)) ?? undefined) : undefined,
+		attributes,
+		raw: row,
+	}
 }
 
 /**
@@ -219,39 +259,29 @@ export async function ingestRows(
 	let index = 0
 
 	for await (const row of rows) {
-		const id = (mapping.id ? row[mapping.id]?.trim() : "") || String(index)
-		const nameValue = pick(row, mapping.name)
-		const orgValue = pick(row, mapping.organization)
-		const addressValue = pick(row, mapping.address, opts.addressSeparator ?? ", ")
-
-		let attributes: Record<string, string> | undefined
-
-		if (mapping.attributes) {
-			for (const [key, columns] of Object.entries(mapping.attributes)) {
-				const value = pick(row, columns)
-
-				if (value) (attributes ??= {})[key] = value
-			}
-		}
-
-		const record: SourceRecord = {
-			id,
-			source: mapping.source,
-			name: nameValue ? parsePersonName(nameValue) : undefined,
-			organization: orgValue ? canonicalizeOrganizationName(orgValue) : undefined,
-			phone: (mapping.phone && row[mapping.phone]?.trim()) || undefined,
-			email: (mapping.email && row[mapping.email]?.trim()?.toLowerCase()) || undefined,
-			address:
-				addressValue && opts.geocodeAddress ? ((await opts.geocodeAddress(addressValue)) ?? undefined) : undefined,
-			attributes,
-			raw: row,
-		}
-
-		records.push(record)
+		records.push(await ingestRow(row, mapping, index, opts))
 		index++
 	}
 
 	return records
+}
+
+/**
+ * Stream a delimited file as normalized {@link SourceRecord}s — `streamRows` + {@link ingestRow} with **no geocoding**.
+ * This is the single-threaded, "fast enough" ergonomic core: column mapping, name parsing, and org canonicalization for
+ * a multi-GB file, line by line. Geocode separately by piping the output through `geocodeStream` (the only heavy step
+ * worth threading); for a light file (e.g. one that already carries geo cells) just consume this and stop.
+ */
+export async function* normalizeCSV(
+	source: string,
+	opts: { mapping: ColumnMapping; delimiter?: Delimiter }
+): AsyncGenerator<SourceRecord> {
+	let index = 0
+
+	for await (const row of streamRows(source, { delimiter: opts.delimiter })) {
+		yield await ingestRow(row, opts.mapping, index)
+		index++
+	}
 }
 
 /**

--- a/registry/normalizeCSV.test.ts
+++ b/registry/normalizeCSV.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterAll, describe, expect, it } from "vitest"
+
+import { normalizeCSV } from "./ingest.js"
+import type { SourceRecord } from "./types.js"
+
+const dir = mkdtempSync(join(tmpdir(), "normalize-csv-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+function fixture(name: string, text: string): string {
+	const p = join(dir, name)
+	writeFileSync(p, text)
+
+	return p
+}
+
+async function collect(gen: AsyncIterable<SourceRecord>): Promise<SourceRecord[]> {
+	const out: SourceRecord[] = []
+
+	for await (const r of gen) out.push(r)
+
+	return out
+}
+
+const MAPPING = { id: "id", name: "name", organization: "org", address: ["addr", "city", "state"] }
+
+describe("normalizeCSV", () => {
+	it("streams normalized records (name parsed, org canonicalized, no geocode)", async () => {
+		const p = fixture(
+			"people.csv",
+			"id,name,org,addr,city,state\n" +
+				"c1,Dr. Robert Smith,Acme Health LLC,123 Main St,Portland,OR\n" +
+				"c2,Maria Garcia,,50 Elm Ave,Seattle,WA\n"
+		)
+
+		const recs = await collect(normalizeCSV(p, { mapping: MAPPING }))
+
+		expect(recs).toHaveLength(2)
+		expect(recs[0]!.id).toBe("c1")
+		expect(recs[0]!.name?.family).toBe("Smith")
+		expect(recs[0]!.organization).toBeTruthy()
+		expect(recs[0]!.address).toBeUndefined() // normalize never geocodes
+		expect(recs[0]!.raw).toMatchObject({ addr: "123 Main St", state: "OR" })
+		expect(recs[1]!.organization).toBeUndefined() // empty org column
+	})
+
+	it("falls back to the row index for a missing id", async () => {
+		const p = fixture("no-id.csv", "name,addr\nJohn Doe,1 A St\nJane Roe,2 B St\n")
+		const recs = await collect(normalizeCSV(p, { mapping: { name: "name", address: "addr" } }))
+
+		expect(recs.map((r) => r.id)).toEqual(["0", "1"])
+	})
+})

--- a/registry/package.json
+++ b/registry/package.json
@@ -32,7 +32,7 @@
 		"@mailwoman/spatial": "workspace:*",
 		"@protomaps/basemaps": "^5.7.2",
 		"csv-parse": "^5.6.0",
-		"spliterator": "^2.2.1"
+		"spliterator": "^3.1.0"
 	},
 	"devDependencies": {
 		"@types/node": ">=26.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4730,7 +4730,7 @@ __metadata:
     pino-pretty: "npm:^13.1.3"
     pluralize: "npm:^8.0.0"
     regenerate: "npm:^1.4.2"
-    spliterator: "npm:^2.2.1"
+    spliterator: "npm:^3.1.0"
     table: "npm:^6.9.0"
   languageName: unknown
   linkType: soft
@@ -4748,7 +4748,7 @@ __metadata:
     fast-glob: "npm:^3.3.3"
     fastest-levenshtein: "npm:^1.0.16"
     lru-cache: "npm:^10.4.3"
-    spliterator: "npm:^2.2.1"
+    spliterator: "npm:^3.1.0"
   languageName: unknown
   linkType: soft
 
@@ -4971,7 +4971,7 @@ __metadata:
     "@protomaps/basemaps": "npm:^5.7.2"
     "@types/node": "npm:>=26.0.1"
     csv-parse: "npm:^5.6.0"
-    spliterator: "npm:^2.2.1"
+    spliterator: "npm:^3.1.0"
   languageName: unknown
   linkType: soft
 
@@ -5108,7 +5108,7 @@ __metadata:
     oxlint: "npm:1.71.0"
     react: "npm:^19.2.7"
     release-it: "npm:^19.2.4"
-    spliterator: "npm:^2.2.1"
+    spliterator: "npm:^3.1.0"
     tap-difflet: "npm:^0.7.2"
     typescript: "npm:^6.0.3"
     vitest: "npm:3.2.6"
@@ -16830,7 +16830,7 @@ __metadata:
     pluralize: "npm:^8.0.0"
     react: "npm:^19.2.7"
     regenerate: "npm:^1.4.2"
-    spliterator: "npm:^2.2.1"
+    spliterator: "npm:^3.1.0"
     zod: "npm:^4.4.3"
     zx: "npm:^8.8.5"
   peerDependencies:
@@ -22966,9 +22966,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spliterator@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "spliterator@npm:2.2.1"
+"spliterator@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "spliterator@npm:3.1.0"
   dependencies:
     yargs: "npm:^18.0.0"
   peerDependencies:
@@ -22981,7 +22981,7 @@ __metadata:
       optional: true
   bin:
     spliterator: out/node/cli/index.js
-  checksum: 10/50895a43470c5b527a30accd720fd562e71b017252895575ed6a6c2cd7c52e0bd7bdd1ec2fce9e1354696ca3ed9100ff34f28f0075d572c3b4de39383ec27033
+  checksum: 10/2ed58d7f5b0fa35f306d9b0346cda963050ab66e698dfbeb0438258425d20ba64b20fdb59c3bfb9a3d984453344a56e06a8c0b6d084299c371f8f8c5216b2e6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

A split pipeline for ingesting giant delimited datasets (NPPES, FCC BDC, state address exports) without loading them into memory:

- **`normalizeCSV`** (`@mailwoman/registry`) — the ergonomic, single-threaded streaming core. Path + `ColumnMapping` in, an async iterable of `SourceRecord`s out (column-map + parse name + canonicalize org). No geocoding. Factored out of `ingestRows` via a new pure `ingestRow`.
- **`geocodeStream`** (`mailwoman/geocode-stream`) — the heavy, threaded half. Runs a record stream's addresses across a `spliterator.parallelMap` worker pool and yields the records back with `address` populated. Each worker rebuilds its classifier / WOF lookup / resolver / shards from a serializable config — nothing but config crosses out, only the enriched record crosses back.
- **`makeGeocodeHandler`** (`@mailwoman/registry`) — the pure per-record step (recompute address from `raw` + mapping, geocode via an injected seam), so it unit-tests against a fake seam with no model/DB.

They compose directly (`geocodeStream(normalizeCSV(file, { mapping }), …)`), with the main thread sitting between them as the place to filter — so you only pay a worker dispatch for rows you keep.

## The honest performance story

I ran the real worker pool end-to-end (neural classifier + 4 GB WOF SQLite + shards) over real NPPES practice-location addresses. It works — but the speedup curve is the interesting part, and it drove a design default:

| Workers | Throughput | Speedup |
| ------: | ---------: | ------: |
|       1 |  43 rows/s |      1× |
|   **2** | **57 rows/s** | **1.4×** |
|       4 |  47 rows/s |   1.1× |
|       6 |  43 rows/s |     1× |

Geocoding *looks* CPU-bound but is latency/memory-bound — random reads into a multi-GB gazetteer, and the classifier already uses several cores per inference. Throughput peaks at **~2 workers** and **degrades past that**; capping per-worker inference threads (`OMP_NUM_THREADS=1`) didn't help. So `geocodeStream` defaults `concurrency` to `min(4, cores)`, not `availableParallelism()` (which would run *slower than single-threaded* here), and the doc says to sweep it.

This is the cautionary half of "is threading worth it": thread the ms-scale stage (geocode), never the µs-scale one (normalize — measured 0.3–0.9× when threaded).

## Also in here

- **Adopts `spliterator@^3.1.0` monorepo-wide** (root, core, corpus, mailwoman, registry), collapsing the prior split (root 3.0.x + nested 2.2.1) onto one resolved version. `parallelMap` is new in 3.1.0 and is what `geocodeStream` runs on.
- **A recipe guide** (`docs/articles/recipes/parallel-csv-ingest.md`) — the normalize/geocode split, the filter-between-stages pattern, and the measured concurrency story. Intended as a template for future mailwoman guides.

## Tests

22 tests, all green against the published 3.1.0:

- `normalizeCSV` — name parsed, org canonicalized, address undefined, id fallback.
- `makeGeocodeHandler` — fake seam; address recomputed + attached, no-address rows pass through.
- `geocodeStream` wiring — fake worker proves config + records flow through the pool and back.
- Existing `ingest` tests still pass.

The real geocode worker is validated by the end-to-end smoke run above (not in CI — it needs the 4 GB gazetteer + model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MVWSryMD1xxhLXKYcKaHC
