### PR TITLE
fix(#887): de-order anchor-OFF ablation via --anchor-off override (no more empty-anchor.json)

### DIFF
--- a/scripts/eval/de-order-eval.ts
+++ b/scripts/eval/de-order-eval.ts
@@ -5,13 +5,14 @@
  *
  *   Both-order order-robustness eval harness (S6). Runs a model through the resolver on German
  *   addresses in BOTH renderings — native German order (the realistic layout) and US/international
- *   order (the layout our OA de-sample ships) — with the postcode anchor fed and zeroed, plus US +
- *   FR for the no-regression gate. The German "collapse" was substantially an eval-order artifact
- *   (docs/articles/evals/2026-06-06-anchor-pilot.md); this makes native-vs-international a
- *   first-class, repeatable measurement instead of a one-off. Self-emits every figure (each run
- *   writes its own .md), then prints a 2x2 + US/FR summary. NOTE: anchor on/off only differs for an
- *   anchor-trained (4-input) model; for a plain model both columns are identical (the anchor inputs
- *   are ignored / absent).
+ *   order (the layout our OA de-sample ships) — with the postcode anchor fed and ablated
+ *   (oa-resolver-eval's `--anchor-off` → `overrides.anchor=false`, the #718-sanctioned declared
+ *   ablation; #887), plus US + FR for the no-regression gate. The German "collapse" was
+ *   substantially an eval-order artifact (docs/articles/evals/2026-06-06-anchor-pilot.md); this
+ *   makes native-vs-international a first-class, repeatable measurement instead of a one-off.
+ *   Self-emits every figure (each run writes its own .md), then prints a 2x2 + US/FR summary. NOTE:
+ *   anchor on/off only differs for an anchor-trained (4-input) model; for a plain model both
+ *   columns are identical (the anchor inputs are ignored / absent).
  *
  *   Usage: node --experimental-strip-types scripts/eval/de-order-eval.ts\
  *   --model /tmp/v092-eval/model.onnx --card /tmp/v092-eval/model-card.json\
@@ -67,19 +68,21 @@ runIfScript(import.meta, async () => {
 	}
 
 	mkdirSync(out, { recursive: true })
-	const empty = join(out, "empty-anchor.json")
-	writeFileSync(empty, "{}") // zeroed anchor = c=0 identity = "anchor off"
 	const deNative = "data/eval/external/openaddresses-de-sample-native-order.jsonl"
 	const deIntl = "data/eval/external/openaddresses-de-sample.jsonl"
 
-	// run <eval-jsonl> <anchor-lookup> <default-country> <out-name>
-	const run = async (evalJsonl: string, anchorLookup: string, country: string, outName: string): Promise<void> => {
+	// run <eval-jsonl> <anchor-on> <default-country> <out-name>
+	const run = async (evalJsonl: string, anchorOn: boolean, country: string, outName: string): Promise<void> => {
+		// Anchor OFF = oa-resolver-eval's `--anchor-off` (overrides.anchor=false — the sanctioned,
+		// declared ablation; #887). The old idiom (an empty-anchor.json fed as --model-anchor-lookup)
+		// is refused by the #718 fail-closed gate: a lookup parsing to size 0 → UnfedChannelError.
+		const anchorArgs = anchorOn ? ["--model-anchor-lookup", lookup] : ["--anchor-off"]
 		// nothrow: oa-resolver-eval exits non-zero on its own internal regression signal even when it wrote
 		// a valid report; this is a MEASUREMENT harness (loc() reads the .md), so under the bash `set -e` we
 		// must not let that exit code abort before the 2x2 summary prints (it false-failed de.native_locality).
 		const r = await $({
 			nothrow: true,
-		})`node --experimental-strip-types scripts/eval/oa-resolver-eval.ts --eval ${evalJsonl} --model ${model} --model-card ${card} --tokenizer ${tok} --model-anchor-lookup ${anchorLookup} --default-country ${country}`
+		})`node --experimental-strip-types scripts/eval/oa-resolver-eval.ts --eval ${evalJsonl} --model ${model} --model-card ${card} --tokenizer ${tok} ${anchorArgs} --default-country ${country}`
 		writeFileSync(join(out, `${outName}.md`), r.stdout)
 		writeFileSync(join(out, `${outName}.log`), r.stderr)
 	}
@@ -105,17 +108,17 @@ runIfScript(import.meta, async () => {
 	}
 
 	console.log("== DE native, anchor ON ==")
-	await run(deNative, lookup, "DE", "de-native-on")
+	await run(deNative, true, "DE", "de-native-on")
 	console.log("== DE native, anchor OFF ==")
-	await run(deNative, empty, "DE", "de-native-off")
+	await run(deNative, false, "DE", "de-native-off")
 	console.log("== DE intl,   anchor ON ==")
-	await run(deIntl, lookup, "DE", "de-intl-on")
+	await run(deIntl, true, "DE", "de-intl-on")
 	console.log("== DE intl,   anchor OFF ==")
-	await run(deIntl, empty, "DE", "de-intl-off")
+	await run(deIntl, false, "DE", "de-intl-off")
 	console.log("== US (anchor ON) ==")
-	await run("data/eval/external/openaddresses-us-sample.jsonl", lookup, "US", "us-on")
+	await run("data/eval/external/openaddresses-us-sample.jsonl", true, "US", "us-on")
 	console.log("== FR (anchor ON) ==")
-	await run("data/eval/external/openaddresses-fr-sample.jsonl", lookup, "FR", "fr-on")
+	await run("data/eval/external/openaddresses-fr-sample.jsonl", true, "FR", "fr-on")
 
 	console.log("")
 	console.log(`### Order-robustness 2x2 — DE locality-match (model: ${model})`)

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -44,6 +44,12 @@
  *   locality resolution is ON by default (no-op where the candidate table has no rows, e.g. US).
  *   Pass `--wof <admin.db>` alone for the admin-only baseline, or append a postcode shard
  *   (postalcode-*.db) to also resolve the postcode node.
+ *
+ *   `--anchor-off` (#887) ablates the model's postcode-anchor INPUT channel — the sanctioned,
+ *   declared ablation (`overrides.anchor=false` through createScorer, warn-not-throw per the #718
+ *   fail-closed gate). de-order-eval.ts uses it for the 2x2 anchor-OFF column; the old
+ *   empty-anchor.json idiom (a lookup that parses to size 0) is refused by the gate. Distinct from
+ *   `--postcode-anchor`, which swaps the resolved COORDINATE, not the model input.
  */
 
 import { readFileSync, writeFileSync } from "node:fs"
@@ -338,6 +344,14 @@ async function main(): Promise<void> {
 	const { createScorer } = await import("@mailwoman/neural/scorer")
 	const modelAnchorPath = arg("model-anchor-lookup", "")
 	const ablateToAnchor = process.argv.includes("--ablate-to-anchor")
+	// `--anchor-off` (#887): the sanctioned anchor ablation — `overrides.anchor=false` through
+	// createScorer (a loud warning, not a throw). Replaces the pre-#718 empty-anchor.json idiom,
+	// which the fail-closed gate now refuses (an empty lookup parses to size 0 → UnfedChannelError).
+	const anchorOff = process.argv.includes("--anchor-off")
+	const overrides: import("@mailwoman/neural/scorer").ScorerOverrides = {
+		...(ablateToAnchor ? { gazetteer: false, conventions: false } : {}),
+		...(anchorOff ? { anchor: false } : {}),
+	}
 	const neural = await createScorer({
 		modelPath: arg("model"),
 		tokenizerPath: arg("tokenizer"),
@@ -345,13 +359,17 @@ async function main(): Promise<void> {
 		...(modelAnchorPath ? { anchorLookupPath: modelAnchorPath } : {}),
 		strict: true,
 		tier: "server",
-		...(ablateToAnchor ? { overrides: { gazetteer: false, conventions: false } } : {}),
+		...(ablateToAnchor || anchorOff ? { overrides } : {}),
 	})
 	console.error(
 		ablateToAnchor
 			? "[scorer] ABLATED to anchor-only (gazetteer + conventions OFF) — #722 before/after baseline"
 			: "[scorer] full ship-config via createScorer (anchor + gazetteer + conventions=auto + suppress)"
 	)
+
+	if (anchorOff) {
+		console.error("[scorer] anchor channel ABLATED (--anchor-off → overrides.anchor=false, #887 declared ablation)")
+	}
 
 	// v0 = our TypeScript port of the Pelias parser. Scoring it through the same resolver makes this a
 	// real "neural vs Pelias parser" head-to-head on non-circular addresses.


### PR DESCRIPTION
Fixes #887.

## What

- `scripts/eval/oa-resolver-eval.ts` gains an explicit `--anchor-off` flag: it passes `overrides: { anchor: false }` through `createScorer` (`@mailwoman/neural/scorer`) — the sanctioned, declared ablation the #718 fail-closed gate names in its own error message. Warn-not-throw: the scorer logs the "Deliberate OOD" override notice and constructs with the anchor channel unfed. The flag composes with `--ablate-to-anchor` (the two override sets merge).
- `scripts/eval/de-order-eval.ts` drops the `empty-anchor.json` idiom entirely. The 2x2's OFF legs now pass `--anchor-off` instead of fabricating a `{}` lookup and feeding it as `--model-anchor-lookup` (which parses to size 0 and trips `UnfedChannelError`, leaving `de-native-off.md` / `de-intl-off.md` 0-byte).

## Why

The pre-#718 "zeroed anchor = c=0 identity" trick is exactly what the #718 capability gate exists to refuse: an empty lookup is indistinguishable from a silently-unfed required channel (#566/#685 trap). Since the gate landed, every `promotion-gate.ts` run lost the de-order 2x2's OFF column (the informational ablation only — the `de.native_locality` floor grades the anchor-ON leg and was never affected). The gate is doing its job; this moves the ablation onto the declared path.

## Verification (local, en-us dev weights v194-int8, CPU, small fixtures — no GPU/long evals)

1. **Repro of the bug** — `oa-resolver-eval.ts` with `--model-anchor-lookup <empty {}.json>` on 2 DE rows dies with:
   `UnfedChannelError: [createScorer] anchor channel is declared REQUIRED by the model-card but cannot be fed: parsed lookup is EMPTY (size 0) ...`
2. **Fixed leg** — same invocation with `--anchor-off` instead: exit 0, stderr shows
   `[createScorer] OVERRIDE: anchor channel ABLATED (override anchor:false) ... Deliberate OOD` + `[scorer] anchor channel ABLATED (--anchor-off → overrides.anchor=false, #887 declared ablation)`, and the report writes the `| **neural** | ... |` row `de-order-eval.ts`'s `loc()` parses.
3. **Full `de-order-eval.ts` end-to-end** on 3-row truncated copies of the four fixtures (scratch cwd mirroring the repo layout): exit 0, all six legs run, the 2x2 prints with **both OFF cells populated**, `de-native-off.md` / `de-intl-off.md` are non-zero (~1.2 KB), the OFF `.log`s carry the declared-ablation notices, and no `empty-anchor.json` appears in the out dir.
4. oxfmt `--check` + oxlint clean on both files.

Not run: a full-sample `de-order-eval` / promotion-gate battery (long eval; the smoke above exercises the exact code path the battery uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA