### PR TITLE
fix(#1017): permissive CORS on the photon/nominatim/libpostal drop-in servers

### DIFF
--- a/libpostal/README.md
+++ b/libpostal/README.md
@@ -40,3 +40,7 @@ const engine: LibpostalEngine = {
 }
 express().use(createLibpostalRouter(engine)).listen(8081)
 ```
+
+## CORS
+
+Browser clients call this cross-origin — including the preflighted `POST /parse` — so the server sends permissive CORS by default: `Access-Control-Allow-Origin: *` and a `204` answer to preflight `OPTIONS`. Behind a reverse proxy that already sets the headers, turn it off with `--no-cors` (or `createLibpostalRouter(engine, { cors: false })`).

--- a/libpostal/cli.ts
+++ b/libpostal/cli.ts
@@ -26,7 +26,11 @@ function serve(): void {
 		options: {
 			port: { type: "string", default: "8081" },
 			host: { type: "string", default: "0.0.0.0" },
+			// Permissive CORS is on by default (browser clients need it). `--no-cors` turns it off for deployments
+			// where a reverse proxy already sets the headers.
+			cors: { type: "boolean", default: true },
 		},
+		allowNegative: true,
 		allowPositionals: true,
 	})
 
@@ -55,9 +59,10 @@ function serve(): void {
 	}
 
 	express()
-		.use(createLibpostalRouter(engine))
+		.use(createLibpostalRouter(engine, { cors: values.cors }))
 		.listen(port, host, () => {
 			console.error(`[@mailwoman/libpostal] listening on http://${host}:${port}`)
+			console.error(`  cors: ${values.cors ? "enabled (Access-Control-Allow-Origin: *)" : "disabled (--no-cors)"}`)
 			console.error(`  endpoints: POST/GET /parse  POST/GET /expand`)
 		})
 }
@@ -69,6 +74,6 @@ switch (command) {
 		serve()
 		break
 	default:
-		console.error("Usage: mailwoman-libpostal serve [--port 8081] [--host 0.0.0.0]")
+		console.error("Usage: mailwoman-libpostal serve [--port 8081] [--host 0.0.0.0] [--no-cors]")
 		process.exit(command ? 1 : 0)
 }

--- a/libpostal/index.test.ts
+++ b/libpostal/index.test.ts
@@ -4,9 +4,18 @@
  * @author Teffen Ellis, et al.
  */
 
+import type { AddressInfo } from "node:net"
+
+import express from "express"
 import { expect, test } from "vitest"
 
-import { COMPONENT_TO_LIBPOSTAL, type ParseMatch, toLibpostalComponents } from "./index.js"
+import {
+	COMPONENT_TO_LIBPOSTAL,
+	createLibpostalRouter,
+	type LibpostalEngine,
+	type ParseMatch,
+	toLibpostalComponents,
+} from "./index.js"
 
 test("toLibpostalComponents: maps our classifications to libpostal labels, in order", () => {
 	const matches: ParseMatch[] = [
@@ -36,4 +45,42 @@ test("COMPONENT_TO_LIBPOSTAL: the core US/EU mappings hold", () => {
 	expect(COMPONENT_TO_LIBPOSTAL.locality).toBe("city")
 	expect(COMPONENT_TO_LIBPOSTAL.region).toBe("state")
 	expect(COMPONENT_TO_LIBPOSTAL.postcode).toBe("postcode")
+})
+
+const corsEngine: LibpostalEngine = { parse: async () => [] }
+
+/** Boot the app on an ephemeral port, hand the base URL to `fn`, always close. */
+async function withServer(app: express.Express, fn: (base: string) => Promise<void>): Promise<void> {
+	const server = app.listen(0)
+	await new Promise((resolve) => server.once("listening", resolve))
+	const { port } = server.address() as AddressInfo
+
+	try {
+		await fn(`http://127.0.0.1:${port}`)
+	} finally {
+		await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
+	}
+}
+
+test("CORS: permissive Access-Control-Allow-Origin on responses (browser clients)", async () => {
+	await withServer(express().use(createLibpostalRouter(corsEngine)), async (base) => {
+		const res = await fetch(`${base}/parse?query=1600+pennsylvania+ave`)
+		expect(res.headers.get("access-control-allow-origin")).toBe("*")
+	})
+})
+
+test("CORS: preflight OPTIONS answers 204 with CORS headers (POST /parse is preflighted)", async () => {
+	await withServer(express().use(createLibpostalRouter(corsEngine)), async (base) => {
+		const res = await fetch(`${base}/parse`, { method: "OPTIONS" })
+		expect(res.status).toBe(204)
+		expect(res.headers.get("access-control-allow-origin")).toBe("*")
+		expect(res.headers.get("access-control-allow-methods")).toContain("POST")
+	})
+})
+
+test("CORS: { cors: false } disables the headers (for a proxy that owns CORS)", async () => {
+	await withServer(express().use(createLibpostalRouter(corsEngine, { cors: false })), async (base) => {
+		const res = await fetch(`${base}/parse?query=x`)
+		expect(res.headers.get("access-control-allow-origin")).toBeNull()
+	})
 })

--- a/libpostal/index.ts
+++ b/libpostal/index.ts
@@ -65,9 +65,41 @@ export interface LibpostalEngine {
 	expand?(address: string): Promise<string[]>
 }
 
+/** Options for {@link createLibpostalRouter}. */
+export interface LibpostalRouterOptions {
+	/**
+	 * Emit permissive CORS headers (`Access-Control-Allow-Origin: *`) on every response and answer preflight `OPTIONS`
+	 * with `204`. Default `true` — browser clients need it: a cross-origin XHR (including the `POST /parse` preflight) is
+	 * blocked without it (#1017). Set `false` when a reverse proxy already owns the CORS headers.
+	 */
+	cors?: boolean
+}
+
+/**
+ * Permissive CORS: `Access-Control-Allow-Origin: *` on every response, plus a `204` answer to preflight `OPTIONS`.
+ * `POST /parse` is a preflighted CORS request, so the `OPTIONS` answer must advertise `POST`. `ACAO: *` is anonymous
+ * (no credentials), so a wildcard `Allow-Headers` is valid.
+ */
+const applyCors: RequestHandler = (req, res, next) => {
+	res.setHeader("Access-Control-Allow-Origin", "*")
+	res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	res.setHeader("Access-Control-Allow-Headers", "*")
+
+	if (req.method === "OPTIONS") {
+		res.setHeader("Access-Control-Max-Age", "86400")
+		res.status(204).end()
+
+		return
+	}
+	next()
+}
+
 /** Build the libpostal-compatible router around an injected {@link LibpostalEngine}. */
-export function createLibpostalRouter(engine: LibpostalEngine): Router {
+export function createLibpostalRouter(engine: LibpostalEngine, options: LibpostalRouterOptions = {}): Router {
 	const router = Router()
+
+	// Browser clients need CORS or their cross-origin XHR is blocked before completing (#1017).
+	if (options.cors !== false) router.use(applyCors)
 
 	const parse: RequestHandler = async (req, res) => {
 		const query = (

--- a/nominatim/README.md
+++ b/nominatim/README.md
@@ -37,6 +37,10 @@ const engine: NominatimEngine = {
 express().use(createNominatimRouter(engine)).listen(8080)
 ```
 
+## CORS
+
+Browser-embedded geocoder clients call this cross-origin, so the server sends permissive CORS by default — `Access-Control-Allow-Origin: *` and a `204` answer to preflight `OPTIONS`. Behind a reverse proxy that already sets the headers, turn it off with `--no-cors` (or `createNominatimRouter(engine, { cors: false })`).
+
 ## Annotations
 
 Every result carries an OpenCage-style `annotations` block — coordinate formats (DMS, MGRS, geohash,

--- a/nominatim/cli.ts
+++ b/nominatim/cli.ts
@@ -114,7 +114,11 @@ async function serve(): Promise<void> {
 			port: { type: "string", default: "8080" },
 			host: { type: "string", default: "0.0.0.0" },
 			"candidate-db": { type: "string" },
+			// Permissive CORS is on by default (browser geocoder clients need it). `--no-cors` turns it off for
+			// deployments where a reverse proxy already sets the headers.
+			cors: { type: "boolean", default: true },
 		},
+		allowNegative: true,
 		allowPositionals: true,
 	})
 
@@ -266,7 +270,7 @@ async function serve(): Promise<void> {
 	}
 
 	express()
-		.use(createNominatimRouter(engine))
+		.use(createNominatimRouter(engine, { cors: values.cors }))
 		.listen(port, host, () => {
 			console.error(`[@mailwoman/nominatim] listening on http://${host}:${port}`)
 			console.error(`  wof: ${adminDBPath ?? "(none found — set MAILWOMAN_WOF_DB)"}`)
@@ -275,6 +279,7 @@ async function serve(): Promise<void> {
 					? `  resolver: candidate gazetteer (worldwide) — ${candidateDb}`
 					: `  resolver: admin-only (US-optimized) — point --candidate-db / $MAILWOMAN_CANDIDATE_DB at a candidate gazetteer for worldwide`
 			)
+			console.error(`  cors: ${values.cors ? "enabled (Access-Control-Allow-Origin: *)" : "disabled (--no-cors)"}`)
 			console.error(`  endpoints: GET /search  GET /reverse  GET /lookup  GET /status`)
 		})
 }
@@ -286,6 +291,6 @@ switch (command) {
 		await serve()
 		break
 	default:
-		console.error("Usage: mailwoman-nominatim serve [--port 8080] [--host 0.0.0.0] [--candidate-db <path>]")
+		console.error("Usage: mailwoman-nominatim serve [--port 8080] [--host 0.0.0.0] [--candidate-db <path>] [--no-cors]")
 		process.exit(command ? 1 : 0)
 }

--- a/nominatim/index.test.ts
+++ b/nominatim/index.test.ts
@@ -4,9 +4,19 @@
  * @author Teffen Ellis, et al.
  */
 
+import type { AddressInfo } from "node:net"
+
+import express from "express"
 import { expect, test } from "vitest"
 
-import { MAILWOMAN_LICENCE, type ResolvedAddress, toFeatureCollection, toNominatimResult } from "./index.js"
+import {
+	createNominatimRouter,
+	MAILWOMAN_LICENCE,
+	type NominatimEngine,
+	type ResolvedAddress,
+	toFeatureCollection,
+	toNominatimResult,
+} from "./index.js"
 
 const dc: ResolvedAddress = {
 	lat: 38.8977,
@@ -75,4 +85,42 @@ test("toNominatimResult: carries class/type/importance/boundingbox when present"
 	expect(r.type).toBe("government")
 	expect(r.importance).toBe(0.8)
 	expect(r.boundingbox).toEqual(["38.89", "38.90", "-77.04", "-77.03"])
+})
+
+const corsEngine: NominatimEngine = { status: async () => ({ status: 0, message: "OK" }) }
+
+/** Boot the app on an ephemeral port, hand the base URL to `fn`, always close. */
+async function withServer(app: express.Express, fn: (base: string) => Promise<void>): Promise<void> {
+	const server = app.listen(0)
+	await new Promise((resolve) => server.once("listening", resolve))
+	const { port } = server.address() as AddressInfo
+
+	try {
+		await fn(`http://127.0.0.1:${port}`)
+	} finally {
+		await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
+	}
+}
+
+test("CORS: permissive Access-Control-Allow-Origin on responses (browser clients)", async () => {
+	await withServer(express().use(createNominatimRouter(corsEngine)), async (base) => {
+		const res = await fetch(`${base}/status`)
+		expect(res.headers.get("access-control-allow-origin")).toBe("*")
+	})
+})
+
+test("CORS: preflight OPTIONS answers 204 with CORS headers", async () => {
+	await withServer(express().use(createNominatimRouter(corsEngine)), async (base) => {
+		const res = await fetch(`${base}/search`, { method: "OPTIONS" })
+		expect(res.status).toBe(204)
+		expect(res.headers.get("access-control-allow-origin")).toBe("*")
+		expect(res.headers.get("access-control-allow-methods")).toContain("GET")
+	})
+})
+
+test("CORS: { cors: false } disables the headers (for a proxy that owns CORS)", async () => {
+	await withServer(express().use(createNominatimRouter(corsEngine, { cors: false })), async (base) => {
+		const res = await fetch(`${base}/status`)
+		expect(res.headers.get("access-control-allow-origin")).toBeNull()
+	})
 })

--- a/nominatim/index.ts
+++ b/nominatim/index.ts
@@ -171,13 +171,44 @@ export function toFeatureCollection(results: readonly NominatimResult[]): Nomina
 	return { type: "FeatureCollection", features }
 }
 
+/** Options for {@link createNominatimRouter}. */
+export interface NominatimRouterOptions {
+	/**
+	 * Emit permissive CORS headers (`Access-Control-Allow-Origin: *`) on every response and answer preflight `OPTIONS`
+	 * with `204`. Default `true` — browser-embedded geocoder clients need it: a cross-origin XHR is blocked without it
+	 * (#1017). Set `false` when a reverse proxy already owns the CORS headers.
+	 */
+	cors?: boolean
+}
+
+/**
+ * Permissive CORS: `Access-Control-Allow-Origin: *` on every response, plus a `204` answer to preflight `OPTIONS`.
+ * `ACAO: *` is anonymous (no credentials), so a wildcard `Allow-Headers` is valid.
+ */
+const applyCors: RequestHandler = (req, res, next) => {
+	res.setHeader("Access-Control-Allow-Origin", "*")
+	res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS")
+	res.setHeader("Access-Control-Allow-Headers", "*")
+
+	if (req.method === "OPTIONS") {
+		res.setHeader("Access-Control-Max-Age", "86400")
+		res.status(204).end()
+
+		return
+	}
+	next()
+}
+
 /**
  * Build the Nominatim-compatible router around an injected {@link NominatimEngine}. Query-param parsing lives here; the
  * result _formatting_ (jsonv2 vs geojson envelope, `address` projection) is #804 and currently passes the engine's
  * results through verbatim.
  */
-export function createNominatimRouter(engine: NominatimEngine): Router {
+export function createNominatimRouter(engine: NominatimEngine, options: NominatimRouterOptions = {}): Router {
 	const router = Router()
+
+	// Browser-embedded geocoder clients need CORS or their cross-origin XHR is blocked before completing (#1017).
+	if (options.cors !== false) router.use(applyCors)
 
 	const search: RequestHandler = async (req, res) => {
 		if (!engine.search) {

--- a/photon/README.md
+++ b/photon/README.md
@@ -32,6 +32,10 @@ const engine: PhotonEngine = {
 express().use(createPhotonRouter(engine)).listen(2322)
 ```
 
+## CORS
+
+Map widgets (`leaflet-control-geocoder`, `@openrunner/photon-geocoder`) call this cross-origin from the browser, so the server sends permissive CORS by default — `Access-Control-Allow-Origin: *` and a `204` answer to preflight `OPTIONS`, matching upstream Photon. Behind a reverse proxy that already sets the headers, turn it off with `--no-cors` (or `createPhotonRouter(engine, { cors: false })`).
+
 ## Status
 
 Shipped. `/api` and `/reverse` resolve over the live engine and return Photon GeoJSON. `/api` runs the

--- a/photon/cli.ts
+++ b/photon/cli.ts
@@ -55,7 +55,11 @@ async function serve(): Promise<void> {
 			port: { type: "string", default: "2322" },
 			host: { type: "string", default: "0.0.0.0" },
 			"candidate-db": { type: "string" },
+			// Permissive CORS is on by default (upstream Photon parity — browser widgets need it). `--no-cors`
+			// turns it off for deployments where a reverse proxy already sets the headers.
+			cors: { type: "boolean", default: true },
 		},
+		allowNegative: true,
 		allowPositionals: true,
 	})
 
@@ -123,7 +127,7 @@ async function serve(): Promise<void> {
 
 	const express = (await import("express")).default
 	express()
-		.use(createPhotonRouter(engine))
+		.use(createPhotonRouter(engine, { cors: values.cors }))
 		.listen(port, host, () => {
 			console.error(`[@mailwoman/photon] listening on http://${host}:${port}`)
 			console.error(`  wof: ${adminDBPath ?? "(none found — set MAILWOMAN_WOF_DB)"}`)
@@ -132,6 +136,7 @@ async function serve(): Promise<void> {
 					? `  resolver: candidate gazetteer (worldwide) — ${candidateDb}`
 					: `  resolver: admin-only (US-optimized) — point --candidate-db / $MAILWOMAN_CANDIDATE_DB at a candidate gazetteer for worldwide`
 			)
+			console.error(`  cors: ${values.cors ? "enabled (Access-Control-Allow-Origin: *)" : "disabled (--no-cors)"}`)
 			console.error(`  endpoints: GET /api  GET /reverse`)
 		})
 }
@@ -143,6 +148,6 @@ switch (command) {
 		await serve()
 		break
 	default:
-		console.error("Usage: mailwoman-photon serve [--port 2322] [--host 0.0.0.0] [--candidate-db <path>]")
+		console.error("Usage: mailwoman-photon serve [--port 2322] [--host 0.0.0.0] [--candidate-db <path>] [--no-cors]")
 		process.exit(command ? 1 : 0)
 }

--- a/photon/index.test.ts
+++ b/photon/index.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import type { AddressInfo } from "node:net"
+
+import express from "express"
+import { expect, test } from "vitest"
+
+import { createPhotonRouter, type PhotonEngine } from "./index.js"
+
+const engine: PhotonEngine = {
+	search: async () => ({ type: "FeatureCollection", features: [] }),
+}
+
+/** Boot the app on an ephemeral port, hand the base URL to `fn`, always close. */
+async function withServer(app: express.Express, fn: (base: string) => Promise<void>): Promise<void> {
+	const server = app.listen(0)
+	await new Promise((resolve) => server.once("listening", resolve))
+	const { port } = server.address() as AddressInfo
+
+	try {
+		await fn(`http://127.0.0.1:${port}`)
+	} finally {
+		await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
+	}
+}
+
+test("CORS: permissive Access-Control-Allow-Origin on responses (upstream Photon parity)", async () => {
+	await withServer(express().use(createPhotonRouter(engine)), async (base) => {
+		const res = await fetch(`${base}/api?q=berlin`)
+		expect(res.headers.get("access-control-allow-origin")).toBe("*")
+	})
+})
+
+test("CORS: preflight OPTIONS answers 204 with CORS headers", async () => {
+	await withServer(express().use(createPhotonRouter(engine)), async (base) => {
+		const res = await fetch(`${base}/api`, { method: "OPTIONS" })
+		expect(res.status).toBe(204)
+		expect(res.headers.get("access-control-allow-origin")).toBe("*")
+		expect(res.headers.get("access-control-allow-methods")).toContain("GET")
+	})
+})
+
+test("CORS: { cors: false } disables the headers (for a proxy that owns CORS)", async () => {
+	await withServer(express().use(createPhotonRouter(engine, { cors: false })), async (base) => {
+		const res = await fetch(`${base}/api?q=berlin`)
+		expect(res.headers.get("access-control-allow-origin")).toBeNull()
+	})
+})

--- a/photon/index.ts
+++ b/photon/index.ts
@@ -102,12 +102,44 @@ function asStringArray(raw: unknown): string[] | undefined {
 
 const EMPTY: PhotonFeatureCollection = { type: "FeatureCollection", features: [] }
 
+/** Options for {@link createPhotonRouter}. */
+export interface PhotonRouterOptions {
+	/**
+	 * Emit permissive CORS headers (`Access-Control-Allow-Origin: *`) on every response and answer preflight `OPTIONS`
+	 * with `204`. Default `true` — upstream komoot/photon serves permissive CORS, and the map-widget use case
+	 * (leaflet-control-geocoder, @openrunner/photon-geocoder, …) needs it: a browser's cross-origin XHR is blocked
+	 * without it (#1017). Set `false` when a reverse proxy already owns the CORS headers.
+	 */
+	cors?: boolean
+}
+
+/**
+ * Permissive CORS, matching upstream Photon: `Access-Control-Allow-Origin: *` on every response, plus a `204` answer to
+ * preflight `OPTIONS`. `ACAO: *` is anonymous (no credentials), so a wildcard `Allow-Headers` is valid.
+ */
+const applyCors: RequestHandler = (req, res, next) => {
+	res.setHeader("Access-Control-Allow-Origin", "*")
+	res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS")
+	res.setHeader("Access-Control-Allow-Headers", "*")
+
+	if (req.method === "OPTIONS") {
+		res.setHeader("Access-Control-Max-Age", "86400")
+		res.status(204).end()
+
+		return
+	}
+	next()
+}
+
 /**
  * Build the Photon-compatible router around an injected {@link PhotonEngine}. Param parsing lives here; the feature
  * _projection_ (resolved place → {@link PhotonProperties}) is the staged work.
  */
-export function createPhotonRouter(engine: PhotonEngine): Router {
+export function createPhotonRouter(engine: PhotonEngine, options: PhotonRouterOptions = {}): Router {
 	const router = Router()
+
+	// Browser-embedded widgets need CORS or their cross-origin XHR is blocked before the request completes (#1017).
+	if (options.cors !== false) router.use(applyCors)
 
 	const search: RequestHandler = async (req, res) => {
 		if (!engine.search) {


### PR DESCRIPTION
Closes #1017.

## Problem

The hosted `@mailwoman/photon@5.4.0` endpoint (and the nominatim/libpostal drop-ins) sent **no** `Access-Control-Allow-Origin`, so any browser-embedded geocoder widget's cross-origin XHR was blocked before the request completed. The map-widget use case — `leaflet-control-geocoder`, `@openrunner/photon-geocoder`, Cartes-style clients — **is** the Photon usage pattern; without CORS the drop-in only works server-to-server. Upstream komoot/photon serves permissive CORS, so drop-in parity requires it. Our hosted endpoint patched this at the proxy layer, but self-hosters hit the same wall — it belongs in the package.

## Fix

Each `createXRouter(engine, { cors? })` now mounts a permissive CORS middleware **by default**:

- `Access-Control-Allow-Origin: *` on every response (+ `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers: *`)
- preflight `OPTIONS` → `204 No Content` with `Access-Control-Max-Age: 86400`

`ACAO: *` is anonymous (no credentials), so the wildcard `Allow-Headers` is valid. Opt out with `createXRouter(engine, { cors: false })` or the CLI `--no-cors` flag (for deployments where a reverse proxy already owns the headers). Boot logs the state.

Applied to all three: `@mailwoman/photon`, `@mailwoman/nominatim`, `@mailwoman/libpostal`.

## Verification

- **TDD**: HTTP-level tests (real Express + `fetch` against the real router) — written RED-first, then GREEN. 18 CORS/formatter tests pass across the three packages; full related suite green (33 tests).
- **Live server** (compiled libpostal):

  ```
  GET  /parse    → 200  Access-Control-Allow-Origin: *   (+ methods, headers)
  OPTIONS /parse → 204  + all CORS headers + Access-Control-Max-Age: 86400
  --no-cors      → 200, no access-control-* headers
  ```
- `tsc -b` clean, oxlint + oxfmt clean.

The issue's third checkbox (interim note that the hosted endpoint adds CORS at the proxy) is informational — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)