### PR TITLE
fix(demo): siteConfig.baseUrl casing (LIVE-broken since v5.0.0) + PipelineExplorer on the shared runCascade

### DIFF
--- a/docs/src/components/PipelineExplorer/PipelineExplorer.tsx
+++ b/docs/src/components/PipelineExplorer/PipelineExplorer.tsx
@@ -148,11 +148,9 @@ const PipelineExplorerInner: React.FC<{ defaultAddress: string }> = ({ defaultAd
 				const tree = pipelineResult.tree
 				const nodes = flattenTree(tree)
 
-				const localityNodes = nodes.filter((n) => n.tag === "locality" || n.tag === "city")
 				const stateNode = nodes
 					.filter((n) => n.tag === "region" || n.tag === "state")
 					.sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))[0]
-				const postcodeNode = nodes.find((n) => n.tag === "postcode" || n.tag === "postal_code")
 
 				const wofLookup = lookup
 
@@ -176,7 +174,7 @@ const PipelineExplorerInner: React.FC<{ defaultAddress: string }> = ({ defaultAd
 				setParseStage(2)
 
 				const tBeforeResolve = performance.now()
-				const cascadeHits = await runCascade(wofLookup, postcodeNode, localityNodes, stateNode, text)
+				const cascadeHits = await runCascade(wofLookup, tree as { roots: unknown[] }, text)
 				const tResolve = performance.now()
 				const candidates: ResolvedHit[] = cascadeHits.map((c) => ({
 					id: c.id,

--- a/docs/src/pages/demo/_app.tsx
+++ b/docs/src/pages/demo/_app.tsx
@@ -110,7 +110,7 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 	// staged into the Pages deploy at `/mailwoman/sqljs/` by the demo-assets plugin and loaded from
 	// there, while the DB the worker range-reads lives on R2 (cross-origin, CORS-allowed).
 	const { siteConfig } = useDocusaurusContext()
-	const sqljsBaseURL = `${siteConfig.baseURL}mailwoman/sqljs`
+	const sqljsBaseURL = `${siteConfig.baseUrl}mailwoman/sqljs`
 	const [manifest, setManifest] = useState<ReleasesManifest | null>(null)
 	const [selectedVersion, setSelectedVersion] = useState<string | null>(null)
 	const [loadingProgress, setLoadingProgress] = useState<string>("Loading releases…")
@@ -212,8 +212,8 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 	// Mount: register the range-chunk service worker (persists validated DB range chunks in Cache
 	// Storage — warm repeat visits, and the root fix for mobile Safari's torn-chunk HTTP cache).
 	useEffect(() => {
-		registerRangeCacheServiceWorker(siteConfig.baseURL)
-	}, [siteConfig.baseURL])
+		registerRangeCacheServiceWorker(siteConfig.baseUrl)
+	}, [siteConfig.baseUrl])
 
 	// Drop cached range chunks belonging to other versions once a version is selected — the URLs are
 	// immutable, so old versions' chunks never expire on their own.

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -50,9 +50,9 @@ const DemoPage: React.FC = () => {
 				<link rel="preconnect" href="https://public.sister.software" crossOrigin="anonymous" />
 				<link rel="dns-prefetch" href="https://public.sister.software" />
 				<link rel="preconnect" href={TILE_WORKER_URL} crossOrigin="anonymous" />
-				<link rel="prefetch" href={`${siteConfig.baseURL}mailwoman/sqljs/index.js`} />
-				<link rel="prefetch" href={`${siteConfig.baseURL}mailwoman/sqljs/sqlite.worker.js`} />
-				<link rel="prefetch" href={`${siteConfig.baseURL}mailwoman/sqljs/sql-wasm.wasm`} />
+				<link rel="prefetch" href={`${siteConfig.baseUrl}mailwoman/sqljs/index.js`} />
+				<link rel="prefetch" href={`${siteConfig.baseUrl}mailwoman/sqljs/sqlite.worker.js`} />
+				<link rel="prefetch" href={`${siteConfig.baseUrl}mailwoman/sqljs/sql-wasm.wasm`} />
 			</Head>
 
 			<main className={styles.demoRoot}>


### PR DESCRIPTION
Production repair, split out of #916 so the voice-review recipe doesn't block it.

**Live evidence (checked tonight):** `curl https://mailwoman.sister.software/demo/` renders `<link rel=prefetch href=undefinedmailwoman/sqljs/index.js>` — the v5.0.0 acronym sweep renamed Docusaurus's `siteConfig.baseUrl` (an EXTERNAL library key, exempt per AGENTS.md) to `.baseURL`, which is undefined at runtime: sqljs worker base, SW registration, and prefetch hints all build `undefined…` paths. Broken in production since 2026-07-01.

Second fix in the same commit: `PipelineExplorer` still called the pre-#861 five-arg `runCascade` (dead since the shared-resolver convergence).

Both are mechanical, typecheck-verified (docs `yarn typecheck` was 7 errors on main → clean). Cherry-picked verbatim from the #818 agent's commit. Merging on green per tonight's merge mode — this restores an already-deployed surface, distinct from the demo-default wall (no model/version pointer changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA