### PR TITLE
feat(#928): postcodeCountryPrior — postcode FORMAT overrides the placer's GB/US conflation (GB 63%→90%)

### DIFF
--- a/mailwoman/geocode-core.test.ts
+++ b/mailwoman/geocode-core.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #928: `countryFromPostcodeFormat` — a parsed postcode's FORMAT as a country signal, used by the
+ *   `postcodeCountryPrior` lever to override the language-based placer (which conflates GB/US). The
+ *   essential guarantee: the GB pattern is UNFORGEABLE across the formats we resolve — it never matches
+ *   a US ZIP, an NL `\d{4} [A-Z]{2}`, an FR 5-digit, or a Canadian `A#A #A#` code — so turning the lever
+ *   on can never mis-route a non-GB address.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { countryFromPostcodeFormat } from "./geocode-core.js"
+
+describe("countryFromPostcodeFormat (#928)", () => {
+	it("matches GB postcodes (spaced and unspaced)", () => {
+		expect(countryFromPostcodeFormat("E4 9AZ")).toBe("GB")
+		expect(countryFromPostcodeFormat("SW1A 1AA")).toBe("GB")
+		expect(countryFromPostcodeFormat("IG5 0NA")).toBe("GB")
+		expect(countryFromPostcodeFormat("E49AZ")).toBe("GB") // unspaced
+		expect(countryFromPostcodeFormat("  CH43 0TR  ")).toBe("GB") // trimmed
+	})
+
+	it("does NOT match a US ZIP, NL, FR, or CA postcode (unforgeable → no mis-route)", () => {
+		expect(countryFromPostcodeFormat("90210")).toBeNull() // US ZIP (all digits)
+		expect(countryFromPostcodeFormat("1012 LG")).toBeNull() // NL (digits-first)
+		expect(countryFromPostcodeFormat("75013")).toBeNull() // FR
+		expect(countryFromPostcodeFormat("K1A 0B1")).toBeNull() // CA (ends digit-letter-digit, not digit-letter-letter)
+	})
+
+	it("is null on empty / missing input", () => {
+		expect(countryFromPostcodeFormat(undefined)).toBeNull()
+		expect(countryFromPostcodeFormat("")).toBeNull()
+		expect(countryFromPostcodeFormat("   ")).toBeNull()
+	})
+})

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -25,6 +25,7 @@
 import { existsSync } from "node:fs"
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { hardCountryFor, isBareLocalityTree } from "@mailwoman/core/pipeline"
 import { normalize } from "@mailwoman/normalize"
 import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } from "@mailwoman/resolver"
@@ -142,6 +143,13 @@ export interface GeocodeDeps {
 	/** #743/#194: override the coverage safelist gating {@link hardPlaceCountry}. Undefined → built-in. */
 	hardCountrySafelist?: ReadonlySet<string>
 	/**
+	 * #928: when the parsed postcode's FORMAT unambiguously implies a country ({@link POSTCODE_FORMAT_COUNTRY} — GB `E4
+	 * 9AZ`), use it as the country prior IN PLACE OF the coarse placer, which conflates GB/US on shared English patterns
+	 * and mis-routes GB → US namesakes at high confidence. Default-OFF (staged pending its gate); only fires when no
+	 * explicit `defaultCountry`. A format is a stronger, unforgeable signal than the language model.
+	 */
+	postcodeCountryPrior?: boolean
+	/**
 	 * Admin descendant-consistency (#263, `ResolveOpts.adminCoherence`) — re-pick a (region, locality) pair so the
 	 * locality descends from the region ("Portland, ME" → Maine, not Messina). **Default-on** for the geocode path; only
 	 * fires when a region's child locality fell through, so the well-resolved path is byte-identical. Pass `false` to opt
@@ -155,6 +163,28 @@ export interface GeocodeDeps {
  * guess is broader/softer than a postcode anchor (2.0), so it blends gently.
  */
 const COARSE_PLACER_ANCHOR_WEIGHT = 1.0
+
+/**
+ * #928: distinctive postcode FORMATS that unambiguously indicate a country — a stronger country signal than the
+ * language-based coarse placer, which conflates GB/US (both carry English street patterns) and mis-routes GB addresses
+ * to US namesakes (`London E4 9AZ` → London, Ohio) at 0.94–0.96 confidence. The format is unforgeable across these
+ * countries: the GB pattern (letters-first) never matches a US ZIP or an NL `\d{4} [A-Z]{2}` code. Extend ONLY with
+ * formats validated as non-overlapping. Feeds the `postcodeCountryPrior` lever (gated, default-off pending its gate).
+ */
+const POSTCODE_FORMAT_COUNTRY: ReadonlyArray<{ readonly re: RegExp; readonly country: string }> = [
+	{ re: /^[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}$/i, country: "GB" },
+]
+
+/** The country a parsed postcode's FORMAT implies, or null. See {@link POSTCODE_FORMAT_COUNTRY}. */
+export function countryFromPostcodeFormat(postcode: string | undefined): string | null {
+	const p = postcode?.trim()
+
+	if (!p) return null
+
+	for (const { re, country } of POSTCODE_FORMAT_COUNTRY) if (re.test(p)) return country
+
+	return null
+}
 
 /** Lowercase 2-letter state slug from a parsed region value / resolver name, else null. */
 export function regionToStateSlug(
@@ -362,6 +392,25 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 
 	// The placer's country (in-map, non-OTHER) — reused below to select an OSM rooftop shard for a non-US parse.
 	let placedCountry: string | null = null
+
+	// #928: a distinctive postcode FORMAT outranks the language-based placer (which conflates GB/US → US
+	// namesakes). When gated on and no explicit defaultCountry, set the country prior from the parsed
+	// postcode's format; the placer block below then no-ops via its `!opts.anchorPosterior` guard. Confidence
+	// 1.0 — a matched format is unambiguous. hardCountry still gates on the safelist (GB isn't on it yet, so
+	// this is a soft anchorPosterior re-rank for GB — enough to de-boost the US namesakes; a safelist add
+	// would make it hard, see #985).
+	if (deps.postcodeCountryPrior && !opts.defaultCountry && !opts.anchorPosterior && !isBareLocalityTree(tree)) {
+		const pcCountry = countryFromPostcodeFormat(decodeAsJSON(tree).postcode as string | undefined)
+
+		if (pcCountry) {
+			placedCountry = pcCountry
+			opts.anchorPosterior = { [pcCountry]: 1.0 }
+			opts.anchorWeight = COARSE_PLACER_ANCHOR_WEIGHT
+			const hardCountry = hardCountryFor(pcCountry, 1.0, opts, deps.hardPlaceCountry ?? true, deps.hardCountrySafelist)
+
+			if (hardCountry) opts.hardCountry = hardCountry
+		}
+	}
 
 	// #912 lever 1: the placer abstains on a single bare locality — OOD input, and the wrong soft
 	// posterior overrides the resolver's better-informed exact-tier/population ranking (see


### PR DESCRIPTION
The coarse placer conflates GB with US (shared English street patterns) — it *confidently* mis-classifies GB addresses as US (0.94–0.96), routing `London E4 9AZ` → **London, Ohio**. 24% of the new GB panel (#983) resolved abroad to US namesakes. The GB postcode **format** (`E4 9AZ`) is an unforgeable GB signal the placer ignores.

Adds `countryFromPostcodeFormat` (a format→country table, GB first) + the `postcodeCountryPrior` geocode dep (**default-off, staged**): when on and no explicit `defaultCountry`, the parsed postcode's format sets the country prior at confidence 1.0 *in place of* the placer. **US-safe by construction** — the GB pattern never matches a US ZIP / NL / FR / CA code (unit-tested).

**Measured on `oa-gb-coord-1k` (n=300):**

| config | ok (<50 km) | abroad | unresolved |
|---|---|---|---|
| baseline (off) | 190 (63%) | 73 (24%) | 34 |
| flag on | 210 | 53 | 34 |
| **flag on + GB safelisted** | **271 (90%)** | **19 (6%)** | **7** |

The full #928 fix = this lever default-on **+ GB on `HARD_PLACE_COUNTRY_SAFELIST`** (safe once the format prior confidently routes GB). Staged default-off pending your promote (WALL: no default flip tonight). Generalizes to any distinctive-postcode country.

🤖 Generated with [Claude Code](https://claude.com/claude-code)