### PR TITLE
chore(#481): name the span-proposer ambiguous-confidence constant — closes the bundle 7/7

### DIFF
--- a/core/pipeline/span-proposer.ts
+++ b/core/pipeline/span-proposer.ts
@@ -361,6 +361,14 @@ const HYPHEN_COMPOUND = /^(\d{1,4})-(\d{1,5})$/
 const FRACTION = /^\d\/\d$/
 
 /**
+ * #481 item 7: the "plausible but genuinely ambiguous" proposal confidence — a FUSED_NUMBER reading that is real but
+ * not the only reading of the token (a trailing-fused slash compound, a hyphen at house-number position). Deliberately
+ * BELOW the confident readings (0.8–0.9) and above coin-flip, and the same operating point as the phrase grouper's
+ * `NEUTRAL_PROPOSAL_CONFIDENCE` — both stages express "emit, but don't let this outrank a confident reading" alike.
+ */
+const AMBIGUOUS_PROPOSAL_CONFIDENCE = 0.55
+
+/**
  * Words that lead NUMBERED ROADS ("Hwy 50/89", "Route 1/9", "I-95") — a bounded structural category (road-type
  * leaders), mirroring the phrase grouper's street-type sets. The leading-designator-shape fallback must not read them
  * as sub-premise designators: a slash after a road leader is a route concurrency, not an AU unit/house split.
@@ -470,7 +478,7 @@ function proposeNumericReadings(
 					start: t.strippedStart,
 					end: t.strippedEnd,
 					kind: "FUSED_NUMBER",
-					confidence: 0.55,
+					confidence: AMBIGUOUS_PROPOSAL_CONFIDENCE,
 					source: "slash:trailing-fused",
 				})
 			}
@@ -520,7 +528,7 @@ function proposeNumericReadings(
 					start: t.strippedStart,
 					end: t.strippedEnd,
 					kind: "FUSED_NUMBER",
-					confidence: 0.55,
+					confidence: AMBIGUOUS_PROPOSAL_CONFIDENCE,
 					source: "hyphen:house-number-position",
 				})
 			}


### PR DESCRIPTION
The last sliver of the #481 code-health bundle: the two raw `0.55` FUSED_NUMBER sites become `AMBIGUOUS_PROPOSAL_CONFIDENCE` (documented, mirrors the phrase grouper's `NEUTRAL_PROPOSAL_CONFIDENCE`). 119 pipeline tests pass, byte-identical behavior.

**Full bundle audit — everything else was already done piecemeal:**
1. ✅ `#decode` extraction (parse/parseWithLogits share the whole path)
2. ✅ repair divergence resolved (repairs run in both; documented at `parseWithLogits`)
3. ✅ `ParseOpts` exported
4. ✅ TLA removed (lazy `getAvailableLanguages`)
5. ✅ `__isCompiledTree` fixed (PR #594)
6. ✅ preference-filter tests (registry.test.ts covers all 4 cases)
7. ✅ lexicon loud-validation (in code, tagged #481) + this constant

Recommend closing #481 on merge. Note: the AGENTS.md bare/subpath Vite interleave (the `adapter.test.ts` side-effect import) is a *structural* bundler behavior beyond the bundle's items — if we want it pursued, it deserves its own issue rather than keeping #481 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)