### PR TITLE
feat(demo): manifest wire-key migration — house casing inside, one tolerant boundary

### DIFF
--- a/docs/src/components/FSTWalker/FSTWalker.tsx
+++ b/docs/src/components/FSTWalker/FSTWalker.tsx
@@ -223,7 +223,7 @@ const FSTWalkerInner: React.FC<FSTWalkerProps> = ({ input }) => {
 					<span className={styles.fallbackIcon}>📡</span>
 					<p>
 						FST gazetteer not loaded for the selected version. The walker requires an FST binary ({" "}
-						<code>fst-en-US.bin</code>) — try a version with <code>hasFst: true</code> in the releases manifest.
+						<code>fst-en-US.bin</code>) — try a version with <code>hasFST: true</code> in the releases manifest.
 					</p>
 				</div>
 			</div>

--- a/docs/src/contexts/DemoEmbed.tsx
+++ b/docs/src/contexts/DemoEmbed.tsx
@@ -16,7 +16,7 @@ import type React from "react"
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
 
 import type { Calibrator, ReleasesManifest } from "../shared/demo-helpers.ts"
-import { createCalibrator, DEFAULT_LOCALE } from "../shared/demo-helpers.ts"
+import { createCalibrator, DEFAULT_LOCALE, normalizeReleasesManifest } from "../shared/demo-helpers.ts"
 import { pruneDBRangeCache, registerRangeCacheServiceWorker } from "../shared/register-range-sw.ts"
 import type {
 	FSTMatcherLike,
@@ -131,7 +131,7 @@ export const DemoEmbedProvider: React.FC<DemoEmbedProviderProps> = ({ sqljsBaseU
 		void (async () => {
 			try {
 				const res = await fetch(assetURL(DEFAULT_LOCALE, "", "releases.json").replace(/\/\/releases/, "/releases"))
-				const data: ReleasesManifest | null = res.ok ? await res.json() : null
+				const data: ReleasesManifest | null = res.ok ? normalizeReleasesManifest(await res.json()) : null
 
 				if (cancelled) return
 
@@ -171,9 +171,9 @@ export const DemoEmbedProvider: React.FC<DemoEmbedProviderProps> = ({ sqljsBaseU
 				// Build staged step labels based on what this release includes.
 				const steps: string[] = ["Loading classifier"]
 
-				if (release?.hasFst) steps.push("Loading FST gazetteer")
+				if (release?.hasFST) steps.push("Loading FST gazetteer")
 
-				if (release?.hasWofDb) steps.push("Loading WOF database")
+				if (release?.hasWOFDb) steps.push("Loading WOF database")
 				setLoadingStepLabels(steps)
 
 				// Dynamic import @mailwoman/neural-web — the webpack alias resolves this to the
@@ -229,7 +229,7 @@ export const DemoEmbedProvider: React.FC<DemoEmbedProviderProps> = ({ sqljsBaseU
 					// No calibration table for this version — raw scores it is.
 				}
 
-				if (release?.hasFst) {
+				if (release?.hasFST) {
 					try {
 						const fstResult = await loadFSTGazetteer(DEFAULT_LOCALE, selectedVersion)
 						setFSTMatcher(fstResult.matcher)
@@ -243,7 +243,7 @@ export const DemoEmbedProvider: React.FC<DemoEmbedProviderProps> = ({ sqljsBaseU
 				// Step 1 complete: FST loaded (or skipped).
 				setLoadingStepIndex(1)
 
-				if (release?.hasWofDb) {
+				if (release?.hasWOFDb) {
 					try {
 						const { loadHTTPVFSDatabase, WOFCandidateTableLookup } = await import("../shared/httpvfs-resolver")
 						const worker = await loadHTTPVFSDatabase(adminGazetteerURL(), sqljsBaseURL)

--- a/docs/src/pages/demo/_app.tsx
+++ b/docs/src/pages/demo/_app.tsx
@@ -39,6 +39,7 @@ import {
 	DEFAULT_LOCALE,
 	EXAMPLE_ADDRESSES,
 	flattenTree,
+	normalizeReleasesManifest,
 	resolveStreet,
 	runCascade,
 } from "../../shared/demo-helpers.ts"
@@ -238,7 +239,7 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 					// to stay immutably cached.
 					fetch(assetURL(DEFAULT_LOCALE, "", "releases.json").replace(/\/\/releases/, "/releases"), {
 						cache: "reload",
-					}).then((r) => (r.ok ? (r.json() as Promise<ReleasesManifest>) : null)),
+					}).then(async (r) => (r.ok ? normalizeReleasesManifest(await r.json()) : null)),
 					import("maplibre-gl"),
 					fetchBasemapSource(),
 				])
@@ -394,7 +395,7 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 
 				if (cancelled) return
 
-				if (release?.hasFst) {
+				if (release?.hasFST) {
 					try {
 						const fstResult = await loadFSTGazetteer(DEFAULT_LOCALE, selectedVersion)
 						setFSTMatcher(fstResult.matcher)
@@ -405,7 +406,7 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 					}
 				}
 
-				if (release?.hasWofDb) {
+				if (release?.hasWOFDb) {
 					setLookupLoader(() => async (onProgress?: (bytesRead: number) => void) => {
 						// Range-load the DB via sql.js-httpvfs — ~5 MB/session vs the whole 53 MB.
 						const { loadHTTPVFSDatabase, WOFCandidateTableLookup } = await import("../../shared/httpvfs-resolver")

--- a/docs/src/shared/demo-helpers.ts
+++ b/docs/src/shared/demo-helpers.ts
@@ -21,13 +21,8 @@ export interface ReleaseInfo {
 	modelSize: string
 	tokenizerVocab: number
 	steps: number
-	// `hasFst` / `hasWofDb` are WIRE KEYS from the published releases.json — a string contract exempt
-	// from the acronym-casing convention (AGENTS.md). The batch-A sweep capitalized these reads while
-	// the live manifest kept the old keys: every release read `undefined`, silently disabling the WOF
-	// cascade AND the FST for the whole demo from 2026-07-01 to 07-04. Pinned by the manifest
-	// contract test — do not re-sweep.
-	hasFst: boolean
-	hasWofDb: boolean
+	hasFST: boolean
+	hasWOFDb: boolean
 	hasAnchor?: boolean
 	hasPolygons?: boolean
 }
@@ -36,6 +31,42 @@ export interface ReleasesManifest {
 	locale: string
 	defaultVersion: string
 	releases: ReleaseInfo[]
+}
+
+/** The raw wire shape of one releases.json entry — either key generation may appear. */
+interface WireReleaseEntry extends Omit<ReleaseInfo, "hasFST" | "hasWOFDb"> {
+	hasFST?: boolean
+	hasWOFDb?: boolean
+	/** Pre-2026-07-04 manifests published lowercase-acronym keys. */
+	hasFst?: boolean
+	hasWofDb?: boolean
+}
+
+/**
+ * Normalize a fetched releases.json into house-cased {@link ReleasesManifest} fields. ALL manifest consumption goes
+ * through here — the wire tolerance lives in exactly one place, and everything past this boundary uses the acronym
+ * convention (`hasFST` / `hasWOFDb`).
+ *
+ * Why the tolerance: the 2026-07-01 acronym sweep renamed the READS while the published R2 manifest kept the old
+ * keys — every release read `undefined`, silently disabling the demo's WOF cascade AND the FST for three days (zero
+ * console errors; "no WOF hits" was the only symptom). The fix is not to freeze the wire keys but to migrate them
+ * deliberately: the publisher now writes house-cased keys, this normalizer accepts both generations (old HF mirrors
+ * still carry the legacy keys), and the contract test pins all three parties.
+ */
+export function normalizeReleasesManifest(raw: {
+	locale: string
+	defaultVersion: string
+	releases: WireReleaseEntry[]
+}): ReleasesManifest {
+	return {
+		locale: raw.locale,
+		defaultVersion: raw.defaultVersion,
+		releases: raw.releases.map((r) => ({
+			...r,
+			hasFST: r.hasFST ?? r.hasFst ?? false,
+			hasWOFDb: r.hasWOFDb ?? r.hasWofDb ?? false,
+		})),
+	}
 }
 
 export type ParsedNode = { tag: string; value?: unknown; confidence?: number }

--- a/docs/src/shared/demo-helpers.ts
+++ b/docs/src/shared/demo-helpers.ts
@@ -47,11 +47,11 @@ interface WireReleaseEntry extends Omit<ReleaseInfo, "hasFST" | "hasWOFDb"> {
  * through here — the wire tolerance lives in exactly one place, and everything past this boundary uses the acronym
  * convention (`hasFST` / `hasWOFDb`).
  *
- * Why the tolerance: the 2026-07-01 acronym sweep renamed the READS while the published R2 manifest kept the old
- * keys — every release read `undefined`, silently disabling the demo's WOF cascade AND the FST for three days (zero
- * console errors; "no WOF hits" was the only symptom). The fix is not to freeze the wire keys but to migrate them
- * deliberately: the publisher now writes house-cased keys, this normalizer accepts both generations (old HF mirrors
- * still carry the legacy keys), and the contract test pins all three parties.
+ * Why the tolerance: the 2026-07-01 acronym sweep renamed the READS while the published R2 manifest kept the old keys —
+ * every release read `undefined`, silently disabling the demo's WOF cascade AND the FST for three days (zero console
+ * errors; "no WOF hits" was the only symptom). The fix is not to freeze the wire keys but to migrate them deliberately:
+ * the publisher now writes house-cased keys, this normalizer accepts both generations (old HF mirrors still carry the
+ * legacy keys), and the contract test pins all three parties.
  */
 export function normalizeReleasesManifest(raw: {
 	locale: string

--- a/docs/src/shared/manifest-wire-keys.test.ts
+++ b/docs/src/shared/manifest-wire-keys.test.ts
@@ -68,7 +68,11 @@ describe("normalizeReleasesManifest — the single wire boundary", () => {
 })
 
 describe("no consumer reads raw legacy wire keys outside the boundary", () => {
-	for (const rel of ["../pages/demo/_app.tsx", "../contexts/DemoEmbed.tsx", "../../../scripts/publish-release-to-hf.ts"]) {
+	for (const rel of [
+		"../pages/demo/_app.tsx",
+		"../contexts/DemoEmbed.tsx",
+		"../../../scripts/publish-release-to-hf.ts",
+	]) {
 		test(`${rel} is house-cased only`, () => {
 			const src = readFileSync(new URL(rel, import.meta.url), "utf8")
 

--- a/docs/src/shared/manifest-wire-keys.test.ts
+++ b/docs/src/shared/manifest-wire-keys.test.ts
@@ -3,32 +3,77 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Wire-key contract for the published releases manifest (the batch-A casing incident). The
- *   acronym sweep capitalized `hasFst`/`hasWofDb` in code while the R2 releases.json kept the old
- *   keys — every release read `undefined`, silently disabling the demo's WOF cascade and FST from
- *   2026-07-01 to 07-04, with zero console errors. releases.json keys are a string contract
- *   (AGENTS.md wire-key exemption): the demo, the embed context, and the publisher must all use
- *   the published casing.
+ *   Wire contract for the releases manifest, post-migration (2026-07-04). History: the acronym
+ *   sweep capitalized the manifest READS while the published R2 json kept the legacy keys — every
+ *   release read `undefined`, silently disabling the demo's WOF cascade and FST for three days.
+ *   The resolution keeps the house casing and migrates the WIRE: the publisher writes
+ *   `hasFST`/`hasWOFDb`, `normalizeReleasesManifest` is the single boundary that tolerates BOTH
+ *   key generations (old HF mirrors still carry `hasFst`/`hasWofDb`), and no consumer reads raw
+ *   wire keys outside it.
  */
 
 import { readFileSync } from "node:fs"
 
 import { describe, expect, test } from "vitest"
 
-const SOURCES = [
-	"./demo-helpers.ts",
-	"../pages/demo/_app.tsx",
-	"../contexts/DemoEmbed.tsx",
-	"../../../scripts/publish-release-to-hf.ts",
-] as const
+import { normalizeReleasesManifest } from "./demo-helpers.ts"
 
-describe("releases.json wire keys (string contract — exempt from the acronym convention)", () => {
-	for (const rel of SOURCES) {
-		test(`${rel} uses the published casing (hasFst / hasWofDb)`, () => {
+const entry = (over: Record<string, unknown>) => ({
+	version: "vX",
+	label: "",
+	description: "",
+	modelSize: "1 MB",
+	tokenizerVocab: 1,
+	steps: 1,
+	...over,
+})
+
+describe("normalizeReleasesManifest — the single wire boundary", () => {
+	test("house-cased wire keys pass through", () => {
+		const m = normalizeReleasesManifest({
+			locale: "en-us",
+			defaultVersion: "vX",
+			releases: [entry({ hasFST: true, hasWOFDb: true })],
+		})
+
+		expect(m.releases[0]).toMatchObject({ hasFST: true, hasWOFDb: true })
+	})
+
+	test("legacy wire keys (pre-2026-07-04 manifests, old HF mirrors) normalize", () => {
+		const m = normalizeReleasesManifest({
+			locale: "en-us",
+			defaultVersion: "vX",
+			releases: [entry({ hasFst: true, hasWofDb: true })],
+		})
+
+		expect(m.releases[0]).toMatchObject({ hasFST: true, hasWOFDb: true })
+	})
+
+	test("house keys win when both generations appear", () => {
+		const m = normalizeReleasesManifest({
+			locale: "en-us",
+			defaultVersion: "vX",
+			releases: [entry({ hasFST: false, hasFst: true, hasWOFDb: false, hasWofDb: true })],
+		})
+
+		expect(m.releases[0]).toMatchObject({ hasFST: false, hasWOFDb: false })
+	})
+
+	test("absent keys default false, never undefined (the silent-disable failure mode)", () => {
+		const m = normalizeReleasesManifest({ locale: "en-us", defaultVersion: "vX", releases: [entry({})] })
+
+		expect(m.releases[0]!.hasFST).toBe(false)
+		expect(m.releases[0]!.hasWOFDb).toBe(false)
+	})
+})
+
+describe("no consumer reads raw legacy wire keys outside the boundary", () => {
+	for (const rel of ["../pages/demo/_app.tsx", "../contexts/DemoEmbed.tsx", "../../../scripts/publish-release-to-hf.ts"]) {
+		test(`${rel} is house-cased only`, () => {
 			const src = readFileSync(new URL(rel, import.meta.url), "utf8")
 
-			expect(src).not.toContain("hasFST")
-			expect(src).not.toContain("hasWOFDb")
+			expect(src).not.toContain("hasFst")
+			expect(src).not.toContain("hasWofDb")
 		})
 	}
 })

--- a/scripts/publish-release-to-hf.ts
+++ b/scripts/publish-release-to-hf.ts
@@ -44,7 +44,7 @@ const REQUIRED_FILES = [
 	// The slim wof-hot.db was RETIRED 2026-06-20: the demo's admin tier now byte-range-resolves
 	// against the global candidate table, hosted version-independently at
 	// mailwoman/gazetteer/<ver>/candidate.db (NOT a per-release asset — it's model-independent). See
-	// RELEASING.md + project-candidate-table-byte-range. `hasWofDb` in releases.json stays true (it now
+	// RELEASING.md + project-candidate-table-byte-range. `hasWOFDb` in releases.json stays true (it now
 	// means "this version has admin resolution", which the version-independent gazetteer always provides).
 ]
 
@@ -264,8 +264,8 @@ async function main() {
 		modelSize: args.modelSize ?? `${Math.round(statSync(args.model as string).size / 1024 / 1024)} MB`,
 		tokenizerVocab: 48000,
 		steps: args.steps ? parseInt(args.steps, 10) : 100000,
-		hasFst: true,
-		hasWofDb: true,
+		hasFST: true,
+		hasWOFDb: true,
 		// These artifacts usually ride the R2 staging rather than this script's flags, so derive the
 		// truth by PROBING the demo's serving path (the four-release hasPolygons:false rectangle bug,
 		// 2026-06-11). CLI args still count; either source sets the flag.


### PR DESCRIPTION
Supersedes #957's approach per operator direction ("we don't want to revert the naming — we want to fix the problem"):

- **House casing stays** (`hasFST`/`hasWOFDb`) everywhere inside the codebase, publisher included.
- **`normalizeReleasesManifest`** is the single wire boundary: tolerates both key generations (legacy manifests + old HF mirrors), house keys win when both appear, absent keys default `false` — the `undefined` silent-disable failure mode is structurally gone.
- Contract tests pin the tolerance table and that no consumer touches raw legacy keys outside the boundary.
- **Sequencing**: R2 `releases.json` migrates to house keys only after this build deploys (the live legacy-reader build must not race the artifact). Values fix (5.x `hasWOFDb: true`) carries over.

Playwright end-to-end verification against production follows the deploy + migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA