### PR TITLE
fix(#961): joint country recovery — the #942 floor no longer trusts the caller's defaultCountry

### DIFF
--- a/resolver/postal-compound-recovery.test.ts
+++ b/resolver/postal-compound-recovery.test.ts
@@ -57,12 +57,14 @@ function makeBackend(places: ResolvedPlace[] = PLACES): ResolverBackend {
 		async findPlace(query) {
 			const key = norm(query.text)
 
-			return places.filter(
-				(p) =>
-					norm(p.name) === key &&
-					(!query.country || p.country === query.country) &&
-					(!query.placetype || query.placetype.includes(p.placetype))
-			).map((p) => ({ ...p }))
+			return places
+				.filter(
+					(p) =>
+						norm(p.name) === key &&
+						(!query.country || p.country === query.country) &&
+						(!query.placetype || query.placetype.includes(p.placetype))
+				)
+				.map((p) => ({ ...p }))
 		},
 	}
 }

--- a/resolver/postal-compound-recovery.test.ts
+++ b/resolver/postal-compound-recovery.test.ts
@@ -52,12 +52,12 @@ const PLACES: ResolvedPlace[] = [
 	},
 ]
 
-function makeBackend(): ResolverBackend {
+function makeBackend(places: ResolvedPlace[] = PLACES): ResolverBackend {
 	return {
 		async findPlace(query) {
 			const key = norm(query.text)
 
-			return PLACES.filter(
+			return places.filter(
 				(p) =>
 					norm(p.name) === key &&
 					(!query.country || p.country === query.country) &&
@@ -188,5 +188,46 @@ describe("postal-compound recovery (#942)", () => {
 		// Both candidates surface; the gate keeps only the SI one.
 		expect(locality).toBeDefined()
 		expect(locality!.lat).toBeCloseTo(45.8, 1)
+	})
+})
+
+describe("#961 joint country recovery — the locale-default trap", () => {
+	// The CLI's en-US locale default scoped both the anchor and the village probe to US, so the SI
+	// floor never fired through geocode-core. The joint pass probes spans unscoped and verifies each
+	// candidate against the postcode resolved in the CANDIDATE's own country — cross-country
+	// promotion only postcode-verified, never ungated.
+	it("recovers under a WRONG defaultCountry via the postcode-verified joint pass", async () => {
+		const resolver = createWOFResolver(makeBackend())
+		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "US" })
+		const locality = out.roots.find((n) => n.tag === "locality" && n.placeID)
+
+		expect(locality).toBeDefined()
+		expect(locality!.lat).toBeCloseTo(45.8, 1)
+		expect(locality!.metadata?.rescore_gated).toBe(true)
+	})
+
+	it("rejects a cross-country namesake whose own country cannot verify the postcode", async () => {
+		// The HR decoy shares the name but HR holds no postcode "1382" → the joint pass must not
+		// promote it; with the SI row removed the tree stays unresolved rather than guessing.
+		const resolver = createWOFResolver(
+			makeBackend(PLACES.filter((p) => !(p.placetype === "locality" && p.country === "SI")))
+		)
+		const out = await resolver.resolveTree(failingTree(), { defaultCountry: "US" })
+
+		expect(out.roots.filter((n) => n.tag === "locality" && n.placeID).length).toBe(0)
+	})
+
+	it("never cross-promotes without a postcode present (no ungated wandering)", async () => {
+		const resolver = createWOFResolver(makeBackend())
+		const tree: AddressTree = {
+			raw: "Kožljek 7",
+			roots: [
+				node({ tag: "street", value: "Kožljek", start: 0, end: 7 }),
+				node({ tag: "house_number", value: "7", start: 8, end: 9 }),
+			],
+		}
+		const out = await resolver.resolveTree(tree, { defaultCountry: "US" })
+
+		expect(out.roots.filter((n) => n.placeID).length).toBe(0)
 	})
 })

--- a/resolver/span-rescore.ts
+++ b/resolver/span-rescore.ts
@@ -260,5 +260,41 @@ export async function findRescoreCandidate(
 		}
 	}
 
+	// #961 joint country recovery: the caller's `country` is a LOCALE DEFAULT, not knowledge — the
+	// CLI's en-US default scoped both the anchor and the village probe to US, so the SI floor never
+	// fired through geocode-core while the same rows resolved 25/25 on the resolver harness. When the
+	// scoped pass finds nothing and a postcode is present, re-probe the spans UNSCOPED (the admin
+	// gazetteer is one shard, all countries), then verify each exact candidate against the postcode's
+	// code subset resolved in the CANDIDATE's own country (postcode shards route by country). A
+	// cross-country promotion is accepted ONLY postcode-verified within the gate — never ungated —
+	// so a US-shaped query can't wander abroad on a name coincidence (the 48026 guard: resolved
+	// trees never reach this code, and unresolved ones must pass the joint postcode check).
+	if (opts.postalCompoundRecovery && postcode && gateKm > 0) {
+		const code = postcodeCodeSubset(postcode) || postcode.trim()
+
+		for (const sp of spans) {
+			const key = norm(sp.text)
+
+			if (key.length < 2 || /^\d+$/.test(key)) continue
+			const hits = await backend.findPlace({ text: sp.text, placetype: "locality", limit: 5 })
+			const exact = hits.filter((h) => h.exactMatch && norm(h.name) === key && (h.lat !== 0 || h.lon !== 0))
+
+			for (const h of exact) {
+				if (!h.country || h.country === country) continue // the scoped pass already covered `country`
+				const pcHits = await backend.findPlace({
+					text: code,
+					country: h.country,
+					placetype: "postalcode",
+					limit: 2,
+				})
+				const verified = pcHits.find((p) => p.lat !== 0 || p.lon !== 0)
+
+				if (verified && haversineKm(verified.lat, verified.lon, h.lat, h.lon) <= gateKm) {
+					return { text: sp.text, start: sp.start, end: sp.end, place: h, gated: true }
+				}
+			}
+		}
+	}
+
 	return null
 }

--- a/resolver/span-rescore.ts
+++ b/resolver/span-rescore.ts
@@ -200,7 +200,11 @@ export async function findRescoreCandidate(
 	let anchor: { lat: number; lon: number } | null = null
 
 	if (postcode && gateKm > 0) {
-		const pcHits = await backend.findPlace({ text: postcode, country, limit: 2 })
+		// #961: both anchor probes are postalcode-TYPED. Untyped, a truncated code fragment (v5.3.0
+		// emits "250 Zabiče" → subset "250") name-matches arbitrary places ("Chak No 250", PK) and the
+		// false anchor then GATES OUT the true village. A typed miss leaves anchor=null → the match is
+		// accepted ungated, which is the correct degradation for an unverifiable code.
+		const pcHits = await backend.findPlace({ text: postcode, country, placetype: "postalcode", limit: 2 })
 		const a = pcHits.find((h) => h.lat !== 0 || h.lon !== 0)
 
 		if (a) anchor = { lat: a.lat, lon: a.lon }
@@ -211,7 +215,7 @@ export async function findRescoreCandidate(
 			const code = postcodeCodeSubset(postcode)
 
 			if (code && code !== postcode) {
-				const codeHits = await backend.findPlace({ text: code, country, limit: 2 })
+				const codeHits = await backend.findPlace({ text: code, country, placetype: "postalcode", limit: 2 })
 				const c = codeHits.find((h) => h.lat !== 0 || h.lon !== 0)
 
 				if (c) anchor = { lat: c.lat, lon: c.lon }


### PR DESCRIPTION
Closes #961. The first post-promote gauntlet run (the insurance leg working as designed) found that v5.3.0's "SI floored by #942" promote rationale was **path-dependent**: the four SI sentinels resolve 25/25 on the resolver harness (explicit country) but were **unresolved through `geocodeAddress`**, because geocode-core populates `defaultCountry` from the locale (`en-US` → `US`) and that scoped both the anchor and the village probe to the wrong country.

## Two changes
1. **Joint unscoped recovery** (`span-rescore.ts`): when the country-scoped pass finds nothing and a postcode is present, probe spans **unscoped** against the admin shard, then verify each cross-country candidate against the postcode's code subset resolved in the **candidate's own country** (postcode shards route by country). Cross-country promotion is accepted **only postcode-verified within the gate — never ungated**, so a US-shaped query can't wander abroad on a name coincidence (the 48026 guard).
2. **Type the anchor probes as `postalcode`** — the actual gauntlet-path mechanism, found by tracing: v5.3.0 emits the postcode as `"250 Zabiče"` (leading-char drop), the untyped code-subset probe `"250"` name-matched `"Chak No 250"` (PK), and that false anchor gated out the true SI village. A typed miss leaves `anchor = null` → the match is accepted ungated, the correct degradation for an unverifiable code.

## Gate (all pre-registered, all green)
- **Gauntlet: PASS** — all four SI sentinels now resolve via `geocodeAddress` (`Zabiče` → 45.5075, 14.3693).
- **Resolver suite 89/89**, incl. 3 new #961 tests: recovers under a wrong `defaultCountry`; **rejects** a cross-country namesake whose own country can't verify the postcode; never cross-promotes without a postcode present.
- **Epoch coordinate legs — BYTE-IDENTICAL**: `#961` vs **freshly-regenerated main** (same-command isolation), us-coord-2k / fr-3k / si-coord-1k all byte-for-byte. The change is inert on resolvable addresses (they resolve via the main walk, so `applySpanRescore` returns early). *Isolation was done against a same-command main baseline, not the stored epoch1 dumps — those were generated with different flags and produced a false 7000–9000 km "regression" on first comparison (the #945 cross-convention trap; noted in the gate log for a provenance follow-up).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA