### PR TITLE
feat(#924): NL postcode format recognition — the query-shape belt

### DIFF
--- a/kind-classifier/rules.ts
+++ b/kind-classifier/rules.ts
@@ -170,6 +170,7 @@ const POSTCODE_FORMATS: ReadonlySet<string> = new Set([
 	"de_postcode",
 	"ca_postcode",
 	"jp_postcode",
+	"nl_postcode",
 ])
 
 /**

--- a/neural/query-shape-prior.ts
+++ b/neural/query-shape-prior.ts
@@ -58,6 +58,7 @@ const FORMAT_TO_LABEL: ReadonlyMap<string, string> = new Map([
 	["uk_postcode", "B-postcode"],
 	["ca_postcode", "B-postcode"],
 	["jp_postcode", "B-postcode"],
+	["nl_postcode", "B-postcode"],
 	["po_box", "B-po_box"],
 ])
 

--- a/query-shape/known-formats.ts
+++ b/query-shape/known-formats.ts
@@ -31,6 +31,12 @@ const PATTERNS: ReadonlyArray<FormatPattern> = [
 	{ format: "uk_postcode", pattern: /^[A-Z]{1,2}\d[A-Z\d]?\d[A-Z]{2}$/i, tokenSpan: 1, confidence: 0.9 },
 	{ format: "uk_postcode", pattern: /^[A-Z]{1,2}\d[A-Z\d]? \d[A-Z]{2}$/i, tokenSpan: 2, confidence: 0.9 },
 	{ format: "ca_postcode", pattern: /^[A-Z]\d[A-Z] \d[A-Z]\d$/i, tokenSpan: 2, confidence: 0.9 },
+	// NL postcode is 4 digits + 2 letters ("1012 LG"), 2 tokens spaced / 1 unspaced. WITHOUT this the
+	// model fragments it as house_number(1012) + street(LG) and the street context pulls the locality
+	// into the US situs tier (#924: "1012 LG Amsterdam" → Amsterdam, NY). The `\d{4} [A-Z]{2}` shape is
+	// unambiguous — no house-number+street pair reads this way — so it's a high-confidence postcode prior.
+	{ format: "nl_postcode", pattern: /^\d{4} [A-Z]{2}$/i, tokenSpan: 2, confidence: 0.9 },
+	{ format: "nl_postcode", pattern: /^\d{4}[A-Z]{2}$/i, tokenSpan: 1, confidence: 0.9 },
 	// Ambiguous 5-digit (US/FR/DE). Tag as us_zip with reduced confidence; caller disambiguates by
 	// locale prior. Multiple format hits on the same span are possible.
 	{ format: "us_zip", pattern: /^\d{5}$/, tokenSpan: 1, confidence: 0.6 },

--- a/query-shape/types.ts
+++ b/query-shape/types.ts
@@ -29,6 +29,7 @@ export type KnownFormat =
 	| "ca_postcode"
 	| "de_postcode"
 	| "jp_postcode"
+	| "nl_postcode"
 	| "po_box"
 
 /** Punctuation grammar separator between consecutive segments. */


### PR DESCRIPTION
The belt to PR #972's braces (your call was the retrain shard; this is the complementary format-recognition layer). Makes the pipeline NL-postcode-aware:

- `query-shape/known-formats.ts` — the `\d{4} [A-Z]{2}` pattern (spaced + unspaced), detected at conf 0.9.
- `neural/query-shape-prior.ts` `FORMAT_TO_LABEL` → `B-postcode` (it was silently skipping the unmapped format).
- `kind-classifier` `POSTCODE_FORMATS`.

Correct + harmless. On its own the soft 0.9-log-odds prior can't flip the model's digits-first house-number reading (that's what the #972 shard retrain is for) — but with the retrained model it's the redundant structural signal, and it already helps the pipeline paths that apply the prior (the demo runtime). Pairs with #972; no behavior change on the default geocode path (which doesn't apply the prior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXRc7gnNQeF2YaYBpt9rPA