### PR TITLE
fix: v5.4.0 dev-weights chain — files_md5 + link-dev-weights defaults missed at the promote

### DIFF
--- a/neural-weights-en-us/model-card.json
+++ b/neural-weights-en-us/model-card.json
@@ -176,22 +176,34 @@
 				"cz": {
 					"v4_15_0": 22.4,
 					"v5_1_0": 14.8,
-					"diff_ci95_pp": [-10.3, -5.1]
+					"diff_ci95_pp": [
+						-10.3,
+						-5.1
+					]
 				},
 				"pl": {
 					"v4_15_0": 27.9,
 					"v5_1_0": 7.9,
-					"diff_ci95_pp": [-22.7, -17.4]
+					"diff_ci95_pp": [
+						-22.7,
+						-17.4
+					]
 				},
 				"sk": {
 					"v4_15_0": 22.2,
 					"v5_1_0": 13.2,
-					"diff_ci95_pp": [-11.5, -6.4]
+					"diff_ci95_pp": [
+						-11.5,
+						-6.4
+					]
 				},
 				"si": {
 					"v4_15_0": 18.9,
 					"v5_1_0": 10.6,
-					"diff_ci95_pp": [-10.4, -6.4]
+					"diff_ci95_pp": [
+						-10.4,
+						-6.4
+					]
 				},
 				"$note": "reservoir-sampled 1k-row OA coord sets (oa-{cz,pl,sk,si}-coord-1k.jsonl), graded parse→resolve→great-circle, int8 ship artifact"
 			},
@@ -340,8 +352,8 @@
 		}
 	},
 	"files_md5": {
-		"$comment": "Source artifact md5s (int8 model-v220-full-family-100k-int8.onnx + tokenizer v0.7.1-nsplice, unchanged from v5.2.0). The PUBLISHED files are re-verified against these at release Step 4.",
-		"model.onnx": "a64ad2e6b9ee73a6b63f3c94c01b1966",
+		"$comment": "Source artifact md5s (int8 model-v230-nl-postcode-int8.onnx [v5.4.0, the #924 fine-tune] + tokenizer v0.7.1-nsplice, unchanged from v5.2.0). The PUBLISHED files are re-verified against these at release Step 4.",
+		"model.onnx": "ea785a70c4e80c0a3ba3c7ec796b3395",
 		"tokenizer.model": "8e1cab7c501af834fbfcd6c4b8d78cad"
 	},
 	"capabilities": {

--- a/neural-weights-en-us/scripts/link-dev-weights.ts
+++ b/neural-weights-en-us/scripts/link-dev-weights.ts
@@ -52,8 +52,8 @@ import { dataRootPath } from "@mailwoman/core/utils"
 // v0.6.0-bsplice tokenizer (58,582 pieces) — the first coordinated model + tokenizer
 // bump, so BOTH paths moved this ship. Bump these two paths on each ship; the expected
 // md5s live in model-card.json `files_md5` (single source — see the header).
-const DEFAULT_MODEL = dataRootPath("models", "quantized", "model-bsplice-meaninit-int8.onnx")
-const DEFAULT_TOKENIZER = dataRootPath("models", "tokenizer", "v0.6.0-bsplice", "tokenizer.model")
+const DEFAULT_MODEL = dataRootPath("models", "quantized", "model-v230-nl-postcode-int8.onnx")
+const DEFAULT_TOKENIZER = dataRootPath("models", "tokenizer", "v0.7.1-nsplice", "tokenizer.model")
 
 const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 


### PR DESCRIPTION
Found reviewing #1003 (its baseline 'pre-existing regression FAIL' was measured on **a64ad2e6 = v5.3.0**). The v5.4.0 promote missed the card's `files_md5` and the `link-dev-weights` `DEFAULT_*` paths — the self-consistent-stale #259 trap. Fixed both; relink asserts **ea785a70**; the full gauntlet on main is **GREEN on the correct model** (24/24, 35/35).

⚠ Merge-order note: **this should land before #1003**, whose xfail maps were measured on v5.3.0 — after this, re-run its gauntlet on ea785a70 to re-validate the new xfail rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)