### PR TITLE
feat(#949): fr.bare_street_intact promotion-gate floor — the class v5.2.0 regressed silently

### DIFF
--- a/scripts/diagnostic/fr-parse-recall.ts
+++ b/scripts/diagnostic/fr-parse-recall.ts
@@ -13,7 +13,7 @@
  *   Run: node scripts/diagnostic/fr-parse-recall.ts
  */
 
-import { readFileSync } from "node:fs"
+import { readFileSync, writeFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
 import { parseArgs } from "node:util"
 
@@ -36,18 +36,43 @@ const { values: args } = parseArgs({
 		tokenizer: { type: "string" },
 		"model-card": { type: "string", default: "neural-weights-en-us/model-card.json" },
 		label: { type: "string", default: "" },
+		// Gate-leg mode (#949): read the FROZEN 40-row sample instead of the live OSM shard, so the
+		// bare-street floor is reproducible anywhere (incl. CI, which has no shard). `--from-db`
+		// re-derives from the live shard — the ONLY way the fixture should ever change, and it must be
+		// committed deliberately (the "pin the golden" discipline; a moving sample is a flaky floor).
+		fixture: { type: "string", default: "scripts/eval/fixtures/fr-bare-street-40.jsonl" },
+		"from-db": { type: "boolean", default: false },
+		// Emit machine-readable rates to <path> for the promotion gate.
+		json: { type: "string" },
+		// Fail (exit 1) when the BARE-intact rate falls below this percent — the enforced floor.
+		floor: { type: "string" },
 	},
 })
 
-const db = new DatabaseSync(`${mailwomanDataRoot()}/osm/address-points-fr-fr.db`, { readOnly: true })
-// Distinct streets with a city + postcode, sampled across the table (not one street repeated).
-const rows = db
-	.prepare(
-		`SELECT street_raw, number, locality_norm, postcode FROM address_point
-		 WHERE locality_norm IS NOT NULL AND postcode IS NOT NULL AND street_raw LIKE '% %'
-		 GROUP BY street_norm ORDER BY number LIMIT 40`
-	)
-	.all() as Array<{ street_raw: string; number: string; locality_norm: string; postcode: string }>
+interface FRRow {
+	street_raw: string
+	number: string
+	locality_norm: string
+	postcode: string
+}
+
+const rows: FRRow[] = args["from-db"]
+	? (() => {
+			const db = new DatabaseSync(`${mailwomanDataRoot()}/osm/address-points-fr-fr.db`, { readOnly: true })
+			// Distinct streets with a city + postcode, sampled across the table (not one street repeated).
+			// DETERMINISTIC (GROUP BY + ORDER BY, no RANDOM) — the same shard yields the same 40 rows.
+			return db
+				.prepare(
+					`SELECT street_raw, number, locality_norm, postcode FROM address_point
+					 WHERE locality_norm IS NOT NULL AND postcode IS NOT NULL AND street_raw LIKE '% %'
+					 GROUP BY street_norm ORDER BY number LIMIT 40`
+				)
+				.all() as FRRow[]
+		})()
+	: readFileSync(args.fixture, "utf8")
+			.split("\n")
+			.filter((l) => l.trim())
+			.map((l) => JSON.parse(l) as FRRow)
 
 async function buildClassifier(): Promise<NeuralAddressClassifier> {
 	if (!args.model || !args.tokenizer) return NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
@@ -121,3 +146,35 @@ console.log(
 console.log(`\nbare failures:`)
 
 for (const f of fails) console.log(f)
+
+const bareRate = (bareOk / rows.length) * 100
+const anchoredRate = (anchoredOk / rows.length) * 100
+
+if (args.json) {
+	writeFileSync(
+		args.json,
+		`${JSON.stringify(
+			{
+				bare_intact: bareOk,
+				anchored_intact: anchoredOk,
+				n: rows.length,
+				bare_rate: Number(bareRate.toFixed(1)),
+				anchored_rate: Number(anchoredRate.toFixed(1)),
+				source: args["from-db"] ? "live-shard" : args.fixture,
+			},
+			null,
+			2
+		)}\n`
+	)
+}
+
+if (args.floor !== undefined) {
+	const floor = Number(args.floor)
+
+	if (bareRate < floor) {
+		console.error(`\n✗ fr.bare_street_intact FAIL: ${bareRate.toFixed(1)}% < floor ${floor}% (${bareOk}/${rows.length})`)
+		process.exit(1)
+	}
+
+	console.log(`\n✓ fr.bare_street_intact PASS: ${bareRate.toFixed(1)}% ≥ floor ${floor}% (${bareOk}/${rows.length})`)
+}

--- a/scripts/diagnostic/fr-parse-recall.ts
+++ b/scripts/diagnostic/fr-parse-recall.ts
@@ -67,7 +67,7 @@ const rows: FRRow[] = args["from-db"]
 					 WHERE locality_norm IS NOT NULL AND postcode IS NOT NULL AND street_raw LIKE '% %'
 					 GROUP BY street_norm ORDER BY number LIMIT 40`
 				)
-				.all() as FRRow[]
+				.all() as unknown as FRRow[]
 		})()
 	: readFileSync(args.fixture, "utf8")
 			.split("\n")

--- a/scripts/eval/fixtures/fr-bare-street-40.jsonl
+++ b/scripts/eval/fixtures/fr-bare-street-40.jsonl
@@ -1,0 +1,40 @@
+{"street_raw":"Rue Tuleu","number":"+32","locality_norm":"eaubonne","postcode":"95600"}
+{"street_raw":"Rue Jean Moulin","number":".36","locality_norm":"margency","postcode":"95580"}
+{"street_raw":"Allée Mauchain","number":"0","locality_norm":"eaubonne","postcode":"95600"}
+{"street_raw":"Moulin de Giboudet","number":"0","locality_norm":"bazainville","postcode":"78550"}
+{"street_raw":"Place Victor Hugo","number":"0","locality_norm":"saint-germain-les-corbeil","postcode":"91250"}
+{"street_raw":"Rue René Cassin","number":"0","locality_norm":"herblay-sur-seine","postcode":"95220"}
+{"street_raw":"Rue des Haies","number":"02","locality_norm":"plessis-saint-benoist","postcode":"91410"}
+{"street_raw":"Rue du Lavoir","number":"03","locality_norm":"mantes-la-jolie","postcode":"78200"}
+{"street_raw":"rue de la chicaudière","number":"0685892126","locality_norm":"jouars-pontchartrain","postcode":"78760"}
+{"street_raw":"Avenue Jean Fourgeaud","number":"07","locality_norm":"villepinte","postcode":"93420"}
+{"street_raw":"Rue Marie Laurencin","number":"09","locality_norm":"saint-pierre-du-perray","postcode":"91280"}
+{"street_raw":"Allée Agrippa d'Aubigné","number":"1","locality_norm":"noisy-le-roi","postcode":"78590"}
+{"street_raw":"Allée Albert Roussel","number":"1","locality_norm":"sarcelles","postcode":"95200"}
+{"street_raw":"Allée Alfred Nakache","number":"1","locality_norm":"sannois","postcode":"95110"}
+{"street_raw":"allée Alice Guy","number":"1","locality_norm":"le pre-saint-gervais","postcode":"93310"}
+{"street_raw":"Allée André Biver","number":"1","locality_norm":"saintry-sur-seine","postcode":"91250"}
+{"street_raw":"Allée Angélique","number":"1","locality_norm":"chatenay-malabry","postcode":"92290"}
+{"street_raw":"Allée Antoine Grossin","number":"1","locality_norm":"clamart","postcode":"92140"}
+{"street_raw":"Allée Aragon","number":"1","locality_norm":"aubervilliers","postcode":"93300"}
+{"street_raw":"Allée Arnaud Beltrame","number":"1","locality_norm":"villejuif","postcode":"94800"}
+{"street_raw":"Allée Bartholdi","number":"1","locality_norm":"bouffemont","postcode":"95570"}
+{"street_raw":"Allée Bernard de Fontenelle","number":"1","locality_norm":"noisy-le-roi","postcode":"78590"}
+{"street_raw":"Allée Blanche","number":"1","locality_norm":"clamart","postcode":"92140"}
+{"street_raw":"Allée Bleu Blanc Rouge","number":"1","locality_norm":"bouffemont","postcode":"95570"}
+{"street_raw":"Allée Bonniec","number":"1","locality_norm":"villiers-le-bel","postcode":"95400"}
+{"street_raw":"Allée Brève","number":"1","locality_norm":"torcy","postcode":"77200"}
+{"street_raw":"Allée Cab Calloway","number":"1","locality_norm":"noisy le roi","postcode":"78590"}
+{"street_raw":"Allée Camille Claudel","number":"1","locality_norm":"mennecy","postcode":"91540"}
+{"street_raw":"Allée Chantal Rabutin","number":"1","locality_norm":"combs-la-ville","postcode":"77380"}
+{"street_raw":"Allée Chantemelle","number":"1","locality_norm":"saclay","postcode":"91400"}
+{"street_raw":"Allée Charles Garnier","number":"1","locality_norm":"bouffemont","postcode":"95570"}
+{"street_raw":"Allée Charles Lindbergh","number":"1","locality_norm":"noisy-le-grand","postcode":"93160"}
+{"street_raw":"Allée Charles Perrault","number":"1","locality_norm":"antony","postcode":"92160"}
+{"street_raw":"Allée Christophe Colomb","number":"1","locality_norm":"noisy-le-grand","postcode":"93160"}
+{"street_raw":"Allée Claude de Bullion","number":"1","locality_norm":"maule","postcode":"78580"}
+{"street_raw":"Allée Claude Debussy","number":"1","locality_norm":"villetaneuse","postcode":"93430"}
+{"street_raw":"Allée Claude Monet","number":"1","locality_norm":"soisy-sous-montmorency","postcode":"95230"}
+{"street_raw":"Allée Count Basie","number":"1","locality_norm":"noisy le roi","postcode":"78590"}
+{"street_raw":"Allée Courbe","number":"1","locality_norm":"torcy","postcode":"77200"}
+{"street_raw":"Allée d'Alsace","number":"1","locality_norm":"la celle-saint-cloud","postcode":"78170"}

--- a/scripts/eval/gates/v5.3.0-family.json
+++ b/scripts/eval/gates/v5.3.0-family.json
@@ -21,11 +21,13 @@
 		"arena.perturb": 71.0,
 		"us.po_box_real": 70.0,
 		"fr.cedex_real": 70.0,
-		"us.intersection_real": 50.0
+		"us.intersection_real": 50.0,
+		"fr.bare_street_intact": 75.0
 	},
 	"int8_vs_fp32_max_delta_pp": 1.5,
 	"ledger_path": "evals/scores-by-version.json",
 	"requires_bridge": true,
 	"$revision_us_postcode": "95 -> 94.8 (2026-07-03, operator-approved in chat for the v5.2.0 cut): MEASUREMENT IDENTITY, not a model dip — the shipped v5.1.0 fp32 reads the identical 94.8 on the same harness, and the candidate's int8 postcode parses are byte-identical to shipped on all 2,660 US gate rows (0 diffs). The prior 95 floor was calibrated on the int8-class/earlier harness generation. Evidence: gate-v193/RESULTS.md (us.postcode attribution block).",
+	"$floor_fr_bare_street_intact": "NEW FLOOR (#949, 2026-07-04): fr.bare_street_intact >= 75.0. The class v5.2.0 silently regressed (bare-street-intact 34/40 -> 16/40) because NO standing leg measured FR street parsing WITHOUT a postcode anchor — the retro's R1 blind-spot instance. The leg (scripts/diagnostic/fr-parse-recall.ts --floor) reads a FROZEN 40-row OSM sample (scripts/eval/fixtures/fr-bare-street-40.jsonl; committed, no live shard needed) and parses each bare + anchored. v5.3.0 reads 34/40=85% bare (37/40=92.5% anchored); the 75% floor (30/40) catches a real regression like v5.2.0's 40% while tolerating +/-1-2 rows of sample noise. Refresh the fixture only via --from-db, committed deliberately (a moving sample is a flaky floor).",
 	"$revision_2026_07_04": "GATE REVISION (operator-approved 2026-07-04, the #901 promote fork): fr.postcode 99.3 -> 99.2. REASON: v2.2.0 reads 99.2 (-0.1, the zero-margin floor the 2026-07-02 scorecard flagged as 'any hair of postcode loss fails loudly' — it did, and the trade was adjudicated, not silently absorbed). The FR COORDINATE is non-inferior on the deconfounded same-stack fr-3k (resolve 0.991=0.991, p50 1.30=1.30, CI[-0.009,0]) and the bare-FR street class the promote exists to fix goes 16/40 -> 34/40. Companion exception, NOT a cap change: the int8<->fp32 homograph delta reads 2.4 vs the 1.5 cap for THIS artifact (quantization delta; the fp32 model passes every floor and int8 country_homograph 85.1 still clears its 83.3 floor) — operator-accepted for this promote; the cap stays 1.5 for the next candidate. SI trade on the record: wrong-city 8.7->11.4% (+2.7pp vs the +2pp re-gate bar), resolve 1.000->0.985, floored model-independently by postalCompoundRecovery (#942 default-ON; the insurance leg proved the candidate+floor recovers ALL 55 composition-lost rows)."
 }

--- a/scripts/eval/promotion-gate.ts
+++ b/scripts/eval/promotion-gate.ts
@@ -305,6 +305,27 @@ runIfScript(import.meta, async () => {
 		if (arena.exitCode !== 0) process.exit(1)
 	}
 
+	// FR bare-street floor (#949) — the class v5.2.0 silently regressed (34/40 → 16/40) because no
+	// standing leg measured FR street parsing WITHOUT a postcode anchor. Reads a FROZEN 40-row OSM
+	// sample (committed fixture, no live shard needed), parses each bare + anchored, and fails if the
+	// bare-intact rate drops below the spec floor. The leg self-reports its verdict + exits non-zero.
+	const bareStreetFloor = (gate.floors ?? {})["fr.bare_street_intact"]
+
+	if (bareStreetFloor !== undefined) {
+		const bare = await $({
+			nothrow: true,
+			env: { ...process.env },
+		})`node scripts/diagnostic/fr-parse-recall.ts --model ${shipModel} --tokenizer ${TOK} --model-card ${CARD} --floor ${String(bareStreetFloor)} --json ${`${OUT_DIR}/fr-bare-street.json`}`
+		writeFileSync(`${OUT_DIR}/fr-bare-street.md`, `${bare.stdout}${bare.stderr}`)
+
+		if (bare.exitCode !== 0) {
+			console.error(`✗ fr.bare_street_intact FAIL (floor ${bareStreetFloor}%) — see ${OUT_DIR}/fr-bare-street.md`)
+			process.exit(1)
+		}
+
+		console.log(`✓ fr.bare_street_intact PASS (floor ${bareStreetFloor}%)`)
+	}
+
 	// --- mask-regression gate (#718) — the "second lock" ------------------------
 	// Re-runs the SHIP artifact mask-off vs the declared conventions mode and FAILS if any tag's UNFOLDED
 	// F1 drops >2pp under the mask — a finer net than createScorer's load-time 5pp delta-gate (it catches


### PR DESCRIPTION
Closes #949 (the retro's remaining open gate-spec item). The lesson, distinct from its instance: v5.2.0 dropped FR bare-street parsing 34/40 → 16/40 and shipped, because **no standing leg measured FR street parsing without a postcode anchor** — golden-dev FR is postcode-anchored canonical, so the blind spot was a slice nobody re-measured (exactly the R1 pattern).

**Made enforced, not discipline:**
- The diagnostic's 40-row OSM sample was already deterministic (`GROUP BY … ORDER BY … LIMIT 40`, no RANDOM). **Frozen as a committed fixture** (`scripts/eval/fixtures/fr-bare-street-40.jsonl`) so the gate needs no live shard — the reason the metric was never gated. `--from-db` regenerates it **byte-identically** (verified); refreshing is a deliberate commit, never a moving sample.
- `fr-parse-recall.ts` gains `--json` / `--floor`, reads the fixture by default, exits non-zero below the floor.
- `promotion-gate.ts` runs it as a leg when the spec declares `fr.bare_street_intact`, mirroring the existing arena-leg pattern.
- `v5.3.0-family.json`: **`fr.bare_street_intact >= 75.0`** with a revision note. v5.3.0 reads 34/40 = 85% (anchored 37/40 = 92.5%); v5.2.0's 40% fails loudly; the floor tolerates ±1–2 rows of sample noise.

**Verified**: PASS at 85% (floor 75), FAIL exit-1 at floor 90, fixture byte-reproduces from `--from-db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA