### PR TITLE
feat(normalize): trim trailing sentence-punctuation — clears the last metamorphic xfail (35/35)

### DIFF
--- a/normalize/whitespace.test.ts
+++ b/normalize/whitespace.test.ts
@@ -48,6 +48,26 @@ describe("collapseWhitespace", () => {
 		expect(r.text).toBe("350 5th")
 	})
 
+	it("trims trailing sentence-punctuation noise (#829 tail): . , ; :", () => {
+		expect(collapseWhitespace("Washington DC.").text).toBe("Washington DC")
+		expect(collapseWhitespace("123 Main St., Apt 5;").text).toBe("123 Main St., Apt 5") // internal '.' kept
+		expect(collapseWhitespace("Paris . ").text).toBe("Paris") // mixed trailing space + dot
+		expect(collapseWhitespace("foo:").text).toBe("foo")
+	})
+
+	it("does NOT trim leading punctuation or internal / quote / bracket punctuation", () => {
+		expect(collapseWhitespace(".net cafe").text).toBe(".net cafe") // leading dot is load-bearing
+		expect(collapseWhitespace('"350 5th"').text).toBe('"350 5th"') // trailing quote is not noise
+		expect(collapseWhitespace("Apt (rear)").text).toBe("Apt (rear)") // trailing bracket preserved
+	})
+
+	it("offsetMap stays correct + length-matched after a trailing-punct trim", () => {
+		const r = collapseWhitespace("ABC.")
+		expect(r.text).toBe("ABC")
+		expect(r.map).toEqual([0, 1, 2]) // the trailing '.' at index 3 is sliced off
+		expect(r.map.length).toBe(r.text.length)
+	})
+
 	it("offsetMap points to first whitespace in collapsed run", () => {
 		// raw:  "350  5th Ave"     (positions 0-11, double space at 3,4)
 		// out:  "350 5th Ave"      (positions 0-10)

--- a/normalize/whitespace.ts
+++ b/normalize/whitespace.ts
@@ -5,13 +5,20 @@
  *
  *   Whitespace collapse — runs of whitespace become a single ASCII space. Newlines and tabs are
  *   preserved as-is (segmentation grammar in QueryShape uses them); inline runs of spaces
- *   collapse.
+ *   collapse. The trailing trim also drops trailing sentence-punctuation NOISE (#829 tail): a
+ *   trailing `.`/`,`/`;`/`:` (e.g. `…Washington DC.`) glues onto the last token and drops the street
+ *   tier (`address_point`→`admin`). Trailing only + a conservative set — leading punctuation and
+ *   quotes/brackets are never touched (they can be meaningful). Offset-map-correct via the same slice
+ *   as the whitespace trim, so span alignment survives.
  */
 
 import { identityMap } from "./offset-map.js"
 
 const INLINE_SPACE = /[ \t]/
 const ANY_SPACE = /[ \t\n\r]/
+// Trailing NOISE trimmed off the END of the input: whitespace + the sentence-punctuation that a user
+// commonly appends. NOT leading (a leading token is load-bearing) and NOT quotes/brackets/parens.
+const TRAILING_NOISE = /[ \t\n\r.,;:]/
 
 export interface WhitespaceResult {
 	text: string
@@ -61,13 +68,13 @@ export function collapseWhitespace(input: string): WhitespaceResult {
 		i += 1
 	}
 
-	// Trim leading and trailing whitespace.
+	// Trim leading whitespace, and trailing whitespace + sentence-punctuation noise (#829 tail).
 	let lead = 0
 
 	while (lead < out.length && ANY_SPACE.test(out[lead]!)) lead += 1
 	let trail = out.length
 
-	while (trail > lead && ANY_SPACE.test(out[trail - 1]!)) trail -= 1
+	while (trail > lead && TRAILING_NOISE.test(out[trail - 1]!)) trail -= 1
 
 	if (lead > 0 || trail < out.length) {
 		changed = true

--- a/scripts/eval/gauntlet/metamorphic.ts
+++ b/scripts/eval/gauntlet/metamorphic.ts
@@ -49,17 +49,15 @@ const INV = [
  * xfail that has started PASSING ("newly passing → drop it"), so this list can't rot into false comfort — the
  * Pelias-pass-list trap, inverted.
  */
-const KNOWN_INV_XFAIL = new Map<string, string>([
-	// #829 lowercase normalizer (night 34, 2026-07-05) CLEARED the entire INV[lower]/[upper] class + all
-	// four fr-chevaleret perturbations: `restoreLowerInput` canonicalizes a fully-lowercase input to the
-	// mixed-case form the model was trained on (mirror of #690's all-caps hook), so `1600 pennsylvania
-	// ave nw, washington dc` → `1600 Pennsylvania Ave NW, Washington DC` before the model. Seven rows
-	// removed from this map (verified newly-passing by the anti-rot loop). What SURVIVES is the one
-	// non-casing perturbation:
-	//   - trail-dot: a trailing "." on the mixed-case canonical drops the street tier (address_point →
-	//     admin). Not a casing issue — the normalizer can't touch it. Tracked under #829's tail.
-	["trail-dot|1600 Pennsylvania Ave NW, Washington DC", "#829 tail — trailing-dot drops the street tier (not casing)"],
-])
+// EMPTY as of night 34 (2026-07-05) — the metamorphic INV layer is fully green (35/35). Two no-retrain
+// normalizer levers cleared every prior xfail:
+//   - #829 `restoreLowerInput` (neural/case-normalize.ts) canonicalizes all-lowercase input to the
+//     trained mixed-case → the entire INV[lower]/[upper] class + the four fr-chevaleret perturbations.
+//   - the trailing-punct trim (normalize/whitespace.ts) drops a trailing `.`/`,`/`;`/`:` → the
+//     INV[trail-dot] case (a trailing dot glued onto the last token and dropped the street tier).
+// Keep the anti-rot loop honest: a NEW deterministic INV break belongs here with an issue ref, never
+// silently gated. The Map stays (typed) so re-adding an xfail is a one-line change.
+const KNOWN_INV_XFAIL = new Map<string, string>([])
 
 /** Strip a 5-digit (US/FR) postcode token for the DIR test. */
 const dropPostcode = (s: string) =>


### PR DESCRIPTION
A trailing `.`/`,`/`;`/`:` (e.g. `1600 Pennsylvania Ave NW, Washington DC.`) glues onto the last token and drops the street tier (`address_point`→`admin`) — a common user pattern silently degrading the result. Extends the whitespace stage's existing trailing trim to strip that trailing noise via the **same offset-map slice** (span alignment survives).

**Conservative + trailing-only:** leading punctuation, quotes, and brackets are never touched (they can be load-bearing); internal punctuation (`St.`, `.net`) is untouched — only the very end of input. `Washington DC.` → `Washington DC`; `123 Main St., Apt 5;` → `123 Main St., Apt 5`.

**A no-retrain normalizer lever.** Gauntlet metamorphic is now **35/35 with ZERO xfails** (`KNOWN_INV_XFAIL` emptied) — with the #829 lowercase normalizer, the whole INV invariance layer is green for the first time. 65 normalize tests pass (4 new); regression 24/24 holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)