### PR TITLE
fix(#1002): locale-unknown abbreviation expansion — Bd du Palais holds the rooftop; INV xfails hit zero

### DIFF
--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -360,7 +360,13 @@ export async function parseForGeocode(
 	input: string,
 	deps: Pick<GeocodeDeps, "classifier" | "normalizeInput" | "normalizeCase">
 ): Promise<AddressTree> {
-	const parseInput = deps.normalizeInput === false ? input : normalize(input).normalized
+	// #1002: expandAbbreviations with the locale-UNKNOWN safe set (Bd/Bvd/Av/Imp → the expanded street
+	// type). The model mis-parses undertrained FR abbreviations ("2 Bd du Palais" → house_number "2 Bd",
+	// which then fails the point-tier number match); the EN suffixes are deliberately NOT expanded (the
+	// model is trained-robust on them, and St/Dr are ambiguous with Saint/Doctor). The locale isn't known
+	// pre-parse, so only the collision-free multi-locale entries apply — see LOCALE_UNKNOWN_DICT.
+	const parseInput =
+		deps.normalizeInput === false ? input : normalize(input, { expandAbbreviations: true, locale: "und" }).normalized
 
 	return recognizeUSRegions(
 		await deps.classifier.parse(parseInput, { postcodeRepair: true, normalizeCase: deps.normalizeCase ?? true })
@@ -377,7 +383,8 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	// createRuntimePipeline wrapper, so without this a double-spaced / odd-punctuation query was fragile. `input` stays
 	// raw for the result; the parse + placer see the normalized form. A caller-supplied `parsedTree` (from
 	// parseForGeocode, same input + opts) skips the re-parse — the address's most expensive step.
-	const parseInput = deps.normalizeInput === false ? input : normalize(input).normalized
+	const parseInput =
+		deps.normalizeInput === false ? input : normalize(input, { expandAbbreviations: true, locale: "und" }).normalized
 	const tree = deps.parsedTree ?? (await parseForGeocode(input, deps))
 	const stateSlug = regionSlugFromTree(tree)
 	const usShards = deps.shards?.(stateSlug) ?? {}

--- a/normalize/abbreviations.ts
+++ b/normalize/abbreviations.ts
@@ -53,8 +53,29 @@ const FR_FR_DICT: ReadonlyArray<AbbreviationEntry> = [
 	{ from: "Sq", to: "Square" },
 ]
 
+/**
+ * #1002: the locale-UNKNOWN expansion set — the entries safe to apply when the input's locale hasn't been established
+ * yet (the geocode path expands BEFORE the parse, which is what determines the locale). Safe = multi-char,
+ * collision-free across the locale dictionaries, and never a plausible standalone token in the other locale (FR
+ * `Bd`/`Bvd`/`Imp` have no EN reading; `Av` reads Avenue in both). Deliberately EXCLUDED: the FR single letters (`R` →
+ * Rue would fire on Washington DC's literal "R St") and the EN suffixes (`St`, `Ave`, `Dr`, … — the model is
+ * trained-robust on those, and `St`/`Dr` are ambiguous with Saint/Doctor).
+ */
+const LOCALE_UNKNOWN_DICT: ReadonlyArray<AbbreviationEntry> = [
+	{ from: "Bd", to: "Boulevard" },
+	{ from: "Bvd", to: "Boulevard" },
+	{ from: "Boul", to: "Boulevard" },
+	{ from: "Av", to: "Avenue" },
+	{ from: "Imp", to: "Impasse" },
+]
+
 function getDictionary(locale: string | undefined): ReadonlyArray<AbbreviationEntry> {
 	const lc = (locale ?? "en-US").toLowerCase()
+
+	// BCP-47 "und" (undetermined) — the caller knows it does NOT know the locale yet (the geocode path
+	// expands before the parse). Only the collision-free multi-locale set applies; `undefined` keeps its
+	// historical en-US default.
+	if (lc === "und") return LOCALE_UNKNOWN_DICT
 
 	if (lc.startsWith("fr")) return FR_FR_DICT
 

--- a/scripts/eval/gauntlet/metamorphic.ts
+++ b/scripts/eval/gauntlet/metamorphic.ts
@@ -244,13 +244,12 @@ const BAND: Perturbation[] = [
 // retrain). `abbrev` holds for the EN suffix swaps (Avenue→Ave, Street→St) because the model trains on both forms — but
 // the FR street-type swap below is a RESOLVER gap, not a model one, and it is a finding, not a reflex xfail (see note).
 // A NEW deterministic INV break belongs here with a tracked note, never silently gated.
-const KNOWN_INV_XFAIL = new Map<string, string>([
-	// FINDING (2026-07-06, tracked as #1002): `Boulevard`→`Bd` drops address_point→admin (~0.24km). The FR street
-	// gazetteer stores the expanded type, so the abbreviated form fails the point-tier name match — a resolver coverage
-	// gap, not a model robustness failure (EN Ave/St hold). Measured anchor-OFF; the gazetteer soft-feed may recover it
-	// in ship-config. Remove this row as part of the #1002 fix — the anti-rot check will flag it once it passes.
-	["abbrev|2 Boulevard du Palais, 75001 Paris", "resolver: FR street-type abbrev name-match gap (#1002)"],
-])
+// The #1002 FR `Boulevard→Bd` xfail was removed 2026-07-06 with its fix: the root cause was NOT the
+// FR gazetteer (street_norm expands `bd` fine) but the MODEL absorbing the undertrained "Bd" into
+// house_number ("2 Bd") pre-lookup — fixed by enabling Stage-1 `expandAbbreviations` in the geocode
+// path with the locale-UNKNOWN safe set (Bd/Bvd/Av/Imp; EN suffixes deliberately untouched). Keep the
+// anti-rot loop honest: a NEW deterministic INV break belongs here with a tracked note, never silently gated.
+const KNOWN_INV_XFAIL = new Map<string, string>([])
 
 /**
  * Known, DETERMINISTIC BAND misses — the tolerance-band analog of KNOWN_INV_XFAIL, same anti-rot bookkeeping. These are


### PR DESCRIPTION
**The #1002 diagnosis was wrong in an interesting way**: the FR gazetteer's `street_norm` expands `bd→boulevard` fine — the real failure is the **model** absorbing the undertrained "Bd" into the house number (`"2 Bd"`), which fails the point-tier *number* match. EN abbreviations never failed because the model is trained-robust on them.

The fix: `expandAbbreviations` (fully built, **zero production callers**) turns on in geocode-core's Stage-1 under a new BCP-47 `"und"` tag — the collision-free multi-locale set only (`Bd/Bvd/Boul/Av/Imp`). FR single letters excluded (`R→Rue` would fire on DC's literal "R St"); EN suffixes excluded (model-robust; `St/Dr` ambiguous). `undefined` keeps its en-US contract (71/71 tests).

**Gates:** the #1002 case → rooftop, byte-identical with the expanded form · metamorphic **INV 53/53, zero xfails** (the tracked row retired with its fix) · full gauntlet PASS · **US-150: 0 rows changed**.

Closes #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)