### PR TITLE
fix(demo): route createWOFResolver through @mailwoman/resolver/resolve — the #861 cascade never executed in production

### DIFF
--- a/docs/plugins/demo-assets/resolve.ts
+++ b/docs/plugins/demo-assets/resolve.ts
@@ -189,6 +189,12 @@ export function buildWorkspaceAliases(): Record<string, string> {
 
 	if (resolverDir) {
 		aliases["@mailwoman/resolver/span-rescore"] = resolveWorkspaceFile(resolverDir, "span-rescore")
+		// `@mailwoman/resolver/resolve` — createWOFResolver/resolveTree for the demo's #861 shared
+		// cascade. The bare-barrel alias above (deliberately) reaches only core's types module — its
+		// "createWOFResolver is never bundled" premise went stale the day #861 landed, and the miss
+		// was invisible for days behind the manifest wire-key bug (the cascade never executed).
+		// Same subpath pattern as span-rescore; package exports carry "./resolve" for node/tsc.
+		aliases["@mailwoman/resolver/resolve"] = resolveWorkspaceFile(resolverDir, "resolve")
 	}
 
 	return aliases

--- a/docs/src/shared/demo-helpers.ts
+++ b/docs/src/shared/demo-helpers.ts
@@ -7,6 +7,12 @@
  *   PipelineExplorer embeddable component and the full demo page.
  */
 
+// STATIC on purpose: a dynamic-import destructure of this barrel gets tree-shaken by webpack's
+// usedExports analysis (httpvfs-resolver statically imports only expandPlacetypeFilter from it),
+// which shipped the demo's WOF cascade as `TypeError: i is not a function` — invisible for days
+// behind the manifest wire-key bug. Static named imports are fully analyzable; do not re-dynamize.
+import { createWOFResolver } from "@mailwoman/resolver/resolve"
+
 import { CandidateResolverBackend } from "./candidate-resolver-backend.ts"
 import type { MailwomanLookupLike } from "./resources.tsx"
 
@@ -319,7 +325,6 @@ export async function runCascade(
 	const usable = (cs: CascadeHits): CascadeHits => cs.filter((c) => !(c.lat === 0 && c.lon === 0))
 
 	const backend = new CandidateResolverBackend(lookup)
-	const { createWOFResolver } = await import("@mailwoman/resolver")
 	const resolver = createWOFResolver(backend as never)
 
 	// adminCoherence is the point of the convergence (the passes the old cascade approximated);

--- a/resolver/package.json
+++ b/resolver/package.json
@@ -18,6 +18,7 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": "./out/index.js",
+		"./resolve": "./out/resolve.js",
 		"./span-rescore": "./out/span-rescore.js"
 	},
 	"publishConfig": {


### PR DESCRIPTION
The last layer of the demo outage. Three stacked failures:

1. **Manifest wire-keys** (#957/#958) silently disabled the WOF path since Jul 1 — which perfectly hid…
2. **#861's `runCascade`** importing `createWOFResolver` from the bare `@mailwoman/resolver` barrel — which the docs webpack **deliberately aliases to core's types module** (`aliases["@mailwoman/resolver$"]`, the old barrel-bypass whose comment still said "`createWOFResolver` is never bundled"). The premise went stale the day #861 merged: every submit threw `TypeError: i is not a function`, and the cascade **never once executed in production**.
3. The build even warned (`export 'createWOFResolver' was not found in '@mailwoman/resolver' (possible exports: DEFAULT_PLACETYPE_MAP, PLACETYPE_FILTER_GROUPS, expandPlacetypeFilter, isPlacetypeFallback)`) — buried in docs-build noise.

**Fix** (the alias file's own `span-rescore` precedent): dedicated `"./resolve"` package export + webpack alias to resolver source; `demo-helpers` imports the subpath statically. The stale alias comment is corrected in place.

**Verified** — Playwright against a clean local production build on the CORS-allowed port:
- `1600 Pennsylvania Ave NW` → **address_point ≤10 m** (38.8977, −77.0365), marker rendered — street tier + cascade + map working together for the first time since Jul 1.
- `Zabiče 8, 6250 Zabiče` → locality 45.5075, 14.3693, marker rendered (the SI sentinel through the browser cascade).
- Zero export-not-found warnings in the build.

Post-merge: live Playwright re-verification on the deployed site closes the operator's report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA