### PR TITLE
feat(neural): guarded GPU execution-provider support for OnnxRunner

### DIFF
--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -202,7 +202,7 @@ export class NeuralAddressClassifier {
 	 * instead.
 	 */
 	static async loadFromWeights(
-		opts: ResolveWeightsOpts & { postcodeAnchorLookup?: AnchorLookup } = {}
+		opts: ResolveWeightsOpts & { postcodeAnchorLookup?: AnchorLookup; executionProviders?: string[] } = {}
 	): Promise<NeuralAddressClassifier> {
 		// /* webpackIgnore: true */ tells webpack to leave the dynamic import statement intact —
 		// it becomes a runtime native ESM import that resolves in Node (which has onnxruntime-node
@@ -229,7 +229,7 @@ export class NeuralAddressClassifier {
 		const crf = readCrfTransitions(resolved.crfTransitionsPath)
 		const [tokenizer, runner] = await Promise.all([
 			MailwomanTokenizer.loadFromFile(resolved.tokenizerPath),
-			OnnxRunner.create(resolved.modelPath),
+			OnnxRunner.create(resolved.modelPath, { executionProviders: opts.executionProviders }),
 		])
 
 		// --- Soft-feed (#718 D1): feed the channels the SHIPPED model was trained against ----------

--- a/neural/onnx-runner.ts
+++ b/neural/onnx-runner.ts
@@ -29,6 +29,14 @@ export interface OnnxRunnerOpts {
 	 * than this are padded with id `0` and masked out via attention_mask=0; inputs longer are truncated.
 	 */
 	fixedSeqLen?: number
+	/**
+	 * ONNX Runtime execution providers to try, in priority order — e.g. `["cuda", "cpu"]` or `["webgpu", "cpu"]`.
+	 * **Default `["cpu"]`** (unchanged behavior). GPU providers (`cuda`, `webgpu`) THROW at session-create when their
+	 * runtime/driver is absent rather than soft-falling-back, so this is **guarded**: if the requested list fails to
+	 * initialize, the runner retries on CPU alone. The cost of a failed GPU probe is a one-time sub-`100 ms` hit at load,
+	 * so a GPU box lights up and a CPU box pays ~nothing. `cpu` is always appended if not present.
+	 */
+	executionProviders?: string[]
 }
 
 /** Default sequence length for v0.1.0 / v0.2.0 (BertConfig max_position_embeddings = 128). */
@@ -51,12 +59,17 @@ export class OnnxRunner {
 	private loadPromise: Promise<ort.InferenceSession> | null = null
 	public readonly fixedSeqLen: number
 
+	private readonly executionProviders: string[]
+
 	private constructor(
 		private readonly modelPath: string,
 		private readonly modelBytes: Uint8Array | null,
 		opts: OnnxRunnerOpts
 	) {
 		this.fixedSeqLen = opts.fixedSeqLen ?? DEFAULT_FIXED_SEQ_LEN
+		const requested = opts.executionProviders ?? ["cpu"]
+		// CPU is the universal final fallback — append it so a GPU-only list still has somewhere to land.
+		this.executionProviders = requested.includes("cpu") ? requested : [...requested, "cpu"]
 	}
 
 	/** Load by path. Reads the model lazily unless `warmup` is true. */
@@ -83,17 +96,37 @@ export class OnnxRunner {
 		if (!this.loadPromise) {
 			this.loadPromise = (async () => {
 				const bytes = this.modelBytes ?? new Uint8Array(await fs.readFile(this.modelPath))
-				const session = await ort.InferenceSession.create(bytes, {
-					executionProviders: ["cpu"],
-					graphOptimizationLevel: "all",
-				})
-				this.session = session
+				this.session = await this.createSession(bytes)
 
-				return session
+				return this.session
 			})()
 		}
 
 		return this.loadPromise
+	}
+
+	/**
+	 * Create the session on the configured execution providers, guarded: GPU providers (`cuda`/`webgpu`) throw at
+	 * create-time when their runtime/driver is missing, so on failure we retry on CPU alone. A box with the GPU runtime
+	 * uses it; a box without one transparently lands on CPU.
+	 */
+	private async createSession(bytes: Uint8Array): Promise<ort.InferenceSession> {
+		try {
+			return await ort.InferenceSession.create(bytes, {
+				executionProviders: this.executionProviders,
+				graphOptimizationLevel: "all",
+			})
+		} catch (err) {
+			if (this.executionProviders.length === 1 && this.executionProviders[0] === "cpu") throw err
+
+			// A requested GPU provider failed to initialize — fall back to CPU so inference still loads.
+			console.warn(
+				`[OnnxRunner] execution providers [${this.executionProviders.join(", ")}] failed to initialize ` +
+					`(${(err as Error).message.split("\n")[0]}); falling back to CPU.`
+			)
+
+			return ort.InferenceSession.create(bytes, { executionProviders: ["cpu"], graphOptimizationLevel: "all" })
+		}
 	}
 
 	/**

--- a/neural/test/onnx-runner-execution-providers.test.ts
+++ b/neural/test/onnx-runner-execution-providers.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The guarded execution-provider selection in OnnxRunner. ORT's GPU providers (cuda/webgpu) THROW at
+ *   session-create when their runtime/driver is absent rather than soft-falling-back, so OnnxRunner
+ *   retries on CPU. Mocks `ort.InferenceSession.create` — no model, no GPU needed.
+ */
+
+import ort from "onnxruntime-node"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { OnnxRunner } from "../onnx-runner.js"
+
+const fakeSession = () =>
+	({ inputNames: [], outputNames: [], run: async () => ({}) }) as unknown as ort.InferenceSession
+const epsOf = (call: unknown[]) => (call[1] as { executionProviders: string[] }).executionProviders
+
+describe("OnnxRunner execution providers (guarded)", () => {
+	afterEach(() => vi.restoreAllMocks())
+
+	test("defaults to cpu — a single create on [cpu]", async () => {
+		const spy = vi.spyOn(ort.InferenceSession, "create").mockResolvedValue(fakeSession())
+
+		await OnnxRunner.fromBytes(new Uint8Array([1]), { warmup: true })
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(epsOf(spy.mock.calls[0]!)).toEqual(["cpu"])
+	})
+
+	test("appends cpu as the final fallback to a GPU-only list", async () => {
+		const spy = vi.spyOn(ort.InferenceSession, "create").mockResolvedValue(fakeSession())
+
+		await OnnxRunner.fromBytes(new Uint8Array([1]), { warmup: true, executionProviders: ["webgpu"] })
+
+		expect(epsOf(spy.mock.calls[0]!)).toEqual(["webgpu", "cpu"])
+	})
+
+	test("a GPU provider that throws at create is caught and retried on cpu alone", async () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {})
+		const spy = vi.spyOn(ort.InferenceSession, "create").mockImplementation(async (_bytes, opts) => {
+			const eps = (opts?.executionProviders ?? []) as string[]
+
+			if (eps.some((ep) => ep !== "cpu")) {
+				throw new Error("Failed to load shared library libonnxruntime_providers_cuda.so")
+			}
+
+			return fakeSession()
+		})
+
+		const runner = await OnnxRunner.fromBytes(new Uint8Array([1]), {
+			warmup: true,
+			executionProviders: ["cuda", "cpu"],
+		})
+
+		expect(runner).toBeDefined()
+		expect(spy).toHaveBeenCalledTimes(2)
+		expect(epsOf(spy.mock.calls[0]!)).toEqual(["cuda", "cpu"]) // GPU attempt
+		expect(epsOf(spy.mock.calls[1]!)).toEqual(["cpu"]) // guarded CPU retry
+	})
+
+	test("a genuine cpu failure is NOT swallowed by the guard", async () => {
+		vi.spyOn(ort.InferenceSession, "create").mockRejectedValue(new Error("corrupt model"))
+
+		await expect(OnnxRunner.fromBytes(new Uint8Array([1]), { warmup: true })).rejects.toThrow("corrupt model")
+	})
+})


### PR DESCRIPTION
## What

`OnnxRunner` hardcoded `executionProviders: ["cpu"]`. This makes it configurable so a GPU-equipped box can use CUDA/WebGPU, **without any change to CPU-only boxes** (default stays `["cpu"]`).

- `OnnxRunner.create` / `fromBytes` and `NeuralAddressClassifier.loadFromWeights` accept `executionProviders?: string[]` — e.g. `["cuda", "cpu"]` or `["webgpu", "cpu"]`.
- **Guarded.** ORT's GPU providers (`cuda`, `webgpu`) *throw* at session-create when their runtime/driver is absent — they do **not** soft-fall-back the way `coreml`/`dml` do. So a failed GPU init is caught and retried on CPU. `cpu` is appended as the final fallback if not present.
- A genuine CPU failure (corrupt model) still propagates — the guard only swallows GPU-init failures.

## Why guarded (measured, not assumed)

Probing `onnxruntime-node@1.26` on a CPU-only box, `["cuda","cpu"]` **throws** (`libcublasLt.so.12: cannot open shared object file`) rather than falling through to CPU. So you cannot naively list a GPU provider — it crashes inference startup. The guard turns that into: *use the GPU if its runtime is really there, else CPU*. The cost of a failed probe is a one-time sub-100 ms hit at load (within session-create noise), not per-inference.

## Honest caveat: the GPU speedup is unverified

We have no CUDA box to measure on. The one GPU available — an AMD Radeon 780M **iGPU** — does work via the WebGPU/Dawn EP once Mesa's RADV driver is installed, and produces **byte-identical parses** (200/200) to CPU. But it's **7× slower** there (24.6 vs 3.5 ms/parse), for structural reasons: batch-1 short-sequence inference is dispatch-overhead-bound, the int8-quantized model forces many ops back to CPU (round-trips), and an iGPU has no bandwidth edge. So:

- This PR is **mechanism, not a perf win on any hardware we have.** It's tested correct + safe (guarded fallback, default unchanged); the actual acceleration is unverified pending a discrete CUDA card.
- A GPU would need **batched inference** + ideally an **fp16** model + a **discrete** card to win — none of which apply to the current per-address pipeline. Don't enable a GPU EP expecting a speedup without measuring on the target box first.

## Tests

`neural/test/onnx-runner-execution-providers.test.ts` (mocked ORT — no model, no GPU): default `["cpu"]` → one create; GPU-only list gets `cpu` appended; a throwing GPU provider is caught and retried on `["cpu"]`; a real CPU failure propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MVWSryMD1xxhLXKYcKaHC
