### PR TITLE
fix(demo): createDbWorker — batch-B acronym sweep renamed an external export, silently killing the street tier

### DIFF
--- a/docs/plugins/demo-assets/resolve.ts
+++ b/docs/plugins/demo-assets/resolve.ts
@@ -272,7 +272,7 @@ export function syncArtifact(sourcePath: string, destPath: string, label: string
 
 /**
  * Stage sql.js-httpvfs's runtime assets (the UMD bundle + its Worker + WASM) into `destDir`. The demo loads these at
- * RUNTIME by URL — the UMD via a classic <script>, the worker + wasm passed to createDBWorker — so webpack never sees
+ * RUNTIME by URL — the UMD via a classic <script>, the worker + wasm passed to createDbWorker — so webpack never sees
  * them. That's deliberate: bundling sql.js-httpvfs (a webpack UMD bundle with dynamic Worker/wasm requires) is exactly
  * what produces "Critical dependency" build warnings, so we keep it out of the graph entirely.
  *

--- a/docs/src/shared/httpvfs-resolver.test.ts
+++ b/docs/src/shared/httpvfs-resolver.test.ts
@@ -98,3 +98,25 @@ describe("browser WOFCandidateTableLookup postal-city side-index (#741)", () => 
 		expect(hits[0]!.name).toBe("Antioch") // no probe → normal population-first ranking
 	})
 })
+
+describe("sql.js-httpvfs external-name contract (the batch-B casing incident)", () => {
+	// The acronym-casing sweep (da54bc8c) renamed `window.createDbWorker` → `createDBWorker` — an
+	// EXTERNAL library's export, explicitly exempt from the house convention (AGENTS.md). The UMD
+	// loaded, the capitalized global never existed, and the demo street tier silently fell back to
+	// the admin cascade for three days. These pins make the next sweep fail loudly instead.
+	test("the library actually exports `createDbWorker` (lowercase b)", async () => {
+		const { createRequire } = await import("node:module")
+		const require = createRequire(import.meta.url)
+		const umd = require("sql.js-httpvfs/dist/index.js") as Record<string, unknown>
+
+		expect(typeof umd.createDbWorker).toBe("function")
+	})
+
+	test("the loader references the library's own casing and never the house-cased variant", async () => {
+		const { readFileSync } = await import("node:fs")
+		const source = readFileSync(new URL("./httpvfs-resolver.ts", import.meta.url), "utf8")
+
+		expect(source).toContain("createDbWorker")
+		expect(source).not.toContain("createDBWorker")
+	})
+})

--- a/docs/src/shared/httpvfs-resolver.ts
+++ b/docs/src/shared/httpvfs-resolver.ts
@@ -16,8 +16,14 @@
  *
  *   Sql.js-httpvfs ships a webpack UMD bundle (not ESM) and a Worker + WASM. The demo-assets plugin
  *   stages all three into `static/mailwoman/sqljs/`; we load the UMD via a classic <script> (→
- *   `window.createDBWorker`) and hand the worker + wasm URLs to it. Nothing here is bundled by
+ *   `window.createDbWorker`) and hand the worker + wasm URLs to it. Nothing here is bundled by
  *   webpack — that's what keeps the Docusaurus build warning-free.
+ *
+ *   `createDbWorker` (lowercase b) is sql.js-httpvfs's OWN export name — the acronym-casing
+ *   convention explicitly exempts external library names (AGENTS.md), and the batch-B sweep
+ *   (da54bc8c) violating that here silently killed the street tier for three days: the UMD loaded,
+ *   `window.createDbWorker` never existed, and the demo fell back to the admin cascade. The
+ *   contract test pins the library's export name against this file.
  */
 
 import { expandPlacetypeFilter } from "@mailwoman/resolver"
@@ -100,7 +106,7 @@ interface HTTPVFSWorker {
 	bytesRead(): Promise<number>
 }
 
-/** The raw shape `createDBWorker` resolves to — `worker` is the Comlink proxy. */
+/** The raw shape `createDbWorker` resolves to — `worker` is the Comlink proxy. */
 interface RawWorkerHTTPVFS {
 	db: HTTPVFSWorker["db"]
 	worker?: { bytesRead?: number | Promise<number> }
@@ -125,9 +131,9 @@ export async function loadHTTPVFSDatabase(
 	sqljsBaseURL: string,
 	options: HTTPSVFSOptions = {}
 ): Promise<HTTPVFSWorker> {
-	const w = window as unknown as { createDBWorker?: (...args: unknown[]) => Promise<RawWorkerHTTPVFS> }
+	const w = window as unknown as { createDbWorker?: (...args: unknown[]) => Promise<RawWorkerHTTPVFS> }
 
-	if (typeof w.createDBWorker !== "function") {
+	if (typeof w.createDbWorker !== "function") {
 		await new Promise<void>((res, rej) => {
 			const s = document.createElement("script")
 			s.src = `${sqljsBaseURL}/index.js`
@@ -137,7 +143,7 @@ export async function loadHTTPVFSDatabase(
 		})
 	}
 
-	if (typeof w.createDBWorker !== "function") throw new Error("createDBWorker missing after UMD load")
+	if (typeof w.createDbWorker !== "function") throw new Error("createDbWorker missing after UMD load")
 
 	// Open over byte-range fetches, then force the header + schema pages through SQLite with a
 	// cheap read. On mobile Safari the HTTP cache can hand sql.js-httpvfs a torn 64 KB range chunk,
@@ -147,7 +153,7 @@ export async function loadHTTPVFSDatabase(
 	// with a cache-busting query param to force fresh chunks. Self-heals a poisoned cache without
 	// permanently defeating caching for the happy path. See the 2026-06 mobile-Safari demo report.
 	const open = async (url: string): Promise<HTTPVFSWorker> => {
-		const raw = await w.createDBWorker!(
+		const raw = await w.createDbWorker!(
 			[
 				{
 					from: "inline",


### PR DESCRIPTION
Fixes the operator-reported `[mailwoman demo] street tier unavailable; falling back to admin cascade — Error: createDBWorker missing after UMD load`.

## Root cause

`da54bc8c` (acronym sweep batch B, Jul 1) capitalized `createDbWorker` → `createDBWorker` in the httpvfs loader — but that identifier is **sql.js-httpvfs's own export name**, set on `window` by its UMD, and external library names are explicitly exempt from the house casing convention (AGENTS.md). The UMD loaded fine; the capitalized global never existed; every street-tier open threw and the demo silently degraded to the admin cascade **for three days** (the fallback log was the only symptom).

Diagnosed statically (no Chrome on the lab box): the deployed UMD is byte-identical to `node_modules` and exports only `createDbWorker`; all 1,129 deployed webpack chunks are clean of `define`/`module` global pollution (ruling out the UMD-branch-hijack theory); a Node `require()` of the dist names the real export.

## Fix + guard

- All 8 references revert to the library's casing, with the exemption + incident cited at the loader head.
- **Contract tests** pin both sides: the library's dist actually exports `createDbWorker`, and this loader never contains the house-cased variant — the next sweep fails loudly in CI instead of silently unshipping the street tier.
- Batch-B audit: this was the sweep's only external-name violation.

Merging redeploys the demo via the path-filtered docs-build; the street tier comes back with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA