### PR TITLE
feat: proximity-bias hints — bias[] follows the map view (the 48026 rule)

### DIFF
--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -84,6 +84,8 @@ export interface ResolverBackend {
 		 * recovering localities the name-match alone misses. Backends without postcode support ignore it.
 		 */
 		postcode?: string
+		/** Proximity-bias points — a SOFT prominence re-rank; backends without support ignore it. */
+		bias?: Array<{ lat: number; lon: number; weight?: number }>
 		limit?: number
 	}): Promise<ResolvedPlace[]>
 	/**
@@ -217,6 +219,13 @@ export interface ResolveOpts {
 	 * overrides it deeper in the tree.
 	 */
 	defaultCountry?: string
+	/**
+	 * Ordered proximity-bias points (viewport center first, then user location, …), each optionally weighted (default
+	 * 1.0). SOFT ranking signal only — candidates near a bias point win prominence ties (the ambiguous-postcode case:
+	 * "48026" follows the map view to Michigan or Italy); recall and filters are untouched, and omitting it keeps ranking
+	 * byte-identical. Callers: the CLI's `--bias lat,lon[:weight]`, the demo's viewport/user hints, `GeocodeDeps.bias`.
+	 */
+	bias?: Array<{ lat: number; lon: number; weight?: number }>
 	/**
 	 * When a resolved parent constrains a child lookup (`parentID` is passed to the backend as a hard descendant filter)
 	 * and that filtered lookup returns NOTHING, retry the lookup once without the parent constraint. Guards against an

--- a/corpus-python/src/mailwoman_train/configs/v2.2.0-full-family.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v2.2.0-full-family.yaml
@@ -1,0 +1,162 @@
+# v2.2.0-full-family — THE #901 ANSWER AS A RECIPE: full FROM-SCRATCH retrain, the v1.9.3a3
+# NOTE (corrected during assembly): v1.9.3a3 was RESUME-lineage, not from-scratch — the modern line
+# never retrained from zero. This config is the v0.8-ERA from-scratch schedule (lr 1.5e-4, warmup
+# 1000, batch 128, 100k steps — the last true from-scratch era) on the v0.10.0-boundary-family
+# corpus (698 shards incl. the validated four-orthography family
+# @6.0) with tokenizer v0.7.1-nsplice (63,913 pieces) — the FIRST ground-up training on the
+# spliced vocab: the mean-init rows finally receive gradients WITH everything else instead of
+# being tipped by partial updates (the four-probe attribution, gate-v193/RESULTS.md 2026-07-03).
+# Acceptance rows: the five #901 knife-edge sentinels (gauntlet) + the full v5.2.0 battery.
+data:
+  # v0.9.4 overlay = v0.9.3a3's 694 shards VERBATIM (re-rooted to /data) + the 1 fr-bare-street shard.
+  corpus_dir: /data/corpus/versioned/v0.10.0-boundary-family/corpus-v0.10.0-boundary-family
+  tokenizer_dir: /data/models/tokenizer/v0.7.1-nsplice
+  max_length: 128
+  country_weights: # VERBATIM from v1.9.3a3 (22 countries) — no new locales (surgical).
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+    ES: 1.0
+    IT: 1.0
+    NL: 1.0
+    PT: 1.0
+    BE: 1.0
+    PL: 1.0
+    AT: 1.0
+    CH: 1.0
+    CZ: 1.0
+    DK: 1.0
+    NO: 1.0
+    SE: 1.0
+    FI: 1.0
+    IE: 1.0
+    GB: 1.0
+    SK: 1.0
+    SI: 1.0
+    HR: 1.0
+    HU: 1.0
+    AU: 1.0
+  source_weights: # VERBATIM from v1.9.3a3 + the one new fr-bare-street shard.
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 3.0
+    synth-fr-admin-split: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    overture: 3.0
+    gnaf: 6.0
+    synth-anchor-absorption: 6.0
+    # #251 NEW: the bare-no-postcode FR street shard. 6.0 = targeted-fix precedent.
+    synth-fr-bare-street: 6.0
+    synth-si-bare-village: 6.0 # the family, balanced polarity
+    synth-no-street-led: 6.0
+    synth-cz-pcfirst-preposition: 6.0
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+  anchor_paint_mode: shaped
+  anchor_value_mode: posterior_latlon
+
+model: # VERBATIM from v1.9.3a3.
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train: # FROM-SCRATCH, the v0.8-era schedule (lr 1.5e-4, warmup 1000, batch 128) at 100k steps.
+  output_dir: /data/output-v220-full-family-s42/checkpoints
+  seed: 42
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  learning_rate: 1.5e-4
+  weight_decay: 0.01
+  warmup_steps: 1000
+  grad_clip_norm: 1.0
+  # Constant LR 1.5e-4; anchor-dropout curriculum at full strength. Eval every 2k → gate 84/86/88/90/92k and
+  # ship the best (FR street-intact up, US floors held).
+  max_steps: 100000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v1.9.8-bare-street-bsplice-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/mailwoman/commands/geocode.test.ts
+++ b/mailwoman/commands/geocode.test.ts
@@ -20,7 +20,8 @@
  */
 
 import { execFileSync } from "node:child_process"
-import { existsSync } from "node:fs"
+import { existsSync, mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { describe, expect, test } from "vitest"
@@ -80,7 +81,7 @@ describe("geocode argument validation", () => {
 		).toThrow()
 	})
 
-	test("missing WOF DB exits 1 with a descriptive error", () => {
+	test("missing WOF DB exits 1 with a descriptive error (empty data root — the default shard set no longer exists)", () => {
 		if (!hasCLICompiled) {
 			console.warn("Skipping: CLI not compiled at", CLI_PATH)
 
@@ -92,8 +93,15 @@ describe("geocode argument validation", () => {
 		try {
 			execFileSync(process.execPath, [CLI_PATH, "geocode", "123 Main St, Anytown, TX 78000"], {
 				encoding: "utf8",
-				// Explicitly unset the env var so the command doesn't find a DB.
-				env: { ...process.env, MAILWOMAN_WOF_DB: undefined },
+				// Unset the env var AND point the data root at an empty dir: since the proximity-bias
+				// pass, geocode auto-attaches the wofShardPaths default set when the env is absent —
+				// on a standard data root that now SUCCEEDS (the new contract). The error contract
+				// only survives when no default shard exists either.
+				env: {
+					...process.env,
+					MAILWOMAN_WOF_DB: undefined,
+					MAILWOMAN_DATA_ROOT: mkdtempSync(join(tmpdir(), "mw-empty-")),
+				},
 				timeout: 15_000,
 			})
 		} catch (err: unknown) {

--- a/mailwoman/commands/geocode.tsx
+++ b/mailwoman/commands/geocode.tsx
@@ -26,6 +26,7 @@
  *   - 1 bad arguments, missing required DB, or fatal parse/resolve error
  */
 
+import { existsSync } from "node:fs"
 import { setImmediate } from "node:timers/promises"
 
 import { Spinner } from "@inkjs/ui"
@@ -46,7 +47,7 @@ import {
 	type ShardResolver,
 } from "../geocode-core.js"
 import { INTERP_RADIUS_CALIBRATION } from "../interp-calibration.js"
-import { createResolverBackend, mailwomanDataRoot, resolveCandidateDBPath } from "../resolver-backend.js"
+import { createResolverBackend, mailwomanDataRoot, resolveCandidateDBPath, wofShardPaths } from "../resolver-backend.js"
 import type { CommandComponent } from "../sdk/cli.js"
 import { resolverDefaultCountry } from "./parse.js"
 
@@ -64,6 +65,13 @@ const OptionsSchema = zod.object({
 		.optional()
 		.default("en-US")
 		.describe("Locale tag matching a weights package (en-US, fr-FR). Default en-US."),
+	bias: zod
+		.string()
+		.optional()
+		.describe(
+			"Proximity-bias points, strongest first: 'lat,lon[:weight];lat,lon' (e.g. the map viewport center, then " +
+				"the user's location). Soft re-rank only — an ambiguous bare postcode follows the nearest hint."
+		),
 	defaultCountry: zod
 		.string()
 		.optional()
@@ -143,17 +151,28 @@ const OptionsSchema = zod.object({
 // Path helpers
 // ---------------------------------------------------------------------------
 
-function resolveWOFPath(options: zod.infer<typeof OptionsSchema>): string {
-	const path = options.resolveDb ?? $public.MAILWOMAN_WOF_DB
+function resolveWOFPath(options: zod.infer<typeof OptionsSchema>): string[] {
+	// Comma-separated multi-shard paths (the HealthRouter/$MAILWOMAN_WOF_DB convention), else the
+	// wofShardPaths default set filtered to what exists on disk — the same auto-attach the server
+	// and drop-ins use, so `mailwoman geocode` works out of the box on a standard data root.
+	const raw = options.resolveDb ?? $public.MAILWOMAN_WOF_DB
+	const paths = (
+		raw
+			? raw
+					.split(",")
+					.map((p: string) => p.trim())
+					.filter(Boolean)
+			: wofShardPaths()
+	).filter((p: string) => existsSync(p))
 
-	if (!path) {
+	if (paths.length === 0) {
 		throw new Error(
 			"geocode needs a WOF admin SQLite path. Set $MAILWOMAN_WOF_DB or pass --resolve-db <path>. " +
 				"Build one with `mailwoman-wof-build-slim` + `mailwoman-wof-build-fts`."
 		)
 	}
 
-	return path
+	return paths
 }
 
 // ---------------------------------------------------------------------------
@@ -167,7 +186,7 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 	// candidate.db (--candidate-db / $MAILWOMAN_CANDIDATE_DB) is the demo-parity backend; when present it
 	// stands alone and a WOF admin path isn't required.
 	const candidateDb = resolveCandidateDBPath(options.candidateDb)
-	const wofPath = candidateDb ? "" : resolveWOFPath(options)
+	const wofPath = candidateDb ? [] : resolveWOFPath(options)
 
 	// Load the neural classifier (required for street-level; weights must be present).
 	let classifier: NeuralAddressClassifier
@@ -225,6 +244,19 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 		// so a single bare locality can skip the locale-INFERRED default country. "Paris" under the
 		// en-US locale must not be hard-scoped to Paris, Texas; an explicit --default-country still
 		// wins (resolverDefaultCountry returns it before the locale inference is consulted).
+		// --bias 'lat,lon[:weight];…' → ordered soft proximity hints (viewport first by convention).
+		const bias = (options.bias ?? "")
+			.split(";")
+			.map((part: string) => part.trim())
+			.filter(Boolean)
+			.map((part: string) => {
+				const [coords, w] = part.split(":")
+				const [lat, lon] = coords!.split(",").map(Number)
+
+				if (!Number.isFinite(lat) || !Number.isFinite(lon)) throw new Error(`--bias: bad point '${part}'`)
+
+				return { lat: lat!, lon: lon!, ...(w !== undefined ? { weight: Number(w) } : {}) }
+			})
 		const parsedTree = await parseForGeocode(input, { classifier })
 		const inferredScopeOK = options.defaultCountry || !isBareLocalityTree(parsedTree)
 		const result = await geocodeAddress(input, {
@@ -232,6 +264,7 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 			resolver,
 			shards,
 			parsedTree,
+			...(bias.length > 0 ? { bias } : {}),
 			defaultCountry: (inferredScopeOK && resolverDefaultCountry(options, !!candidateDb)) || undefined,
 			// Explicit --interp-calibration forces a single multiplier; unset → the per-region table (#584).
 			interpCalibration: options.interpCalibration ?? INTERP_RADIUS_CALIBRATION,

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -129,6 +129,11 @@ export interface GeocodeDeps {
 	 */
 	placeCountry?: PlaceCountryFn | false
 	/**
+	 * Proximity-bias points (viewport center, user location, …), strongest first — forwarded to the resolver as
+	 * ResolveOpts.bias (soft prominence re-rank; the ambiguous-postcode disambiguator).
+	 */
+	bias?: Array<{ lat: number; lon: number; weight?: number }>
+	/**
 	 * #743/#194: promote a CONFIDENT placer guess to a HARD country filter (empty→unresolved) for coverage-safelisted
 	 * countries — see {@link hardCountryFor}. **DEFAULT-ON** (#743): a pure win on well-covered countries
 	 * (US/ES/IT/NL/DE/FR), soft (no-op) for the rest. Pass `false` to opt out.
@@ -347,6 +352,8 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	opts.adminCoherence = deps.adminCoherence !== false
 
 	if (deps.defaultCountry) opts.defaultCountry = deps.defaultCountry
+
+	if (deps.bias && deps.bias.length > 0) opts.bias = deps.bias
 	// Coarse country router (#244, soft prior) — DEFAULT-ON (#244 M2). undefined → the bundled placer;
 	// a function → that placer; false → disabled. A confident in-map guess feeds the resolver's
 	// anchorPosterior re-rank; abstain/OTHER are no-ops and an explicit defaultCountry isn't disturbed.
@@ -462,7 +469,10 @@ export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeR
 	}
 
 	if (tier === "admin") {
-		const adminPriority: ReadonlyArray<string> = ["locality", "dependent_locality", "region", "country"]
+		// `postcode` joins the ladder (after the locality tiers, before region): a lone-postcode
+		// query resolves the postcode node itself — without it here the result reported 0,0 despite
+		// a resolved coordinate (found building the proximity-bias feature's 48026 case).
+		const adminPriority: ReadonlyArray<string> = ["locality", "dependent_locality", "postcode", "region", "country"]
 
 		for (const tag of adminPriority) {
 			const node = allNodes.find((n) => n.tag === tag && n.lat != null && n.lon != null)

--- a/resolver-wof-sqlite/exact-match-tiering.test.ts
+++ b/resolver-wof-sqlite/exact-match-tiering.test.ts
@@ -221,6 +221,37 @@ describe("findPlace — exact-match tiering", () => {
 		expect(gb).toHaveLength(0)
 	})
 
+	// The 48026 rule (proximity bias): two same-name postcode rows on different continents — with
+	// no hints, population-first picks the bigger one; with a bias point near the smaller, the
+	// prominence sort follows the hint. Soft only: both candidates still return.
+	test("bias re-ranks a cross-country postcode tie; absent bias = population order", async () => {
+		const db = buildDB([
+			{ id: 31, name: "48026", country: "IT", lat: 44.37, lon: 12.03, placetype: "postalcode", population: 12000 },
+			{ id: 32, name: "48026", country: "US", lat: 42.54, lon: -82.95, placetype: "postalcode", population: 900 },
+		])
+		lookup = new WOFSqlitePlaceLookup({ database: db, buildFTS: true })
+
+		const noBias = await lookup.findPlace({ text: "48026", placetype: "postalcode", limit: 2 })
+		expect(noBias[0]?.country).toBe("IT") // population-first, unchanged default
+
+		const usBias = await lookup.findPlace({
+			text: "48026",
+			placetype: "postalcode",
+			limit: 2,
+			bias: [{ lat: 42.33, lon: -83.05 }], // Detroit viewport
+		})
+		expect(usBias[0]?.country).toBe("US")
+		expect(usBias).toHaveLength(2) // soft — nothing filtered
+
+		const itBias = await lookup.findPlace({
+			text: "48026",
+			placetype: "postalcode",
+			limit: 2,
+			bias: [{ lat: 44.42, lon: 12.2 }], // Ravenna viewport
+		})
+		expect(itBias[0]?.country).toBe("IT")
+	})
+
 	test("a single candidate is unaffected (no tier to split)", async () => {
 		lookup = new WOFSqlitePlaceLookup({
 			database: buildDB([

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -39,7 +39,13 @@ import {
 import { bboxAround, haversineKm } from "./geo.js"
 import type { WOFPostalCityAliasLookup } from "./postal-city-alias-lookup.js"
 import type { WOFDatabase } from "./schema.js"
-import { pickShardForPlacetype, resolveShards, type ResolvedShard, type ShardConfig } from "./sharding.js"
+import {
+	pickShardForPlacetype,
+	pickShardsForPlacetype,
+	resolveShards,
+	type ResolvedShard,
+	type ShardConfig,
+} from "./sharding.js"
 import { SqliteConventionSource } from "./sqlite-convention-source.js"
 import type { FindPlaceQuery, PlaceCandidate, PlaceLookup, WOFPlacetype } from "./types.js"
 
@@ -114,6 +120,13 @@ export interface RankingWeights {
 	 * strong text match.
 	 */
 	proximityBoost: number
+	/**
+	 * Magnitude of the bias-hint term inside the exact-tier PROMINENCE sort (the `bias`/viewport path). Deliberately
+	 * population-scale (default = populationBoost) so a candidate near the map view / the user beats a distant-but-bigger
+	 * namesake — "the map view wins" is the feature; same-region ties (all candidates far from every hint) still fall to
+	 * population.
+	 */
+	biasBoost: number
 	/** Distance (km) at which the proximity boost halves. Tune to the typical query radius. */
 	proximityScaleKm: number
 	/**
@@ -161,6 +174,7 @@ const DEFAULT_WEIGHTS: RankingWeights = {
 	lengthPenaltyWeight: 0.1,
 	proximityBoost: 0.8,
 	proximityScaleKm: 100,
+	biasBoost: 4.0,
 	// populationBoost is intentionally large — empirical tuning against real WOF showed BM25 gaps
 	// of 1.5-3.0 between famous places and tiny same-name peers (because the famous ones have
 	// hundreds of alt-name entries that hurt their FTS document score). To consistently surface
@@ -636,7 +650,7 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 	 * Strategy `fallback_fuzzy_name_match` — the BM25 FTS name-match over the gazetteer, the universal fallback. Always
 	 * returns an array (never null), so it terminates the dispatch chain.
 	 */
-	async #fuzzyNameMatch(query: FindPlaceQuery): Promise<PlaceCandidate[]> {
+	async #fuzzyNameMatch(query: FindPlaceQuery, forceShard?: ResolvedShard): Promise<PlaceCandidate[]> {
 		const limit = query.limit ?? 10
 		// Over-fetch so post-scoring + exact-match tiering have room to re-rank. SHORT queries (a 2–3-char
 		// region abbreviation like "NY"/"VT") are the danger case the `exactMatchTiering` docstring flags:
@@ -663,10 +677,43 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 		// `placetype` always goes to main. (Mixed-placetype queries with multiple shards aren't
 		// supported in v1 — caller can issue two findPlace calls and merge in TS if needed.)
 		const firstPlacetype = placetypes?.[0]
-		const shard = pickShardForPlacetype(this.#shards, firstPlacetype, {
-			country: query.country,
-			countriesBySchema: this.#shardCountries,
-		})
+
+		// Bias fan-out (#58/proximity-bias): a country-less query WITH proximity hints must see the
+		// cross-shard ambiguity the hints exist to resolve — "48026" lives in postalcode-us AND
+		// postalcode-intl, and single-shard routing would hide one side. Query every matching shard
+		// (self-recursion with a shard pin), merge by id, and re-sort by the same (exact, prominence)
+		// keys the per-shard tier sort used. Bounded: hints + no country + >1 matching shard only.
+		const hasBiasHints = !!query.near || (query.bias?.length ?? 0) > 0
+
+		if (!forceShard && hasBiasHints && !query.country) {
+			const matching = pickShardsForPlacetype(this.#shards, firstPlacetype)
+
+			if (matching.length > 1) {
+				const pools: PlaceCandidate[][] = []
+
+				for (const sh of matching) pools.push(await this.#fuzzyNameMatch(query, sh))
+				const byID = new Map<PlaceCandidate["id"], PlaceCandidate>()
+
+				for (const c of pools.flat()) {
+					if (!byID.has(c.id)) byID.set(c.id, c)
+				}
+				const merged = [...byID.values()]
+				merged.sort(
+					(a, b) =>
+						Number(b.exactMatch ?? false) - Number(a.exactMatch ?? false) ||
+						(b.prominence ?? 0) - (a.prominence ?? 0) ||
+						b.score - a.score
+				)
+
+				return merged.slice(0, limit)
+			}
+		}
+		const shard =
+			forceShard ??
+			pickShardForPlacetype(this.#shards, firstPlacetype, {
+				country: query.country,
+				countriesBySchema: this.#shardCountries,
+			})
 		const sch = shard.schemaName // bare schema name; safe to interpolate (validated at construction)
 
 		// Filter out historical / superseded / deprecated places by default — they live in the same
@@ -832,22 +879,52 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 			// coordinates. The formula decays smoothly with distance so close-but-not-exact hits
 			// still benefit; tunable via proximityBoost + proximityScaleKm.
 			let distanceKm: number | undefined
+			// The best decayed-distance term over `near` + every `bias` point (each point's term is
+			// scaled by its weight; the MAX wins — a candidate near ANY hint is "nearby"). Carried
+			// into the exact-tier prominence sort below when hints are present.
+			let proximityTerm = 0
 
-			if (query.near && row.lat !== null && row.lon !== null && !(row.lat === 0 && row.lon === 0)) {
-				distanceKm = haversineKm(query.near.lat, query.near.lon, row.lat, row.lon)
-				score += this.#weights.proximityBoost / (1 + distanceKm / this.#weights.proximityScaleKm)
+			if (row.lat !== null && row.lon !== null && !(row.lat === 0 && row.lon === 0)) {
+				const hints: Array<{ lat: number; lon: number; weight: number }> = []
+
+				if (query.near) hints.push({ lat: query.near.lat, lon: query.near.lon, weight: 1 })
+
+				for (const b of query.bias ?? []) hints.push({ lat: b.lat, lon: b.lon, weight: b.weight ?? 1 })
+
+				let scoreTerm = 0
+
+				for (const h of hints) {
+					const d = haversineKm(h.lat, h.lon, row.lat, row.lon)
+					const decay = h.weight / (1 + d / this.#weights.proximityScaleKm)
+					const prom = decay * this.#weights.biasBoost
+
+					if (prom > proximityTerm) {
+						proximityTerm = prom
+						distanceKm = d
+						scoreTerm = decay * this.#weights.proximityBoost
+					}
+				}
+				score += scoreTerm
 			}
 
 			// Population boost: capped at `populationBoost` magnitude at `10^populationScaleLog10`
 			// people. Missing population → no contribution. Never penalizes.
+			let popTerm = 0
+
 			if (row.population !== null && row.population > 0 && this.#weights.populationScaleLog10 > 0) {
 				const popLog = Math.log10(1 + row.population)
 				const popFraction = Math.min(1, popLog / this.#weights.populationScaleLog10)
-				score += this.#weights.populationBoost * popFraction
+				popTerm = this.#weights.populationBoost * popFraction
+				score += popTerm
 			}
+			// Combined prominence for the exact-tier sort when proximity hints are present: population
+			// and nearness in the SAME additive units, so the map view / the user's location can win a
+			// cross-country postcode tie without a hard filter.
+			const prominence = popTerm + proximityTerm
 
 			const candidate: PlaceCandidate = {
 				id: row.id,
+				prominence,
 				name: row.name,
 				placetype: row.placetype as WOFPlacetype,
 				country: row.country ?? "",
@@ -922,13 +999,22 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 
 					return norm(String(c.name ?? "")) === needle ? 2 : 1
 				}
+				// With proximity hints (near/bias), prominence (population + nearness, same units)
+				// replaces raw population as the within-tier key — the 48026 rule: the map view or
+				// the user's location breaks a cross-country postcode tie. Without hints, population
+				// ordering is byte-identical to before.
+				const hasHints = !!query.near || (query.bias?.length ?? 0) > 0
 				candidates.sort((a, b) => {
 					const ax = kind(a)
 					const bx = kind(b)
 
 					if (bx !== ax) return bx - ax
 
-					if (ax >= 1) return (b.population ?? 0) - (a.population ?? 0) || b.score - a.score
+					if (ax >= 1) {
+						if (hasHints) return (b.prominence ?? 0) - (a.prominence ?? 0) || b.score - a.score
+
+						return (b.population ?? 0) - (a.population ?? 0) || b.score - a.score
+					}
 
 					return b.score - a.score
 				})

--- a/resolver-wof-sqlite/sharding.ts
+++ b/resolver-wof-sqlite/sharding.ts
@@ -151,6 +151,35 @@ export function resolveShards(input: string | ReadonlyArray<string | ShardConfig
  * the typical mailwoman query has a single placetype anyway. If a caller needs cross-shard results they can issue two
  * `findPlace` calls.
  */
+/**
+ * All placetype-matching shards, in routing order (the country-aware pick chooses among these). Used by the bias path:
+ * a country-less postcode query with proximity hints fans out across every matching shard and merges, because
+ * single-shard routing would hide the cross-country ambiguity the hints exist to resolve ("48026" lives in
+ * postalcode-us AND postalcode-intl).
+ */
+export function pickShardsForPlacetype(shards: ResolvedShard[], placetype: string | undefined): ResolvedShard[] {
+	if (!placetype) return [shards[0]!]
+	const matches: ResolvedShard[] = []
+
+	for (const s of shards) {
+		if (s.placetypes.includes(placetype)) matches.push(s)
+	}
+
+	for (const s of shards) {
+		if (s.schemaName === "main" || matches.includes(s)) continue
+
+		if (
+			s.schemaName === placetype ||
+			s.schemaName.startsWith(`${placetype}_`) ||
+			s.schemaName.endsWith(`_${placetype}`)
+		) {
+			matches.push(s)
+		}
+	}
+
+	return matches.length > 0 ? matches : [shards[0]!]
+}
+
 export function pickShardForPlacetype(
 	shards: ResolvedShard[],
 	placetype: string | undefined,

--- a/resolver-wof-sqlite/types.ts
+++ b/resolver-wof-sqlite/types.ts
@@ -64,6 +64,12 @@ export interface PlaceCandidate {
 	 */
 	exactMatch?: boolean
 	/**
+	 * Combined prominence (population term + best proximity-bias term, same additive units) — populated by the FTS
+	 * lookup; the exact-tier sort orders by THIS instead of raw population when the query carried proximity hints
+	 * (`near`/`bias`).
+	 */
+	prominence?: number
+	/**
 	 * Population from WOF's `wof:population` property. Only present when the candidate has it on record — WOF carries
 	 * population for ~15% of localities (mostly larger ones). Absent does NOT mean zero, just unknown.
 	 */
@@ -132,6 +138,15 @@ export interface FindPlaceQuery {
 	postcode?: string
 	/** Proximity hint — candidates close to this point get a ranking boost. */
 	near?: GeoPoint & { maxDistanceKm?: number }
+	/**
+	 * Ordered proximity-bias points (viewport center, user location, …), each optionally weighted (default 1.0, first
+	 * entry strongest by convention). SOFT — a re-rank signal, never a filter: with bias present, exact-tier candidates
+	 * order by combined prominence (population + the best decayed-distance term over these points) instead of population
+	 * alone, which is how an ambiguous bare postcode ("48026": Fraser MI vs Russi IT) follows the map view / the user.
+	 * Absent (and no `near`) → ranking is byte-identical to today. `near` is treated as a weight-1.0 bias point for
+	 * back-compat.
+	 */
+	bias?: Array<GeoPoint & { weight?: number }>
 	/** Bounding-box filter — only candidates whose bbox intersects this box are returned. */
 	bbox?: GeoBbox
 	/** Default 10. */

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -51,6 +51,8 @@ interface ResolutionState {
 	 * can inject postcode-proximal locality candidates.
 	 */
 	postcode?: string
+	/** Proximity-bias points (viewport, user location) — forwarded to every primary lookup. */
+	bias?: Array<{ lat: number; lon: number; weight?: number }>
 	/** Postcode-anchor country posterior (#369). Undefined = no re-rank (byte-stable default). */
 	anchorPosterior?: Record<string, number>
 	/** Weight on the posterior in the locality re-rank. Only used when `anchorPosterior` is set. */
@@ -614,6 +616,7 @@ class WOFResolver implements Resolver {
 			defaultCountry: opts.defaultCountry,
 			parentFallback: opts.parentFallback ?? true,
 			postcode: firstPostcodeValue(tree.roots),
+			bias: opts.bias,
 			anchorPosterior: opts.anchorPosterior,
 			anchorWeight: opts.anchorWeight ?? 2.0,
 			hardCountry: opts.hardCountry,
@@ -768,6 +771,11 @@ class WOFResolver implements Resolver {
 			placetype,
 			limit: state.candidatesPerLookup,
 		}
+
+		// Proximity bias (viewport center, user location, …) — a SOFT re-rank the backend folds into
+		// its exact-tier prominence; never a filter, so recall is untouched. This is how an ambiguous
+		// bare postcode ("48026") follows the map view instead of a global population coin-flip.
+		if (state.bias && state.bias.length > 0) query.bias = state.bias
 
 		// Pass the inherited parent constraint to the backend when available — `parentID` scopes to
 		// the resolved parent's descendants. For `country`: a resolved parent's country wins, else


### PR DESCRIPTION
Your 48026 case, end to end: `mailwoman geocode "48026" --bias "44.42,12.20"` → Russi, Ravenna; `--bias "42.33,-83.05"` → Fraser, Michigan; no bias → unchanged byte-identical ranking (US-2k dump-verified).

**Design:** `bias: Array<{lat, lon, weight?}>` — ordered, weighted, SOFT. In hint mode the exact tier sorts by prominence = population term + a population-ceiling distance decay (max over hints), so the map view wins cross-continent ties while same-region ties still fall to population. Country-less hinted queries fan out across all placetype-matching shards and merge — single-shard routing otherwise hides exactly the ambiguity the hints resolve. Plumbed through `ResolveOpts` → `GeocodeDeps` → CLI `--bias 'lat,lon[:weight];…'`; the demo's viewport-center + IP-location wiring is the follow-up consumer.

Drive-bys: the geocode CLI now auto-attaches the `wofShardPaths` default set (and accepts comma lists) — it works out of the box on a standard data root; `postcode` joined the result coordinate ladder (lone-postcode geocodes reported 0,0).

Ranking-behavior surface — flagged for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA