### PR TITLE
feat(demo): /debug route + in-demo model-visualizer drawer (#941)

### DIFF
--- a/docs/src/pages/debug.tsx
+++ b/docs/src/pages/debug.tsx
@@ -1,0 +1,18 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `/debug` — the geocoder demo with the model-visualizer drawer open by default. Same client-side
+ *   stack as `/demo`; the drawer traces the SAME address you geocode on the map (tokens, retrieval
+ *   channels, emissions, priors, repairs) so a lever's effect is visible in place. A dev/inspection
+ *   surface, not a separate app — it reuses the demo body wholesale via {@link DemoPageInner}.
+ */
+
+import type React from "react"
+
+import { DemoPageInner } from "./demo/index.tsx"
+
+const DebugPage: React.FC = () => <DemoPageInner debugDefault />
+
+export default DebugPage

--- a/docs/src/pages/demo/_app.tsx
+++ b/docs/src/pages/demo/_app.tsx
@@ -29,6 +29,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { AboutDemo } from "../../components/AboutDemo/AboutDemo.tsx"
 import { LayerToggleControl } from "../../components/LayerToggleControl/LayerToggleControl.tsx"
 import { LoadingIndicator } from "../../components/LoadingIndicator/LoadingIndicator.tsx"
+import { ModelVisualizer } from "../../components/ModelVisualizer/ModelVisualizer.tsx"
 import { PermalinkButton } from "../../components/PermalinkButton/PermalinkButton.tsx"
 import { ResultPanel } from "../../components/ResultPanel/ResultPanel.tsx"
 import { VersionCompare } from "../../components/VersionCompare/VersionCompare.tsx"
@@ -50,6 +51,7 @@ import {
 	adminGazetteerURL,
 	assetURL,
 	type DemoResult,
+	type ParseTraceLike,
 	type DualRole,
 	type FSTMatcherLike,
 	type FSTProvenanceLike,
@@ -103,9 +105,11 @@ function initialAddress(): string {
 
 export interface DemoAppProps {
 	initialCenter: [number, number]
+	/** Open the model-visualizer debug drawer by default (the /debug route). */
+	debugDefault?: boolean
 }
 
-export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
+export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter, debugDefault = false }) => {
 	// Asset hosting split: the DBs + model + everything else come from R2 (assetURL → the
 	// public.sister.software bucket — raw ranges, CORS, free egress). The sql.js-httpvfs WORKER must
 	// stay SAME-ORIGIN though — browsers block cross-origin `new Worker()` — so the worker + wasm are
@@ -159,6 +163,12 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 	const suppressAutocompleteRef = useRef(false)
 	const [parseStage, setParseStage] = useState(-1)
 	const [result, setResult] = useState<DemoResult | null>(null)
+	// Model-visualizer debug drawer (#941 component, in-demo per operator): a dev-mode toggle that
+	// traces the SAME address being geocoded on the map. `debugTrace` is the decode-path trace for the
+	// current input; recomputed on each submit while debug mode is on. Gated on the classifier exposing
+	// `traceParse` (older bundles lack the seam).
+	const [debug, setDebug] = useState(debugDefault)
+	const [debugTrace, setDebugTrace] = useState<ParseTraceLike | null>(null)
 	const [selectedCandidateIndex, setSelectedCandidateIndex] = useState(0)
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
 	const [compareErrorMessage, setCompareErrorMessage] = useState<string | null>(null)
@@ -886,6 +896,17 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 					fst: (fstMatcher ?? undefined) as Parameters<typeof runPipeline>[1]["fst"],
 				})
 				const tClassify = performance.now()
+
+				// Debug drawer (#941): trace the SAME input through the decode path when dev mode is on.
+				// Best-effort + feature-detected — a trace failure or an older bundle never blocks the parse.
+				if (debug && classifier.traceParse) {
+					classifier
+						.traceParse(text, { addressSystemConventions: "auto" })
+						.then(setDebugTrace)
+						.catch(() => setDebugTrace(null))
+				} else if (!debug) {
+					setDebugTrace(null)
+				}
 				const nodes = flattenTree(tree)
 				const localityNodes = nodes.filter((n) => n.tag === "locality" || n.tag === "city")
 				// Highest-confidence region, not the first in source order: a street name like
@@ -1123,6 +1144,7 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 			selectedVersion,
 			sqljsBaseURL,
 			map,
+			debug,
 		]
 	)
 
@@ -1381,6 +1403,38 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 						</span>
 					</label>
 				) : null}
+				{classifier?.traceParse ? (
+					<label
+						style={{
+							display: "inline-flex",
+							alignItems: "center",
+							gap: 6,
+							fontSize: 13,
+							margin: "8px 0",
+							cursor: "pointer",
+							color: "var(--ifm-color-emphasis-800)",
+						}}
+						title="Open the model-visualizer drawer: trace this address through the decode path — tokens, retrieval channels, emissions, priors, repairs — beside the map."
+					>
+						<input
+							type="checkbox"
+							checked={debug}
+							onChange={(e) => {
+								setDebug(e.target.checked)
+
+								if (!e.target.checked) setDebugTrace(null)
+								else if (result && classifier.traceParse) {
+									classifier
+										.traceParse(text, { addressSystemConventions: "auto" })
+										.then(setDebugTrace)
+										.catch(() => setDebugTrace(null))
+								}
+							}}
+						/>
+						🐛 Dev mode
+						<span style={{ color: "var(--ifm-color-emphasis-600)" }}>— trace the decode path</span>
+					</label>
+				) : null}
 				{result ? (
 					<ResultPanel
 						result={displayResult ?? result}
@@ -1397,6 +1451,25 @@ export const DemoApp: React.FC<DemoAppProps> = ({ initialCenter }) => {
 					/>
 				) : null}
 			</section>
+
+			{/* Model-visualizer drawer — slides over the map's right edge so you inspect the SAME address
+			    the map is geocoding without leaving the demo. Mounts only in dev mode with a trace ready. */}
+			{debug && debugTrace ? (
+				<aside className={styles.debugDrawer} aria-label="Model decode-path visualizer">
+					<div className={styles.debugDrawerHeader}>
+						<strong>🐛 Decode path</strong>
+						<button
+							type="button"
+							className={styles.exampleBtn}
+							onClick={() => setDebug(false)}
+							aria-label="Close debug drawer"
+						>
+							✕
+						</button>
+					</div>
+					<ModelVisualizer trace={debugTrace} />
+				</aside>
+			) : null}
 		</div>
 	)
 }

--- a/docs/src/pages/demo/index.tsx
+++ b/docs/src/pages/demo/index.tsx
@@ -34,14 +34,22 @@ const LoadingFallback: React.FC = () => {
 	return <p>Loading…</p>
 }
 
-const DemoPage: React.FC = () => {
+/**
+ * The demo page body — shared by `/demo` and `/debug` (the latter opens with the model-visualizer drawer on by
+ * default). Exported so the thin `debug.tsx` route can mount it with `debugDefault`.
+ */
+export const DemoPageInner: React.FC<{ debugDefault?: boolean }> = ({ debugDefault = false }) => {
 	const { siteConfig } = useDocusaurusContext()
 	const buildCommit = (siteConfig.customFields?.buildCommit as string) ?? "?"
 	const buildTimeDisplay = (siteConfig.customFields?.buildTimeDisplay as string) ?? "?"
 	const initialCenter = useBrowserGeolocation()
 
 	return (
-		<Layout title="Demo" description="Client-side address geocoder demo for mailwoman." noFooter>
+		<Layout
+			title={debugDefault ? "Debug" : "Demo"}
+			description="Client-side address geocoder demo for mailwoman."
+			noFooter
+		>
 			{/* Resource hints: the DBs/model range-load from R2 and the basemap tiles from tiles.* the
 			    moment the app boots — preconnecting here overlaps DNS+TLS with hydration. The sqljs
 			    worker assets are same-origin and fetched on (or before) first lookup; prefetch warms
@@ -72,11 +80,13 @@ const DemoPage: React.FC = () => {
 				{() => {
 					if (!initialCenter) return <LoadingFallback />
 
-					return <DemoApp initialCenter={initialCenter} />
+					return <DemoApp initialCenter={initialCenter} debugDefault={debugDefault} />
 				}}
 			</BrowserOnly>
 		</Layout>
 	)
 }
+
+const DemoPage: React.FC = () => <DemoPageInner />
 
 export default DemoPage

--- a/docs/src/pages/demo/styles.module.css
+++ b/docs/src/pages/demo/styles.module.css
@@ -311,3 +311,50 @@
 		width: 340px;
 	}
 }
+
+/* Model-visualizer debug drawer (#941 component, in-demo). Slides in over the map's right edge; on
+   mobile it becomes a full-width bottom sheet so the map + control panel stay usable. */
+.debugDrawer {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: min(560px, 92vw);
+	overflow-y: auto;
+	padding: 12px 16px 24px;
+	background: var(--ifm-background-surface-color);
+	border-left: 1px solid var(--ifm-color-emphasis-300);
+	box-shadow: -8px 0 24px rgba(0, 0, 0, 0.18);
+	z-index: 6;
+	animation: debugDrawerSlideIn 0.25s ease-out;
+}
+
+.debugDrawerHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 8px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+@keyframes debugDrawerSlideIn {
+	from {
+		transform: translateX(16px);
+		opacity: 0;
+	}
+	to {
+		transform: translateX(0);
+		opacity: 1;
+	}
+}
+
+@media (max-width: 768px) {
+	.debugDrawer {
+		top: auto;
+		width: 100%;
+		max-height: 60vh;
+		border-left: none;
+		border-top: 1px solid var(--ifm-color-emphasis-300);
+	}
+}

--- a/docs/test/browser/270-demo-debug-drawer.spec.ts
+++ b/docs/test/browser/270-demo-debug-drawer.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * @file `/debug` route + the in-demo model-visualizer drawer (operator's #941 integration). The debug drawer traces the
+ *   SAME address geocoded on the map. Asserts: /debug opens with the drawer on, a parse populates the decode-path
+ *   visualizer, and the plain /demo has no drawer until dev mode is toggled.
+ */
+
+import { expect, test } from "#e2e"
+
+test.describe("Demo — model-visualizer debug drawer", () => {
+	test("/debug opens the drawer and traces the parsed address", async ({ demo, page }) => {
+		await page.goto("/debug/", { waitUntil: "networkidle" })
+		await demo.expectReady()
+		await demo.setAddress("1600 Pennsylvania Ave NW, Washington, DC 20500")
+		await demo.submit()
+
+		const drawer = page.locator("aside[aria-label='Model decode-path visualizer']")
+		await expect(drawer).toBeVisible({ timeout: 30_000 })
+		// The visualizer renders the decode path — the input pieces show up in the drawer.
+		await expect(drawer).toContainText("Pennsylvania", { timeout: 30_000 })
+		demo.console.assertNoFailEvents()
+	})
+
+	test("/demo has no drawer until dev mode is toggled", async ({ demo, page }) => {
+		await demo.goto("Chicago, IL")
+		await demo.submit()
+		await expect(page.locator("aside[aria-label='Model decode-path visualizer']")).toHaveCount(0)
+
+		await page.getByText("Dev mode").click()
+		await expect(page.locator("aside[aria-label='Model decode-path visualizer']")).toBeVisible({ timeout: 30_000 })
+		demo.console.assertNoFailEvents()
+	})
+})


### PR DESCRIPTION
Per your pick — the model visualizer as an in-demo drawer, not a separate page. A **🐛 Dev mode** toggle (and the `/debug` route, which opens with it on) slides a drawer over the map that traces the **same address you're geocoding**: tokens, retrieval channels (anchor/gazetteer), the emission heatmap, priors, and repairs — so you can watch a lever's effect in place.

- Reuses the existing `ModelVisualizer` + the demo's already-loaded classifier. `traceParse` is best-effort + feature-detected, so it never blocks the parse (and the toggle only appears when the bundle exposes the trace seam).
- `/debug` and `/demo` share the page body via `DemoPageInner({ debugDefault })` — no duplication.
- Drawer slides in over the map's right edge; full-width bottom sheet on mobile.

**Verified** (Playwright, local build): `/debug` opens the drawer and renders the decode path for the parsed address; plain `/demo` has no drawer until you toggle Dev mode; baseline smoke + viewport-bias specs unregressed (4/4). Screenshot in the session (it happens to illustrate #924 — "1012 LG" fragmenting in the emissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA