### PR TITLE
fix(#1014): photon forward /api decorates from the resolved place (names + country + osm schema)

### DIFF
--- a/mailwoman/geocode-core.test.ts
+++ b/mailwoman/geocode-core.test.ts
@@ -10,9 +10,10 @@
  *   on can never mis-route a non-GB address.
  */
 
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { describe, expect, it } from "vitest"
 
-import { countryFromPostcodeFormat } from "./geocode-core.js"
+import { countryFromPostcodeFormat, extractGeocodeResult } from "./geocode-core.js"
 
 describe("countryFromPostcodeFormat (#928)", () => {
 	it("matches GB postcodes (spaced and unspaced)", () => {
@@ -55,5 +56,52 @@ describe("countryFromPostcodeFormat (#928)", () => {
 		expect(countryFromPostcodeFormat(undefined)).toBeNull()
 		expect(countryFromPostcodeFormat("")).toBeNull()
 		expect(countryFromPostcodeFormat("   ")).toBeNull()
+	})
+})
+
+function node(partial: Partial<AddressNode> & Pick<AddressNode, "tag" | "value">): AddressNode {
+	return { start: 0, end: 0, confidence: 1, children: [], ...partial }
+}
+
+describe("extractGeocodeResult — resolved-place surfacing (#1014)", () => {
+	// The parse span was lowercase "paris"; the resolver's canonical name is "Paris", ISO2 "FR".
+	const resolvedParis = (): AddressTree => ({
+		raw: "55 rue du faubourg saint-honoré 75008 paris",
+		roots: [
+			node({
+				tag: "locality",
+				value: "paris",
+				lat: 48.8566,
+				lon: 2.3522,
+				placeID: "wof:1159322569",
+				metadata: { resolver_name: "Paris", resolver_country: "FR" },
+			}),
+		],
+	})
+
+	it("surfaces the resolved gazetteer name on each hierarchy entry (not the parsed span)", () => {
+		const r = extractGeocodeResult("55 rue du faubourg saint-honoré 75008 paris", resolvedParis())
+		expect(r.hierarchy[0]?.name).toBe("Paris") // resolver_name — proper casing
+		expect(r.hierarchy[0]?.value).toBe("paris") // the raw parsed span stays available
+	})
+
+	it("surfaces the resolved ISO-3166 alpha-2 country code", () => {
+		expect(extractGeocodeResult("…", resolvedParis()).countryCode).toBe("FR")
+	})
+
+	it("countryCode is null when no node carries a resolved country", () => {
+		const tree: AddressTree = {
+			raw: "berlin",
+			roots: [node({ tag: "locality", value: "Berlin", lat: 52.5, lon: 13.4, placeID: "wof:101909779" })],
+		}
+		expect(extractGeocodeResult("berlin", tree).countryCode).toBeNull()
+	})
+
+	it("hierarchy entry name falls back to the parsed value when unresolved-named", () => {
+		const tree: AddressTree = {
+			raw: "berlin",
+			roots: [node({ tag: "locality", value: "Berlin", lat: 52.5, lon: 13.4, placeID: "wof:101909779" })],
+		}
+		expect(extractGeocodeResult("berlin", tree).hierarchy[0]?.name).toBe("Berlin")
 	})
 })

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -54,8 +54,17 @@ export interface GeocodeResult {
 	locality: string | null
 	region: string | null
 	postcode: string | null
-	/** Admin hierarchy from the resolver, locality → country (most specific first). */
-	hierarchy: Array<{ tag: string; value: string; lat?: number; lon?: number; placeID?: string }>
+	/**
+	 * ISO-3166 alpha-2 of the resolved place (the gazetteer/candidate country of the deepest resolved node), or null.
+	 * #1014 — lets a forward consumer fill `country`/`countrycode` without a full ancestry walk (the candidate backend
+	 * carries the country code even when it has no `ancestors()` table).
+	 */
+	countryCode: string | null
+	/**
+	 * Admin hierarchy from the resolver, locality → country (most specific first). `name` is the resolved gazetteer name
+	 * (proper-cased canonical, #1014) — distinct from `value`, the raw parsed input span.
+	 */
+	hierarchy: Array<{ tag: string; value: string; name: string; lat?: number; lon?: number; placeID?: string }>
 }
 
 /**
@@ -584,9 +593,36 @@ export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeR
 		.map((n) => ({
 			tag: n.tag,
 			value: n.value.trim(),
+			// The resolver stamps the gazetteer's canonical name (proper casing) on `resolver_name`; fall back to the raw
+			// parsed span when a node resolved without one. #1014: consumers should DISPLAY this, not `value`.
+			name: (n.metadata?.["resolver_name"] as string | undefined)?.trim() || n.value.trim(),
 			...(n.lat != null ? { lat: n.lat, lon: n.lon! } : {}),
 			...(n.placeID ? { placeID: n.placeID } : {}),
 		}))
 
-	return { input, lat, lon, resolution_tier: tier, uncertainty_m: uncertaintyM, locality, region, postcode, hierarchy }
+	// #1014: the resolved ISO-3166 alpha-2 country (`resolver_country`, stamped by decorateNode). Same for every
+	// resolved node of one address, so the first that carries it wins.
+	let countryCode: string | null = null
+
+	for (const n of allNodes) {
+		const c = (n.metadata?.["resolver_country"] as string | undefined)?.trim()
+
+		if (c) {
+			countryCode = c.toUpperCase()
+			break
+		}
+	}
+
+	return {
+		input,
+		lat,
+		lon,
+		resolution_tier: tier,
+		uncertainty_m: uncertaintyM,
+		locality,
+		region,
+		postcode,
+		countryCode,
+		hierarchy,
+	}
 }

--- a/photon/cli.ts
+++ b/photon/cli.ts
@@ -34,7 +34,7 @@ import {
 	photonCollection,
 	photonFeature,
 	photonForwardFeature,
-	photonOsmTags,
+	photonOSMTags,
 	type PhotonEngine,
 	type PhotonProperties,
 } from "./index.js"
@@ -126,7 +126,7 @@ async function serve(): Promise<void> {
 			const properties: PhotonProperties = {
 				name: deepest.name,
 				countrycode: deepest.country?.toLowerCase(),
-				...photonOsmTags(deepest.placetype),
+				...photonOSMTags(deepest.placetype),
 			}
 
 			for (const place of hierarchy) {

--- a/photon/cli.ts
+++ b/photon/cli.ts
@@ -18,6 +18,7 @@ import { existsSync } from "node:fs"
 import { join } from "node:path"
 import { parseArgs } from "node:util"
 
+import { matchCountry } from "@mailwoman/codex/country"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
@@ -32,6 +33,8 @@ import {
 	createPhotonRouter,
 	photonCollection,
 	photonFeature,
+	photonForwardFeature,
+	photonOsmTags,
 	type PhotonEngine,
 	type PhotonProperties,
 } from "./index.js"
@@ -95,16 +98,21 @@ async function serve(): Promise<void> {
 			const result = await geocodeAddress(query, { classifier, resolver, shards: shards.for })
 
 			if (result.lat == null || result.lon == null) return photonCollection([])
-			const properties: PhotonProperties = {
-				name: result.locality ?? result.region ?? undefined,
-				city: result.locality ?? undefined,
-				state: result.region ?? undefined,
-				postcode: result.postcode ?? undefined,
-			}
+			// #1014: decorate from the RESOLVED gazetteer place — proper-cased ancestry names (`hierarchy[].name`,
+			// not the parsed span) + the resolved country (ISO2 → canonical name via codex) + osm_key/value/type so
+			// Photon clients don't TypeError. The candidate backend fills only the locality (no ancestors() table),
+			// so state/county come through only on an ancestry-capable backend — country still lands from the code.
+			const country = matchCountry(result.countryCode)
 
-			for (const h of result.hierarchy) if (h.tag === "country") properties.country = h.value
-
-			return photonCollection([photonFeature(result.lon, result.lat, properties)])
+			return photonCollection([
+				photonForwardFeature({
+					lat: result.lat,
+					lon: result.lon,
+					postcode: result.postcode,
+					country: country ? { name: country.canonical, code: country.iso2 } : undefined,
+					places: result.hierarchy.map((h) => ({ tag: h.tag, name: h.name })),
+				}),
+			])
 		},
 
 		async reverse(params) {
@@ -113,7 +121,13 @@ async function serve(): Promise<void> {
 
 			if (hierarchy.length === 0) return photonCollection([])
 			const deepest = hierarchy[0]!
-			const properties: PhotonProperties = { name: deepest.name, countrycode: deepest.country?.toLowerCase() }
+			// #1014: carry osm_key/osm_value/type (from the deepest placetype) so /reverse matches /api's schema —
+			// no Photon client should dereference an undefined osm_key on a reverse result either.
+			const properties: PhotonProperties = {
+				name: deepest.name,
+				countrycode: deepest.country?.toLowerCase(),
+				...photonOsmTags(deepest.placetype),
+			}
 
 			for (const place of hierarchy) {
 				const key = PLACETYPE_TO_KEY[place.placetype]

--- a/photon/index.test.ts
+++ b/photon/index.test.ts
@@ -9,7 +9,13 @@ import type { AddressInfo } from "node:net"
 import express from "express"
 import { expect, test } from "vitest"
 
-import { createPhotonRouter, type PhotonEngine } from "./index.js"
+import {
+	createPhotonRouter,
+	type PhotonEngine,
+	photonForwardFeature,
+	photonForwardProperties,
+	photonOsmTags,
+} from "./index.js"
 
 const engine: PhotonEngine = {
 	search: async () => ({ type: "FeatureCollection", features: [] }),
@@ -27,6 +33,97 @@ async function withServer(app: express.Express, fn: (base: string) => Promise<vo
 		await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
 	}
 }
+
+// #1014 — forward /api must decorate properties from the RESOLVED gazetteer place (proper-cased
+// names + ancestry + country), not the parsed input span, and carry osm_key/osm_value/type so
+// Photon client libs (leaflet-control-geocoder, @openrunner/photon-geocoder) don't TypeError.
+
+test("forward: name/city from the RESOLVED gazetteer name, not the parsed span casing", () => {
+	// The parse span was lowercase "paris"; the resolver's canonical name is "Paris".
+	const props = photonForwardProperties({
+		lat: 48.8566,
+		lon: 2.3522,
+		postcode: "75008",
+		country: { name: "France", code: "FR" },
+		places: [{ tag: "locality", name: "Paris" }],
+	})
+	expect(props.name).toBe("Paris")
+	expect(props.city).toBe("Paris")
+	expect(props.postcode).toBe("75008")
+	expect(props.country).toBe("France")
+	expect(props.countrycode).toBe("fr")
+})
+
+test("forward: always carries osm_key/osm_value/type (client TypeErrors without them — #1014 P0)", () => {
+	// A city primary maps to place/city/city…
+	const city = photonForwardProperties({ lat: 52.5, lon: 13.4, places: [{ tag: "locality", name: "Berlin" }] })
+	expect(city.osm_key).toBe("place")
+	expect(city.osm_value).toBe("city")
+	expect(city.type).toBe("city")
+	// …and even an unmapped/empty resolution still sets the fields (never undefined).
+	const bare = photonForwardProperties({ lat: 0, lon: 0, places: [] })
+	expect(bare.osm_key).toBeDefined()
+	expect(bare.osm_value).toBeDefined()
+	expect(bare.type).toBeDefined()
+})
+
+test("forward: fills the full admin ladder from resolved ancestry (parity with /reverse)", () => {
+	const props = photonForwardProperties({
+		lat: 38.9,
+		lon: -77.0,
+		country: { name: "United States", code: "US" },
+		places: [
+			{ tag: "locality", name: "Washington" },
+			{ tag: "county", name: "District of Columbia" },
+			{ tag: "region", name: "District of Columbia" },
+			{ tag: "country", name: "United States" },
+		],
+	})
+	expect(props.city).toBe("Washington")
+	expect(props.county).toBe("District of Columbia")
+	expect(props.state).toBe("District of Columbia")
+	expect(props.country).toBe("United States")
+	// name = the most-specific resolved place.
+	expect(props.name).toBe("Washington")
+	expect(props.type).toBe("city")
+})
+
+test("forward: a street-primary result names the street and types as street", () => {
+	const props = photonForwardProperties({
+		lat: 38.8977,
+		lon: -77.0365,
+		places: [
+			{ tag: "street", name: "Pennsylvania Avenue Northwest" },
+			{ tag: "locality", name: "Washington" },
+		],
+	})
+	expect(props.name).toBe("Pennsylvania Avenue Northwest")
+	expect(props.street).toBe("Pennsylvania Avenue Northwest")
+	expect(props.city).toBe("Washington")
+	expect(props.type).toBe("street")
+})
+
+test("photonOsmTags: maps place tiers to the Photon osm schema, with a safe fallback", () => {
+	expect(photonOsmTags("locality")).toEqual({ osm_key: "place", osm_value: "city", type: "city" })
+	expect(photonOsmTags("localadmin")).toEqual({ osm_key: "place", osm_value: "city", type: "city" }) // reverse placetype
+	expect(photonOsmTags("region")).toEqual({ osm_key: "place", osm_value: "state", type: "state" })
+	expect(photonOsmTags("country")).toEqual({ osm_key: "place", osm_value: "country", type: "country" })
+	expect(photonOsmTags("whatever")).toEqual({ osm_key: "place", osm_value: "yes", type: "other" }) // unknown → fallback
+})
+
+test("contract: /api and /reverse derive the same osm tags for a place (#1014 checkbox 4)", () => {
+	// The forward projection (primary=locality) and the /reverse path (deepest.placetype=locality) both go through
+	// photonOsmTags, so they can't drift.
+	const fwd = photonForwardProperties({ lat: 0, lon: 0, places: [{ tag: "locality", name: "X" }] })
+	expect({ osm_key: fwd.osm_key, osm_value: fwd.osm_value, type: fwd.type }).toEqual(photonOsmTags("locality"))
+})
+
+test("photonForwardFeature: wraps properties as a Point Feature at [lon, lat]", () => {
+	const f = photonForwardFeature({ lat: 52.5, lon: 13.4, places: [{ tag: "locality", name: "Berlin" }] })
+	expect(f.type).toBe("Feature")
+	expect(f.geometry).toEqual({ type: "Point", coordinates: [13.4, 52.5] })
+	expect(f.properties.city).toBe("Berlin")
+})
 
 test("CORS: permissive Access-Control-Allow-Origin on responses (upstream Photon parity)", async () => {
 	await withServer(express().use(createPhotonRouter(engine)), async (base) => {

--- a/photon/index.test.ts
+++ b/photon/index.test.ts
@@ -14,7 +14,7 @@ import {
 	type PhotonEngine,
 	photonForwardFeature,
 	photonForwardProperties,
-	photonOsmTags,
+	photonOSMTags,
 } from "./index.js"
 
 const engine: PhotonEngine = {
@@ -103,19 +103,19 @@ test("forward: a street-primary result names the street and types as street", ()
 	expect(props.type).toBe("street")
 })
 
-test("photonOsmTags: maps place tiers to the Photon osm schema, with a safe fallback", () => {
-	expect(photonOsmTags("locality")).toEqual({ osm_key: "place", osm_value: "city", type: "city" })
-	expect(photonOsmTags("localadmin")).toEqual({ osm_key: "place", osm_value: "city", type: "city" }) // reverse placetype
-	expect(photonOsmTags("region")).toEqual({ osm_key: "place", osm_value: "state", type: "state" })
-	expect(photonOsmTags("country")).toEqual({ osm_key: "place", osm_value: "country", type: "country" })
-	expect(photonOsmTags("whatever")).toEqual({ osm_key: "place", osm_value: "yes", type: "other" }) // unknown → fallback
+test("photonOSMTags: maps place tiers to the Photon osm schema, with a safe fallback", () => {
+	expect(photonOSMTags("locality")).toEqual({ osm_key: "place", osm_value: "city", type: "city" })
+	expect(photonOSMTags("localadmin")).toEqual({ osm_key: "place", osm_value: "city", type: "city" }) // reverse placetype
+	expect(photonOSMTags("region")).toEqual({ osm_key: "place", osm_value: "state", type: "state" })
+	expect(photonOSMTags("country")).toEqual({ osm_key: "place", osm_value: "country", type: "country" })
+	expect(photonOSMTags("whatever")).toEqual({ osm_key: "place", osm_value: "yes", type: "other" }) // unknown → fallback
 })
 
 test("contract: /api and /reverse derive the same osm tags for a place (#1014 checkbox 4)", () => {
 	// The forward projection (primary=locality) and the /reverse path (deepest.placetype=locality) both go through
-	// photonOsmTags, so they can't drift.
+	// photonOSMTags, so they can't drift.
 	const fwd = photonForwardProperties({ lat: 0, lon: 0, places: [{ tag: "locality", name: "X" }] })
-	expect({ osm_key: fwd.osm_key, osm_value: fwd.osm_value, type: fwd.type }).toEqual(photonOsmTags("locality"))
+	expect({ osm_key: fwd.osm_key, osm_value: fwd.osm_value, type: fwd.type }).toEqual(photonOSMTags("locality"))
 })
 
 test("photonForwardFeature: wraps properties as a Point Feature at [lon, lat]", () => {

--- a/photon/index.ts
+++ b/photon/index.ts
@@ -272,7 +272,7 @@ const DEFAULT_OSM_TAGS = { osm_key: "place", osm_value: "yes", type: "other" } a
  * falling back to a safe default so the fields are always present. Shared by the forward projection and `/reverse` so
  * the two endpoints report a place the SAME way. #1014.
  */
-export function photonOsmTags(tagOrPlacetype: string): { osm_key: string; osm_value: string; type: string } {
+export function photonOSMTags(tagOrPlacetype: string): { osm_key: string; osm_value: string; type: string } {
 	const proj = FORWARD_TAG_PROJECTION[tagOrPlacetype]
 
 	return proj ? { osm_key: proj.osmKey, osm_value: proj.osmValue, type: proj.type } : { ...DEFAULT_OSM_TAGS }
@@ -290,7 +290,7 @@ export function photonForwardProperties(input: PhotonForwardInput): PhotonProper
 
 	if (primary) {
 		props.name = primary.name
-		Object.assign(props, photonOsmTags(primary.tag))
+		Object.assign(props, photonOSMTags(primary.tag))
 	}
 
 	for (const place of input.places) {

--- a/photon/index.ts
+++ b/photon/index.ts
@@ -224,3 +224,91 @@ export function photonFeature(lon: number, lat: number, properties: PhotonProper
 export function photonCollection(features: PhotonFeature[]): PhotonFeatureCollection {
 	return { type: "FeatureCollection", features }
 }
+
+/**
+ * The resolved-place info a forward `/api` result carries: the admin ladder (MOST-SPECIFIC first) with GAZETTEER names,
+ * the coordinate, the resolved country, and the postcode. {@link photonForwardProperties} projects it onto Photon's
+ * schema. #1014 — decorate from the resolved place, not the parsed input span.
+ */
+export interface PhotonForwardInput {
+	lat: number
+	lon: number
+	postcode?: string | null
+	/** The resolved country, mapped by the caller (ISO2 → canonical name via `@mailwoman/codex`). */
+	country?: { name?: string; code?: string } | null
+	/** Resolved admin ancestry, most-specific first, each carrying the gazetteer's canonical name (not the parsed span). */
+	places: ReadonlyArray<{ tag: string; name: string }>
+}
+
+/**
+ * How a resolved tag projects onto Photon's schema: the property key that holds its name, plus the OSM `key`/`value`/
+ * `type` a Photon client reads. Kept close to komoot Photon's own values so client label-builders behave.
+ */
+const FORWARD_TAG_PROJECTION: Record<
+	string,
+	{ key: keyof PhotonProperties; osmKey: string; osmValue: string; type: string }
+> = {
+	venue: { key: "name", osmKey: "amenity", osmValue: "yes", type: "house" },
+	house: { key: "name", osmKey: "building", osmValue: "yes", type: "house" },
+	street: { key: "street", osmKey: "highway", osmValue: "residential", type: "street" },
+	neighbourhood: { key: "district", osmKey: "place", osmValue: "suburb", type: "district" },
+	dependent_locality: { key: "district", osmKey: "place", osmValue: "suburb", type: "district" },
+	borough: { key: "district", osmKey: "place", osmValue: "borough", type: "district" },
+	locality: { key: "city", osmKey: "place", osmValue: "city", type: "city" },
+	// WOF placetypes the /reverse hierarchy uses (so both endpoints derive osm tags from ONE table).
+	localadmin: { key: "city", osmKey: "place", osmValue: "city", type: "city" },
+	subregion: { key: "county", osmKey: "place", osmValue: "county", type: "county" },
+	county: { key: "county", osmKey: "place", osmValue: "county", type: "county" },
+	region: { key: "state", osmKey: "place", osmValue: "state", type: "state" },
+	macroregion: { key: "state", osmKey: "place", osmValue: "state", type: "state" },
+	country: { key: "country", osmKey: "place", osmValue: "country", type: "country" },
+}
+
+/** Fallback OSM tags — a Photon client reads `osm_key`/`osm_value`/`type` unconditionally, so they must never be absent. */
+const DEFAULT_OSM_TAGS = { osm_key: "place", osm_value: "yes", type: "other" } as const
+
+/**
+ * The Photon `osm_key`/`osm_value`/`type` for a resolved tag or WOF placetype (`locality`, `region`, `country`, …),
+ * falling back to a safe default so the fields are always present. Shared by the forward projection and `/reverse` so
+ * the two endpoints report a place the SAME way. #1014.
+ */
+export function photonOsmTags(tagOrPlacetype: string): { osm_key: string; osm_value: string; type: string } {
+	const proj = FORWARD_TAG_PROJECTION[tagOrPlacetype]
+
+	return proj ? { osm_key: proj.osmKey, osm_value: proj.osmValue, type: proj.type } : { ...DEFAULT_OSM_TAGS }
+}
+
+/**
+ * Project a resolved forward result into Photon properties — decorating from the RESOLVED gazetteer place (proper-cased
+ * names + ancestry + country), NOT the parsed input span, and ALWAYS emitting `osm_key`/`osm_value`/`type` so Photon
+ * client libraries (leaflet-control-geocoder, @openrunner/photon-geocoder) never dereference undefined. #1014.
+ */
+export function photonForwardProperties(input: PhotonForwardInput): PhotonProperties {
+	// Safe defaults: a Photon client reads osm_key/osm_value/type unconditionally, so they must never be undefined.
+	const props: PhotonProperties = { ...DEFAULT_OSM_TAGS }
+	const [primary] = input.places
+
+	if (primary) {
+		props.name = primary.name
+		Object.assign(props, photonOsmTags(primary.tag))
+	}
+
+	for (const place of input.places) {
+		const proj = FORWARD_TAG_PROJECTION[place.tag]
+
+		if (proj && props[proj.key] == null) props[proj.key] = place.name
+	}
+
+	if (input.postcode) props.postcode = input.postcode
+
+	if (input.country?.name && props.country == null) props.country = input.country.name
+
+	if (input.country?.code) props.countrycode = input.country.code.toLowerCase()
+
+	return props
+}
+
+/** {@link photonForwardProperties}, wrapped as a Photon Point `Feature` at the resolved coordinate. #1014. */
+export function photonForwardFeature(input: PhotonForwardInput): PhotonFeature {
+	return photonFeature(input.lon, input.lat, photonForwardProperties(input))
+}

--- a/photon/package.json
+++ b/photon/package.json
@@ -25,6 +25,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@mailwoman/codex": "workspace:*",
 		"@mailwoman/neural": "workspace:*",
 		"@mailwoman/resolver": "workspace:*",
 		"@mailwoman/resolver-wof-sqlite": "workspace:*",

--- a/photon/tsconfig.json
+++ b/photon/tsconfig.json
@@ -8,6 +8,7 @@
 	"include": ["./**/*"],
 	"exclude": ["./out/**/*", "./**/*.test.ts", "./**/*.test.tsx"],
 	"references": [
+		{ "path": "../codex" },
 		{ "path": "../neural" },
 		{ "path": "../resolver" },
 		{ "path": "../resolver-wof-sqlite" },

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -989,6 +989,11 @@ function decorateNode(node: AddressNode, resolved: ResolvedPlace, alternatives: 
 	// the right PLACE (gazetteer-name vs ground-truth) rather than merely echoing the parser's text.
 	node.metadata = { ...node.metadata, resolver_score: resolved.score, resolver_name: resolved.name }
 
+	// The resolved place's ISO-3166 alpha-2 country (from the gazetteer/candidate row), when known. #1014: lets a
+	// forward consumer fill country/countrycode without an ancestry walk — the candidate backend carries this even
+	// though it has no `ancestors()` table.
+	if (resolved.country) node.metadata["resolver_country"] = resolved.country
+
 	// The postcode/locality conflict flag (the falsehood differentiator): the postcode pointed to a
 	// geographically different place than the parsed city name. Surface it so callers can warn rather
 	// than silently trust the resolved point.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,6 +4895,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mailwoman/photon@workspace:photon"
   dependencies:
+    "@mailwoman/codex": "workspace:*"
     "@mailwoman/neural": "workspace:*"
     "@mailwoman/resolver": "workspace:*"
     "@mailwoman/resolver-wof-sqlite": "workspace:*"


### PR DESCRIPTION
Closes #1014.

## Problem

Forward `/api` built its GeoJSON `properties` from the **parsed input spans**, not the resolved gazetteer place:

| Query | Before |
|---|---|
| `berlin` | `{name:"Berlin", city:"Berlin"}` |
| `55 rue…paris` | `{name:"paris", city:"paris", postcode:"75008"}` — lowercase echo |
| `Gent Sint-Pietersnieuwstraat 25` | `{name:"Gent Sint-Pietersnieuwstraat", city:"…"}` — span leaked into city |

No `country`/`countrycode`/`state`, and **no `osm_key`/`osm_value`/`type`** — the field a Photon client dereferences, which is the `@openrunner/photon-geocoder` **TypeError (the P0)**. `/reverse` already decorated from the resolved place; forward didn't.

## Fix

Decorate the forward result from the **resolved** place (the source `/reverse` uses), and emit the osm schema:

- **resolver** (`decorateNode`): stamp the resolved ISO-3166 alpha-2 country (`resolver_country`). The candidate backend carries the country code even though it has no `ancestors()` table.
- **geocode-core** (`extractGeocodeResult`): surface the gazetteer's canonical name (`hierarchy[].name`, proper-cased, distinct from the parsed `value`) and the resolved `countryCode`. Additive — existing fields unchanged.
- **photon**: a pure, unit-tested projection — `photonForwardProperties` / `photonForwardFeature` / `photonOsmTags` — builds `name`/`city`/`state`/`county`/`country` + `osm_key`/`osm_value`/`type` from the resolved ancestry (osm fields **always** present so clients never deref undefined). The CLI wires it, resolving the country name via codex `matchCountry`. `/reverse` routes through the same `photonOsmTags`, so both endpoints report a place identically (checkbox 4).

## Verification

- **Unit (TDD, RED→GREEN)**: 20 new/updated tests across `photon/index.test.ts` + `mailwoman/geocode-core.test.ts`; resolver's 48 still pass (the `resolver_country` stamp is additive). `tsc -b` clean, oxlint/oxfmt clean.
- **End-to-end on a local build** (candidate backend, real data):

  | Query | After |
  |---|---|
  | `berlin` | `+country:"Germany"/de` + `osm place/city/city` |
  | `55 rue…paris` | `name:"Paris"` (was `"paris"`) `+country:"France"` |
  | `Gent…` | `name:"Gent"` (**leak fixed**) `+country:"Belgium"` |
  | `1600 Pennsylvania Ave NW Washington DC 20500` | `name/city:Washington, state:District of Columbia, postcode:20500, country:US` + osm |
  | `/reverse` | now carries `osm_key/osm_value/type` alongside the existing block |

## Backend note (honest scope)

Full `state`/`county` parity needs the resolver's `ancestors()` (`includeAncestors`, #404). The hosted `photon.sister.software` **candidate** backend has no `ancestors` table, so `state`/`county` fill only when a region node resolves (as in the DC case above) — **country always lands from the resolved code**. Ships in the next release; the hosted service repoints then. A follow-up could wire `includeAncestors` on an ancestry-capable backend (or reverse-enrich) for guaranteed state/county on every result.

Related wire-polish cluster: #1016 (honor limit/bias/lang) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)