### PR TITLE
feat(#1016): photon /api honors limit (ranked top-N) + lat/lon proximity bias

### DIFF
--- a/docs/articles/concepts/switching-from-photon.mdx
+++ b/docs/articles/concepts/switching-from-photon.mdx
@@ -23,14 +23,19 @@ curl "http://localhost:2322/reverse?lat=52.52&lon=13.405"
 
 ## Endpoint map
 
-| Photon         | Mailwoman      | Notes                                             |
-| -------------- | -------------- | ------------------------------------------------- |
-| `GET /api`     | `GET /api`     | `q`, `limit`, `lat`/`lon` bias, `lang`, `osm_tag` |
-| `GET /reverse` | `GET /reverse` | `lat` / `lon`                                     |
+| Photon         | Mailwoman      | Parameters honored                |
+| -------------- | -------------- | --------------------------------- |
+| `GET /api`     | `GET /api`     | `q`, `limit`, `lat`/`lon` bias     |
+| `GET /reverse` | `GET /reverse` | `lat` / `lon`                     |
+
+`limit` returns the top-N ranked matches (an ambiguous name like `Springfield` yields each instance),
+and `lat`/`lon` is a proximity bias — the same query near different map centers re-ranks the results
+toward the viewport. `lang` and `osm_tag` are accepted for wire compatibility but not yet applied:
+`lang` because the model ships a single (en-US) locale, and `osm_tag` layer filtering is on the roadmap.
 
 Both return a GeoJSON `FeatureCollection` of `Point` features with `properties` (`name`, `street`,
-`postcode`, `city`, `county`, `state`, `country`, `countrycode`, …) — the shape a Photon client already
-parses.
+`postcode`, `city`, `county`, `state`, `country`, `countrycode`, `osm_key`, `osm_value`, `type`, …) —
+the shape a Photon client already parses.
 
 ## What's different
 

--- a/mailwoman/geocode-core.test.ts
+++ b/mailwoman/geocode-core.test.ts
@@ -105,3 +105,86 @@ describe("extractGeocodeResult — resolved-place surfacing (#1014)", () => {
 		expect(extractGeocodeResult("berlin", tree).hierarchy[0]?.name).toBe("Berlin")
 	})
 })
+
+describe("extractGeocodeResult — ranked candidates for limit>1 (#1016)", () => {
+	it("surfaces the resolved primary plus its alternatives, self first", () => {
+		const tree: AddressTree = {
+			raw: "springfield",
+			roots: [
+				node({
+					tag: "locality",
+					value: "springfield",
+					lat: 37.19,
+					lon: -93.29,
+					placeID: "wof:100",
+					metadata: { resolver_name: "Springfield", resolver_country: "US" },
+					// ranked runner-ups (Springfield MA, then IL) the resolver captured on the node
+					alternatives: [
+						{ id: 201, name: "Springfield", placetype: "locality", lat: 42.11, lon: -72.54, country: "US" },
+						{ id: 202, name: "Springfield", placetype: "locality", lat: 39.77, lon: -89.65, country: "US" },
+					],
+				}),
+			],
+		}
+		const r = extractGeocodeResult("springfield", tree)
+		expect(r.candidates).toHaveLength(3) // self + 2 alternatives
+		expect(r.candidates[0]).toMatchObject({
+			name: "Springfield",
+			tag: "locality",
+			lat: 37.19,
+			countryCode: "US",
+			placeID: "wof:100",
+		})
+		expect(r.candidates[1]).toMatchObject({ name: "Springfield", lat: 42.11, countryCode: "US", placeID: "wof:201" })
+		expect(r.candidates[2]).toMatchObject({ lat: 39.77, placeID: "wof:202" })
+	})
+
+	it("collapses same-coordinate duplicates (a city + its coincident township)", () => {
+		const tree: AddressTree = {
+			raw: "springfield",
+			roots: [
+				node({
+					tag: "locality",
+					value: "springfield",
+					lat: 37.194291,
+					lon: -93.291579,
+					placeID: "wof:100",
+					metadata: { resolver_name: "Springfield", resolver_country: "US" },
+					alternatives: [
+						// same point as the primary (~0.2 m) → dropped
+						{
+							id: 101,
+							name: "Springfield Township",
+							placetype: "localadmin",
+							lat: 37.194301,
+							lon: -93.291581,
+							country: "US",
+						},
+						// a genuinely distinct namesake → kept
+						{ id: 201, name: "Springfield", placetype: "locality", lat: 42.115503, lon: -72.53952, country: "US" },
+					],
+				}),
+			],
+		}
+		const r = extractGeocodeResult("springfield", tree)
+		expect(r.candidates).toHaveLength(2) // primary + the distinct MA one; the coincident township is dropped
+		expect(r.candidates.map((c) => c.placeID)).toEqual(["wof:100", "wof:201"])
+	})
+
+	it("is a single entry for an unambiguous result (no alternatives)", () => {
+		const tree: AddressTree = {
+			raw: "berlin",
+			roots: [
+				node({
+					tag: "locality",
+					value: "Berlin",
+					lat: 52.5,
+					lon: 13.4,
+					placeID: "wof:101909779",
+					metadata: { resolver_name: "Berlin", resolver_country: "DE" },
+				}),
+			],
+		}
+		expect(extractGeocodeResult("berlin", tree).candidates).toHaveLength(1)
+	})
+})

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -65,6 +65,20 @@ export interface GeocodeResult {
 	 * (proper-cased canonical, #1014) — distinct from `value`, the raw parsed input span.
 	 */
 	hierarchy: Array<{ tag: string; value: string; name: string; lat?: number; lon?: number; placeID?: string }>
+	/**
+	 * Ranked candidate resolutions for the query's primary place — the winning place first, then the resolver's
+	 * same-query alternatives (Springfield MO, MA, IL, …), each with its own coordinate + country. #1016 — lets a
+	 * `limit`>1 / autocomplete client return the top-N matches instead of only the single best. The order reflects any
+	 * proximity `bias`; an unambiguous result yields a single entry.
+	 */
+	candidates: Array<{
+		name: string
+		tag: string
+		lat: number
+		lon: number
+		countryCode: string | null
+		placeID?: string
+	}>
 }
 
 /**
@@ -613,6 +627,60 @@ export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeR
 		}
 	}
 
+	// #1016: ranked candidate places for the winning result — the resolved primary node (self) plus its
+	// `alternatives` (the resolver's same-query runner-ups, already ranked and bias-aware). Each is a distinct place
+	// with its own coordinate, so an ambiguous name (Springfield MO/MA/IL) returns all its instances for limit>1.
+	// The primary is the resolved node whose coordinate WON (else the first resolved admin node — a bare-name query).
+	const primaryNode =
+		allNodes.find((n) => n.metadata?.["resolver_name"] && n.lat === lat && n.lon === lon) ??
+		allNodes.find((n) => n.metadata?.["resolver_name"] && n.lat != null)
+	const candidates: GeocodeResult["candidates"] = []
+
+	if (primaryNode?.lat != null) {
+		// Collapse same-point duplicates (a city + its coincident township share a centroid): two places at one
+		// coordinate are not distinct autocomplete suggestions. ~11 m grid (4 decimals) keeps genuinely distinct
+		// namesakes (Springfield MA vs IL are far apart) while dropping the variants.
+		const seen = new Set<string>()
+		const coordKey = (lt: number, ln: number): string => `${lt.toFixed(4)},${ln.toFixed(4)}`
+		seen.add(coordKey(primaryNode.lat, primaryNode.lon!))
+		candidates.push({
+			name: (primaryNode.metadata?.["resolver_name"] as string | undefined)?.trim() || primaryNode.value.trim(),
+			tag: primaryNode.tag,
+			lat: primaryNode.lat,
+			lon: primaryNode.lon!,
+			countryCode: (primaryNode.metadata?.["resolver_country"] as string | undefined)?.trim()?.toUpperCase() ?? null,
+			...(primaryNode.placeID ? { placeID: primaryNode.placeID } : {}),
+		})
+
+		const alts =
+			(primaryNode.alternatives as
+				| ReadonlyArray<{
+						name?: string
+						placetype?: string
+						lat?: number
+						lon?: number
+						country?: string
+						id?: number | string
+				  }>
+				| undefined) ?? []
+
+		for (const a of alts) {
+			if (a.lat == null || a.lon == null || !a.name) continue
+			const key = coordKey(a.lat, a.lon)
+
+			if (seen.has(key)) continue
+			seen.add(key)
+			candidates.push({
+				name: String(a.name).trim(),
+				tag: a.placetype ?? primaryNode.tag,
+				lat: a.lat,
+				lon: a.lon,
+				countryCode: a.country ? String(a.country).trim().toUpperCase() : null,
+				...(a.id != null ? { placeID: `wof:${a.id}` } : {}),
+			})
+		}
+	}
+
 	return {
 		input,
 		lat,
@@ -624,5 +692,6 @@ export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeR
 		postcode,
 		countryCode,
 		hierarchy,
+		candidates,
 	}
 }

--- a/photon/cli.ts
+++ b/photon/cli.ts
@@ -33,7 +33,8 @@ import {
 	createPhotonRouter,
 	photonCollection,
 	photonFeature,
-	photonForwardFeature,
+	photonForwardCollection,
+	type PhotonForwardInput,
 	photonOSMTags,
 	type PhotonEngine,
 	type PhotonProperties,
@@ -92,10 +93,13 @@ async function serve(): Promise<void> {
 			const query = params.q?.trim()
 
 			if (!query || query.length > MAX_QUERY_LEN) return photonCollection([])
+			// #1016: forward the client's viewport/user location as a proximity bias — a SOFT re-rank the resolver
+			// folds into candidate scoring (Springfield near the map center wins). Only when both coords are present.
+			const bias = params.lat != null && params.lon != null ? [{ lat: params.lat, lon: params.lon }] : undefined
 			// No country constraint: the default-on #244 placer routes the query's country (Berlin→DE,
 			// Boston→US). Forcing "US" here is a HARD override (geocode-core.ts:102) that resolved every
 			// non-US query to its US namesake — wrong for a global autocomplete front.
-			const result = await geocodeAddress(query, { classifier, resolver, shards: shards.for })
+			const result = await geocodeAddress(query, { classifier, resolver, shards: shards.for, bias })
 
 			if (result.lat == null || result.lon == null) return photonCollection([])
 			// #1014: decorate from the RESOLVED gazetteer place — proper-cased ancestry names (`hierarchy[].name`,
@@ -103,16 +107,27 @@ async function serve(): Promise<void> {
 			// Photon clients don't TypeError. The candidate backend fills only the locality (no ancestors() table),
 			// so state/county come through only on an ancestry-capable backend — country still lands from the code.
 			const country = matchCountry(result.countryCode)
+			const primary: PhotonForwardInput = {
+				lat: result.lat,
+				lon: result.lon,
+				postcode: result.postcode,
+				country: country ? { name: country.canonical, code: country.iso2 } : undefined,
+				places: result.hierarchy.map((h) => ({ tag: h.tag, name: h.name })),
+			}
+			// #1016: candidates[0] is the primary itself; its ranked alternatives (Springfield MA/IL/…) become the
+			// extra features, up to the requested `limit`. Each alternative is a single resolved place.
+			const alternatives = result.candidates.slice(1).map((c) => {
+				const cc = matchCountry(c.countryCode)
 
-			return photonCollection([
-				photonForwardFeature({
-					lat: result.lat,
-					lon: result.lon,
-					postcode: result.postcode,
-					country: country ? { name: country.canonical, code: country.iso2 } : undefined,
-					places: result.hierarchy.map((h) => ({ tag: h.tag, name: h.name })),
-				}),
-			])
+				return {
+					lat: c.lat,
+					lon: c.lon,
+					country: cc ? { name: cc.canonical, code: cc.iso2 } : undefined,
+					places: [{ tag: c.tag, name: c.name }],
+				}
+			})
+
+			return photonForwardCollection({ primary, alternatives }, params.limit)
 		},
 
 		async reverse(params) {

--- a/photon/index.test.ts
+++ b/photon/index.test.ts
@@ -11,10 +11,12 @@ import { expect, test } from "vitest"
 
 import {
 	createPhotonRouter,
-	type PhotonEngine,
+	photonForwardCollection,
 	photonForwardFeature,
+	type PhotonForwardInput,
 	photonForwardProperties,
 	photonOSMTags,
+	type PhotonEngine,
 } from "./index.js"
 
 const engine: PhotonEngine = {
@@ -116,6 +118,25 @@ test("contract: /api and /reverse derive the same osm tags for a place (#1014 ch
 	// photonOSMTags, so they can't drift.
 	const fwd = photonForwardProperties({ lat: 0, lon: 0, places: [{ tag: "locality", name: "X" }] })
 	expect({ osm_key: fwd.osm_key, osm_value: fwd.osm_value, type: fwd.type }).toEqual(photonOSMTags("locality"))
+})
+
+test("photonForwardCollection: primary first, then alternatives, capped at limit (#1016)", () => {
+	const primary: PhotonForwardInput = { lat: 37.19, lon: -93.29, places: [{ tag: "locality", name: "Springfield" }] }
+	const alternatives: PhotonForwardInput[] = [
+		{ lat: 42.11, lon: -72.54, places: [{ tag: "locality", name: "Springfield" }] },
+		{ lat: 39.77, lon: -89.65, places: [{ tag: "locality", name: "Springfield" }] },
+	]
+	const fc = photonForwardCollection({ primary, alternatives }, 2)
+	expect(fc.features).toHaveLength(2) // capped at limit
+	expect(fc.features[0]!.geometry.coordinates).toEqual([-93.29, 37.19]) // primary first
+	expect(fc.features[1]!.geometry.coordinates).toEqual([-72.54, 42.11])
+})
+
+test("photonForwardCollection: limit≥available returns all; limit<1 floors to the single best", () => {
+	const primary: PhotonForwardInput = { lat: 0, lon: 0, places: [{ tag: "locality", name: "A" }] }
+	const alternatives: PhotonForwardInput[] = [{ lat: 1, lon: 1, places: [{ tag: "locality", name: "B" }] }]
+	expect(photonForwardCollection({ primary, alternatives }, 10).features).toHaveLength(2)
+	expect(photonForwardCollection({ primary, alternatives }, 0).features).toHaveLength(1)
 })
 
 test("photonForwardFeature: wraps properties as a Point Feature at [lon, lat]", () => {

--- a/photon/index.ts
+++ b/photon/index.ts
@@ -312,3 +312,27 @@ export function photonForwardProperties(input: PhotonForwardInput): PhotonProper
 export function photonForwardFeature(input: PhotonForwardInput): PhotonFeature {
 	return photonFeature(input.lon, input.lat, photonForwardProperties(input))
 }
+
+/** The winning place plus its ranked alternatives — the input to {@link photonForwardCollection}. #1016. */
+export interface PhotonForwardResult {
+	/** The winning place, with full admin ancestry (from the resolved hierarchy). */
+	primary: PhotonForwardInput
+	/** Ranked alternative places (Springfield MA / IL / …), each a single-place input; excludes the primary. */
+	alternatives: PhotonForwardInput[]
+}
+
+/**
+ * Assemble a Photon `FeatureCollection` honoring `limit` (#1016): the primary feature first, then ranked alternatives,
+ * capped at `limit`. `limit` floors to 1 (Photon always returns at least the best match).
+ */
+export function photonForwardCollection(result: PhotonForwardResult, limit: number): PhotonFeatureCollection {
+	const cap = Math.max(1, Math.floor(limit) || 1)
+	const features = [photonForwardFeature(result.primary)]
+
+	for (const alt of result.alternatives) {
+		if (features.length >= cap) break
+		features.push(photonForwardFeature(alt))
+	}
+
+	return photonCollection(features)
+}


### PR DESCRIPTION
Closes #1016.

## Problem

Live-client test found `/api` honored only `q` — `limit` always returned exactly 1 feature, `lat`/`lon` bias was ignored (a query biased to Paris vs Marseille returned byte-identical results), and `lang` was dropped. The advertised param table overclaimed.

## Fix

- **`limit`** — the resolver already ranks same-query candidates (`Springfield` → MO, MA, IL) as `alternatives` on the resolved node; `extractGeocodeResult` now surfaces them as a ranked `candidates` array, and `/api` returns the top-N (capped at `limit`, floor 1). Coordinate-deduped, so a city and its coincident township collapse to one suggestion.
- **`lat`/`lon` bias** — `geocodeAddress` already accepts a proximity `bias` (a soft re-rank); the CLI now forwards the client's viewport/user coords to it. Ambiguous names re-rank toward the map center.
- **`lang` / `osm_tag`** — accepted for wire compatibility but not yet applied; the `switching-from-photon` doc now says so honestly (`lang` — single-locale en-US model; `osm_tag` layer filtering — roadmap) rather than overclaiming.

### Where

- `mailwoman/geocode-core.ts` — `GeocodeResult.candidates` (ranked, coordinate-deduped, bias-aware).
- `photon/index.ts` — `photonForwardCollection` assembles the FeatureCollection honoring `limit` (pure, tested).
- `photon/cli.ts` — passes `lat`/`lon` as `bias`; maps candidates → features.

## Verification

- **Unit** (13 geocode-core + 12 photon; 88 across affected suites): candidate surfacing, coordinate dedup, `photonForwardCollection` ordering + limit cap + floor. `tsc -b` clean, oxlint/oxfmt clean.
- **End-to-end** (local build, real data):

  | Request | Result |
  |---|---|
  | `Springfield&limit=5` | 3 distinct instances — MO `[-93.29,37.19]`, MA `[-72.54,42.12]`, IL `[-89.65,39.77]` (dupes collapsed) |
  | `Springfield&limit=1` | 1 feature (default preserved) |
  | `Springfield&lat=42.1&lon=-72.6` | top = MA `[-72.54,42.12]` |
  | `Springfield&lat=39.8&lon=-89.6` | top = IL `[-89.65,39.77]` |

## Notes

Candidate depth is bounded by the resolver's alternative set (~5 today), so very large `limit` returns what's available. `lang` remains a genuine gap tied to the single-locale model. Wire-polish cluster: #1017 ✅ (5.5.0), #1014 ✅ (#1019), #1016 ✅ (this) — remaining: #1015 (BE reverse), #1009/#1010 (cold-start/data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)