### PR TITLE
feat(#901): boundary-family campaign artifacts — recipes, configs, probe record (KILLED at 2k)

### DIFF
--- a/corpus-python/src/mailwoman_train/configs/v1.9.8-bare-street-bsplice.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v1.9.8-bare-street-bsplice.yaml
@@ -1,0 +1,205 @@
+# === v1.9.8-bare-street-bsplice (#901 run 1 — the fr-bare-street shard on the SHIPPED spliced base) ===
+# NIGHT-31 (2026-07-02, $30 cap). Restores the v4.16.0-demo-only fr-bare-street capability that the v5.1.0
+# repoint traded away — now trained ON the spliced vocab so it ships in the main line. ONE variable vs the
+# shipped v5.1.0 model: the synth-fr-bare-street shard (the corpus + weights below are v1.9.4 VERBATIM,
+# which is v1.9.3a3 + that one shard).
+#
+# CASE-AUG DELIBERATELY EXCLUDED (schedule adjustment vs the night plan): v1.9.6-surface-aug-full was
+# SHELVED 2026-06-30 (#261) — the metamorphic layer introduced 2 casing/whitespace regressions, and the
+# deterministic fix (#834 normalize + #895 normalizeCase default-ON, landed 2026-07-02) covers the gap.
+# Revisit only with a recipe that clears the metamorphic gate; not tonight, not as a second variable.
+#
+# INIT: init_from /data/models/bsplice-expanded (the v5.1.0 surgery export: v1.9.3a3 weights + 10,582
+# mean-init rows). resume is IMPOSSIBLE here — the export carries no optimizer state and the old moments
+# would not match the expanded embedding shape; the skill's resume-rule presumes a resumable ckpt. The
+# v1.9.7 fine-tune block is the precedented idiom (fresh optimizer, lr 5e-5, warmup 200, constant).
+#
+# SEQUENCE: PROBE = 2k steps (this file as-is). Probe gate (pre-registered, gate-v193/RESULTS.md):
+# fr-parse-recall.ts bare-FR street-intact rate moves UP from the shipped-pair baseline AND US quick
+# slices hold. Early-kill @1k on non-decreasing loss. PASS -> RESUME this run's step-002000 ckpt with
+# max_steps bumped to 12000 (the +10k full-run precedent from v1.9.4). Full gate = the night plan table.
+# Launch: modal run -d scripts/modal/train_remote.py --config v1.9.8-bare-street-bsplice.yaml
+#
+# --- v1.9.4 header (the shard's rationale) kept below for the record ---
+# === v1.9.4-fr-bare-street (#251/#148 — teach the FR street→locality boundary WITHOUT a postcode anchor) ===
+# FULL RUN (probe GREEN: 2k-step step-082000 gave bare-FR street-intact 89→92%, demo "Rue du Chevaleret,
+# Paris" FIXED, US 4/4 tag-identical → imbalance confirmed, not modeling deficit). Continue from the probe's
+# step-082000 (--resume auto) to step-092000 (+10k); eval every 2k → gate each checkpoint (US per-tag floors)
+# and ship the FR-up/US-held sweet spot. SAME single variable (the fr-bare-street shard) — clean attribution.
+# v1.9.3a3 (shipped v4.16.x) is verbatim below EXCEPT: corpus_dir → the v0.9.4 overlay, and ONE new
+# source_weight (synth-fr-bare-street). Everything else — model, anchor knobs, class_weights, country_weights,
+# the other source_weights, LR/schedule — is IDENTICAL to v193a3, so the SINGLE variable is the new shard
+# (clean attribution).
+#
+# ROOT MECHANISM (DeepSeek Pro 019f1097 + libpostal's own documented practice, both independent): every
+# comprehensive FR source (BAN, OSM) is postcode-COMPLETE, so the decoder learned the FR street→locality
+# boundary as "the token after the 5-digit postcode," NEVER as "comma + city." Strip the postcode and proper-
+# noun street tokens leak into the following locality ("Rue René Cassin, Paris" → street="Rue Ren",
+# locality="Cassin"). Measured: 90% FR streets intact, a ~10% bare-no-postcode tail that owns the demo
+# address. NOT data absence (BAN is in the corpus) — postcode-anchoring DISTRIBUTION imbalance.
+#
+# THE CHANGE (ONE variable): the synth-fr-bare-street shard — 10.8k real BAN (street, number, city) tuples
+# rendered as the MISSING distribution: bare comma form "<n> Rue <proper-noun name>, <City>", NO postcode.
+# BAN-sourced (Licence Ouverte / permissive) on purpose — the model must stay clean of the ODbL OSM data
+# (that is quarantined to the opt-in rooftop shards). Weight 6.0 = the targeted-fix precedent
+# (synth-german / synth-fr-admin-split / gnaf all 6.0).
+#
+# GATE (the probe — falsifies coverage-imbalance vs modeling-deficit, per DeepSeek): re-run
+# scripts/diagnostic/fr-parse-recall.ts (bare FR street-intact rate, target the 90%→tail) AND US/intl
+# no-regression (the per-tag floors). MOVES → imbalance confirmed → scale to a full run within the $20 cap.
+# FLAT → modeling deficit (comma-boundary feature / decoder), a different fix. conventions-loss-mask is OFF
+# in this lineage already (v193a3), and FR street_prefix is taught by synth-fr-admin-split today, so the
+# v1.6.0 ~7M-loss mask blow-up does NOT apply here. NOT promoted without operator GO + the gate.
+# Launch: modal run -d scripts/modal/train_remote.py --config v1.9.4-fr-bare-street.yaml --resume auto
+data:
+  # v0.9.4 overlay = v0.9.3a3's 694 shards VERBATIM (re-rooted to /data) + the 1 fr-bare-street shard.
+  corpus_dir: /data/corpus/versioned/v0.9.4-fr-bare-street/corpus-v0.9.4-fr-bare-street
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-bsplice
+  max_length: 128
+  country_weights: # VERBATIM from v1.9.3a3 (22 countries) — no new locales (surgical).
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+    ES: 1.0
+    IT: 1.0
+    NL: 1.0
+    PT: 1.0
+    BE: 1.0
+    PL: 1.0
+    AT: 1.0
+    CH: 1.0
+    CZ: 1.0
+    DK: 1.0
+    NO: 1.0
+    SE: 1.0
+    FI: 1.0
+    IE: 1.0
+    GB: 1.0
+    SK: 1.0
+    SI: 1.0
+    HR: 1.0
+    HU: 1.0
+    AU: 1.0
+  source_weights: # VERBATIM from v1.9.3a3 + the one new fr-bare-street shard.
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 3.0
+    synth-fr-admin-split: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    overture: 3.0
+    gnaf: 6.0
+    synth-anchor-absorption: 6.0
+    # #251 NEW: the bare-no-postcode FR street shard. 6.0 = targeted-fix precedent.
+    synth-fr-bare-street: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+  anchor_paint_mode: shaped
+  anchor_value_mode: posterior_latlon
+
+model: # VERBATIM from v1.9.3a3.
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train: # v1.9.7 init_from idiom (fresh optimizer over the surgery export); data blocks v1.9.4-verbatim.
+  init_from: /data/models/bsplice-expanded
+  output_dir: /data/output-v198-bare-street-bsplice-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 5.0e-5
+  weight_decay: 0.01
+  warmup_steps: 200
+  grad_clip_norm: 1.0
+  # FULL RUN: --resume auto picks the probe's step-082000 (latest in output_dir); max_steps 92000 → +10k.
+  # Constant LR 1.5e-4; anchor-dropout curriculum at full strength. Eval every 2k → gate 84/86/88/90/92k and
+  # ship the best (FR street-intact up, US floors held).
+  max_steps: 12000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v1.9.8-bare-street-bsplice-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/configs/v1.9.9-bare-street-si.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v1.9.9-bare-street-si.yaml
@@ -1,0 +1,224 @@
+# === v1.9.9-bare-street-si (#901 run 2 — fr-bare-street + the SI no-street counter-shard) ===
+# NIGHT-31. v1.9.8 was FALSIFIED at its full gate: US/CZ/PL/SK ni PASS but SI ni FAIL at 6k AND 10k
+# (resolve -3.4pp; 37 rows lost, all the Slovenian no-street "Village N, Postcode Village" form —
+# "Apače 108" split into street "Apače 10" + house "8"). The bare-street boundary lesson generalizes
+# onto a form where the leading name must keep its number whole and the trailing mention must stay
+# locality-bound. Per the falsified-lever rule nothing from v1.9.8 ships; THIS run pairs the shard
+# with its counter-distribution: synth-si-bare-village (6,285 real OA SI village tuples, 3 orders,
+# gold = street:V / house_number:n / postcode:pc / locality:V-trailing).
+# ONE compositional change vs v1.9.8 (corpus overlay v0.9.9 = v0.9.4 + the SI shard, weight 6.0).
+#
+# PROBE GATE (2k, pre-registered in gate-v193/RESULTS.md BEFORE launch — now WITH the failure slice,
+# the run-1 lesson): (a) FR bare-intact >= 92% (n=40 fr-parse-recall); (b) the 37 v1.9.8-lost SI rows
+# graded end-to-end (si-lost37.jsonl): >= 30/37 resolved; (c) US 12-row spot byte-identical-ish.
+# FULL GATE: unchanged from v1.9.8's registration (US-2k ni, CZ/PL/SK/SI 1k ni incl. SI PASS, FR
+# bare-street WIN, 17 floors).
+# Launch: modal run -d scripts/modal/train_remote.py --config v1.9.9-bare-street-si.yaml --resume none
+#
+# --- v1.9.8 header below for the record ---
+# === v1.9.8-bare-street-bsplice (#901 run 1 — the fr-bare-street shard on the SHIPPED spliced base) ===
+# NIGHT-31 (2026-07-02, $30 cap). Restores the v4.16.0-demo-only fr-bare-street capability that the v5.1.0
+# repoint traded away — now trained ON the spliced vocab so it ships in the main line. ONE variable vs the
+# shipped v5.1.0 model: the synth-fr-bare-street shard (the corpus + weights below are v1.9.4 VERBATIM,
+# which is v1.9.3a3 + that one shard).
+#
+# CASE-AUG DELIBERATELY EXCLUDED (schedule adjustment vs the night plan): v1.9.6-surface-aug-full was
+# SHELVED 2026-06-30 (#261) — the metamorphic layer introduced 2 casing/whitespace regressions, and the
+# deterministic fix (#834 normalize + #895 normalizeCase default-ON, landed 2026-07-02) covers the gap.
+# Revisit only with a recipe that clears the metamorphic gate; not tonight, not as a second variable.
+#
+# INIT: init_from /data/models/bsplice-expanded (the v5.1.0 surgery export: v1.9.3a3 weights + 10,582
+# mean-init rows). resume is IMPOSSIBLE here — the export carries no optimizer state and the old moments
+# would not match the expanded embedding shape; the skill's resume-rule presumes a resumable ckpt. The
+# v1.9.7 fine-tune block is the precedented idiom (fresh optimizer, lr 5e-5, warmup 200, constant).
+#
+# SEQUENCE: PROBE = 2k steps (this file as-is). Probe gate (pre-registered, gate-v193/RESULTS.md):
+# fr-parse-recall.ts bare-FR street-intact rate moves UP from the shipped-pair baseline AND US quick
+# slices hold. Early-kill @1k on non-decreasing loss. PASS -> RESUME this run's step-002000 ckpt with
+# max_steps bumped to 12000 (the +10k full-run precedent from v1.9.4). Full gate = the night plan table.
+# Launch: modal run -d scripts/modal/train_remote.py --config v1.9.8-bare-street-bsplice.yaml
+#
+# --- v1.9.4 header (the shard's rationale) kept below for the record ---
+# === v1.9.4-fr-bare-street (#251/#148 — teach the FR street→locality boundary WITHOUT a postcode anchor) ===
+# FULL RUN (probe GREEN: 2k-step step-082000 gave bare-FR street-intact 89→92%, demo "Rue du Chevaleret,
+# Paris" FIXED, US 4/4 tag-identical → imbalance confirmed, not modeling deficit). Continue from the probe's
+# step-082000 (--resume auto) to step-092000 (+10k); eval every 2k → gate each checkpoint (US per-tag floors)
+# and ship the FR-up/US-held sweet spot. SAME single variable (the fr-bare-street shard) — clean attribution.
+# v1.9.3a3 (shipped v4.16.x) is verbatim below EXCEPT: corpus_dir → the v0.9.4 overlay, and ONE new
+# source_weight (synth-fr-bare-street). Everything else — model, anchor knobs, class_weights, country_weights,
+# the other source_weights, LR/schedule — is IDENTICAL to v193a3, so the SINGLE variable is the new shard
+# (clean attribution).
+#
+# ROOT MECHANISM (DeepSeek Pro 019f1097 + libpostal's own documented practice, both independent): every
+# comprehensive FR source (BAN, OSM) is postcode-COMPLETE, so the decoder learned the FR street→locality
+# boundary as "the token after the 5-digit postcode," NEVER as "comma + city." Strip the postcode and proper-
+# noun street tokens leak into the following locality ("Rue René Cassin, Paris" → street="Rue Ren",
+# locality="Cassin"). Measured: 90% FR streets intact, a ~10% bare-no-postcode tail that owns the demo
+# address. NOT data absence (BAN is in the corpus) — postcode-anchoring DISTRIBUTION imbalance.
+#
+# THE CHANGE (ONE variable): the synth-fr-bare-street shard — 10.8k real BAN (street, number, city) tuples
+# rendered as the MISSING distribution: bare comma form "<n> Rue <proper-noun name>, <City>", NO postcode.
+# BAN-sourced (Licence Ouverte / permissive) on purpose — the model must stay clean of the ODbL OSM data
+# (that is quarantined to the opt-in rooftop shards). Weight 6.0 = the targeted-fix precedent
+# (synth-german / synth-fr-admin-split / gnaf all 6.0).
+#
+# GATE (the probe — falsifies coverage-imbalance vs modeling-deficit, per DeepSeek): re-run
+# scripts/diagnostic/fr-parse-recall.ts (bare FR street-intact rate, target the 90%→tail) AND US/intl
+# no-regression (the per-tag floors). MOVES → imbalance confirmed → scale to a full run within the $20 cap.
+# FLAT → modeling deficit (comma-boundary feature / decoder), a different fix. conventions-loss-mask is OFF
+# in this lineage already (v193a3), and FR street_prefix is taught by synth-fr-admin-split today, so the
+# v1.6.0 ~7M-loss mask blow-up does NOT apply here. NOT promoted without operator GO + the gate.
+# Launch: modal run -d scripts/modal/train_remote.py --config v1.9.4-fr-bare-street.yaml --resume auto
+data:
+  # v0.9.4 overlay = v0.9.3a3's 694 shards VERBATIM (re-rooted to /data) + the 1 fr-bare-street shard.
+  corpus_dir: /data/corpus/versioned/v0.9.9-si-bare-village/corpus-v0.9.9-si-bare-village
+  tokenizer_dir: /data/models/tokenizer/v0.6.0-bsplice
+  max_length: 128
+  country_weights: # VERBATIM from v1.9.3a3 (22 countries) — no new locales (surgical).
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+    ES: 1.0
+    IT: 1.0
+    NL: 1.0
+    PT: 1.0
+    BE: 1.0
+    PL: 1.0
+    AT: 1.0
+    CH: 1.0
+    CZ: 1.0
+    DK: 1.0
+    NO: 1.0
+    SE: 1.0
+    FI: 1.0
+    IE: 1.0
+    GB: 1.0
+    SK: 1.0
+    SI: 1.0
+    HR: 1.0
+    HU: 1.0
+    AU: 1.0
+  source_weights: # VERBATIM from v1.9.3a3 + the one new fr-bare-street shard.
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 3.0
+    synth-fr-admin-split: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    overture: 3.0
+    gnaf: 6.0
+    synth-anchor-absorption: 6.0
+    # #251 NEW: the bare-no-postcode FR street shard. 6.0 = targeted-fix precedent.
+    synth-fr-bare-street: 6.0
+    synth-si-bare-village: 6.0 # run-2 counter-shard (see header)
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+  anchor_paint_mode: shaped
+  anchor_value_mode: posterior_latlon
+
+model: # VERBATIM from v1.9.3a3.
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train: # v1.9.7 init_from idiom (fresh optimizer over the surgery export); data blocks v1.9.4-verbatim.
+  init_from: /data/models/bsplice-expanded
+  output_dir: /data/output-v199-bare-street-si-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 5.0e-5
+  weight_decay: 0.01
+  warmup_steps: 200
+  grad_clip_norm: 1.0
+  # FULL RUN: --resume auto picks the probe's step-082000 (latest in output_dir); max_steps 92000 → +10k.
+  # Constant LR 1.5e-4; anchor-dropout curriculum at full strength. Eval every 2k → gate 84/86/88/90/92k and
+  # ship the best (FR street-intact up, US floors held).
+  max_steps: 6000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v1.9.9-bare-street-si-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/configs/v2.1.0-boundary-family-probe.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v2.1.0-boundary-family-probe.yaml
@@ -1,0 +1,169 @@
+# 2k PROBE variant of v2.1.0-boundary-family — diagnostic-before-fix. Bars in gate-v193/RESULTS.md.
+# v2.1.0-boundary-family — #901 re-scoped: the four-orthography leading-name-boundary family,
+# trained as ONE variable on the SHIPPED v5.2.0 base (nsplice-v2-expanded, tokenizer v0.7.1-nsplice).
+#
+# The family (one decode class, four orthographies — all real-tuple synthetic, 3 orders each,
+# balanced polarity per the v1.9.9 lesson):
+#   synth-fr-bare-street        (#831: "181 Rue du Chevaleret, Paris" — in the v0.9.4 base)
+#   synth-si-bare-village       (v1.9.9: "Zabiče 8, 6250 Zabiče" — the run-2 counter-form)
+#   synth-no-street-led         (post-#920 row-read: street-led 30% vs pc-first 7% residual)
+#   synth-cz-pcfirst-preposition(#897 close-out: leading postcode → house_number, "nad X" shatters)
+#
+# init_from (fresh optimizer over the surgery export — the v1.9.7 idiom; the nsplice-v2 export has
+# no optimizer state). Probe 2k FIRST; the probe gate covers EVERY graded locale at reduced n
+# (the run-1 lesson). Pre-registration in gate-v193/RESULTS.md before any grade.
+data:
+  # v0.9.4 overlay = v0.9.3a3's 694 shards VERBATIM (re-rooted to /data) + the 1 fr-bare-street shard.
+  corpus_dir: /data/corpus/versioned/v0.10.0-boundary-family/corpus-v0.10.0-boundary-family
+  tokenizer_dir: /data/models/tokenizer/v0.7.1-nsplice
+  max_length: 128
+  country_weights: # VERBATIM from v1.9.3a3 (22 countries) — no new locales (surgical).
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+    ES: 1.0
+    IT: 1.0
+    NL: 1.0
+    PT: 1.0
+    BE: 1.0
+    PL: 1.0
+    AT: 1.0
+    CH: 1.0
+    CZ: 1.0
+    DK: 1.0
+    NO: 1.0
+    SE: 1.0
+    FI: 1.0
+    IE: 1.0
+    GB: 1.0
+    SK: 1.0
+    SI: 1.0
+    HR: 1.0
+    HU: 1.0
+    AU: 1.0
+  source_weights: # VERBATIM from v1.9.3a3 + the one new fr-bare-street shard.
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 3.0
+    synth-fr-admin-split: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    overture: 3.0
+    gnaf: 6.0
+    synth-anchor-absorption: 6.0
+    # #251 NEW: the bare-no-postcode FR street shard. 6.0 = targeted-fix precedent.
+    synth-fr-bare-street: 6.0
+    synth-si-bare-village: 6.0 # the family, balanced polarity
+    synth-no-street-led: 6.0
+    synth-cz-pcfirst-preposition: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+  anchor_paint_mode: shaped
+  anchor_value_mode: posterior_latlon
+
+model: # VERBATIM from v1.9.3a3.
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train: # v1.9.7 init_from idiom (fresh optimizer over the surgery export); data blocks v1.9.4-verbatim.
+  init_from: /data/models/nsplice-v2-expanded
+  output_dir: /data/output-v210-probe-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 5.0e-5
+  weight_decay: 0.01
+  warmup_steps: 200
+  grad_clip_norm: 1.0
+  # FULL RUN: --resume auto picks the probe's step-082000 (latest in output_dir); max_steps 92000 → +10k.
+  # Constant LR 1.5e-4; anchor-dropout curriculum at full strength. Eval every 2k → gate 84/86/88/90/92k and
+  # ship the best (FR street-intact up, US floors held).
+  max_steps: 2000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v1.9.8-bare-street-bsplice-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/configs/v2.1.0-boundary-family.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v2.1.0-boundary-family.yaml
@@ -1,0 +1,168 @@
+# v2.1.0-boundary-family — #901 re-scoped: the four-orthography leading-name-boundary family,
+# trained as ONE variable on the SHIPPED v5.2.0 base (nsplice-v2-expanded, tokenizer v0.7.1-nsplice).
+#
+# The family (one decode class, four orthographies — all real-tuple synthetic, 3 orders each,
+# balanced polarity per the v1.9.9 lesson):
+#   synth-fr-bare-street        (#831: "181 Rue du Chevaleret, Paris" — in the v0.9.4 base)
+#   synth-si-bare-village       (v1.9.9: "Zabiče 8, 6250 Zabiče" — the run-2 counter-form)
+#   synth-no-street-led         (post-#920 row-read: street-led 30% vs pc-first 7% residual)
+#   synth-cz-pcfirst-preposition(#897 close-out: leading postcode → house_number, "nad X" shatters)
+#
+# init_from (fresh optimizer over the surgery export — the v1.9.7 idiom; the nsplice-v2 export has
+# no optimizer state). Probe 2k FIRST; the probe gate covers EVERY graded locale at reduced n
+# (the run-1 lesson). Pre-registration in gate-v193/RESULTS.md before any grade.
+data:
+  # v0.9.4 overlay = v0.9.3a3's 694 shards VERBATIM (re-rooted to /data) + the 1 fr-bare-street shard.
+  corpus_dir: /data/corpus/versioned/v0.10.0-boundary-family/corpus-v0.10.0-boundary-family
+  tokenizer_dir: /data/models/tokenizer/v0.7.1-nsplice
+  max_length: 128
+  country_weights: # VERBATIM from v1.9.3a3 (22 countries) — no new locales (surgical).
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+    ES: 1.0
+    IT: 1.0
+    NL: 1.0
+    PT: 1.0
+    BE: 1.0
+    PL: 1.0
+    AT: 1.0
+    CH: 1.0
+    CZ: 1.0
+    DK: 1.0
+    NO: 1.0
+    SE: 1.0
+    FI: 1.0
+    IE: 1.0
+    GB: 1.0
+    SK: 1.0
+    SI: 1.0
+    HR: 1.0
+    HU: 1.0
+    AU: 1.0
+  source_weights: # VERBATIM from v1.9.3a3 + the one new fr-bare-street shard.
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 3.0
+    synth-fr-admin-split: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    overture: 3.0
+    gnaf: 6.0
+    synth-anchor-absorption: 6.0
+    # #251 NEW: the bare-no-postcode FR street shard. 6.0 = targeted-fix precedent.
+    synth-fr-bare-street: 6.0
+    synth-si-bare-village: 6.0 # the family, balanced polarity
+    synth-no-street-led: 6.0
+    synth-cz-pcfirst-preposition: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+  anchor_paint_mode: shaped
+  anchor_value_mode: posterior_latlon
+
+model: # VERBATIM from v1.9.3a3.
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train: # v1.9.7 init_from idiom (fresh optimizer over the surgery export); data blocks v1.9.4-verbatim.
+  init_from: /data/models/nsplice-v2-expanded
+  output_dir: /data/output-v210-boundary-family-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 5.0e-5
+  weight_decay: 0.01
+  warmup_steps: 200
+  grad_clip_norm: 1.0
+  # FULL RUN: --resume auto picks the probe's step-082000 (latest in output_dir); max_steps 92000 → +10k.
+  # Constant LR 1.5e-4; anchor-dropout curriculum at full strength. Eval every 2k → gate 84/86/88/90/92k and
+  # ship the best (FR street-intact up, US floors held).
+  max_steps: 12000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v1.9.8-bare-street-bsplice-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus/src/shard-recipes/cz-pcfirst-preposition.ts
+++ b/corpus/src/shard-recipes/cz-pcfirst-preposition.ts
@@ -1,0 +1,80 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `cz-pcfirst-preposition` — the Czech pc-first prepositional-locality shard, fourth orthography
+ *   of the #901 leading-name-boundary family. The #897 close-out read all 8 residual CZ rows as one
+ *   class: a LEADING postcode mis-assigned as house_number while the multi-word "nad/pod/u X"
+ *   locality shatters ("51244 Rokytnice nad Jizerou, Dolní Rokytnice 111" → street
+ *   'RokytnicenadJizerou' + house_number '51244'). That leading-5-digit confusion is the
+ *   anchor-pollution class whose decode-time OVERRIDE was correctly killed in #723 — this shard is
+ *   the model-first fix as DATA: real prepositional localities in the order that breaks, so the
+ *   model learns that a leading postcode before a multi-word name is a postcode. pc-first leads the
+ *   cycle (the lesson); canonical and city-first keep the polarity balanced (the v1.9.9 lesson).
+ */
+
+import { alignAndWrite, makeMulberry32, readTuples, type ShardRecipe, shardSourceID } from "./scaffold.js"
+
+export const czPcFirstPrepositionRecipe: ShardRecipe = {
+	name: "cz-pcfirst-preposition",
+	description:
+		"CZ pc-first + prepositional locality (#901 family): '«pc» «city nad X», «st» «n»' — the #723 class as data",
+	mode: "tuples",
+	async run(opts, write) {
+		makeMulberry32(opts.seed)
+		let read = 0
+		let emitted = 0
+		let skipped = 0
+
+		for await (const t of readTuples(opts.input!)) {
+			read++
+			const street = String(t.street ?? "").trim()
+			const city = String(t.locality ?? "").trim()
+			const number = String(t.number ?? "").trim()
+			const postcode = String(t.postcode ?? "").trim()
+
+			if (!street || !city || !number || !postcode) {
+				skipped++
+				continue
+			}
+			const order = read % 3
+			let raw: string
+			const components: Record<string, string> = {
+				street,
+				house_number: number,
+				postcode,
+				locality: city,
+			}
+
+			if (order === 0) {
+				raw = `${postcode} ${city}, ${street} ${number}`
+			} else if (order === 1) {
+				raw = `${street} ${number}, ${postcode} ${city}`
+			} else {
+				raw = `${city}, ${postcode}, ${street} ${number}`
+			}
+			const source_id = shardSourceID("synth-cz-pcfirst-preposition", {
+				...components,
+				o: String(order),
+				v: String(read),
+			})
+			const canonical = {
+				raw,
+				components,
+				country: "CZ",
+				locale: "cs-CZ",
+				source: "synth-cz-pcfirst-preposition",
+				source_id,
+				corpus_version: "0.10.0",
+				license:
+					"Synthetic — cz-pcfirst-preposition; (street, number, postcode, city) from OpenAddresses CZ (per-source attribution in the model card)",
+			}
+
+			if (alignAndWrite(write, canonical, "cz-pcfirst-preposition")) emitted++
+			else skipped++
+		}
+
+		return { read, emitted, skipped }
+	},
+}

--- a/corpus/src/shard-recipes/index.ts
+++ b/corpus/src/shard-recipes/index.ts
@@ -11,6 +11,7 @@
 import { anchorAbsorptionRecipe } from "./anchor-absorption.js"
 import { boundaryStressRecipe } from "./boundary-stress.js"
 import { countryBalancedRecipe } from "./country-balanced.js"
+import { czPcFirstPrepositionRecipe } from "./cz-pcfirst-preposition.js"
 import { frAdminSplitRecipe } from "./fr-admin-split.js"
 import { frBareStreetRecipe } from "./fr-bare-street.js"
 import { frOrderRecipe } from "./fr-order.js"
@@ -18,10 +19,12 @@ import { germanRecipe } from "./german.js"
 import { houseVenueRecipe } from "./house-venue.js"
 import { intersectionRecipe } from "./intersection.js"
 import { localeRecipe } from "./locale.js"
+import { noStreetLedRecipe } from "./no-street-led.js"
 import { noStreetRecipe } from "./no-street.js"
 import { poBoxCedexRecipe } from "./po-box-cedex.js"
 import { poBoxRecipe } from "./po-box.js"
 import type { ShardRecipe } from "./scaffold.js"
+import { siBareVillageRecipe } from "./si-bare-village.js"
 import { streetAffixRecipe } from "./street-affix.js"
 import { streetBareRecipe } from "./street-bare.js"
 import { streetRecipe } from "./street.js"
@@ -45,6 +48,9 @@ const RECIPES: readonly ShardRecipe[] = [
 	frOrderRecipe,
 	frAdminSplitRecipe,
 	frBareStreetRecipe,
+	czPcFirstPrepositionRecipe,
+	noStreetLedRecipe,
+	siBareVillageRecipe,
 	countryBalancedRecipe,
 	boundaryStressRecipe,
 	anchorAbsorptionRecipe,

--- a/corpus/src/shard-recipes/no-street-led.ts
+++ b/corpus/src/shard-recipes/no-street-led.ts
@@ -1,0 +1,77 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `no-street-led` — the Norwegian street-led shard, third orthography of the #901
+ *   leading-name-boundary family. The post-#920 NO row-read measured the residual as
+ *   ORDER-SENSITIVE decode: street-led forms ("Tangavegen 40, 5620 Tørvikbygd") carry a 30%
+ *   residual vs pc-first's 7% — the diacritic street head (…vegen/…veien with ø/å/æ) is the same
+ *   leading-name-before-comma boundary the FR bare-street and SI village forms exercise, in a
+ *   third orthography. All three real orders cycle per tuple (balanced polarity — the v1.9.9
+ *   lesson: a one-order gradient loses at convergence):
+ *
+ *   1. canonical  "«st» «n», «pc» «city»"   (the 30% residual class — the lesson)
+ *   2. city-first "«city», «pc», «st» «n»"
+ *   3. pc-first   "«pc» «city», «st» «n»"   (the 7% floor — the anchor the others converge to)
+ */
+
+import { alignAndWrite, makeMulberry32, readTuples, type ShardRecipe, shardSourceID } from "./scaffold.js"
+
+export const noStreetLedRecipe: ShardRecipe = {
+	name: "no-street-led",
+	description: "NO street-led boundary form (#901 family): '«st» «n», «pc» «city»' — diacritic street heads",
+	mode: "tuples",
+	async run(opts, write) {
+		makeMulberry32(opts.seed)
+		let read = 0
+		let emitted = 0
+		let skipped = 0
+
+		for await (const t of readTuples(opts.input!)) {
+			read++
+			const street = String(t.street ?? "").trim()
+			const city = String(t.locality ?? "").trim()
+			const number = String(t.number ?? "").trim()
+			const postcode = String(t.postcode ?? "").trim()
+
+			if (!street || !city || !number || !postcode) {
+				skipped++
+				continue
+			}
+			const order = read % 3
+			let raw: string
+			const components: Record<string, string> = {
+				street,
+				house_number: number,
+				postcode,
+				locality: city,
+			}
+
+			if (order === 0) {
+				raw = `${street} ${number}, ${postcode} ${city}`
+			} else if (order === 1) {
+				raw = `${city}, ${postcode}, ${street} ${number}`
+			} else {
+				raw = `${postcode} ${city}, ${street} ${number}`
+			}
+			const source_id = shardSourceID("synth-no-street-led", { ...components, o: String(order), v: String(read) })
+			const canonical = {
+				raw,
+				components,
+				country: "NO",
+				locale: "nb-NO",
+				source: "synth-no-street-led",
+				source_id,
+				corpus_version: "0.10.0",
+				license:
+					"Synthetic — no-street-led; (street, number, postcode, city) from OpenAddresses NO (per-source attribution in the model card)",
+			}
+
+			if (alignAndWrite(write, canonical, "no-street-led")) emitted++
+			else skipped++
+		}
+
+		return { read, emitted, skipped }
+	},
+}

--- a/corpus/src/shard-recipes/si-bare-village.ts
+++ b/corpus/src/shard-recipes/si-bare-village.ts
@@ -1,0 +1,85 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `si-bare-village` — the Slovenian no-street counter-shard (#901 run-2). Slovenia's rural
+ *   addressing has NO street line: the village name is the street-level token and repeats as the
+ *   locality ("Zabiče 8, 6250 Zabiče"). The v1.9.8 gate FALSIFIED the fr-bare-street shard alone on
+ *   exactly this class (SI resolve −3.4pp; "Apače 108" split into street "Apače 10" + house "8") —
+ *   the bare-street boundary lesson generalizes onto a form where the leading name must keep its
+ *   number whole and the trailing mention must stay locality-bound. This shard is the paired
+ *   counter-distribution: same lesson ("name before number, comma, then admin"), opposite polarity
+ *   on the trailing mention.
+ *
+ *   Three real-order templates cycle per tuple (mirrors the coord-golden orders so the eval and the
+ *   training distribution agree):
+ *
+ *   1. canonical  "«V» «n», «pc» «V»"
+ *   2. bare       "«V» «n», «V»"        (no postcode — the anchor-free form, the fr-bare lesson)
+ *   3. pc-first   "«pc» «V», «V» «n»"
+ *
+ *   Gold spans: leading «V» = street (matches OA ground truth — the village IS the address line),
+ *   «n» = house_number (NEVER split mid-digits), «pc» = postcode (never swallowing the neighbor),
+ *   trailing «V» = locality (the binding the resolver needs).
+ */
+
+import { alignAndWrite, makeMulberry32, readTuples, type ShardRecipe, shardSourceID } from "./scaffold.js"
+
+export const siBareVillageRecipe: ShardRecipe = {
+	name: "si-bare-village",
+	description: "SI no-street village form (#901 run-2): '«V» «n», «pc» «V»' — the fr-bare-street counter-distribution",
+	mode: "tuples",
+	async run(opts, write) {
+		makeMulberry32(opts.seed)
+		let read = 0
+		let emitted = 0
+		let skipped = 0
+
+		for await (const t of readTuples(opts.input!)) {
+			read++
+			const village = String(t.locality ?? "").trim()
+			const number = String(t.number ?? "").trim()
+			const postcode = String(t.postcode ?? "").trim()
+
+			if (!village || !number || !postcode) {
+				skipped++
+				continue
+			}
+			const order = read % 3
+			let raw: string
+			const components: Record<string, string> = {
+				street: village,
+				house_number: number,
+				locality: village,
+			}
+
+			if (order === 0) {
+				components.postcode = postcode
+				raw = `${village} ${number}, ${postcode} ${village}`
+			} else if (order === 1) {
+				raw = `${village} ${number}, ${village}`
+			} else {
+				components.postcode = postcode
+				raw = `${postcode} ${village}, ${village} ${number}`
+			}
+			const source_id = shardSourceID("synth-si-bare-village", { ...components, o: String(order), v: String(read) })
+			const canonical = {
+				raw,
+				components,
+				country: "SI",
+				locale: "sl-SI",
+				source: "synth-si-bare-village",
+				source_id,
+				corpus_version: "0.9.9",
+				license:
+					"Synthetic — si-bare-village; (village, number, postcode) from OpenAddresses SI (per-source attribution in the model card)",
+			}
+
+			if (alignAndWrite(write, canonical, "si-bare-village")) emitted++
+			else skipped++
+		}
+
+		return { read, emitted, skipped }
+	},
+}

--- a/scripts/modal/train_remote.py
+++ b/scripts/modal/train_remote.py
@@ -1296,6 +1296,47 @@ def sync_nsplice():
 @app.function(
     image=training_image,
     volumes={VOL_MOUNT: vol},
+    secrets=[r2_secret],
+    timeout=1800,
+)
+def sync_v210():
+    """#901 re-scoped: v2.1.0-boundary-family — the v0.10.0 overlay (v0.9.4 base VERBATIM + the
+    three new family shards si/no/cz; fr-bare-street already in the base) + code/configs. The
+    nsplice-v2-expanded init ckpt and the v0.7.1-nsplice tokenizer are already on the volume from
+    the v5.2.0 staging chain."""
+    import shutil
+    import subprocess
+
+    print("Syncing v0.10.0 overlay + code/configs from R2...")
+    vol.reload()
+    R = "--low-level-retries 30 --retries 8 --transfers 8 --checkers 16"
+    commands = [
+        f"rclone copy :s3:{BUCKET}/corpus-python/src/ {VOL_MOUNT}/corpus-python/src/ {R}",
+        f"rclone copy :s3:{BUCKET}/corpus/v0.10.0-boundary-family/corpus-v0.10.0-boundary-family/ "
+        f"{VOL_MOUNT}/corpus/versioned/v0.10.0-boundary-family/corpus-v0.10.0-boundary-family/ {R}",
+    ]
+    for i, cmd in enumerate(commands):
+        print(f"[{i+1}/{len(commands)}] {cmd[:90]}...")
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"rclone failed: {result.stderr[:300]}")
+    pyc = f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/__pycache__"
+    if os.path.isdir(pyc):
+        shutil.rmtree(pyc)
+    vol.commit()
+    for check, path in [
+        ("v2.1.0 config", f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/configs/v2.1.0-boundary-family.yaml"),
+        ("probe config", f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/configs/v2.1.0-boundary-family-probe.yaml"),
+        ("overlay MANIFEST", f"{VOL_MOUNT}/corpus/versioned/v0.10.0-boundary-family/corpus-v0.10.0-boundary-family/MANIFEST.json"),
+        ("init ckpt", f"{VOL_MOUNT}/models/nsplice-v2-expanded/pytorch_model.bin"),
+        ("tokenizer", f"{VOL_MOUNT}/models/tokenizer/v0.7.1-nsplice/tokenizer.model"),
+    ]:
+        print(f"  {check} present:", os.path.isfile(path))
+
+
+@app.function(
+    image=training_image,
+    volumes={VOL_MOUNT: vol},
     timeout=1200,
 )
 def mean_init_nsplice():


### PR DESCRIPTION
The #901 re-scoped campaign's reusable artifacts: two new orthography recipes (NO street-led from 117k real tuples; CZ pc-first prepositional — the entire 8.5k-tuple class), the v0.10.0 overlay assembly, v2.1.0 configs (full + probe), the sync fn, and the night-31 recipe/config salvage. The 2k probe was **killed by its pre-registered gate** (SI −3.4pp — third strike across three compositions; treadmill guard fired; fork posted on #901 with two single-knob options: synthetic-mass reduction vs width-48). The artifacts are the fork's raw material either way.

Ship-and-flag: recipes + configs are judgment surface — your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA