### PR TITLE
chore(gauntlet): retire passing #831 xfails, track v5.3.0's #829 shapes, addendum #894 correction

### DIFF
--- a/docs/articles/reviews/2026-07-04-re-railing-retrospective.md
+++ b/docs/articles/reviews/2026-07-04-re-railing-retrospective.md
@@ -242,7 +242,10 @@ measurement, which is the discipline working exactly as this review describes it
 
 ### The open list, re-scored at day's end
 
-- **#894** — unchanged in content, tripled in urgency; the demo outage is its fourth exhibit.
+- **#894** — correction upon checking: closed on 07-02 (#902, `version-parity.yml` + daily
+  schedule; verified passing against the live surfaces today). What the demo outage actually
+  exposes is the adjacent gap: version parity is checked, **functional** parity is not — a
+  scheduled live-demo Playwright smoke is the missing structural check, filed in today's triage.
 - **The #942 insurance leg in the standing battery** — this review recommended it; still to land.
 - **#949's fr.street gate floor** — the convention epoch gave FR standing baselines; the gate-spec
   floor remains unwritten.

--- a/scripts/eval/gauntlet/metamorphic.ts
+++ b/scripts/eval/gauntlet/metamorphic.ts
@@ -52,13 +52,13 @@ const INV = [
 const KNOWN_INV_XFAIL = new Map<string, string>([
 	["lower|1600 Pennsylvania Ave NW, Washington DC", "#829 — US lowercase model sensitivity (retrain)"],
 	["lower|Damrak 1, 1012 LG Amsterdam", "#829 — lowercase sensitivity, NL: resolution → null (more severe)"],
-	// #831 — the no-postcode form of the FR demo address sits on a rooftop/admin boundary: the canonical
-	// MISSES rooftop while every surface perturbation HITS it. Likely the same case-sensitive-parse root as
-	// #829 (mixed-case canonical parses differently from its lower/upper variants).
-	["lower|181 Rue du Chevaleret, Paris", "#831 — FR no-postcode rooftop/admin boundary"],
-	["upper|181 Rue du Chevaleret, Paris", "#831 — FR no-postcode rooftop/admin boundary"],
-	["trail-dot|181 Rue du Chevaleret, Paris", "#831 — FR no-postcode rooftop/admin boundary"],
-	["comma-tight|181 Rue du Chevaleret, Paris", "#831 — FR no-postcode rooftop/admin boundary"],
+	// #829 family, v5.3.0 shapes (first gauntlet run post-promote, 2026-07-04): the WITH-ZIP Penn
+	// canonical degrades address_point → admin under these variants. Same case-sensitive-parse root.
+	["lower|1600 Pennsylvania Ave NW, Washington DC 20500", "#829 — v5.3.0: with-ZIP variant drops the street tier"],
+	["trail-dot|1600 Pennsylvania Ave NW, Washington DC", "#829 — v5.3.0: trail-dot drops the street tier"],
+	// The four #831 fr-chevaleret rows were REMOVED 2026-07-04: v5.3.0 (the retrain built to fix that
+	// class) makes all four variants PASS — the runner flagged them newly-passing, promoting them to
+	// gated coverage by their absence here.
 ])
 
 /** Strip a 5-digit (US/FR) postcode token for the DIR test. */


### PR DESCRIPTION
Bookkeeping from the first post-promote gauntlet run (details on #961, which stays deliberately red until fixed). Mechanical; merging on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA