### PR TITLE
ci: typecheck the docs app (#917's class fix)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Typecheck scripts
         run: yarn typecheck:scripts
 
+      # The docs app ships real runtime code (the /demo page). Its typecheck sat outside CI and
+      # went 7-errors red on main unnoticed — one of those errors was the LIVE demo's undefined
+      # baseUrl paths (#917, broken in production since v5.0.0). This step is that bug's class fix.
+      - name: Typecheck docs
+        run: yarn workspace @mailwoman/docs typecheck
+
       - name: Test
         run: yarn ci:test
 


### PR DESCRIPTION
The docs workspace ships real runtime code (the /demo page) but its typecheck ran nowhere in CI — it was 7 errors red on main for a day and one of those errors was the live demo's `undefined` baseUrl paths (#917). One step in test.yml after the scripts typecheck. Verified green locally against current main. Mechanical; merging on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA