### PR TITLE
fix: dev-weights pins missed the v5.1.0 bump — shipped bsplice pair + card-sourced md5 guard

### DIFF
--- a/neural-weights-en-us/scripts/link-dev-weights.ts
+++ b/neural-weights-en-us/scripts/link-dev-weights.ts
@@ -27,14 +27,15 @@
  *
  *   To make drift impossible to ignore, when the DEFAULT artifacts are used (no
  *   MAILWOMAN_DEV_MODEL / MAILWOMAN_DEV_TOKENIZER override) this script asserts the
- *   linked bytes match EXPECTED_*_MD5 — the md5 of what the demo actually serves at
- *     https://public.sister.software/mailwoman/en-us/<defaultVersion>/{model,tokenizer}
- *   A mismatch FAILS LOUD instead of grading the wrong model.
+ *   linked bytes match the package's own `model-card.json` `files_md5` — the md5s the
+ *   release pipeline re-verifies the PUBLISHED tarball against. A mismatch FAILS LOUD
+ *   instead of grading the wrong model.
  *
- *   ON DEFAULT PROMOTION (releases.json `defaultVersion` bump): update the four
- *   DEFAULT_* values below to the new artifact + its md5 in ONE place. Recompute via:
- *     curl -s https://public.sister.software/mailwoman/en-us/<ver>/model.onnx | md5sum
- *     curl -s https://public.sister.software/mailwoman/en-us/<ver>/tokenizer.model | md5sum
+ *   ON SHIP: bump the two DEFAULT_* paths below to the new artifacts. The md5s are NOT
+ *   duplicated here — they come from model-card.json, which the release-prep PR updates
+ *   anyway. A path bumped without the card (or vice versa) fails the guard immediately;
+ *   the 2026-07-02 v5.1.0 ship missed the path bump here and the duplicated-md5 design
+ *   couldn't catch it (the stale pin was self-consistent — #259's trap, post-release form).
  *   ---------------------------------------------------------------------------
  */
 
@@ -46,19 +47,30 @@ import { fileURLToPath } from "node:url"
 import { $public } from "@mailwoman/core/env"
 import { dataRootPath } from "@mailwoman/core/utils"
 
-// --- current default (releases.json defaultVersion = v4.16.0) --------------
-// v4.16.0 en-us ships the v1.9.4-fr-bare-street model (step 92000 — v1.9.3a3 resumed
-// with the FR-bare-street shard). These md5s are the authoritative bytes the demo
-// serves at .../mailwoman/en-us/v4.16.0/{model,tokenizer}, so the capability-gate
-// certifies the SHIPPED model. (2026-06-30 #259: pinned off the stale v1.9.3a3
-// step-80000 default, which kept grading v4.15.0's model after v4.16.0 shipped. Bump
-// these two lines on each ship; the #397 guard below only checks self-consistency.)
-const DEFAULT_MODEL = dataRootPath("models", "quantized", "model-v194-step-92000-int8.onnx")
-const DEFAULT_MODEL_MD5 = "eb76ae49adab7dc7ca412b306cc1aab6"
-const DEFAULT_TOKENIZER = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
-const DEFAULT_TOKENIZER_MD5 = "b6137e8c52914c9715374268ecaa4bc6"
+// --- current default (npm v5.1.0 = demo defaultVersion v5.1.0) --------------
+// v5.1.0 ships the #884 vocab-splice pair: bsplice-meaninit int8 model + the spliced
+// v0.6.0-bsplice tokenizer (58,582 pieces) — the first coordinated model + tokenizer
+// bump, so BOTH paths moved this ship. Bump these two paths on each ship; the expected
+// md5s live in model-card.json `files_md5` (single source — see the header).
+const DEFAULT_MODEL = dataRootPath("models", "quantized", "model-bsplice-meaninit-int8.onnx")
+const DEFAULT_TOKENIZER = dataRootPath("models", "tokenizer", "v0.6.0-bsplice", "tokenizer.model")
 
 const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+
+// The shipped-bytes truth (#397 guard): the card's files_md5 block, which release Step 4
+// re-verifies against the published tarball — so dev symlinks, the card, and npm agree.
+const CARD = JSON.parse(readFileSync(resolve(PKG_DIR, "model-card.json"), "utf8")) as {
+	files_md5?: Record<string, string>
+}
+const DEFAULT_MODEL_MD5 = CARD.files_md5?.["model.onnx"]
+const DEFAULT_TOKENIZER_MD5 = CARD.files_md5?.["tokenizer.model"]
+
+if (!DEFAULT_MODEL_MD5 || !DEFAULT_TOKENIZER_MD5) {
+	console.error(
+		"ERROR (#397 guard): model-card.json has no files_md5.{model.onnx,tokenizer.model} — cannot verify the dev pin."
+	)
+	process.exit(1)
+}
 
 // An explicit override means the caller is deliberately experimenting with a
 // non-default model — skip the hash assertion in that case (but warn loudly).

--- a/neural-weights-fr-fr/scripts/link-dev-weights.ts
+++ b/neural-weights-fr-fr/scripts/link-dev-weights.ts
@@ -10,10 +10,13 @@
  *   A single multilingual model serves both en-us and fr-fr (byte-identical artifact;
  *   fr-fr just carries its own calibration). Re-symlinks the SAME files as en-us until
  *   per-locale training lands. Keep these defaults in lockstep with en-us's DEFAULT_*
- *   on every defaultVersion bump (currently v4.16.0 = v1.9.4-fr-bare-street, tokenizer 0.6.0-a0).
+ *   on every ship (currently v5.1.0 = bsplice-meaninit + the spliced v0.6.0-bsplice
+ *   tokenizer). The md5 guard reads en-us's model-card `files_md5` — one truth for the
+ *   one artifact (fr-fr's own card carries no files_md5 block).
  */
 
-import { existsSync, symlinkSync, unlinkSync } from "node:fs"
+import { createHash } from "node:crypto"
+import { existsSync, readFileSync, symlinkSync, unlinkSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -21,11 +24,12 @@ import { $public } from "@mailwoman/core/env"
 import { dataRootPath } from "@mailwoman/core/utils"
 
 const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
-// In lockstep with en-us's DEFAULT_MODEL (one multilingual artifact serves both). 2026-06-30 #259: pinned
-// to the v4.16.0 / v1.9.4-fr-bare-street shipped model (was the stale v1.9.3a3 step-80000 / v4.15.0 default).
-const SRC_MODEL = $public.MAILWOMAN_DEV_MODEL || dataRootPath("models", "quantized", "model-v194-step-92000-int8.onnx")
+// In lockstep with en-us's DEFAULT_* (one multilingual artifact serves both) — v5.1.0
+// bsplice pair (#884). The 2026-07-02 ship missed this bump (both linkers still pinned
+// the demo-only v4.16.0 pair); the guard below now fails loud on any future miss.
+const SRC_MODEL = $public.MAILWOMAN_DEV_MODEL || dataRootPath("models", "quantized", "model-bsplice-meaninit-int8.onnx")
 const SRC_TOKENIZER =
-	$public.MAILWOMAN_DEV_TOKENIZER || dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
+	$public.MAILWOMAN_DEV_TOKENIZER || dataRootPath("models", "tokenizer", "v0.6.0-bsplice", "tokenizer.model")
 
 if (!existsSync(SRC_MODEL)) {
 	console.error(`missing source model: ${SRC_MODEL}`)
@@ -48,3 +52,40 @@ linkForce(SRC_MODEL, resolve(PKG_DIR, "model.onnx"))
 linkForce(SRC_TOKENIZER, resolve(PKG_DIR, "tokenizer.model"))
 
 console.log(`linked ${PKG_DIR}/{model.onnx,tokenizer.model}`)
+
+// #397 guard, lockstep form: the fr-fr artifact IS the en-us artifact, so verify the
+// linked default bytes against en-us's model-card `files_md5` (skipped under an
+// explicit MAILWOMAN_DEV_* override — deliberate experimentation).
+if (!$public.MAILWOMAN_DEV_MODEL || !$public.MAILWOMAN_DEV_TOKENIZER) {
+	const enUSCard = JSON.parse(
+		readFileSync(resolve(PKG_DIR, "..", "neural-weights-en-us", "model-card.json"), "utf8")
+	) as { files_md5?: Record<string, string> }
+	const checks: Array<[string, string, string | undefined]> = [
+		["model", resolve(PKG_DIR, "model.onnx"), enUSCard.files_md5?.["model.onnx"]],
+		["tokenizer", resolve(PKG_DIR, "tokenizer.model"), enUSCard.files_md5?.["tokenizer.model"]],
+	]
+
+	for (const [label, path, expected] of checks) {
+		if (
+			($public.MAILWOMAN_DEV_MODEL && label === "model") ||
+			($public.MAILWOMAN_DEV_TOKENIZER && label === "tokenizer")
+		)
+			continue
+
+		if (!expected) {
+			console.error(
+				`ERROR (#397 guard): en-us model-card.json has no files_md5 entry for ${label} — cannot verify the dev pin.`
+			)
+			process.exit(1)
+		}
+		const actual = createHash("md5").update(readFileSync(path)).digest("hex")
+
+		if (actual !== expected) {
+			console.error(
+				`ERROR (#397 guard): linked default ${label} md5 ${actual} != shipped ${expected} (en-us card files_md5).`
+			)
+			console.error("  Bump this script's SRC_* defaults in lockstep with en-us on each ship.")
+			process.exit(1)
+		}
+	}
+}


### PR DESCRIPTION
The #259 trap, post-release form: v5.1.0 shipped a coordinated model+tokenizer bump, but both `link-dev-weights.ts` scripts still pinned the demo-only v4.16.0 pair (`model-v194-step-92000-int8` + pre-splice `v0.6.0-a0` tokenizer). Every `yarn test` run (via `weights.test.ts`) re-linked dev weights to a non-shipped model — the exact drift class that wasted an eval shift before (#397).

**Root cause of the miss:** the guard's expected md5s were duplicated constants in the same file as the paths — a stale pin is perfectly self-consistent, so the guard passed while pointing at the wrong ship.

**Fix:** md5 truth moves to `model-card.json` `files_md5` (the block the release pipeline re-verifies the published tarball against — release-prep must update it anyway). Now a ship that misses the pin bump fails the guard the first time anything links weights. fr-fr guards against en-us's card (byte-identical artifact by design) since its own card has no `files_md5` block.

**Verified:** both linkers now link the shipped pair (model `12fa2d64…`, tokenizer `b0397ce3…`), guards PASS, `weights.test.ts` 4/4.

⚠ If `v194-step-92000` was a deliberate dev line rather than the missed bump, say so and I'll revert the paths — but the tokenizer pairing (v194 model + a0 tokenizer) matches the retired v4.16.0 demo pair, not any live line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA