### PR TITLE
fix(#945): sanitizeFTSQuery splits intra-token punctuation — hyphenated names were unmatchable at the FTS layer

### DIFF
--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -693,7 +693,9 @@ export class WOFSqlitePlaceLookup implements PlaceLookup, Disposable {
 		// fuzzy "Brooklyn Park, MN" won instead. Order-preserving: the FIRST entry stays the
 		// requested placetype, which is what shard routing keys off below.
 		const placetypes = expandPlacetypeFilter(normalizePlacetypes(query.placetype)) as WOFPlacetype[] | null
-		const ftsQuery = sanitizeFTSQuery(query.text)
+		// Postcode-typed queries keep the #920 fused name-law shape; everything else splits on
+		// intra-token punctuation so hyphenated names reach the FTS as their real terms (#945).
+		const ftsQuery = sanitizeFTSQuery(query.text, { fuseTokens: placetypes?.includes("postalcode") ?? false })
 
 		if (!ftsQuery) return []
 
@@ -1404,10 +1406,13 @@ function normalizePlacetypes(p: FindPlaceQuery["placetype"]): WOFPlacetype[] | n
  * - `"Paris"` → `"Paris"` (phrase)
  * - `"627*"` → `627*` (prefix)
  * - `"St. (Petersburg)"` → `"St" "Petersburg"` (two phrases, AND-joined)
+ * - `"Thiron-Gardais"` → `"Thiron" "Gardais"` (intra-token punctuation SPLITS — #945; fusing to
+ *   `ThironGardais` matched nothing because the FTS doc tokenizes the hyphenated name as two terms)
+ * - `"110 00"` with `fuseTokens` (postcode-typed) → `"110" "00"` per-token fused — the #920 name law
  * - `"Pari* TX"` → `Pari* "TX"` (mixed prefix + phrase)
  * - `"*"` alone → `""` (no body → drop)
  */
-function sanitizeFTSQuery(text: string): string {
+function sanitizeFTSQuery(text: string, opts?: { fuseTokens?: boolean }): string {
 	const out: string[] = []
 
 	for (const rawToken of text.normalize("NFKC").split(/\s+/u)) {
@@ -1415,12 +1420,33 @@ function sanitizeFTSQuery(text: string): string {
 
 		if (!trimmed) continue
 		const hasPrefixStar = trimmed.endsWith("*")
-		// Strip everything except letters + numbers from the token body. Apostrophes / hyphens /
-		// any embedded `*` all go. The trailing `*` (if any) is reapplied separately below.
-		const body = trimmed.replace(/[^\p{L}\p{N}]/gu, "")
 
-		if (!body) continue
-		out.push(hasPrefixStar ? `${body}*` : `"${body.replace(/"/g, '""')}"`)
+		// #920 name law (postcode-typed queries ONLY): delete intra-token punctuation and FUSE the
+		// remainder — postal names are stored in this collapsed shape ("SW1A" stays one term).
+		if (opts?.fuseTokens) {
+			const body = trimmed.replace(/[^\p{L}\p{N}]/gu, "")
+
+			if (!body) continue
+			out.push(hasPrefixStar ? `${body}*` : `"${body.replace(/"/g, '""')}"`)
+			continue
+		}
+
+		// Everything else SPLITS on intra-token punctuation — the behavior the docstring always
+		// promised ("St. (Petersburg)" → two phrases). The old code DELETED punctuation instead,
+		// fusing "Thiron-Gardais" into the unmatchable single term `ThironGardais` while the FTS
+		// doc holds two terms (#945 — the entire hyphenated-name class missed at the raw lookup;
+		// masked for years because pre-splice tokenizers never emitted hyphen-preserved values).
+		const parts = trimmed.split(/[^\p{L}\p{N}]+/u).filter(Boolean)
+
+		if (parts.length === 0) continue
+
+		for (let i = 0; i < parts.length; i++) {
+			const body = parts[i]!.replace(/\*/g, "")
+
+			if (!body) continue
+			// The caller's trailing `*` applies to the FINAL part ("Thiron-Gard*" → "Thiron" Gard*).
+			out.push(hasPrefixStar && i === parts.length - 1 ? `${body}*` : `"${body.replace(/"/g, '""')}"`)
+		}
 	}
 
 	return out.join(" ")

--- a/resolver-wof-sqlite/lookup.ts
+++ b/resolver-wof-sqlite/lookup.ts
@@ -1406,8 +1406,8 @@ function normalizePlacetypes(p: FindPlaceQuery["placetype"]): WOFPlacetype[] | n
  * - `"Paris"` → `"Paris"` (phrase)
  * - `"627*"` → `627*` (prefix)
  * - `"St. (Petersburg)"` → `"St" "Petersburg"` (two phrases, AND-joined)
- * - `"Thiron-Gardais"` → `"Thiron" "Gardais"` (intra-token punctuation SPLITS — #945; fusing to
- *   `ThironGardais` matched nothing because the FTS doc tokenizes the hyphenated name as two terms)
+ * - `"Thiron-Gardais"` → `"Thiron" "Gardais"` (intra-token punctuation SPLITS — #945; fusing to `ThironGardais` matched
+ *   nothing because the FTS doc tokenizes the hyphenated name as two terms)
  * - `"110 00"` with `fuseTokens` (postcode-typed) → `"110" "00"` per-token fused — the #920 name law
  * - `"Pari* TX"` → `Pari* "TX"` (mixed prefix + phrase)
  * - `"*"` alone → `""` (no body → drop)

--- a/resolver-wof-sqlite/sanitize.test.ts
+++ b/resolver-wof-sqlite/sanitize.test.ts
@@ -32,6 +32,8 @@ function buildFixtureDB(): DatabaseSync {
 		INSERT INTO spr VALUES (4, NULL, '90210', 'postalcode', 'US', 34.07, -118.41, 34.05, 34.09, -118.43, -118.39, -1, 0);
 		INSERT INTO spr VALUES (5, NULL, 'Paris', 'locality', 'FR', 48.85, 2.34, 48.81, 48.90, 2.22, 2.46, -1, 0);
 		INSERT INTO spr VALUES (6, NULL, 'St. Petersburg', 'locality', 'US', 27.77, -82.64, 27.66, 27.85, -82.78, -82.51, -1, 0);
+		INSERT INTO spr VALUES (7, NULL, 'Thiron-Gardais', 'locality', 'FR', 48.32, 0.99, 48.30, 48.34, 0.97, 1.01, -1, 0);
+		INSERT INTO spr VALUES (8, NULL, 'Penne-d''Agenais', 'locality', 'FR', 44.39, 0.87, 44.37, 44.41, 0.85, 0.89, -1, 0);
 	`)
 
 	return db
@@ -105,5 +107,42 @@ describe("sanitizeFTSQuery — punctuation stripping (existing behavior, regress
 		// Confirm no crash from embedded asterisks; assertion is just "no SQL error". Result depends on
 		// fixture; here the prefix doesn't match anything.
 		await expect(lookup.findPlace({ text: "abc*xyz*", placetype: "postalcode" })).resolves.toBeInstanceOf(Array)
+	})
+})
+
+describe("sanitizeFTSQuery — intra-token punctuation SPLITS for non-postcode queries (#945)", () => {
+	test("hyphenated locality resolves — `Thiron-Gardais` reaches the FTS as two terms", async () => {
+		// The old fuse produced the single term `ThironGardais`, matching nothing: the unicode61
+		// tokenizer indexes the stored name as `thiron` + `gardais`. This class was masked for years
+		// because pre-splice models never emitted hyphen-preserved span values (#945).
+		const r = await lookup.findPlace({ text: "Thiron-Gardais", placetype: "locality" })
+
+		expect(r.length).toBe(1)
+		expect(r[0]?.name).toBe("Thiron-Gardais")
+	})
+
+	test("apostrophe + hyphen combined — `Penne-d'Agenais` resolves", async () => {
+		const r = await lookup.findPlace({ text: "Penne-d'Agenais", placetype: "locality" })
+
+		expect(r.length).toBe(1)
+		expect(r[0]?.name).toBe("Penne-d'Agenais")
+	})
+
+	test("trailing `*` applies to the final split part — `Thiron-Gard*` prefix-matches", async () => {
+		const r = await lookup.findPlace({ text: "Thiron-Gard*", placetype: "locality" })
+
+		expect(r.length).toBe(1)
+		expect(r[0]?.name).toBe("Thiron-Gardais")
+	})
+
+	test("postcode-typed queries KEEP the #920 fused name-law shape", async () => {
+		// A spaced/hyphenated postcode query must still fuse per token — the postal names are stored
+		// collapsed. `62-701` fused per-token is `62701`, matching the stored row; split it would be
+		// `"62" "701"`, which unicode61 also tokenizes to match — but the fuse is the contract the
+		// geonames-postal name law was built against, so pin it explicitly.
+		const r = await lookup.findPlace({ text: "62-701", placetype: "postalcode" })
+
+		expect(r.length).toBe(1)
+		expect(r[0]?.name).toBe("62701")
 	})
 })

--- a/resolver-wof-wasm/lookup.ts
+++ b/resolver-wof-wasm/lookup.ts
@@ -100,7 +100,12 @@ export class WOFWasmPlaceLookup implements PlaceLookup {
 
 		if (!text) return []
 
-		const ftsQuery = sanitizeFTSQuery(text)
+		// Postcode-typed queries keep the #920 fused name-law shape; everything else splits on
+		// intra-token punctuation so hyphenated names reach the FTS as their real terms (#945) —
+		// parity with the resolver-wof-sqlite implementation.
+		const ftsQuery = sanitizeFTSQuery(text, {
+			fuseTokens: normalizePlacetypes(query.placetype)?.includes("postalcode") ?? false,
+		})
 
 		if (!ftsQuery) return []
 
@@ -304,7 +309,7 @@ export class WOFWasmPlaceLookup implements PlaceLookup {
  * resolver-wof-sqlite implementation). Strips characters FTS5 treats as punctuation or operators so a user typing
  * `Paris's` or `St. (Petersburg)` doesn't trigger an "fts5: syntax error" inside the WASM runtime.
  */
-function sanitizeFTSQuery(text: string): string {
+function sanitizeFTSQuery(text: string, opts?: { fuseTokens?: boolean }): string {
 	const out: string[] = []
 
 	for (const rawToken of text.normalize("NFKC").split(/\s+/u)) {
@@ -312,10 +317,26 @@ function sanitizeFTSQuery(text: string): string {
 
 		if (!trimmed) continue
 		const hasPrefixStar = trimmed.endsWith("*")
-		const body = trimmed.replace(/[^\p{L}\p{N}]/gu, "")
 
-		if (!body) continue
-		out.push(hasPrefixStar ? `${body}*` : `"${body.replace(/"/g, '""')}"`)
+		// #920 name law (postcode-typed queries): delete intra-token punctuation and fuse.
+		if (opts?.fuseTokens) {
+			const body = trimmed.replace(/[^\p{L}\p{N}]/gu, "")
+
+			if (!body) continue
+			out.push(hasPrefixStar ? `${body}*` : `"${body.replace(/"/g, '""')}"`)
+			continue
+		}
+
+		// Non-postcode queries SPLIT on intra-token punctuation — fusing made "Thiron-Gardais" an
+		// unmatchable single term while the FTS doc holds two (#945).
+		const parts = trimmed.split(/[^\p{L}\p{N}]+/u).filter(Boolean)
+
+		for (let i = 0; i < parts.length; i++) {
+			const body = parts[i]!.replace(/\*/g, "")
+
+			if (!body) continue
+			out.push(hasPrefixStar && i === parts.length - 1 ? `${body}*` : `"${body.replace(/"/g, '""')}"`)
+		}
 	}
 
 	return out.join(" ")


### PR DESCRIPTION
**Flagged for your merge** — this is an unflagged behavior change (all non-postcode lookups) and carries one reported bar-miss needing your signature.

## The true root cause of #945 (third and final attribution)

Not a code regression, not the model *per se*: the **ancient FTS sanitizer** (#95-era) deletes intra-token punctuation, fusing `Thiron-Gardais` into the single term `ThironGardais` — unmatchable, since the FTS doc tokenizes the stored name as two terms. **Every hyphenated/apostrophed name has missed at the raw `findPlace` level in every code era** (verified pre-#922 through current). The class was masked for years because pre-splice tokenizers never emitted hyphen-preserved span values; v5.2.0's nsplice vocab preserves them faithfully and exposed it on FR. The 03:31 v1 dump (2.64/1.000) was irreproducible under 7 code points × 8 data configs × 4 flag sets — consistent only with v1-era values dodging the fuse. (A direct v1 rerun is impossible: the v1 tokenizer was **overwritten in place** at 03:47 — process note below.)

## The fix

Non-postcode queries **split** on intra-token punctuation — the behavior the function's own docstring always promised (`"St. (Petersburg)" → "St" "Petersburg"`). Postcode-typed queries keep the **#920 fused name law** via `fuseTokens` (pinned by test). Both twins (sqlite + wasm) for parity; trailing `*` applies to the final split part.

## Gate (pre-registered; full log in `$GATE/RESULTS.md`)

| leg | bar | result |
|---|---|---|
| FR-3k, shipped pair | resolve ≥0.99 ∧ res-p50 ≤3.0 | resolve **0.9987** ✓ / p50 **3.43 — bar MISS** (pre-fix 4.12/0.9593; 118/122 lost rows recovered; strict improvement on every metric). Residual 3.43-vs-2.64 stays open on #945 (suspect: the eval harness ranks `postalcode` above `locality` for the coordinate, so postcode-tier coords dominate the 2,250 postcode rows) |
| US-2k | byte-identical | **BYTE-IDENTICAL** |
| FI-1k | byte-identical | **BYTE-IDENTICAL** |
| CZ-1k | ≥ 1.80/0.998 (name-law contract) | **1.80/0.998** — at bar |
| SI-1k | byte-identical or wins-only | **one diff, a win**: Hrib-Loški Potok 40.3→1.9 km (a hyphenated village — the fix itself) |
| units | green | sanitize 12/12 (incl. the fused-postcode pin), suite 310 |

## Process findings shipped alongside (in RESULTS.md as standing rules)

1. **Never copy dumps across model labels** — 9 of 16 v5.2.0 "baselines" were v1 byte-copies; 8 benign, FR was the one that mattered.
2. **Tokenizer dirs are immutable** — v0.7.1-nsplice was overwritten in place at release, destroying the v1 artifact and with it the ability to re-grade.
3. All `*-nsv2` dumps retired; today's shipped-pair dumps are canonical baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA