### PR TITLE
feat(#912): exact-tier sub-tier — name-exact outranks alias-exact

### DIFF
--- a/resolver-wof-sqlite/exact-match-tiering.test.ts
+++ b/resolver-wof-sqlite/exact-match-tiering.test.ts
@@ -111,6 +111,33 @@ describe("findPlace — exact-match tiering", () => {
 		expect(results[0]!.id).toBe(2) // the populous non-exact match — pre-fix behavior
 	})
 
+	// #912 sub-tier: the query IS one place's own name and only an ALIAS of the other. The name
+	// holder must win even when the alias holder is more populous — 'Paris' (the capital's own name)
+	// over 'Paris Township' (alias 'Paris'), scale-model edition. ME→Maine (alias-exact, no
+	// name-exact competitor) is covered by the tests above and must keep passing unchanged.
+	test("#912: name-exact outranks alias-exact regardless of population", async () => {
+		const db = buildDB([
+			{ id: 11, name: "Capitalia", country: "FR", lat: 48.8, lon: 2.3, population: 50_000 },
+			{
+				id: 12,
+				name: "Capitalia Township",
+				country: "US",
+				lat: 40.5,
+				lon: -81.5,
+				aliases: ["Capitalia"],
+				population: 9_000_000,
+			},
+		])
+		lookup = new WOFSqlitePlaceLookup({ database: db, buildFTS: true }, POP_DOMINATES)
+		const results = await lookup.findPlace({ text: "Capitalia", placetype: "region", limit: 2 })
+
+		expect(results[0]?.name).toBe("Capitalia")
+		expect(results[1]?.name).toBe("Capitalia Township")
+		// Both still stamp exactMatch — the sub-tier reorders WITHIN the tier, not across the flag.
+		expect(results[0]?.exactMatch).toBe(true)
+		expect(results[1]?.exactMatch).toBe(true)
+	})
+
 	test("alignment: among EQUALLY-exact matches, population still decides (Springfield by pop)", async () => {
 		// Both exact name matches → same tier → the population prior orders them, unchanged. This is
 		// the guarantee that tiering aligns with (rather than overrides) population/importance.

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -875,13 +875,27 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 				// order the tier is what sent unscoped "Paris" to an Ohio township. The partial tier
 				// keeps score order — text relevance still means something there. This makes the
 				// exactMatchTiering docstring literal: match quality primary, prominence within.
+				//
+				// #912 sub-tier: a NAME-exact candidate (spr.name equals the query) outranks an
+				// ALIAS-exact one ('Paris' the place beats 'Paris Township' held via alias 'Paris').
+				// The place's own name is a stronger identity claim than an alias — aliases exist to
+				// widen recall, not to tie primaries. ME→Maine is untouched: 'ME' name-exact-matches
+				// nothing, so the alias sub-tier still decides there. Population orders within each
+				// sub-tier as before.
+				const norm = (v: string): string => v.toLowerCase().trim().replace(/\s+/g, " ")
+				const needle = norm(query.text)
+				const kind = (c: PlaceCandidate): number => {
+					if (!exactIds.has(c.id as number)) return 0
+
+					return norm(String(c.name ?? "")) === needle ? 2 : 1
+				}
 				candidates.sort((a, b) => {
-					const ax = exactIds.has(a.id as number) ? 1 : 0
-					const bx = exactIds.has(b.id as number) ? 1 : 0
+					const ax = kind(a)
+					const bx = kind(b)
 
 					if (bx !== ax) return bx - ax
 
-					if (ax === 1) return (b.population ?? 0) - (a.population ?? 0) || b.score - a.score
+					if (ax >= 1) return (b.population ?? 0) - (a.population ?? 0) || b.score - a.score
 
 					return b.score - a.score
 				})


### PR DESCRIPTION
Lever 2 of the #912 sketch (attack order 2→1→3→4). Within the exact tier: NAME-exact (the candidate's own `spr.name` equals the query) above ALIAS-exact, population within each sub-tier. Handles the case population can't: an alias-holder more populous than the name-holder. `exactMatch` stamping unchanged (downstream #369 re-rank unaffected).

**Gate (pre-registered):** gauntlet 15/15 gated cases PASS (the five bare-namesake `improvement_target` rows are production-cascade cases — levers 1+3 — and stay tracked); US-2k, CZ, SK, SI **byte-inert**; PL changed exactly one row and it's the mechanism's signature: `Wodzisław, 00-000, Brzezie 16` **135.88 → 0.83 km** (name-exact Wodzisław over the alias-exact Wodzisław-Śląski-class namesake), ni PASS. New unit test: name-exact wins under 180× population dominance; ME→Maine suite unchanged (7/7).

Resolver-scoring change — flagged for your merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA