### PR TITLE
feat(#942): postalCompoundRecovery default ON — operator promote

### DIFF
--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -360,8 +360,12 @@ export interface ResolveOpts {
 	 *
 	 * When on and the tree resolved nothing: the failed postcode span only blocks its CODE-shaped tokens (digit-bearing;
 	 * the residual city tokens become recoverable), the postcode-consistency anchor retries with that code subset, and
-	 * the failed postcode NODE is decorated from the code resolution (a postcode-tier coordinate floor even when no city
-	 * matches). Never fires on a resolved tree (the #685 brake). Default false pending its gate battery.
+	 * the failed postcode NODE is decorated from the code resolution (a postcode-tier coordinate floor, strictly
+	 * subordinate to a recovered locality). Never fires on a resolved tree (the #685 brake).
+	 *
+	 * **Default ON** (operator-promoted 2026-07-03 after the pre-registered gate: SI 25/25 recovery at p50 0.67 km, US/FR
+	 * byte-identical, and the insurance leg — the composition-failed v2.2.0 candidate recovers all 55 lost rows). Set
+	 * `false` to opt out (byte-stable then).
 	 */
 	postalCompoundRecovery?: boolean
 	/**

--- a/resolver/postal-compound-recovery.test.ts
+++ b/resolver/postal-compound-recovery.test.ts
@@ -96,12 +96,21 @@ describe("postcodeCodeSubset", () => {
 })
 
 describe("postal-compound recovery (#942)", () => {
-	it("flag OFF (default): the tree stays unresolved — today's behavior", async () => {
+	it("flag OFF (explicit): the tree stays unresolved — the pre-#942 behavior", async () => {
 		const resolver = createWOFResolver(makeBackend())
-		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "SI" })
+		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "SI", postalCompoundRecovery: false })
 		const resolved = out.roots.filter((n) => n.placeID)
 
 		expect(resolved.length).toBe(0)
+	})
+
+	it("DEFAULT (flag ON since the 2026-07-03 promote): the compound recovers without opting in", async () => {
+		const resolver = createWOFResolver(makeBackend())
+		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "SI" })
+		const locality = out.roots.find((n) => n.tag === "locality" && n.placeID)
+
+		expect(locality).toBeDefined()
+		expect(locality!.lat).toBeCloseTo(45.8, 1)
 	})
 
 	it("flag ON: recovers the trailing city from the globbed postcode span, gate-validated", async () => {

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -299,7 +299,8 @@ async function applySpanRescore(
 			country: opts.defaultCountry,
 			postcode: firstPostcodeValue(roots),
 			gateKm: opts.spanRescoreGateKm,
-			postalCompoundRecovery: opts.postalCompoundRecovery,
+			// Default-ON (promoted 2026-07-03); explicit `false` opts out — the spanRescore idiom.
+			postalCompoundRecovery: opts.postalCompoundRecovery !== false,
 		})
 	} catch {
 		return
@@ -311,7 +312,7 @@ async function applySpanRescore(
 	// medoid postcode centroid is COARSER than the exact village centroid, and consumers that rank
 	// postcode above locality (the eval harness does) would otherwise trade a 0.2 km village pin for a
 	// 5 km area centroid. Same unresolved tree, so the #685 brake semantics hold.
-	if (!hit && opts.postalCompoundRecovery) {
+	if (!hit && opts.postalCompoundRecovery !== false) {
 		try {
 			await recoverPostcodeNode(roots, backend, opts.defaultCountry)
 		} catch {

--- a/scripts/eval/fr-admin-split-gate.ts
+++ b/scripts/eval/fr-admin-split-gate.ts
@@ -21,6 +21,7 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { type AddressNode, type AddressTree, decodeAsJSON } from "@mailwoman/core/decoder"
 import { $public } from "@mailwoman/core/env"
@@ -120,29 +121,37 @@ async function main() {
 		tier: "server",
 	})
 	// #936 option 3 gate legs: `--official-name-exact` flips the official-name sub-tier promotion on
-	// (default floor 100k). Absent flag = library default (off) — byte-stable baselines.
-	const officialNameExact = process.argv.includes("--official-name-exact")
+	// Boolean pin flags via node:util parseArgs (strict off — the string args ride the `arg()` helper).
+	// #895/#718 discipline: the tri-state pins keep gate legs reproducible against pre-flip baselines —
+	// the positive flag pins ON, the `--no-*`/inverse flag pins OFF (the historical config), no flag =
+	// the current library default. Pin explicitly in pre-registered legs.
+	const { values: pins } = parseArgs({
+		options: {
+			// #936: official-language names join the name-exact sub-tier (library default ON since 2026-07-03).
+			"official-name-exact": { type: "boolean" },
+			"admin-coherence": { type: "boolean" },
+			"no-admin-coherence": { type: "boolean" },
+			"normalize-case": { type: "boolean" },
+			"raw-case": { type: "boolean" },
+			// #375 night-31: opt-in postcodeConsistency (the #370 lever A namesake binder).
+			"postcode-consistency": { type: "boolean" },
+			// #942: postal-compound recovery (library default ON since the 2026-07-03 promote).
+			"postal-compound-recovery": { type: "boolean" },
+			"no-postal-compound-recovery": { type: "boolean" },
+		},
+		strict: false,
+	})
+	const tri = (on: keyof typeof pins, off: keyof typeof pins): boolean | undefined =>
+		pins[on] === true ? true : pins[off] === true ? false : undefined
+
+	const officialNameExact = pins["official-name-exact"] === true
 	const resolver = createWOFResolver(
 		new WOFSqlitePlaceLookup({ databasePath: wofDB }, officialNameExact ? { officialNameExact } : undefined) as never
 	)
-	// #895: the library defaults flipped ON (drift D1/D2). Tri-state pins keep gate legs reproducible
-	// against pre-flip baselines: `--no-admin-coherence`/`--raw-case` reproduce the historical config,
-	// no flag = the current library default. Pin explicitly in pre-registered legs (#718 discipline).
-	const adminCoherencePin = process.argv.includes("--admin-coherence")
-		? true
-		: process.argv.includes("--no-admin-coherence")
-			? false
-			: undefined
-	const normalizeCasePin = process.argv.includes("--normalize-case")
-		? true
-		: process.argv.includes("--raw-case")
-			? false
-			: undefined
-	// #375 night-31: opt-in postcodeConsistency pin (the #370 lever A namesake binder) for the
-	// taxonomy-driven experiment; unset = library default (off).
-	const postcodeConsistencyPin = process.argv.includes("--postcode-consistency") ? true : undefined
-	// #942: opt-in postal-compound recovery (globbed no-street shapes); unset = library default (off).
-	const postalCompoundPin = process.argv.includes("--postal-compound-recovery") ? true : undefined
+	const adminCoherencePin = tri("admin-coherence", "no-admin-coherence")
+	const normalizeCasePin = tri("normalize-case", "raw-case")
+	const postcodeConsistencyPin = pins["postcode-consistency"] === true ? true : undefined
+	const postalCompoundPin = tri("postal-compound-recovery", "no-postal-compound-recovery")
 	// `--default-country none` = truly UNSCOPED resolution (no country prior at all) — the #936
 	// namesake legs need it; an empty string would still be a (falsy, ambiguous) country value.
 	const defaultCountryArg = arg("default-country", "FR")


### PR DESCRIPTION
The promote step for #946, operator-authorized ("Promote and merge"), batched with the #945 investigation per the same authorization.

- **Default flipped**: `postalCompoundRecovery` follows the `spanRescore` idiom — on unless explicitly `false`. Floor stays subordinate to a recovered locality.
- **Harness**: boolean pin flags migrated to `node:util parseArgs` (operator correction); tri-state pins are `--x`/`--no-x` pairs.
- **Post-flip verify** (live stack, library default, no flags): si-unres-25 → **25/25 at p50 0.67 km**, dump byte-identical to the gate's flag-on leg.
- Suites: resolver 85, mailwoman 531, lint + typecheck green.

Companion finding from the same session (no code here): #945 root-caused — v5.2.0's FR regression traces to the nsplice-v2 model itself, masked at release grading by v1 dump-copies; full erratum + corrected baselines on the issue and in `$GATE/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA