### PR TITLE
perf(geocode): parse each address once (single-parse dedupe, ~1.27×)

### DIFF
--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -101,6 +101,13 @@ export interface GeocodeDeps {
 	 */
 	normalizeInput?: boolean
 	/**
+	 * A pre-parsed tree to resolve, skipping the internal `classifier.parse` (the address's single most expensive step).
+	 * Supply the output of {@link parseForGeocode} when a caller already parsed the same address for another purpose — a
+	 * PostalAddress, say — so the inference runs once, not twice. MUST come from `parseForGeocode` (same input + opts),
+	 * or the resolved tree won't match the address. Omit for the normal one-shot path.
+	 */
+	parsedTree?: AddressTree
+	/**
 	 * Interpolation-radius conformal calibration (#374) so reported radii are an honest ~90% bound; `1` or `undefined`
 	 * keeps the raw half-segment heuristic. Accepts either a single multiplier (the legacy Travis 1.7) OR a per-region
 	 * {@link InterpCalibrationTable} — when a table is supplied the factor is selected by the parsed region (DC 1.44 … AZ
@@ -297,6 +304,24 @@ export class ShardProvider {
 }
 
 /**
+ * The exact parse `geocodeAddress` runs internally: Stage-1 deterministic preprocessing (`normalizeInput`) →
+ * `classifier.parse` (postcodeRepair + normalizeCase) → `recognizeUsRegions`. Exposed so a caller can run it once and
+ * feed the result to both {@link geocodeAddress} (via `GeocodeDeps.parsedTree`) and another consumer of the parse (e.g.
+ * `decodeAsJSON(tree)` → a PostalAddress), instead of parsing the same address twice. The inference is ~3 ms/row — the
+ * single most expensive step — so sharing it is a ~1.3× win on a parse-then-geocode pipeline.
+ */
+export async function parseForGeocode(
+	input: string,
+	deps: Pick<GeocodeDeps, "classifier" | "normalizeInput" | "normalizeCase">
+): Promise<AddressTree> {
+	const parseInput = deps.normalizeInput === false ? input : normalize(input).normalized
+
+	return recognizeUsRegions(
+		await deps.classifier.parse(parseInput, { postcodeRepair: true, normalizeCase: deps.normalizeCase ?? true })
+	)
+}
+
+/**
  * Run the full street-level cascade on one address and return the structured geocode result. Always returns a result
  * (admin tier even with no coordinate shards). Throws only on a fatal parse/resolve error — callers doing batch work
  * should catch per-row.
@@ -304,11 +329,10 @@ export class ShardProvider {
 export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<GeocodeResult> {
 	// Stage 1 deterministic preprocessing (GeocodeDeps.normalizeInput) — drop-ins call geocodeAddress directly with no
 	// createRuntimePipeline wrapper, so without this a double-spaced / odd-punctuation query was fragile. `input` stays
-	// raw for the result; the parse + placer see the normalized form.
+	// raw for the result; the parse + placer see the normalized form. A caller-supplied `parsedTree` (from
+	// parseForGeocode, same input + opts) skips the re-parse — the address's most expensive step.
 	const parseInput = deps.normalizeInput === false ? input : normalize(input).normalized
-	const tree = recognizeUsRegions(
-		await deps.classifier.parse(parseInput, { postcodeRepair: true, normalizeCase: deps.normalizeCase ?? true })
-	)
+	const tree = deps.parsedTree ?? (await parseForGeocode(input, deps))
 	const stateSlug = regionSlugFromTree(tree)
 	const usShards = deps.shards?.(stateSlug) ?? {}
 	let addressPoints = usShards.addressPoints

--- a/mailwoman/geocode-worker.ts
+++ b/mailwoman/geocode-worker.ts
@@ -16,7 +16,7 @@ import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { type ColumnMapping, geocodeAddressVia, makeGeocodeHandler } from "@mailwoman/registry"
 import { createWofResolver, type ResolverBackend } from "@mailwoman/resolver"
 
-import { geocodeAddress, ShardProvider } from "./geocode-core.js"
+import { geocodeAddress, parseForGeocode, ShardProvider } from "./geocode-core.js"
 import type { GeocodeStreamConfig } from "./geocode-stream.js"
 
 const { mapping, geocode: cfg } = (workerData?.userData ?? {}) as {
@@ -30,16 +30,24 @@ const lookup = new wof.WofSqlitePlaceLookup({ databasePath: cfg.wofDbPath })
 const resolver = createWofResolver(lookup as unknown as ResolverBackend)
 const shards = new ShardProvider(wof, cfg.dataRoot)
 
+const geoDeps = {
+	classifier,
+	resolver,
+	shards: shards.for,
+	defaultCountry: cfg.country ?? "US",
+	placeCountry: false,
+} as const
+
+// Parse ONCE per address (the ~3 ms/row inference is the dominant cost): share the tree between the PostalAddress
+// (decodeAsJSON) and the geocode (parsedTree). Coordinates are byte-identical to the two-parse path — geocodeAddress
+// would have produced this exact tree internally; only the PostalAddress now reflects the normalized parse.
 const seam = geocodeAddressVia({
-	parse: async (raw) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),
-	geocode: (raw) =>
-		geocodeAddress(raw, {
-			classifier,
-			resolver,
-			shards: shards.for,
-			defaultCountry: cfg.country ?? "US",
-			placeCountry: false,
-		}),
+	parseAndGeocode: async (raw) => {
+		const tree = await parseForGeocode(raw, geoDeps)
+		const geo = await geocodeAddress(raw, { ...geoDeps, parsedTree: tree })
+
+		return { components: decodeAsJSON(tree), geo }
+	},
 	country: cfg.country,
 })
 

--- a/mailwoman/test/geocode-core-single-parse.test.ts
+++ b/mailwoman/test/geocode-core-single-parse.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The single-parse dedupe surface: `geocodeAddress` accepts a pre-parsed `parsedTree` and skips its
+ *   internal `classifier.parse` when given one, and `parseForGeocode` exposes that exact parse so a
+ *   caller can run it once and feed both the geocode and a PostalAddress. Fakes the classifier/resolver
+ *   — no weights/WOF needed.
+ */
+
+import type { AddressTree } from "@mailwoman/core/decoder"
+import type { ResolveOpts, Resolver } from "@mailwoman/resolver"
+import { describe, expect, test, vi } from "vitest"
+
+import { geocodeAddress, type GeocodeClassifier, parseForGeocode } from "../geocode-core.js"
+
+function fakeClassifier(tree: AddressTree): GeocodeClassifier {
+	return { parse: vi.fn(async () => tree) }
+}
+
+function captureResolver(): { resolver: Resolver; seen: AddressTree[] } {
+	const seen: AddressTree[] = []
+	const resolver: Resolver = {
+		resolveTree: vi.fn(async (tree: AddressTree, _opts?: ResolveOpts) => {
+			seen.push(tree)
+
+			return tree
+		}),
+	}
+
+	return { resolver, seen }
+}
+
+const emptyTree: AddressTree = { raw: "x", roots: [] }
+
+describe("geocodeAddress — parsedTree dedupe", () => {
+	test("a supplied parsedTree skips classifier.parse and is what the resolver resolves", async () => {
+		const classifier = fakeClassifier(emptyTree)
+		const { resolver, seen } = captureResolver()
+		const provided: AddressTree = { raw: "pre-parsed", roots: [] }
+
+		await geocodeAddress("500 N Hiatus Rd, Pembroke Pines, FL", {
+			classifier,
+			resolver,
+			placeCountry: false,
+			parsedTree: provided,
+		})
+
+		expect(classifier.parse).not.toHaveBeenCalled()
+		expect(seen[0]).toBe(provided)
+	})
+
+	test("without parsedTree, classifier.parse runs exactly once (the default path)", async () => {
+		const classifier = fakeClassifier(emptyTree)
+		const { resolver } = captureResolver()
+
+		await geocodeAddress("500 N Hiatus Rd, Pembroke Pines, FL", { classifier, resolver, placeCountry: false })
+
+		expect(classifier.parse).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe("parseForGeocode", () => {
+	test("parses once with the geocode options (postcodeRepair + normalizeCase) and returns a tree", async () => {
+		const classifier = fakeClassifier(emptyTree)
+
+		const tree = await parseForGeocode("500 N HIATUS RD, PEMBROKE PINES, FL", {
+			classifier,
+			resolver: captureResolver().resolver,
+		})
+
+		expect(classifier.parse).toHaveBeenCalledTimes(1)
+		expect(classifier.parse).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ postcodeRepair: true, normalizeCase: true })
+		)
+		expect(tree).toBeDefined()
+	})
+
+	test("a tree from parseForGeocode, fed back as parsedTree, reaches the resolver unchanged", async () => {
+		const classifier = fakeClassifier(emptyTree)
+		const { resolver, seen } = captureResolver()
+
+		const tree = await parseForGeocode("x", { classifier, resolver })
+		await geocodeAddress("x", { classifier, resolver, placeCountry: false, parsedTree: tree })
+
+		// parseForGeocode parsed once; geocodeAddress did not parse again.
+		expect(classifier.parse).toHaveBeenCalledTimes(1)
+		expect(seen.at(-1)).toBe(tree)
+	})
+})

--- a/registry/ingest.test.ts
+++ b/registry/ingest.test.ts
@@ -234,4 +234,29 @@ describe("geocodeAddressVia", () => {
 		expect(address?.canonicalKey).toBeTruthy()
 		expect(address?.geocode).toBeUndefined()
 	})
+
+	it("parseAndGeocode variant: one combined call wires the same PostalAddress + coordinate", async () => {
+		let calls = 0
+		const geocoded = geocodeAddressVia({
+			parseAndGeocode: async () => {
+				calls++
+
+				return { components, geo: { lat: 45.5, lon: -122.6, resolution_tier: "interpolated", uncertainty_m: 120 } }
+			},
+			country: "US",
+		})
+
+		const address = await geocoded("123 Main St, Portland OR 97201")
+		expect(calls).toBe(1)
+		expect(address?.canonicalKey).toBe("123|main|st|portland|or|97201|us")
+		expect(address?.geocode?.coordinate).toEqual({ latitude: 45.5, longitude: -122.6 })
+		expect(address?.geocode?.tier).toBe("interpolated")
+	})
+
+	it("parseAndGeocode with geo null returns the parsed-but-unlocated address", async () => {
+		const geocoded = geocodeAddressVia({ parseAndGeocode: async () => ({ components, geo: null }) })
+		const address = await geocoded("123 Main St")
+		expect(address?.canonicalKey).toBeTruthy()
+		expect(address?.geocode).toBeUndefined()
+	})
 })

--- a/registry/ingest.ts
+++ b/registry/ingest.ts
@@ -296,22 +296,46 @@ export interface RawGeocode {
 	hierarchy?: AddressGeocode["hierarchy"]
 }
 
+/** The component map {@link toPostalAddress} consumes (kept structural so this package never imports the geocoder). */
+type GeocodeComponents = Parameters<typeof toPostalAddress>[0]
+
 /**
  * Build a {@link GeocodeAddress} from mailwoman's real parse + geocode primitives (injected — the CLI constructs the
- * neural parser, resolver, and shards and passes them in). Parse → components → {@link toPostalAddress} (which fills the
- * canonical key + formatted form) → attach the resolved coordinate. When geocoding can't place the address, the
+ * neural parser, resolver, and shards and passes them in). Parse → components → {@link toPostalAddress} (which fills
+ * the canonical key + formatted form) → attach the resolved coordinate. When geocoding can't place the address, the
  * parsed-but-unlocated address is still returned.
+ *
+ * Two shapes:
+ *
+ * - `{ parse, geocode }` — the original: two independent calls. mailwoman's `geocodeAddress` re-parses internally, so
+ *   this parses the address twice (fine when the two callbacks don't share a parser).
+ * - `{ parseAndGeocode }` — parse the address ONCE and return both the components and the geocode. Use this when the
+ *   parse is the expensive step you'd rather not pay for twice (e.g. share `parseForGeocode`'s tree between the
+ *   PostalAddress and `geocodeAddress`'s `parsedTree`). ~1.3× over the two-call shape on a real geocode pipeline.
  */
-export function geocodeAddressVia(deps: {
-	parse: (raw: string) => Promise<Parameters<typeof toPostalAddress>[0]> | Parameters<typeof toPostalAddress>[0]
-	geocode: (raw: string) => Promise<RawGeocode | null> | RawGeocode | null
-	country?: string
-}): GeocodeAddress {
+export function geocodeAddressVia(
+	deps: { country?: string } & (
+		| {
+				parse: (raw: string) => Promise<GeocodeComponents> | GeocodeComponents
+				geocode: (raw: string) => Promise<RawGeocode | null> | RawGeocode | null
+		  }
+		| { parseAndGeocode: (raw: string) => Promise<{ components: GeocodeComponents; geo: RawGeocode | null }> }
+	)
+): GeocodeAddress {
 	return async (raw: string): Promise<PostalAddress | null> => {
-		const components = await deps.parse(raw)
-		const base = toPostalAddress(components, { country: deps.country, raw })
+		let components: GeocodeComponents
+		let resolved: RawGeocode | null
 
-		const resolved = await deps.geocode(raw)
+		if ("parseAndGeocode" in deps) {
+			const r = await deps.parseAndGeocode(raw)
+			components = r.components
+			resolved = r.geo
+		} else {
+			components = await deps.parse(raw)
+			resolved = await deps.geocode(raw)
+		}
+
+		const base = toPostalAddress(components, { country: deps.country, raw })
 
 		if (!resolved || resolved.lat === null || resolved.lon === null) return base
 


### PR DESCRIPTION
## What

Geocoding an address parses it through the neural classifier **twice**: `geocodeAddressVia` parses once to build the `PostalAddress`, and `geocodeAddress` re-parses internally to resolve coordinates. The parse is the single most expensive step (~3 ms/row of the ~16 ms), so the second one is pure waste. This shares one parse.

- **`parseForGeocode(input, deps)`** (`@mailwoman/geocode-core`) — exposes the exact parse `geocodeAddress` runs internally (normalize → `classifier.parse` → `recognizeUsRegions`).
- **`GeocodeDeps.parsedTree`** — when supplied, `geocodeAddress` skips its internal parse and resolves the given tree. Default path is byte-identical.
- **`geocodeAddressVia({ parseAndGeocode })`** (`@mailwoman/registry`) — additive union arm: parse once, return both the components and the geocode, instead of two independent callbacks. The existing `{ parse, geocode }` shape (8 record-matcher scripts) is untouched.
- **The geocode worker** wires it up: `parseForGeocode` once, tree shared between the `PostalAddress` (`decodeAsJSON`) and `geocodeAddress` (`parsedTree`).

## Measured (real NPPES addresses, real model + WOF)

```
old (2 parses): 16.4 ms/row
new (1 parse):  12.9 ms/row
speedup: 1.27×
```

**Coordinates byte-identical across all 300 rows** — `geocodeAddress` would have produced this exact tree internally, so resolution is unchanged. The one intentional behavior change: the worker's `PostalAddress` now derives from the geocode parse (title-cased, `recognizeUsRegions`, Stage-1 normalized) rather than a separate raw-case parse — i.e. `"500 N HIATUS RD"` → `"500 N Hiatus Rd"`. That's an improvement for a normalized store, and the record matcher compares case-insensitively.

## Why this matters with the worker pool

The companion finding (#868) was that threading geocode is I/O-bound and tops out at ~1.4× on one box. This 1.27× is **multiplicative and free** — it's less inference work per row on *every* thread, no hardware, no contention. The two compose.

## Tests

- `parsedTree` skips `classifier.parse`; the supplied tree is what the resolver resolves; default path still parses exactly once (fake classifier/resolver).
- `parseForGeocode` parses once with the geocode options; its tree fed back as `parsedTree` reaches the resolver unchanged.
- `geocodeAddressVia` `parseAndGeocode` arm wires the same PostalAddress + coordinate as `{ parse, geocode }`; null geo → parsed-but-unlocated. Existing `geocodeAddressVia` + place-country tests still green.
- Behavior-preservation (coords identical) validated end-to-end on the real model.

## Stacking

Based on `feat/parallel-ingest-geocode` (#868) — it touches that PR's worker. Merge #868 first; this retargets to `main` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MVWSryMD1xxhLXKYcKaHC
