### PR TITLE
feat(#920): wire postalcode-intl — quad shard set (ES/NL/DE/FR/IT postcode coverage)

### DIFF
--- a/core/utils/data-root.ts
+++ b/core/utils/data-root.ts
@@ -40,10 +40,11 @@ export function dataRootPath(...segments: string[]): string {
  * `--data-root` option through). A fresh array each call; callers filter with `existsSync`, so a deployment without the
  * tail shard degrades to the pre-#920 pair.
  */
-export function wofShardPaths(dataRoot: string = mailwomanDataRoot()): [string, string, string] {
+export function wofShardPaths(dataRoot: string = mailwomanDataRoot()): [string, string, string, string] {
 	return [
 		String(resolvePathBuilder(dataRoot, "wof", "admin-global-priority.db")),
 		String(resolvePathBuilder(dataRoot, "wof", "postalcode-us.db")),
 		String(resolvePathBuilder(dataRoot, "wof", "postalcode-geonames-tail.db")),
+		String(resolvePathBuilder(dataRoot, "wof", "postalcode-intl.db")),
 	]
 }

--- a/mailwoman/resolver-backend.test.ts
+++ b/mailwoman/resolver-backend.test.ts
@@ -24,11 +24,12 @@ afterEach(() => {
 	for (const k of ENV_KEYS) setEnv(k, original[k])
 })
 
-test("wofShardPaths: builds the admin + postcode + tail shard paths under a data root (#920)", () => {
+test("wofShardPaths: builds the admin + postcode + tail + intl shard paths under a data root (#920)", () => {
 	expect(wofShardPaths("/data")).toEqual([
 		"/data/wof/admin-global-priority.db",
 		"/data/wof/postalcode-us.db",
 		"/data/wof/postalcode-geonames-tail.db",
+		"/data/wof/postalcode-intl.db",
 	])
 })
 


### PR DESCRIPTION
The second #920 increment: `postalcode-intl.db` (built long ago, never wired) joins `wofShardPaths` as the fourth shard. The #922 country-aware routing handles the set unchanged; intl received its standard FTS pass (444,708 rows indexed).

## Gate (pre-registered in `gate-v193/RESULTS.md`)
| leg | result |
|---|---|
| ES-1k | namesake **61→7**, unresolved **13→0**, ni PASS |
| NL-1k | namesake 12→3, unresolved **43→3** — numeric-stem coverage far outperformed the predicted null (letter-suffix follow-up filed separately) |
| FR-3k | resolve **65.3→100%**, overall-p50 improved 2.68→2.64, p90res **109.5→6.6 km**; resolved-p50 leg failed strict ni (1.43→2.64) and is **SIGNED** (operator): composition confound — the denominator gained the previously-unresolvable harder third |
| US-2k | quad BYTE-INERT vs trio |
| FI-1k | quad BYTE-INERT vs trio (tail routing undisturbed) |

Registration lesson recorded: strict-ni on resolved-p50 is the wrong instrument when resolve moves double digits — future gates pair it with overall-p50 ni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA