### PR TITLE
chore(argv): the drawer triage's outstanding half — parseArgs standardization

### DIFF
--- a/docs/superpowers/specs/2026-07-07-scripts-drawer-to-zero.md
+++ b/docs/superpowers/specs/2026-07-07-scripts-drawer-to-zero.md
@@ -1,6 +1,14 @@
 # UNFUCK_SCRIPTS.md — Triaging the scripts drawer to zero
 
 **Date:** 2026-07-07 · **Status:** APPROVED as amended (operator: "you've got the helm")
+**Standardization addendum (PR #1033):** the argv/env cleanup the migration left behind is DONE —
+57 local-helper/inline-scan files → `parseArgs` (codemod v2), the 4 gitignored diagnostic files with
+broken cli-args imports fixed (`rg` respects .gitignore — always recount with `--no-ignore`),
+promotion-gate converted STRICT with exit-2 parity, photon/libpostal/nominatim dispatch →
+positionals, smoke-resolve's hardcoded playpen path → `dataRootPath`. Deliberately NOT converted:
+the lookup CLIs' documented negative-coordinate hand-parse and the resolver build CLIs' structured
+tested parsers — neither is the scan anti-pattern.
+
 **Amendments at approval:** Phase 0 is COMPLETE (PRs #1027/#1028/#1030/#1031 — see
 `project-gazetteer-cli-sealed-artifacts`); Phase 2 lands as **module files in `core/coarse-placer/`**
 (not Ink commands); Phase 3 lands as **`registry/tools/` modules** (commands are a later nicety).

--- a/libpostal/cli.ts
+++ b/libpostal/cli.ts
@@ -67,7 +67,8 @@ function serve(): void {
 		})
 }
 
-const command = process.argv[2]
+// Subcommand dispatch via parseArgs (strict:false — the per-command parsers own their flags).
+const command = parseArgs({ strict: false, allowPositionals: true }).positionals[0]
 
 switch (command) {
 	case "serve":

--- a/nominatim/cli.ts
+++ b/nominatim/cli.ts
@@ -308,7 +308,8 @@ async function serve(): Promise<void> {
 		})
 }
 
-const command = process.argv[2]
+// Subcommand dispatch via parseArgs (strict:false — the per-command parsers own their flags).
+const command = parseArgs({ strict: false, allowPositionals: true }).positionals[0]
 
 switch (command) {
 	case "serve":

--- a/photon/cli.ts
+++ b/photon/cli.ts
@@ -172,7 +172,8 @@ async function serve(): Promise<void> {
 		})
 }
 
-const command = process.argv[2]
+// Subcommand dispatch via parseArgs (strict:false — the per-command parsers own their flags).
+const command = parseArgs({ strict: false, allowPositionals: true }).positionals[0]
 
 switch (command) {
 	case "serve":

--- a/registry/tools/dedup-ceiling.ts
+++ b/registry/tools/dedup-ceiling.ts
@@ -31,21 +31,30 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { dataRootPath } from "@mailwoman/core/utils"
 import { addressFrequencyKey, streamRows } from "@mailwoman/registry"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const CAP = Number(arg("cap", "50000"))
-const STATE = arg("state", "TX").toUpperCase()
-const TAU = Number(arg("tau", "0.7"))
-const OUT_MD = arg("out-md", "")
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		cap: { type: "string" },
+		"out-md": { type: "string" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		tau: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { cap?: string; "out-md"?: string; sources?: string; state?: string; tau?: string }
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const CAP = Number(values["cap"] || "50000")
+const STATE = (values["state"] || "TX").toUpperCase()
+const TAU = Number(values["tau"] || "0.7")
+const OUT_MD = values["out-md"] || ""
 const REGISTRY = `${SOURCES}/nppes_npi-registry_20260607.tsv`
 
 const norm = (s: string | undefined) => (s ?? "").trim()

--- a/registry/tools/gold-set-sample.ts
+++ b/registry/tools/gold-set-sample.ts
@@ -21,22 +21,39 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { dataRootPath } from "@mailwoman/core/utils"
 import { addressFrequencyKey, streamRows } from "@mailwoman/registry"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		cap: { type: "string" },
+		n: { type: "string" },
+		"out-jsonl": { type: "string" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		tau: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	cap?: string
+	n?: string
+	"out-jsonl"?: string
+	sources?: string
+	state?: string
+	tau?: string
 }
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const CAP = Number(arg("cap", "200000"))
-const STATE = arg("state", "TX").toUpperCase()
-const TAU = Number(arg("tau", "0.7"))
-const N = Number(arg("n", "300"))
-const OUT = arg("out-jsonl", "")
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const CAP = Number(values["cap"] || "200000")
+const STATE = (values["state"] || "TX").toUpperCase()
+const TAU = Number(values["tau"] || "0.7")
+const N = Number(values["n"] || "300")
+const OUT = values["out-jsonl"] || ""
 const REGISTRY = `${SOURCES}/nppes_npi-registry_20260607.tsv`
 
 const norm = (s: string | undefined) => (s ?? "").trim()

--- a/registry/tools/matcher-scale.ts
+++ b/registry/tools/matcher-scale.ts
@@ -17,22 +17,30 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { resolveEntities, type SourceRecord } from "@mailwoman/registry"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
-const SIZES = arg("sizes", "10000,50000,100000,250000,500000")
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		dup: { type: "string" },
+		em: { type: "boolean" },
+		"out-md": { type: "string" },
+		sizes: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { dup?: string; em?: boolean; "out-md"?: string; sizes?: string }
+const SIZES = (values["sizes"] || "10000,50000,100000,250000,500000")
 	.split(",")
 	.map((s) => Number(s.trim()))
 	.filter((n) => n > 0)
-const DUP = Number(arg("dup", "3")) // avg records per distinct place
-const EM = process.argv.includes("--em")
-const OUT_MD = arg("out-md", "")
+const DUP = Number(values["dup"] || "3") // avg records per distinct place
+const EM = values["em"] ?? false
+const OUT_MD = values["out-md"] || ""
 
 /** Deterministic LCG so the eval is reproducible run to run (no Math.random). */
 function lcg(seed: number): () => number {

--- a/registry/tools/viz/cross-dataset-map.ts
+++ b/registry/tools/viz/cross-dataset-map.ts
@@ -28,18 +28,21 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { dataRootPath } from "@mailwoman/core/utils"
 import { toMapHTML } from "@mailwoman/registry"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
-const IN = arg("in", dataRootPath("record-matcher", "2026-06-16-cross-dataset-links.geojson"))
-const OUT = arg("out-html", "/tmp/cross-dataset-map.html")
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { "cross-agency-only": { type: "boolean" }, in: { type: "string" }, "out-html": { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { "cross-agency-only"?: boolean; in?: string; "out-html"?: string }
+const IN = values["in"] || dataRootPath("record-matcher", "2026-06-16-cross-dataset-links.geojson")
+const OUT = values["out-html"] || "/tmp/cross-dataset-map.html"
 
 const SOURCE_LABELS: Record<string, string> = {
 	nppes: "NPPES",
@@ -60,7 +63,7 @@ const SOURCE_AGENCY: Record<string, string> = {
 	"txhhsc-nursing": "TX HHSC",
 }
 const agencyOf = (s: string) => SOURCE_AGENCY[s] ?? s
-const CROSS_AGENCY_ONLY = process.argv.includes("--cross-agency-only")
+const CROSS_AGENCY_ONLY = values["cross-agency-only"] ?? false
 
 const sourcesOf = (f: { properties: Record<string, unknown> | null }) =>
 	Array.isArray(f.properties?.["sources"]) ? (f.properties!["sources"] as string[]) : []

--- a/registry/tools/viz/geocode-first-surface.ts
+++ b/registry/tools/viz/geocode-first-surface.ts
@@ -38,17 +38,20 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { lambda: { type: "string" }, "out-html": { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { lambda?: string; "out-html"?: string }
 // Illustrative prior. Production's record matcher uses λ=1e-4 (calibrated for the full multi-field
 // model with phone + spatial exact-key); here we want the boundary visible in a two-axis slice.
-const LAMBDA = Number(arg("lambda", "0.02"))
-const OUT_HTML = arg("out-html", "/tmp/geocode-first-surface.html")
+const LAMBDA = Number(values["lambda"] || "0.02")
+const OUT_HTML = values["out-html"] || "/tmp/geocode-first-surface.html"
 
 // ── Real Bayes-factor weights, transcribed from source (values kept in sync by comment, not import,
 //    so this generator is self-contained / independent of the match package's build state). ───────────

--- a/registry/tools/viz/source-provenance-map.ts
+++ b/registry/tools/viz/source-provenance-map.ts
@@ -29,22 +29,39 @@
 
 import { writeFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 import { dataRootPath } from "@mailwoman/core/utils"
 import { toMapHTML } from "@mailwoman/registry"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		cap: { type: "string" },
+		db: { type: "string" },
+		"nad-mod": { type: "string" },
+		"oa-mod": { type: "string" },
+		"out-html": { type: "string" },
+		state: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	cap?: string
+	db?: string
+	"nad-mod"?: string
+	"oa-mod"?: string
+	"out-html"?: string
+	state?: string
 }
-
-const STATE = arg("state", "ny").toLowerCase()
-const DB = arg("db", `${dataRootPath("address-points")}/address-points-us-${STATE}.db`)
-const OUT = arg("out-html", "/tmp/source-provenance.html")
-const NAD_MOD = Number(arg("nad-mod", "700")) // keep ~1/700 of NAD points
-const OA_MOD = Number(arg("oa-mod", "120")) // keep ~1/120 of OpenAddresses points
-const CAP = Number(arg("cap", "7000")) // per-source marker cap
+const STATE = (values["state"] || "ny").toLowerCase()
+const DB = values["db"] || `${dataRootPath("address-points")}/address-points-us-${STATE}.db`
+const OUT = values["out-html"] || "/tmp/source-provenance.html"
+const NAD_MOD = Number(values["nad-mod"] || "700") // keep ~1/700 of NAD points
+const OA_MOD = Number(values["oa-mod"] || "120") // keep ~1/120 of OpenAddresses points
+const CAP = Number(values["cap"] || "7000") // per-source marker cap
 
 // Collapse the raw `source` string into a human, mappable category. The address-point DB stores e.g.
 // "overture:NAD" or "overture:OpenAddresses/NY/NYC Open Data" — the suffix is the real upstream

--- a/registry/tools/viz/yardstick-figure.ts
+++ b/registry/tools/viz/yardstick-figure.ts
@@ -25,13 +25,17 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-const OUT = arg("out-svg", "docs/articles/evals/charts/dedup-yardstick.svg")
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { "out-svg": { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { "out-svg"?: string }
+const OUT = values["out-svg"] || "docs/articles/evals/charts/dedup-yardstick.svg"
 
 // ── The committed measurement (2026-06-16-dedup-dual-level-benchmark.md). ────────────────────────
 

--- a/scripts/check-release-parity.ts
+++ b/scripts/check-release-parity.ts
@@ -23,7 +23,16 @@
 import { readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { parseArgs } from "node:util"
 
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { "warn-only": { type: "boolean" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { "warn-only"?: boolean }
 const NPM_REGISTRY_URL = "https://registry.npmjs.org/mailwoman"
 // The demo's own fetch path (docs/src/contexts/DemoEmbed.tsx) — check what the demo actually reads,
 // not what the publisher believes it wrote.
@@ -80,7 +89,7 @@ function readDocsCurrentVersion(): string {
 	return normalizeVersion(version)
 }
 
-const warnOnly = process.argv.includes("--warn-only")
+const warnOnly = values["warn-only"] ?? false
 
 const npmLatest = await readNPMLatest()
 const checks: ParityCheck[] = []

--- a/scripts/diagnostic/export-fr-bare-tuples.ts
+++ b/scripts/diagnostic/export-fr-bare-tuples.ts
@@ -21,12 +21,16 @@ import { createInterface } from "node:readline"
 
 import { mailwomanDataRoot } from "mailwoman/resolver-backend"
 
-import { arg } from "../lib/cli-args.ts"
+import { parseArgs } from "node:util"
 
-const N = Number(arg("n", "12000"))
-const STRIDE = Number(arg("stride", "1200"))
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({ options: { "n": { type: "string" }, "out": { type: "string" }, "stride": { type: "string" } }, strict: false, allowPositionals: true })
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { "n"?: string; "out"?: string; "stride"?: string }
+const N = Number((values["n"] || "12000"))
+const STRIDE = Number((values["stride"] || "1200"))
 const BAN = `${mailwomanDataRoot()}/corpus/staging/ban-france.csv`
-const OUT = arg("out", `${mailwomanDataRoot()}/osm/fr-bare-tuples.jsonl`)
+const OUT = (values["out"] || `${mailwomanDataRoot()}/osm/fr-bare-tuples.jsonl`)
 
 // BAN header: id;id_fantoir;numero;rep;nom_voie;code_postal;code_insee;nom_commune;…
 const NUMERO = 2

--- a/scripts/eval/anchor-resolver-delta.ts
+++ b/scripts/eval/anchor-resolver-delta.ts
@@ -34,18 +34,45 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { dataRootPath } from "@mailwoman/core/utils"
 import type { ResolvedPlace } from "@mailwoman/resolver"
 import { haversineKm } from "@mailwoman/spatial"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"anchor-weight": { type: "string" },
+		candidates: { type: "string" },
+		eval: { type: "string" },
+		limit: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		"out-json": { type: "string" },
+		"out-md": { type: "string" },
+		"postcode-shards": { type: "string" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"anchor-weight"?: string
+	candidates?: string
+	eval?: string
+	limit?: string
+	model?: string
+	"model-card"?: string
+	"out-json"?: string
+	"out-md"?: string
+	"postcode-shards"?: string
+	tokenizer?: string
+	wof?: string
 }
-
 interface OaRow {
 	input: string
 	lat: number
@@ -129,18 +156,18 @@ interface DeltaRow {
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval", "data/eval/external/openaddresses-de-sample.jsonl")
-	const limit = Number(arg("limit", "0")) || Infinity
-	const anchorWeight = Number(arg("anchor-weight", "2.0"))
-	const K = Number(arg("candidates", "10"))
-	const wofPaths = arg(
-		"wof",
+	const evalPath = values["eval"] || "data/eval/external/openaddresses-de-sample.jsonl"
+	const limit = Number(values["limit"] || "0") || Infinity
+	const anchorWeight = Number(values["anchor-weight"] || "2.0")
+	const K = Number(values["candidates"] || "10")
+	const wofPaths = (
+		values["wof"] ||
 		`${dataRootPath("wof", "admin-global-priority.db")},${dataRootPath("wof", "postcode-locality-intl.db")}`
 	)
 		.split(",")
 		.map((s) => s.trim())
-	const shards = arg(
-		"postcode-shards",
+	const shards = (
+		values["postcode-shards"] ||
 		`${dataRootPath("wof", "postalcode-us.db")},${dataRootPath("wof", "postalcode-intl.db")}`
 	)
 		.split(",")
@@ -155,10 +182,10 @@ async function main(): Promise<void> {
 	const { NeuralAddressClassifier } = await import("@mailwoman/neural")
 	const { ONNXRunner } = await import("@mailwoman/neural/onnx-runner")
 	const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
-	const modelCard = JSON.parse(readFileSync(arg("model-card", "neural-weights-en-us/model-card.json"), "utf8"))
+	const modelCard = JSON.parse(readFileSync(values["model-card"] || "neural-weights-en-us/model-card.json", "utf8"))
 	const [tokenizer, runner] = await Promise.all([
-		MailwomanTokenizer.loadFromFile(arg("tokenizer", "neural-weights-en-us/tokenizer.model")),
-		ONNXRunner.create(arg("model", "neural-weights-en-us/model.onnx")),
+		MailwomanTokenizer.loadFromFile(values["tokenizer"] || "neural-weights-en-us/tokenizer.model"),
+		ONNXRunner.create(values["model"] || "neural-weights-en-us/model.onnx"),
 	])
 	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels })
 	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
@@ -333,7 +360,7 @@ async function main(): Promise<void> {
 	)
 	lines.push("")
 
-	const outMd = arg("out-md")
+	const outMd = values["out-md"] || ""
 
 	if (outMd) {
 		writeFileSync(outMd, lines.join("\n") + "\n")
@@ -341,7 +368,7 @@ async function main(): Promise<void> {
 	} else {
 		console.log(lines.join("\n"))
 	}
-	const outJson = arg("out-json")
+	const outJson = values["out-json"] || ""
 
 	if (outJson) {
 		writeFileSync(outJson, JSON.stringify({ evalPath, anchorWeight, K, n, skip, results }, null, 2))

--- a/scripts/eval/boundary-stress-baseline.ts
+++ b/scripts/eval/boundary-stress-baseline.ts
@@ -11,6 +11,8 @@
  *   300]
  */
 
+import { parseArgs } from "node:util"
+
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 
@@ -19,7 +21,9 @@ import {
 	synthesizeBoundaryStressRow,
 } from "../../corpus/src/synthesize-boundary-stress.ts"
 
-const N = Number(process.argv[process.argv.indexOf("--n") + 1] || "300")
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({ options: { n: { type: "string" } }, strict: false, allowPositionals: true })
+const N = Number((rawValues.n as string | undefined) || "300")
 function mulberry32(seed: number): () => number {
 	let a = seed >>> 0
 

--- a/scripts/eval/build-fr-golden-diversified.ts
+++ b/scripts/eval/build-fr-golden-diversified.ts
@@ -34,12 +34,21 @@
 
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
+import { parseArgs } from "node:util"
 
 import { pyJsonDumps } from "@mailwoman/core/utils"
 import { SeededRandom } from "@mailwoman/core/utils"
 
 import { csvRecordsFromZip } from "./lib/zip-csv.ts"
 
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { inplace: { type: "boolean" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { inplace?: boolean }
 const OA_ZIP = "/tmp/oa-cache/fr__countrywide.zip"
 const OA_ENTRY = "fr/countrywide.csv"
 const OUT_FILE = "data/eval/golden/v0.1.2/dev/fr-diversified.jsonl"
@@ -251,7 +260,7 @@ function reportDistribution(rows: Record<string, unknown>[]): void {
 }
 
 async function main(): Promise<void> {
-	const inplace = process.argv.includes("--inplace")
+	const inplace = values["inplace"] ?? false
 
 	const rng = new SeededRandom(RNG_SEED)
 	const cityPool = await loadOaSamples()

--- a/scripts/eval/coarse-placer-country-disambig.ts
+++ b/scripts/eval/coarse-placer-country-disambig.ts
@@ -39,6 +39,7 @@
 
 import { readFileSync, writeFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 import { CoarsePlacer, inMapPosterior } from "@mailwoman/core/coarse-placer"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
@@ -48,22 +49,46 @@ import { ONNXRunner } from "@mailwoman/neural/onnx-runner"
 import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
 import { createWOFResolver, type ResolveOpts } from "@mailwoman/resolver"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"abstain-below": { type: "string" },
+		"anchor-weight": { type: "string" },
+		distribution: { type: "boolean" },
+		eval: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		openset: { type: "boolean" },
+		"out-md": { type: "string" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"abstain-below"?: string
+	"anchor-weight"?: string
+	distribution?: boolean
+	eval?: string
+	model?: string
+	"model-card"?: string
+	openset?: boolean
+	"out-md"?: string
+	tokenizer?: string
+	wof?: string
 }
-
 /** The coarse-placer's 11 in-map countries (everything else is OTHER / off-map). */
 const IN_MAP = new Set(["US", "FR", "GB", "CN", "NL", "IT", "DE", "JP", "ES", "KR", "TW"])
 
 /** Soft-prior wiring defaults from the spec: abstain below 0.9, anchorWeight 1.0. */
-const ABSTAIN_BELOW = Number(arg("abstain-below", "0.9"))
-const ANCHOR_WEIGHT = Number(arg("anchor-weight", "1.0"))
+const ABSTAIN_BELOW = Number(values["abstain-below"] || "0.9")
+const ANCHOR_WEIGHT = Number(values["anchor-weight"] || "1.0")
 /** `--openset` uses the M2 in-map-mass reject rule (1 - P(OTHER)) instead of top-class prob. */
-const OPENSET = process.argv.includes("--openset")
+const OPENSET = values["openset"] ?? false
 // `--distribution` feeds the full in-map posterior (vs the one-hot argmax) as anchorPosterior (#244 residual).
-const DISTRIBUTION = process.argv.includes("--distribution")
+const DISTRIBUTION = values["distribution"] ?? false
 
 interface HomographRow {
 	raw: string
@@ -105,12 +130,12 @@ function resolvedWOFNodes(tree: AddressTree): Array<{ id: number; rank: number; 
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval", "data/eval/external/country-homograph-real.jsonl")
-	const wofPath = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-	const modelPath = arg("model", "neural-weights-en-us/model.onnx")
-	const tokPath = arg("tokenizer", "neural-weights-en-us/tokenizer.model")
-	const cardPath = arg("model-card", "neural-weights-en-us/model-card.json")
-	const outMd = arg("out-md", "")
+	const evalPath = values["eval"] || "data/eval/external/country-homograph-real.jsonl"
+	const wofPath = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+	const modelPath = values["model"] || "neural-weights-en-us/model.onnx"
+	const tokPath = values["tokenizer"] || "neural-weights-en-us/tokenizer.model"
+	const cardPath = values["model-card"] || "neural-weights-en-us/model-card.json"
+	const outMd = values["out-md"] || ""
 
 	const rows: HomographRow[] = readFileSync(evalPath, "utf8")
 		.split("\n")

--- a/scripts/eval/coarse-placer-inmap-misroute.ts
+++ b/scripts/eval/coarse-placer-inmap-misroute.ts
@@ -29,6 +29,7 @@
 
 import { readFileSync, writeFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 import { CoarsePlacer, inMapPosterior } from "@mailwoman/core/coarse-placer"
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
@@ -38,21 +39,47 @@ import { ONNXRunner } from "@mailwoman/neural/onnx-runner"
 import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
 import { createWOFResolver, type ResolveOpts } from "@mailwoman/resolver"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"abstain-below": { type: "string" },
+		"anchor-weight": { type: "string" },
+		distribution: { type: "boolean" },
+		eval: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		"out-md": { type: "string" },
+		"per-country": { type: "string" },
+		"posterior-floor": { type: "string" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"abstain-below"?: string
+	"anchor-weight"?: string
+	distribution?: boolean
+	eval?: string
+	model?: string
+	"model-card"?: string
+	"out-md"?: string
+	"per-country"?: string
+	"posterior-floor"?: string
+	tokenizer?: string
+	wof?: string
 }
-
 /** The 11 in-map countries; TW is excluded — the WOF admin DB has 0 TW locality/region rows. */
 const COUNTRIES = ["US", "FR", "GB", "CN", "NL", "IT", "DE", "JP", "ES", "KR"]
-const ANCHOR_WEIGHT = Number(arg("anchor-weight", "1.0"))
-const ABSTAIN_BELOW = Number(arg("abstain-below", "0.9"))
-const PER_COUNTRY = Number(arg("per-country", "200"))
+const ANCHOR_WEIGHT = Number(values["anchor-weight"] || "1.0")
+const ABSTAIN_BELOW = Number(values["abstain-below"] || "0.9")
+const PER_COUNTRY = Number(values["per-country"] || "200")
 // #928: the posterior epsilon floor under test (passed through to inMapPosterior).
-const POSTERIOR_FLOOR = Number(arg("posterior-floor", "0.05"))
+const POSTERIOR_FLOOR = Number(values["posterior-floor"] || "0.05")
 // `--distribution` feeds the full in-map posterior (vs one-hot argmax) as anchorPosterior (#244 residual).
-const DISTRIBUTION = process.argv.includes("--distribution")
+const DISTRIBUTION = values["distribution"] ?? false
 
 // Trailing explicit country tokens to strip so the country must be inferred (where the prior bites).
 const COUNTRY_TOKENS =
@@ -100,12 +127,12 @@ function resolvedWOFNodes(tree: AddressTree): Array<{ id: number; rank: number }
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval", "data/coarse-placer/test.jsonl")
-	const wofPath = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-	const modelPath = arg("model", "neural-weights-en-us/model.onnx")
-	const tokPath = arg("tokenizer", "neural-weights-en-us/tokenizer.model")
-	const cardPath = arg("model-card", "neural-weights-en-us/model-card.json")
-	const outMd = arg("out-md", "")
+	const evalPath = values["eval"] || "data/coarse-placer/test.jsonl"
+	const wofPath = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+	const modelPath = values["model"] || "neural-weights-en-us/model.onnx"
+	const tokPath = values["tokenizer"] || "neural-weights-en-us/tokenizer.model"
+	const cardPath = values["model-card"] || "neural-weights-en-us/model-card.json"
+	const outMd = values["out-md"] || ""
 
 	// Deterministic per-country sample (first PER_COUNTRY rows of each country, stable order).
 	const all = readFileSync(evalPath, "utf8")

--- a/scripts/eval/collect-span-confidences.ts
+++ b/scripts/eval/collect-span-confidences.ts
@@ -40,16 +40,37 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { dataRootPath } from "@mailwoman/core/utils"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"anchor-lookup": { type: "string" },
+		"gazetteer-lexicon": { type: "string" },
+		limit: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		out: { type: "string" },
+		set: { type: "string" },
+		tokenizer: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"anchor-lookup"?: string
+	"gazetteer-lexicon"?: string
+	limit?: string
+	model?: string
+	"model-card"?: string
+	out?: string
+	set?: string
+	tokenizer?: string
 }
-
 interface CalibRow {
 	raw: string
 	gold: [string, string][]
@@ -145,9 +166,9 @@ function gradeSpan(predTag: string, predValue: string, row: CalibRow): boolean |
 }
 
 async function main(): Promise<void> {
-	const setPath = arg("set", "data/eval/calibration/calibration-set.jsonl")
-	const outPath = arg("out", "data/eval/calibration/confidences.jsonl")
-	const limit = Number(arg("limit", "0")) || Infinity
+	const setPath = values["set"] || "data/eval/calibration/calibration-set.jsonl"
+	const outPath = values["out"] || "data/eval/calibration/confidences.jsonl"
+	const limit = Number(values["limit"] || "0") || Infinity
 
 	const rows: CalibRow[] = readFileSync(setPath, "utf8")
 		.split("\n")
@@ -158,16 +179,16 @@ async function main(): Promise<void> {
 	const { NeuralAddressClassifier } = await import("@mailwoman/neural")
 	const { ONNXRunner } = await import("@mailwoman/neural/onnx-runner")
 	const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
-	const modelCard = JSON.parse(readFileSync(arg("model-card", "neural-weights-en-us/model-card.json"), "utf8"))
+	const modelCard = JSON.parse(readFileSync(values["model-card"] || "neural-weights-en-us/model-card.json", "utf8"))
 	const [tokenizer, runner] = await Promise.all([
-		MailwomanTokenizer.loadFromFile(arg("tokenizer", "neural-weights-en-us/tokenizer.model")),
-		ONNXRunner.create(arg("model", "neural-weights-en-us/model.onnx")),
+		MailwomanTokenizer.loadFromFile(values["tokenizer"] || "neural-weights-en-us/tokenizer.model"),
+		ONNXRunner.create(values["model"] || "neural-weights-en-us/model.onnx"),
 	])
 	// Ship-config channels (v4.4.0): the calibrator must describe the model AS DEPLOYED — anchor +
 	// gazetteer (+ suppression), conventions, and the span bridge all change span confidences.
 	const { parseAnchorLookup, parseGazetteerLexicon } = await import("@mailwoman/neural")
-	const anchorPath = arg("anchor-lookup", dataRootPath("anchor", "pilot-anchor-lookup.json"))
-	const gazPath = arg("gazetteer-lexicon", "data/gazetteer/anchor-lexicon-v1.json")
+	const anchorPath = values["anchor-lookup"] || dataRootPath("anchor", "pilot-anchor-lookup.json")
+	const gazPath = values["gazetteer-lexicon"] || "data/gazetteer/anchor-lexicon-v1.json"
 	const neural = new NeuralAddressClassifier({
 		tokenizer,
 		runner,

--- a/scripts/eval/competitive-benchmark.ts
+++ b/scripts/eval/competitive-benchmark.ts
@@ -44,6 +44,8 @@ const { values: rawValues } = parseArgs({
 		out: { type: "string" },
 		systems: { type: "string" },
 		wof: { type: "string" },
+		messy: { type: "boolean" },
+		"span-rescore": { type: "boolean" },
 	},
 	strict: false,
 	allowPositionals: true,
@@ -57,6 +59,8 @@ const values = rawValues as {
 	out?: string
 	systems?: string
 	wof?: string
+	messy?: boolean
+	"span-rescore"?: boolean
 }
 const TOK = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 const CARD = "neural-weights-en-us/model-card.json"
@@ -75,10 +79,10 @@ const SYSTEMS = (values["systems"] || "mailwoman,nominatim,pelias").split(",")
 const OUT = values["out"] || ""
 // --span-rescore grades mailwoman TWICE per row — base (lever off) AND #370 spanRescore (lever on) — from
 // the SAME parse, so the off→on lift sits in the same harness as Nominatim/Pelias without doubling API calls.
-const RESCORE = process.argv.includes("--span-rescore")
+const RESCORE = values["span-rescore"] ?? false
 const THRESHOLDS = [1, 5, 25] // km — coarse "right-place" tiers
 const NOMINATIM_UA = "mailwoman-benchmark/1.0 (teffen@sister.software)"
-const MESSY = process.argv.includes("--messy")
+const MESSY = values["messy"] ?? false
 // Real-world degradation — the slice where a calibrated parser should beat a search index that leans
 // on exact tokens + the comma structure + the postcode. SAFE: drops commas/dash-postcodes + lowercases
 // + abbreviates common street words; never touches the house number.

--- a/scripts/eval/confidence-discrimination.ts
+++ b/scripts/eval/confidence-discrimination.ts
@@ -67,6 +67,8 @@ const { values: rawValues } = parseArgs({
 		"rows-in": { type: "string" },
 		"rows-out": { type: "string" },
 		svg: { type: "string" },
+		"no-messy": { type: "boolean" },
+		"no-nominatim": { type: "boolean" },
 	},
 	strict: false,
 	allowPositionals: true,
@@ -82,6 +84,8 @@ const values = rawValues as {
 	"rows-in"?: string
 	"rows-out"?: string
 	svg?: string
+	"no-messy"?: boolean
+	"no-nominatim"?: boolean
 }
 // The first collection died silently at PL ~60/80 (no JS stack → a process-level kill). Surface it
 // next time instead of exiting blind; the incremental --rows-out checkpoint makes a crash recoverable.
@@ -96,8 +100,8 @@ const CALIB = "data/eval/calibration/isotonic-en-us-v4.13.0.json"
 const MODEL = values["model"] || "out/v191/model.onnx" // shipped v4.13.0 int8
 const LOCALES = (values["locales"] || "us,it,pt,pl,fr,au").split(",")
 const N = Number(values["n"] || "80")
-const MESSY = !process.argv.includes("--no-messy")
-const NO_NOMINATIM = process.argv.includes("--no-nominatim") // skip the competitor fetch (canary/regression use)
+const MESSY = !(values["no-messy"] ?? false)
+const NO_NOMINATIM = values["no-nominatim"] ?? false // skip the competitor fetch (canary/regression use)
 const AGG = (values["agg"] || "min") as "node" | "min"
 const TAU_GRID = [0, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 0.92, 0.94, 0.95, 0.96, 0.97, 0.98, 0.99, 0.995]
 const THRESH_KM = 25

--- a/scripts/eval/conformal-calibrate.ts
+++ b/scripts/eval/conformal-calibrate.ts
@@ -49,21 +49,46 @@
  */
 
 import { readFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import type { AddressTree } from "@mailwoman/core/decoder"
 import { dataRootPath } from "@mailwoman/core/utils"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { haversine } from "@mailwoman/spatial"
 
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"address-points": { type: "string" },
+		alpha: { type: "string" },
+		"cal-frac": { type: "string" },
+		holdout: { type: "string" },
+		interpolation: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		seed: { type: "string" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"address-points"?: string
+	alpha?: string
+	"cal-frac"?: string
+	holdout?: string
+	interpolation?: string
+	model?: string
+	"model-card"?: string
+	seed?: string
+	tokenizer?: string
+	wof?: string
+}
 // ---------------------------------------------------------------------------
 // CLI helpers
 // ---------------------------------------------------------------------------
-
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
 
 // ---------------------------------------------------------------------------
 // Percentile (0-indexed: p=0.9 → 90th)
@@ -177,21 +202,21 @@ interface HoldoutRow {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-	const holdoutPath = arg("holdout", "/tmp/ood-truth.jsonl")
-	const addressPointsDb = arg("address-points", "/tmp/tx-situs.db")
-	const interpolationDb = arg("interpolation", "/tmp/tx-metro-interp.db")
-	const modelPath = arg("model", "neural-weights-en-us/model.onnx")
-	const tokenizerPath = arg("tokenizer", "neural-weights-en-us/tokenizer.model")
-	const modelCardPath = arg("model-card", "neural-weights-en-us/model-card.json")
-	const wofPaths = arg(
-		"wof",
+	const holdoutPath = values["holdout"] || "/tmp/ood-truth.jsonl"
+	const addressPointsDb = values["address-points"] || "/tmp/tx-situs.db"
+	const interpolationDb = values["interpolation"] || "/tmp/tx-metro-interp.db"
+	const modelPath = values["model"] || "neural-weights-en-us/model.onnx"
+	const tokenizerPath = values["tokenizer"] || "neural-weights-en-us/tokenizer.model"
+	const modelCardPath = values["model-card"] || "neural-weights-en-us/model-card.json"
+	const wofPaths = (
+		values["wof"] ||
 		`${dataRootPath("wof", "admin-global-priority.db")},${dataRootPath("wof", "postcode-locality-intl.db")}`
 	)
 		.split(",")
 		.map((s) => s.trim())
-	const calFrac = Number(arg("cal-frac", "0.5"))
-	const alpha = Number(arg("alpha", "0.9")) // target coverage level
-	const seed = Number(arg("seed", "20260614"))
+	const calFrac = Number(values["cal-frac"] || "0.5")
+	const alpha = Number(values["alpha"] || "0.9") // target coverage level
+	const seed = Number(values["seed"] || "20260614")
 
 	// --- load holdout ---
 	const rows: HoldoutRow[] = readFileSync(holdoutPath, "utf8")

--- a/scripts/eval/de-duplicate-locality-diag.ts
+++ b/scripts/eval/de-duplicate-locality-diag.ts
@@ -22,16 +22,31 @@
  */
 
 import { readFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { dataRootPath } from "@mailwoman/core/utils"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"anchor-lookup": { type: "string" },
+		eval: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		tokenizer: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"anchor-lookup"?: string
+	eval?: string
+	model?: string
+	"model-card"?: string
+	tokenizer?: string
 }
-
 interface OaRow {
 	input: string
 	expected: { locality?: string; region?: string }
@@ -79,7 +94,7 @@ function firstByTag(tree: AddressTree, tag: string): AddressNode | undefined {
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval", "data/eval/external/openaddresses-de-sample.jsonl")
+	const evalPath = values["eval"] || "data/eval/external/openaddresses-de-sample.jsonl"
 	const rows: OaRow[] = readFileSync(evalPath, "utf8")
 		.split("\n")
 		.filter((l) => l.trim())
@@ -88,14 +103,14 @@ async function main(): Promise<void> {
 	const { NeuralAddressClassifier, parseAnchorLookup } = await import("@mailwoman/neural")
 	const { ONNXRunner } = await import("@mailwoman/neural/onnx-runner")
 	const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
-	const modelCard = JSON.parse(readFileSync(arg("model-card", "neural-weights-en-us/model-card.json"), "utf8"))
-	const anchorPath = arg("anchor-lookup", dataRootPath("anchor", "pilot-anchor-lookup.json"))
+	const modelCard = JSON.parse(readFileSync(values["model-card"] || "neural-weights-en-us/model-card.json", "utf8"))
+	const anchorPath = values["anchor-lookup"] || dataRootPath("anchor", "pilot-anchor-lookup.json")
 	const postcodeAnchorLookup = anchorPath ? parseAnchorLookup(JSON.parse(readFileSync(anchorPath, "utf8"))) : undefined
 	const [tokenizer, runner] = await Promise.all([
 		MailwomanTokenizer.loadFromFile(
-			arg("tokenizer", dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model"))
+			values["tokenizer"] || dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 		),
-		ONNXRunner.create(arg("model", "/tmp/v093-eval/model.onnx")),
+		ONNXRunner.create(values["model"] || "/tmp/v093-eval/model.onnx"),
 	])
 	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels, postcodeAnchorLookup })
 	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]

--- a/scripts/eval/failure-dump.ts
+++ b/scripts/eval/failure-dump.ts
@@ -27,12 +27,20 @@ const { values: rawValues } = parseArgs({
 		model: { type: "string" },
 		n: { type: "string" },
 		show: { type: "string" },
+		"postcode-consistency": { type: "boolean" },
 	},
 	strict: false,
 	allowPositionals: true,
 })
 // Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
-const values = rawValues as { "candidate-db"?: string; locales?: string; model?: string; n?: string; show?: string }
+const values = rawValues as {
+	"candidate-db"?: string
+	locales?: string
+	model?: string
+	n?: string
+	show?: string
+	"postcode-consistency"?: boolean
+}
 const TOK = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 const CARD = "neural-weights-en-us/model-card.json"
 const ANCHOR = dataRootPath("anchor", "pilot-anchor-lookup.json")
@@ -41,7 +49,7 @@ const CAND = values["candidate-db"] || dataRootPath("wof", "candidate-global-20i
 const N = Number(values["n"] || "60")
 const SHOW = Number(values["show"] || "10") // misses to print per locale
 const LOCALES = (values["locales"] || "it,pt,pl,at,cz,fr,au").split(",")
-const PC_CONSISTENCY = process.argv.includes("--postcode-consistency") // #370 Lever A probe
+const PC_CONSISTENCY = values["postcode-consistency"] ?? false // #370 Lever A probe
 
 const PLACETYPE_RANK: Record<string, number> = {
 	country: 0,

--- a/scripts/eval/geocode-case-diag.ts
+++ b/scripts/eval/geocode-case-diag.ts
@@ -29,7 +29,7 @@ const shards = new ShardProvider(mod, mailwomanDataRoot())
 import { readFileSync } from "node:fs"
 const SRC = process.argv[2] ?? "txhhsc"
 const N = Number(process.argv[3] ?? "200")
-const NOCOMMA = process.argv.includes("nocomma") // #694: ingestRows space-joins columns (no commas)
+const NOCOMMA = process.argv.slice(2).includes("nocomma") // bare positional mode token — #694: ingestRows space-joins columns (no commas)
 let addrs: string[]
 
 if (SRC === "fcc") {

--- a/scripts/eval/hn-regression-diff.ts
+++ b/scripts/eval/hn-regression-diff.ts
@@ -17,6 +17,7 @@
 
 import { existsSync, readdirSync, readFileSync } from "node:fs"
 import { join } from "node:path"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import type { ComponentTag } from "@mailwoman/core/types"
@@ -25,19 +26,37 @@ import { NeuralAddressClassifier, parseAnchorLookup, parseGazetteerLexicon } fro
 import { ONNXRunner } from "@mailwoman/neural/onnx-runner"
 import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		anchor: { type: "string" },
+		base: { type: "string" },
+		candidate: { type: "string" },
+		"gazetteer-lexicon": { type: "string" },
+		golden: { type: "string" },
+		"model-card": { type: "string" },
+		tokenizer: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	anchor?: string
+	base?: string
+	candidate?: string
+	"gazetteer-lexicon"?: string
+	golden?: string
+	"model-card"?: string
+	tokenizer?: string
 }
-
-const BASE = arg("base", dataRootPath("models", "quantized", "model-v192-step-40000-int8.onnx"))
-const CAND = arg("candidate", "./out/v193a2/model.onnx")
-const GOLDEN = arg("golden", "data/eval/golden/v0.1.2")
-const TOK = arg("tokenizer", dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model"))
-const CARD = arg("model-card", "neural-weights-en-us/model-card.json")
-const ANCHOR = arg("anchor", dataRootPath("anchor", "pilot-anchor-lookup.json"))
-const GAZ = arg("gazetteer-lexicon", "data/gazetteer/anchor-lexicon-v1.json")
+const BASE = values["base"] || dataRootPath("models", "quantized", "model-v192-step-40000-int8.onnx")
+const CAND = values["candidate"] || "./out/v193a2/model.onnx"
+const GOLDEN = values["golden"] || "data/eval/golden/v0.1.2"
+const TOK = values["tokenizer"] || dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
+const CARD = values["model-card"] || "neural-weights-en-us/model-card.json"
+const ANCHOR = values["anchor"] || dataRootPath("anchor", "pilot-anchor-lookup.json")
+const GAZ = values["gazetteer-lexicon"] || "data/gazetteer/anchor-lexicon-v1.json"
 
 interface Row {
 	raw: string

--- a/scripts/eval/joint-vs-argmax.ts
+++ b/scripts/eval/joint-vs-argmax.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 /**
  * @copyright Sister Software
@@ -30,12 +31,34 @@ import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { createRuntimePipeline } from "mailwoman"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"default-country": { type: "string" },
+		eval: { type: "string" },
+		limit: { type: "string" },
+		model: { type: "string" },
+		"model-anchor-lookup": { type: "string" },
+		"model-card": { type: "string" },
+		"out-json": { type: "string" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"default-country"?: string
+	eval?: string
+	limit?: string
+	model?: string
+	"model-anchor-lookup"?: string
+	"model-card"?: string
+	"out-json"?: string
+	tokenizer?: string
+	wof?: string
 }
-
 interface GoldRow {
 	input: string
 	expected: { locality?: string | null; region?: string | null; postcode?: string | null }
@@ -81,17 +104,16 @@ function percentile(xs: number[], p: number): number {
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval")
-	const limit = Number(arg("limit", "0")) || Infinity
-	const dc = arg("default-country", "")
-	const modelPath = arg("model")
-	const cardPath = arg("model-card")
-	const tokPath = arg("tokenizer", dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model"))
-	const anchorPath = arg("model-anchor-lookup")
-	const wof = arg(
-		"wof",
+	const evalPath = values["eval"] || ""
+	const limit = Number(values["limit"] || "0") || Infinity
+	const dc = values["default-country"] || ""
+	const modelPath = values["model"] || ""
+	const cardPath = values["model-card"] || ""
+	const tokPath = values["tokenizer"] || dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
+	const anchorPath = values["model-anchor-lookup"] || ""
+	const wof =
+		values["wof"] ||
 		`${dataRootPath("wof", "admin-global-priority.db")},${dataRootPath("wof", "postcode-locality-intl.db")}`
-	)
 
 	if (!evalPath || !modelPath || !cardPath) throw new Error("need --eval, --model, --model-card")
 
@@ -250,7 +272,7 @@ async function main(): Promise<void> {
 		`  accuracy delta = ${report.accuracyDeltaPp >= 0 ? "+" : ""}${report.accuracyDeltaPp.toFixed(2)}pp  ·  latency p99 ×${report.latencyP99Multiplier.toFixed(2)}`
 	)
 
-	const outJson = arg("out-json")
+	const outJson = values["out-json"] || ""
 
 	if (outJson) {
 		writeFileSync(outJson, JSON.stringify(report, null, 2))

--- a/scripts/eval/leakage-split-f1.ts
+++ b/scripts/eval/leakage-split-f1.ts
@@ -25,15 +25,34 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		eval: { type: "string" },
+		held: { type: "string" },
+		limit: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		"out-md": { type: "string" },
+		tokenizer: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	eval?: string
+	held?: string
+	limit?: string
+	model?: string
+	"model-card"?: string
+	"out-md"?: string
+	tokenizer?: string
 }
-
 interface OaRow {
 	input: string
 	expected: { locality?: string; region?: string; postcode?: string }
@@ -125,13 +144,9 @@ function f1(c: Counts): { p: number; r: number; f1: number } {
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval", "data/eval/external/openaddresses-us-sample.jsonl")
-	const held = new Set(
-		arg("held", "VT,WY,ND")
-			.split(",")
-			.map((s) => s.trim().toUpperCase())
-	)
-	const limit = Number(arg("limit", "0")) || Infinity
+	const evalPath = values["eval"] || "data/eval/external/openaddresses-us-sample.jsonl"
+	const held = new Set((values["held"] || "VT,WY,ND").split(",").map((s) => s.trim().toUpperCase()))
+	const limit = Number(values["limit"] || "0") || Infinity
 
 	const rows: OaRow[] = readFileSync(evalPath, "utf8")
 		.split("\n")
@@ -142,10 +157,10 @@ async function main(): Promise<void> {
 	const { NeuralAddressClassifier } = await import("@mailwoman/neural")
 	const { ONNXRunner } = await import("@mailwoman/neural/onnx-runner")
 	const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
-	const modelCard = JSON.parse(readFileSync(arg("model-card", "neural-weights-en-us/model-card.json"), "utf8"))
+	const modelCard = JSON.parse(readFileSync(values["model-card"] || "neural-weights-en-us/model-card.json", "utf8"))
 	const [tokenizer, runner] = await Promise.all([
-		MailwomanTokenizer.loadFromFile(arg("tokenizer", "neural-weights-en-us/tokenizer.model")),
-		ONNXRunner.create(arg("model", "neural-weights-en-us/model.onnx")),
+		MailwomanTokenizer.loadFromFile(values["tokenizer"] || "neural-weights-en-us/tokenizer.model"),
+		ONNXRunner.create(values["model"] || "neural-weights-en-us/model.onnx"),
 	])
 	const neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels })
 	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
@@ -197,7 +212,7 @@ async function main(): Promise<void> {
 	)
 	lines.push("")
 	lines.push(
-		`- held-out rows: ${heldN} · in-training rows: ${inN} · model: ${arg("model", "neural-weights-en-us/model.onnx")}`
+		`- held-out rows: ${heldN} · in-training rows: ${inN} · model: ${values["model"] || "neural-weights-en-us/model.onnx"}`
 	)
 	lines.push("")
 	lines.push("| tag | held-out F1 | in-training F1 | gap (in − held) |")
@@ -230,7 +245,7 @@ async function main(): Promise<void> {
 	lines.push("")
 
 	const out = lines.join("\n") + "\n"
-	const outMd = arg("out-md")
+	const outMd = values["out-md"] || ""
 
 	if (outMd) {
 		writeFileSync(outMd, out)

--- a/scripts/eval/measure-locale-gate.ts
+++ b/scripts/eval/measure-locale-gate.ts
@@ -16,18 +16,21 @@
 
 import { readdirSync, readFileSync } from "node:fs"
 import { join } from "node:path"
+import { parseArgs } from "node:util"
 
 import { detectLocaleSync } from "@mailwoman/locale-gate"
 import { computeQueryShape } from "@mailwoman/query-shape"
 
-function arg(name: string, fallback: string): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
-const GOLDEN = arg("golden", "data/eval/golden/v0.1.2")
-const FALSEHOODS = arg("falsehoods", "data/eval/falsehoods")
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { falsehoods: { type: "string" }, golden: { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { falsehoods?: string; golden?: string }
+const GOLDEN = values["golden"] || "data/eval/golden/v0.1.2"
+const FALSEHOODS = values["falsehoods"] || "data/eval/falsehoods"
 
 interface Sample {
 	input: string

--- a/scripts/eval/oa-oracle-locality.ts
+++ b/scripts/eval/oa-oracle-locality.ts
@@ -51,6 +51,7 @@
 
 import { readFileSync, writeFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { dataRootPath } from "@mailwoman/core/utils"
@@ -58,12 +59,36 @@ import type { ParseOpts } from "@mailwoman/neural"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { haversineKm } from "@mailwoman/spatial"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"default-country": { type: "string" },
+		eval: { type: "string" },
+		"examples-json": { type: "string" },
+		limit: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		"oracle-only": { type: "boolean" },
+		"out-md": { type: "string" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"default-country"?: string
+	eval?: string
+	"examples-json"?: string
+	limit?: string
+	model?: string
+	"model-card"?: string
+	"oracle-only"?: boolean
+	"out-md"?: string
+	tokenizer?: string
+	wof?: string
 }
-
 interface OaRow {
 	input: string
 	lat: number
@@ -193,10 +218,10 @@ const localityExpanded = (rs: Resolved[]): Resolved | undefined => {
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval", "data/eval/external/openaddresses-us-sample.jsonl")
-	const limit = Number(arg("limit", "0")) || Infinity
-	const dbPath = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-	const dc = arg("default-country", "US")
+	const evalPath = values["eval"] || "data/eval/external/openaddresses-us-sample.jsonl"
+	const limit = Number(values["limit"] || "0") || Infinity
+	const dbPath = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+	const dc = values["default-country"] || "US"
 
 	const rows: OaRow[] = readFileSync(evalPath, "utf8")
 		.split("\n")
@@ -206,7 +231,7 @@ async function main(): Promise<void> {
 
 	// --- model (CURRENT arm). `--oracle-only` skips the model entirely (fast bucketing iteration; the
 	// `current` column is then blank — the oracle arms + buckets don't depend on the model). ---
-	const oracleOnly = process.argv.includes("--oracle-only")
+	const oracleOnly = values["oracle-only"] ?? false
 	let neural: { parse: (text: string, opts?: ParseOpts) => Promise<AddressTree> } | null = null
 	let parseOpts: ParseOpts = {}
 
@@ -214,12 +239,12 @@ async function main(): Promise<void> {
 		const { NeuralAddressClassifier } = await import("@mailwoman/neural")
 		const { ONNXRunner } = await import("@mailwoman/neural/onnx-runner")
 		const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
-		const modelCard = JSON.parse(readFileSync(arg("model-card", "neural-weights-en-us/model-card.json"), "utf8"))
+		const modelCard = JSON.parse(readFileSync(values["model-card"] || "neural-weights-en-us/model-card.json", "utf8"))
 		const [tokenizer, runner] = await Promise.all([
 			MailwomanTokenizer.loadFromFile(
-				arg("tokenizer", dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model"))
+				values["tokenizer"] || dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 			),
-			ONNXRunner.create(arg("model", dataRootPath("models", "quantized", "model-v150-step-40000-int8.onnx"))),
+			ONNXRunner.create(values["model"] || dataRootPath("models", "quantized", "model-v150-step-40000-int8.onnx")),
 		])
 		neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels })
 		parseOpts = { postcodeRepair: true }
@@ -615,7 +640,9 @@ async function main(): Promise<void> {
 	const N = arm.current.overall.n || arm.oracleExpanded.overall.n
 	lines.push(`# OA oracle-locality diagnostic — MODEL vs RESOLVER/GAZETTEER (${N} rows)`)
 	lines.push("")
-	lines.push(`Model (CURRENT): ${arg("model") || "(default v1.5.0 int8)"} | DB: ${dbPath} | default-country: ${dc}`)
+	lines.push(
+		`Model (CURRENT): ${values["model"] || "" || "(default v1.5.0 int8)"} | DB: ${dbPath} | default-country: ${dc}`
+	)
 	lines.push("")
 	lines.push(`## Current (model parse) vs Oracle (gold locality) — locality-match`)
 	lines.push("")
@@ -716,14 +743,14 @@ async function main(): Promise<void> {
 	const report = lines.join("\n")
 	console.log(report)
 
-	if (arg("out-md")) {
-		writeFileSync(arg("out-md"), report + "\n")
-		console.error(`wrote markdown → ${arg("out-md")}`)
+	if (values["out-md"] || "") {
+		writeFileSync(values["out-md"] || "", report + "\n")
+		console.error(`wrote markdown → ${values["out-md"] || ""}`)
 	}
 
-	if (arg("examples-json")) {
+	if (values["examples-json"] || "") {
 		writeFileSync(
-			arg("examples-json"),
+			values["examples-json"] || "",
 			JSON.stringify(
 				{
 					coverage: buckets.coverage,
@@ -735,7 +762,7 @@ async function main(): Promise<void> {
 				2
 			)
 		)
-		console.error(`wrote examples → ${arg("examples-json")}`)
+		console.error(`wrote examples → ${values["examples-json"] || ""}`)
 	}
 }
 

--- a/scripts/eval/oa-resolver-eval.ts
+++ b/scripts/eval/oa-resolver-eval.ts
@@ -54,6 +54,7 @@
 
 import { readFileSync, writeFileSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 import { lookupGermanState } from "@mailwoman/codex/de"
 import { lookupFrenchRegion } from "@mailwoman/codex/fr"
@@ -72,12 +73,86 @@ import {
 
 import { v0RecordToTree } from "./v0-tree-adapter.ts"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"ablate-to-anchor": { type: "boolean" },
+		"address-points": { type: "string" },
+		"admin-coherence": { type: "boolean" },
+		"anchor-min-conf": { type: "string" },
+		"anchor-off": { type: "boolean" },
+		"anchor-rerank": { type: "boolean" },
+		assembled: { type: "boolean" },
+		"candidate-db": { type: "string" },
+		cascade: { type: "boolean" },
+		"city-state-fallback": { type: "boolean" },
+		"data-root": { type: "string" },
+		"default-country": { type: "string" },
+		"errors-json": { type: "string" },
+		eval: { type: "string" },
+		"hierarchy-completion": { type: "boolean" },
+		interpolation: { type: "string" },
+		limit: { type: "string" },
+		model: { type: "string" },
+		"model-anchor-lookup": { type: "string" },
+		"model-card": { type: "string" },
+		"no-admin-coherence": { type: "boolean" },
+		"normalize-case": { type: "boolean" },
+		"out-json": { type: "string" },
+		"out-md": { type: "string" },
+		"out-resolved": { type: "string" },
+		"out-rows": { type: "string" },
+		"place-country": { type: "boolean" },
+		"place-country-hard": { type: "boolean" },
+		"place-country-hard-all": { type: "boolean" },
+		"postal-city-alias-db": { type: "string" },
+		"postcode-anchor": { type: "boolean" },
+		"postcode-shards": { type: "string" },
+		"raw-case": { type: "boolean" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"ablate-to-anchor"?: boolean
+	"address-points"?: string
+	"admin-coherence"?: boolean
+	"anchor-min-conf"?: string
+	"anchor-off"?: boolean
+	"anchor-rerank"?: boolean
+	assembled?: boolean
+	"candidate-db"?: string
+	cascade?: boolean
+	"city-state-fallback"?: boolean
+	"data-root"?: string
+	"default-country"?: string
+	"errors-json"?: string
+	eval?: string
+	"hierarchy-completion"?: boolean
+	interpolation?: string
+	limit?: string
+	model?: string
+	"model-anchor-lookup"?: string
+	"model-card"?: string
+	"no-admin-coherence"?: boolean
+	"normalize-case"?: boolean
+	"out-json"?: string
+	"out-md"?: string
+	"out-resolved"?: string
+	"out-rows"?: string
+	"place-country"?: boolean
+	"place-country-hard"?: boolean
+	"place-country-hard-all"?: boolean
+	"postal-city-alias-db"?: string
+	"postcode-anchor"?: boolean
+	"postcode-shards"?: string
+	"raw-case"?: boolean
+	tokenizer?: string
+	wof?: string
 }
-
 interface OaRow {
 	input: string
 	lat: number
@@ -321,14 +396,14 @@ function percentile(xs: number[], p: number): number | null {
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval", "data/eval/external/openaddresses-us-sample.jsonl")
-	const limit = Number(arg("limit", "0")) || Infinity
+	const evalPath = values["eval"] || "data/eval/external/openaddresses-us-sample.jsonl"
+	const limit = Number(values["limit"] || "0") || Infinity
 	// Default attaches the coordinate-first candidate shard (postcode-locality-intl.db) alongside the
 	// admin gazetteer, so locality resolution is coordinate-first by default for the locales it covers
 	// (DE/FR/GB/NL functional). It no-ops where the table has no rows (e.g. US), so US stays unchanged.
 	// Override `--wof` to measure the admin-only baseline.
-	const wofPaths = arg(
-		"wof",
+	const wofPaths = (
+		values["wof"] ||
 		`${dataRootPath("wof", "admin-global-priority.db")},${dataRootPath("wof", "postcode-locality-intl.db")}`
 	)
 		.split(",")
@@ -348,20 +423,20 @@ async function main(): Promise<void> {
 	// default /mnt pilot + the repo gazetteer lexicon). `--ablate-to-anchor` drops back to anchor-only
 	// (gazetteer + conventions OFF) for the #722 before/after comparison.
 	const { createScorer } = await import("@mailwoman/neural/scorer")
-	const modelAnchorPath = arg("model-anchor-lookup", "")
-	const ablateToAnchor = process.argv.includes("--ablate-to-anchor")
+	const modelAnchorPath = values["model-anchor-lookup"] || ""
+	const ablateToAnchor = values["ablate-to-anchor"] ?? false
 	// `--anchor-off` (#887): the sanctioned anchor ablation — `overrides.anchor=false` through
 	// createScorer (a loud warning, not a throw). Replaces the pre-#718 empty-anchor.json idiom,
 	// which the fail-closed gate now refuses (an empty lookup parses to size 0 → UnfedChannelError).
-	const anchorOff = process.argv.includes("--anchor-off")
+	const anchorOff = values["anchor-off"] ?? false
 	const overrides: import("@mailwoman/neural/scorer").ScorerOverrides = {
 		...(ablateToAnchor ? { gazetteer: false, conventions: false } : {}),
 		...(anchorOff ? { anchor: false } : {}),
 	}
 	const neural = await createScorer({
-		modelPath: arg("model"),
-		tokenizerPath: arg("tokenizer"),
-		modelCardPath: arg("model-card"),
+		modelPath: values["model"] || "",
+		tokenizerPath: values["tokenizer"] || "",
+		modelCardPath: values["model-card"] || "",
 		...(modelAnchorPath ? { anchorLookupPath: modelAnchorPath } : {}),
 		strict: true,
 		tier: "server",
@@ -384,11 +459,11 @@ async function main(): Promise<void> {
 	// `--candidate-db <candidate.db>` swaps the FTS backend for the byte-range candidate-table lookup
 	// (the SAME backend + ranking the browser demo uses). This is the "CLI matches demo" gate: run the
 	// eval both ways and confirm US locality/coord don't regress before defaulting the CLI to it.
-	const candidateDb = arg("candidate-db", "")
+	const candidateDb = values["candidate-db"] || ""
 	// `--postal-city-alias-db <db>` (#475) attaches the opt-in postal-city alias scorer on the FTS
 	// path: a user-typed postal city resolves to its geographic locality. Run the eval with and
 	// without to measure the lift. No-op on the candidate backend (it folds aliases at build time).
-	const postalCityAliasDB = arg("postal-city-alias-db", "")
+	const postalCityAliasDB = values["postal-city-alias-db"] || ""
 	const { WOFSqlitePlaceLookup, WOFCandidateTableLookup, WOFPostalCityAliasLookup } =
 		await import("@mailwoman/resolver-wof-sqlite")
 	const postalCityAliases = postalCityAliasDB
@@ -497,11 +572,7 @@ async function main(): Promise<void> {
 	// (default-ON at the classifier since #895). `--normalize-case` pins ON, `--raw-case` pins OFF,
 	// neither = the library default. Silent config shifts in a gate battery are the #718 sin — pin
 	// explicitly in pre-registered legs.
-	const normalizeCase = process.argv.includes("--normalize-case")
-		? true
-		: process.argv.includes("--raw-case")
-			? false
-			: undefined
+	const normalizeCase = (values["normalize-case"] ?? false) ? true : (values["raw-case"] ?? false) ? false : undefined
 	const parseOpts = {
 		postcodeRepair: true,
 		...(normalizeCase !== undefined ? { normalizeCase } : {}),
@@ -510,21 +581,17 @@ async function main(): Promise<void> {
 	// resolved country node. It MUST match the dataset's locale — hardcoding "US" silently filters a
 	// non-US eval to US places (a German "Berlin" then loses to a tiny US Berlin). Settable via
 	// `--default-country <ISO|none>`; `none` disables the filter so ranking alone decides.
-	const dc = arg("default-country", "US")
+	const dc = values["default-country"] || "US"
 	// `--hierarchy-completion` (#405, generalizes #387's `--city-state-fallback`): recover the locality
 	// the parser drops for a DUAL-ROLE place (city-state or capital-seat province), via the precomputed
 	// coincident-roles relation (#403). Opt-in, default-off → by default this eval is byte-identical;
 	// pass it to measure the before/after. Applied to BOTH the neural and rules resolve paths (they
 	// share `resolveOpts`), so the comparison stays fair. `--city-state-fallback` kept as an alias.
-	const hierarchyCompletion =
-		process.argv.includes("--hierarchy-completion") || process.argv.includes("--city-state-fallback")
+	const hierarchyCompletion = (values["hierarchy-completion"] ?? false) || (values["city-state-fallback"] ?? false)
 	// #895: adminCoherence is default-ON in the resolver now (drift D1 settled). Tri-state pin for gate
 	// legs: `--admin-coherence` ON, `--no-admin-coherence` OFF, neither = the library default.
-	const adminCoherence = process.argv.includes("--admin-coherence")
-		? true
-		: process.argv.includes("--no-admin-coherence")
-			? false
-			: undefined
+	const adminCoherence =
+		(values["admin-coherence"] ?? false) ? true : (values["no-admin-coherence"] ?? false) ? false : undefined
 	const resolveOpts = {
 		...(dc && dc.toLowerCase() !== "none" ? { defaultCountry: dc } : {}),
 		...(hierarchyCompletion ? { hierarchyCompletion: true } : {}),
@@ -540,7 +607,7 @@ async function main(): Promise<void> {
 	// `--address-points <db>` (#476): the street-level exact-point tier. Adds `addressPoints` to
 	// resolveOpts; the `neural+addrpt` row keeps neural's admin flags but takes the COORDINATE from
 	// the address-point hit when present (the tier's whole contribution is "where", street-level).
-	const addressPointsDb = arg("address-points", "")
+	const addressPointsDb = values["address-points"] || ""
 	let addressPoints: import("@mailwoman/resolver").AddressPointLookup | null = null
 
 	if (addressPointsDb) {
@@ -552,7 +619,7 @@ async function main(): Promise<void> {
 	// from the exact point when present, else the interpolated estimate, else the admin centroid — the
 	// full street-level coordinate cascade. The delta vs `neural+addrpt` is interpolation's lift on the
 	// long tail of valid-but-unlisted numbers the exact tier misses.
-	const interpolationDb = arg("interpolation", "")
+	const interpolationDb = values["interpolation"] || ""
 	let interpolation: import("@mailwoman/resolver").InterpolationLookup | null = null
 
 	if (interpolationDb) {
@@ -568,8 +635,8 @@ async function main(): Promise<void> {
 	// --address-points/--interpolation flags still work for a one-state run; --cascade supersedes them
 	// with multi-state per-row selection. --data-root locates the shards (<root>/address-points/,
 	// <root>/interpolation/).
-	const cascadeOn = process.argv.includes("--cascade")
-	const dataRoot = arg("data-root", mailwomanDataRoot())
+	const cascadeOn = values["cascade"] ?? false
+	const dataRoot = values["data-root"] || mailwomanDataRoot()
 	let cascadeProvider: import("mailwoman/geocode-core").ShardProvider | null = null
 
 	if (cascadeOn) {
@@ -580,11 +647,11 @@ async function main(): Promise<void> {
 	// The addrpt + interp arms run when EITHER a single-state shard was given OR --cascade is on.
 	const runAddrPt = !!addressPoints || cascadeOn
 	const runInterp = !!interpolation || cascadeOn
-	const useAnchor = process.argv.includes("--postcode-anchor")
+	const useAnchor = values["postcode-anchor"] ?? false
 	// `--anchor-rerank` (#369 S8): feed the postcode anchor's country posterior into the resolver's
 	// locality re-rank (`ResolveOpts.anchorPosterior`), to measure whether the merged re-ranker pulls
 	// resolves into the right country's polygon when no locale gate is set (`--default-country none`).
-	const anchorRerank = process.argv.includes("--anchor-rerank")
+	const anchorRerank = values["anchor-rerank"] ?? false
 	let postcodeLookup: {
 		lookup(pc: string): Array<{ country: string; lat: number; lon: number }>
 		close(): void
@@ -592,8 +659,8 @@ async function main(): Promise<void> {
 	let extractAnchors: typeof import("@mailwoman/neural/postcode-anchor").extractPostcodeAnchors | null = null
 
 	if (useAnchor || anchorRerank) {
-		const shards = arg(
-			"postcode-shards",
+		const shards = (
+			values["postcode-shards"] ||
 			`${dataRootPath("wof", "postalcode-us.db")},${dataRootPath("wof", "postalcode-intl.db")}`
 		)
 			.split(",")
@@ -607,7 +674,7 @@ async function main(): Promise<void> {
 	// real code scores ≥0.52 (valid in ≤3 countries). The 0.5 floor keeps the latter and rejects the
 	// former, so a span the position prior flags as a house number falls back to the resolver coordinate
 	// (the right city centroid) instead of placing the address at a far-away same-shaped ZIP.
-	const anchorMinConf = Number(arg("anchor-min-conf", "0.5"))
+	const anchorMinConf = Number(values["anchor-min-conf"] || "0.5")
 	/** The postcode anchor's centroid for a raw address, preferring the eval's country (`dc`). */
 	const anchorCoordFor = (input: string): { lat: number; lon: number } | null => {
 		if (!postcodeLookup || !extractAnchors) return null
@@ -757,16 +824,16 @@ async function main(): Promise<void> {
 	// representative config — load the same bundled placer and feed it to the pipeline — which is the
 	// #743 EU country-constraint integrity fix: without it the assembled EU coords are not what a real
 	// caller sees (ambiguous EU names without a country constraint land off-continent).
-	const runAssembled = process.argv.includes("--assembled")
+	const runAssembled = values["assembled"] ?? false
 	// `--place-country-hard` (#194/#743) promotes a CONFIDENT placer guess to a HARD country filter
 	// (empty→unresolved) — the lever for the low-pop EU tail the soft prior can't move. Production-
 	// representative: gated by the built-in coverage safelist (only well-covered countries hard-filter).
 	// `--place-country-hard-all` measures UNGATED (every confident country hard-filters, via a safelist
 	// override of the full in-map set) — how per-country hard-resolve-rates are measured to GROW the
 	// safelist. Both imply the placer is loaded.
-	const useHardCountryAll = process.argv.includes("--place-country-hard-all")
-	const useHardCountry = process.argv.includes("--place-country-hard") || useHardCountryAll
-	const usePlaceCountry = process.argv.includes("--place-country") || useHardCountry
+	const useHardCountryAll = values["place-country-hard-all"] ?? false
+	const useHardCountry = (values["place-country-hard"] ?? false) || useHardCountryAll
+	const usePlaceCountry = (values["place-country"] ?? false) || useHardCountry
 	const evalPlacer = runAssembled && usePlaceCountry ? await loadDefaultPlaceCountry() : null
 
 	if (usePlaceCountry && !evalPlacer) {
@@ -836,20 +903,20 @@ async function main(): Promise<void> {
 	// Per-row failure dump (--errors-json): one record per row where neural OR v0 missed locality,
 	// carrying each parser's resolved admin names so failures can be bucketed offline (resolve-wrong
 	// vs unresolved vs neural-only vs v0-only). Aggregates are unaffected.
-	const collectErrors = !!arg("errors-json")
+	const collectErrors = !!(values["errors-json"] || "")
 	const errorRows: Record<string, unknown>[] = []
 
 	// `--out-resolved <path>`: per-row dump for the PIP-containment metric (scripts/eval/pip-containment.py).
 	// Carries the gold OA point + the neural-resolved locality's WOF id, so an offline pass can test
 	// whether the gold point lies INSIDE the resolved locality's polygon — a name-surface-independent
 	// truth check (the "Plauen" vs gold "Plauen Vogtl" name-match artifact, see the coordinate-first plan).
-	const collectResolvedDump = !!arg("out-resolved")
+	const collectResolvedDump = !!(values["out-resolved"] || "")
 	const resolvedRows: Record<string, unknown>[] = []
 
 	// `--out-rows <path>`: per-row neural-vs-v0 outcome dump (EVERY row, not just misses), for the
 	// per-address-type head-to-head (scripts/eval/per-type-report.ts buckets by input shape offline).
 	// Reuses the same scoreTree the aggregates use — no extra inference, no scoring duplication.
-	const collectRows = !!arg("out-rows")
+	const collectRows = !!(values["out-rows"] || "")
 	const outRows: Record<string, unknown>[] = []
 
 	let i = 0
@@ -1088,18 +1155,18 @@ async function main(): Promise<void> {
 	}
 
 	if (collectErrors) {
-		writeFileSync(arg("errors-json"), JSON.stringify(errorRows, null, 2))
-		console.error(`wrote ${errorRows.length} failure rows → ${arg("errors-json")}`)
+		writeFileSync(values["errors-json"] || "", JSON.stringify(errorRows, null, 2))
+		console.error(`wrote ${errorRows.length} failure rows → ${values["errors-json"] || ""}`)
 	}
 
 	if (collectRows) {
-		writeFileSync(arg("out-rows"), JSON.stringify(outRows))
-		console.error(`wrote ${outRows.length} per-row outcomes → ${arg("out-rows")}`)
+		writeFileSync(values["out-rows"] || "", JSON.stringify(outRows))
+		console.error(`wrote ${outRows.length} per-row outcomes → ${values["out-rows"] || ""}`)
 	}
 
 	if (collectResolvedDump) {
-		writeFileSync(arg("out-resolved"), JSON.stringify(resolvedRows))
-		console.error(`wrote ${resolvedRows.length} resolved rows → ${arg("out-resolved")}`)
+		writeFileSync(values["out-resolved"] || "", JSON.stringify(resolvedRows))
+		console.error(`wrote ${resolvedRows.length} resolved rows → ${values["out-resolved"] || ""}`)
 	}
 
 	// ---- report (self-emitted; eval figures are NEVER hand-typed into docs) ----
@@ -1108,7 +1175,7 @@ async function main(): Promise<void> {
 	const lines: string[] = []
 	lines.push(`# OpenAddresses real-point resolver eval (${agg.neural.overall.n} rows, non-circular)`)
 	lines.push("")
-	lines.push(`Model: ${arg("model") || "(shipped weights)"} | WOF shards: ${wofPaths.length}`)
+	lines.push(`Model: ${values["model"] || "" || "(shipped weights)"} | WOF shards: ${wofPaths.length}`)
 	lines.push("")
 	lines.push(`## Head-to-head — neural vs v0 (Pelias parser), both through the same resolver`)
 	lines.push("")
@@ -1237,12 +1304,12 @@ async function main(): Promise<void> {
 	const report = lines.join("\n")
 	console.log(report)
 
-	if (arg("out-md")) {
-		writeFileSync(arg("out-md"), report + "\n")
-		console.error(`wrote markdown → ${arg("out-md")}`)
+	if (values["out-md"] || "") {
+		writeFileSync(values["out-md"] || "", report + "\n")
+		console.error(`wrote markdown → ${values["out-md"] || ""}`)
 	}
 
-	if (arg("out-json")) {
+	if (values["out-json"] || "") {
 		const dump = (g: { overall: Agg; byState: Map<string, Agg> }) => ({
 			overall: { ...g.overall, errs: undefined, errN: g.overall.errs.length },
 			coord: {
@@ -1252,8 +1319,8 @@ async function main(): Promise<void> {
 			},
 			byState: Object.fromEntries([...g.byState].map(([k, v]) => [k, { ...v, errs: undefined }])),
 		})
-		writeFileSync(arg("out-json"), JSON.stringify({ neural: dump(agg.neural), v0: dump(agg.v0) }, null, 2))
-		console.error(`wrote json → ${arg("out-json")}`)
+		writeFileSync(values["out-json"] || "", JSON.stringify({ neural: dump(agg.neural), v0: dump(agg.v0) }, null, 2))
+		console.error(`wrote json → ${values["out-json"] || ""}`)
 	}
 
 	postcodeLookup?.close()

--- a/scripts/eval/oracle-locality-injection.ts
+++ b/scripts/eval/oracle-locality-injection.ts
@@ -26,6 +26,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { parseArgs } from "node:util"
 
+import { $public } from "@mailwoman/core/env"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { haversineKm } from "@mailwoman/spatial"
@@ -148,7 +149,7 @@ const go = oracleTight && (deltaP50Rel >= 20 || closedShare >= 50)
 const L: string[] = []
 L.push(`# #825 oracle-locality injection — ${LABEL || GOLDEN} (${go ? "GO" : "NO-GO"})`)
 L.push("")
-L.push(`_Gazetteer: ${process.env["MAILWOMAN_CANDIDATE_DB"] ?? "admin shards"}. n=${n}._`)
+L.push(`_Gazetteer: ${$public.MAILWOMAN_CANDIDATE_DB ?? "admin shards"}. n=${n}._`)
 L.push(`_ORIGINAL = shipped model parse → resolve. ORACLE = gold locality resolved directly (perfect parse)._`)
 L.push("")
 L.push(

--- a/scripts/eval/parser-coverage-audit.ts
+++ b/scripts/eval/parser-coverage-audit.ts
@@ -26,6 +26,7 @@
  */
 
 import { readFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { dataRootPath } from "@mailwoman/core/utils"
@@ -33,15 +34,33 @@ import { NeuralAddressClassifier, parseAnchorLookup, parseGazetteerLexicon } fro
 import { ONNXRunner } from "@mailwoman/neural/onnx-runner"
 import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
 
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		eval: { type: "string" },
+		"gazetteer-lexicon": { type: "string" },
+		model: { type: "string" },
+		"model-anchor-lookup": { type: "string" },
+		"model-card": { type: "string" },
+		"per-state-cap": { type: "string" },
+		tokenizer: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	eval?: string
+	"gazetteer-lexicon"?: string
+	model?: string
+	"model-anchor-lookup"?: string
+	"model-card"?: string
+	"per-state-cap"?: string
+	tokenizer?: string
+}
 // ---------------------------------------------------------------------------
 // Args
 // ---------------------------------------------------------------------------
-
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
 
 const DEFAULT_MODEL = dataRootPath("models", "quantized", "model-v150-step-40000-int8.onnx")
 const DEFAULT_TOKENIZER = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
@@ -49,13 +68,13 @@ const DEFAULT_MODEL_CARD = "neural-weights-en-us/model-card.json"
 const DEFAULT_EVAL = "data/eval/external/openaddresses-us-sample.jsonl"
 const DEFAULT_CAP = 300
 
-const modelPath = arg("model", DEFAULT_MODEL)
-const tokenizerPath = arg("tokenizer", DEFAULT_TOKENIZER)
-const modelCardPath = arg("model-card", DEFAULT_MODEL_CARD)
-const evalPath = arg("eval", DEFAULT_EVAL)
-const perStateCap = parseInt(arg("per-state-cap", String(DEFAULT_CAP)), 10)
-const anchorPath = arg("model-anchor-lookup", "")
-const gazetteerPath = arg("gazetteer-lexicon", "")
+const modelPath = values["model"] || DEFAULT_MODEL
+const tokenizerPath = values["tokenizer"] || DEFAULT_TOKENIZER
+const modelCardPath = values["model-card"] || DEFAULT_MODEL_CARD
+const evalPath = values["eval"] || DEFAULT_EVAL
+const perStateCap = parseInt(values["per-state-cap"] || String(DEFAULT_CAP), 10)
+const anchorPath = values["model-anchor-lookup"] || ""
+const gazetteerPath = values["gazetteer-lexicon"] || ""
 
 // ---------------------------------------------------------------------------
 // OA row shape

--- a/scripts/eval/perturb-golden.ts
+++ b/scripts/eval/perturb-golden.ts
@@ -21,16 +21,19 @@
 
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
+import { parseArgs } from "node:util"
 
-function arg(name: string, fallback: string): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
-const GOLDEN = arg("golden", "data/eval/golden/v0.1.2")
-const OUT = arg("out", "/tmp/perturb-eval/perturbed.jsonl")
-const PER_FILE = Number(arg("per-file", "60"))
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { golden: { type: "string" }, out: { type: "string" }, "per-file": { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { golden?: string; out?: string; "per-file"?: string }
+const GOLDEN = values["golden"] || "data/eval/golden/v0.1.2"
+const OUT = values["out"] || "/tmp/perturb-eval/perturbed.jsonl"
+const PER_FILE = Number(values["per-file"] || "60")
 
 interface GoldenRow {
 	raw: string

--- a/scripts/eval/postal-city-alias-eval.ts
+++ b/scripts/eval/postal-city-alias-eval.ts
@@ -29,17 +29,34 @@
  */
 
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 import { dataRootPath } from "@mailwoman/core/utils"
 import { WOFPostalCityAliasLookup, WOFSqlitePlaceLookup } from "@mailwoman/resolver-wof-sqlite"
 import { haversineKm } from "@mailwoman/spatial"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"alias-db": { type: "string" },
+		country: { type: "string" },
+		limit: { type: "string" },
+		"near-km": { type: "string" },
+		"postcode-db": { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"alias-db"?: string
+	country?: string
+	limit?: string
+	"near-km"?: string
+	"postcode-db"?: string
+	wof?: string
 }
-
 const pct = (xs: number[], p: number): number => {
 	if (xs.length === 0) return NaN
 	const s = [...xs].sort((a, b) => a - b)
@@ -48,15 +65,15 @@ const pct = (xs: number[], p: number): number => {
 }
 
 async function main(): Promise<void> {
-	const aliasDBPath = arg("alias-db", dataRootPath("wof", "postal-city-alias-us.db"))
-	const postcodeDBPath = arg("postcode-db", dataRootPath("wof", "postalcode-us.db"))
-	const wof = arg(
-		"wof",
+	const aliasDBPath = values["alias-db"] || dataRootPath("wof", "postal-city-alias-us.db")
+	const postcodeDBPath = values["postcode-db"] || dataRootPath("wof", "postalcode-us.db")
+	const wof = (
+		values["wof"] ||
 		`${dataRootPath("wof", "admin-global-priority.db")},${dataRootPath("wof", "postcode-locality-us.db")}`
 	).split(",")
-	const country = arg("country", "US")
-	const limit = Number(arg("limit", "0")) // 0 = all
-	const nearKm = Number(arg("near-km", "50")) // "resolved near the postcode" threshold
+	const country = values["country"] || "US"
+	const limit = Number(values["limit"] || "0") // 0 = all
+	const nearKm = Number(values["near-km"] || "50") // "resolved near the postcode" threshold
 
 	// Truth: postcode → centroid (independent of the alias table).
 	const pcDB = new DatabaseSync(postcodeDBPath, { readOnly: true })

--- a/scripts/eval/postcode-conflict-eval.ts
+++ b/scripts/eval/postcode-conflict-eval.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 /**
  * @copyright Sister Software
@@ -22,12 +23,14 @@ import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { dataRootPath } from "@mailwoman/core/utils"
 import { createWOFResolver } from "@mailwoman/resolver"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { eval: { type: "string" }, "out-md": { type: "string" }, wof: { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { eval?: string; "out-md"?: string; wof?: string }
 interface Row {
 	input: string
 	locale?: string
@@ -63,13 +66,13 @@ function flagged(tree: AddressTree): boolean {
 	return hit
 }
 
-const rows: Row[] = readFileSync(arg("eval", "data/eval/falsehoods/postcode-city-conflicts.jsonl"), "utf8")
+const rows: Row[] = readFileSync(values["eval"] || "data/eval/falsehoods/postcode-city-conflicts.jsonl", "utf8")
 	.split("\n")
 	.filter(Boolean)
 	.map((l) => JSON.parse(l))
 
-const wofPaths = arg(
-	"wof",
+const wofPaths = (
+	values["wof"] ||
 	`${dataRootPath("wof", "admin-global-priority.db")},${dataRootPath("wof", "postcode-locality-intl.db")}`
 ).split(",")
 const { WOFSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
@@ -119,9 +122,9 @@ for (const r of results) {
 const report = lines.join("\n")
 console.log(report)
 
-if (arg("out-md")) {
-	writeFileSync(arg("out-md"), report + "\n")
-	console.error(`wrote markdown → ${arg("out-md")}`)
+if (values["out-md"] || "") {
+	writeFileSync(values["out-md"] || "", report + "\n")
+	console.error(`wrote markdown → ${values["out-md"] || ""}`)
 }
 backend.close?.()
 process.exit(results.every((r) => r.ok) ? 0 : 1)

--- a/scripts/eval/promote-canary.ts
+++ b/scripts/eval/promote-canary.ts
@@ -51,12 +51,20 @@ const { values: rawValues } = parseArgs({
 		n: { type: "string" },
 		out: { type: "string" },
 		shipped: { type: "string" },
+		allcaps: { type: "boolean" },
 	},
 	strict: false,
 	allowPositionals: true,
 })
 // Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
-const values = rawValues as { candidate?: string; locales?: string; n?: string; out?: string; shipped?: string }
+const values = rawValues as {
+	candidate?: string
+	locales?: string
+	n?: string
+	out?: string
+	shipped?: string
+	allcaps?: boolean
+}
 const TOK = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 const CARD = "neural-weights-en-us/model-card.json"
 const ANCHOR = dataRootPath("anchor", "pilot-anchor-lookup.json")
@@ -66,7 +74,7 @@ const SHIPPED = values["shipped"] || "out/v191/model.onnx"
 const CANDIDATE = values["candidate"] || "out/v192/model-int8.onnx"
 const LOCALES = (values["locales"] || "us,it,pt,pl,fr,au").split(",")
 const N = Number(values["n"] || "60")
-const ALLCAPS = process.argv.includes("--allcaps")
+const ALLCAPS = values["allcaps"] ?? false
 const THRESH_KM = 25
 const HIGH_CONF = 0.9
 const AGG_TOL = 2 // pp aggregate right@25 regression that blocks

--- a/scripts/eval/promotion-gate.ts
+++ b/scripts/eval/promotion-gate.ts
@@ -42,6 +42,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
+import { parseArgs } from "node:util"
 
 import { dataRootPath } from "@mailwoman/core/utils"
 import { runIfScript } from "mailwoman/sdk/scripting"
@@ -64,45 +65,35 @@ runIfScript(import.meta, async () => {
 	$.verbose = false
 
 	// --- arg parse (faithful to the .sh: --flag value; unknown / missing-required → exit 2) ---
-	let MODEL = ""
-	let INT8 = ""
-	let GATE = ""
-	let OUT_DIR = ""
-	let TOK = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
-	let CARD = "neural-weights-en-us/model-card.json"
-	let GAZ = "data/gazetteer/anchor-lexicon-v1.json"
-	const LK = dataRootPath("anchor", "pilot-anchor-lookup.json")
+	let parsed: { values: Record<string, string | boolean | undefined> }
 
-	const argv = process.argv.slice(2)
-
-	for (let i = 0; i < argv.length; i++) {
-		switch (argv[i]) {
-			case "--model":
-				MODEL = argv[++i] ?? ""
-				break
-			case "--int8":
-				INT8 = argv[++i] ?? ""
-				break
-			case "--gate":
-				GATE = argv[++i] ?? ""
-				break
-			case "--tokenizer":
-				TOK = argv[++i] ?? ""
-				break
-			case "--card":
-				CARD = argv[++i] ?? ""
-				break
-			case "--gazetteer-lexicon":
-				GAZ = argv[++i] ?? ""
-				break
-			case "--out-dir":
-				OUT_DIR = argv[++i] ?? ""
-				break
-			default:
-				console.error(`unknown arg: ${argv[i]}`)
-				process.exit(2)
-		}
+	try {
+		parsed = parseArgs({
+			options: {
+				model: { type: "string" },
+				int8: { type: "string" },
+				gate: { type: "string" },
+				tokenizer: { type: "string" },
+				card: { type: "string" },
+				"gazetteer-lexicon": { type: "string" },
+				"out-dir": { type: "string" },
+			},
+		})
+	} catch (e) {
+		console.error(`unknown arg: ${e instanceof Error ? e.message : e}`)
+		process.exit(2)
 	}
+	const args = parsed.values
+	const MODEL = (args.model as string | undefined) ?? ""
+	const INT8 = (args.int8 as string | undefined) ?? ""
+	const GATE = (args.gate as string | undefined) ?? ""
+	let OUT_DIR = (args["out-dir"] as string | undefined) ?? ""
+	const TOK =
+		(args.tokenizer as string | undefined) ??
+		String(dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model"))
+	const CARD = (args.card as string | undefined) ?? "neural-weights-en-us/model-card.json"
+	const GAZ = (args["gazetteer-lexicon"] as string | undefined) ?? "data/gazetteer/anchor-lexicon-v1.json"
+	const LK = dataRootPath("anchor", "pilot-anchor-lookup.json")
 
 	if (!MODEL || !GATE) {
 		console.error("✗ --model and --gate required")

--- a/scripts/eval/record-matcher/coverage-reconciliation.ts
+++ b/scripts/eval/record-matcher/coverage-reconciliation.ts
@@ -30,6 +30,7 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -49,19 +50,37 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		cap: { type: "string" },
+		"data-root": { type: "string" },
+		"out-geojson": { type: "string" },
+		"out-md": { type: "string" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	cap?: string
+	"data-root"?: string
+	"out-geojson"?: string
+	"out-md"?: string
+	sources?: string
+	state?: string
+	wof?: string
 }
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const CAP = Number(arg("cap", "2000"))
-const STATE = arg("state", "TX").toUpperCase()
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT_MD = arg("out-md", "")
-const OUT_GEOJSON = arg("out-geojson", "")
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const CAP = Number(values["cap"] || "2000")
+const STATE = (values["state"] || "TX").toUpperCase()
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT_MD = values["out-md"] || ""
+const OUT_GEOJSON = values["out-geojson"] || ""
 
 const norm = (s: string | undefined) => (s ?? "").trim()
 

--- a/scripts/eval/record-matcher/cross-dataset-correlation.ts
+++ b/scripts/eval/record-matcher/cross-dataset-correlation.ts
@@ -20,6 +20,7 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -38,28 +39,45 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		cap: { type: "string" },
+		"data-root": { type: "string" },
+		"no-corpus-frequency": { type: "boolean" },
+		"out-geojson": { type: "string" },
+		"out-md": { type: "string" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	cap?: string
+	"data-root"?: string
+	"no-corpus-frequency"?: boolean
+	"out-geojson"?: string
+	"out-md"?: string
+	sources?: string
+	state?: string
+	wof?: string
 }
-function hasFlag(name: string): boolean {
-	return process.argv.includes(`--${name}`)
-}
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const CAP = Number(arg("cap", "300")) // rows kept per source for geocoding (TX-scoped)
-const STATE = arg("state", "TX").toUpperCase()
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT_MD = arg("out-md", "")
-const OUT_GEOJSON = arg("out-geojson", "") // the reconciliation artifact (FeatureCollection, QGIS-ready)
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const CAP = Number(values["cap"] || "300") // rows kept per source for geocoding (TX-scoped)
+const STATE = (values["state"] || "TX").toUpperCase()
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT_MD = values["out-md"] || ""
+const OUT_GEOJSON = values["out-geojson"] || "" // the reconciliation artifact (FeatureCollection, QGIS-ready)
 // The inverse-address-frequency lever is a CORPUS statistic — it can't be synthesized from the geocoded
 // sample. By default we scan the FULL files (cheap, parse-free) for an in-state corpus-wide frequency
 // table and feed it to the matcher, so the proven #617 lever actually bites on a sub-sampled run. The
 // scan adds a full pass over the 4.8 GB NPPES file (~5 min); `--no-corpus-frequency` skips it and falls
 // back to resolveEntities' zero-config input-scoped default (#86).
-const CORPUS_FREQ = !hasFlag("no-corpus-frequency")
+const CORPUS_FREQ = !(values["no-corpus-frequency"] ?? false)
 
 const norm = (s: string | undefined) => (s ?? "").trim()
 

--- a/scripts/eval/record-matcher/cross-source-threshold-sweep.ts
+++ b/scripts/eval/record-matcher/cross-source-threshold-sweep.ts
@@ -28,6 +28,7 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -49,21 +50,39 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		candidate: { type: "string" },
+		cap: { type: "string" },
+		"data-root": { type: "string" },
+		"out-md": { type: "string" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	candidate?: string
+	cap?: string
+	"data-root"?: string
+	"out-md"?: string
+	sources?: string
+	state?: string
+	wof?: string
 }
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const CAP = Number(arg("cap", "2000"))
-const STATE = arg("state", "TX").toUpperCase()
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT_MD = arg("out-md", "")
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const CAP = Number(values["cap"] || "2000")
+const STATE = (values["state"] || "TX").toUpperCase()
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT_MD = values["out-md"] || ""
 // #655 option 2: a trained CROSS-SOURCE GBT module (exports CROSS_SOURCE_GBT_MODEL + _META) to grade as
 // a third arm at its recommended threshold — the model train-cross-gbt.ts emits.
-const CANDIDATE = arg("candidate", "")
+const CANDIDATE = values["candidate"] || ""
 
 const norm = (s: string | undefined) => (s ?? "").trim()
 

--- a/scripts/eval/record-matcher/geocoder-namesake-probe.ts
+++ b/scripts/eval/record-matcher/geocoder-namesake-probe.ts
@@ -13,19 +13,24 @@
  *   Run: node --experimental-strip-types scripts/eval/record-matcher/geocoder-namesake-probe.ts
  */
 
+import { parseArgs } from "node:util"
+
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { haversineKm } from "@mailwoman/spatial"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { "data-root": { type: "string" }, wof: { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { "data-root"?: string; wof?: string }
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
 
 // TX namesake cities with their real Texas coordinates + the famous foreign/other namesake to watch for.
 const CASES: Array<{ city: string; zip: string; tx: [number, number]; namesake: string }> = [

--- a/scripts/eval/record-matcher/geocoder-vs-provided-coords.ts
+++ b/scripts/eval/record-matcher/geocoder-vs-provided-coords.ts
@@ -21,6 +21,7 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
 import { haversineKm } from "@mailwoman/match"
@@ -29,17 +30,25 @@ import { streamRows } from "@mailwoman/registry"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const MAX = Number(arg("max", "2000"))
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT_MD = arg("out-md", "")
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"data-root": { type: "string" },
+		max: { type: "string" },
+		"out-md": { type: "string" },
+		sources: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { "data-root"?: string; max?: string; "out-md"?: string; sources?: string; wof?: string }
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const MAX = Number(values["max"] || "2000")
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT_MD = values["out-md"] || ""
 
 const FILE = `${SOURCES}/txhhsc_nursing-facilities_20260611.tsv`
 const norm = (s: string | undefined) => (s ?? "").trim()

--- a/scripts/eval/record-matcher/learned-scorer-clustering-eval.ts
+++ b/scripts/eval/record-matcher/learned-scorer-clustering-eval.ts
@@ -29,6 +29,7 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -50,20 +51,42 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"data-root": { type: "string" },
+		npis: { type: "string" },
+		"out-md": { type: "string" },
+		seed: { type: "string" },
+		seeds: { type: "string" },
+		sources: { type: "string" },
+		split: { type: "string" },
+		state: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"data-root"?: string
+	npis?: string
+	"out-md"?: string
+	seed?: string
+	seeds?: string
+	sources?: string
+	split?: string
+	state?: string
+	wof?: string
 }
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const STATE = arg("state", "TX").toUpperCase()
-const NPIS = Number(arg("npis", "2000"))
-const SPLIT = Number(arg("split", "0.67"))
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const SEED = Number(arg("seed", "1"))
-const OUT_MD = arg("out-md", "")
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const STATE = (values["state"] || "TX").toUpperCase()
+const NPIS = Number(values["npis"] || "2000")
+const SPLIT = Number(values["split"] || "0.67")
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const SEED = Number(values["seed"] || "1")
+const OUT_MD = values["out-md"] || ""
 
 const REGISTRY = `${SOURCES}/nppes_npi-registry_20260607.tsv`
 const OTHER_NAMES = `${SOURCES}/nppes_other-names_20260607.tsv`
@@ -391,7 +414,7 @@ async function main(): Promise<void> {
 		return Math.sqrt(mean(xs.map((x) => (x - m) ** 2)))
 	}
 
-	const SEEDS = Number(arg("seeds", "4"))
+	const SEEDS = Number(values["seeds"] || "4")
 	console.error(`[D-F] ${SEEDS} held-out-NPI splits: FS baseline vs GBT vs LR…`)
 	const results: SeedResult[] = []
 

--- a/scripts/eval/record-matcher/learned-scorer-crossstate-eval.ts
+++ b/scripts/eval/record-matcher/learned-scorer-crossstate-eval.ts
@@ -22,6 +22,7 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -45,18 +46,37 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"data-root": { type: "string" },
+		"eval-state": { type: "string" },
+		npis: { type: "string" },
+		"out-md": { type: "string" },
+		sources: { type: "string" },
+		"train-state": { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"data-root"?: string
+	"eval-state"?: string
+	npis?: string
+	"out-md"?: string
+	sources?: string
+	"train-state"?: string
+	wof?: string
 }
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const TRAIN_STATE = arg("train-state", "TX").toUpperCase()
-const EVAL_STATE = arg("eval-state", "CA").toUpperCase()
-const NPIS = Number(arg("npis", "2000"))
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT_MD = arg("out-md", "")
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const TRAIN_STATE = (values["train-state"] || "TX").toUpperCase()
+const EVAL_STATE = (values["eval-state"] || "CA").toUpperCase()
+const NPIS = Number(values["npis"] || "2000")
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT_MD = values["out-md"] || ""
 
 const REGISTRY = `${SOURCES}/nppes_npi-registry_20260607.tsv`
 const OTHER_NAMES = `${SOURCES}/nppes_other-names_20260607.tsv`

--- a/scripts/eval/record-matcher/learned-scorer-eval.ts
+++ b/scripts/eval/record-matcher/learned-scorer-eval.ts
@@ -36,6 +36,7 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -54,19 +55,39 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"data-root": { type: "string" },
+		npis: { type: "string" },
+		"out-md": { type: "string" },
+		seed: { type: "string" },
+		seeds: { type: "string" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"data-root"?: string
+	npis?: string
+	"out-md"?: string
+	seed?: string
+	seeds?: string
+	sources?: string
+	state?: string
+	wof?: string
 }
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const STATE = arg("state", "TX").toUpperCase()
-const NPIS = Number(arg("npis", "1500"))
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const SEED = Number(arg("seed", "1"))
-const OUT_MD = arg("out-md", "")
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const STATE = (values["state"] || "TX").toUpperCase()
+const NPIS = Number(values["npis"] || "1500")
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const SEED = Number(values["seed"] || "1")
+const OUT_MD = values["out-md"] || ""
 
 const REGISTRY = `${SOURCES}/nppes_npi-registry_20260607.tsv`
 const OTHER_NAMES = `${SOURCES}/nppes_other-names_20260607.tsv`
@@ -418,7 +439,7 @@ async function main(): Promise<void> {
 	}
 
 	console.error("[E] training across seeds…")
-	const SEEDS = Number(arg("seeds", "8"))
+	const SEEDS = Number(values["seeds"] || "8")
 	const splits = Array.from({ length: SEEDS }, (_, k) => runSplit(SEED + k))
 	const mean = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / Math.max(1, xs.length)
 	const std = (xs: number[]) => {

--- a/scripts/eval/record-matcher/nppes-dedup-benchmark.ts
+++ b/scripts/eval/record-matcher/nppes-dedup-benchmark.ts
@@ -29,6 +29,7 @@
 import { writeFileSync } from "node:fs"
 import { resolve as resolvePath } from "node:path"
 import { pathToFileURL } from "node:url"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -48,31 +49,67 @@ import { createWOFResolver } from "@mailwoman/resolver"
 import { latLngToCell } from "h3-js"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		candidate: { type: "string" },
+		"data-root": { type: "string" },
+		"dump-overmerges": { type: "string" },
+		"geo-concurrency": { type: "string" },
+		"h3-res": { type: "string" },
+		"legacy-join": { type: "boolean" },
+		"max-npis": { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		"no-train-em": { type: "boolean" },
+		"out-md": { type: "string" },
+		"parallel-geocode": { type: "boolean" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	candidate?: string
+	"data-root"?: string
+	"dump-overmerges"?: string
+	"geo-concurrency"?: string
+	"h3-res"?: string
+	"legacy-join"?: boolean
+	"max-npis"?: string
+	model?: string
+	"model-card"?: string
+	"no-train-em"?: boolean
+	"out-md"?: string
+	"parallel-geocode"?: boolean
+	sources?: string
+	state?: string
+	tokenizer?: string
+	wof?: string
 }
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const STATE = arg("state", "TX").toUpperCase()
-const MAX_NPIS = Number(arg("max-npis", "300"))
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT_MD = arg("out-md", "")
-const TRAIN_EM = !process.argv.includes("--no-train-em")
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const STATE = (values["state"] || "TX").toUpperCase()
+const MAX_NPIS = Number(values["max-npis"] || "300")
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT_MD = values["out-md"] || ""
+const TRAIN_EM = !(values["no-train-em"] ?? false)
 // #694 A/B: `--legacy-join` reproduces the pre-flip ingest (space-joined address columns + normalizeCase
 // OFF). Default (no flag) is the validated flip: comma-join (the correct address shape) + #690 all-caps
 // normalization. Same data + GBT, only the flip toggled — so a delta here is attributable to the flip.
-const LEGACY = process.argv.includes("--legacy-join")
+const LEGACY = values["legacy-join"] ?? false
 // Optional A/B: a path to a trained dedup-gbt TS module (exports DEDUP_GBT_MODEL + DEDUP_GBT_META) to
 // score alongside the shipped GBT at both truth levels — e.g. grade the #625 corroboration candidate.
-const CANDIDATE = arg("candidate", "")
+const CANDIDATE = values["candidate"] || ""
 // `--parallel-geocode`: geocode the sample across a worker pool (spliterator.geocodeStream) instead of the
 // serial in-process seam. Heavy per-row work (ONNX parse + WOF SQLite) → threading pays; measured ~1.5× at 2
 // workers, coordinates identical. Concurrency low on purpose (geocode is I/O-bound). `--geo-concurrency N` tunes.
-const PARALLEL_GEOCODE = process.argv.includes("--parallel-geocode")
-const GEO_CONC = Number(arg("geo-concurrency", "2"))
+const PARALLEL_GEOCODE = values["parallel-geocode"] ?? false
+const GEO_CONC = Number(values["geo-concurrency"] || "2")
 
 const REGISTRY = `${SOURCES}/nppes_npi-registry_20260607.tsv`
 const OTHER_NAMES = `${SOURCES}/nppes_other-names_20260607.tsv`
@@ -313,9 +350,9 @@ async function main(): Promise<void> {
 	} else {
 		const classifier = await NeuralAddressClassifier.loadFromWeights({
 			locale: "en-US",
-			...(arg("model") ? { modelPath: arg("model") } : {}),
-			...(arg("tokenizer") ? { tokenizerPath: arg("tokenizer") } : {}),
-			...(arg("model-card") ? { modelCardPath: arg("model-card") } : {}),
+			...(values["model"] || "" ? { modelPath: values["model"] || "" } : {}),
+			...(values["tokenizer"] || "" ? { tokenizerPath: values["tokenizer"] || "" } : {}),
+			...(values["model-card"] || "" ? { modelCardPath: values["model-card"] || "" } : {}),
 		})
 		const mod = await import("@mailwoman/resolver-wof-sqlite")
 		const lookup = new mod.WOFSqlitePlaceLookup({ databasePath: WOF })
@@ -581,7 +618,7 @@ async function main(): Promise<void> {
 	// matches, the number isn't an artifact of the 50 m threshold, and cell-blocking is O(n) not O(n²).
 	// Caveat: a hard cell boundary can split a same-building pair into adjacent cells (a slight
 	// under-count vs the radius); res 10 (~65 m edge) absorbs most of it. ---
-	const H3_RES = Number(arg("h3-res", "11")) // res 11 ≈ 25 m edge; res 10 ≈ 65 m (block scale)
+	const H3_RES = Number(values["h3-res"] || "11") // res 11 ≈ 25 m edge; res 10 ≈ 65 m (block scale)
 	const parentH = new Map<string, string>()
 	const findH = (x: string): string => {
 		if (!parentH.has(x)) {
@@ -782,7 +819,7 @@ async function main(): Promise<void> {
 	// per-pair adjudication (same entity? distinct co-located?) is the only instrument left that can
 	// separate model error from yardstick error. Each cluster prints its members grouped by org-name
 	// label with every matcher-visible field, so a reviewer can adjudicate in one glance.
-	const DUMP_OVERMERGES = arg("dump-overmerges")
+	const DUMP_OVERMERGES = values["dump-overmerges"] || ""
 
 	if (DUMP_OVERMERGES) {
 		const rowByID = new Map(rows.map((r) => [r.npi, r]))

--- a/scripts/eval/record-matcher/train-cross-gbt.ts
+++ b/scripts/eval/record-matcher/train-cross-gbt.ts
@@ -33,6 +33,7 @@
 import { createReadStream, mkdirSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 import { createInterface } from "node:readline"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -52,22 +53,44 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		"data-root": { type: "string" },
+		date: { type: "string" },
+		locale: { type: "string" },
+		npis: { type: "string" },
+		out: { type: "string" },
+		"precision-bar": { type: "string" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	"data-root"?: string
+	date?: string
+	locale?: string
+	npis?: string
+	out?: string
+	"precision-bar"?: string
+	sources?: string
+	state?: string
+	wof?: string
 }
-
-const SOURCES = arg("sources", String(dataRootPath("record-matcher", "sources")))
-const STATE = arg("state", "TX").toUpperCase()
-const NPIS = Number(arg("npis", "2000"))
-const WOF = arg("wof", String(dataRootPath("wof", "admin-global-priority.db")))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT = arg("out", "registry/models/crosssource-gbt-en-us.ts")
-const LOCALE = arg("locale", "en-US")
+const SOURCES = values["sources"] || String(dataRootPath("record-matcher", "sources"))
+const STATE = (values["state"] || "TX").toUpperCase()
+const NPIS = Number(values["npis"] || "2000")
+const WOF = values["wof"] || String(dataRootPath("wof", "admin-global-priority.db"))
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT = values["out"] || "registry/models/crosssource-gbt-en-us.ts"
+const LOCALE = values["locale"] || "en-US"
 /** #655 threshold rule: max cross-source recall subject to this held-out pairwise precision. */
-const PRECISION_BAR = Number(arg("precision-bar", "0.95"))
-const TRAIN_DATE = arg("date", new Date().toISOString().slice(0, 10))
+const PRECISION_BAR = Number(values["precision-bar"] || "0.95")
+const TRAIN_DATE = values["date"] || new Date().toISOString().slice(0, 10)
 
 const REGISTRY = `${SOURCES}/nppes_npi-registry_20260607.tsv`
 const OP_PROFILE = `${SOURCES}/openpayments_covered-recipient-profile_20260603.csv`

--- a/scripts/eval/record-matcher/train-gbt.ts
+++ b/scripts/eval/record-matcher/train-gbt.ts
@@ -21,6 +21,7 @@
 
 import { mkdirSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -41,24 +42,46 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		cost: { type: "string" },
+		"data-root": { type: "string" },
+		date: { type: "string" },
+		locale: { type: "string" },
+		npis: { type: "string" },
+		out: { type: "string" },
+		sources: { type: "string" },
+		state: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	cost?: string
+	"data-root"?: string
+	date?: string
+	locale?: string
+	npis?: string
+	out?: string
+	sources?: string
+	state?: string
+	wof?: string
 }
-
-const SOURCES = arg("sources", dataRootPath("record-matcher", "sources"))
-const STATE = arg("state", "TX").toUpperCase()
-const NPIS = Number(arg("npis", "3000"))
-const WOF = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT = arg("out", "registry/models/dedup-gbt-en-us.ts")
-const LOCALE = arg("locale", "en-US")
+const SOURCES = values["sources"] || dataRootPath("record-matcher", "sources")
+const STATE = (values["state"] || "TX").toUpperCase()
+const NPIS = Number(values["npis"] || "3000")
+const WOF = values["wof"] || dataRootPath("wof", "admin-global-priority.db")
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT = values["out"] || "registry/models/dedup-gbt-en-us.ts"
+const LOCALE = values["locale"] || "en-US"
 // Cost-sensitive training (#625): up-weight the NEGATIVE (distinct-pair) class by this factor so the
 // model is more conservative about merging — directly trades recall for precision to cut over-merge.
 // 1 = the symmetric class-balanced default; >1 penalizes a false merge more than a missed one.
-const COST = Number(arg("cost", "1"))
-const TRAIN_DATE = arg("date", new Date().toISOString().slice(0, 10)) // overridable for reproducible commits
+const COST = Number(values["cost"] || "1")
+const TRAIN_DATE = values["date"] || new Date().toISOString().slice(0, 10) // overridable for reproducible commits
 
 const REGISTRY = `${SOURCES}/nppes_npi-registry_20260607.tsv`
 const OTHER_NAMES = `${SOURCES}/nppes_other-names_20260607.tsv`

--- a/scripts/eval/record-matcher/train-org-cross-gbt.ts
+++ b/scripts/eval/record-matcher/train-org-cross-gbt.ts
@@ -29,6 +29,7 @@
 import { createReadStream, mkdirSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 import { createInterface } from "node:readline"
+import { parseArgs } from "node:util"
 
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { dataRootPath, mailwomanDataRoot } from "@mailwoman/core/utils"
@@ -48,21 +49,41 @@ import {
 import { createWOFResolver } from "@mailwoman/resolver"
 import { geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		cap: { type: "string" },
+		"data-root": { type: "string" },
+		date: { type: "string" },
+		locale: { type: "string" },
+		out: { type: "string" },
+		"precision-bar": { type: "string" },
+		sources: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	cap?: string
+	"data-root"?: string
+	date?: string
+	locale?: string
+	out?: string
+	"precision-bar"?: string
+	sources?: string
+	wof?: string
 }
-
-const SOURCES = arg("sources", String(dataRootPath("record-matcher", "sources")))
-const CAP = Number(arg("cap", "6000"))
-const WOF = arg("wof", String(dataRootPath("wof", "admin-global-priority.db")))
-const DATA_ROOT = arg("data-root", mailwomanDataRoot())
-const OUT = arg("out", "registry/models/org-crosssource-gbt-en-us.ts")
-const LOCALE = arg("locale", "en-US")
+const SOURCES = values["sources"] || String(dataRootPath("record-matcher", "sources"))
+const CAP = Number(values["cap"] || "6000")
+const WOF = values["wof"] || String(dataRootPath("wof", "admin-global-priority.db"))
+const DATA_ROOT = values["data-root"] || mailwomanDataRoot()
+const OUT = values["out"] || "registry/models/org-crosssource-gbt-en-us.ts"
+const LOCALE = values["locale"] || "en-US"
 /** #655 threshold rule: max cross-source recall subject to this held-out pairwise precision. */
-const PRECISION_BAR = Number(arg("precision-bar", "0.95"))
-const TRAIN_DATE = arg("date", new Date().toISOString().slice(0, 10))
+const PRECISION_BAR = Number(values["precision-bar"] || "0.95")
+const TRAIN_DATE = values["date"] || new Date().toISOString().slice(0, 10)
 
 const POS = `${SOURCES}/cms-pos_hospital-other_2026q1.csv`
 const CARE_COMPARE = `${SOURCES}/cms-carecompare_hospital-general_20260706.csv`

--- a/scripts/eval/resolver-eval.ts
+++ b/scripts/eval/resolver-eval.ts
@@ -33,6 +33,7 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { dataRootPath } from "@mailwoman/core/utils"
@@ -42,12 +43,36 @@ import { type ClassificationRecord, createAddressParser } from "mailwoman"
 
 import { v0RecordToTree } from "./v0-tree-adapter.ts"
 
-function arg(name: string, fallback = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		country: { type: "string" },
+		eval: { type: "string" },
+		"exact-tiering": { type: "string" },
+		limit: { type: "string" },
+		model: { type: "string" },
+		"model-card": { type: "string" },
+		"out-json": { type: "string" },
+		"parent-fallback": { type: "string" },
+		tokenizer: { type: "string" },
+		wof: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	country?: string
+	eval?: string
+	"exact-tiering"?: string
+	limit?: string
+	model?: string
+	"model-card"?: string
+	"out-json"?: string
+	"parent-fallback"?: string
+	tokenizer?: string
+	wof?: string
 }
-
 interface EvalRow {
 	input: string
 	expected_id: number
@@ -130,11 +155,9 @@ interface RowResult {
 }
 
 async function main(): Promise<void> {
-	const evalPath = arg("eval", "/tmp/wof-bootstrap/eval.jsonl")
-	const limit = Number(arg("limit", "0")) || Infinity
-	const wofPaths = arg("wof", dataRootPath("wof", "admin-global-priority.db"))
-		.split(",")
-		.map((s) => s.trim())
+	const evalPath = values["eval"] || "/tmp/wof-bootstrap/eval.jsonl"
+	const limit = Number(values["limit"] || "0") || Infinity
+	const wofPaths = (values["wof"] || dataRootPath("wof", "admin-global-priority.db")).split(",").map((s) => s.trim())
 
 	const rows: EvalRow[] = readFileSync(evalPath, "utf8")
 		.split("\n")
@@ -144,15 +167,15 @@ async function main(): Promise<void> {
 
 	// --- load parsers + resolver ---
 	const { NeuralAddressClassifier } = await import("@mailwoman/neural")
-	const modelPath = arg("model")
+	const modelPath = values["model"] || ""
 	let neural: InstanceType<typeof NeuralAddressClassifier>
 
 	if (modelPath) {
 		const { ONNXRunner } = await import("@mailwoman/neural/onnx-runner")
 		const { MailwomanTokenizer } = await import("@mailwoman/neural/tokenizer")
-		const modelCard = JSON.parse(readFileSync(arg("model-card"), "utf8"))
+		const modelCard = JSON.parse(readFileSync(values["model-card"] || "", "utf8"))
 		const [tokenizer, runner] = await Promise.all([
-			MailwomanTokenizer.loadFromFile(arg("tokenizer")),
+			MailwomanTokenizer.loadFromFile(values["tokenizer"] || ""),
 			ONNXRunner.create(modelPath),
 		])
 		neural = new NeuralAddressClassifier({ tokenizer, runner, labels: modelCard.labels })
@@ -163,8 +186,8 @@ async function main(): Promise<void> {
 	const { WOFSqlitePlaceLookup } = await import("@mailwoman/resolver-wof-sqlite")
 	// PR1 A/B flags: `--exact-tiering false` / `--parent-fallback false` restore the pre-PR1 baseline
 	// so the before/after table is one toggle apart.
-	const exactTiering = arg("exact-tiering", "true") !== "false"
-	const parentFallback = arg("parent-fallback", "true") !== "false"
+	const exactTiering = (values["exact-tiering"] || "true") !== "false"
+	const parentFallback = (values["parent-fallback"] || "true") !== "false"
 	const backend = new WOFSqlitePlaceLookup(
 		{ databasePath: wofPaths.length === 1 ? wofPaths[0]! : wofPaths },
 		{ exactMatchTiering: exactTiering }
@@ -172,7 +195,7 @@ async function main(): Promise<void> {
 	const resolver = createWOFResolver(backend as never)
 
 	const parseOpts = { postcodeRepair: true } as Parameters<typeof neural.parse>[1]
-	const country = arg("country", "US")
+	const country = values["country"] || "US"
 	const resolveOpts = { defaultCountry: country, parentFallback }
 	console.error(`exactMatchTiering=${exactTiering} parentFallback=${parentFallback}`)
 	const results: RowResult[] = []
@@ -308,9 +331,9 @@ async function main(): Promise<void> {
 		`- VERDICT: ${pass ? "CONTINUE — build the router" : "does not clear the gate — investigate / pivot to coverage"}`
 	)
 
-	if (arg("out-json")) {
-		writeFileSync(arg("out-json"), JSON.stringify(results, null, 2))
-		console.error(`wrote ${results.length} rows → ${arg("out-json")}`)
+	if (values["out-json"] || "") {
+		writeFileSync(values["out-json"] || "", JSON.stringify(results, null, 2))
+		console.error(`wrote ${results.length} rows → ${values["out-json"] || ""}`)
 	}
 }
 

--- a/scripts/eval/span-rescore-e2e.ts
+++ b/scripts/eval/span-rescore-e2e.ts
@@ -23,12 +23,17 @@ import { haversineKm } from "@mailwoman/spatial"
 
 // Loose scan parity with the retired scripts/lib/cli-args helpers: unknown flags tolerated.
 const { values: rawValues } = parseArgs({
-	options: { "candidate-db": { type: "string" }, model: { type: "string" }, n: { type: "string" } },
+	options: {
+		"candidate-db": { type: "string" },
+		model: { type: "string" },
+		n: { type: "string" },
+		nominatim: { type: "boolean" },
+	},
 	strict: false,
 	allowPositionals: true,
 })
 // Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
-const values = rawValues as { "candidate-db"?: string; model?: string; n?: string }
+const values = rawValues as { "candidate-db"?: string; model?: string; n?: string; nominatim?: boolean }
 const TOK = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 const CARD = "neural-weights-en-us/model-card.json"
 const ANCHOR = dataRootPath("anchor", "pilot-anchor-lookup.json")
@@ -38,7 +43,7 @@ const N = Number(values["n"] || "150")
 // Same-harness confirm (#780): also grade Nominatim on the same rows + grading, so mailwoman-with-lever
 // vs Nominatim is apples-to-apples (no cross-harness baseline gap). Opt-in — the public API is rate-
 // limited to ~1 req/s, so only run when explicitly confirming. Reuses #775's queryNominatim verbatim.
-const NOM = process.argv.includes("--nominatim")
+const NOM = values["nominatim"] ?? false
 const NOMINATIM_UA = "mailwoman-eval/1.0 (https://mailwoman.sister.software)"
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 async function queryNominatim(raw: string, cc: string): Promise<{ lat: number; lon: number } | null> {

--- a/scripts/eval/split-golden-dev-test.ts
+++ b/scripts/eval/split-golden-dev-test.ts
@@ -22,20 +22,23 @@
 import { createHash } from "node:crypto"
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
+import { parseArgs } from "node:util"
 
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { golden: { type: "string" }, seed: { type: "string" }, "test-ratio": { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { golden?: string; seed?: string; "test-ratio"?: string }
 // -------------------------------------------------------------------------------------------------
 // Args
 // -------------------------------------------------------------------------------------------------
 
-function arg(name: string, fallback: string): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback
-}
-
-const GOLDEN_DIR = arg("golden", "data/eval/golden/v0.1.2")
-const TEST_RATIO = Number(arg("test-ratio", "0.1"))
-const SEED = Number(arg("seed", "20260529"))
+const GOLDEN_DIR = values["golden"] || "data/eval/golden/v0.1.2"
+const TEST_RATIO = Number(values["test-ratio"] || "0.1")
+const SEED = Number(values["seed"] || "20260529")
 
 // -------------------------------------------------------------------------------------------------
 // Deterministic PRNG (mulberry32) + Fisher-Yates

--- a/scripts/generate-official-languages.ts
+++ b/scripts/generate-official-languages.ts
@@ -21,15 +21,13 @@
 
 import { readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
+import { parseArgs } from "node:util"
 
-const args = process.argv.slice(2)
-const get = (flag: string): string | undefined => {
-	const i = args.indexOf(flag)
-
-	return i >= 0 ? args[i + 1] : undefined
-}
-const CLDR_VERSION = get("--cldr-version") ?? "47.0.0"
-const cldrDir = get("--cldr-dir")
+const { values: cliValues } = parseArgs({
+	options: { "cldr-version": { type: "string" }, "cldr-dir": { type: "string" } },
+})
+const CLDR_VERSION = cliValues["cldr-version"] ?? "47.0.0"
+const cldrDir = cliValues["cldr-dir"]
 const OUT_PATH = join(import.meta.dirname, "..", "codex", "country", "official-languages.ts")
 
 async function loadCLDR(file: string): Promise<unknown> {

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -17,6 +17,7 @@
 
 import { mkdir, writeFile } from "node:fs/promises"
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 // import { Presets, SingleBar } from "cli-progress"
 import type { WhosOnFirstPlacetype } from "@mailwoman/core/resources/whosonfirst"
@@ -45,12 +46,14 @@ await mkdir(resourceDictionaryDirectory, {
 	recursive: true,
 })
 
-if (process.argv.length !== 3) {
+const { positionals } = parseArgs({ allowPositionals: true })
+
+if (positionals.length !== 1) {
 	console.error("usage: node %s {dbpath.sqlite}", resourceDictionaryPathBuilder("whosonfirst").toString())
 	process.exit(1)
 }
 
-const databasePath = process.argv[2]!
+const databasePath = positionals[0]!
 
 console.log(`Opening database... ${databasePath}`)
 const db = new DatabaseSync(databasePath, {

--- a/scripts/lint-mdx-angles.ts
+++ b/scripts/lint-mdx-angles.ts
@@ -17,6 +17,7 @@
 
 import { execFileSync } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 /**
  * The build-breaking class is `<55`-style numeric prose and `{word`-style MDX JSX expressions. Uppercase `<Component>`
@@ -60,7 +61,7 @@ function violations(file: string): string[] {
 	return hits
 }
 
-const files = process.argv.slice(2)
+const { positionals: files } = parseArgs({ allowPositionals: true })
 const targets = files.length > 0 ? files : stagedDocsMarkdown()
 
 if (targets.length === 0) {

--- a/scripts/smoke-resolve.ts
+++ b/scripts/smoke-resolve.ts
@@ -5,9 +5,13 @@
  *
  * Run: node --experimental-strip-types scripts/smoke-resolve.ts
  */
+import { parseArgs } from "node:util"
+
+import { dataRootPath } from "@mailwoman/core/utils"
 import { WOFSqlitePlaceLookup } from "@mailwoman/resolver-wof-sqlite"
 
-const DB = process.argv[2] ?? "/mnt/playpen/mailwoman-data/wof/admin-global-priority.db"
+const { positionals } = parseArgs({ allowPositionals: true })
+const DB = positionals[0] ?? String(dataRootPath("wof", "admin-global-priority.db"))
 const lookup = new WOFSqlitePlaceLookup({ databasePath: DB })
 
 console.log("=== plain: 'New York' (locality) ===")

--- a/tiger/tools/race-dots-map.ts
+++ b/tiger/tools/race-dots-map.ts
@@ -17,23 +17,42 @@
  */
 
 import { writeFileSync } from "node:fs"
+import { parseArgs } from "node:util"
 
 import { layers, namedFlavor } from "@protomaps/basemaps"
 
-function arg(name: string, fb = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fb
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: {
+		lat: { type: "string" },
+		lng: { type: "string" },
+		out: { type: "string" },
+		per: { type: "string" },
+		"pmtiles-url": { type: "string" },
+		title: { type: "string" },
+		zoom: { type: "string" },
+	},
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as {
+	lat?: string
+	lng?: string
+	out?: string
+	per?: string
+	"pmtiles-url"?: string
+	title?: string
+	zoom?: string
 }
-
-const PMTILES_URL = arg("pmtiles-url", "http://localhost:8899/race-dots-oc.pmtiles")
-const OUT = arg("out", "/tmp/race-dots-oc.html")
-const PER = Number(arg("per", "5"))
+const PMTILES_URL = values["pmtiles-url"] || "http://localhost:8899/race-dots-oc.pmtiles"
+const OUT = values["out"] || "/tmp/race-dots-oc.html"
+const PER = Number(values["per"] || "5")
 const PER_PHRASE = PER === 1 ? "one dot is one person" : `one dot ≈ ${PER} people`
-const TITLE = arg("title", `Race in Orange County, CA — ${PER_PHRASE} (2020 Census)`)
-const CENTER_LNG = Number(arg("lng", "-117.83"))
-const CENTER_LAT = Number(arg("lat", "33.68"))
-const ZOOM = Number(arg("zoom", "9.4"))
+const TITLE = values["title"] || `Race in Orange County, CA — ${PER_PHRASE} (2020 Census)`
+const CENTER_LNG = Number(values["lng"] || "-117.83")
+const CENTER_LAT = Number(values["lat"] || "33.68")
+const ZOOM = Number(values["zoom"] || "9.4")
 
 const MAPLIBRE_VERSION = "5.24.0"
 const MAPLIBRE_JS_SRI = "sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp"

--- a/tiger/tools/race-dots.ts
+++ b/tiger/tools/race-dots.ts
@@ -24,20 +24,23 @@
 
 import { createWriteStream } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 import { dataRootPath } from "@mailwoman/core/utils"
 import booleanContains from "@turf/boolean-contains"
 
-function arg(name: string, fb = ""): string {
-	const i = process.argv.indexOf(`--${name}`)
-
-	return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fb
-}
-
-const DB = arg("db", dataRootPath("tiger", "tiger-oc.db"))
-const OUT = arg("out", "/tmp/race-dots.ndjson")
-const PER = Number(arg("per", "10")) // people represented by one dot
-const LAYER = arg("layer", "dots")
+// Loose scan parity with the retired local argv helpers: unknown flags tolerated.
+const { values: rawValues } = parseArgs({
+	options: { db: { type: "string" }, layer: { type: "string" }, out: { type: "string" }, per: { type: "string" } },
+	strict: false,
+	allowPositionals: true,
+})
+// Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
+const values = rawValues as { db?: string; layer?: string; out?: string; per?: string }
+const DB = values["db"] || dataRootPath("tiger", "tiger-oc.db")
+const OUT = values["out"] || "/tmp/race-dots.ndjson"
+const PER = Number(values["per"] || "10") // people represented by one dot
+const LAYER = values["layer"] || "dots"
 
 // The eight P2 categories (columns in pl_block) that partition each block's population.
 const CATEGORIES = ["hispanic", "white", "black", "asian", "aian", "nhpi", "other", "multi"] as const


### PR DESCRIPTION
Finishes the standardization half of `UNFUCK_SCRIPTS.md` (migration shipped in #1032). Every success metric in the doc now ticks.

## Ground-truth corrections to the doc's audit

- **"44 cli-args imports remain" was a false positive** — the Phase-1 codemod's banner comment matches the loose search pattern in every converted file. The TRUE remainder was **4 gitignored `diagnostic/` files** with *broken* imports of the deleted module: `rg` respects `.gitignore`, so the Phase-1 codemod's file list — and its "zero imports" verification — both missed them. Fixed, and the lesson (recount with `--no-ignore`) is in the spec.
- "1 `.mjs` remains" — stale; converted in #1032.
- Part C's `rewrite-workspace-imports`/`smoke-clean-install` entries — stale; no env access exists.

## What converted (57 files + hand work)

- **Codemod v2** kills the local argv-helper idiom (each file's own `indexOf(\`--\${name}\`)` scan — the pattern cli-args was invented to absorb): helper defs removed, call sites → `strict:false` parseArgs + typed view, options **merged** into existing Phase-1 blocks where present. registry/tools, tiger/tools, eval, diagnostic all covered.
- **P0 promotion-gate** → STRICT parseArgs; unknown-arg and missing-required both smoked at **exit 2 parity** with the shell original.
- **Dispatch CLIs**: photon/libpostal/nominatim `process.argv[2]` → `parseArgs` positionals — photon `serve --port … --candidate-db …` smoked live (HTTP 200), bare invocation still prints usage.
- **P1 named**: check-release-parity, smoke-resolve (+ its hardcoded `/mnt/playpen` path → `dataRootPath` — a data-root rule violation), generate.ts, generate-official-languages, lint-mdx-angles.
- **Env**: oracle-locality-injection → `$public` (schema'd var). Release tooling was already typed — the one `process.env` is child-process passthrough.

## Deliberately NOT converted (with reasons in the spec)

- nuts/un-locode/timezone CLIs: already `parseArgs` + a **documented** hand-parse — negative coordinates (`-73.9`) break parseArgs positionals.
- The 4 resolver-wof-sqlite build CLIs: structured, tested local parsers with documented `--in ""` semantics — proper parsers, not the scan anti-pattern.

## Gates

Full clean-tree `tsc -b` 0 (touched workspaces wiped first, per the #1032 lesson) · `typecheck:scripts` 0 · oxlint 0 · **3,147 tests** · promotion-gate/promote-canary/photon-serve behavior smokes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)