### PR TITLE
Input robustness: concepts article + metamorphic abbrev/typo/transpose/number-spell perturbations

### DIFF
--- a/docs/articles/concepts/eval-discipline.mdx
+++ b/docs/articles/concepts/eval-discipline.mdx
@@ -143,6 +143,7 @@ Before shipping a model release:
 
 ## See also
 
+- [Input robustness](./input-robustness.mdx) — the metamorphic INV/DIR gate in context: the three absorption layers upstream of it and the coverage matrix
 - [v0.4.0 ablation campaign retrospective](/research/v0-4-0-ablation-campaign) — the original false-negative bucketing analysis
 - [VERDICT_SMOKES.md](../plan/reference/VERDICT_SMOKES.mdx) — smoke-test discipline for training experiments
 - [Dual-loss curvature conflict](./dual-loss-curvature-conflict.mdx) — the training divergence this methodology helped diagnose

--- a/docs/articles/concepts/input-robustness.mdx
+++ b/docs/articles/concepts/input-robustness.mdx
@@ -92,7 +92,7 @@ context, and case normalization bridges the systematic gap between them.
 Absorption you can't measure is absorption you can't trust. Three gates watch these
 layers, and they grade different things on purpose.
 
-### Metamorphic INV/DIR — the un-gameable layer
+### Metamorphic INV/DIR/BAND — the un-gameable layer
 
 The one that matters most is `scripts/eval/gauntlet/metamorphic.ts`, layer 2 of
 [the Gauntlet](./eval-discipline.mdx). It asserts _relations_ between outputs rather
@@ -101,25 +101,41 @@ confidence in it. It also grades the **assembled geocode**, coordinate and tier,
 parse F1, because a robustness bug that leaves the tags intact but moves the pin is
 still a bug that ships a wrong answer.
 
-Two relation families:
+Three relation families, split by what a perturbation is _allowed_ to do to the
+answer:
 
-- **INV (invariance).** A label-preserving perturbation of a base address (lowercase
-  it, uppercase it, double the spaces, append a stray dot, tighten the space after a
-  comma) must not move the coordinate more than a metre (`INV_EPSILON_KM = 0.001`) or
-  change the resolution tier. Same address, same answer. A drift is a surface-form
-  robustness bug, full stop.
-- **DIR (directional).** Drop the postcode and the result must still land within 5km
-  of the with-postcode anchor. This is the #251 failure class, a parser that falls
+- **INV (invariance, ≤1m).** A label-preserving perturbation of a base address
+  (lowercase it, uppercase it, double the spaces, append a stray dot, tighten the
+  space after a comma, swap an expanded suffix for its abbreviation) must not move the
+  coordinate more than a metre (`INV_EPSILON_KM = 0.001`) or change the resolution
+  tier. Same address, same answer. The `abbrev` case inverts the `normalize/`
+  abbreviation table (`Avenue`→`Ave`), and it holds because the model trains on both
+  forms, so the coordinate has no excuse to budge.
+- **DIR (directional, ≤5km).** Drop the postcode and the result must still land within
+  5km of the with-postcode anchor. This is the #251 failure class, a parser that falls
   apart the moment a user omits the ZIP, frozen here as a standing property.
+- **BAND (tolerance, ≤5km).** A _corrupting_ perturbation (a single-character transpose
+  or substitution, an ordinal or house-number spelled out) is allowed to shift the
+  parse, so demanding byte-identical output would be the wrong contract. It still has
+  to land within a tolerance band of the clean coordinate. This is the family that
+  catches the classes the pipeline never trained on.
 
-When a perturbation deterministically fails, it doesn't get swept under the rug and
-it doesn't block the build either. It goes in `KNOWN_INV_XFAIL` with an issue
-reference: visible, tracked, non-blocking, so the gate fails only on _new_
-regressions. The bookkeeping cuts the other way too: an xfail that starts passing
-gets flagged for removal, so the list can't rot into the Pelias pass-list trap it was
-built to avoid. As of this writing that map is empty. The INV layer is 35/35 green,
-cleared by the two normalizer levers above (#829's lowercase restore and the
-trailing-punctuation trim) with no retraining.
+When a perturbation deterministically fails, it doesn't get swept under the rug and it
+doesn't block the build either. It goes in `KNOWN_INV_XFAIL` or `KNOWN_BAND_XFAIL` with
+a tracked note: visible, non-blocking, so the gate fails only on _new_ regressions. The
+bookkeeping cuts the other way too: an xfail that starts passing gets flagged for
+removal, so the list can't rot into the Pelias pass-list trap it was built to avoid.
+
+Casing and spacing are green, cleared by the two normalizer levers above (#829's
+lowercase restore and the trailing-punctuation trim) with no retraining. The EN suffix
+abbreviations hold. The tracked xfails are honest about the rest: the FR `Boulevard`→`Bd`
+swap drops from a rooftop to admin tier (the street gazetteer stores the expanded type,
+so the abbreviation misses the point-tier name match, a resolver gap rather than a model
+one), house-number spelling misses the band outright, and a single-char typo in a
+locality or street can lose the pin. Those last are measured with the anchor and
+gazetteer channels off, which is the harness default; the gazetteer soft-feed is exactly
+what would recover a typo'd `Amsterdam` in ship-config, so read them as the anchor-off
+floor, not a verdict on production.
 
 ### Golden `graceful/*` slices — labeled adversarial cases
 
@@ -143,22 +159,26 @@ It's a generator you run when you want that arena, not a standing gate.
 Put the perturbation classes against the layers that absorb them and the gates that
 watch them, and the honest picture falls out, thin spots included.
 
-| Class                                        | `normalize/` (runtime)                     | Trained (corpus aug) | Gated                                          |
-| -------------------------------------------- | ------------------------------------------ | -------------------- | ---------------------------------------------- |
-| Casing                                       | yes (case-normalize #690/#829, model-side) | yes                  | INV[lower/upper] green                         |
-| Spacing                                      | yes (whitespace.ts)                        | incidental           | INV[ws], INV[comma-tight]                      |
-| Abbreviation swap (Road↔Rd)                  | capable but OFF at runtime (deliberate)    | yes                  | labeled golden entries only, no stability gate |
-| Number spelling (5th↔Fifth, 100↔One Hundred) | no                                         | no                   | nowhere                                        |
-| Typos (single-char edit)                     | no                                         | no                   | ~10 labeled golden cases only                  |
-| Transpositions                               | no                                         | no                   | folded into golden typo slice                  |
+| Class                                        | `normalize/` (runtime)                     | Trained (corpus aug) | Gated                                                                                                     |
+| -------------------------------------------- | ------------------------------------------ | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| Casing                                       | yes (case-normalize #690/#829, model-side) | yes                  | INV[lower/upper] green                                                                                    |
+| Spacing                                      | yes (whitespace.ts)                        | incidental           | INV[ws], INV[comma-tight] green                                                                           |
+| Abbreviation swap (Road↔Rd)                  | capable but OFF at runtime (deliberate)    | yes                  | INV[abbrev]: EN suffixes green; FR `Bd` tracked-xfail (resolver name-match gap)                           |
+| Number spelling (5th↔Fifth, 100↔One Hundred) | no                                         | no                   | BAND[num-ordinal] green; BAND[num-house] tracked-xfail (untrained)                                        |
+| Typos (single-char edit)                     | no                                         | no                   | BAND[typo-sub]: most bases green; tracked-xfail where a typo'd locality/street loses the pin (anchor-off) |
+| Transpositions                               | no                                         | no                   | BAND[transpose]: same anchor-off gaps as typo-sub                                                         |
 
 The top two rows are the settled ones: casing and spacing are absorbed at runtime,
-reinforced in the corpus, and held green by a standing invariant. The bottom four are
-where the coverage is honest about its holes. Abbreviation swaps are trained in but
-have no coordinate-stability gate, so the model handles them and we just don't assert
-it. Number spelling is absorbed nowhere. Typos and transpositions live only in a
-handful of hand-labeled golden cases. Naming a gap out loud is how you keep it from
-hiding.
+reinforced in the corpus, and held green by a standing invariant. The bottom four used
+to be blind spots. They run through the metamorphic gate now, and the surprise was that
+several of them already hold. The EN suffix abbreviations pass the strict metre
+invariant. Ordinal street spelling (`5th`↔`Fifth`) stays inside the tolerance band even
+though nothing trains it. The genuine gaps came out smaller than feared, and they're
+named in the xfail maps rather than hiding: a French street-type abbreviation the
+resolver can't match at rooftop tier, house-number spelling, and single-character typos
+that lose a locality or street when the anchor and gazetteer channels are off. Each one
+is a tracked, watched line item instead of a silent hole, which is the whole point of
+running them.
 
 ## See also
 

--- a/docs/articles/concepts/input-robustness.mdx
+++ b/docs/articles/concepts/input-robustness.mdx
@@ -1,0 +1,170 @@
+---
+sidebar_position: 16
+title: Input robustness — absorbing the mess users actually type
+tags:
+  - concepts
+  - eval
+  - robustness
+---
+
+# Input robustness — absorbing the mess users actually type
+
+The addresses in a test fixture are clean. The addresses a geocoder receives are
+not. They arrive in all caps from a compliance export, comma-crushed from a
+spreadsheet paste, missing a letter because someone typed fast, with `Ave` where
+the fixture said `Avenue`. A parser that only holds up on the tidy form is a
+demo. Holding up on the mess is the product.
+
+So the question that matters isn't "does it parse `1600 Pennsylvania Avenue NW,
+Washington, DC 20500`?" Of course it does. It's "does `1600 PENNSYLVANIA AVE
+NW,WASHINGTON DC` land on the same rooftop?" This page is how Mailwoman answers
+that: three layers that absorb surface noise before it can move the coordinate,
+and the gates that keep those layers honest.
+
+## The absorption stack
+
+Robustness here comes in three layers, deliberately ordered from the cheapest and
+most certain transforms to the most learned, each catching what the one before it
+shouldn't.
+
+### Layer 1 — deterministic normalization
+
+The first pass is pure code, no model, in [`@mailwoman/normalize`](../plan/reference/STAGES.mdx).
+It does the transforms that are always safe because they have a single correct
+answer: Unicode NFC, so a composed `é` and a decomposed `é` stop being different
+strings; punctuation folding; whitespace collapse, where a run of spaces becomes
+one and a trailing `.`/`,`/`;`/`:` is trimmed off the tail (`normalize/whitespace.ts`).
+That last one earns its keep: a stray period glued onto the final token
+(`…Washington DC.`) used to drop the street tier from `address_point` to `admin`,
+and trimming it is free.
+
+Every transform is offset-mapped. The normalized string carries a map back to the
+raw character positions, so a span the model finds in the clean text still points
+at the right bytes of what the user typed. Robustness that corrupted the offsets
+would be worse than none.
+
+One thing this layer deliberately does **not** do at runtime: expand
+abbreviations. `normalize/abbreviations.ts` can turn `Rd` into `Road` and `Ave`
+into `Avenue`, and it's fully built, but it's opt-in, and the runtime pipeline
+leaves it off (`normalize/compute.ts`). That's a choice, not an oversight.
+Abbreviation is the model's job. Hard-coding `Ave → Avenue` in front of the parser
+would be the sieve regrowing: a rule seizing a decision the model is supposed to
+own, and one it can't unlearn if the rule turns out wrong for a locale. See
+[What Mailwoman is](./what-mailwoman-is.mdx) on why knowledge stays out of the
+learner's front door.
+
+### Layer 2 — model-side case normalization
+
+Some noise is too locale-sensitive for Layer 1 but too systematic to leave to the
+corpus alone. Casing is the case in point. A model trained on mixed-case text is
+partly out of domain on a fully-shouting compliance record, where it drops and
+mis-bounds tokens (`214 JONES RD, ELKHART, TX 75839` mangles into a locality of
+`ALESTINE`). So `neural/case-normalize.ts` title-cases an all-caps input before the
+model sees it (#690), and restores the trained mixed-case shape of an all-lowercase
+input (#829). Both are on by default.
+
+The detection is strict on purpose: only a fully-shouting or fully-whispering input
+qualifies, so ordinary mixed-case text is never touched and its byte path stays
+identical. It's also offset-stable, and it has to be. It targets pure-ASCII input,
+because title-casing accented or non-Latin text can change length (`ß`→`SS`, the
+Turkish dotted and dotless I) and break the very offset invariant Layer 1 worked
+to preserve. The measured payoff was concrete: TX HHSC locality recall went from
+90.1% to 99.7%.
+
+### Layer 3 — trained-in variation
+
+The last layer isn't a pass at all. It's the corpus. The parser learns to shrug off
+surface variation because the training data contains it: casing permutations
+(`corpus/src/shard-recipes/intersection.ts`, `locale.ts`), abbreviation variants in
+both directions (`street-affix.ts`, the `unit.ts` designators from #454,
+`fr-bare-street.ts`). This is where `Ave` and `Avenue` both become the same street
+to the model. No rule rewrote one into the other; the model simply saw both forms
+in training and learned they point at the same place.
+
+This is the layer that makes Layer 1's abstention safe. Because the model trains on
+both forms, `normalize/` can leave abbreviations alone and trust the learner to
+handle them. The three layers are a division of labor: deterministic code takes the
+transforms with one right answer, the corpus takes the ones whose answer depends on
+context, and case normalization bridges the systematic gap between them.
+
+## The gates
+
+Absorption you can't measure is absorption you can't trust. Three gates watch these
+layers, and they grade different things on purpose.
+
+### Metamorphic INV/DIR — the un-gameable layer
+
+The one that matters most is `scripts/eval/gauntlet/metamorphic.ts`, layer 2 of
+[the Gauntlet](./eval-discipline.mdx). It asserts _relations_ between outputs rather
+than stored expected values, which is exactly why a curated corpus can't breed false
+confidence in it. It also grades the **assembled geocode**, coordinate and tier, not
+parse F1, because a robustness bug that leaves the tags intact but moves the pin is
+still a bug that ships a wrong answer.
+
+Two relation families:
+
+- **INV (invariance).** A label-preserving perturbation of a base address (lowercase
+  it, uppercase it, double the spaces, append a stray dot, tighten the space after a
+  comma) must not move the coordinate more than a metre (`INV_EPSILON_KM = 0.001`) or
+  change the resolution tier. Same address, same answer. A drift is a surface-form
+  robustness bug, full stop.
+- **DIR (directional).** Drop the postcode and the result must still land within 5km
+  of the with-postcode anchor. This is the #251 failure class, a parser that falls
+  apart the moment a user omits the ZIP, frozen here as a standing property.
+
+When a perturbation deterministically fails, it doesn't get swept under the rug and
+it doesn't block the build either. It goes in `KNOWN_INV_XFAIL` with an issue
+reference: visible, tracked, non-blocking, so the gate fails only on _new_
+regressions. The bookkeeping cuts the other way too: an xfail that starts passing
+gets flagged for removal, so the list can't rot into the Pelias pass-list trap it was
+built to avoid. As of this writing that map is empty. The INV layer is 35/35 green,
+cleared by the two normalizer levers above (#829's lowercase restore and the
+trailing-punctuation trim) with no retraining.
+
+### Golden `graceful/*` slices — labeled adversarial cases
+
+The golden set (`data/eval/golden/v0.1.2`) carries a small hand-labeled adversarial
+track under `graceful/*`: typos (`Pensylvania`, `Portlnad`, `Fransisco`), mis-casing,
+mis-punctuation, whitespace abuse. Around ten of these are single-character typo
+cases. They're a stress test with expected components attached, not a coordinate
+gate: the parse should survive with lower confidence, and the labels say what
+"survive" means.
+
+### `perturb-golden.ts` — the one-off arena
+
+`scripts/eval/perturb-golden.ts` takes golden rows and applies rule-defeating
+perturbations (strip the delimiters, lowercase everything, glue the region to the
+postcode as `OR97214`) while keeping the component labels intact. It exists to show
+that a contextual model degrades more gracefully than a delimiter-hungry rule parser.
+It's a generator you run when you want that arena, not a standing gate.
+
+## The coverage matrix
+
+Put the perturbation classes against the layers that absorb them and the gates that
+watch them, and the honest picture falls out, thin spots included.
+
+| Class                                        | `normalize/` (runtime)                     | Trained (corpus aug) | Gated                                          |
+| -------------------------------------------- | ------------------------------------------ | -------------------- | ---------------------------------------------- |
+| Casing                                       | yes (case-normalize #690/#829, model-side) | yes                  | INV[lower/upper] green                         |
+| Spacing                                      | yes (whitespace.ts)                        | incidental           | INV[ws], INV[comma-tight]                      |
+| Abbreviation swap (Road↔Rd)                  | capable but OFF at runtime (deliberate)    | yes                  | labeled golden entries only, no stability gate |
+| Number spelling (5th↔Fifth, 100↔One Hundred) | no                                         | no                   | nowhere                                        |
+| Typos (single-char edit)                     | no                                         | no                   | ~10 labeled golden cases only                  |
+| Transpositions                               | no                                         | no                   | folded into golden typo slice                  |
+
+The top two rows are the settled ones: casing and spacing are absorbed at runtime,
+reinforced in the corpus, and held green by a standing invariant. The bottom four are
+where the coverage is honest about its holes. Abbreviation swaps are trained in but
+have no coordinate-stability gate, so the model handles them and we just don't assert
+it. Number spelling is absorbed nowhere. Typos and transpositions live only in a
+handful of hand-labeled golden cases. Naming a gap out loud is how you keep it from
+hiding.
+
+## See also
+
+- [Eval discipline](./eval-discipline.mdx) — the full Gauntlet, and why the
+  coordinate is graded, not the name string
+- [What Mailwoman is](./what-mailwoman-is.mdx) — why knowledge stays outside the
+  learner, the principle behind Layer 1's abstention
+- [The pipeline contract](./staged-pipeline-contract.mdx) — where the normalize stage
+  plugs into the runtime pipeline

--- a/docs/articles/plan/CONTRIBUTING_MODEL_WORK.mdx
+++ b/docs/articles/plan/CONTRIBUTING_MODEL_WORK.mdx
@@ -66,6 +66,12 @@ Run for _every_ candidate, regardless of what you changed (this is what
 | Affix split         | `scripts/eval/score-affix.ts` (NOT `per-locale-f1` — its fold can't see the split) | hold gated numbers                      |
 | Demo smoke          | `eval-model` skill / `demo-preset-compare.ts`                                      | presets stable                          |
 | Honest geography    | `scripts/eval/honest-eval.ts`                                                      | region-match + coord p50/p90 + PIP hold |
+| Input robustness    | `scripts/eval/gauntlet/metamorphic.ts` (INV/DIR)                                   | no new drift; xfails tracked            |
+
+The input-robustness gate is the metamorphic layer of the Gauntlet — label-preserving
+perturbations that must not move the assembled coordinate. See
+[Input robustness](../concepts/input-robustness.mdx) for the absorption layers behind it and the
+coverage matrix.
 
 The ship-config channels are part of the contract: a gaz-trained model is graded with
 `--gazetteer-lexicon` + `--suppress-gaz-near-postcode`, and (v4.3.0+) `--conventions auto` —

--- a/docs/superpowers/specs/2026-07-06-input-robustness-gate-design.md
+++ b/docs/superpowers/specs/2026-07-06-input-robustness-gate-design.md
@@ -1,0 +1,100 @@
+# Input-robustness gate — design
+
+**Date:** 2026-07-06
+**Status:** approved (operator, this session)
+**Owners:** docs (`@mailwoman/docs`), eval (`scripts/eval/gauntlet`), normalize (`@mailwoman/normalize`)
+
+## Problem
+
+Input-perturbation robustness is a real, implemented capability — three absorption
+layers plus a standing metamorphic gate — but it was never written up, and an audit found
+three perturbation classes with no stability gate at all. The concept is invisible to a reader
+of the docs, and the gate silently omits abbreviation swaps, single-character corruptions, and
+number-spelling variants.
+
+Two deliverables, docs first:
+
+1. Document the current state.
+2. Extend the metamorphic gate's perturbation set to cover the untested classes, recording the
+   ones that legitimately fail as tracked, non-blocking xfails rather than hiding or blocking on
+   them.
+
+## Current state (verified against source, 2026-07-06)
+
+Three absorption layers sit upstream of the gate:
+
+1. **Deterministic `normalize/`** — Unicode NFC, punctuation, whitespace collapse + trailing-
+   punctuation trim (`normalize/whitespace.ts`). Note: `normalize/abbreviations.ts` (Rd→Road etc.)
+   EXISTS but is opt-in (`normalize/compute.ts`) and NOT wired into the runtime pipeline —
+   abbreviation handling is deliberately the model's job.
+2. **Model-side case normalization** (`neural/case-normalize.ts`) — #690 all-caps title-casing +
+   #829 all-lowercase restore, on by default, offset-stable.
+3. **Trained-in variation** via corpus shard augmentation — casing
+   (`corpus/src/shard-recipes/intersection.ts`, `locale.ts`), abbreviation variants
+   (`street-affix.ts`, `unit.ts` #454, `fr-bare-street.ts`).
+
+Gates:
+
+- **Metamorphic INV/DIR** (`scripts/eval/gauntlet/metamorphic.ts`) — the un-gameable layer. Grades
+  the ASSEMBLED geocode (coordinate + tier), never parse F1. INV = label-preserving perturbations
+  must not move the coordinate (`INV_EPSILON_KM = 0.001`, 1m) or tier. Current INV set:
+  `lower`, `upper`, `ws`, `trail-dot`, `comma-tight`. DIR = drop the postcode, must stay within
+  5km. Known deterministic failures live in `KNOWN_INV_XFAIL` (currently empty; INV is 35/35 green)
+  with anti-rot bookkeeping — an xfail that starts passing is flagged.
+- **Golden `graceful/*` slices** (`data/eval/golden/v0.1.2`) — small labeled adversarial slices
+  (`graceful/typo|mis-casing|mis-punctuation|whitespace`, ~10 typo cases).
+- **`perturb-golden.ts`** — a one-off perturbation generator (delimiter-strip, lowercase, glue),
+  never a standing gate.
+
+### Coverage matrix (article centerpiece)
+
+| Class | normalize/ (runtime) | Trained (corpus aug) | Gated |
+|---|---|---|---|
+| Casing | yes (case-normalize #690/#829) | yes | INV[lower/upper] green |
+| Spacing | yes (whitespace.ts) | incidental | INV[ws], INV[comma-tight] |
+| Abbreviation swap | capable but OFF at runtime (deliberate) | yes | golden entries only — no stability gate |
+| Number spelling | no | no | nowhere |
+| Typos (single-char edit) | no | no | ~10 labeled golden cases only |
+| Transpositions | no | no | folded into golden typo slice |
+
+## Deliverable 1 — docs
+
+- New `docs/articles/concepts/input-robustness.mdx`: the three absorption layers, then the gates,
+  closing with the coverage matrix. Current state only.
+- Match sibling concept articles (`what-mailwoman-is.mdx`, `eval-discipline.mdx`) for frontmatter,
+  tone, structure. House voice.
+- One pointer row/sentence in `CONTRIBUTING_MODEL_WORK.mdx`'s gate section + a cross-link from
+  `eval-discipline.mdx`.
+
+## Deliverable 2 — metamorphic INV extension
+
+Extend `scripts/eval/gauntlet/metamorphic.ts`:
+
+1. **`abbrev`** — expanded→abbreviated suffix perturbation, sourced by INVERTING the
+   `normalize/abbreviations.ts` table (import it; do not duplicate the data). Strict INV (≤1m): the
+   model trains on both forms, the coordinate must not move. Single-letter abbreviations (N/S/E/W/R)
+   are excluded — ambiguous with initials. Applies only to bases containing an expandable suffix;
+   add realistic bases where a locale lacks one.
+2. **`transpose` + `typo-sub`** — deterministic single-character edits at a FIXED position (middle
+   of the longest alphabetic token ≥5 chars, never the house number or postcode). NO RNG. New
+   tolerance-band relation (≤5km, modeled on DIR), NOT the 1m INV epsilon — a corrupted input may
+   legitimately shift the parse.
+3. **`number-spell`** — ordinal street swap (`5th Ave` ↔ `Fifth Ave`) and spelled-out house number
+   (`100` → `One Hundred`). Tolerance-band relation. EXPECTED to fail initially (never trained,
+   never normalized); record in a known-xfail map (the band analog of `KNOWN_INV_XFAIL`) so the gate
+   documents the gap non-blocking.
+
+Report per class. Update the coverage-matrix rows this changes; note xfail'd gaps honestly.
+
+### Out of scope
+
+Casing/spacing additions (already green), corpus/training changes, matcher block-stability,
+promoting `perturb-golden`.
+
+## Verification
+
+1. Before: metamorphic 35/35 green baseline recorded.
+2. After: existing INV green (zero regressions); `abbrev` INV passes; `transpose`/`typo-sub` pass
+   the 5km band or are xfail-recorded with the failing case named; `number-spell` likely xfails —
+   record it.
+3. MDX frontmatter/imports match sibling articles.

--- a/normalize/abbreviations.ts
+++ b/normalize/abbreviations.ts
@@ -13,7 +13,7 @@
 
 import type { SpanRange } from "./types.js"
 
-interface AbbreviationEntry {
+export interface AbbreviationEntry {
 	from: string // short form (case-insensitive match)
 	to: string // canonical long form
 }
@@ -59,6 +59,15 @@ function getDictionary(locale: string | undefined): ReadonlyArray<AbbreviationEn
 	if (lc.startsWith("fr")) return FR_FR_DICT
 
 	return EN_US_DICT
+}
+
+/**
+ * The per-locale abbreviation table (short↔long), exposed so consumers can reuse the SAME data instead of duplicating
+ * it. The metamorphic gauntlet inverts this table to generate expanded→abbreviated perturbations (`Avenue`→`Ave`); the
+ * "no load-bearing trivia" rule means that data lives in exactly one place — here.
+ */
+export function abbreviationDictionary(locale?: string): ReadonlyArray<AbbreviationEntry> {
+	return getDictionary(locale)
 }
 
 export interface AbbreviationResult {

--- a/normalize/index.ts
+++ b/normalize/index.ts
@@ -13,7 +13,7 @@
  *   See `docs/articles/plan/reference/STAGES.md` § Stage 1 for the contract.
  */
 
-export { expandAbbreviations } from "./abbreviations.js"
+export { type AbbreviationEntry, abbreviationDictionary, expandAbbreviations } from "./abbreviations.js"
 export { applyCjkNormalization, type CjkResult } from "./cjk.js"
 export { normalize } from "./compute.js"
 export { applyNFC } from "./nfc.js"

--- a/scripts/eval/gauntlet/metamorphic.ts
+++ b/scripts/eval/gauntlet/metamorphic.ts
@@ -3,18 +3,29 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Metamorphic Gauntlet (CheckList INV/DIR) — the un-gameable layer. It asserts RELATIONS between outputs,
- *   not stored expected values, so a curated corpus can't breed false trust here.
+ *   Metamorphic Gauntlet (CheckList INV/DIR/BAND) — the un-gameable layer. It asserts RELATIONS between
+ *   outputs, not stored expected values, so a curated corpus can't breed false trust here.
  *
- *   - INV (invariance): a label-preserving perturbation (casing, whitespace, trailing punctuation) must NOT
- *       move the assembled coordinate or tier. A drift is a surface-form robustness bug.
- *   - DIR (directional): dropping the postcode must NOT break resolution — the result must still land near
- *       the with-postcode coordinate. This is exactly the #251 failure class, frozen as a standing property.
+ *   - INV (invariance, ≤1m): a label-preserving perturbation (casing, whitespace, trailing punctuation,
+ *       expanded↔abbreviated suffix) must NOT move the assembled coordinate or tier. A drift is a
+ *       surface-form robustness bug. `abbrev` inverts the `normalize/abbreviations.ts` table — the model
+ *       trains on both `Avenue` and `Ave`, so the coordinate must not budge.
+ *   - DIR (directional, ≤5km): dropping the postcode must NOT break resolution — the result must still
+ *       land near the with-postcode coordinate. This is exactly the #251 failure class, frozen as a
+ *       standing property.
+ *   - BAND (tolerance, ≤5km): a CORRUPTING perturbation (single-char transpose / substitution, ordinal
+ *       or house-number spelling) may legitimately shift the parse — byte-identical output is the wrong
+ *       contract — but it must still land within a tolerance band of the clean coordinate. Perturbations
+ *       the pipeline neither normalizes nor trained on (number-spelling) are EXPECTED to miss the band;
+ *       those are recorded in KNOWN_BAND_XFAIL so the gap is documented, non-blocking, and can't be
+ *       silently hidden.
  *
- *   GATE: any INV violation, or a DIR that fails to resolve near the anchor, fails the run. Run:
+ *   GATE: any INV violation, a DIR that fails to resolve near the anchor, or a NEW (untracked) BAND miss
+ *   fails the run. Run:
  *     node scripts/eval/gauntlet/metamorphic.ts [--model <candidate.onnx>]
  */
 
+import { abbreviationDictionary } from "@mailwoman/normalize"
 import { haversineKm } from "@mailwoman/spatial"
 
 import { arg } from "../../lib/cli-args.ts"
@@ -22,25 +33,205 @@ import { buildGauntletDeps, runOne } from "./harness.ts"
 
 const INV_EPSILON_KM = 0.001 // 1m — same address, identical resolution expected.
 const DIR_NEAR_KM = 5 // dropping the postcode may lose the rooftop, but must still land in the right area.
+const BAND_NEAR_KM = 5 // a corrupted surface may shift the parse, but must stay within the tolerance band.
 
-/** Base inputs. The postcode'd ones drive the DIR (drop-postcode) test; all drive INV. */
-const BASES = [
-	{ input: "181 Rue du Chevaleret, Paris", postcode: false },
-	{ input: "181 Rue du Chevaleret, 75013 Paris", postcode: true },
-	{ input: "1600 Pennsylvania Ave NW, Washington DC", postcode: false },
-	{ input: "1600 Pennsylvania Ave NW, Washington DC 20500", postcode: true },
-	{ input: "350 5th Ave, New York, NY", postcode: false },
-	{ input: "Unter den Linden 77, 10117 Berlin", postcode: true }, // DE rooftop tier (D10)
-	{ input: "Damrak 1, 1012 LG Amsterdam", postcode: false }, // NL rooftop tier (D10); NL postcode ≠ \d{5}, so INV-only
+interface Base {
+	input: string
+	/** Drives the DIR (drop-postcode) test; all bases drive INV + BAND. */
+	postcode: boolean
+	/** Selects the abbreviation dictionary for the `abbrev` INV perturbation. */
+	locale: string
+}
+
+/** Base inputs. The postcode'd ones drive the DIR (drop-postcode) test; all drive INV + BAND. */
+const BASES: Base[] = [
+	{ input: "181 Rue du Chevaleret, Paris", postcode: false, locale: "fr-FR" },
+	{ input: "181 Rue du Chevaleret, 75013 Paris", postcode: true, locale: "fr-FR" },
+	{ input: "1600 Pennsylvania Ave NW, Washington DC", postcode: false, locale: "en-US" },
+	{ input: "1600 Pennsylvania Ave NW, Washington DC 20500", postcode: true, locale: "en-US" },
+	{ input: "350 5th Ave, New York, NY", postcode: false, locale: "en-US" },
+	{ input: "Unter den Linden 77, 10117 Berlin", postcode: true, locale: "de-DE" }, // DE rooftop tier (D10)
+	{ input: "Damrak 1, 1012 LG Amsterdam", postcode: false, locale: "nl-NL" }, // NL rooftop tier (D10); NL postcode ≠ \d{5}, so INV-only
+	// Added for the abbrev + number-spell classes (the original 7 carry no expandable suffix, no ordinal,
+	// no spell-able house number). Verified landmark coordinates cited in the design doc; the metamorphic
+	// relations are self-referential (perturbed-vs-clean), so the base only needs to resolve sanely.
+	{ input: "350 Fifth Avenue, New York, NY", postcode: false, locale: "en-US" }, // Empire State Building (≈40.7484, -73.9857)
+	{ input: "100 Centre Street, New York, NY", postcode: false, locale: "en-US" }, // Manhattan Municipal Building (≈40.7132, -74.0041)
+	{ input: "2 Boulevard du Palais, 75001 Paris", postcode: false, locale: "fr-FR" }, // Palais de la Cité (≈48.8556, 2.3450)
 ]
 
-/** Label-preserving perturbations — the output must be invariant to these. */
-const INV = [
-	{ name: "lower", f: (s: string) => s.toLowerCase() },
-	{ name: "upper", f: (s: string) => s.toUpperCase() },
-	{ name: "ws", f: (s: string) => s.replace(/ /g, "  ") },
-	{ name: "trail-dot", f: (s: string) => `${s}.` },
-	{ name: "comma-tight", f: (s: string) => s.replace(/, /g, ",") }, // surface-form: drop the space after a comma
+/**
+ * Expanded→abbreviated inverse of the shared `normalize/abbreviations.ts` table (imported, never duplicated — "no
+ * load-bearing trivia"). Single-letter abbreviations (N/S/E/W/R) are dropped: they're ambiguous with initials, and the
+ * invariant tests only unambiguous multi-char suffix swaps. First-wins on ambiguous long forms (FR `Boulevard` maps
+ * from both `Bd` and `Bvd` → `Bd`).
+ */
+function inverseAbbrev(locale: string): Map<string, string> {
+	const inv = new Map<string, string>()
+
+	for (const entry of abbreviationDictionary(locale)) {
+		if (entry.from.length < 2) continue
+
+		const key = entry.to.toLowerCase()
+
+		if (!inv.has(key)) inv.set(key, entry.from)
+	}
+
+	return inv
+}
+
+/** Replace the first expandable long-form token with its abbreviation (`Avenue`→`Ave`). Null if none present. */
+function abbreviate(input: string, locale: string): string | null {
+	const inv = inverseAbbrev(locale)
+	const tokens = input.split(/(\s+)/)
+
+	for (let i = 0; i < tokens.length; i++) {
+		const bare = tokens[i]!.replace(/[.,]+$/, "")
+		const trail = tokens[i]!.slice(bare.length)
+		const abbr = inv.get(bare.toLowerCase())
+
+		if (abbr) {
+			tokens[i] = abbr + trail
+
+			return tokens.join("")
+		}
+	}
+
+	return null
+}
+
+/** The longest maximal run of letters, length ≥5, leftmost on ties. Null if none — nothing safe to corrupt. */
+function longestAlphaToken(s: string): { start: number; body: string } | null {
+	let best: { start: number; body: string } | null = null
+	const re = /\p{L}+/gu
+	let m: RegExpExecArray | null
+
+	while ((m = re.exec(s))) {
+		const body = m[0]!
+
+		if (body.length < 5) continue
+
+		if (!best || body.length > best.body.length) best = { start: m.index, body }
+	}
+
+	return best
+}
+
+/** Adjacent-char swap at the middle of the longest alphabetic token. Deterministic, no RNG. Null if not applicable. */
+function transposeMiddle(s: string): string | null {
+	const tok = longestAlphaToken(s)
+
+	if (!tok) return null
+
+	const chars = [...tok.body]
+	const mid = Math.floor(chars.length / 2) // ≥2 for len ≥5
+	// Prefer the pair (mid-1, mid); if those chars are identical the swap is a no-op, so fall to (mid, mid+1).
+	let i = mid - 1
+
+	if (chars[i] === chars[i + 1]) {
+		if (mid + 1 < chars.length && chars[mid] !== chars[mid + 1]) i = mid
+		else return null
+	}
+	const swapped = [...chars]
+	const tmp = swapped[i]!
+	swapped[i] = swapped[i + 1]!
+	swapped[i + 1] = tmp
+
+	return s.slice(0, tok.start) + swapped.join("") + s.slice(tok.start + tok.body.length)
+}
+
+/** Single-char substitution at the middle of the longest alphabetic token (→`x`, or `z` when already `x`). */
+function substituteMiddle(s: string): string | null {
+	const tok = longestAlphaToken(s)
+
+	if (!tok) return null
+
+	const chars = [...tok.body]
+	const mid = Math.floor(chars.length / 2)
+	const orig = chars[mid]!
+	const isUpper = orig === orig.toUpperCase() && orig !== orig.toLowerCase()
+	const repl = orig.toLowerCase() === "x" ? "z" : "x"
+	chars[mid] = isUpper ? repl.toUpperCase() : repl
+	const body = chars.join("")
+
+	if (body === tok.body) return null
+
+	return s.slice(0, tok.start) + body + s.slice(tok.start + tok.body.length)
+}
+
+/** Numeral↔spelled ordinal street names (`5th`↔`Fifth`). */
+const ORDINALS: ReadonlyArray<readonly [string, string]> = [
+	["1st", "First"],
+	["2nd", "Second"],
+	["3rd", "Third"],
+	["4th", "Fourth"],
+	["5th", "Fifth"],
+	["6th", "Sixth"],
+	["7th", "Seventh"],
+	["8th", "Eighth"],
+	["9th", "Ninth"],
+	["10th", "Tenth"],
+	["11th", "Eleventh"],
+	["12th", "Twelfth"],
+]
+
+/** Swap the first ordinal-street token between numeral and spelled form (`5th Ave`↔`Fifth Ave`). Null if none. */
+function swapOrdinal(s: string): string | null {
+	const numToWord = new Map(ORDINALS.map(([n, w]) => [n.toLowerCase(), w]))
+	const wordToNum = new Map(ORDINALS.map(([n, w]) => [w.toLowerCase(), n]))
+	const tokens = s.split(/(\s+)/)
+
+	for (let i = 0; i < tokens.length; i++) {
+		const bare = tokens[i]!.replace(/[.,]+$/, "")
+		const trail = tokens[i]!.slice(bare.length)
+		const hit = numToWord.get(bare.toLowerCase()) ?? wordToNum.get(bare.toLowerCase())
+
+		if (hit) {
+			tokens[i] = hit + trail
+
+			return tokens.join("")
+		}
+	}
+
+	return null
+}
+
+/** Spell out the LEADING house-number token (`100`→`One Hundred`). Bounded map — never a general algorithm. */
+const HOUSE_SPELL = new Map<string, string>([["100", "One Hundred"]])
+
+function spellHouseNumber(s: string): string | null {
+	const m = /^(\s*)(\d+)\b/.exec(s)
+
+	if (!m) return null
+
+	const spelled = HOUSE_SPELL.get(m[2]!)
+
+	if (!spelled) return null
+
+	return s.slice(0, m[1]!.length) + spelled + s.slice(m[1]!.length + m[2]!.length)
+}
+
+interface Perturbation {
+	name: string
+	f: (s: string, base: Base) => string | null
+}
+
+/** Label-preserving perturbations — the output must be INVARIANT (≤1m, same tier). */
+const INV: Perturbation[] = [
+	{ name: "lower", f: (s) => s.toLowerCase() },
+	{ name: "upper", f: (s) => s.toUpperCase() },
+	{ name: "ws", f: (s) => s.replace(/ /g, "  ") },
+	{ name: "trail-dot", f: (s) => `${s}.` },
+	{ name: "comma-tight", f: (s) => s.replace(/, /g, ",") }, // surface-form: drop the space after a comma
+	{ name: "abbrev", f: (s, base) => abbreviate(s, base.locale) }, // expanded→abbreviated suffix (trained both ways)
+]
+
+/** Corrupting perturbations — output may shift, but must stay within the BAND (≤5km). */
+const BAND: Perturbation[] = [
+	{ name: "transpose", f: (s) => transposeMiddle(s) },
+	{ name: "typo-sub", f: (s) => substituteMiddle(s) },
+	{ name: "num-ordinal", f: (s) => swapOrdinal(s) },
+	{ name: "num-house", f: (s) => spellHouseNumber(s) },
 ]
 
 /**
@@ -49,15 +240,36 @@ const INV = [
  * xfail that has started PASSING ("newly passing → drop it"), so this list can't rot into false comfort — the
  * Pelias-pass-list trap, inverted.
  */
-// EMPTY as of night 34 (2026-07-05) — the metamorphic INV layer is fully green (35/35). Two no-retrain
-// normalizer levers cleared every prior xfail:
-//   - #829 `restoreLowerInput` (neural/case-normalize.ts) canonicalizes all-lowercase input to the
-//     trained mixed-case → the entire INV[lower]/[upper] class + the four fr-chevaleret perturbations.
-//   - the trailing-punct trim (normalize/whitespace.ts) drops a trailing `.`/`,`/`;`/`:` → the
-//     INV[trail-dot] case (a trailing dot glued onto the last token and dropped the street tier).
-// Keep the anti-rot loop honest: a NEW deterministic INV break belongs here with an issue ref, never
-// silently gated. The Map stays (typed) so re-adding an xfail is a one-line change.
-const KNOWN_INV_XFAIL = new Map<string, string>([])
+// Casing/spacing are fully green (the #829 lowercase restore + trailing-punct trim cleared every prior xfail with no
+// retrain). `abbrev` holds for the EN suffix swaps (Avenue→Ave, Street→St) because the model trains on both forms — but
+// the FR street-type swap below is a RESOLVER gap, not a model one, and it is a finding, not a reflex xfail (see note).
+// A NEW deterministic INV break belongs here with a tracked note, never silently gated.
+const KNOWN_INV_XFAIL = new Map<string, string>([
+	// FINDING (2026-07-06): `Boulevard`→`Bd` drops address_point→admin (~0.24km). The FR street gazetteer stores the
+	// expanded type, so the abbreviated form fails the point-tier name match — a resolver coverage gap, not a model
+	// robustness failure (EN Ave/St hold). Measured anchor-OFF; the gazetteer soft-feed may recover it in ship-config.
+	["abbrev|2 Boulevard du Palais, 75001 Paris", "resolver: FR street-type abbrev name-match gap (address_point→admin)"],
+])
+
+/**
+ * Known, DETERMINISTIC BAND misses — the tolerance-band analog of KNOWN_INV_XFAIL, same anti-rot bookkeeping. These are
+ * perturbation classes the pipeline neither normalizes nor was trained on, so a corrupted surface legitimately lands
+ * outside the band. Tracked (visible, non-blocking) rather than hidden or gated. See the input-robustness coverage
+ * matrix (docs/articles/concepts/input-robustness.mdx) for the gaps these pin.
+ */
+// All measured anchor-OFF/gazetteer-OFF (the harness default; the weights package ships no anchor artifacts). The
+// gazetteer soft-feed is exactly the channel that recovers a typo'd locality/street in ship-config, so some of these
+// may hold with the retrieval channels ON — tracked here as the anchor-off floor, not a claim about production.
+const KNOWN_BAND_XFAIL = new Map<string, string>([
+	// House-number spelling is neither normalized nor trained — the expected miss (input-robustness matrix).
+	["num-house|100 Centre Street, New York, NY", "untrained: house-number spelling (input-robustness matrix)"],
+	// A single-char corruption of a rooftop street token drops the exact match to a ~6.4km fallback (anchor-off).
+	["transpose|100 Centre Street, New York, NY", "anchor-off: corrupted street token loses the rooftop (~6.4km)"],
+	["typo-sub|100 Centre Street, New York, NY", "anchor-off: corrupted street token loses the rooftop (~6.4km)"],
+	// A typo'd NL locality with no \d{5} anchor loses resolution entirely — the case the gazetteer soft-feed exists for.
+	["transpose|Damrak 1, 1012 LG Amsterdam", "anchor-off: typo'd locality, no postcode anchor → no-resolve"],
+	["typo-sub|Damrak 1, 1012 LG Amsterdam", "anchor-off: typo'd locality, no postcode anchor → no-resolve"],
+])
 
 /** Strip a 5-digit (US/FR) postcode token for the DIR test. */
 const dropPostcode = (s: string) =>
@@ -69,36 +281,64 @@ const dropPostcode = (s: string) =>
 
 const deps = await buildGauntletDeps(arg("model", "") ? { modelPath: arg("model", "") } : {})
 
+interface Tally {
+	checks: number
+	held: number
+	fails: number
+	xfail: number
+}
+const invTally = new Map<string, Tally>()
+const bandTally = new Map<string, Tally>()
+
+function bump(m: Map<string, Tally>, name: string, key: keyof Tally): void {
+	const t = m.get(name) ?? { checks: 0, held: 0, fails: 0, xfail: 0 }
+	t[key] += 1
+	m.set(name, t)
+}
+
 let invChecks = 0
 let invFails = 0
 let dirChecks = 0
 let dirFails = 0
+let bandChecks = 0
+let bandFails = 0
 const fails: string[] = []
 const xfails: string[] = []
 const xfailHit = new Set<string>()
+const bandXfailHit = new Set<string>()
 
 for (const base of BASES) {
 	const canon = await runOne(base.input, deps)
 
 	// INV: every label-preserving perturbation must reproduce the canonical coordinate + tier.
 	for (const p of INV) {
+		const perturbed = p.f(base.input, base)
+
+		if (perturbed == null) continue // perturbation not applicable to this base (e.g. no expandable suffix)
+
 		invChecks++
-		const r = await runOne(p.f(base.input), deps)
+		bump(invTally, p.name, "checks")
+		const r = await runOne(perturbed, deps)
 		const moved =
 			r.tier !== canon.tier ||
 			(canon.lat != null && r.lat != null && haversineKm(canon.lat, canon.lon!, r.lat, r.lon!) > INV_EPSILON_KM) ||
 			(canon.lat == null) !== (r.lat == null)
 
-		if (!moved) continue
+		if (!moved) {
+			bump(invTally, p.name, "held")
+			continue
+		}
 		const key = `${p.name}|${base.input}`
 		const tracked = KNOWN_INV_XFAIL.get(key)
-		const line = `INV[${p.name}] "${base.input}" → tier ${canon.tier}→${r.tier}, coord ${canon.lat},${canon.lon} → ${r.lat},${r.lon}`
+		const line = `INV[${p.name}] "${base.input}" → "${perturbed}" · tier ${canon.tier}→${r.tier}, coord ${canon.lat},${canon.lon} → ${r.lat},${r.lon}`
 
 		if (tracked) {
 			xfailHit.add(key)
+			bump(invTally, p.name, "xfail")
 			xfails.push(`  ~ ${line}  [xfail: ${tracked}]`)
 		} else {
 			invFails++
+			bump(invTally, p.name, "fails")
 			fails.push(`  ✗ ${line}`)
 		}
 	}
@@ -119,17 +359,75 @@ for (const base of BASES) {
 			)
 		}
 	}
+
+	// BAND: a corrupting perturbation may shift the parse, but must land within the tolerance band.
+	for (const p of BAND) {
+		const perturbed = p.f(base.input, base)
+
+		if (perturbed == null || perturbed === base.input) continue
+
+		if (canon.lat == null) continue // no clean anchor to measure a band against
+
+		bandChecks++
+		bump(bandTally, p.name, "checks")
+		const r = await runOne(perturbed, deps)
+		const dist = r.lat != null ? haversineKm(canon.lat, canon.lon!, r.lat, r.lon!) : null
+		const ok = dist != null && dist <= BAND_NEAR_KM
+
+		if (ok) {
+			bump(bandTally, p.name, "held")
+			continue
+		}
+		const key = `${p.name}|${base.input}`
+		const tracked = KNOWN_BAND_XFAIL.get(key)
+		const movedBy = dist != null ? `${dist.toFixed(1)}km` : "no-resolve"
+		const line = `BAND[${p.name}] "${base.input}" → "${perturbed}" · moved ${movedBy} (anchor ${canon.lat},${canon.lon} → ${r.lat},${r.lon})`
+
+		if (tracked) {
+			bandXfailHit.add(key)
+			bump(bandTally, p.name, "xfail")
+			xfails.push(`  ~ ${line}  [xfail: ${tracked}]`)
+		} else {
+			bandFails++
+			bump(bandTally, p.name, "fails")
+			fails.push(`  ✗ ${line}`)
+		}
+	}
 }
 deps.close()
 
 // Anti-rot: a tracked xfail that did NOT fire has been fixed — surface it so the list can't accrete stale entries.
-const newlyPassing = [...KNOWN_INV_XFAIL].filter(([key]) => !xfailHit.has(key))
+const newlyPassing = [
+	...[...KNOWN_INV_XFAIL].filter(([key]) => !xfailHit.has(key)),
+	...[...KNOWN_BAND_XFAIL].filter(([key]) => !bandXfailHit.has(key)),
+]
 
 console.log(`\n=== Gauntlet · metamorphic ===`)
 console.log(
-	`  INV (label-preserving invariance): ${invChecks - invFails - xfailHit.size}/${invChecks} held, ${xfailHit.size} known-xfail`
+	`  INV  (label-preserving, ≤1m):  ${invChecks - invFails - xfailHit.size}/${invChecks} held, ${xfailHit.size} known-xfail`
 )
-console.log(`  DIR (drop-postcode still resolves): ${dirChecks - dirFails}/${dirChecks} held`)
+console.log(`  DIR  (drop-postcode, ≤5km):    ${dirChecks - dirFails}/${dirChecks} held`)
+console.log(
+	`  BAND (corrupting, ≤5km):       ${bandChecks - bandFails - bandXfailHit.size}/${bandChecks} held, ${bandXfailHit.size} known-xfail`
+)
+
+console.log(`\nper-class:`)
+
+for (const [set, tally] of [
+	["INV", invTally],
+	["BAND", bandTally],
+] as const) {
+	const order = set === "INV" ? INV : BAND
+
+	for (const p of order) {
+		const t = tally.get(p.name)
+
+		if (!t) continue
+		const heldStr = `${t.held}/${t.checks} held`
+		const notes = [t.fails ? `${t.fails} FAIL` : "", t.xfail ? `${t.xfail} xfail` : ""].filter(Boolean).join(", ")
+		console.log(`  ${set}[${p.name}]`.padEnd(22) + `${heldStr}${notes ? ` (${notes})` : ""}`)
+	}
+}
 
 if (fails.length) {
 	console.log(`\nNEW violations (gate-failing):`)
@@ -144,13 +442,14 @@ if (xfails.length) {
 }
 
 if (newlyPassing.length) {
-	console.log(`\n⚠ xfails that now PASS — remove from KNOWN_INV_XFAIL:`)
+	console.log(`\n⚠ xfails that now PASS — remove from the KNOWN_*_XFAIL map:`)
 
 	for (const [key, issue] of newlyPassing) console.log(`  + ${key}  [was: ${issue}]`)
 }
 // The gate fails on NEW regressions only. A newly-passing xfail is a bookkeeping nudge, not a failure.
-const pass = invFails === 0 && dirFails === 0
+const pass = invFails === 0 && dirFails === 0 && bandFails === 0
+const trackedTotal = xfailHit.size + bandXfailHit.size
 console.log(
-	`\nverdict: ${pass ? "PASS" : "FAIL"}${pass && xfailHit.size ? ` (with ${xfailHit.size} tracked xfails)` : ""}`
+	`\nverdict: ${pass ? "PASS" : "FAIL"}${pass && trackedTotal ? ` (with ${trackedTotal} tracked xfails)` : ""}`
 )
 process.exit(pass ? 0 : 1)

--- a/scripts/eval/gauntlet/metamorphic.ts
+++ b/scripts/eval/gauntlet/metamorphic.ts
@@ -245,10 +245,11 @@ const BAND: Perturbation[] = [
 // the FR street-type swap below is a RESOLVER gap, not a model one, and it is a finding, not a reflex xfail (see note).
 // A NEW deterministic INV break belongs here with a tracked note, never silently gated.
 const KNOWN_INV_XFAIL = new Map<string, string>([
-	// FINDING (2026-07-06): `Boulevard`→`Bd` drops address_point→admin (~0.24km). The FR street gazetteer stores the
-	// expanded type, so the abbreviated form fails the point-tier name match — a resolver coverage gap, not a model
-	// robustness failure (EN Ave/St hold). Measured anchor-OFF; the gazetteer soft-feed may recover it in ship-config.
-	["abbrev|2 Boulevard du Palais, 75001 Paris", "resolver: FR street-type abbrev name-match gap (address_point→admin)"],
+	// FINDING (2026-07-06, tracked as #1002): `Boulevard`→`Bd` drops address_point→admin (~0.24km). The FR street
+	// gazetteer stores the expanded type, so the abbreviated form fails the point-tier name match — a resolver coverage
+	// gap, not a model robustness failure (EN Ave/St hold). Measured anchor-OFF; the gazetteer soft-feed may recover it
+	// in ship-config. Remove this row as part of the #1002 fix — the anti-rot check will flag it once it passes.
+	["abbrev|2 Boulevard du Palais, 75001 Paris", "resolver: FR street-type abbrev name-match gap (#1002)"],
 ])
 
 /**


### PR DESCRIPTION
## What

Two deliverables, sequenced docs-first:

1. **`docs/articles/concepts/input-robustness.mdx`** — writes up how input-perturbation robustness works today: the three absorption layers (deterministic `normalize/` → model-side `case-normalize` #690/#829 → trained-in corpus variation), the gates (metamorphic INV/DIR, golden `graceful/*` slices, `perturb-golden.ts`), and a per-class coverage matrix. Pointer added to `CONTRIBUTING_MODEL_WORK.mdx`'s gate list + cross-link from `eval-discipline.mdx`. The concept was implemented but never documented.
2. **Metamorphic gauntlet extension** (`scripts/eval/gauntlet/metamorphic.ts`):
   - `abbrev` — expanded→abbreviated suffix swap (strict INV, ≤1m), inverting the shared `normalize/abbreviations.ts` table (now exported as `abbreviationDictionary` — small new `@mailwoman/normalize` API; no duplicated data).
   - `transpose` / `typo-sub` — deterministic single-char edits (fixed position, no RNG) on a new ≤5km tolerance-band relation modeled on DIR — byte-identical output is the wrong contract for a corrupted input.
   - `number-spell` — ordinal street swap (`5th`↔`Fifth`) + spelled house number (`100`→`One Hundred`), tolerance-band.
   - Known misses recorded in the xfail maps with the existing anti-rot bookkeeping (a newly-passing xfail is flagged) — gaps stay visible and non-blocking.

Casing/spacing deliberately not extended (already gated green). 3 base addresses added (Empire State Building, Manhattan Municipal Building, Palais de la Cité) so every class has a qualifying base.

## Results (model a64ad2e6, anchor-OFF harness default; byte-identical across two runs)

Baseline before change: INV 35/35, DIR 3/3, PASS. After: **PASS, 6 tracked xfails**.

| Class | Result |
|---|---|
| INV lower/upper/ws/trail-dot/comma-tight | 10/10 each — zero regressions |
| INV abbrev | 2/3 — EN `Avenue→Ave`/`Street→St` green; FR `Boulevard→Bd` xfail → **#1002** |
| DIR drop-postcode | 3/3 |
| BAND transpose / typo-sub | 7/9 each — 2 xfail (Amsterdam no-resolve, Centre St 6.4km) |
| BAND num-ordinal | 2/2 — held untrained |
| BAND num-house | 0/1 xfail — never trained, never normalized |

## Findings

- **#1002** — the FR `Boulevard→Bd` xfail is a resolver coverage gap (FR street gazetteer stores the expanded type; abbreviated form misses the point-tier name match), not a model failure. Filed separately; the xfail row carries the reference and comes out with the fix.
- All BAND misses were measured anchor-OFF (the harness default) — they're the floor, not a ship-config verdict; the gazetteer soft-feed is exactly what would recover a typo'd locality.
- `num-ordinal` holding without training was a positive surprise.

Design spec committed at `docs/superpowers/specs/2026-07-06-input-robustness-gate-design.md`. Lint, format, and `tsc --noEmit` pass. Pre-existing regression-layer FAIL in the `run.ts` orchestrator is unrelated (untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)