### PR TITLE
feat(#920): postcode coverage for the namesake-tail locales — GeoNames-postal source + country-aware shard routing

### DIFF
--- a/core/utils/data-root.ts
+++ b/core/utils/data-root.ts
@@ -34,12 +34,16 @@ export function dataRootPath(...segments: string[]): string {
 
 /**
  * The default WOF shard list the FTS backend probes when no single `--wof-db` is given: the global admin-priority shard
- * + the US postcode shard, both under `dataRoot` (defaults to the configured {@link mailwomanDataRoot}; callers thread a
- * `--data-root` option through). A fresh array each call.
+ * + the US postcode shard + the GeoNames-postal tail shard (#920 — postcode coverage for the namesake-tail locales
+ * FI/CZ/SK/SI/DK/NO/HR/PL; country-aware routing in `pickShardForPlacetype` sends each postcode query to the shard that
+ * claims its country). All under `dataRoot` (defaults to the configured {@link mailwomanDataRoot}; callers thread a
+ * `--data-root` option through). A fresh array each call; callers filter with `existsSync`, so a deployment without the
+ * tail shard degrades to the pre-#920 pair.
  */
-export function wofShardPaths(dataRoot: string = mailwomanDataRoot()): [string, string] {
+export function wofShardPaths(dataRoot: string = mailwomanDataRoot()): [string, string, string] {
 	return [
 		String(resolvePathBuilder(dataRoot, "wof", "admin-global-priority.db")),
 		String(resolvePathBuilder(dataRoot, "wof", "postalcode-us.db")),
+		String(resolvePathBuilder(dataRoot, "wof", "postalcode-geonames-tail.db")),
 	]
 }

--- a/docs/articles/evals/2026-07-02-night-31-postmortem.md
+++ b/docs/articles/evals/2026-07-02-night-31-postmortem.md
@@ -143,7 +143,7 @@ voice pass), **#918** (#473: TW postcode table + JP Overture gold — agent).
 
 | item                        | value                                                                 |
 | --------------------------- | --------------------------------------------------------------------- |
-| Shift                       | 05:56 → 14:29 UTC (operator returned early; wrapped on request)      |
+| Shift                       | 05:56 → 14:29 UTC (operator returned early; wrapped on request)       |
 | Modal spend                 | ≈ $4–5 of $30 (2 training runs, 2 probes, ~8 exports/quants, syncs)   |
 | Training                    | v1.9.8 (2k+10k, falsified at full gate), v1.9.9 (2k+4k, killed at 6k) |
 | NaN incidents               | 0                                                                     |

--- a/mailwoman/resolver-backend.test.ts
+++ b/mailwoman/resolver-backend.test.ts
@@ -24,8 +24,12 @@ afterEach(() => {
 	for (const k of ENV_KEYS) setEnv(k, original[k])
 })
 
-test("wofShardPaths: builds the admin + postcode shard paths under a data root", () => {
-	expect(wofShardPaths("/data")).toEqual(["/data/wof/admin-global-priority.db", "/data/wof/postalcode-us.db"])
+test("wofShardPaths: builds the admin + postcode + tail shard paths under a data root (#920)", () => {
+	expect(wofShardPaths("/data")).toEqual([
+		"/data/wof/admin-global-priority.db",
+		"/data/wof/postalcode-us.db",
+		"/data/wof/postalcode-geonames-tail.db",
+	])
 })
 
 test("mailwomanDataRoot: honors MAILWOMAN_DATA_ROOT, else the lab default; threads into wofShardPaths", () => {

--- a/resolver-wof-sqlite/geonames-postal.test.ts
+++ b/resolver-wof-sqlite/geonames-postal.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #920 — the GeoNames postal fold's two laws, as tests: (1) the name law (stored names match the
+ *   sanitized-query token shape — spaced CZ and dashed PL forms measured broken/worse in the
+ *   night-31 experiment), (2) medoid centroids (the member point, never an off-settlement mean —
+ *   the p50-tax law).
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { describe, expect, it } from "vitest"
+
+import { GEONAMES_POSTAL_ID_BASE, ingestGeonamesPostal, normalizePostcodeName } from "./geonames-postal.js"
+
+describe("normalizePostcodeName (the #920 name law)", () => {
+	it("strips the spaced CZ/SK form to the query-token shape", () => {
+		expect(normalizePostcodeName("110 00")).toBe("11000")
+	})
+
+	it("strips the dashed PL form", () => {
+		expect(normalizePostcodeName("11-041")).toBe("11041")
+	})
+
+	it("keeps plain alphanumerics whole", () => {
+		expect(normalizePostcodeName("8281")).toBe("8281")
+		expect(normalizePostcodeName("AD500")).toBe("AD500")
+	})
+})
+
+function fixtureDB(): DatabaseSync {
+	const db = new DatabaseSync(":memory:")
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL DEFAULT -1, name TEXT NOT NULL DEFAULT '',
+			placetype TEXT NOT NULL DEFAULT '', country TEXT NOT NULL DEFAULT '',
+			latitude REAL NOT NULL DEFAULT 0, longitude REAL NOT NULL DEFAULT 0,
+			min_latitude REAL NOT NULL DEFAULT 0, min_longitude REAL NOT NULL DEFAULT 0,
+			max_latitude REAL NOT NULL DEFAULT 0, max_longitude REAL NOT NULL DEFAULT 0,
+			is_current INTEGER NOT NULL DEFAULT 1, is_deprecated INTEGER NOT NULL DEFAULT 0,
+			is_ceased INTEGER NOT NULL DEFAULT 0, is_superseded INTEGER NOT NULL DEFAULT 0,
+			is_superseding INTEGER NOT NULL DEFAULT 0, lastmodified INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE names (id INTEGER NOT NULL, name TEXT, placetype TEXT, country TEXT, language TEXT, lastmodified INTEGER);
+	`)
+
+	return db
+}
+
+describe("ingestGeonamesPostal", () => {
+	it("folds one medoid row per normalized code, with the display form as an alt name", () => {
+		const dir = mkdtempSync(join(tmpdir(), "gn-postal-"))
+		// Three members of "110 00": two clustered at ~50.08, one outlier pulling the mean north.
+		// The medoid must be one of the REAL points (the cluster member nearest the mean), never
+		// the mean itself.
+		writeFileSync(
+			join(dir, "CZ.txt"),
+			[
+				"CZ\t110 00\tPraha 1\tPraha\t10\t\t\t\t\t50.08\t14.42\t4",
+				"CZ\t110 00\tPraha 1-x\tPraha\t10\t\t\t\t\t50.09\t14.43\t4",
+				"CZ\t110 00\tOutlier\tPraha\t10\t\t\t\t\t50.30\t14.60\t4",
+				"CZ\t500 02\tHradec\tKralovehradecky\t\t\t\t\t\t50.21\t15.83\t4",
+			].join("\n"),
+			"utf8"
+		)
+		const db = fixtureDB()
+		const result = ingestGeonamesPostal(db, ["CZ"], dir)
+
+		expect(result.inserted).toBe(2)
+		expect(result.byCountry.CZ).toBe(2)
+
+		const row = db.prepare("SELECT id, name, placetype, latitude, longitude FROM spr WHERE name = '11000'").get() as {
+			id: number
+			name: string
+			placetype: string
+			latitude: number
+			longitude: number
+		}
+
+		expect(row.placetype).toBe("postalcode")
+		expect(row.id).toBeGreaterThanOrEqual(GEONAMES_POSTAL_ID_BASE)
+		// Medoid = a real member (50.09 is nearest the outlier-pulled mean), NOT the mean (~50.157).
+		expect([50.08, 50.09, 50.3]).toContain(row.latitude)
+		expect(row.latitude).toBe(50.09)
+
+		const names = db
+			.prepare("SELECT name FROM names WHERE id = ? ORDER BY name")
+			.all(row.id)
+			.map((r) => (r as { name: string }).name)
+
+		expect(names).toEqual(["110 00", "11000"])
+	})
+
+	it("reports missing country files instead of throwing", () => {
+		const dir = mkdtempSync(join(tmpdir(), "gn-postal-empty-"))
+		const db = fixtureDB()
+		const result = ingestGeonamesPostal(db, ["FI"], dir)
+
+		expect(result.inserted).toBe(0)
+		expect(result.missing).toEqual(["FI"])
+	})
+})

--- a/resolver-wof-sqlite/geonames-postal.ts
+++ b/resolver-wof-sqlite/geonames-postal.ts
@@ -1,0 +1,148 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #920 — fold GeoNames POSTAL codes into a WOF/unified postcode shard as first-class
+ *   `postalcode` places, for the countries whose WOF postalcode repos don't exist (the
+ *   namesake-tail locales: FI/CZ/SK/SI/DK/NO/HR/PL and any future gap).
+ *
+ *   Why: the night-31 taxonomy measured the cross-locale resolve tail as NAMESAKE COLLISION
+ *   (FI 300/1k … PL 75/1k offender rows), and the controlled experiment showed postcode-shard
+ *   coverage alone collapses it (FI 300→1, CZ 131→4): a resolvable postcode node feeds the
+ *   resolver's coordinate-first sibling-postcode candidate injection, which binds the locality
+ *   pick to its postcode neighborhood. The machinery already ships; it was coverage-starved.
+ *
+ *   Two hard-won laws from the experiment are enforced HERE, in code, not in a runbook:
+ *
+ *   1. **The name law (#920 format law):** a postcode row's `name` is stored in the
+ *      SANITIZED-QUERY token shape — every non-letter/number stripped — because that is what
+ *      `sanitizeFTSQuery` reduces the parsed token to at lookup time. Stored `"110 00"` (CZ) or
+ *      `"11-041"` (PL) can never match the query `"11000"`/`"11041"`; the spaced CZ build
+ *      measured WORSE than no coverage (+13 namesake rows) because its bigrams partial-matched
+ *      WRONG codes. The display form is preserved as an alt row in `names`.
+ *   2. **Medoid centroids:** GeoNames postal is one row per (postcode, settlement); the naive
+ *      mean-of-members centroid displaced tighter village coordinates on already-correct rows
+ *      (the p50-tax that ni-failed SK/SI/HR at 1.10–1.94 km CI). The MEDOID — the member point
+ *      nearest the mean — keeps the coordinate on a real settlement.
+ *
+ *   Package home for the same reason as `geonames-aliases.ts`: `build-unified-wof
+ *   --geonames-postal-countries`, any standalone fold, and the `mailwoman gazetteer` commands
+ *   share ONE implementation. GeoNames postal dump = `download.geonames.org/export/zip/<CC>.zip`
+ *   → `<CC>.txt` (TSV: country, postcode, place, admin1, code1, admin2, code2, admin3, code3,
+ *   lat, lon, accuracy). License CC BY 4.0 — attribution rides the shard's `meta` provenance and
+ *   the model card like the existing GeoNames alias fold.
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import type { DatabaseSync } from "node:sqlite"
+
+/**
+ * Synthetic id base for GeoNames-POSTAL rows — its own namespace above the alias fold's {@link GEONAMES_ID_BASE} (9e12)
+ * allocation so all four sources (WOF, Overture, GeoNames-alias, GeoNames-postal) coexist collision-free in a combined
+ * DB.
+ */
+export const GEONAMES_POSTAL_ID_BASE = 9_500_000_000_000
+
+/**
+ * The #920 name law: reduce a postal code to the sanitized-query token shape — strip every non-letter/number — so the
+ * stored name matches what `sanitizeFTSQuery` produces from the parsed postcode token. `"110 00"` → `"11000"`,
+ * `"11-041"` → `"11041"`, `"AD500"` → `"AD500"`.
+ */
+export function normalizePostcodeName(raw: string): string {
+	return raw.replace(/[^\p{L}\p{N}]/gu, "")
+}
+
+export interface GeonamesPostalIngestResult {
+	/** Distinct postcodes inserted across all countries. */
+	inserted: number
+	/** Per-country distinct-postcode counts. */
+	byCountry: Record<string, number>
+	/** Countries whose `<CC>.txt` was missing under the postal dir (skipped, reported). */
+	missing: string[]
+}
+
+/**
+ * Fold GeoNames postal codes for `countries` into an open unified/postcode ingest DB: one `spr` row per distinct
+ * normalized postcode (placetype `postalcode`, medoid centroid, degenerate bbox), the normalized form as `name`, and
+ * the display form as an extra `names` row when it differs. The caller owns the FTS rebuild (rows ride the standard
+ * freeze phase).
+ */
+export function ingestGeonamesPostal(
+	db: DatabaseSync,
+	countries: readonly string[],
+	postalDir: string
+): GeonamesPostalIngestResult {
+	const sprInsert = db.prepare(
+		`INSERT OR REPLACE INTO spr (id, parent_id, name, placetype, country, latitude, longitude, min_latitude, min_longitude, max_latitude, max_longitude, is_current, is_deprecated, is_ceased, is_superseded, is_superseding, lastmodified) VALUES (?, -1, ?, 'postalcode', ?, ?, ?, ?, ?, ?, ?, 1, 0, 0, 0, 0, 0)`
+	)
+	const namesInsert = db.prepare(
+		`INSERT INTO names (id, name, placetype, country, language, lastmodified) VALUES (?, ?, 'postalcode', ?, '', 0)`
+	)
+
+	let nextID = GEONAMES_POSTAL_ID_BASE
+	const byCountry: Record<string, number> = {}
+	const missing: string[] = []
+	let inserted = 0
+
+	for (const country of countries) {
+		const cc = country.toUpperCase()
+		const file = join(postalDir, `${cc}.txt`)
+
+		if (!existsSync(file)) {
+			missing.push(cc)
+			console.error(
+				`  GeoNames postal ${cc}: ${file} missing — download from download.geonames.org/export/zip/${cc}.zip; skipped`
+			)
+			continue
+		}
+		// Group member settlement points per NORMALIZED code; remember one display form.
+		const members = new Map<string, { display: string; pts: Array<[number, number]> }>()
+
+		for (const line of readFileSync(file, "utf8").split("\n")) {
+			const cols = line.split("\t")
+
+			if (cols.length < 11) continue
+			const display = cols[1]!.trim()
+			const name = normalizePostcodeName(display)
+			const lat = Number(cols[9])
+			const lon = Number(cols[10])
+
+			if (!name || !Number.isFinite(lat) || !Number.isFinite(lon)) continue
+			const m = members.get(name) ?? { display, pts: [] }
+			m.pts.push([lat, lon])
+			members.set(name, m)
+		}
+
+		db.exec("BEGIN")
+
+		for (const [name, m] of members) {
+			// Medoid: the member point nearest the mean — stays on a real settlement (the p50-tax law).
+			const meanLat = m.pts.reduce((s, p) => s + p[0], 0) / m.pts.length
+			const meanLon = m.pts.reduce((s, p) => s + p[1], 0) / m.pts.length
+			let best = m.pts[0]!
+			let bestD = Infinity
+
+			for (const p of m.pts) {
+				const d = (p[0] - meanLat) ** 2 + (p[1] - meanLon) ** 2
+
+				if (d < bestD) {
+					bestD = d
+					best = p
+				}
+			}
+			const id = nextID++
+			sprInsert.run(id, name, cc, best[0], best[1], best[0], best[1], best[0], best[1])
+			namesInsert.run(id, name, cc)
+
+			if (m.display !== name) namesInsert.run(id, m.display, cc)
+			inserted++
+		}
+		db.exec("COMMIT")
+		byCountry[cc] = members.size
+		console.error(`  GeoNames postal ${cc}: ${members.size.toLocaleString()} distinct codes (medoid centroids)`)
+	}
+
+	return { inserted, byCountry, missing }
+}

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -319,6 +319,8 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 * override) schema names.
 	 */
 	readonly #shards: ResolvedShard[]
+	/** #920: per-schema probed country sets for country-aware shard routing (non-main shards only). */
+	readonly #shardCountries: Map<string, ReadonlySet<string>>
 	/**
 	 * The Geographic Rule Engine (Direction E, #289). `#conventionSource` supplies per-WOF-polygon resolution profiles;
 	 * `#strategies` is the named-primitive registry the merged convention dispatches. Empty source → every query resolves
@@ -392,6 +394,26 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 			this.#hasBboxIndex.set(s.schemaName, this.#shardHasTable(s.schemaName, PLACE_BBOX_TABLE))
 			this.#hasPopulationIndex.set(s.schemaName, this.#shardHasTable(s.schemaName, PLACE_POPULATION_TABLE))
 		}
+		// #920 country-aware shard routing: probe each NON-MAIN shard's country set once at
+		// construction (they're small, purpose-built shards — postcode/locality slices; main is the
+		// multi-GB admin DB and is the fallback anyway, so it is deliberately NOT scanned). Feeds
+		// pickShardForPlacetype so two postcode shards (postalcode-us + postalcode-geonames-tail)
+		// route by the query's country instead of first-match starving the second shard.
+		this.#shardCountries = new Map()
+
+		for (const sh of this.#shards) {
+			if (sh.schemaName === "main") continue
+
+			try {
+				const rows = this.#db
+					.prepare(`SELECT DISTINCT country FROM ${sh.schemaName}.spr WHERE country != ''`)
+					.all() as Array<{ country: string }>
+				this.#shardCountries.set(sh.schemaName, new Set(rows.map((r) => r.country)))
+			} catch {
+				// A shard without spr (or an attach oddity) just doesn't participate in country routing.
+			}
+		}
+
 		// The postcode_locality table can live on any attached shard (typically its own
 		// `postcode-locality-<cc>.db`). Find the first shard that has it; null = coord-first disabled.
 		this.#postcodeLocalityShard =
@@ -608,7 +630,10 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 		// `placetype` always goes to main. (Mixed-placetype queries with multiple shards aren't
 		// supported in v1 — caller can issue two findPlace calls and merge in TS if needed.)
 		const firstPlacetype = placetypes?.[0]
-		const shard = pickShardForPlacetype(this.#shards, firstPlacetype)
+		const shard = pickShardForPlacetype(this.#shards, firstPlacetype, {
+			country: query.country,
+			countriesBySchema: this.#shardCountries,
+		})
 		const sch = shard.schemaName // bare schema name; safe to interpolate (validated at construction)
 
 		// Filter out historical / superseded / deprecated places by default — they live in the same

--- a/resolver-wof-sqlite/package.json
+++ b/resolver-wof-sqlite/package.json
@@ -38,6 +38,7 @@
 		"./ancestry-backfill": "./out/ancestry-backfill.js",
 		"./coincident-roles": "./out/coincident-roles.js",
 		"./geonames-aliases": "./out/geonames-aliases.js",
+		"./geonames-postal": "./out/geonames-postal.js",
 		"./geo": "./out/geo.js",
 		"./street-normalize": "./out/street-normalize.js",
 		"./build-candidate": "./out/build-candidate.js",

--- a/resolver-wof-sqlite/sharding.test.ts
+++ b/resolver-wof-sqlite/sharding.test.ts
@@ -127,4 +127,32 @@ describe("pickShardForPlacetype", () => {
 		const odd = resolveShards(["/tmp/whosonfirst-data-admin-us-latest.db", { path: "/tmp/arboregion.db" }])
 		expect(pickShardForPlacetype(odd, "region").schemaName).toBe("main")
 	})
+
+	// #920 — country-aware routing across MULTIPLE placetype-matching shards: first-match starved
+	// the second postcode shard (a FI postcode could never reach postalcode-geonames-tail behind
+	// postalcode-us). With the query country + probed country sets, the claiming shard wins; the
+	// original first-match order stays the tiebreak when no shard claims the country.
+	test("country routes across two postcode shards (#920)", () => {
+		const two = resolveShards([
+			"/tmp/whosonfirst-data-admin-us-latest.db",
+			"/tmp/whosonfirst-data-postalcode-us-latest.db",
+			"/tmp/postalcode-geonames-tail.db",
+		])
+		const countries = new Map([
+			["postalcode_us", new Set(["US"])],
+			["postalcode_geonames_tail", new Set(["FI", "CZ", "PL"])],
+		])
+
+		expect(pickShardForPlacetype(two, "postalcode", { country: "FI", countriesBySchema: countries }).schemaName).toBe(
+			"postalcode_geonames_tail"
+		)
+		expect(pickShardForPlacetype(two, "postalcode", { country: "US", countriesBySchema: countries }).schemaName).toBe(
+			"postalcode_us"
+		)
+		// Unknown country / no probe → first placetype match (the pre-#920 behavior, unchanged).
+		expect(pickShardForPlacetype(two, "postalcode", { country: "XX", countriesBySchema: countries }).schemaName).toBe(
+			"postalcode_us"
+		)
+		expect(pickShardForPlacetype(two, "postalcode").schemaName).toBe("postalcode_us")
+	})
 })

--- a/resolver-wof-sqlite/sharding.ts
+++ b/resolver-wof-sqlite/sharding.ts
@@ -151,15 +151,32 @@ export function resolveShards(input: string | ReadonlyArray<string | ShardConfig
  * the typical mailwoman query has a single placetype anyway. If a caller needs cross-shard results they can issue two
  * `findPlace` calls.
  */
-export function pickShardForPlacetype(shards: ResolvedShard[], placetype: string | undefined): ResolvedShard {
+export function pickShardForPlacetype(
+	shards: ResolvedShard[],
+	placetype: string | undefined,
+	opts?: {
+		/**
+		 * #920: the query's country constraint, when the caller has one. With MULTIPLE shards matching a placetype
+		 * (postalcode-us + postalcode-geonames-tail), first-match routing sent every postcode query to the first shard and
+		 * starved the rest — a FI postcode could never reach the tail shard. When `country` is given and a matching shard's
+		 * probed country set contains it, that shard wins; shards without the country are skipped; the placetype-match
+		 * order remains the tiebreak when no shard claims the country (or none was probed).
+		 */
+		country?: string
+		/** Per-schema probed country sets (see `WOFSqlitePlaceLookup`'s construction probe). */
+		countriesBySchema?: ReadonlyMap<string, ReadonlySet<string>>
+	}
+): ResolvedShard {
 	if (!placetype) return shards[0]!
 
+	const matches: ResolvedShard[] = []
+
 	for (const s of shards) {
-		if (s.placetypes.includes(placetype)) return s
+		if (s.placetypes.includes(placetype)) matches.push(s)
 	}
 
 	for (const s of shards) {
-		if (s.schemaName === "main") continue
+		if (s.schemaName === "main" || matches.includes(s)) continue
 
 		// Substring match: `postalcode_us` matches `postalcode`. Conservative — requires the
 		// placetype to appear at a word boundary in the schema name to avoid false hits like
@@ -169,9 +186,17 @@ export function pickShardForPlacetype(shards: ResolvedShard[], placetype: string
 			s.schemaName.startsWith(`${placetype}_`) ||
 			s.schemaName.endsWith(`_${placetype}`)
 		) {
-			return s
+			matches.push(s)
 		}
 	}
 
-	return shards[0]!
+	if (matches.length === 0) return shards[0]!
+
+	if (opts?.country && opts.countriesBySchema) {
+		for (const s of matches) {
+			if (opts.countriesBySchema.get(s.schemaName)?.has(opts.country)) return s
+		}
+	}
+
+	return matches[0]!
 }

--- a/scripts/build-unified-wof.ts
+++ b/scripts/build-unified-wof.ts
@@ -30,12 +30,14 @@ import { readFile } from "node:fs/promises"
 import { DatabaseSync } from "node:sqlite"
 
 import { DuckDBInstance } from "@duckdb/node-api"
+import { dataRootPath } from "@mailwoman/core/utils"
 import {
 	backfillAncestorsFromHierarchy,
 	discoverAdminDataRoots,
 } from "@mailwoman/resolver-wof-sqlite/ancestry-backfill"
 import { buildCoincidentRoles } from "@mailwoman/resolver-wof-sqlite/coincident-roles"
 import { ingestGeonamesAliases } from "@mailwoman/resolver-wof-sqlite/geonames-aliases"
+import { ingestGeonamesPostal } from "@mailwoman/resolver-wof-sqlite/geonames-postal"
 import {
 	createUnifiedIndexes,
 	createUnifiedSchema,
@@ -54,6 +56,8 @@ const OVERTURE_ID_BASE = 8_000_000_000_000
 const OVERTURE_DIVISION_SUBTYPES = ["locality", "region", "county", "localadmin"]
 /** Default GeoNames per-country dump directory (`<CC>.txt`, from download.geonames.org/export/dump). */
 const DEFAULT_GEONAMES_DIR = "/mnt/playpen/mailwoman-data/geonames"
+/** Default GeoNames per-country POSTAL dump directory (`<CC>.txt`, from download.geonames.org/export/zip). */
+const DEFAULT_GEONAMES_POSTAL_DIR = String(dataRootPath("geonames-postal"))
 /** Pinned Overture release for the divisions theme (the release the EU coverage was validated on). */
 const DEFAULT_OVERTURE_RELEASE = "2026-06-17.0"
 
@@ -81,6 +85,13 @@ interface Args {
 	 * Karjaa↔Karis) AFTER the WOF + Overture ingest. Reads `<CC>.txt` from {@link geonamesDir}. Off unless provided.
 	 */
 	geonamesCountries?: string[]
+	/**
+	 * #920: fold GeoNames POSTAL codes (download.geonames.org/export/zip) for these countries as `postalcode` places —
+	 * the tail locales without WOF postalcode repos. Name law + medoid centroids enforced in
+	 * `@mailwoman/resolver-wof-sqlite/geonames-postal`. Off unless provided.
+	 */
+	geonamesPostalCountries?: string[]
+	geonamesPostalDir: string
 	/** Directory of GeoNames per-country dumps (`<CC>.txt`). Default {@link DEFAULT_GEONAMES_DIR}. */
 	geonamesDir: string
 }
@@ -96,6 +107,8 @@ function parseArgs(): Args {
 	let overtureRelease = DEFAULT_OVERTURE_RELEASE
 	let geonamesCountries: string[] | undefined
 	let geonamesDir = DEFAULT_GEONAMES_DIR
+	let geonamesPostalCountries: string[] | undefined
+	let geonamesPostalDir = DEFAULT_GEONAMES_POSTAL_DIR
 
 	for (let i = 0; i < args.length; i++) {
 		if (args[i] === "--data" && args[i + 1]) dataDir = args[++i]
@@ -116,6 +129,8 @@ function parseArgs(): Args {
 				.map((s) => s.trim().toUpperCase())
 				.filter(Boolean)
 		else if (args[i] === "--geonames-dir" && args[i + 1]) geonamesDir = args[++i]!
+		else if (args[i] === "--geonames-postal-countries" && args[i + 1]) geonamesPostalCountries = args[++i]!.split(",")
+		else if (args[i] === "--geonames-postal-dir" && args[i + 1]) geonamesPostalDir = args[++i]!
 	}
 
 	if (!dataDir || !outputPath) {
@@ -135,6 +150,8 @@ function parseArgs(): Args {
 		overtureRelease,
 		geonamesCountries,
 		geonamesDir,
+		geonamesPostalCountries,
+		geonamesPostalDir,
 	}
 }
 
@@ -393,6 +410,8 @@ async function main() {
 		overtureRelease,
 		geonamesCountries,
 		geonamesDir,
+		geonamesPostalCountries,
+		geonamesPostalDir,
 	} = parseArgs()
 	const activePlacetypes = placetypes ? new Set(placetypes) : ADMIN_PLACETYPES
 	console.error(`Ingesting placetypes: ${[...activePlacetypes].join(", ")}`)
@@ -541,6 +560,17 @@ async function main() {
 		console.error(`Backfilling GeoNames aliases for ${geonamesCountries.join(",")} from ${geonamesDir}...`)
 		geonamesIngested = ingestGeonamesAliases(db, geonamesCountries, geonamesDir)
 		console.error(`  GeoNames places ingested: ${geonamesIngested.toLocaleString()}`)
+	}
+
+	// -----------------------------------------------------------------------
+	// Phase 2d: GeoNames postal backfill (#920 — postcode coverage for the namesake-tail locales)
+	// -----------------------------------------------------------------------
+	if (geonamesPostalCountries && geonamesPostalCountries.length > 0) {
+		console.error(
+			`Backfilling GeoNames postal codes for ${geonamesPostalCountries.join(",")} from ${geonamesPostalDir}...`
+		)
+		const postal = ingestGeonamesPostal(db, geonamesPostalCountries, geonamesPostalDir)
+		console.error(`  GeoNames postal codes ingested: ${postal.inserted.toLocaleString()}`)
 	}
 
 	// -----------------------------------------------------------------------

--- a/scripts/eval/fr-admin-split-gate.ts
+++ b/scripts/eval/fr-admin-split-gate.ts
@@ -95,7 +95,10 @@ const FR_CENTROID = { lat: 46.6, lon: 2.5 }
 async function main() {
 	const goldenPath = arg("golden", "/tmp/reg/fr-admin-split-golden.jsonl")
 	const label = arg("label", "model")
-	const wofDB = arg("wof-db", dataRootPath("wof", "admin-global-priority.db"))
+	// Comma-separated multi-shard support (night-31): postcodeConsistency needs a resolvable postcode
+	// node, which needs a postalcode shard attached alongside the admin DB.
+	const wofDBArg = arg("wof-db", dataRootPath("wof", "admin-global-priority.db"))
+	const wofDB = wofDBArg.includes(",") ? wofDBArg.split(",") : wofDBArg
 	const rows = readFileSync(goldenPath, "utf8")
 		.trim()
 		.split("\n")
@@ -130,9 +133,13 @@ async function main() {
 		: process.argv.includes("--raw-case")
 			? false
 			: undefined
+	// #375 night-31: opt-in postcodeConsistency pin (the #370 lever A namesake binder) for the
+	// taxonomy-driven experiment; unset = library default (off).
+	const postcodeConsistencyPin = process.argv.includes("--postcode-consistency") ? true : undefined
 	const resolveOpts = {
 		defaultCountry: arg("default-country", "FR"),
 		...(adminCoherencePin !== undefined ? { adminCoherence: adminCoherencePin } : {}),
+		...(postcodeConsistencyPin !== undefined ? { postcodeConsistency: postcodeConsistencyPin } : {}),
 	}
 
 	const errs: number[] = []


### PR DESCRIPTION
Closes #920. The production form of the night-31 discovery: the cross-locale namesake tail (the largest residual class in every non-US panel) collapses when postcodes can resolve — the coordinate-first machinery already shipped; it was coverage-starved.

## What's in it
1. **`@mailwoman/resolver-wof-sqlite/geonames-postal`** — the fold module (aliases-fold pattern) with both experiment-derived laws IN CODE: the name law (names stored in the sanitized-query token shape — spaced `110 00` and dashed `11-041` source forms measured broken/worse) and medoid centroids (the p50-tax mitigation). 5 unit tests.
2. **`build-unified-wof` Phase 2d** (`--geonames-postal-countries/--geonames-postal-dir`, data-root-defaulted). Built artifact beside canonicals: `wof/postalcode-geonames-tail.db` — 37,205 codes, FI/CZ/SK/SI/DK/NO/HR/PL, FTS+bbox.
3. **Country-aware shard routing** — `pickShardForPlacetype(placetype, {country, countriesBySchema})` + a one-time per-shard country probe: with two postcode shards, first-match starved the second (FI could never route past `postalcode-us`). Pre-#920 behavior preserved absent country/probe; unit-tested.
4. **`wofShardPaths`** gains the tail shard (existsSync-filtered by all callers — shardless deployments degrade unchanged).

## The gate (pre-registered; full log in `gate-v193/RESULTS.md`)
| cc | namesake | p90res km | resolve | ni |
|---|---|---|---|---|
| FI | 300→1 | → tight | 98.7→100% | PASS |
| CZ | 131→8 | | 98.8→99.8% | PASS |
| DK | 167→39 | | +held | PASS |
| NO | 141→75 | | +5.8pp | PASS |
| SK | 131→3 | 59.7→4.7 | +1.6pp | p50 miss — **SIGNED** |
| SI | 91→26 | 23.8→6.1 | +0.2pp | p50 miss — **SIGNED** |
| HR | 94→45 | 33.9→10.0 | +0.2pp | p50 miss — **SIGNED** |
| PL | 75→6 | 10.2→6.3 | 98→**100%** | p50 miss — **SIGNED** |

**Signed gate revision (operator-approved, option 1 in chat):** the four resolved-p50 ni misses (CI uppers 1.25–1.92 km vs the 1 km bar) are an accepted trade — medians rise ~1–1.7 km where the injected postcode-area coordinate displaces the exact village centroid, buying tail collapse + wrong-city elimination. Right city at 2 km beats a tight median with a 1-in-10 wrong-city tail.

**Trio verification:** all 8 tail legs BYTE-IDENTICAL between single-shard and full-trio runs (routing non-perturbing); **US byte-inert** ([admin+postalcode-us] vs trio, 2000/2000). Suites: 1,286 tests green.

GeoNames postal is CC BY 4.0 — attribution follows the existing GeoNames-alias precedent (shard meta + model-card at next release prep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA