### PR TITLE
ci(#963): scheduled production demo smoke — version parity is not functional parity

### DIFF
--- a/.github/workflows/demo-smoke.yml
+++ b/.github/workflows/demo-smoke.yml
@@ -1,0 +1,70 @@
+# Production functional-smoke for the live demo (#963 — sibling of version-parity.yml).
+#
+# version-parity.yml checks the demo's pinned VERSION tracks npm. It stayed green for three days
+# (2026-07-01..04) while the demo served no WOF hits, no FST, and no street tier — because version
+# parity is not FUNCTIONAL parity, and all three failures produced zero console errors. This runs
+# the `@smoke` browser spec against the DEPLOYED site (`MAILWOMAN_DEMO_URL`) so a functional
+# regression becomes visible the day it ships, not three days later via a bug report.
+#
+# The same spec also runs in the local build gate (test/browser, webServer mode) on every docs
+# change — this workflow is the SCHEDULED production half. Grades the results (address_point tier +
+# WOF cascade + markers), not the absence of errors.
+name: Demo smoke
+
+on:
+  schedule:
+    # Daily, 06:37 UTC — 20 min after version-parity, so any overnight repoint has settled.
+    - cron: "37 6 * * *"
+  workflow_dispatch:
+    inputs:
+      demo_url:
+        description: "Deployed demo origin to smoke (default: production)"
+        type: string
+        default: "https://mailwoman.sister.software"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: demo-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # workflow_dispatch override wins; the scheduled run uses production.
+      MAILWOMAN_DEMO_URL: ${{ inputs.demo_url || 'https://mailwoman.sister.software' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Enable Corepack (yarn 4)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      # Remote mode (MAILWOMAN_DEMO_URL set) skips the local build+serve + the `build` project,
+      # so only the browser chromium is needed. `--with-deps` pulls the system libs on the runner.
+      - name: Install Playwright chromium
+        working-directory: docs
+        run: yarn playwright install --with-deps chromium
+
+      - name: Smoke the deployed demo
+        working-directory: docs
+        run: yarn test:e2e --project=chromium --grep @smoke
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-smoke-report
+          path: docs/playwright-report/
+          retention-days: 14

--- a/docs/test/browser/000-demo-production-smoke.spec.ts
+++ b/docs/test/browser/000-demo-production-smoke.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * @file Production functional-smoke — the check the 2026-07-04 demo triple outage went missing for.
+ *
+ *   `version-parity.yml` confirmed the demo's PINNED VERSION tracked npm, and stayed green for three
+ *   days while the demo served no WOF hits, no FST, and no street tier — version parity is not
+ *   functional parity. Every one of those three failures produced zero console errors; the only
+ *   symptom was degraded results. So this smoke grades the RESULTS, not the absence of errors.
+ *
+ *   Tagged `@smoke`: `demo-smoke.yml` runs THIS spec (and only this) against the deployed site daily
+ *   via `MAILWOMAN_DEMO_URL`. It also runs in the local build gate like every other browser spec, so
+ *   a refactor that breaks the cascade fails in CI before it ships. Two addresses, chosen to light up
+ *   all three tiers at once:
+ *     - 1600 Pennsylvania Ave NW → the STREET tier (situs/interp shards) + an address_point rooftop.
+ *     - Zabiče 8, 6250 Zabiče   → the WOF admin cascade AND the #942/#961 postal-compound floor.
+ *   If either regresses to admin-only (or drops its marker), a tier is dead — exactly what shipped
+ *   silently before.
+ */
+
+import { expect, test } from "#e2e"
+
+test.describe("Demo — production functional smoke @smoke", () => {
+	test("1600 Pennsylvania Ave NW → address_point rooftop + marker (street tier alive)", async ({ demo }) => {
+		await demo.goto("1600 Pennsylvania Ave NW, Washington, DC 20500")
+		await demo.submit()
+
+		const { resolved, markerCount, parsedRows } = await demo.readResult()
+		expect(parsedRows.length, "parse produced no component rows").toBeGreaterThan(0)
+		expect(resolved["placetype"], "degraded off the street tier to admin — the #955 failure mode").toBe(
+			"address_point"
+		)
+		const [lat, lon] = (resolved["coords"] ?? "").split(",").map((s) => Number.parseFloat(s.trim()))
+		expect(lat, `resolved lat ${lat} should be at the White House`).toBeGreaterThan(38.85)
+		expect(lat).toBeLessThan(38.95)
+		expect(lon).toBeGreaterThan(-77.1)
+		expect(lon).toBeLessThan(-77.0)
+		expect(markerCount, "no marker rendered").toBeGreaterThan(0)
+		demo.console.assertNoFailEvents()
+	})
+
+	test("Zabiče 8, 6250 Zabiče → SI locality via the WOF cascade + #942 floor + marker", async ({ demo }) => {
+		await demo.goto("Zabiče 8, 6250 Zabiče")
+		await demo.submit()
+
+		const { resolved, markerCount } = await demo.readResult()
+		expect(resolved["placetype"], "the WOF admin cascade returned no hit — the #957/#958 failure mode").toBe(
+			"locality"
+		)
+		const [lat, lon] = (resolved["coords"] ?? "").split(",").map((s) => Number.parseFloat(s.trim()))
+		expect(lat, `resolved lat ${lat} should be in Slovenia`).toBeGreaterThan(45.4)
+		expect(lat).toBeLessThan(45.7)
+		expect(lon, `resolved lon ${lon} should be in Slovenia`).toBeGreaterThan(14.2)
+		expect(lon).toBeLessThan(14.5)
+		expect(markerCount, "no marker rendered").toBeGreaterThan(0)
+		demo.console.assertNoFailEvents()
+	})
+})

--- a/docs/test/browser/000-demo-production-smoke.spec.ts
+++ b/docs/test/browser/000-demo-production-smoke.spec.ts
@@ -1,19 +1,16 @@
 /**
  * @file Production functional-smoke — the check the 2026-07-04 demo triple outage went missing for.
+ *   `version-parity.yml` confirmed the demo's PINNED VERSION tracked npm, and stayed green for three days while the
+ *   demo served no WOF hits, no FST, and no street tier — version parity is not functional parity. Every one of those
+ *   three failures produced zero console errors; the only symptom was degraded results. So this smoke grades the
+ *   RESULTS, not the absence of errors. Tagged `@smoke`: `demo-smoke.yml` runs THIS spec (and only this) against the
+ *   deployed site daily via `MAILWOMAN_DEMO_URL`. It also runs in the local build gate like every other browser spec,
+ *   so a refactor that breaks the cascade fails in CI before it ships. Two addresses, chosen to light up all three
+ *   tiers at once:
  *
- *   `version-parity.yml` confirmed the demo's PINNED VERSION tracked npm, and stayed green for three
- *   days while the demo served no WOF hits, no FST, and no street tier — version parity is not
- *   functional parity. Every one of those three failures produced zero console errors; the only
- *   symptom was degraded results. So this smoke grades the RESULTS, not the absence of errors.
- *
- *   Tagged `@smoke`: `demo-smoke.yml` runs THIS spec (and only this) against the deployed site daily
- *   via `MAILWOMAN_DEMO_URL`. It also runs in the local build gate like every other browser spec, so
- *   a refactor that breaks the cascade fails in CI before it ships. Two addresses, chosen to light up
- *   all three tiers at once:
- *     - 1600 Pennsylvania Ave NW → the STREET tier (situs/interp shards) + an address_point rooftop.
- *     - Zabiče 8, 6250 Zabiče   → the WOF admin cascade AND the #942/#961 postal-compound floor.
- *   If either regresses to admin-only (or drops its marker), a tier is dead — exactly what shipped
- *   silently before.
+ *   - 1600 Pennsylvania Ave NW → the STREET tier (situs/interp shards) + an address_point rooftop.
+ *   - Zabiče 8, 6250 Zabiče → the WOF admin cascade AND the #942/#961 postal-compound floor. If either regresses to
+ *     admin-only (or drops its marker), a tier is dead — exactly what shipped silently before.
  */
 
 import { expect, test } from "#e2e"
@@ -25,9 +22,7 @@ test.describe("Demo — production functional smoke @smoke", () => {
 
 		const { resolved, markerCount, parsedRows } = await demo.readResult()
 		expect(parsedRows.length, "parse produced no component rows").toBeGreaterThan(0)
-		expect(resolved["placetype"], "degraded off the street tier to admin — the #955 failure mode").toBe(
-			"address_point"
-		)
+		expect(resolved["placetype"], "degraded off the street tier to admin — the #955 failure mode").toBe("address_point")
 		const [lat, lon] = (resolved["coords"] ?? "").split(",").map((s) => Number.parseFloat(s.trim()))
 		expect(lat, `resolved lat ${lat} should be at the White House`).toBeGreaterThan(38.85)
 		expect(lat).toBeLessThan(38.95)
@@ -42,9 +37,7 @@ test.describe("Demo — production functional smoke @smoke", () => {
 		await demo.submit()
 
 		const { resolved, markerCount } = await demo.readResult()
-		expect(resolved["placetype"], "the WOF admin cascade returned no hit — the #957/#958 failure mode").toBe(
-			"locality"
-		)
+		expect(resolved["placetype"], "the WOF admin cascade returned no hit — the #957/#958 failure mode").toBe("locality")
 		const [lat, lon] = (resolved["coords"] ?? "").split(",").map((s) => Number.parseFloat(s.trim()))
 		expect(lat, `resolved lat ${lat} should be in Slovenia`).toBeGreaterThan(45.4)
 		expect(lat).toBeLessThan(45.7)


### PR DESCRIPTION
Closes #963. The structural check that would have caught the three-day demo outage on day one.

`version-parity.yml` confirmed the demo's pinned *version* tracked npm and stayed green throughout the outage — but versions were in parity, **function wasn't**, and all three failure layers produced zero console errors. So this grades the **results**:

- **1600 Pennsylvania Ave NW** → asserts `address_point` placetype (street tier alive — the #955 failure mode was degrade-to-admin), a DC coordinate box, and a marker.
- **Zabiče 8, 6250 Zabiče** → asserts `locality` via the WOF admin cascade (the #957/#958 failure mode was no-cascade) + a Slovenia box + a marker — also exercises the #942/#961 postal-compound floor in the browser.

**Wiring**: `@smoke`-tagged spec under `test/browser/`, so it runs both in the local build gate (every docs change) *and* — via the new `demo-smoke.yml` — against the deployed site daily (06:37 UTC) + on manual dispatch with a `demo_url` override. First CI wiring for the existing `docs/test/e2e` suite (fixtures were already there).

**Validated**: ran green against production before landing (`MAILWOMAN_DEMO_URL=https://mailwoman.sister.software`, 2 passed, 19.4s) — which also re-confirms all three tiers healthy post-#959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA