### PR TITLE
fix(publish): compile before release-it — publish-workspace.ts now needs core/out (#874)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,6 +141,11 @@ jobs:
           MAILWOMAN_SKIP_WEIGHTS: ${{ inputs.dry_run && '1' || '' }}
         run: | # shell
           set -euo pipefail
+          # publish-workspace.ts (a release-it hook) imports @mailwoman/core/env, which resolves
+          # to the COMPILED core/out tree (#874 moved env into core) — compile before release-it
+          # or every workspace publish dies ERR_MODULE_NOT_FOUND. The publish_only path below
+          # already compiles; this is the same requirement on the normal path (first bit v5.1.0).
+          yarn compile
           ARGS=(--ci --increment="${{ inputs.version }}")
           if [ "${{ inputs.dry_run }}" = "true" ]; then
               ARGS+=(--dry-run)


### PR DESCRIPTION
The v5.1.0 dry-run failed ERR_MODULE_NOT_FOUND: publish-workspace.ts (release-it hook)
imports @mailwoman/core/env, which resolves to the compiled core/out tree since #874 moved
env into core — and the normal Release step never compiled. The publish_only recovery path
already runs yarn compile; this adds the same to the normal path. First publish since #874.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ga4p3yrrxKNP9qFYEDw722
