### PR TITLE
feat(#928): PROMOTE postcodeCountryPrior default-ON + GB/CA safelisted

### DIFF
--- a/core/pipeline/runtime-pipeline.ts
+++ b/core/pipeline/runtime-pipeline.ts
@@ -75,7 +75,19 @@ const HARD_PLACE_COUNTRY_MIN_CONF = 0.9
 // for the rest (DeepSeek-advised, 2026-06-22). Measured resolve-rate under hard: US 100, FR 100, DE
 // 100, ES 99.8, NL 97.3, IT 96.8 (in); FI 69.5, PL 77.8 (out). Grow as more countries clear the bar.
 // Override per-call with `PipelineOpts.hardCountrySafelist` (the eval measures ungated to grow it).
-export const HARD_PLACE_COUNTRY_SAFELIST: ReadonlySet<string> = new Set(["US", "ES", "IT", "NL", "DE", "FR"])
+// GB + CA added at the #928 promote (2026-07-06): the postcodeCountryPrior format signal routes them
+// confidently (the language placer conflated both with US), and their OSM-panel gates passed with the
+// hard filter on — GB 271/300 ok / 7 unresolved, CA 200/300 ok / 31 unresolved (night 34).
+export const HARD_PLACE_COUNTRY_SAFELIST: ReadonlySet<string> = new Set([
+	"US",
+	"ES",
+	"IT",
+	"NL",
+	"DE",
+	"FR",
+	"GB",
+	"CA",
+])
 
 /**
  * #912 lever 1 — is this parse a single BARE locality ("Paris", "Dublin")? The coarse placer is out-of-distribution on

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -144,9 +144,11 @@ export interface GeocodeDeps {
 	hardCountrySafelist?: ReadonlySet<string>
 	/**
 	 * #928: when the parsed postcode's FORMAT unambiguously implies a country ({@link POSTCODE_FORMAT_COUNTRY} — GB `E4
-	 * 9AZ`), use it as the country prior IN PLACE OF the coarse placer, which conflates GB/US on shared English patterns
-	 * and mis-routes GB → US namesakes at high confidence. Default-OFF (staged pending its gate); only fires when no
-	 * explicit `defaultCountry`. A format is a stronger, unforgeable signal than the language model.
+	 * 9AZ`, CA `K2P 1L4`), use it as the country prior IN PLACE OF the coarse placer, which conflates GB/CA with US on
+	 * shared English patterns and mis-routes them to US namesakes at high confidence (London E4 → London, Ohio).
+	 * **DEFAULT-ON** (promoted 2026-07-06; gate: GB 63→90% ok, CA 42→67%, US byte-identical 0/150 — the formats never
+	 * match a US ZIP / NL / FR code). Only fires when no explicit `defaultCountry`. Pass `false` to opt out (the
+	 * pre-promote behavior). A format is a stronger, unforgeable signal than the language model.
 	 */
 	postcodeCountryPrior?: boolean
 	/**
@@ -403,7 +405,12 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	// 1.0 — a matched format is unambiguous. hardCountry still gates on the safelist (GB isn't on it yet, so
 	// this is a soft anchorPosterior re-rank for GB — enough to de-boost the US namesakes; a safelist add
 	// would make it hard, see #985).
-	if (deps.postcodeCountryPrior && !opts.defaultCountry && !opts.anchorPosterior && !isBareLocalityTree(tree)) {
+	if (
+		deps.postcodeCountryPrior !== false &&
+		!opts.defaultCountry &&
+		!opts.anchorPosterior &&
+		!isBareLocalityTree(tree)
+	) {
 		const pcCountry = countryFromPostcodeFormat(decodeAsJSON(tree).postcode as string | undefined)
 
 		if (pcCountry) {


### PR DESCRIPTION
Operator-approved full promote. `postcodeCountryPrior` → **default-ON** (opt-out `false`) + **GB, CA join `HARD_PLACE_COUNTRY_SAFELIST`**.

**Gate:** GB 63→90% ok, CA 42→67% ok, US byte-identical (0/150, scoped + unscoped). This PR: 527 unit tests pass; gauntlet regression 24/24, metamorphic 35/35, DIR 3/3 with the promoted defaults.

Reaches users at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)