### PR TITLE
feat(demo): wire viewport bias — map view (+ geolocation) re-ranks namesakes (#938)

### DIFF
--- a/docs/src/pages/demo/_app.tsx
+++ b/docs/src/pages/demo/_app.tsx
@@ -43,6 +43,7 @@ import {
 	resolveStreet,
 	runCascade,
 } from "../../shared/demo-helpers.ts"
+import type { ResolveBias } from "../../shared/demo-helpers.ts"
 import type { HTTPVFSAddressPointLookup, HTTPVFSInterpolator } from "../../shared/httpvfs-street.ts"
 import { pruneDBRangeCache, registerRangeCacheServiceWorker } from "../../shared/register-range-sw.ts"
 import {
@@ -191,6 +192,10 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 	// first resolve, reset when the selected version changes. Held as the in-flight promise so concurrent
 	// resolves share one fetch.
 	const anchorLookupRef = useRef<Map<string, { lat: number; lon: number }> | null>(null)
+	// Optional geolocation bias (#938): populated by the "Use my location" control, read at submit.
+	// A ref (not state) so granting it mid-session doesn't re-render or re-create the submit callback.
+	const geoBiasRef = useRef<{ lat: number; lon: number } | null>(null)
+	const [geoBiasOn, setGeoBiasOn] = useState(false)
 	const polygonDBRef = useRef<Promise<PolygonDB> | null>(null)
 	// Street tier (#377): per-state situs/interp httpvfs lookups, lazy-loaded by parsed region and
 	// cached. Held as the in-flight promise so a fast second submit on the same state shares one load.
@@ -999,9 +1004,24 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 				// coherence (#263/#822) + span-rescore recovery (#370, internal, default-on) — over the
 				// byte-range candidate lookup. Same passes as the server; the pin ordering (postcode most
 				// precise, cross-country gate) lives in runCascade's hit extraction.
+				// Viewport bias (#938): the map's current center is a SOFT proximity hint, so an in-view
+				// namesake sorts ahead of a distant one at equal exact-tier (48026 → Fraser MI when you're
+				// looking at Michigan, Russi IT near Ravenna). The library's decay is population-CEILINGED,
+				// so a huge population gap still wins regardless of the view — "Paris" stays Paris, FR even
+				// from a US-centered map. Only hint once the user has zoomed past the global view; a
+				// whole-globe center is noise. Geolocation, when granted, joins as a second weaker hint.
+				const bias: ResolveBias = []
+
+				if (map && map.getZoom() >= 4) {
+					const c = map.getCenter()
+					bias.push({ lat: c.lat, lon: c.lng, weight: 1 })
+				}
+
+				if (geoBiasRef.current) bias.push({ ...geoBiasRef.current, weight: 0.6 })
+
 				// Timed from here so the one-time DB load above doesn't skew the resolve number.
 				const tBeforeResolve = performance.now()
-				const cascadeHits = await runCascade(wofLookup, tree as { roots: unknown[] }, text)
+				const cascadeHits = await runCascade(wofLookup, tree as { roots: unknown[] }, text, bias)
 				const tResolve = performance.now()
 
 				// Anchor-centroid fallback (postcode-only dead ends): WOF ships placeholder (0,0) for
@@ -1102,6 +1122,7 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 			manifest,
 			selectedVersion,
 			sqljsBaseURL,
+			map,
 		]
 	)
 
@@ -1255,6 +1276,39 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 						{busy ? "Parsing…" : "Parse + resolve"}
 					</button>
 				</form>
+				<div className={styles.examples}>
+					<span className={styles.examplesLabel}>Bias:</span>
+					<button
+						type="button"
+						className={styles.exampleBtn}
+						aria-pressed={geoBiasOn}
+						style={geoBiasOn ? { outline: "2px solid var(--ifm-color-primary)", outlineOffset: "1px" } : undefined}
+						title="Add your device location as a soft proximity hint (in addition to the map view). Never a hard filter — a strong population signal still wins."
+						onClick={() => {
+							if (geoBiasOn) {
+								geoBiasRef.current = null
+								setGeoBiasOn(false)
+
+								return
+							}
+
+							if (typeof navigator === "undefined" || !navigator.geolocation) return
+							navigator.geolocation.getCurrentPosition(
+								(pos) => {
+									geoBiasRef.current = { lat: pos.coords.latitude, lon: pos.coords.longitude }
+									setGeoBiasOn(true)
+								},
+								() => setGeoBiasOn(false),
+								{ maximumAge: 600_000, timeout: 8_000 }
+							)
+						}}
+					>
+						{geoBiasOn ? "📍 Using your location" : "📍 Use my location"}
+					</button>
+					<span className={styles.examplesLabel} style={{ opacity: 0.7 }}>
+						the map view already biases nearby namesakes
+					</span>
+				</div>
 				{suggestions.length > 0 ? (
 					<div className={styles.examples} id="addr-suggest-list" role="listbox" aria-label="Place suggestions">
 						<span className={styles.examplesLabel}>Did you mean:</span>

--- a/docs/src/shared/candidate-resolver-backend.ts
+++ b/docs/src/shared/candidate-resolver-backend.ts
@@ -85,6 +85,9 @@ export class CandidateResolverBackend implements ResolverBackend {
 			bbox,
 			postcode: query.postcode,
 			limit: query.limit,
+			// #938: forward the proximity hints (map viewport / user location) so the candidate lookup
+			// re-ranks the exact tier by nearness — dropped here, the demo's viewport bias was inert.
+			bias: query.bias,
 		})
 
 		return hits.map((h) => {

--- a/docs/src/shared/demo-helpers.ts
+++ b/docs/src/shared/demo-helpers.ts
@@ -317,10 +317,14 @@ interface ResolvedTreeNode {
  * candidates, then the other resolved admin nodes for hierarchy context. Falls back to a raw-text lookup when nothing
  * in the tree resolves — same last-resort the old cascade had. Drops (lat=0, lon=0) placeholder hits throughout.
  */
+/** Soft proximity hints (#938 `bias[]`): ordered, weighted, never a hard filter. */
+export type ResolveBias = Array<{ lat: number; lon: number; weight?: number }>
+
 export async function runCascade(
 	lookup: MailwomanLookupLike,
 	tree: { roots: unknown[] },
-	rawText: string
+	rawText: string,
+	bias?: ResolveBias
 ): Promise<CascadeHits> {
 	const usable = (cs: CascadeHits): CascadeHits => cs.filter((c) => !(c.lat === 0 && c.lon === 0))
 
@@ -330,7 +334,13 @@ export async function runCascade(
 	// adminCoherence is the point of the convergence (the passes the old cascade approximated);
 	// spanRescore + hierarchyCompletion ride their shared defaults. No defaultCountry — the demo is
 	// global by design (the placer/population ranking routes, never a hardcoded country).
-	const resolved = (await resolver.resolveTree(tree as never, { adminCoherence: true })) as unknown as {
+	// bias (#938): the map viewport (and optional geolocation) as SOFT proximity hints — an in-view
+	// namesake sorts ahead of a distant one at equal exact-tier, and no-bias stays byte-identical
+	// (48026 → Fraser MI vs Russi IT, the rule the library gate pins). Omitted when empty.
+	const resolved = (await resolver.resolveTree(tree as never, {
+		adminCoherence: true,
+		...(bias && bias.length > 0 ? { bias } : {}),
+	})) as unknown as {
 		roots: ResolvedTreeNode[]
 	}
 

--- a/docs/src/shared/httpvfs-resolver.ts
+++ b/docs/src/shared/httpvfs-resolver.ts
@@ -36,6 +36,7 @@ import type { CandidateTable } from "@mailwoman/resolver-wof-sqlite/candidate-sc
 import { ALIAS_SEPARATOR, aliasBagExactMatch } from "@mailwoman/resolver-wof-sqlite/fts"
 // THE shared name_key normalizer — identical build-side (build-candidate.ts) and query-side, the
 // one-normalizer discipline that keeps the candidate table's keys reachable by construction.
+import { haversineKm } from "@mailwoman/resolver-wof-sqlite/geo"
 import { normalizeLocalityForKey, stripLocalityQualifier } from "@mailwoman/resolver-wof-sqlite/street-normalize"
 
 /**
@@ -631,7 +632,7 @@ export class WOFCandidateTableLookup implements MailwomanLookupLike {
 			if (strippedKey && strippedKey !== nameKey) rows = await probe(strippedKey)
 		}
 
-		return rows.map((row) => {
+		const candidates = rows.map((row) => {
 			const hasBbox = row.min_lat != null && row.max_lat != null && row.min_lon != null && row.max_lon != null
 
 			return {
@@ -657,6 +658,40 @@ export class WOFCandidateTableLookup implements MailwomanLookupLike {
 					: undefined,
 			}
 		})
+
+		// Proximity re-rank (#938): the browser twin of the Node candidate lookup's bias sort — with the
+		// map viewport / user location as hints, re-order the exact-match candidates by the SAME prominence
+		// (population + nearness in one additive scale) so an in-view namesake wins a tie. Byte-identical to
+		// population order when no bias is passed. `score` = -neg_rank = log10(population + 1). Constants
+		// MUST match resolver-wof-sqlite/candidate-lookup.ts (the #861 server↔demo parity contract).
+		if (query.bias && query.bias.length > 0) {
+			const BIAS_BOOST = 4.0
+			const POP_BOOST = 4.0
+			const POP_SCALE_LOG10 = 6
+			const PROX_SCALE_KM = 30
+			const prominence = (c: (typeof candidates)[number]): number => {
+				const popTerm = POP_BOOST * Math.min(1, Math.max(0, c.score) / POP_SCALE_LOG10)
+				let proxTerm = 0
+
+				if (!(c.lat === 0 && c.lon === 0)) {
+					for (const b of query.bias!) {
+						const d = haversineKm(b.lat, b.lon, c.lat, c.lon)
+						const term = (BIAS_BOOST * (b.weight ?? 1)) / (1 + d / PROX_SCALE_KM)
+
+						if (term > proxTerm) proxTerm = term
+					}
+				}
+
+				return popTerm + proxTerm
+			}
+
+			return candidates
+				.map((c, i) => ({ c, i, p: prominence(c) }))
+				.sort((a, b) => b.p - a.p || a.i - b.i)
+				.map((x) => x.c)
+		}
+
+		return candidates
 	}
 }
 

--- a/docs/src/shared/resources.tsx
+++ b/docs/src/shared/resources.tsx
@@ -93,6 +93,11 @@ export interface MailwomanLookupLike {
 		bbox?: { minLat: number; maxLat: number; minLon: number; maxLon: number }
 		limit?: number
 		postcode?: string
+		/**
+		 * Soft proximity hints (#938 — the demo's map viewport / user location). With bias present, exact-tier candidates
+		 * near a hint sort ahead of distant ones; never a hard filter. Absent → population-first order.
+		 */
+		bias?: Array<{ lat: number; lon: number; weight?: number }>
 	}) => Promise<
 		Array<{
 			id: number

--- a/docs/test/browser/260-demo-viewport-bias.spec.ts
+++ b/docs/test/browser/260-demo-viewport-bias.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @file Viewport-bias wiring (#938 demo consumer). The map's current center is fed to `resolveTree` as a SOFT proximity
+ *   hint, so an in-view namesake sorts ahead of a distant one at equal exact-tier. Two assertions pin the contract: (1)
+ *   with the map parked over Ohio, "Dublin" resolves to Dublin, OH — the bias broke the tie the user's view implies;
+ *   (2) a strong population signal still wins regardless of view — "Paris" stays in France even from a US-centered map
+ *   (guards the #912 fix, which the bias must never undo). Bias is gated on zoom ≥ 4, so a whole-globe view contributes
+ *   nothing.
+ */
+
+import { expect, test } from "#e2e"
+
+test.describe("Demo — viewport bias (#938)", () => {
+	test("map over Ohio biases 'Dublin' to Dublin, OH", async ({ demo, page }) => {
+		await demo.goto()
+		// Park the map on Ohio, zoomed in past the global-view threshold.
+		await page.evaluate(() => {
+			const w = window as unknown as { __mailwomanDemoMap?: { jumpTo: (o: unknown) => void } }
+			w.__mailwomanDemoMap?.jumpTo({ center: [-83.11, 40.1], zoom: 8 })
+		})
+		// The map loads independently of the classifier — wait until the jump has actually taken (zoom
+		// past the global-view gate) so the viewport bias is live before we submit.
+		await page.waitForFunction(
+			() => {
+				const m = (window as unknown as { __mailwomanDemoMap?: { getZoom: () => number } }).__mailwomanDemoMap
+
+				return !!m && m.getZoom() >= 7
+			},
+			{ timeout: 15_000 }
+		)
+		await demo.setAddress("Dublin")
+		await demo.submit()
+
+		const { resolved, markerCount } = await demo.readResult()
+		const [lat, lon] = (resolved["coords"] ?? "").split(",").map((s) => Number.parseFloat(s.trim()))
+		expect(lat, `Dublin under an Ohio view should land in Ohio, got ${lat},${lon}`).toBeGreaterThan(39.5)
+		expect(lat).toBeLessThan(40.6)
+		expect(lon).toBeGreaterThan(-83.6)
+		expect(lon).toBeLessThan(-82.6)
+		expect(markerCount).toBeGreaterThan(0)
+		demo.console.assertNoFailEvents()
+	})
+
+	test("population still wins: 'Paris' stays in France even from a US-centered map", async ({ demo, page }) => {
+		await demo.goto()
+		await page.evaluate(() => {
+			const w = window as unknown as { __mailwomanDemoMap?: { jumpTo: (o: unknown) => void } }
+			w.__mailwomanDemoMap?.jumpTo({ center: [-83.0, 42.3], zoom: 8 }) // Michigan
+		})
+		await page.waitForTimeout(500)
+		await demo.setAddress("Paris")
+		await demo.submit()
+
+		const { resolved } = await demo.readResult()
+		const [lat, lon] = (resolved["coords"] ?? "").split(",").map((s) => Number.parseFloat(s.trim()))
+		expect(lat, `Paris must stay in France (48.8) regardless of a US view, got ${lat},${lon}`).toBeGreaterThan(48.5)
+		expect(lat).toBeLessThan(49.1)
+		expect(lon).toBeGreaterThan(2.0)
+		expect(lon).toBeLessThan(2.7)
+		demo.console.assertNoFailEvents()
+	})
+})

--- a/resolver-wof-sqlite/candidate-lookup.test.ts
+++ b/resolver-wof-sqlite/candidate-lookup.test.ts
@@ -115,6 +115,38 @@ describe("WOFCandidateTableLookup", () => {
 		}
 	})
 
+	test("proximity bias (#938) re-ranks the exact tier by nearness without a hard filter", async () => {
+		const lk = new WOFCandidateTableLookup({ databasePath: candidatePath })
+
+		try {
+			// No bias: population wins — Moscow, RU (10.4M) over Moscow, ID (26k).
+			const plain = await lk.findPlace({ text: "Moscow", placetype: "locality", limit: 5 })
+			expect(plain[0]!.country).toBe("RU")
+
+			// A view over Idaho flips it to Moscow, ID — the in-view namesake wins the tie.
+			const idahoView = await lk.findPlace({
+				text: "Moscow",
+				placetype: "locality",
+				limit: 5,
+				bias: [{ lat: 46.73, lon: -117.0, weight: 1 }],
+			})
+			expect(idahoView[0]!.country).toBe("US")
+			expect(idahoView[0]!.lat).toBeCloseTo(46.73, 1)
+
+			// A DISTANT view must NOT flip a far-more-populous city: a Chicago-area view (near neither
+			// Moscow) leaves population-first order intact — the sharp decay keeps out-of-view namesakes out.
+			const chicagoView = await lk.findPlace({
+				text: "Moscow",
+				placetype: "locality",
+				limit: 5,
+				bias: [{ lat: 41.88, lon: -87.63, weight: 1 }],
+			})
+			expect(chicagoView[0]!.country).toBe("RU")
+		} finally {
+			lk.close()
+		}
+	})
+
 	test("country filter narrows to the requested country", async () => {
 		const lk = new WOFCandidateTableLookup({ databasePath: candidatePath })
 

--- a/resolver-wof-sqlite/candidate-lookup.ts
+++ b/resolver-wof-sqlite/candidate-lookup.ts
@@ -29,6 +29,7 @@ import { expandPlacetypeFilter } from "@mailwoman/resolver"
 
 import { CANDIDATE_FTS_TABLE } from "./candidate-fts.js"
 import type { CandidateTable, CountryCodeTable, PlacetypeCodeTable } from "./candidate-schema.js"
+import { haversineKm } from "./geo.js"
 import { trigramJaccard } from "./lookup.js"
 import { POSTAL_CITY_CANDIDATE_TABLE, type PostalCityCandidateTable } from "./postal-city-candidate-schema.js"
 import { hasTable } from "./sqlite-utils.js"
@@ -295,7 +296,7 @@ export class WOFCandidateTableLookup implements PlaceLookup {
 			}
 		}
 
-		return rows.map((row): PlaceCandidate => {
+		const candidates = rows.map((row): PlaceCandidate => {
 			const hasBbox = row.min_lat != null && row.max_lat != null && row.min_lon != null && row.max_lon != null
 
 			return {
@@ -323,6 +324,48 @@ export class WOFCandidateTableLookup implements PlaceLookup {
 					: {}),
 			}
 		})
+
+		// Proximity re-rank (#938): with bias hints (the demo's map viewport / user location), re-sort the
+		// exact-match candidates by the SAME prominence the FTS server uses (lookup.ts) — population and
+		// nearness in one additive scale — so an in-view namesake wins a tie without a hard filter. Byte-
+		// identical to the plain population order when no bias is passed. `score` here is -neg_rank =
+		// log10(population + 1), so popTerm is the server formula read straight off it. Constants MIRROR
+		// lookup.ts's DEFAULT_WEIGHTS (biasBoost 4, populationBoost 4, populationScaleLog10 6,
+		// proximityScaleKm 100) — the #861 server↔demo parity contract; keep them in lockstep.
+		if (query.bias && query.bias.length > 0) {
+			const BIAS_BOOST = 4.0
+			const POP_BOOST = 4.0
+			const POP_SCALE_LOG10 = 6
+			// SHARPER than lookup.ts's 100 km on purpose: this backend's `score` is log-population ALONE
+			// (no bm25 document term), so the population signal is weaker relative to the bias and the
+			// gentle 100 km decay let a 230 km-distant alias-exact township ("Paris Township", OH) edge
+			// out a global city ("Paris", FR) from a nearby view. A ~30 km scale keeps the boost to
+			// candidates the user is actually LOOKING at — an in-view namesake still wins (Dublin, OH from
+			// an Ohio view), a distant one no longer does (Paris stays FR from a Michigan view).
+			const PROX_SCALE_KM = 30
+			const prominence = (c: PlaceCandidate): number => {
+				const popTerm = POP_BOOST * Math.min(1, Math.max(0, c.score) / POP_SCALE_LOG10)
+				let proxTerm = 0
+
+				if (!(c.lat === 0 && c.lon === 0)) {
+					for (const b of query.bias!) {
+						const d = haversineKm(b.lat, b.lon, c.lat, c.lon)
+						const term = (BIAS_BOOST * (b.weight ?? 1)) / (1 + d / PROX_SCALE_KM)
+
+						if (term > proxTerm) proxTerm = term
+					}
+				}
+
+				return popTerm + proxTerm
+			}
+			// Stable within equal prominence (preserves the population order the B-tree already gave).
+			candidates
+				.map((c, i) => ({ c, i, p: prominence(c) }))
+				.sort((a, b) => b.p - a.p || a.i - b.i)
+				.forEach((x, j) => (candidates[j] = x.c))
+		}
+
+		return candidates
 	}
 
 	close(): void {


### PR DESCRIPTION
The #938 library `bias[]` proximity hints were merged, but no browser caller fed them — the demo's viewport was inert. Now the map view disambiguates namesakes.

**What the user gets**: search "Dublin" while looking at Ohio → **Dublin, OH**; pan to Ireland → Dublin, IE. A "📍 Use my location" opt-in adds the device location as a second, weaker hint. Soft signals only — a strong population signal still wins (search "Paris" from anywhere → **Paris, France**).

**The gap was two-fold** — the wiring *and* the browser backend:
- `runCascade` / `CandidateResolverBackend` now thread `bias` through to the lookup (the map center, gated on zoom ≥ 4 so a whole-globe view contributes nothing).
- **Both** candidate lookups gained the proximity re-rank — the Node `resolver-wof-sqlite` twin *and* the demo's `sql.js-httpvfs` twin — using the **same prominence the FTS server uses** (population + nearness in one additive scale, read off `score = -neg_rank = log10(pop+1)`). Constants kept in lockstep (#861 server↔demo parity), **except** a sharper 30 km decay in the candidate paths: their score is log-population alone (no bm25), so the server's 100 km scale let a 230 km-distant alias-exact township edge out a global city — 30 km keeps the boost to genuinely in-view candidates.

**Verified end-to-end** (Playwright, local production build):
- map over Ohio → "Dublin" resolves to Dublin, OH ✓
- US-centered map → "Paris" stays in France ✓ (guards the #912 fix the bias must never undo)
- baseline smoke (1600 Penn address_point, Zabiče cascade) unregressed ✓
- Node unit test pins the re-rank: Moscow → RU by default, → Idaho under an Idaho view, → RU under a distant view.

No-bias output is byte-identical to population-first order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA