### PR TITLE
refactor: recognizeUsRegions → recognizeUSRegions + document the acronym-sweep gaps (#875)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Read the workspace-local docstrings before changing infrastructure files. The he
 
 ### Acronym casing in identifiers
 
-Acronyms are capitalized as whole camelCase components: `createWOFResolver`, `parseJSON`, `readID`, `fetchOSM`, `WOFSqlitePlaceLookup`, `modelURL`. Not `createWOFResolver` / `parseJson` / `readId`. This applies to TS/TSX identifiers (functions, classes, types, interfaces, object properties) and the code examples in living reference docs. It does **not** touch:
+Acronyms are capitalized as whole camelCase components: `createWOFResolver`, `parseJSON`, `readID`, `fetchOSM`, `WOFSqlitePlaceLookup`, `modelURL`. Not `createWofResolver` / `parseJson` / `readId`. This applies to TS/TSX identifiers (functions, classes, types, interfaces, object properties) and the code examples in living reference docs. It does **not** touch:
 
 - **`snake_case`** — DB columns and wire keys (`parent_id`, `place_id`, `name_key`) stay as-is; they're string contracts, and the convention is camelCase-only by construction.
 - **External library names** — match the dependency's own casing (`HttpStatusCode` from axios, `createQueryId`/`createWithSql` from kysely, `sqlite-wasm`).
@@ -161,3 +161,5 @@ Acronyms are capitalized as whole camelCase components: `createWOFResolver`, `pa
 - **Dated historical records** — `docs/articles/evals/`, `reviews/`, postmortems, and phase docs are point-in-time; don't rewrite their acronyms.
 
 There's no lint rule for this (oxlint can't express it); it's reviewer discipline. When adding an acronym, cap the whole component.
+
+**Known gaps (#875):** the v5.0.0 sweep enumerated a fixed acronym list that omitted `Us` and generic `Json`/`Jsonl`. `recognizeUsRegions` → `recognizeUSRegions` is done (internal). Still pending: `isUsStateAbbreviation` + codex `us/*` (public `@mailwoman/codex` → breaking), and the whole `Json`/`Jsonl` family (`writeJsonl`, `readJsonl`, `fetchJson`, `GeoJsonFeatureCollection`, `pyJsonDumps`, … — ~28 identifiers across packages, some public). These are a version-gated batch, not a piecemeal fix — bundle with the next major, don't half-apply (a partial `Json` sweep half-renames callers vs their def).

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -32,7 +32,7 @@ import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } f
 import { type DataReleaseManifest, readReleaseManifest, resolveShardPath } from "./data-release.js"
 import { loadDefaultPlaceCountry, type PlaceCountryFn } from "./default-placer.js"
 import { interpCalibrationForRegion, type InterpCalibrationTable } from "./interp-calibration.js"
-import { recognizeUsRegions } from "./region-recognition.js"
+import { recognizeUSRegions } from "./region-recognition.js"
 
 /**
  * The resolution tier that produced the coordinate. `address_point` > `interpolated` > `admin`.
@@ -305,7 +305,7 @@ export class ShardProvider {
 
 /**
  * The exact parse `geocodeAddress` runs internally: Stage-1 deterministic preprocessing (`normalizeInput`) →
- * `classifier.parse` (postcodeRepair + normalizeCase) → `recognizeUsRegions`. Exposed so a caller can run it once and
+ * `classifier.parse` (postcodeRepair + normalizeCase) → `recognizeUSRegions`. Exposed so a caller can run it once and
  * feed the result to both {@link geocodeAddress} (via `GeocodeDeps.parsedTree`) and another consumer of the parse (e.g.
  * `decodeAsJSON(tree)` → a PostalAddress), instead of parsing the same address twice. The inference is ~3 ms/row — the
  * single most expensive step — so sharing it is a ~1.3× win on a parse-then-geocode pipeline.
@@ -316,7 +316,7 @@ export async function parseForGeocode(
 ): Promise<AddressTree> {
 	const parseInput = deps.normalizeInput === false ? input : normalize(input).normalized
 
-	return recognizeUsRegions(
+	return recognizeUSRegions(
 		await deps.classifier.parse(parseInput, { postcodeRepair: true, normalizeCase: deps.normalizeCase ?? true })
 	)
 }

--- a/mailwoman/region-recognition.test.ts
+++ b/mailwoman/region-recognition.test.ts
@@ -7,7 +7,7 @@
 import type { AddressNode, AddressTree, ComponentTag } from "@mailwoman/core/decoder"
 import { describe, expect, it } from "vitest"
 
-import { recognizeUsRegions, usStateSlug } from "./region-recognition.js"
+import { recognizeUSRegions, usStateSlug } from "./region-recognition.js"
 
 const loc = (value: string, start = 0, end = value.length, children: AddressNode[] = []): AddressNode => ({
 	tag: "locality" as ComponentTag,
@@ -40,42 +40,42 @@ describe("usStateSlug", () => {
 	})
 })
 
-describe("recognizeUsRegions (#642)", () => {
+describe("recognizeUSRegions (#642)", () => {
 	it('nests a sibling city under a state-name locality ("Dublin, Texas" → 2 localities)', () => {
-		const t = recognizeUsRegions(tree([loc("Dublin"), loc("Texas")]))
+		const t = recognizeUSRegions(tree([loc("Dublin"), loc("Texas")]))
 		expect(t.roots.map(tagsOf)).toEqual(["region:Texas[locality:Dublin]"])
 	})
 
 	it('splits a merged "City, ST" locality into region → locality', () => {
-		const t = recognizeUsRegions(tree([loc("Dublin, TX")]))
+		const t = recognizeUSRegions(tree([loc("Dublin, TX")]))
 		expect(t.roots.map(tagsOf)).toEqual(["region:TX[locality:Dublin]"])
 	})
 
 	it('splits a merged "City, State" (full name) locality', () => {
-		const t = recognizeUsRegions(tree([loc("Athens, Texas")]))
+		const t = recognizeUSRegions(tree([loc("Athens, Texas")]))
 		expect(t.roots.map(tagsOf)).toEqual(["region:Texas[locality:Athens]"])
 	})
 
 	it("leaves an already-correct parse (explicit region) untouched", () => {
 		const region: AddressNode = { ...loc("TX"), tag: "region" as ComponentTag, children: [loc("Dublin")] }
-		const t = recognizeUsRegions(tree([region]))
+		const t = recognizeUSRegions(tree([region]))
 		expect(t.roots.map(tagsOf)).toEqual(["region:TX[locality:Dublin]"])
 	})
 
 	it("leaves a LONE state-name locality untouched (no sibling city to nest — ambiguous city/state)", () => {
-		const t = recognizeUsRegions(tree([loc("Washington")]))
+		const t = recognizeUSRegions(tree([loc("Washington")]))
 		expect(t.roots.map(tagsOf)).toEqual(["locality:Washington"]) // not converted
 	})
 
 	it("does not fire when BOTH tokens are state-names (ambiguous; conservative no-op)", () => {
-		const t = recognizeUsRegions(tree([loc("Washington"), loc("Pennsylvania")]))
+		const t = recognizeUSRegions(tree([loc("Washington"), loc("Pennsylvania")]))
 		// Neither is unambiguously the city, so leave both as the parser had them.
 		expect(t.roots.map(tagsOf)).toEqual(["locality:Washington", "locality:Pennsylvania"])
 	})
 
 	it("preserves a street + recognizes the region in a fuller address", () => {
 		const street: AddressNode = { ...loc("100 Main St"), tag: "street" as ComponentTag }
-		const t = recognizeUsRegions(tree([street, loc("Dublin"), loc("Texas")]))
+		const t = recognizeUSRegions(tree([street, loc("Dublin"), loc("Texas")]))
 		const tags = t.roots.map(tagsOf).sort()
 		expect(tags).toContain("region:Texas[locality:Dublin]")
 		expect(tags).toContain("street:100 Main St")

--- a/mailwoman/region-recognition.ts
+++ b/mailwoman/region-recognition.ts
@@ -218,7 +218,7 @@ function annotateUsRegions(node: AddressNode): void {
  * resolver scopes the locality to its state (#642). Mutates + returns the tree. A no-op when no US state token is found
  * mis-tagged — byte-stable for already-correct parses.
  */
-export function recognizeUsRegions(tree: AddressTree): AddressTree {
+export function recognizeUSRegions(tree: AddressTree): AddressTree {
 	tree.roots = correctSiblings(tree.roots).map(correctNode)
 
 	for (const root of tree.roots) annotateUsRegions(root)

--- a/resolver/admin-coherence.test.ts
+++ b/resolver/admin-coherence.test.ts
@@ -83,7 +83,7 @@ const node = (over: Partial<AddressNode> & Pick<AddressNode, "tag" | "value" | "
 	children: [],
 	...over,
 })
-// region(ME) → locality(Portland), the shape recognizeUsRegions produces for "Portland, ME".
+// region(ME) → locality(Portland), the shape recognizeUSRegions produces for "Portland, ME".
 const portlandMeTree = (): AddressTree => ({
 	raw: "Portland, ME",
 	roots: [

--- a/resolver/country-hint.test.ts
+++ b/resolver/country-hint.test.ts
@@ -4,7 +4,7 @@
  * @author Teffen Ellis, et al.
  *
  *   Tests for the #833 forward `country_hint` linkage. A region node carrying `metadata.country_hint`
- *   (an address-system recognizer's derived country — `recognizeUsRegions` stamps "US" on a 2-letter US
+ *   (an address-system recognizer's derived country — `recognizeUSRegions` stamps "US" on a 2-letter US
  *   state abbrev) constrains THAT node's lookup to the hinted country, below a resolved parent's country
  *   but above the global defaults. It breaks the two-consistent-pairs tie ("Augusta, ME" → Maine, not
  *   the more-populous Augusta under Messina) that geographic consistency alone cannot.

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -783,7 +783,7 @@ class WOFResolver implements Resolver {
 		// global fallback collapses back to the soft-prior baseline (FI p90 3050, PL p90 1078); pure-hard
 		// collapses the tail (FI 18 km, PL p99 8172→494) at a coverage-bounded recall cost.
 		// #833 forward linkage: a node's own `country_hint` (an address-system recognizer's derived country —
-		// today `recognizeUsRegions` stamping "US" on a recognized closed-set US state) constrains THIS node's
+		// today `recognizeUSRegions` stamping "US" on a recognized closed-set US state) constrains THIS node's
 		// lookup, below a resolved parent's country but above the global defaults. It breaks the two-consistent-
 		// pairs tie ("Augusta, ME" → Maine, not Augusta/Messina) that pure geographic consistency cannot.
 		const countryHint = node.metadata?.["country_hint"]

--- a/scripts/eval/gauntlet/cases/regression.ts
+++ b/scripts/eval/gauntlet/cases/regression.ts
@@ -170,7 +170,7 @@ export const REGRESSION_CASES: SeedCase[] = [
 		expectToleranceM: 25000,
 		addedAt: "2026-06-29",
 		bugRef: "#833",
-		note: "Was Augusta, Sicily — the two-consistent-pairs case (Augusta under both Maine and Messina). Fixed by the abbrev-only country_hint forward linkage (recognizeUsRegions → resolver country=US), not the descendant-consistency pass.",
+		note: "Was Augusta, Sicily — the two-consistent-pairs case (Augusta under both Maine and Messina). Fixed by the abbrev-only country_hint forward linkage (recognizeUSRegions → resolver country=US), not the descendant-consistency pass.",
 	},
 	{
 		// A clean US 'City, ST' that resolves correctly — guards the working path so a placer/ranking change


### PR DESCRIPTION
Small, internal-only slice of #875 (the two acronyms the v5.0.0 sweep missed).

**Done here:** `recognizeUsRegions` → `recognizeUSRegions`. It's internal to the `mailwoman` package (no public re-export — verified), so no release/breaking impact. Renamed the def, its one caller (`geocode-core.ts`), the test, and the live comments in `resolver/*` + the gauntlet note that reference it. Compile clean; region-recognition + admin-coherence + country-hint tests green (16/16).

**Deliberately NOT done** (documented in `AGENTS.md` + #875 as a version-gated batch):
- `isUsStateAbbreviation` + codex `us/*` — public `@mailwoman/codex` API → breaking.
- The whole `Json`/`Jsonl` family (~28 identifiers: `writeJsonl`, `readJsonl`, `fetchJson`, `GeoJsonFeatureCollection`, `pyJsonDumps`, …), several public. A partial sweep half-renames callers vs their def (learned the hard way tonight) — this belongs in one deliberate major, not piecemeal.

Also fixed a stale example in the acronym note (`Not createWOFResolver` → `Not createWofResolver`).