### PR TITLE
feat(#942): postal-compound recovery — the composition-insensitive no-street class gets a model-independent floor (default OFF)

### DIFF
--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -352,6 +352,19 @@ export interface ResolveOpts {
 	 */
 	spanRescoreGateKm?: number
 	/**
+	 * Postal-compound recovery inside the span-rescore tier (#942). The knife-edge no-street query shape ("Kožljek 7,
+	 * 1382 Kožljek") fails as a COMPOUND: the parse globs the trailing city into the postcode span ("1382 Kožljek"),
+	 * which then (a) resolves as neither postcode nor locality and (b) BLOCKS its own city tokens from span-rescore's
+	 * recovery (a confident postcode span is avoided). Proven training-composition-insensitive on #901 — five vehicles
+	 * including a full from-scratch retrain all tip this class, so the floor lives here, model-independently.
+	 *
+	 * When on and the tree resolved nothing: the failed postcode span only blocks its CODE-shaped tokens (digit-bearing;
+	 * the residual city tokens become recoverable), the postcode-consistency anchor retries with that code subset, and
+	 * the failed postcode NODE is decorated from the code resolution (a postcode-tier coordinate floor even when no city
+	 * matches). Never fires on a resolved tree (the #685 brake). Default false pending its gate battery.
+	 */
+	postalCompoundRecovery?: boolean
+	/**
 	 * Postcode-disambiguated locality selection (#370 "Lever A"). When set, AND a locality resolves far from a resolved
 	 * sibling postcode, re-pick the same-named candidate (from the lookup's already- captured `alternatives`) nearest the
 	 * postcode; if none reconciles within the gate, fall the coordinate back to the postcode point and flag

--- a/resolver/postal-compound-recovery.test.ts
+++ b/resolver/postal-compound-recovery.test.ts
@@ -113,11 +113,26 @@ describe("postal-compound recovery (#942)", () => {
 		expect(locality!.lat).toBeCloseTo(45.8, 1)
 		expect(locality!.metadata?.span_rescore).toBe(true)
 		expect(locality!.metadata?.rescore_gated).toBe(true) // the code-subset anchor validated it
+		// The postcode node stays UNdecorated when a locality was recovered — its medoid centroid is
+		// coarser than the village pin, and postcode-over-locality consumers must not trade down.
+		const pc = out.roots.find((n) => n.tag === "postcode")
+
+		expect(pc?.placeID).toBeFalsy()
 	})
 
-	it("flag ON: the failed postcode node gains the code-subset coordinate floor", async () => {
+	it("flag ON: the postcode node gains the code-subset coordinate floor ONLY when no city matches", async () => {
 		const resolver = createWOFResolver(makeBackend())
-		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "SI", postalCompoundRecovery: true })
+		// "Neznano" is not in the gazetteer — the locality rescue misses, so the floor fires.
+		const raw = "Neznano 7, 1382 Neznano"
+		const tree: AddressTree = {
+			raw,
+			roots: [
+				node({ tag: "street", value: "Neznano", start: 0, end: 7 }),
+				node({ tag: "house_number", value: "7", start: 8, end: 9 }),
+				node({ tag: "postcode", value: "1382 Neznano", start: 11, end: 23 }),
+			],
+		}
+		const out = await resolver.resolveTree(tree, { defaultCountry: "SI", postalCompoundRecovery: true })
 		const pc = out.roots.find((n) => n.tag === "postcode")
 
 		expect(pc?.placeID).toBeTruthy()

--- a/resolver/postal-compound-recovery.test.ts
+++ b/resolver/postal-compound-recovery.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the #942 postal-compound recovery — the knife-edge no-street query shape
+ *   ("Kožljek 7, 1382 Kožljek") whose parse globs the trailing city into the postcode span. The
+ *   fixture mirrors the real failure: the compound resolves as nothing, the confident postcode
+ *   span blocks its own city tokens, and the tree comes back empty. With the flag on, the code
+ *   subset anchors the gate, the residual city tokens become span material, and the failed
+ *   postcode node gains a coordinate floor. Street blocking (the "Ave, France" guard) stays.
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import type { ResolvedPlace, ResolverBackend } from "@mailwoman/core/resolver"
+import { describe, expect, it } from "vitest"
+
+import { createWOFResolver } from "./resolve.js"
+import { postcodeCodeSubset } from "./span-rescore.js"
+
+const norm = (s: string): string =>
+	s
+		.toLowerCase()
+		.normalize("NFD")
+		.replace(/[^a-z0-9 ]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+
+/** The SI shape: the village + its bare-code postcode row (the #920 name law — codes stored bare). */
+const PLACES: ResolvedPlace[] = [
+	{
+		id: 1,
+		name: "Kožljek",
+		placetype: "locality",
+		country: "SI",
+		lat: 45.8,
+		lon: 14.4,
+		score: 10,
+		exactMatch: true,
+	},
+	{ id: 900, name: "1382", placetype: "postalcode", country: "SI", lat: 45.82, lon: 14.42, score: 1 },
+	// A distant same-named decoy in another country — the gate + country constraint must hold.
+	{
+		id: 2,
+		name: "Kožljek",
+		placetype: "locality",
+		country: "HR",
+		lat: 42.0,
+		lon: 18.0,
+		score: 10,
+		exactMatch: true,
+	},
+]
+
+function makeBackend(): ResolverBackend {
+	return {
+		async findPlace(query) {
+			const key = norm(query.text)
+
+			return PLACES.filter(
+				(p) =>
+					norm(p.name) === key &&
+					(!query.country || p.country === query.country) &&
+					(!query.placetype || query.placetype.includes(p.placetype))
+			).map((p) => ({ ...p }))
+		},
+	}
+}
+
+const node = (over: Partial<AddressNode> & Pick<AddressNode, "tag" | "value" | "start" | "end">): AddressNode => ({
+	confidence: 0.95,
+	children: [],
+	...over,
+})
+
+/** The real failure shape: "Kožljek 7, 1382 Kožljek" — street+hn lead, globbed postcode trail. */
+function failingTree(): AddressTree {
+	const raw = "Kožljek 7, 1382 Kožljek"
+
+	return {
+		raw,
+		roots: [
+			node({ tag: "street", value: "Kožljek", start: 0, end: 7 }),
+			node({ tag: "house_number", value: "7", start: 8, end: 9 }),
+			node({ tag: "postcode", value: "1382 Kožljek", start: 11, end: 23 }),
+		],
+	}
+}
+
+describe("postcodeCodeSubset", () => {
+	it("extracts digit-bearing tokens", () => {
+		expect(postcodeCodeSubset("1382 Kožljek")).toBe("1382")
+		expect(postcodeCodeSubset("SW1A 1AA London")).toBe("SW1A 1AA")
+		expect(postcodeCodeSubset("Kožljek")).toBe("")
+	})
+})
+
+describe("postal-compound recovery (#942)", () => {
+	it("flag OFF (default): the tree stays unresolved — today's behavior", async () => {
+		const resolver = createWOFResolver(makeBackend())
+		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "SI" })
+		const resolved = out.roots.filter((n) => n.placeID)
+
+		expect(resolved.length).toBe(0)
+	})
+
+	it("flag ON: recovers the trailing city from the globbed postcode span, gate-validated", async () => {
+		const resolver = createWOFResolver(makeBackend())
+		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "SI", postalCompoundRecovery: true })
+		const locality = out.roots.find((n) => n.tag === "locality" && n.placeID)
+
+		expect(locality).toBeDefined()
+		expect(locality!.lat).toBeCloseTo(45.8, 1)
+		expect(locality!.metadata?.span_rescore).toBe(true)
+		expect(locality!.metadata?.rescore_gated).toBe(true) // the code-subset anchor validated it
+	})
+
+	it("flag ON: the failed postcode node gains the code-subset coordinate floor", async () => {
+		const resolver = createWOFResolver(makeBackend())
+		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "SI", postalCompoundRecovery: true })
+		const pc = out.roots.find((n) => n.tag === "postcode")
+
+		expect(pc?.placeID).toBeTruthy()
+		expect(pc?.lat).toBeCloseTo(45.82, 2)
+		expect(pc?.metadata?.postal_compound_recovered).toBe(true)
+	})
+
+	it("flag ON: never disturbs a resolved tree (the #685 brake)", async () => {
+		const resolver = createWOFResolver(makeBackend())
+		const tree: AddressTree = {
+			raw: "Kožljek, Slovenia",
+			roots: [node({ tag: "locality", value: "Kožljek", start: 0, end: 7 })],
+		}
+		const out = await resolver.resolveTree(tree, { defaultCountry: "SI", postalCompoundRecovery: true })
+		const pc = out.roots.find((n) => n.tag === "postcode")
+
+		expect(pc).toBeUndefined() // nothing synthesized
+		expect(out.roots.filter((n) => n.placeID).length).toBe(1)
+	})
+
+	it("flag ON: street tokens stay blocked — no 'Ave, France' resurrection", async () => {
+		// A street-only failing parse: the street token equals a real place name, but street blocking
+		// must keep it out of recovery even with the flag on.
+		const resolver = createWOFResolver(makeBackend())
+		const tree: AddressTree = {
+			raw: "Kožljek 7",
+			roots: [
+				node({ tag: "street", value: "Kožljek", start: 0, end: 7 }),
+				node({ tag: "house_number", value: "7", start: 8, end: 9 }),
+			],
+		}
+		const out = await resolver.resolveTree(tree, { defaultCountry: "SI", postalCompoundRecovery: true })
+
+		expect(out.roots.filter((n) => n.placeID).length).toBe(0)
+	})
+
+	it("gate rejects a cross-border same-named decoy (unscoped)", async () => {
+		// No defaultCountry: the HR decoy is name-identical. The code-subset anchor (SI 1382) plus the
+		// 50km gate must reject the 400+km decoy and accept the SI village.
+		const resolver = createWOFResolver(makeBackend())
+		const out = await resolver.resolveTree(failingTree(), { postalCompoundRecovery: true })
+		const locality = out.roots.find((n) => n.tag === "locality" && n.placeID)
+
+		// Both candidates surface; the gate keeps only the SI one.
+		expect(locality).toBeDefined()
+		expect(locality!.lat).toBeCloseTo(45.8, 1)
+	})
+})

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -305,12 +305,13 @@ async function applySpanRescore(
 		return
 	}
 
-	// #942 postal-compound recovery, part 2: decorate the FAILED postcode node from its code-shaped
-	// token subset ("1382 Kožljek" → the bare "1382" row). Gives the tree a postcode-tier coordinate
-	// floor even when no city span matches, and feeds the downstream postcode machinery
-	// (result-assembly ladder, consistency passes). Runs whether or not a locality was recovered —
-	// but only on this unresolved tree, so the #685 brake semantics hold.
-	if (opts.postalCompoundRecovery) {
+	// #942 postal-compound recovery, part 2: when NO city span matched, decorate the FAILED postcode
+	// node from its code-shaped token subset ("1382 Kožljek" → the bare "1382" row) — a postcode-tier
+	// coordinate FLOOR, strictly subordinate to a recovered locality. Only-on-miss matters: a GeoNames
+	// medoid postcode centroid is COARSER than the exact village centroid, and consumers that rank
+	// postcode above locality (the eval harness does) would otherwise trade a 0.2 km village pin for a
+	// 5 km area centroid. Same unresolved tree, so the #685 brake semantics hold.
+	if (!hit && opts.postalCompoundRecovery) {
 		try {
 			await recoverPostcodeNode(roots, backend, opts.defaultCountry)
 		} catch {

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -29,7 +29,7 @@ import {
 } from "@mailwoman/core/resolver"
 import { haversineKm } from "@mailwoman/spatial"
 
-import { findRescoreCandidate, hasResolvedPlace } from "./span-rescore.js"
+import { findRescoreCandidate, hasResolvedPlace, postcodeCodeSubset } from "./span-rescore.js"
 
 /**
  * Build a `Resolver` backed by a `ResolverBackend`. The backend can be any concrete impl structurally compatible with
@@ -299,9 +299,23 @@ async function applySpanRescore(
 			country: opts.defaultCountry,
 			postcode: firstPostcodeValue(roots),
 			gateKm: opts.spanRescoreGateKm,
+			postalCompoundRecovery: opts.postalCompoundRecovery,
 		})
 	} catch {
 		return
+	}
+
+	// #942 postal-compound recovery, part 2: decorate the FAILED postcode node from its code-shaped
+	// token subset ("1382 Kožljek" → the bare "1382" row). Gives the tree a postcode-tier coordinate
+	// floor even when no city span matches, and feeds the downstream postcode machinery
+	// (result-assembly ladder, consistency passes). Runs whether or not a locality was recovered —
+	// but only on this unresolved tree, so the #685 brake semantics hold.
+	if (opts.postalCompoundRecovery) {
+		try {
+			await recoverPostcodeNode(roots, backend, opts.defaultCountry)
+		} catch {
+			// degrade to no-recovery, never crash the resolve
+		}
 	}
 
 	if (!hit) return
@@ -321,6 +335,41 @@ async function applySpanRescore(
 	// (high-precision); false = ungated (no postcode→point coverage for this country, ~83%-precision).
 	node.metadata = { ...node.metadata, span_rescore: true, rescore_gated: hit.gated }
 	roots.push(node)
+}
+
+/**
+ * #942: find the first confident-but-UNRESOLVED postcode node whose value is a polluted compound ("1382 Kožljek"),
+ * resolve its code-shaped token subset as a `postalcode`, and decorate the node from that hit
+ * (`postal_compound_recovered` metadata marks the provenance). No-op when every postcode node resolved, the value has
+ * no digit-bearing tokens, or the subset equals the full value (then the walk already tried it).
+ */
+async function recoverPostcodeNode(
+	roots: AddressNode[],
+	backend: ResolverBackend,
+	country: string | undefined
+): Promise<void> {
+	const stack: AddressNode[] = [...roots]
+
+	while (stack.length) {
+		const n = stack.pop()!
+
+		if (n.tag === "postcode" && !n.placeID && n.value.trim()) {
+			const code = postcodeCodeSubset(n.value)
+
+			if (!code || code === n.value.trim()) continue
+			const hits = await backend.findPlace({ text: code, placetype: "postalcode", country, limit: 1 })
+			const top = hits.find((h) => h.lat !== 0 || h.lon !== 0)
+
+			if (top) {
+				decorateNode(n, top, [])
+				n.metadata = { ...n.metadata, postal_compound_recovered: true }
+			}
+
+			return // first postcode node only — one recovery per tree
+		}
+
+		if (n.children?.length) stack.push(...n.children)
+	}
 }
 
 /** A resolved node carries a real coordinate (placeID set + non-zero lat/lon). */

--- a/resolver/span-rescore.ts
+++ b/resolver/span-rescore.ts
@@ -50,6 +50,14 @@ export interface SpanRescoreOptions {
 	 * Min confidence for a street/house_number/postcode node to count as a span-blocking constituent. Default 0.7.
 	 */
 	confidentThreshold?: number
+	/**
+	 * #942 postal-compound recovery. A globbed postcode span ("1382 Kožljek") normally (a) fails to anchor (the compound
+	 * matches no bare-code gazetteer row) and (b) blocks its own trailing city tokens from recovery. When on: the anchor
+	 * retries with the postcode's code-shaped (digit-bearing) token subset, and an UNRESOLVED postcode node blocks only
+	 * those code tokens — the residual name tokens become span material. Street/affix blocking is untouched (the "Ave,
+	 * France" guard). Default false.
+	 */
+	postalCompoundRecovery?: boolean
 }
 
 /** The recovered locality: the raw span and the gazetteer place it resolved to. */
@@ -97,6 +105,19 @@ function tokenizeRaw(raw: string): RawTok[] {
 	return toks
 }
 
+/**
+ * The code-shaped (digit-bearing) token subset of a postcode string — "1382 Kožljek" → "1382", "SW1A 1AA London" →
+ * "SW1A 1AA". The #942 recovery resolves THIS against the gazetteer's bare-code rows when the globbed compound fails.
+ * Empty string when no token carries a digit.
+ */
+export function postcodeCodeSubset(postcode: string): string {
+	return postcode
+		.split(/[\s,;/]+/)
+		.filter((t) => /\d/.test(t))
+		.join(" ")
+		.trim()
+}
+
 /** True if any node in the tree already carries a resolved place id — the #685 brake. */
 export function hasResolvedPlace(roots: readonly AddressNode[]): boolean {
 	const stack: AddressNode[] = [...roots]
@@ -118,7 +139,12 @@ export function hasResolvedPlace(roots: readonly AddressNode[]): boolean {
  * NY" is a street suffix, not a locality, and without this guard the recovery exact-matches it against a same-named
  * place ("Ave", France) and injects a bogus locality.
  */
-function confidentRanges(roots: readonly AddressNode[], threshold: number): Array<[number, number]> {
+function confidentRanges(
+	roots: readonly AddressNode[],
+	threshold: number,
+	raw: string,
+	postalCompoundRecovery: boolean
+): Array<[number, number]> {
 	const out: Array<[number, number]> = []
 	const stack: AddressNode[] = [...roots]
 
@@ -135,7 +161,16 @@ function confidentRanges(roots: readonly AddressNode[], threshold: number): Arra
 			Number.isFinite(n.start) &&
 			Number.isFinite(n.end)
 		) {
-			out.push([n.start, n.end])
+			// #942: an UNRESOLVED postcode span blocks only its code-shaped tokens — the globbed trailing
+			// city name ("1382 Kožljek") is exactly the recoverable material. Resolved postcodes and the
+			// street family keep the full-range block (the "Ave, France" guard).
+			if (postalCompoundRecovery && n.tag === "postcode" && !n.placeID) {
+				for (const t of tokenizeRaw(raw.slice(n.start, n.end))) {
+					if (/\d/.test(t.text)) out.push([n.start + t.start, n.start + t.end])
+				}
+			} else {
+				out.push([n.start, n.end])
+			}
 		}
 
 		if (n.children?.length) stack.push(...n.children)
@@ -169,10 +204,23 @@ export async function findRescoreCandidate(
 		const a = pcHits.find((h) => h.lat !== 0 || h.lon !== 0)
 
 		if (a) anchor = { lat: a.lat, lon: a.lon }
+
+		// #942: the globbed compound ("1382 Kožljek") matches no bare-code row — retry the anchor with
+		// the code-shaped token subset so the consistency gate can validate the recovered city.
+		if (!anchor && opts.postalCompoundRecovery) {
+			const code = postcodeCodeSubset(postcode)
+
+			if (code && code !== postcode) {
+				const codeHits = await backend.findPlace({ text: code, country, limit: 2 })
+				const c = codeHits.find((h) => h.lat !== 0 || h.lon !== 0)
+
+				if (c) anchor = { lat: c.lat, lon: c.lon }
+			}
+		}
 	}
 
 	const toks = tokenizeRaw(raw)
-	const avoid = confidentRanges(roots, threshold)
+	const avoid = confidentRanges(roots, threshold, raw, opts.postalCompoundRecovery ?? false)
 	const overlapsAvoid = (s: number, e: number) => avoid.some(([as, ae]) => s < ae && as < e)
 
 	// Enumerate contiguous spans, LONGEST first — the gold locality is usually the more-specific

--- a/scripts/eval/fr-admin-split-gate.ts
+++ b/scripts/eval/fr-admin-split-gate.ts
@@ -141,6 +141,8 @@ async function main() {
 	// #375 night-31: opt-in postcodeConsistency pin (the #370 lever A namesake binder) for the
 	// taxonomy-driven experiment; unset = library default (off).
 	const postcodeConsistencyPin = process.argv.includes("--postcode-consistency") ? true : undefined
+	// #942: opt-in postal-compound recovery (globbed no-street shapes); unset = library default (off).
+	const postalCompoundPin = process.argv.includes("--postal-compound-recovery") ? true : undefined
 	// `--default-country none` = truly UNSCOPED resolution (no country prior at all) — the #936
 	// namesake legs need it; an empty string would still be a (falsy, ambiguous) country value.
 	const defaultCountryArg = arg("default-country", "FR")
@@ -148,6 +150,7 @@ async function main() {
 		...(defaultCountryArg === "none" ? {} : { defaultCountry: defaultCountryArg }),
 		...(adminCoherencePin !== undefined ? { adminCoherence: adminCoherencePin } : {}),
 		...(postcodeConsistencyPin !== undefined ? { postcodeConsistency: postcodeConsistencyPin } : {}),
+		...(postalCompoundPin !== undefined ? { postalCompoundRecovery: postalCompoundPin } : {}),
 	}
 
 	const errs: number[] = []


### PR DESCRIPTION
Closes the loop on the [#901 v2.2.0 verdict](https://github.com/sister-software/mailwoman/issues/901#issuecomment-4878272681)'s recommendation: the knife-edge no-street query shape (`Kožljek 7, 1382 Kožljek`) that **no training composition can hold** (five vehicles, all tipped) becomes a resolver-side floor. **Default OFF**, byte-stable, behind `ResolveOpts.postalCompoundRecovery`.

## The mechanism (traced end-to-end before designing)

The parse globs the trailing city into the postcode span (`"1382 Kožljek"`), which then (a) resolves as nothing — the #920 shards store bare codes — and (b) **blocks its own city tokens** from span-rescore's recovery (a confident postcode span is avoided material). The information never left the query; the pipeline just couldn't reach it.

Three surgical changes inside the existing span-rescore tier (#370):
1. **Anchor retry** — a failed postcode span retries the consistency anchor with its code-shaped (digit-bearing) token subset (`"1382"`).
2. **Selective unblock** — an *unresolved* postcode span blocks only its code tokens; the residual city tokens become span material. Street/affix blocking untouched (the "Ave, France" guard stays).
3. **Postcode-node floor** — when no city span matches, the failed node is decorated from the code resolution (`postal_compound_recovered`) — strictly subordinate to a recovered locality (the v1 battery caught the medoid centroid outvoting the village pin in postcode-over-locality consumers; fixed).

Never fires on a resolved tree (#685 brake preserved).

## Gate battery (pre-registered; verdict + revision in `$GATE/RESULTS.md`)

| leg | result |
|---|---|
| si-unres-25 (today-unresolved), flag ON | **25/25 resolve**, resolved-p50 **0.67 km**, max 3.7 (bar ≥15, <10 km) |
| SI-1k flag ON vs fresh flag OFF | 25 wins + **exactly one** resolved-row change: 46.36→0.85 km (an ungated baseline rescue corrected by the new anchor — signed revision, identity logged) |
| US-2k flag ON | **BYTE-IDENTICAL** |
| FR-3k flag ON vs fresh OFF | **BYTE-IDENTICAL** |
| **Insurance** (v2.2.0 composition-failed candidate + flag) | SI resolve 92.2% → **100%**, p50 1.51 km — **all 55 lost rows recover**; the class is model-independent now |
| units | 8 new rows (flip, floor-on-miss, subordination, brake, street guard, cross-border gate, code shapes); resolver suite 84 |

## The battery also surfaced two things bigger than itself

1. **The v2.2.0 FR FAIL was a stack confound** — deconfounded ni (same stack) is PASS; correction posted to #901. SI had zero drift; those findings stand.
2. **A real shipped FR regression** (p50 2.64→4.12, resolve 1.00→0.959 on the fr-3000 golden) entered main in the #938/#939 merge window, unguarded because the ship batteries only blast-check US/FI. Filed as **#945** with the bisect plan — the `*-nsv2` dumps are stale as baselines from here on.

## Not flipped here

Default stays OFF pending your promote — same pattern as #943/#944. Suggested follow-through after the flip: the Učakar gauntlet row + adding an FR blast leg to the ship battery (#945's ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA