### PR TITLE
feat(#370): postcodeConsistency default ON + the coordinate-convention epoch — operator promote

### DIFF
--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -375,7 +375,11 @@ export interface ResolveOpts {
 	 * `postcode_city_mismatch`. Targets the dominant failure mode on the EU/AU panel — a same-named town resolved to the
 	 * wrong instance while the postcode that would disambiguate it sits resolved in the same tree (e.g. "06260
 	 * Saint-Pierre" → 617 km off, postcode 06260 correct). Only bites where the backend resolved the postcode to a point
-	 * (so it composes with postcode coverage, #193). Default-off + byte-stable when unset.
+	 * (so it composes with postcode coverage, #193).
+	 *
+	 * **Default ON** (operator-promoted 2026-07-04 after the corrected gate: FI 231 wins / 0 losses, SI 37/6, CZ 47/2, US
+	 * aggregates byte-flat with 9/2,000 rows touched — the four losses being two golden-data errors the pass correctly
+	 * flags as `postcode_city_mismatch` and one bad ZIP centroid). Explicit `false` opts out (byte-stable then).
 	 */
 	postcodeConsistency?: boolean
 	/**

--- a/resolver/postcode-consistency.test.ts
+++ b/resolver/postcode-consistency.test.ts
@@ -115,10 +115,23 @@ describe("resolveTree + postcodeConsistency (Lever A)", () => {
 		expect(loc.metadata?.postcode_city_mismatch).toBeUndefined()
 	})
 
-	it("is byte-stable when postcodeConsistency is unset (keeps the wrong top match)", async () => {
+	it("DEFAULT (ON since the 2026-07-04 promote): unset opts re-pick the consistent instance", async () => {
 		const resolver = createWOFResolver(makeBackend([PC, SP_FAR, SP_NEAR]))
 		const out = await resolver.resolveTree(tree([postcodeNode(), localityNode()]), { defaultCountry: "FR" })
 		const loc = out.roots.find((n) => n.tag === "locality")!
+
+		expect(loc.placeID).toBe("wof:2") // the postcode-consistent instance wins by default now
+		expect(loc.metadata?.postcode_repicked).toBe(true)
+	})
+
+	it("is byte-stable when postcodeConsistency is EXPLICITLY false (keeps the wrong top match)", async () => {
+		const resolver = createWOFResolver(makeBackend([PC, SP_FAR, SP_NEAR]))
+		const out = await resolver.resolveTree(tree([postcodeNode(), localityNode()]), {
+			defaultCountry: "FR",
+			postcodeConsistency: false,
+		})
+		const loc = out.roots.find((n) => n.tag === "locality")!
+
 		expect(loc.placeID).toBe("wof:1") // the far one — untouched without the lever
 		expect(loc.lat).toBeCloseTo(44.0)
 	})

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -709,10 +709,11 @@ class WOFResolver implements Resolver {
 			await applyExplicitCountryCoherence(newRoots, this.#backend)
 		}
 
-		// Postcode-consistency (#370 "Lever A"): opt-in. After the admin walk (needs both the locality
-		// and the postcode resolved) and before the street tiers (which key off the postcode/street, not
-		// the locality coordinate this adjusts). Byte-stable when opts.postcodeConsistency is unset.
-		if (opts.postcodeConsistency) {
+		// Postcode-consistency (#370 "Lever A"): default-ON (promoted 2026-07-04 — the corrected gate:
+		// FI 231/0, SI 37/6, CZ 47/2, US byte-flat; see the ResolveOpts docstring). After the admin walk
+		// (needs both the locality and the postcode resolved) and before the street tiers (which key off
+		// the postcode/street, not the locality coordinate this adjusts). `false` opts out, byte-stable.
+		if (opts.postcodeConsistency !== false) {
 			applyPostcodeConsistency(newRoots, opts.postcodeConsistencyGateKm ?? 50)
 		}
 

--- a/scripts/eval/fr-admin-split-gate.ts
+++ b/scripts/eval/fr-admin-split-gate.ts
@@ -30,9 +30,16 @@ import { haversineKm } from "@mailwoman/spatial"
 
 import { arg } from "../lib/cli-args.ts"
 
+/**
+ * CONVENTION EPOCH 2026-07-04 (#945, operator-promoted): the DEFAULT scoring coordinate is the one production's
+ * result-assembly ladder picks — LOCALITY over postcode (geocode-core `adminPriority`). The harness historically scored
+ * the postcode point (rank 6 > 5), which measured a non-production preference and hid a 1.5 km-class FR gap for weeks.
+ * All dumps BEFORE this epoch are postcode-convention: NEVER compare across conventions (the tokenizer-F1 rule,
+ * coordinate edition). `--prefer-postcode-coord` reproduces the old convention for continuity runs only.
+ */
 const PLACETYPE_RANK: Record<string, number> = {
-	postalcode: 6,
-	locality: 5,
+	locality: 6,
+	postalcode: 5,
 	localadmin: 4,
 	borough: 4,
 	county: 3,
@@ -40,13 +47,8 @@ const PLACETYPE_RANK: Record<string, number> = {
 	country: 0,
 }
 
-/**
- * #945 residual instrumentation: production's result-assembly ladder (geocode-core `adminPriority`) prefers LOCALITY
- * over postcode; this harness historically preferred the postcode point (rank 6 > 5). `--prefer-locality-coord` mirrors
- * production so the two coordinate conventions can be measured against the same golden. Not a default flip — the choice
- * is the open trade-off on #945.
- */
-const PRODUCTION_LADDER_RANK: Record<string, number> = { ...PLACETYPE_RANK, locality: 6, postalcode: 5 }
+/** The pre-epoch (postcode-point) convention — continuity runs against pre-2026-07-04 dumps only. */
+const POSTCODE_CONVENTION_RANK: Record<string, number> = { ...PLACETYPE_RANK, postalcode: 6, locality: 5 }
 interface Resolved {
 	id: number
 	name: string
@@ -145,7 +147,11 @@ async function main() {
 			// #942: postal-compound recovery (library default ON since the 2026-07-03 promote).
 			"postal-compound-recovery": { type: "boolean" },
 			"no-postal-compound-recovery": { type: "boolean" },
-			// #945 residual: score the coordinate production's ladder would pick (locality over postcode).
+			// Convention epoch 2026-07-04: locality-first is the DEFAULT (production's ladder). This flag
+			// reproduces the pre-epoch postcode-point convention for continuity against old dumps only.
+			"prefer-postcode-coord": { type: "boolean" },
+			// Pre-epoch spelling — accepted so in-flight scripts don't silently change convention; it IS
+			// the default now, so it's a no-op.
 			"prefer-locality-coord": { type: "boolean" },
 		},
 		strict: false,
@@ -212,7 +218,7 @@ async function main() {
 		}
 		const best = mostSpecific(
 			collectResolved(await resolver.resolveTree(tree, resolveOpts)),
-			pins["prefer-locality-coord"] === true ? PRODUCTION_LADDER_RANK : PLACETYPE_RANK
+			pins["prefer-postcode-coord"] === true ? POSTCODE_CONVENTION_RANK : PLACETYPE_RANK
 		)
 
 		if (best) {


### PR DESCRIPTION
Both flips from the #945 contemplation, operator-approved ("in favor of both so long as American post codes don't regress meaningfully") — the condition measured and met.

## The US condition

Locality-first convention, consistency ON vs OFF: **p50/p90 byte-flat** (3.54/10.05), 9 of 2,000 rows differ — 5 wins, 4 losses. The losses decompose to **two golden-data errors** (Tama IA listed with Dallas ZIP 75248; the pass correctly trusts the postcode and flags `postcode_city_mismatch` — the "1,067 km loss" is the gold being wrong) and **one bad ZIP centroid** (Hungry Horse 59919, both rows). Under the postcode convention: byte-identical.

## What the flips buy (corrected gate; v5.3.0 pair)

| leg | OFF → ON |
|---|---|
| FI-1k | **231 wins / 0 losses**, p50 → 0.75 km |
| SI-1k | 37/6, p50 1.51 → **0.76 km** |
| CZ-1k | 47/2, p50 → 1.72 km |
| FR-3k | p50 1.97 → **1.92**, p90 8.25 → **7.62** |

## The retraction inside the gate log

The first battery's "NOT READY" verdict was graded on a broken driver — zsh doesn't word-split unquoted `$4`, so every double-flag leg ran **flagless** (the scary "byte-identity" was literally the default run; the pass's code is faithful to its documented >50 km gate). Third zsh word-split casualty this session; drivers now pass flags as real argv.

## Epoch

Harness default scoring coordinate = production's ladder (locality over postcode). **Convention epoch 2026-07-04**: all pre-epoch dumps retired for comparisons; `--prefer-postcode-coord` reproduces the old convention for continuity runs. Epoch-1 baselines dumped under pure defaults and **byte-verified identical** to the flagged gate legs: us 3.54/10.05 · fr 1.92/7.62 · si 0.76/4.7 · fi 0.75/3.15 · cz 1.72/6.92.

Residuals filed: Hungry Horse ZIP centroid (gazetteer data), two golden rows with wrong postcodes (eval data).

Suites: resolver 86, mailwoman 531, lint green. Merging on green per the pre-authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA