### PR TITLE
chore(evals): v5.3.0 ledger row (cadence entry #2) + the operator-exception escape

### DIFF
--- a/evals/scores-by-version.json
+++ b/evals/scores-by-version.json
@@ -629,6 +629,47 @@
 				}
 			},
 			"notes": "Coordinated model+code cut on gate v5.2.0-nordic (one $revision: us.postcode 95→94.8, measurement identity — shipped-fp32 reads the same 94.8, 0/2660 parse diffs; operator-approved). Nordic vocab-splice: SE 83.8→90.2 (p90res 113→12.7km), NO 92.7→98.1, DK 91.4→95.2, Åbo 0.12km; 14/14 ni; US byte-identical. Post-ship gauntlet 19/19 + metamorphic PASS. Carries the resolver arc #910/#920/#922/#923/#927/#929/#930/#931. [graded_artifact=fp32; gate=v4.15.0-boundary; out-dir=/mnt/playpen/mailwoman-data/scratch-825/gate-v193/v520-gate-out]"
+		},
+		{
+			"run_id": "v220-full-family-100k-postship-20260704",
+			"model_version": "5.3.0",
+			"model_path": "@mailwoman/neural-weights-en-us@5.3.0 (model.onnx md5 a64ad2e6b9ee73a6b63f3c94c01b1966; tokenizer v0.7.1-nsplice md5 8e1cab7c unchanged from 5.2.0)",
+			"corpus_version": "corpus-v0.10.0-boundary-family",
+			"corpus_sha256": "see the shipped model-card corpus_version (practiced-shape pointer, not a digest)",
+			"eval_set_version": "promotion-gate battery (v5.3.0-family): golden v0.1.2 + real-OOD + arena perturb",
+			"eval_set_sha256": "per-file, see data/eval/external",
+			"trained_at": "2026-07-03",
+			"hardware": "NVIDIA A100-SXM4-40GB (Modal cloud)",
+			"training_steps": 100000,
+			"training_wall_clock_seconds": 0,
+			"metrics": {
+				"us": {
+					"postcode": 96.5,
+					"country_homograph": 85.1,
+					"micro": 87.3,
+					"locality": 78.7,
+					"region": 90.7,
+					"street": 82.1,
+					"street_prefix": 98,
+					"street_suffix": 94.9,
+					"unit": 97,
+					"po_box_real": 90.1,
+					"intersection_real": 100
+				},
+				"fr": {
+					"postcode": 99.2,
+					"house_number": 98.2,
+					"region": 52,
+					"cedex_real": 93.1
+				},
+				"de": {
+					"native_locality_anchor_on": 91.3
+				},
+				"arena": {
+					"perturb": 79
+				}
+			},
+			"notes": "v2.2.0-full-family promoted from the 2026-07-03 archive at the #901 operator fork (fixes #949: FR bare street 16->34/40; CZ wrong-city 13.7->6.6, SK 13.3->6.6; SE +4.6pp; Abo fixed; US/FR ni identical; SI +2.7pp trade floored by #942 default-ON). POST-SHIP battery on the published pair: every floor PASS incl. fr.postcode at exactly its revised 99.2 floor (gate v5.3.0-family.json) and fr.cedex_real recovered 89.4->93.1 (the 07-02 scorecard's unsigned drift substantially healed). Re-score cadence entry #2. OPERATOR-EXCEPTED CHECKS (adjudicated at the promote fork, see the gate spec's revision comment): int8_delta.us.country_homograph_f1. [graded_artifact=int8; gate=v5.3.0-family; out-dir=/mnt/playpen/mailwoman-data/scratch-825/gate-v530-postship]"
 		}
 	]
 }

--- a/scripts/eval/ledger-append.ts
+++ b/scripts/eval/ledger-append.ts
@@ -38,6 +38,12 @@ const { values } = parseArgs({
 		"trained-at": { type: "string" },
 		notes: { type: "string", default: "" },
 		replace: { type: "boolean", default: false },
+		// The gate-revision escape (mirrors the no-silent-gate-drift discipline): a FAIL verdict may
+		// be ledgered ONLY when every failing check is named here — i.e. the operator adjudicated the
+		// exact miss at a fork (e.g. a per-artifact int8-delta exception recorded in the gate spec's
+		// $revision comment). The excepted checks are stamped into the row's notes; any UNnamed
+		// failure still refuses. Repeatable.
+		"operator-exception": { type: "string", multiple: true },
 	},
 })
 
@@ -63,10 +69,26 @@ interface Verdict {
 }
 
 const verdict = JSON.parse(readFileSync(`${values["out-dir"]}/verdict.json`, "utf8")) as Verdict
+const exceptions = values["operator-exception"] ?? []
+let exceptionNote = ""
 
 if (verdict.verdict !== "PASS") {
-	console.error(`✗ refusing to ledger a ${verdict.verdict} verdict — the ledger records shipped/shippable runs`)
-	process.exit(1)
+	const failing = Object.entries(verdict.results)
+		.filter(([, r]) => !r.pass)
+		.map(([k]) => k)
+	const unexcepted = failing.filter((k) => !exceptions.includes(k))
+
+	if (unexcepted.length > 0) {
+		console.error(
+			`✗ refusing to ledger a ${verdict.verdict} verdict — the ledger records shipped/shippable runs.\n` +
+				`  failing checks: ${failing.join(", ")}\n` +
+				`  (only ${exceptions.length ? exceptions.join(", ") : "none"} are operator-excepted; ` +
+				`name each adjudicated miss via --operator-exception)`
+		)
+		process.exit(1)
+	}
+	exceptionNote = ` OPERATOR-EXCEPTED CHECKS (adjudicated at the promote fork, see the gate spec's revision comment): ${failing.join(", ")}.`
+	console.error(`! ledgering a FAIL verdict under operator exception: ${failing.join(", ")}`)
 }
 
 // verdict floor keys → the ledger's practiced metrics shape (the v4.4.0 row).
@@ -126,7 +148,7 @@ const row = {
 	training_wall_clock_seconds: 0,
 	metrics,
 	notes:
-		`${values.notes} [graded_artifact=${verdict.graded_artifact}; gate=${verdict.label}; out-dir=${values["out-dir"]}]`.trim(),
+		`${values.notes}${exceptionNote} [graded_artifact=${verdict.graded_artifact}; gate=${verdict.label}; out-dir=${values["out-dir"]}]`.trim(),
 }
 
 interface Ledger {


### PR DESCRIPTION
Post-ship battery on the published pair: every floor PASS (fr.postcode exactly at its revised
99.2; fr.cedex_real 89.4->93.1 — the 07-02 unsigned drift substantially healed); verdict FAIL
on exactly the documented per-artifact int8-homograph exception (2.4 vs the 1.5 cap, fp32
clean, adjudicated at the #901 fork, cap unchanged).

ledger-append.ts gains --operator-exception <check> (repeatable): a FAIL verdict ledgers ONLY
when every failing check is named (the gate-revision discipline, mechanized); the excepted
checks are stamped into the row notes; any unnamed failure still refuses — verified both ways.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ga4p3yrrxKNP9qFYEDw722
