### PR TITLE
feat(#900): splice safety gate — pre-registered codepoint-overlap assertion

### DIFF
--- a/corpus-python/src/mailwoman_train/tokenizer_splice.py
+++ b/corpus-python/src/mailwoman_train/tokenizer_splice.py
@@ -166,6 +166,71 @@ def verify_source_identical(base_tokenizer: Path, spliced_tokenizer: Path, probe
         )
 
 
+
+
+def collect_sample_codepoints(sample_path: Path, *, cap_bytes: int = 4_000_000) -> set[str]:
+    """The set of non-ASCII codepoints in a locale sample file (first ``cap_bytes``, utf-8, errors ignored).
+
+    Deliberately format-agnostic (CSV/JSONL/plain all work): the #900 gate needs a locale's CHARACTER
+    inventory, not its parse — reading raw text keeps the gate free of per-format code.
+    """
+    raw = sample_path.read_bytes()[:cap_bytes].decode("utf-8", errors="ignore")
+    return {c for c in raw if ord(c) >= 128}
+
+
+def gate_codepoint_overlap(
+    new_pieces: list[str],
+    locale_samples: dict[str, Path],
+    report_path: Path,
+    *,
+    accepted_overlap: set[str] | None = None,
+) -> dict[str, list[str]]:
+    """#900 — the splice safety gate, pre-registered as a GATE rather than a postmortem note.
+
+    The v5.1.0 splice shipped on a "byte-identical by construction" claim that turned out ASCII-only:
+    FR/DE/ES share codepoints with the spliced pieces, so 52/15,000 EU rows re-tokenized — measured
+    AFTER the fact (net-positive, by luck and row-reads). This gate makes the overlap visible BEFORE
+    grading: for every trained locale sample, compute the non-ASCII codepoints shared between the
+    NEW pieces and that locale's character inventory, write the per-locale report artifact, and FAIL
+    LOUD on any overlapping locale that was not explicitly accepted.
+
+    "Accepted" is a commitment, not a waiver: per CONTRIBUTING_MODEL_WORK.mdx, accepting a locale
+    means a per-locale non-inferiority leg for it is pre-registered in the gate spec BEFORE the
+    first measurement (the FR n=3000 leg from v5.1.0 is the template).
+    """
+    accepted = accepted_overlap or set()
+    new_cps = {c for piece in new_pieces for c in _core(piece) if ord(c) >= 128}
+    report: dict[str, list[str]] = {}
+    for locale, sample in sorted(locale_samples.items()):
+        overlap = sorted(new_cps & collect_sample_codepoints(sample))
+        report[locale] = overlap
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(
+            {
+                "new_piece_codepoints": sorted(new_cps),
+                "per_locale_overlap": report,
+                "accepted_overlap": sorted(accepted),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    offending = [loc for loc, cps in report.items() if cps and loc not in accepted]
+    if offending:
+        detail = "; ".join(f"{loc}: {''.join(report[loc][:12])}" for loc in offending)
+        raise AssertionError(
+            f"#900 splice gate: codepoint overlap with trained locale(s) {offending} ({detail}). "
+            f"Either the overlap is a bug, or pre-register a per-locale non-inferiority leg for each "
+            f"and re-run with --accept-overlap {','.join(offending)}. Report: {report_path}"
+        )
+    return report
+
+
 def mean_init_embeddings(
     checkpoint_dir: Path, base_tokenizer: Path, spliced_tokenizer: Path, out_dir: Path
 ) -> tuple[int, int]:
@@ -216,6 +281,20 @@ def _main() -> None:
     bt.add_argument("--out-tokenizer", type=Path, required=True)
     bt.add_argument("--vocab-size", type=int, default=24_000)
     bt.add_argument("--work-dir", type=Path, default=Path("out/bsplice-work"))
+    bt.add_argument(
+        "--trained-samples",
+        default="",
+        help="#900 gate: comma list of locale=samplePath pairs for every TRAINED locale "
+        "(e.g. fr=data/eval/external/openaddresses-fr-sample.jsonl,de=...). When set, the "
+        "codepoint-overlap gate runs and FAILS on unaccepted overlap; the per-locale report "
+        "is written next to the spliced tokenizer either way.",
+    )
+    bt.add_argument(
+        "--accept-overlap",
+        default="",
+        help="#900 gate: comma list of locales whose overlap is ACCEPTED — i.e. a per-locale "
+        "non-inferiority leg is pre-registered in the gate spec (CONTRIBUTING_MODEL_WORK.mdx).",
+    )
 
     mi = sub.add_parser("mean-init", help="expand a checkpoint's embeddings to the spliced vocab")
     mi.add_argument("--checkpoint", type=Path, required=True)
@@ -233,6 +312,16 @@ def _main() -> None:
         new_pieces = splice_vocab(args.base_tokenizer, sp_model, args.out_tokenizer)
         print(f"spliced {len(new_pieces)} diacritic pieces -> {args.out_tokenizer}")
         print("English tokenization verified byte-identical (0 diff).")
+        if args.trained_samples:
+            samples = {
+                loc.strip(): Path(path.strip())
+                for loc, _, path in (pair.partition("=") for pair in args.trained_samples.split(","))
+            }
+            accepted = {x.strip() for x in args.accept_overlap.split(",") if x.strip()}
+            report_path = args.out_tokenizer.with_suffix(".overlap-report.json")
+            report = gate_codepoint_overlap(new_pieces, samples, report_path, accepted_overlap=accepted)
+            overlapping = [loc for loc, cps in report.items() if cps]
+            print(f"#900 overlap gate PASS — report {report_path}; overlapping (accepted): {overlapping or 'none'}")
     elif args.cmd == "mean-init":
         old_v, new_v = mean_init_embeddings(args.checkpoint, args.base_tokenizer, args.spliced_tokenizer, args.out_dir)
         print(f"expanded token_embeddings {old_v} -> {new_v}; wrote {args.out_dir}")

--- a/corpus-python/tests/mailwoman_train/test_tokenizer_splice_gate.py
+++ b/corpus-python/tests/mailwoman_train/test_tokenizer_splice_gate.py
@@ -1,0 +1,52 @@
+"""#900 — the splice codepoint-overlap safety gate.
+
+The v5.1.0 finding: "byte-identical by construction" was ASCII-only; FR/DE/ES shared codepoints
+with the spliced pieces and 52/15k EU rows re-tokenized, measured only after the fact. The gate
+must (a) report per-locale overlap, (b) fail loud on unaccepted overlap, (c) pass when overlap
+is either absent or explicitly accepted (= a pre-registered ni leg per CONTRIBUTING).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mailwoman_train.tokenizer_splice import collect_sample_codepoints, gate_codepoint_overlap
+
+
+@pytest.fixture()
+def samples(tmp_path: Path) -> dict[str, Path]:
+    fr = tmp_path / "fr.jsonl"
+    fr.write_text('{"raw": "12 Rue de la Lozère, Paris"}\n', encoding="utf-8")
+    us = tmp_path / "us.jsonl"
+    us.write_text('{"raw": "350 Fifth Avenue, New York, NY 10118"}\n', encoding="utf-8")
+    return {"fr": fr, "us": us}
+
+
+def test_collect_sample_codepoints_nonascii_only(samples: dict[str, Path]) -> None:
+    assert collect_sample_codepoints(samples["us"]) == set()
+    assert "è" in collect_sample_codepoints(samples["fr"])
+
+
+def test_gate_passes_and_reports_when_disjoint(tmp_path: Path, samples: dict[str, Path]) -> None:
+    report_path = tmp_path / "report.json"
+    # ą/ż do not appear in either sample → disjoint → PASS, empty overlaps in the report.
+    report = gate_codepoint_overlap(["▁Grudzi", "ądz", "ż"], samples, report_path)
+    assert report == {"fr": [], "us": []}
+    on_disk = json.loads(report_path.read_text(encoding="utf-8"))
+    assert on_disk["per_locale_overlap"] == {"fr": [], "us": []}
+
+
+def test_gate_fails_loud_on_unaccepted_overlap(tmp_path: Path, samples: dict[str, Path]) -> None:
+    report_path = tmp_path / "report.json"
+    with pytest.raises(AssertionError, match=r"\bfr\b"):
+        gate_codepoint_overlap(["▁Lozère", "è"], samples, report_path)
+    # The report is still written before the raise — the artifact is the point.
+    assert json.loads(report_path.read_text(encoding="utf-8"))["per_locale_overlap"]["fr"] == ["è"]
+
+
+def test_gate_passes_when_overlap_accepted(tmp_path: Path, samples: dict[str, Path]) -> None:
+    report_path = tmp_path / "report.json"
+    report = gate_codepoint_overlap(["▁Lozère", "è"], samples, report_path, accepted_overlap={"fr"})
+    assert report["fr"] == ["è"]
+    assert json.loads(report_path.read_text(encoding="utf-8"))["accepted_overlap"] == ["fr"]

--- a/docs/articles/plan/CONTRIBUTING_MODEL_WORK.mdx
+++ b/docs/articles/plan/CONTRIBUTING_MODEL_WORK.mdx
@@ -127,6 +127,21 @@ zero margin is by construction, not fragility. Any dip triggers rule 1, and the
 [#901](https://github.com/sister-software/mailwoman/issues/901) campaign gate must name both
 postcode slices explicitly.
 
+### Splice safety gate — codepoint overlap is pre-registered, not post-measured ([#900](https://github.com/sister-software/mailwoman/issues/900))
+
+Any tokenizer vocab splice must run the overlap gate **before grading begins**
+(`tokenizer_splice.py build-tokenizer --trained-samples <locale=sample,…>`): it computes the
+non-ASCII codepoints shared between the NEW pieces and every trained locale's character
+inventory, writes the per-locale report artifact next to the spliced tokenizer, and fails loud
+on any overlapping locale that was not explicitly accepted. Accepting a locale
+(`--accept-overlap fr,de`) is a commitment, not a waiver: a per-locale non-inferiority leg for
+each accepted locale must be pre-registered in the gate spec before the first measurement — the
+FR n=3000 coordinate leg from v5.1.0 is the template.
+
+Why this is a gate: the v5.1.0 splice shipped on "byte-identical by construction," which turned
+out ASCII-only — FR/DE/ES shared é/ü/ö with the spliced pieces and 52/15,000 EU rows
+re-tokenized, measured only after the fact. Net-positive that time; the gate removes the luck.
+
 ## Adding a shard
 
 1. Generator lives in `corpus/` (`synthesize-*.ts`) or `scripts/build-*-shard.mjs`; every row


### PR DESCRIPTION
Closes #900. The ASCII-only-guarantee finding (v5.1.0) becomes a gate: any future splice computes per-trained-locale codepoint overlap against REAL sample files, writes the report artifact (even on failure — the artifact is the point), and fails loud unless each overlapping locale is explicitly accepted. Accepting = pre-registering a per-locale ni leg (CONTRIBUTING rule included).

Tests: 4/4 (disjoint pass, unaccepted fail-loud with report still written, accepted pass, codepoint collection).

Mechanical per tonight's merge mode — will self-merge on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA