### PR TITLE
fix(demo): releases.json wire keys — the sweep silently disabled the WOF cascade + FST

### DIFF
--- a/docs/src/components/FSTWalker/FSTWalker.tsx
+++ b/docs/src/components/FSTWalker/FSTWalker.tsx
@@ -223,7 +223,7 @@ const FSTWalkerInner: React.FC<FSTWalkerProps> = ({ input }) => {
 					<span className={styles.fallbackIcon}>📡</span>
 					<p>
 						FST gazetteer not loaded for the selected version. The walker requires an FST binary ({" "}
-						<code>fst-en-US.bin</code>) — try a version with <code>hasFST: true</code> in the releases manifest.
+						<code>fst-en-US.bin</code>) — try a version with <code>hasFst: true</code> in the releases manifest.
 					</p>
 				</div>
 			</div>

--- a/docs/src/contexts/DemoEmbed.tsx
+++ b/docs/src/contexts/DemoEmbed.tsx
@@ -171,9 +171,9 @@ export const DemoEmbedProvider: React.FC<DemoEmbedProviderProps> = ({ sqljsBaseU
 				// Build staged step labels based on what this release includes.
 				const steps: string[] = ["Loading classifier"]
 
-				if (release?.hasFST) steps.push("Loading FST gazetteer")
+				if (release?.hasFst) steps.push("Loading FST gazetteer")
 
-				if (release?.hasWOFDb) steps.push("Loading WOF database")
+				if (release?.hasWofDb) steps.push("Loading WOF database")
 				setLoadingStepLabels(steps)
 
 				// Dynamic import @mailwoman/neural-web — the webpack alias resolves this to the
@@ -229,7 +229,7 @@ export const DemoEmbedProvider: React.FC<DemoEmbedProviderProps> = ({ sqljsBaseU
 					// No calibration table for this version — raw scores it is.
 				}
 
-				if (release?.hasFST) {
+				if (release?.hasFst) {
 					try {
 						const fstResult = await loadFSTGazetteer(DEFAULT_LOCALE, selectedVersion)
 						setFSTMatcher(fstResult.matcher)
@@ -243,7 +243,7 @@ export const DemoEmbedProvider: React.FC<DemoEmbedProviderProps> = ({ sqljsBaseU
 				// Step 1 complete: FST loaded (or skipped).
 				setLoadingStepIndex(1)
 
-				if (release?.hasWOFDb) {
+				if (release?.hasWofDb) {
 					try {
 						const { loadHTTPVFSDatabase, WOFCandidateTableLookup } = await import("../shared/httpvfs-resolver")
 						const worker = await loadHTTPVFSDatabase(adminGazetteerURL(), sqljsBaseURL)

--- a/docs/src/pages/demo/_app.tsx
+++ b/docs/src/pages/demo/_app.tsx
@@ -394,7 +394,7 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 
 				if (cancelled) return
 
-				if (release?.hasFST) {
+				if (release?.hasFst) {
 					try {
 						const fstResult = await loadFSTGazetteer(DEFAULT_LOCALE, selectedVersion)
 						setFSTMatcher(fstResult.matcher)
@@ -405,7 +405,7 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 					}
 				}
 
-				if (release?.hasWOFDb) {
+				if (release?.hasWofDb) {
 					setLookupLoader(() => async (onProgress?: (bytesRead: number) => void) => {
 						// Range-load the DB via sql.js-httpvfs — ~5 MB/session vs the whole 53 MB.
 						const { loadHTTPVFSDatabase, WOFCandidateTableLookup } = await import("../../shared/httpvfs-resolver")

--- a/docs/src/shared/demo-helpers.ts
+++ b/docs/src/shared/demo-helpers.ts
@@ -21,8 +21,13 @@ export interface ReleaseInfo {
 	modelSize: string
 	tokenizerVocab: number
 	steps: number
-	hasFST: boolean
-	hasWOFDb: boolean
+	// `hasFst` / `hasWofDb` are WIRE KEYS from the published releases.json — a string contract exempt
+	// from the acronym-casing convention (AGENTS.md). The batch-A sweep capitalized these reads while
+	// the live manifest kept the old keys: every release read `undefined`, silently disabling the WOF
+	// cascade AND the FST for the whole demo from 2026-07-01 to 07-04. Pinned by the manifest
+	// contract test — do not re-sweep.
+	hasFst: boolean
+	hasWofDb: boolean
 	hasAnchor?: boolean
 	hasPolygons?: boolean
 }

--- a/docs/src/shared/manifest-wire-keys.test.ts
+++ b/docs/src/shared/manifest-wire-keys.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Wire-key contract for the published releases manifest (the batch-A casing incident). The
+ *   acronym sweep capitalized `hasFst`/`hasWofDb` in code while the R2 releases.json kept the old
+ *   keys — every release read `undefined`, silently disabling the demo's WOF cascade and FST from
+ *   2026-07-01 to 07-04, with zero console errors. releases.json keys are a string contract
+ *   (AGENTS.md wire-key exemption): the demo, the embed context, and the publisher must all use
+ *   the published casing.
+ */
+
+import { readFileSync } from "node:fs"
+
+import { describe, expect, test } from "vitest"
+
+const SOURCES = [
+	"./demo-helpers.ts",
+	"../pages/demo/_app.tsx",
+	"../contexts/DemoEmbed.tsx",
+	"../../../scripts/publish-release-to-hf.ts",
+] as const
+
+describe("releases.json wire keys (string contract — exempt from the acronym convention)", () => {
+	for (const rel of SOURCES) {
+		test(`${rel} uses the published casing (hasFst / hasWofDb)`, () => {
+			const src = readFileSync(new URL(rel, import.meta.url), "utf8")
+
+			expect(src).not.toContain("hasFST")
+			expect(src).not.toContain("hasWOFDb")
+		})
+	}
+})

--- a/scripts/publish-release-to-hf.ts
+++ b/scripts/publish-release-to-hf.ts
@@ -44,7 +44,7 @@ const REQUIRED_FILES = [
 	// The slim wof-hot.db was RETIRED 2026-06-20: the demo's admin tier now byte-range-resolves
 	// against the global candidate table, hosted version-independently at
 	// mailwoman/gazetteer/<ver>/candidate.db (NOT a per-release asset — it's model-independent). See
-	// RELEASING.md + project-candidate-table-byte-range. `hasWOFDb` in releases.json stays true (it now
+	// RELEASING.md + project-candidate-table-byte-range. `hasWofDb` in releases.json stays true (it now
 	// means "this version has admin resolution", which the version-independent gazetteer always provides).
 ]
 
@@ -264,8 +264,8 @@ async function main() {
 		modelSize: args.modelSize ?? `${Math.round(statSync(args.model as string).size / 1024 / 1024)} MB`,
 		tokenizerVocab: 48000,
 		steps: args.steps ? parseInt(args.steps, 10) : 100000,
-		hasFST: true,
-		hasWOFDb: true,
+		hasFst: true,
+		hasWofDb: true,
 		// These artifacts usually ride the R2 staging rather than this script's flags, so derive the
 		// truth by PROBING the demo's serving path (the four-release hasPolygons:false rectangle bug,
 		// 2026-06-11). CLI args still count; either source sets the flag.


### PR DESCRIPTION
Second wire-contract casualty of the acronym sweep (sibling of #955), and the actual cause of the operator's "demo always shows no WOF hits":

- **Batch A** capitalized the manifest reads (`hasFST`/`hasWOFDb`) while the published R2 `releases.json` keeps `hasFst`/`hasWofDb` → every release read `undefined` → **no WOF cascade, no FST, for the entire demo since Jul 1**, zero console errors (Playwright-verified: parse rows render, `resolved: {}`, 0 markers, street tier healthy post-#955).
- Latent second bug behind the mismatch: the 5.x manifest entries carried `hasWofDb: false` — **already fixed live on R2** (`v5.1.0/v5.2.0/v5.3.0 → true`; the 2026-07-03a candidate.db serves, 1.39 GB, HTTP 200).

Reads + the publisher revert to the published casing (wire-key exemption cited); a contract test pins all four sources against the next sweep. Post-merge deploy re-verified with Playwright before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA