### PR TITLE
fix(#873): drop the unnecessary `as unknown as ResolverBackend` cast

### DIFF
--- a/docs/articles/evals/2026-07-02-night-postmortem.md
+++ b/docs/articles/evals/2026-07-02-night-postmortem.md
@@ -1,0 +1,95 @@
+# Night Shift Postmortem — 2026-07-01/02 (30th shift)
+
+Living document — sketched during the shift, finalized at hand-off. Window: ~05:30 UTC → 15:00 UTC.
+Posture: autonomous, CPU/local, ~$0 Modal (GPU levers flagged, not run). PRs shipped + flagged for
+operator merge (no self-merge).
+
+## What shipped / opened
+
+- **Diagnostic scripts repaired** — 21 untracked `scripts/diagnostic/*` + eval scratch scripts broken by
+  the v5.0.0 acronym rename now `typecheck:scripts` clean (**70 errors → 0**). Fixed the rename collateral
+  (Wof/Osm/Json/Id/Us) + the pre-existing strict-null gaps; left `casing-ab`/`portland-833b` async-drift
+  fixed too. Untracked, so local-only.
+- **#875 filed** — the v5.0.0 sweep missed two acronyms: `Us` and generic `Json`/`Jsonl` (~28 identifiers,
+  some public). Documented in AGENTS.md as a version-gated batch.
+- **PR #876** — `recognizeUsRegions` → `recognizeUSRegions` (internal-only slice of #875; no public
+  re-export → zero release impact). Compile + affected tests green. Flagged for merge.
+- **Coverage quantified (lever C, closes the #823 loop).** Ran `frontier-gap.ts` against the live
+  `candidate.db` (→ `candidate-global-coverage.db`, the post-#266/#267 build), geonames cities15000 top-2/country:
+  **resolve-rate bare 88.9% → +hint 94.3%**, across 187 countries. **181 bare-supported · 3 placer-recoverable
+  (AR/GE/PR — 0→2/2 with hint, the #244/#822 lever) · 3 residual · 0 wrong-place.** The residual is a clean
+  exonym-indexing lever: Israel/Kuwait/Antigua fail because the English name (Tel Aviv, Kuwait City) matches no
+  in-country record — index alt-name surface forms (Warsaw↔Warszawa is already proven). Down from the ~97
+  residual countries the coverage arc started with. #823 was closed on a 5-city spot-check; this is the honest
+  full measure.
+- **#305 — measured + FALSIFIED (not shipped).** Implemented the proximity gate on the coord-first exact
+  tier (`coordFirstExactProximityKm`, default-off/byte-stable), A/B'd on the JP end-to-end eval:
+  baseline KEN_ALL 98.5% / GeoNames 93.9% → **gated 90.3% / 72.8%** (−8/−21pp). 50km ≡ 200km (identical),
+  so it's the `pcInfo`-membership gate suppressing correct FTS-exacts, not distance. Reverted; posted the
+  data + redesign direction to #305; lowered priority (the 98.5% baseline is already good, the existing
+  mismatch-flag is the right conservative behavior).
+
+- **Exonym-residual diagnostic (#877).** Dumped C's 3 residual cities against the live gazetteer — all
+  **exist** (Tel Aviv pop 432k, Kuwait City, Jerusalem), so the endgame is indexing/ranking, not more data.
+  The bare-form keys **match** (`normalizeLocalityForKey("Tel Aviv")` = `"tel aviv"` = 1 row); the frontier
+  miss is the geonames name-**variant** (`Tel Aviv-Yafo` → `"tel aviv-yafo"` = 0 rows) + primary/pop ranking.
+  Filed + corrected #877.
+
+- **PR #878 — unknown-span report (#493 acceptance item).** A tracked eval that runs the parser over golden
+  and aggregates the all-O runs into a corpus-gap shopping list, **separating trivial delimiter gaps from
+  content gaps**. Honest read: **9.0% content-gap rate** (1.0% of chars; the raw 98% is delimiters). Top
+  signal (verified): accented/foreign-influenced mis-segmentations (`Montréal, QC` → model drops the `C`;
+  clean `Austin, TX` tags fine) → an accent-robustness lever, plus fr `sainte`, plus non-Latin scripts.
+
+- **Multi-locale corpus-gap read → #825 shopping list (verified).** Ran the #878 tool over the `oa-*-coord-150`
+  external OpenAddresses sets. **CZ 84% / PL 77%** content-gap rate (the worst by far; PT 27, AT 15, FR 10, IT 2,
+  AU 0, US 0). Root cause **verified by dumping cases** (probe before write-up this time): a **Slavic-diacritic
+  tokenization/offset failure** — `Grudziądz` splits at `ą`, `Bohaterów` at `ó`, and the span shift eats trailing
+  digits (`39`→`9`). Told #825 the lever is diacritic robustness + CZ-in-scope, not per-locale volume (AU/US
+  already 0%). The 3 PRs (#874/#876/#878) all verified MERGEABLE/CLEAN + green.
+
+## What went well
+
+- **Verify-before-verdict earned its keep on #305.** The issue's hypothesis was plausible; the eval said
+  −21pp. Shipping on the hypothesis would have been a real regression. Grade the assembled output.
+- **Scope discipline on the acronym gaps.** The `Json` sweep is ~28 identifiers across packages incl.
+  public API — recognized it as a version-gated batch, not an overnight slip-in, after a partial sweep
+  half-renamed callers vs their def (caught + reverted immediately).
+
+## What could've gone better
+
+- **Spent disproportionate effort on untracked scratch scripts early** (the `Fix'em up` task). 70→0 was
+  the ask, but it ate several tool-cycles on throwaway diagnostics with genuine API drift. Time-budget
+  discipline: the rename collateral (my v5.0.0 doing) was the core; the pre-existing strict-null was gravy.
+- **Over-narrated the mechanism before verifying — TWICE (#877 name-key, #878 partial-token).** Both times
+  I wrote the causal story ("name-key mismatch", "systematic region-abbrev truncation") into an issue/PR
+  before running the one probe that tests it; both times the probe flipped the story (keys DO match; clean
+  region abbrevs DO tag). Caught + corrected each on the next step, but the pattern is clear: **the numbers
+  were solid, the mechanism interpretation kept outrunning the probe.** Rule for the rest of the shift and
+  next: dump the specific case BEFORE writing the "why", not after. The verify-before-verdict reflex fired
+  on the correction, not the claim — it needs to fire one step earlier.
+
+## Decisions made autonomously
+
+- **Did not ship #305.** A default-off lever that regresses 21pp when enabled is misleading scaffolding,
+  not a fix. Reverted rather than ship-behind-a-flag.
+- **Deferred the `Json`/public-`Us` acronym batch to the operator** (breaking, version-gated) rather than
+  do a piecemeal overnight sweep.
+
+## Open questions / for the operator
+
+- **#875** — do we want a deliberate acronym-completion pass (`Json`/`Jsonl` + public codex `Us`) bundled
+  into the next major? Or leave the convention gap? (Internal `recognizeUsRegions` already done in #876.)
+- **PR #874** (env SDK → `@mailwoman/core/env`) + **PR #876** await your merge.
+
+## Numbers
+
+| | |
+|---|---|
+| Shift window | ~05:30–15:00 UTC |
+| Models trained | 0 (no Modal budget) |
+| Modal $ | $0 |
+| PRs opened | #876 (+ #874 from the day session) |
+| Issues filed | #875 |
+| Evals run | JP resolver A/B (falsified #305) |
+| Regressions shipped | 0 |

--- a/mailwoman/commands/geocode.tsx
+++ b/mailwoman/commands/geocode.tsx
@@ -31,7 +31,7 @@ import { setImmediate } from "node:timers/promises"
 import { Spinner } from "@inkjs/ui"
 import { CoarsePlacer } from "@mailwoman/core/coarse-placer"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 import { Text } from "ink"
 import { useEffect, useState } from "react"
 import zod from "zod"
@@ -212,7 +212,7 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 		: undefined
 
 	try {
-		const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+		const resolver = createWOFResolver(lookup)
 		const result = await geocodeAddress(input, {
 			classifier,
 			resolver,

--- a/mailwoman/commands/parse.tsx
+++ b/mailwoman/commands/parse.tsx
@@ -335,7 +335,7 @@ async function withResolver<T>(
 	try {
 		// PlaceLookup is structurally compatible with ResolverBackend — the cast is just to satisfy
 		// the type, no runtime conversion.
-		const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+		const resolver = createWOFResolver(lookup)
 
 		return await fn(resolver)
 	} finally {

--- a/mailwoman/commands/registry.tsx
+++ b/mailwoman/commands/registry.tsx
@@ -42,7 +42,7 @@ import {
 	type GeocodeAddress,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 import type { GeoFeatureCollection, PointLiteral } from "@mailwoman/spatial"
 import { Text } from "ink"
 import { useEffect, useState } from "react"
@@ -241,7 +241,7 @@ async function buildGeocoder(
 	const shardProvider = new ShardProvider(mod, options.dataRoot)
 	const shards: ShardResolver = shardProvider.for
 	const defaultCountry = resolverDefaultCountry(options, !!resolveCandidateDBPath()) || undefined
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 
 	const seam = geocodeAddressVia({
 		parse: async (raw) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),

--- a/mailwoman/geocode-worker.ts
+++ b/mailwoman/geocode-worker.ts
@@ -14,7 +14,7 @@ import { workerData } from "node:worker_threads"
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { type ColumnMapping, geocodeAddressVia, makeGeocodeHandler } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, parseForGeocode, ShardProvider } from "./geocode-core.js"
 import type { GeocodeStreamConfig } from "./geocode-stream.js"
@@ -27,7 +27,7 @@ const { mapping, geocode: cfg } = (workerData?.userData ?? {}) as {
 const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: cfg.locale })
 const wof = await import("@mailwoman/resolver-wof-sqlite")
 const lookup = new wof.WOFSqlitePlaceLookup({ databasePath: cfg.wofDBPath })
-const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+const resolver = createWOFResolver(lookup)
 const shards = new ShardProvider(wof, cfg.dataRoot)
 
 const geoDeps = {

--- a/mailwoman/server/GeocodeRouter.ts
+++ b/mailwoman/server/GeocodeRouter.ts
@@ -85,7 +85,7 @@ async function getDeps(): Promise<GeocodeDepsBundle | null> {
 		}
 		const classifier = await neuralMod.NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 		const backend = createResolverBackend(resolverMod, { wofPaths: paths })
-		const resolver = createWOFResolver(backend as unknown as ResolverBackend)
+		const resolver = createWOFResolver(backend)
 		const shards = new ShardProvider(resolverMod, DATA_ROOT)
 
 		// Candidate backend → country-agnostic default (demo's global, population-first behavior); a

--- a/mailwoman/server/ResolveRouter.ts
+++ b/mailwoman/server/ResolveRouter.ts
@@ -111,7 +111,7 @@ async function getResolverPipeline() {
 		const neural = await neuralMod.NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 		const lookup = createResolverBackend(resolverMod, { wofPaths })
 		// The lookup is structurally compatible with `ResolverBackend` — same shape.
-		const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+		const resolver = createWOFResolver(lookup)
 
 		return {
 			parse: (text: string) => neural.parse(text),

--- a/nominatim/cli.ts
+++ b/nominatim/cli.ts
@@ -22,7 +22,7 @@ import { composeAnnotators, toOpenCage } from "@mailwoman/annotations"
 import { countryReferenceAnnotator, matchCountry } from "@mailwoman/codex/country"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { makeNutsAnnotator, NutsLookup } from "@mailwoman/nuts-lookup"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 import { coordinateFormatAnnotator } from "@mailwoman/spatial"
 import { makeTimezoneAnnotator, TimezoneLookup } from "@mailwoman/timezone-lookup"
 import { makeUnLocodeAnnotator, UnLocodeLookup } from "@mailwoman/un-locode-lookup"
@@ -137,7 +137,7 @@ async function serve(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const parser = createAddressParser()
 	const backend = createResolverBackend(resolverMod, { wofPaths, candidateDb })
-	const resolver = createWOFResolver(backend as unknown as ResolverBackend)
+	const resolver = createWOFResolver(backend)
 	const shards = new ShardProvider(resolverMod, mailwomanDataRoot())
 	// NOT a geocode country constraint. The default-on #244 placer already routes the query's country
 	// (Berlin→DE, Boston→US) and `defaultCountry` is a HARD override that beats it (geocode-core.ts:102),

--- a/photon/cli.ts
+++ b/photon/cli.ts
@@ -19,7 +19,7 @@ import { join } from "node:path"
 import { parseArgs } from "node:util"
 
 import { NeuralAddressClassifier } from "@mailwoman/neural"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 import {
 	createResolverBackend,
@@ -75,7 +75,7 @@ async function serve(): Promise<void> {
 
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const backend = createResolverBackend(resolverMod, { wofPaths, candidateDb })
-	const resolver = createWOFResolver(backend as unknown as ResolverBackend)
+	const resolver = createWOFResolver(backend)
 	const shards = new ShardProvider(resolverMod, mailwomanDataRoot())
 	const reverseGeo = adminDBPath ? new resolverMod.WOFReverseGeocoder({ adminDBPath }) : undefined
 

--- a/scripts/eval/geocode-case-diag.ts
+++ b/scripts/eval/geocode-case-diag.ts
@@ -12,7 +12,7 @@
 
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -23,7 +23,7 @@ const mod = await import("@mailwoman/resolver-wof-sqlite")
 const lookup = new mod.WOFSqlitePlaceLookup({
 	databasePath: dataRootPath("wof", "admin-global-priority.db"),
 })
-const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+const resolver = createWOFResolver(lookup)
 const shards = new ShardProvider(mod, mailwomanDataRoot())
 
 import { readFileSync } from "node:fs"

--- a/scripts/record-matcher/coverage-reconciliation.ts
+++ b/scripts/record-matcher/coverage-reconciliation.ts
@@ -46,7 +46,7 @@ import {
 	type ReconcileConfig,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -148,7 +148,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 
 	let geo = 0

--- a/scripts/record-matcher/cross-dataset-correlation.ts
+++ b/scripts/record-matcher/cross-dataset-correlation.ts
@@ -35,7 +35,7 @@ import {
 	type ResolvedEntity,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -238,7 +238,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 
 	let geo = 0

--- a/scripts/record-matcher/cross-source-threshold-sweep.ts
+++ b/scripts/record-matcher/cross-source-threshold-sweep.ts
@@ -46,7 +46,7 @@ import {
 	type ResolvedEntity,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -237,7 +237,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 	const seam = geocodeAddressVia({
 		parse: async (raw: string) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),

--- a/scripts/record-matcher/geocoder-namesake-probe.ts
+++ b/scripts/record-matcher/geocoder-namesake-probe.ts
@@ -15,7 +15,7 @@
 
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 import { haversineKm } from "@mailwoman/spatial"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 
 	const geo = (address: string) =>

--- a/scripts/record-matcher/geocoder-vs-provided-coords.ts
+++ b/scripts/record-matcher/geocoder-vs-provided-coords.ts
@@ -26,7 +26,7 @@ import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
 import { haversineKm } from "@mailwoman/match"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { streamRows } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 
 	console.error(`[B] geocoding ≤${MAX} TX nursing facilities + measuring delta to provided coords…`)

--- a/scripts/record-matcher/learned-scorer-clustering-eval.ts
+++ b/scripts/record-matcher/learned-scorer-clustering-eval.ts
@@ -47,7 +47,7 @@ import {
 	type ResolvedEntity,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -213,7 +213,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 	const seam = geocodeAddressVia({
 		parse: async (raw: string) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),

--- a/scripts/record-matcher/learned-scorer-crossstate-eval.ts
+++ b/scripts/record-matcher/learned-scorer-crossstate-eval.ts
@@ -42,7 +42,7 @@ import {
 	type ResolvedEntity,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -194,7 +194,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 	const seam = geocodeAddressVia({
 		parse: async (raw: string) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),

--- a/scripts/record-matcher/learned-scorer-eval.ts
+++ b/scripts/record-matcher/learned-scorer-eval.ts
@@ -51,7 +51,7 @@ import {
 	type ColumnMapping,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -179,7 +179,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 	const seam = geocodeAddressVia({
 		parse: async (raw: string) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),

--- a/scripts/record-matcher/nppes-dedup-benchmark.ts
+++ b/scripts/record-matcher/nppes-dedup-benchmark.ts
@@ -44,7 +44,7 @@ import {
 	type ResolvedEntity,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 import { latLngToCell } from "h3-js"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
@@ -296,7 +296,7 @@ async function main(): Promise<void> {
 		})
 		const mod = await import("@mailwoman/resolver-wof-sqlite")
 		const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-		const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+		const resolver = createWOFResolver(lookup)
 		const shardProvider = new ShardProvider(mod, DATA_ROOT)
 		const seam = geocodeAddressVia({
 			parse: async (raw: string) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),

--- a/scripts/record-matcher/train-gbt.ts
+++ b/scripts/record-matcher/train-gbt.ts
@@ -38,7 +38,7 @@ import {
 	type ColumnMapping,
 	type SourceRecord,
 } from "@mailwoman/registry"
-import { createWOFResolver, type ResolverBackend } from "@mailwoman/resolver"
+import { createWOFResolver } from "@mailwoman/resolver"
 
 import { geocodeAddress, ShardProvider } from "../../mailwoman/out/geocode-core.js"
 
@@ -212,7 +212,7 @@ async function main(): Promise<void> {
 	const classifier = await NeuralAddressClassifier.loadFromWeights({ locale: LOCALE })
 	const mod = await import("@mailwoman/resolver-wof-sqlite")
 	const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
-	const resolver = createWOFResolver(lookup as unknown as ResolverBackend)
+	const resolver = createWOFResolver(lookup)
 	const shardProvider = new ShardProvider(mod, DATA_ROOT)
 	const seam = geocodeAddressVia({
 		parse: async (raw: string) => decodeAsJSON(await classifier.parse(raw, { postcodeRepair: true })),


### PR DESCRIPTION
Closes #873. I filed that issue during the env-SDK day session assuming `createWOFResolver(lookup)` failed to typecheck and needed the `as unknown as ResolverBackend` cast. **It doesn't** — verified by removing one cast and compiling clean.

`PlaceCandidate` (what `PlaceLookup.findPlace` returns) is structurally assignable to `ResolverBackend`'s `ResolvedPlace` (`id: number` → `number|string`, `WOFPlacetype` → `string`, extra fields fine), and the interface-method query param is bivariant — so `WOFSqlitePlaceLookup` / `WOFCandidateTableLookup` **is** a `ResolverBackend`. The cast was defensive cruft.

Removed all **18** sites (mailwoman commands + server routers + nominatim/photon CLIs + record-matcher + eval scripts) plus the now-dead `type ResolverBackend` imports. **Pure type-level change** — `as` casts erase at runtime, so behavior is byte-identical.

Verification: `yarn compile` + `typecheck:scripts` + oxlint + oxfmt all clean; resolver + resolve tests green. Removes the papercut from the public API surface (and the `api.mdx` example once #874 merges — its cast can drop too).