### PR TITLE
feat(#936): officialNameExact default ON — operator promote

### DIFF
--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -170,8 +170,10 @@ export interface RankingWeights {
 	 * Fixes unscoped "Åbo" → Turku (its official Swedish name) over a hamlet literally named Åbo; population still orders
 	 * within the sub-tier, so Paris → Paris FR is untouched.
 	 *
-	 * Default false (byte-stable). Requires a gazetteer built with the #940 ingest bit — on older DBs without the
-	 * `official` column the probe fails soft and behavior is identical to the flag being off.
+	 * Default true (operator-promoted 2026-07-03 after the pre-registered gate battery: four intended exonym flips —
+	 * Berne→Bern, Bruges→Brugge, Roma→Rome, Åbo→Turku — with the namesake/abbreviation rows and the US/FI panels
+	 * byte-identical). Requires a gazetteer carrying the #940 ingest bit — on older DBs without the `official` column the
+	 * probe fails soft and behavior is identical to the flag being off.
 	 */
 	officialNameExact: boolean
 	/**
@@ -210,8 +212,8 @@ const DEFAULT_WEIGHTS: RankingWeights = {
 	// consulted — keeps population as an intra-tier prominence tiebreaker, not a cross-tier promoter.
 	// Fixes the 2-letter-region-abbrev bug ("ME" → Maine, not the more-populous Missouri).
 	exactMatchTiering: true,
-	// #936 option 3 ships default-OFF behind its gate battery; see the RankingWeights docstring.
-	officialNameExact: false,
+	// #936 option 3 — promoted default-ON 2026-07-03 (gate battery PASS; see the RankingWeights docstring).
+	officialNameExact: true,
 	officialNameExactFloor: 100_000,
 }
 

--- a/resolver-wof-sqlite/official-name-exact.test.ts
+++ b/resolver-wof-sqlite/official-name-exact.test.ts
@@ -88,16 +88,16 @@ let lookup: WOFSqlitePlaceLookup
 afterEach(() => lookup?.close())
 
 describe("findPlace — officialNameExact (#936 option 3)", () => {
-	test("flag OFF (default): the hamlet's own name beats Turku's official alias — today's behavior", async () => {
-		lookup = new WOFSqlitePlaceLookup({ database: buildDB(TURKU_ABO), buildFTS: true })
+	test("flag OFF (explicit): the hamlet's own name beats Turku's official alias — the pre-#936 behavior", async () => {
+		lookup = new WOFSqlitePlaceLookup({ database: buildDB(TURKU_ABO), buildFTS: true }, { officialNameExact: false })
 		const results = await lookup.findPlace({ text: "Åbo", placetype: "locality" })
 
 		expect(results.length).toBeGreaterThan(1)
 		expect(results[0]!.id).toBe(1)
 	})
 
-	test("flag ON: Turku's official name joins the name-exact sub-tier and population decides", async () => {
-		lookup = new WOFSqlitePlaceLookup({ database: buildDB(TURKU_ABO), buildFTS: true }, FLAG_ON)
+	test("DEFAULT (flag ON since the 2026-07-03 promote): Turku's official name joins the name-exact sub-tier", async () => {
+		lookup = new WOFSqlitePlaceLookup({ database: buildDB(TURKU_ABO), buildFTS: true })
 		const results = await lookup.findPlace({ text: "Åbo", placetype: "locality" })
 
 		expect(results[0]!.id).toBe(2)


### PR DESCRIPTION
The promote step for #943, operator-authorized ("Merge it, swap the DB, and flip the default").

- **DB swapped**: `admin-global-priority.db` now carries the #940 official bits (build-on-copy artifact from the gate battery; backup at `admin-global-priority.db.bak-pre-936-2026-07-03`).
- **Default flipped**: `DEFAULT_WEIGHTS.officialNameExact: true` (floor stays 100k). Pre-#940 gazetteers fail soft — the probe is inert without the `official` column.
- **Post-swap verify on the promoted stack** (live DB, library default, no flags): Åbo **0.12 km**; namesake dump **byte-identical** to the gate's flag-on leg.
- Suites: resolver-wof-sqlite 306, mailwoman 531, lint green.
- Follow-up (tracked in #936): candidate/browser DB doesn't carry the bit yet — browser parity rides the next `gazetteer build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA