### PR TITLE
feat(#625): exactDiscriminators mechanism + A5 taxonomy leg — measured neutral, recorded honestly

### DIFF
--- a/registry/resolve.test.ts
+++ b/registry/resolve.test.ts
@@ -207,6 +207,25 @@ describe("secondary-identifier discriminators (#625)", () => {
 	})
 })
 
+describe("exactDiscriminators — code-SET overlap (#625 A5)", () => {
+	it("agrees on ANY shared code regardless of slot order/count; never via string similarity", () => {
+		// 207R vs 207Q are near-identical strings but DIFFERENT specialties — string similarity would
+		// mis-score them "high"; the set-overlap comparator reads them as disjoint (level: different).
+		const a: SourceRecord = {
+			...coLocated("1", "Acme", "Health"),
+			attributes: { taxonomy: "207R00000X 208D00000X" },
+		}
+		const b: SourceRecord = { ...coLocated("2", "Acme", "Health"), attributes: { taxonomy: "208D00000X" } } // shared 208D
+		const c: SourceRecord = { ...coLocated("3", "Acme", "Health"), attributes: { taxonomy: "207Q00000X" } } // disjoint
+		const shared = resolveEntities([a, b], { threshold: -100, exactDiscriminators: ["taxonomy"] })
+		expect(shared.entities).toHaveLength(1)
+		// The disjoint pair still merges here (same name+address dominate) — the assertion is the model
+		// BUILDS and the comparator runs; the weight-level separation is the benchmark's to measure.
+		const disjoint = resolveEntities([a, c], { threshold: -100, exactDiscriminators: ["taxonomy"] })
+		expect(disjoint.entities.length).toBeGreaterThanOrEqual(1)
+	})
+})
+
 describe("toGeoJSON", () => {
 	it("emits a Point feature per geocoded entity with analyst-facing properties", () => {
 		const { entities } = resolveEntities(records, { learnedScorer: false }) // FS-baseline pipeline assertion

--- a/registry/resolve.ts
+++ b/registry/resolve.ts
@@ -75,6 +75,25 @@ const PHONE_LEVELS: ComparisonLevel[] = [
 	{ label: "different", minSimilarity: 0, m: 0.4, u: 0.998 },
 ]
 
+/**
+ * Exact-vs-different levels for a closed-vocabulary code SET ({@link DefaultModelOptions.exactDiscriminators} — NPPES
+ * taxonomy codes, license numbers). Seeds only — EM refits. `u` starts well above phone's 0.002: two RANDOM providers
+ * share a specialty far more often than a phone line (dermatologists cluster in dermatology buildings).
+ */
+const CODE_SET_LEVELS: ComparisonLevel[] = [
+	{ label: "exact", minSimilarity: 1.0, m: 0.75, u: 0.08 },
+	{ label: "different", minSimilarity: 0, m: 0.25, u: 0.92 },
+]
+
+/** 1 when the whitespace-joined code sets share ANY code, else 0 (order/count-insensitive, case-folded). */
+function codeSetOverlap(a: string, b: string): number {
+	const sa = new Set(a.toUpperCase().split(/\s+/).filter(Boolean))
+
+	for (const t of b.toUpperCase().split(/\s+/)) if (t && sa.has(t)) return 1
+
+	return 0
+}
+
 /** Last-10-digits normalization for phone agreement (drops country code, punctuation, extensions). */
 function normalizePhone(raw: string | null | undefined): string | null {
 	if (!raw) return null
@@ -119,6 +138,14 @@ export interface DefaultModelOptions {
 	 * phone where the data has one (#625).
 	 */
 	discriminators?: string[]
+	/**
+	 * Closed-vocabulary CODE-SET discriminators drawn from {@link SourceRecord.attributes} (#625 taxonomy lever). The
+	 * attribute value is a whitespace-joined set of codes (NPPES taxonomy codes, license numbers, …); agreement = ANY
+	 * shared code (set overlap, not string similarity — `207R00000X` vs `207Q00000X` are DIFFERENT specialties despite
+	 * near-identical text, exactly the case string similarity mis-scores). The over-merge separator: two co-located
+	 * records of ONE entity nearly always share a code, two distinct co-located providers usually don't.
+	 */
+	exactDiscriminators?: string[]
 }
 
 /**
@@ -155,6 +182,17 @@ export function buildDefaultModel(opts: DefaultModelOptions = {}): FellegiSunter
 				name: `attr:${key}`,
 				extract: (r) => r.attributes?.[key],
 				levels: NAME_LEVELS,
+			})
+		)
+	}
+
+	for (const key of opts.exactDiscriminators ?? []) {
+		identity.push(
+			similarityComparison<SourceRecord>({
+				name: `attr:${key}`,
+				extract: (r) => r.attributes?.[key],
+				similarity: codeSetOverlap, // ANY shared code = 1, else 0 — never string similarity (see the config doc)
+				levels: CODE_SET_LEVELS,
 			})
 		)
 	}
@@ -264,6 +302,11 @@ export interface ResolveConfig {
 	 */
 	discriminators?: string[]
 	/**
+	 * Closed-vocabulary code-SET discriminator keys ({@link DefaultModelOptions.exactDiscriminators} — set-overlap
+	 * agreement, e.g. `["taxonomy"]`). Also corroborators. Ignored if `model` is supplied.
+	 */
+	exactDiscriminators?: string[]
+	/**
 	 * Override the Fellegi-Sunter link weight with a LEARNED score (#603). When set, a candidate pair's match weight is
 	 * this function's return value (same threshold-comparable units as the FS weight) instead of {@link scorePair}'s.
 	 * Default undefined (pure FS). The blocking + clustering are unchanged, so a trained scorer can be A/B'd against the
@@ -324,6 +367,7 @@ export function resolveEntities(records: readonly SourceRecord[], config: Resolv
 			collapseSpatial,
 			usePhone: config.usePhone,
 			discriminators: config.discriminators,
+			exactDiscriminators: config.exactDiscriminators,
 		})
 	const blockingKeys = config.blockingKeys ?? defaultBlockingKeys()
 

--- a/scripts/record-matcher/nppes-dedup-benchmark.ts
+++ b/scripts/record-matcher/nppes-dedup-benchmark.ts
@@ -99,6 +99,8 @@ const C = {
 	isSubpart: "Is Organization Subpart",
 	parentLBN: "Parent Organization LBN",
 	parentTIN: "Parent Organization TIN",
+	// #625 taxonomy discriminator: the 15 taxonomy slots; collected as a set (any shared code = agreement).
+	taxonomy: Array.from({ length: 15 }, (_, i) => `Healthcare Provider Taxonomy Code_${i + 1}`),
 }
 
 const norm = (s: string | undefined) => (s ?? "").trim()
@@ -153,6 +155,8 @@ interface MessyRow {
 	org: string
 	address: string
 	auth: string
+	/** Whitespace-joined taxonomy-code set (up to 15 slots) — the #625 code-set discriminator. */
+	taxonomy: string
 	entityID: string
 }
 
@@ -212,6 +216,13 @@ async function main(): Promise<void> {
 			if (primaryName) {
 				const org = isOrg ? norm(r[C.orgLegal]) : ""
 				const auth = `${norm(r[C.authFirst])} ${norm(r[C.authLast])}`.trim() // the NPI's registrant — shared across its records
+				// #625: the taxonomy-code set (up to 15 slots), whitespace-joined — identical across the NPI's
+				// records by construction (it's a per-NPI registry attribute), so it NEVER splits one entity;
+				// it only separates co-located DISTINCT providers whose sets are disjoint.
+				const taxonomy = C.taxonomy
+					.map((col) => norm(r[col]))
+					.filter(Boolean)
+					.join(" ")
 				// Entity-level (site) truth: same org + same physical address. Subparts (NPPES
 				// "Is Organization Subpart" + parent LBN/TIN) collapse to their PARENT, so the matcher isn't
 				// charged for correctly fusing one org's many subpart-NPIs at a site; an NPI's mailing-vs-
@@ -224,15 +235,15 @@ async function main(): Promise<void> {
 
 				if (org) npiPrimary.set(npi, { tokens: orgTokens(org), addrKey: addressFrequencyKey(practice) })
 				kept.add(npi)
-				rows.push({ npi, name: primaryName, org, address: practice, auth, entityID: eid(practice) })
+				rows.push({ npi, name: primaryName, org, address: practice, auth, taxonomy, entityID: eid(practice) })
 
 				// primary
 				for (const alt of altNames.get(npi)!)
-					rows.push({ npi, name: alt, org: alt, address: practice, auth, entityID: eid(practice) }) // name drift
+					rows.push({ npi, name: alt, org: alt, address: practice, auth, taxonomy, entityID: eid(practice) }) // name drift
 				const mailing = addr(r[C.mAddr]!, r[C.mCity]!, r[C.mState]!, r[C.mZip]!)
 
 				if (mailing && mailing !== practice)
-					rows.push({ npi, name: primaryName, org, address: mailing, auth, entityID: eid(mailing) }) // address variation
+					rows.push({ npi, name: primaryName, org, address: mailing, auth, taxonomy, entityID: eid(mailing) }) // address variation
 			}
 		}
 	}
@@ -259,7 +270,7 @@ async function main(): Promise<void> {
 		address: "address",
 		// `entityTruth` rides as an attribute purely for scoring (NOT a discriminator → never used in
 		// matching); it carries the site-level entity-level label alongside the NPI (record.id).
-		attributes: { authorizedOfficial: "auth", entityTruth: "entityID" },
+		attributes: { authorizedOfficial: "auth", taxonomy: "taxonomy", entityTruth: "entityID" },
 		source: "nppes",
 	}
 
@@ -590,6 +601,7 @@ async function main(): Promise<void> {
 		requireCorroboration?: boolean
 		usePhone?: boolean
 		linkage?: "single" | "average"
+		exactDiscriminators?: string[]
 	}
 	// The proven levers are now DEFAULT-ON in resolveEntities (#86). Each row sets BOTH `collapseSpatial`
 	// and `addressFrequency` EXPLICITLY so the progression isolates one lever at a time — otherwise the
@@ -640,6 +652,20 @@ async function main(): Promise<void> {
 				requireCorroboration: true,
 				usePhone: true,
 				linkage: "average",
+			},
+		},
+		// A5 (#625): the taxonomy code-set discriminator — set-overlap agreement over the NPI's 15 taxonomy
+		// slots. The named "still-more-distinctive identifier" from the 2026-06-16 report: co-located
+		// DISTINCT providers usually have disjoint sets (the over-merge separator) while an entity's own
+		// records always share theirs (never splits). Stacked on the BEST prior classical config (A1 +
+		// authorized-official; A3 phone + A4 avg-linkage were measured neutral-to-negative and are left off).
+		{
+			label: "+ taxonomy code-set discriminator (A5, #625)",
+			config: {
+				collapseSpatial: true,
+				addressFrequency,
+				discriminators: ["authorizedOfficial"],
+				exactDiscriminators: ["taxonomy"],
 			},
 		},
 	]


### PR DESCRIPTION
Adds the **code-set discriminator mechanism** (`exactDiscriminators`: set-overlap agreement — `207R` vs `207Q` are different specialties despite near-identical text, so string similarity is the wrong comparator) + the **A5 benchmark leg** wiring NPPES's 15 taxonomy slots through the TX-300 panel.

**Pre-registered A/B verdict: NEUTRAL.** t0 F1 60.5% (−0.8 vs base), best-threshold 62.9% (= authorized-official's), over-merged 37→36 but pairwise precision down. The hypothesis fails empirically: **same-specialty co-location is common** (medical office buildings), so taxonomy-agreement glue cancels the disagreement separation. Consistent with the 2026-06-16 finding that the residual over-merge is mostly yardstick error.

The mechanism ships (generalizable — license numbers/EINs on other datasets); the taxonomy *use* stays a benchmark leg, not a default. 68 registry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)