### PR TITLE
feat(#977): NL PC6 shard + granularity rule — "1012 LG" resolves to its street block

### DIFF
--- a/core/utils/data-root.ts
+++ b/core/utils/data-root.ts
@@ -40,11 +40,14 @@ export function dataRootPath(...segments: string[]): string {
  * `--data-root` option through). A fresh array each call; callers filter with `existsSync`, so a deployment without the
  * tail shard degrades to the pre-#920 pair.
  */
-export function wofShardPaths(dataRoot: string = mailwomanDataRoot()): [string, string, string, string] {
+export function wofShardPaths(dataRoot: string = mailwomanDataRoot()): [string, string, string, string, string] {
 	return [
 		String(resolvePathBuilder(dataRoot, "wof", "admin-global-priority.db")),
 		String(resolvePathBuilder(dataRoot, "wof", "postalcode-us.db")),
 		String(resolvePathBuilder(dataRoot, "wof", "postalcode-geonames-tail.db")),
 		String(resolvePathBuilder(dataRoot, "wof", "postalcode-intl.db")),
+		// #977: the NL PC6 full-postcode shard (CBS via PDOK; scripts/build-postalcode-nl-pc6.ts) — the
+		// data the lookup's NL PC6 ladder ("1012 LG" → joined "1012LG" → 4-digit stem) resolves against.
+		String(resolvePathBuilder(dataRoot, "wof", "postalcode-nl-pc6.db")),
 	]
 }

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -537,7 +537,23 @@ export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeR
 		// `postcode` joins the ladder (after the locality tiers, before region): a lone-postcode
 		// query resolves the postcode node itself — without it here the result reported 0,0 despite
 		// a resolved coordinate (found building the proximity-bias feature's 48026 case).
-		const adminPriority: ReadonlyArray<string> = ["locality", "dependent_locality", "postcode", "region", "country"]
+		//
+		// #977: EXCEPT when the resolved postcode is a full NL PC6 EXACT hit — a PC6 is street-block-class
+		// (avg ~8 addresses; the CBS polygon centroid), categorically tighter than any locality centroid,
+		// so it leads the ladder. Guarded three ways so the locality-first epoch convention (adopted for
+		// FR, where 5-digit zone centroids are COARSER than communes) is untouched everywhere else:
+		// (1) the parsed text is the full NL shape (`1012 LG`), (2) the node resolved, and (3) the
+		// resolver's hit is the FULL code, not the 4-digit-stem fallback (the stem is area-class — the
+		// lookup ladder can coarsen to it, and a stem hit must NOT outrank the locality).
+		const pcNode = allNodes.find((n) => n.tag === "postcode" && n.lat != null && n.lon != null)
+		const alnum = (s: string): string => s.replace(/[^\p{L}\p{N}]/gu, "").toUpperCase()
+		const pc6Exact =
+			pcNode !== undefined &&
+			/^\d{4}\s?[A-Z]{2}$/i.test(pcNode.value.trim()) &&
+			alnum(String(pcNode.metadata?.["resolver_name"] ?? "")) === alnum(pcNode.value)
+		const adminPriority: ReadonlyArray<string> = pc6Exact
+			? ["postcode", "locality", "dependent_locality", "region", "country"]
+			: ["locality", "dependent_locality", "postcode", "region", "country"]
 
 		for (const tag of adminPriority) {
 			const node = allNodes.find((n) => n.tag === tag && n.lat != null && n.lon != null)

--- a/mailwoman/resolver-backend.test.ts
+++ b/mailwoman/resolver-backend.test.ts
@@ -24,12 +24,13 @@ afterEach(() => {
 	for (const k of ENV_KEYS) setEnv(k, original[k])
 })
 
-test("wofShardPaths: builds the admin + postcode + tail + intl shard paths under a data root (#920)", () => {
+test("wofShardPaths: builds the admin + postcode + tail + intl + NL-PC6 shard paths under a data root (#920/#977)", () => {
 	expect(wofShardPaths("/data")).toEqual([
 		"/data/wof/admin-global-priority.db",
 		"/data/wof/postalcode-us.db",
 		"/data/wof/postalcode-geonames-tail.db",
 		"/data/wof/postalcode-intl.db",
+		"/data/wof/postalcode-nl-pc6.db",
 	])
 })
 

--- a/scripts/build-postalcode-nl-pc6.ts
+++ b/scripts/build-postalcode-nl-pc6.ts
@@ -1,0 +1,105 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build `postalcode-nl-pc6.db` — the NL full-postcode (PC6) shard, #977 tier 2. WOF NL carries NO
+ *   `postalcode` tier at all, so `1012 LG` could only resolve to the Amsterdam locality centroid.
+ *   Source: the CBS "Postcode6 statistieken" GeoPackage via PDOK (CC-BY 4.0 — provenance in `meta`),
+ *   pre-extracted to a centroid CSV with ogr2ogr:
+ *
+ *     ogr2ogr -f CSV pc6-centroids.csv cbs_pc6_2024.gpkg -dialect sqlite \
+ *       -sql "SELECT postcode6 AS pc6, ST_X(ST_Centroid(ST_Transform(geom, 4326))) AS lon,
+ *             ST_Y(ST_Centroid(ST_Transform(geom, 4326))) AS lat FROM postcode6"
+ *
+ *   One `spr` row per PC6 (placetype `postalcode`, country NL, polygon centroid, degenerate bbox),
+ *   the normalized form (`1012LG`) as `name` + the display form (`1012 LG`) as an extra `names` row —
+ *   the same convention as `ingestGeonamesPostal`. The lookup's NL PC6 ladder (`lookup.ts` — full code
+ *   → joined → 4-digit stem) was already built and is waiting on exactly this data. FTS + ANALYZE via
+ *   the canonical `buildPlaceSearchFTS`. Readonly artifact: build to `.tmp`, swap into place
+ *   (build-on-copy — the previous version moves aside, never mutated).
+ *
+ *   Run: node scripts/build-postalcode-nl-pc6.ts [--csv <pc6-centroids.csv>] [--out <postalcode-nl-pc6.db>]
+ */
+
+import { existsSync, readFileSync, renameSync, rmSync } from "node:fs"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { dataRootPath } from "@mailwoman/core/utils"
+import { buildPlaceSearchFTS } from "@mailwoman/resolver-wof-sqlite"
+import { normalizePostcodeName } from "@mailwoman/resolver-wof-sqlite/geonames-postal"
+import { createUnifiedIndexes, createUnifiedSchema } from "@mailwoman/resolver-wof-sqlite/unified-schema"
+
+/** Synthetic id base — distinct from the GeoNames postal range (9500000000000). */
+const NL_PC6_ID_BASE = 9_600_000_000_000
+
+async function main(): Promise<void> {
+	const { values } = parseArgs({
+		options: {
+			csv: { type: "string", default: "/mnt/playpen/mailwoman-data/cbs/pc6-centroids.csv" },
+			out: { type: "string", default: String(dataRootPath("wof", "postalcode-nl-pc6.db")) },
+		},
+	})
+	const csvPath = values.csv!
+	const outPath = values.out!
+	const tmpPath = `${outPath}.tmp`
+
+	const lines = readFileSync(csvPath, "utf8").trim().split("\n")
+	const header = lines.shift()
+
+	if (header !== "pc6,lon,lat") throw new Error(`unexpected CSV header: ${header}`)
+
+	rmSync(tmpPath, { force: true })
+	const db = new DatabaseSync(tmpPath)
+	db.exec("PRAGMA journal_mode = OFF")
+	db.exec("PRAGMA synchronous = OFF")
+	await createUnifiedSchema(db)
+
+	const sprInsert = db.prepare(
+		`INSERT OR REPLACE INTO spr (id, parent_id, name, placetype, country, latitude, longitude, min_latitude, min_longitude, max_latitude, max_longitude, is_current, is_deprecated, is_ceased, is_superseded, is_superseding, lastmodified) VALUES (?, -1, ?, 'postalcode', 'NL', ?, ?, ?, ?, ?, ?, 1, 0, 0, 0, 0, 0)`
+	)
+	const namesInsert = db.prepare(
+		`INSERT INTO names (id, name, placetype, country, language, lastmodified) VALUES (?, ?, 'postalcode', 'NL', '', 0)`
+	)
+
+	let inserted = 0
+	let skipped = 0
+	db.exec("BEGIN")
+
+	for (const line of lines) {
+		const [pc6Raw, lonS, latS] = line.split(",")
+		const pc6 = (pc6Raw ?? "").trim().toUpperCase()
+		const lon = Number(lonS)
+		const lat = Number(latS)
+
+		// A valid PC6 is 4 digits + 2 letters; the CBS file is already normalized (no space).
+		if (!/^\d{4}[A-Z]{2}$/.test(pc6) || !Number.isFinite(lat) || !Number.isFinite(lon)) {
+			skipped++
+			continue
+		}
+		const name = normalizePostcodeName(pc6) // identity for the CBS form; keeps the convention explicit
+		const display = `${pc6.slice(0, 4)} ${pc6.slice(4)}`
+		const id = NL_PC6_ID_BASE + inserted
+
+		sprInsert.run(id, name, lat, lon, lat, lon, lat, lon)
+		namesInsert.run(id, name)
+
+		if (display !== name) namesInsert.run(id, display)
+		inserted++
+	}
+	db.exec("COMMIT")
+	await createUnifiedIndexes(db)
+
+	process.stderr.write(`spr rows: ${inserted} (skipped ${skipped}) — building place_search + place_bbox…\n`)
+	buildPlaceSearchFTS(db, { drop: true })
+	db.exec("ANALYZE")
+	db.close()
+
+	// Build-on-copy: the previous version moves aside; the new artifact swaps in atomically.
+	if (existsSync(outPath)) renameSync(outPath, `${outPath}.prev`)
+	renameSync(tmpPath, outPath)
+	process.stderr.write(`wrote ${inserted} NL PC6 rows -> ${outPath}\n`)
+}
+
+await main()


### PR DESCRIPTION
Tier-2 of #977. WOF NL has no `postalcode` tier, so `1012 LG Amsterdam` could only resolve to the city centroid. Now:

- **`postalcode-nl-pc6.db`** (new builder, CBS Postcode6 via PDOK, CC-BY): 464,964 PC6 centroids in the `ingestGeonamesPostal` spr convention. The lookup's NL PC6 ladder (full → joined → stem) **already existed** — it was waiting on this data.
- **`wofShardPaths`** gains the shard (5-tuple; `existsSync`-filtered, country-probed → NL-only routing).
- **The admin ladder**: a full NL PC6 *exact* hit leads (street-block-class, ~8 addresses). Triple-guarded (full-shape parse + resolved + full-code hit, not the stem fallback) so the locality-first epoch convention is untouched everywhere else.

**Gates:** `1012 LG Amsterdam` city→block centroid (52.3769, 4.8977); `Damrak 1…` rooftop untouched; bare `1012` doesn't hijack; NL rooftop panel byte-identical; **US-150: 0 rows changed**.

Deploy note: the shard is a server-side data artifact (193 MB) — it rides `$MAILWOMAN_DATA_ROOT/wof/`; the demo's browser resolver is unaffected until a slim variant is published (follow-up if wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)