### PR TITLE
chore(#379): housekeeping — scratch gitignore + dependabot safe bumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ output-*/
 
 # Night-shift ephemera — operational plans, logs, and session notes produced during
 # autonomous overnight shifts. AI-agent scratch, not project source (#379).
+# ds-*.txt / session-notes-*.md were previously only ignored inside
+# .agents/skills/deepseek-consult/ (below); the global patterns catch the same
+# scratch when it lands at the repo root or elsewhere. No tracked file matches either.
 *-NIGHT-SHIFT-*.md
 *-NIGHT-SHIFT-*.log
 *-NIGHT-SHIFT-*.sh
@@ -141,6 +144,8 @@ output-*/
 HANDOFF-*.md
 *-SESSION-RECAP.md
 *-DEEP-DIVE-REVIEW.md
+ds-*.txt
+session-notes-*.md
 
 # DeepSeek consult skill directory — the skill definition (SKILL.md) IS tracked;
 # all other files (conversation transcripts, session notes, plans) are AI-agent

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,30 +677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.21.3, @babel/core@npm:^7.25.9":
-  version: 7.29.0
-  resolution: "@babel/core@npm:7.29.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.29.0"
-    "@babel/generator": "npm:^7.29.0"
-    "@babel/helper-compilation-targets": "npm:^7.28.6"
-    "@babel/helper-module-transforms": "npm:^7.28.6"
-    "@babel/helpers": "npm:^7.28.6"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/traverse": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
-    "@jridgewell/remapping": "npm:^2.3.5"
-    convert-source-map: "npm:^2.0.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.3"
-    semver: "npm:^6.3.1"
-  checksum: 10/25f4e91688cdfbaf1365831f4f245b436cdaabe63d59389b75752013b8d61819ee4257101b52fc328b0546159fd7d0e74457ed7cf12c365fea54be4fb0a40229
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.28.0":
+"@babel/core@npm:^7.21.3, @babel/core@npm:^7.25.9, @babel/core@npm:^7.28.0":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -1008,16 +985,6 @@ __metadata:
     "@babel/traverse": "npm:^7.28.6"
     "@babel/types": "npm:^7.28.6"
   checksum: 10/d8a895a75399904746f4127db33593a20021fc55d1a5b5dfeb060b87cc13a8dceea91e70a4951bcd376ba9bd8232b0c04bff9a86c1dab83d691e01852c3b5bcd
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^7.28.6":
-  version: 7.29.2
-  resolution: "@babel/helpers@npm:7.29.2"
-  dependencies:
-    "@babel/template": "npm:^7.28.6"
-    "@babel/types": "npm:^7.29.0"
-  checksum: 10/ad77706f3f917bd224e037fd0fbc67c45b240d2a45981321b093f70b7c535bee9bbddb0a19e34c362cb000ae21cdd8638f8a87a5f305a5bd7547e93fdcc524fe
   languageName: node
   linkType: hard
 
@@ -16177,25 +16144,25 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.0.2, js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/172e0b6007b0bf0fc8d2469c94424f7dd765c64a047d2b790831fecef2204a4054eabf4d911eb73ab8c9a3256ab8ba1ee8d655b789bf24bf059c772acc2075a1
+  checksum: 10/2fdf3a1453ed93a8e06d6ca8054c0bec145cf40ab51f305d1071736a03668b95e40f47cfd0239d7d50019b4780a18cdaca3c935def935594c9876964c49f1185
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/51de2067a2b44b07ba5206132e56005f8b568ff279bb4d2f645068958c56fa4827d40a6841c983234671fa0a134bf094d0b0717873c2a3d319185297af145a6d
+  checksum: 10/2bcec3a8118d7f744badeb04e14366578d234a736f353d41fe35d2305e4ce2409a8e041d277f07cd6bbc8aaa12128d650a68ce43247072519bede20962d2126f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Executes both halves of #379. Two commits: the scratch-pattern gitignore delta, and the safe dependabot bumps.

## Half 1 — untracked scratch decisions (per-file)

Most of this half already landed in a prior pass: `.gitignore` carries `#379`-annotated sections for night-shift ephemera (`*-NIGHT-SHIFT-*.md`, `HANDOFF-*.md`, …), the `deepseek-consult` skill dir, diag scripts, and `nightshift/`. The primary checkout currently has **zero untracked-unignored files** — nothing needed committing, nothing was removed.

Per-file record of what sits on disk (all already ignored, all untouched):

| File / group | Decision | Rationale |
| --- | --- | --- |
| `HANDOFF-825-rev.md` (repo root) | Ephemera — already ignored by the existing `HANDOFF-*.md` pattern | `git log --all -- HANDOFF-825-rev.md` is empty (never tracked). Noted here because it's referenced in conversation; it stays on disk in the primary checkout. |
| `HANDOFF-825.md` (repo root) | Ephemera — same pattern | Never tracked. |
| `nightshift/` (repo root) | Ephemera — already ignored by the existing `nightshift` entry | Shift scratch dir. |
| `.agents/skills/deepseek-consult/*` (~40 `ds-*.txt`, `session-notes-*.md`, plans, probes) | Ephemera — already ignored by the existing dir pattern; `SKILL.md` files stay tracked | Consult transcripts, not project source. |
| `scripts/diag-saintalbans.ts` | Keeper — **already tracked** (committed in a prior pass) | Cited by docs/memories; no action needed. |
| `docs/articles/releases.mdx` (modified, not untracked) | Untouched | Operator WIP in the primary checkout. |
| Unknown category | None found | No untracked file falls outside the ignore patterns. |

**This PR's delta:** global `ds-*.txt` + `session-notes-*.md` ignore patterns. They were previously only ignored inside `.agents/skills/deepseek-consult/`; the deprecated `ds-consult.sh` wrapper used to write the same scratch at the repo root. Verified no tracked file matches either glob.

## Half 2 — dependabot triage

The issue text ("44 alerts, 1 critical, 19 high") is stale: the critical (#71, shell-quote) was fixed 2026-06-19, and the tracker now shows **17 open** (9 high / 5 medium / 3 low), 85 fixed, 3 auto-dismissed lifetime.

**Fixed here (2 alerts)** — in-range, dev/build-only lockfile re-resolutions via `yarn up -R`:

- **#80** `@babel/core` 7.29.0 → **7.29.7** (low, GHSA-4x5r-pxfx-6jf8) — docusaurus/svgr build chain.
- **#112** `js-yaml` 3.14.2 → **3.15.0** (medium, GHSA-h67p-54hq-rp68) — `gray-matter` ← `@docusaurus/utils` and `tap-parser-yaml` ← `tap-difflet` (root devDependency). The non-vulnerable 4.x entry rode along in-range (4.2.0 → 4.3.0).

**Logged, not bumped (15 alerts)** — every one needs a major/out-of-range bump or has no patched release:

| Alert(s) | Package | Severity | Runtime vs dev | Installed | Patched in | Recommended action |
| --- | --- | --- | --- | --- | --- | --- |
| #21 #22 #24 #27 #36 #37, #83 | tar | high ×6, medium ×1 | dev/build-only — `cacache` ← `make-fetch-happen`, `node-gyp` ← `fsevents` (native-build tooling; nothing shipped depends on it) | 6.2.1 | 7.5.16 (all 6.x vulnerable — **major 6→7**) | Log. Fix = `resolutions` override to `tar@^7.5.16` + verify node-gyp@10/cacache@18 native builds, or wait for upstream bumps. We don't extract untrusted tarballs at runtime. |
| #54 #55 | thrift | high ×2 | **runtime** — exact-pinned `thrift@0.21.0` by `@dsnp/parquetjs@1.8.7`, which sits in published `@mailwoman/corpus` `dependencies` | 0.21.0 | 0.23.0 (0.x jump; latest parquetjs still pins 0.21.0 — **no upstream fix**) | Log — the highest-priority runtime item. Options: `resolutions` override to 0.23.0 + corpus parquet round-trip test; upstream PR to @dsnp/parquetjs; or move parquet ingest out of corpus's runtime deps (it's a data-pipeline path). |
| #62 #65 | serialize-javascript | high, medium | dev/build-only — `copy-webpack-plugin` / `css-minimizer-webpack-plugin` ← docusaurus (private docs site) | 6.0.2 | 7.0.3 / 7.0.5 (**major 6→7**) | Log. Rides the next webpack-plugin majors; build-time only, inputs are our own config. |
| #64 | uuid | medium | dev-only — `sockjs` ← `webpack-dev-server` (docs dev server); mermaid's uuid@14 is already clean | 8.3.2 | 11.1.1 (**major 8→11**) | Log. sockjs pins `^8.3.2`; dev-server only. |
| #53 | ip-address | medium | dev/build-only — `socks` ← `socks-proxy-agent` (npm fetch/proxy tooling) | 9.0.5 | 10.1.1 (**major 9→10**) | Log. XSS in `Address6` HTML-emitting methods we never call. |
| #74 | esbuild | low | dev-only — `vite@7.3.5` pins `^0.27.0` (storybook's 0.28.1 is already patched) | 0.27.7 | 0.28.1 (outside vite's range) | Log. Windows-only dev-server file read; rides the next vite bump (vite 8 drops esbuild for rolldown). |
| #72 | torch | low | training-only — `corpus-python/uv.lock` (Modal training env) | ≤2.12.0 | none published | Log. No patched release exists; revisit on the next torch bump. |

### Verification

- `yarn install` — clean.
- `yarn compile` — clean.
- `yarn ci:smoke` — **PASS** (the clean-install guard from #596: packs all 25 published workspaces, installs tarballs without hoisting, runs the CLI + drop-in entrypoints). This is the designated gate for dependency changes; the bumped chains (docs build tooling + root `tap-difflet`) have no dedicated workspace test suite.

Closes the dependabot half of #379; the scratch half was mostly pre-landed and this PR records the decisions + closes the pattern gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA
