### PR TITLE
feat(#912): splice-tool exonym feed + nsplice staging Modal functions

### DIFF
--- a/corpus-python/src/mailwoman_train/tokenizer_splice.py
+++ b/corpus-python/src/mailwoman_train/tokenizer_splice.py
@@ -70,7 +70,15 @@ def _is_ascii(s: str) -> bool:
     return all(ord(c) < 128 for c in s)
 
 
-def build_slavic_corpus(oa_root: Path, locales: list[str], out_path: Path, *, per_file_cap: int = 400_000) -> int:
+def build_slavic_corpus(
+    oa_root: Path,
+    locales: list[str],
+    out_path: Path,
+    *,
+    per_file_cap: int = 400_000,
+    extra_text: Path | None = None,
+    extra_repeat: int = 10,
+) -> int:
     """Stream the OpenAddresses STREET/CITY columns for ``locales`` into a deduped SP-training corpus.
 
     Returns the line count written. Reproducible: fixed seed + fixed sample size.
@@ -98,6 +106,14 @@ def build_slavic_corpus(oa_root: Path, locales: list[str], out_path: Path, *, pe
     corpus = [ln for ln in lines if ln and len(ln) < 80]
     random.Random(_SEED).shuffle(corpus)
     corpus = corpus[:_CORPUS_SAMPLE]
+    # Exonym awareness (#912 lever 4's Åbo lesson): OA STREET/CITY text carries only the NATIVE
+    # names, so an exonym like "Åbo" (Swedish for Turku) never earns a piece and its decode drop
+    # survives the splice. extra_text feeds gazetteer ALIAS names in, repeated extra_repeat× so a
+    # once-per-name list has enough unigram mass to compete for vocab slots.
+    if extra_text is not None and extra_text.is_file():
+        extra = [ln.strip() for ln in extra_text.read_text(encoding="utf-8").splitlines()]
+        extra = [ln for ln in extra if ln and len(ln) < 80]
+        corpus.extend(extra * max(1, extra_repeat))
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text("\n".join(corpus), encoding="utf-8")
     return len(corpus)
@@ -287,6 +303,8 @@ def _main() -> None:
         "codepoint-overlap gate runs and FAILS on unaccepted overlap; the per-locale report "
         "is written next to the spliced tokenizer either way.",
     )
+    bt.add_argument("--extra-text", type=Path, default=None, help="extra corpus lines (gazetteer alias names) — the exonym-awareness feed")
+    bt.add_argument("--extra-repeat", type=int, default=10)
     bt.add_argument(
         "--accept-overlap",
         default="",
@@ -304,7 +322,9 @@ def _main() -> None:
     if args.cmd == "build-tokenizer":
         args.work_dir.mkdir(parents=True, exist_ok=True)
         corpus = args.work_dir / "slavic-corpus.txt"
-        n = build_slavic_corpus(args.oa_root, args.locales.split(","), corpus)
+        n = build_slavic_corpus(
+            args.oa_root, args.locales.split(","), corpus, extra_text=args.extra_text, extra_repeat=args.extra_repeat
+        )
         print(f"corpus: {n} lines")
         sp_model = train_diacritic_sp(corpus, args.work_dir / "slavic-sp", vocab_size=args.vocab_size)
         new_pieces = splice_vocab(args.base_tokenizer, sp_model, args.out_tokenizer)

--- a/scripts/modal/train_remote.py
+++ b/scripts/modal/train_remote.py
@@ -1258,6 +1258,67 @@ def versions():
 
 
 @app.function(
+    image=training_image,
+    volumes={VOL_MOUNT: vol},
+    secrets=[r2_secret],
+    timeout=1800,
+)
+def sync_nsplice():
+    """#912 lever 4 — Nordic splice staging. Pulls the v0.7.0-nsplice tokenizer (v0.6.0-bsplice's
+    58,582 pieces + 8,613 Nordic diacritic pieces from OA fi/se/no/dk/is; #900 overlap gate PASS,
+    accepted set stamped in the report next to the local artifact) and refreshes the training code.
+    The mean-init input is models/bsplice-expanded — the SHIPPED v5.1.0 fp32 (the pure mean-init
+    artifact; the fine-tune washed, see tokenizer_splice.py's header) — already on the volume."""
+    import shutil
+    import subprocess
+
+    print("Syncing nsplice tokenizer + code from R2...")
+    vol.reload()
+    R = "--low-level-retries 30 --retries 8 --transfers 8 --checkers 16"
+    commands = [
+        f"rclone copy :s3:{BUCKET}/corpus-python/src/ {VOL_MOUNT}/corpus-python/src/ {R}",
+        f"rclone copy :s3:{BUCKET}/models/tokenizer/v0.7.0-nsplice/ {VOL_MOUNT}/models/tokenizer/v0.7.0-nsplice/ {R}",
+        f"rclone copy :s3:{BUCKET}/models/tokenizer/v0.7.1-nsplice/ {VOL_MOUNT}/models/tokenizer/v0.7.1-nsplice/ {R}",
+    ]
+    for i, cmd in enumerate(commands):
+        print(f"[{i+1}/{len(commands)}] {cmd[:90]}...")
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"rclone failed: {result.stderr[:300]}")
+    pyc = f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/__pycache__"
+    if os.path.isdir(pyc):
+        shutil.rmtree(pyc)
+    vol.commit()
+    print("  nsplice tokenizer present:", os.path.isfile(f"{VOL_MOUNT}/models/tokenizer/v0.7.0-nsplice/tokenizer.model"))
+    print("  base ckpt present:", os.path.isfile(f"{VOL_MOUNT}/models/bsplice-expanded/pytorch_model.bin"))
+
+
+@app.function(
+    image=training_image,
+    volumes={VOL_MOUNT: vol},
+    timeout=1200,
+)
+def mean_init_nsplice():
+    """#912 lever 4: expand the shipped bsplice-expanded checkpoint's embeddings to the nsplice
+    vocab (FVT mean-init — same surgery that produced v5.1.0). Writes /data/models/nsplice-expanded."""
+    import sys
+    sys.path.insert(0, "/data/corpus-python/src")
+    from pathlib import Path
+
+    from mailwoman_train.tokenizer_splice import mean_init_embeddings
+
+    vol.reload()
+    old_v, new_v = mean_init_embeddings(
+        Path(f"{VOL_MOUNT}/models/bsplice-expanded"),
+        Path(f"{VOL_MOUNT}/models/tokenizer/v0.6.0-bsplice/tokenizer.model"),
+        Path(f"{VOL_MOUNT}/models/tokenizer/v0.7.1-nsplice/tokenizer.model"),
+        Path(f"{VOL_MOUNT}/models/nsplice-v2-expanded"),
+    )
+    vol.commit()
+    print(f"mean-init done: {old_v} -> {new_v} rows; /data/models/nsplice-expanded committed")
+
+
+@app.function(
     volumes={VOL_MOUNT: vol},
     image=training_image,
     timeout=600,


### PR DESCRIPTION
Infrastructure from the lever-4 staging arc: `build-tokenizer --extra-text/--extra-repeat` (the Åbo lesson — exonyms don't appear in OA native text, so gazetteer alias names need explicit unigram mass) and the `sync_nsplice`/`mean_init_nsplice` Modal functions on the v197 idiom. No model artifacts ship in this PR; the staging record + artifact md5s live in `gate-v193/RESULTS.md`, ship call is the operator's. Mechanical infra; merging on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA