### PR TITLE
feat(#936): officialNameExact — official-language names join the name-exact sub-tier (option 3, default OFF)

### DIFF
--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -163,6 +163,25 @@ export interface RankingWeights {
 	 * handful of states match a 2-letter query).
 	 */
 	exactMatchTiering: boolean
+	/**
+	 * #936 option 3 — official-language names ARE names. When true, a candidate holding the query as an OFFICIAL name
+	 * (`names.official = 1`: a preferred-form name in an official language of its country, stamped at ingest) joins the
+	 * NAME-exact sub-tier rather than the alias-exact one, provided its population clears {@link officialNameExactFloor}.
+	 * Fixes unscoped "Åbo" → Turku (its official Swedish name) over a hamlet literally named Åbo; population still orders
+	 * within the sub-tier, so Paris → Paris FR is untouched.
+	 *
+	 * Default false (byte-stable). Requires a gazetteer built with the #940 ingest bit — on older DBs without the
+	 * `official` column the probe fails soft and behavior is identical to the flag being off.
+	 */
+	officialNameExact: boolean
+	/**
+	 * Minimum population for a candidate's official names to join the name-exact sub-tier. The #936 review's no-floor
+	 * census measured the boundary: ≥100k holders are the famous-exonym class (757 flips, intent-correct; 7 collisions,
+	 * none harmful) while 10k–100k holders are junk-dominated (3,481 flips led by short-form mis-tags — Villeneuve-Loubet
+	 * carrying "villeneuve" would bury five real villages of that name). Rank-time knob: tunable without re-ingest;
+	 * below-floor official names simply stay alias-tier (today's behavior).
+	 */
+	officialNameExactFloor: number
 }
 
 const DEFAULT_WEIGHTS: RankingWeights = {
@@ -191,6 +210,9 @@ const DEFAULT_WEIGHTS: RankingWeights = {
 	// consulted — keeps population as an intra-tier prominence tiebreaker, not a cross-tier promoter.
 	// Fixes the 2-letter-region-abbrev bug ("ME" → Maine, not the more-populous Missouri).
 	exactMatchTiering: true,
+	// #936 option 3 ships default-OFF behind its gate battery; see the RankingWeights docstring.
+	officialNameExact: false,
+	officialNameExactFloor: 100_000,
 }
 
 /**
@@ -994,10 +1016,28 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 				// sub-tier as before.
 				const norm = (v: string): string => v.toLowerCase().trim().replace(/\s+/g, " ")
 				const needle = norm(query.text)
+				// #936 option 3: an OFFICIAL name (preferred form in an official language of the place's
+				// country, `names.official = 1`) counts as the place's own name for the sub-tier — "Åbo" is
+				// Turku's name, not merely its alias. Floor-gated on the holder's population (see the
+				// RankingWeights docstring for the measured 100k boundary). officialIds ⊆ exactIds by
+				// construction (official rows are names rows), so only the sub-tier KIND changes.
+				const officialIds = this.#weights.officialNameExact
+					? this.#officialNameIds(
+							sch,
+							candidates
+								.filter(
+									(c) => exactIds.has(c.id as number) && (c.population ?? 0) >= this.#weights.officialNameExactFloor
+								)
+								.map((c) => c.id as number),
+							query.text
+						)
+					: undefined
 				const kind = (c: PlaceCandidate): number => {
 					if (!exactIds.has(c.id as number)) return 0
 
-					return norm(String(c.name ?? "")) === needle ? 2 : 1
+					if (norm(String(c.name ?? "")) === needle) return 2
+
+					return officialIds?.has(c.id as number) ? 2 : 1
 				}
 				// With proximity hints (near/bias), prominence (population + nearness, same units)
 				// replaces raw population as the within-tier key — the 48026 rule: the map view or
@@ -1275,6 +1315,34 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 			}
 		} catch {
 			// Shard without place_search either → no exact-match tier. Falls back to weighted-sum order.
+		}
+
+		return out
+	}
+
+	/**
+	 * Among `ids` (already known exact matches), the subset holding `text` as an OFFICIAL name (`names.official = 1`, the
+	 * #940 ingest bit). Same COLLATE NOCASE semantics as {@link WOFSqlitePlaceLookup.#exactMatchIds} so the two probes
+	 * agree on what "equals the query" means. Fails soft on gazetteers built before #940 (no `official` column) — the
+	 * sub-tier then behaves exactly as if `officialNameExact` were off.
+	 */
+	#officialNameIds(schemaName: string, ids: number[], text: string): Set<number> {
+		const out = new Set<number>()
+		const trimmed = text.trim()
+
+		if (ids.length === 0 || !trimmed) return out
+		const placeholders = ids.map(() => "?").join(", ")
+
+		try {
+			const rows = this.#db
+				.prepare(
+					`SELECT DISTINCT id FROM ${schemaName}.names WHERE id IN (${placeholders}) AND official = 1 AND name = ? COLLATE NOCASE`
+				)
+				.all(...ids, trimmed) as Array<{ id: number }>
+
+			for (const r of rows) out.add(r.id)
+		} catch {
+			// Pre-#940 gazetteer (no `official` column) or a names-less slim shard — feature inert.
 		}
 
 		return out

--- a/resolver-wof-sqlite/official-name-exact.test.ts
+++ b/resolver-wof-sqlite/official-name-exact.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #936 option 3 — `officialNameExact`: an OFFICIAL name (preferred form in an official language
+ *   of the place's country, `names.official = 1` from the #940 ingest bit) joins the NAME-exact
+ *   sub-tier instead of the alias-exact one, floor-gated on the holder's population. The Åbo
+ *   fixture mirrors the motivating row: unscoped "Åbo" must reach Turku (its official Swedish
+ *   name, pop 207k) rather than a hamlet literally named Åbo — while Paris Township's plain alias
+ *   still loses to Paris' own name, and pre-#940 gazetteers (no `official` column) fail soft.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+
+import { afterEach, describe, expect, test } from "vitest"
+
+import type { RankingWeights } from "./lookup.js"
+import { WOFSqlitePlaceLookup } from "./lookup.js"
+
+interface SeedPlace {
+	id: number
+	name: string
+	country: string
+	population?: number
+	/** Plain aliases (official = 0). */
+	aliases?: string[]
+	/** Official-language aliases (official = 1) — the #940 ingest bit. */
+	officialAliases?: string[]
+}
+
+/** Same production shape as the exact-match-tiering fixture, plus the #940 `official` column. */
+function buildDB(places: SeedPlace[], opts?: { omitOfficialColumn?: boolean }): DatabaseSync {
+	const db = new DatabaseSync(":memory:")
+
+	db.exec(`
+		CREATE TABLE spr (
+			id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, placetype TEXT, country TEXT,
+			latitude REAL, longitude REAL,
+			min_latitude REAL, max_latitude REAL, min_longitude REAL, max_longitude REAL,
+			is_current INTEGER, is_deprecated INTEGER
+		);
+		CREATE TABLE names (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, language TEXT, name TEXT${
+			opts?.omitOfficialColumn ? "" : ", official INTEGER NOT NULL DEFAULT 0"
+		});
+		CREATE TABLE ancestors (rowid INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, ancestor_id INTEGER, ancestor_placetype TEXT);
+		CREATE TABLE place_population (id INTEGER PRIMARY KEY, population INTEGER NOT NULL DEFAULT 0);
+	`)
+	const insertSpr = db.prepare(`
+		INSERT INTO spr (id, parent_id, name, placetype, country, latitude, longitude,
+			min_latitude, max_latitude, min_longitude, max_longitude, is_current, is_deprecated)
+		VALUES (?, NULL, ?, 'locality', ?, 60, 22, 59.5, 60.5, 21.5, 22.5, -1, 0)
+	`)
+	const insertName = opts?.omitOfficialColumn
+		? db.prepare(`INSERT INTO names (id, language, name) VALUES (?, ?, ?)`)
+		: db.prepare(`INSERT INTO names (id, language, name, official) VALUES (?, ?, ?, ?)`)
+	const insertPop = db.prepare(`INSERT INTO place_population (id, population) VALUES (?, ?)`)
+	const run = (id: number, language: string, name: string, official: number): void => {
+		if (opts?.omitOfficialColumn) insertName.run(id, language, name)
+		else insertName.run(id, language, name, official)
+	}
+
+	for (const p of places) {
+		insertSpr.run(p.id, p.name, p.country)
+		run(p.id, "", p.name, 0)
+
+		for (const a of p.aliases ?? []) run(p.id, "", a, 0)
+
+		for (const a of p.officialAliases ?? []) run(p.id, "swe", a, 1)
+
+		if (p.population !== undefined) insertPop.run(p.id, p.population)
+	}
+
+	return db
+}
+
+// Turku holds "Åbo" as its OFFICIAL Swedish name; the hamlet holds "Åbo" as its own primary. Under
+// the plain #912 sub-tier the hamlet's primary wins; under option 3 Turku joins the name-exact
+// sub-tier and its population decides.
+const TURKU_ABO: SeedPlace[] = [
+	{ id: 1, name: "Åbo", country: "SE", population: 300 },
+	{ id: 2, name: "Turku", country: "FI", population: 207_000, officialAliases: ["Åbo"] },
+]
+
+const FLAG_ON: Partial<RankingWeights> = { officialNameExact: true }
+
+let lookup: WOFSqlitePlaceLookup
+afterEach(() => lookup?.close())
+
+describe("findPlace — officialNameExact (#936 option 3)", () => {
+	test("flag OFF (default): the hamlet's own name beats Turku's official alias — today's behavior", async () => {
+		lookup = new WOFSqlitePlaceLookup({ database: buildDB(TURKU_ABO), buildFTS: true })
+		const results = await lookup.findPlace({ text: "Åbo", placetype: "locality" })
+
+		expect(results.length).toBeGreaterThan(1)
+		expect(results[0]!.id).toBe(1)
+	})
+
+	test("flag ON: Turku's official name joins the name-exact sub-tier and population decides", async () => {
+		lookup = new WOFSqlitePlaceLookup({ database: buildDB(TURKU_ABO), buildFTS: true }, FLAG_ON)
+		const results = await lookup.findPlace({ text: "Åbo", placetype: "locality" })
+
+		expect(results[0]!.id).toBe(2)
+		expect(results[0]!.name).toBe("Turku")
+	})
+
+	test("holder below the population floor stays alias-tier (the junk-tier guard)", async () => {
+		lookup = new WOFSqlitePlaceLookup(
+			{ database: buildDB(TURKU_ABO), buildFTS: true },
+			{ officialNameExact: true, officialNameExactFloor: 500_000 }
+		)
+		const results = await lookup.findPlace({ text: "Åbo", placetype: "locality" })
+
+		expect(results[0]!.id).toBe(1)
+	})
+
+	test("a plain (non-official) alias still loses to the name holder — Paris Township stays down", async () => {
+		lookup = new WOFSqlitePlaceLookup(
+			{
+				database: buildDB([
+					{ id: 10, name: "Paris", country: "FR", population: 2_100_000 },
+					{ id: 11, name: "Paris Township", country: "US", population: 150_000, aliases: ["Paris"] },
+				]),
+				buildFTS: true,
+			},
+			FLAG_ON
+		)
+		const results = await lookup.findPlace({ text: "Paris", placetype: "locality" })
+
+		expect(results[0]!.id).toBe(10)
+	})
+
+	test("official alias of the SMALLER place cannot demote the bigger name holder (population within tier)", async () => {
+		lookup = new WOFSqlitePlaceLookup(
+			{
+				database: buildDB([
+					{ id: 20, name: "Córdoba", country: "AR", population: 2_106_734 },
+					{ id: 21, name: "Cordoba", country: "ES", population: 328_841, officialAliases: ["Córdoba"] },
+				]),
+				buildFTS: true,
+			},
+			FLAG_ON
+		)
+		const results = await lookup.findPlace({ text: "Córdoba", placetype: "locality" })
+
+		expect(results[0]!.id).toBe(20)
+	})
+
+	test("pre-#940 gazetteer (no official column) fails soft: flag ON behaves as OFF", async () => {
+		lookup = new WOFSqlitePlaceLookup(
+			{ database: buildDB(TURKU_ABO, { omitOfficialColumn: true }), buildFTS: true },
+			FLAG_ON
+		)
+		const results = await lookup.findPlace({ text: "Åbo", placetype: "locality" })
+
+		expect(results[0]!.id).toBe(1)
+	})
+})

--- a/scripts/augment-admin-official-names.ts
+++ b/scripts/augment-admin-official-names.ts
@@ -1,0 +1,118 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #936 option 3 data bridge — stamp `names.official` onto a COPY of the live admin DB from a
+ *   pairs file, until the next full `build-unified-wof` rebuild carries the #940 ingest bit
+ *   natively. Same build-on-copy idiom as `augment-admin-overture.ts` (the operator-validated
+ *   alternative to a full rebuild — see the 2026-06-20 night postmortem): the shipped DB is never
+ *   touched; the output is a NEW artifact that must pass its gate battery before any swap.
+ *
+ *   Pairs come from the #936 risk probe
+ *   (`scripts/diagnostic/exonym-official-collision-probe.ts --emit-pairs`): one JSON line per
+ *   `{id, name}` where `name` is a LOWERCASED official-language, preferred-form, non-historic
+ *   alias of place `id` (cut A officialness, name-level historic exclusion — the reviewed rule).
+ *   Matching against the DB's original-case rows happens here in JS because SQLite's NOCASE
+ *   collation folds ASCII only ("åbo" would never match "Åbo" in SQL).
+ *
+ *   Usage: node scripts/augment-admin-official-names.ts \
+ *     --in  $MAILWOMAN_DATA_ROOT/wof/admin-global-priority.db \
+ *     --out $MAILWOMAN_DATA_ROOT/wof/admin-global-priority-official.db \
+ *     --pairs <pairs.jsonl>
+ */
+
+import { copyFileSync, existsSync, readFileSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { dataRootPath } from "@mailwoman/core/utils"
+
+const { values: a } = parseArgs({
+	options: {
+		in: { type: "string", default: String(dataRootPath("wof", "admin-global-priority.db")) },
+		out: { type: "string", default: String(dataRootPath("wof", "admin-global-priority-official.db")) },
+		pairs: { type: "string" },
+	},
+})
+
+const input = a.in!
+const output = a.out!
+const pairsPath = a.pairs
+
+if (!pairsPath || !existsSync(pairsPath)) {
+	console.error("--pairs <pairs.jsonl> required (from the #936 probe's --emit-pairs)")
+	process.exit(1)
+}
+
+if (input === output) {
+	console.error("refusing to write over the input — pick a distinct --out (build-on-copy, never in place)")
+	process.exit(1)
+}
+
+if (!existsSync(input)) {
+	console.error(`input DB not found: ${input}`)
+	process.exit(1)
+}
+
+const pairs = readFileSync(pairsPath, "utf8")
+	.trim()
+	.split("\n")
+	.map((l) => JSON.parse(l) as { id: number; name: string })
+
+console.error(`official-name augment → ${output}`)
+console.error(`  source (read via copy, never mutated): ${input}`)
+console.error(`  pairs: ${pairs.length.toLocaleString()} from ${pairsPath}`)
+
+copyFileSync(input, output)
+const db = new DatabaseSync(output)
+
+// Idempotent column add — the next full rebuild ships the column natively via createUnifiedSchema.
+const hasColumn = (db.prepare(`PRAGMA table_info(names)`).all() as Array<{ name: string }>).some(
+	(c) => c.name === "official"
+)
+
+if (!hasColumn) db.exec(`ALTER TABLE names ADD COLUMN official INTEGER NOT NULL DEFAULT 0`)
+
+const selectNames = db.prepare(`SELECT rowid, name FROM names WHERE id = ?`)
+const stamp = db.prepare(`UPDATE names SET official = 1 WHERE rowid = ?`)
+
+// Group pairs by id so each place's names are fetched once.
+const byID = new Map<number, Set<string>>()
+
+for (const p of pairs) {
+	let set = byID.get(p.id)
+
+	if (!set) byID.set(p.id, (set = new Set()))
+	set.add(p.name)
+}
+
+let stamped = 0
+let missed = 0
+
+db.exec("BEGIN")
+
+for (const [id, wanted] of byID) {
+	const rows = selectNames.all(id) as Array<{ rowid: number; name: string }>
+	let hit = false
+
+	for (const r of rows) {
+		if (wanted.has(r.name.toLowerCase().trim())) {
+			stamp.run(r.rowid)
+			stamped++
+			hit = true
+		}
+	}
+
+	if (!hit) missed++
+}
+db.exec("COMMIT")
+db.exec("ANALYZE")
+
+const integrity = db.prepare(`PRAGMA quick_check`).get() as { quick_check: string }
+
+console.error(`  stamped ${stamped.toLocaleString()} name rows official=1 (${missed} places had no matching row)`)
+console.error(`  quick_check: ${integrity.quick_check}`)
+db.close()
+
+if (integrity.quick_check !== "ok") process.exit(1)

--- a/scripts/eval/fr-admin-split-gate.ts
+++ b/scripts/eval/fr-admin-split-gate.ts
@@ -119,7 +119,12 @@ async function main() {
 		strict: true,
 		tier: "server",
 	})
-	const resolver = createWOFResolver(new WOFSqlitePlaceLookup({ databasePath: wofDB }) as never)
+	// #936 option 3 gate legs: `--official-name-exact` flips the official-name sub-tier promotion on
+	// (default floor 100k). Absent flag = library default (off) — byte-stable baselines.
+	const officialNameExact = process.argv.includes("--official-name-exact")
+	const resolver = createWOFResolver(
+		new WOFSqlitePlaceLookup({ databasePath: wofDB }, officialNameExact ? { officialNameExact } : undefined) as never
+	)
 	// #895: the library defaults flipped ON (drift D1/D2). Tri-state pins keep gate legs reproducible
 	// against pre-flip baselines: `--no-admin-coherence`/`--raw-case` reproduce the historical config,
 	// no flag = the current library default. Pin explicitly in pre-registered legs (#718 discipline).
@@ -136,8 +141,11 @@ async function main() {
 	// #375 night-31: opt-in postcodeConsistency pin (the #370 lever A namesake binder) for the
 	// taxonomy-driven experiment; unset = library default (off).
 	const postcodeConsistencyPin = process.argv.includes("--postcode-consistency") ? true : undefined
+	// `--default-country none` = truly UNSCOPED resolution (no country prior at all) — the #936
+	// namesake legs need it; an empty string would still be a (falsy, ambiguous) country value.
+	const defaultCountryArg = arg("default-country", "FR")
 	const resolveOpts = {
-		defaultCountry: arg("default-country", "FR"),
+		...(defaultCountryArg === "none" ? {} : { defaultCountry: defaultCountryArg }),
 		...(adminCoherencePin !== undefined ? { adminCoherence: adminCoherencePin } : {}),
 		...(postcodeConsistencyPin !== undefined ? { postcodeConsistency: postcodeConsistencyPin } : {}),
 	}


### PR DESCRIPTION
The lookup half of #936, closing the loop opened by the design note, sized by the [risk probe](https://github.com/sister-software/mailwoman/pull/936#issuecomment-4878040201), hardened by the [DeepSeek review round](https://github.com/sister-software/mailwoman/pull/936#issuecomment-4878734209), and fed by #940's ingest bit. **Default OFF; byte-stable; the demo/production DB is untouched.**

## The rule

A candidate holding the query as an **official name** (`names.official = 1`: preferred-form, official-language, non-historic — the #940 contract) joins the **NAME-exact** sub-tier instead of alias-exact, gated on `officialNameExactFloor` (default **100k** — the review's measured boundary: ≥100k holders are the famous-exonym class; 10k–100k is junk-dominated, so below-floor officials stay alias-tier = today's behavior). `officialIds ⊆ exactIds` by construction — only the sub-tier *kind* changes; population still orders within the tier. Fails soft on pre-#940 gazetteers (no `official` column → flag is inert).

## Gate battery (pre-registered in `$GATE/RESULTS.md`) — PASS all legs

| leg | bar | result |
|---|---|---|
| us-2k flag OFF vs shipped-DB dump | byte-identical | **BYTE-IDENTICAL** |
| fi-1k flag OFF vs shipped-DB dump | byte-identical | **BYTE-IDENTICAL** |
| us-2k / fi-1k flag ON vs OFF | no blast on addressed queries | **BYTE-IDENTICAL** both |
| Åbo (unscoped→FI) flag ON | < 5 km (baseline 859 km) | **0.12 km — Turku** |
| namesake golden, truly unscoped, OFF→ON | famous cities + ME/NY must not move; exonyms expected to flip | Paris/Dublin/Melbourne/Vancouver/Portland-ME/Albany-NY **unchanged**; **exactly 4 flips**: Berne→Bern 0.4 km, Bruges→Brugge 0.2 km, Roma→Rome IT 4.1 km, Åbo→Turku 0.1 km |
| unit suite | green | 306 passed (6 new: flip, floor, Paris guard, Córdoba within-tier, soft-fail, default-off) |

## Data bridge

`scripts/augment-admin-official-names.ts` — build-on-copy (the `augment-admin-overture` idiom): stamps `names.official` onto a **copy** from the probe's cut-A pairs (name-level historic exclusion; 7,275 pairs → 17,184 rows; `quick_check` ok). The live DB is never touched. Candidate artifact: `admin-global-priority-official.db`. The next full `build-unified-wof` rebuild carries the bit natively and retires the bridge.

## Harness

`fr-admin-split-gate` gains `--official-name-exact` and `--default-country none` (truly unscoped legs — the namesake battery is meaningless under a country prior; the first battery run also taught, again, that harness legs grade the **compiled** tree: `yarn compile` before grading).

## Not flipped here

- The library default stays OFF — the flip + candidate-DB swap are the operator's promote.
- Browser/candidate-DB parity (the bit isn't in the candidate build yet) — follow-up when the flip is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA