### PR TITLE
chore: friendly drop-in root response (#1022) + hosted-endpoint docs pointer (#1011)

### DIFF
--- a/docs/articles/concepts/switching-from-photon.mdx
+++ b/docs/articles/concepts/switching-from-photon.mdx
@@ -10,6 +10,12 @@ description: A Photon-compatible autocomplete API without the Elasticsearch clus
 also an Elasticsearch cluster you feed a Photon import before it answers anything. Mailwoman speaks the
 same `/api` contract from a SQLite file, so your autocomplete keeps working without the cluster.
 
+**Try it first.** We host a live instance at [photon.sister.software](https://photon.sister.software) —
+nothing to install, no import to wait on. Open
+[`/api?q=berlin&limit=3`](https://photon.sister.software/api?q=berlin&limit=3) in a browser (or point your
+existing Photon client at the host) and read the GeoJSON that comes back. When it looks right, the one
+command below runs the same thing on your own machine.
+
 ## One command
 
 ```bash

--- a/libpostal/index.test.ts
+++ b/libpostal/index.test.ts
@@ -84,3 +84,15 @@ test("CORS: { cors: false } disables the headers (for a proxy that owns CORS)", 
 		expect(res.headers.get("access-control-allow-origin")).toBeNull()
 	})
 })
+
+test("root: GET / serves a friendly HTML banner, not a bare 404 (#1022)", async () => {
+	await withServer(express().use(createLibpostalRouter(corsEngine)), async (base) => {
+		const res = await fetch(`${base}/`)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("content-type")).toContain("text/html")
+		const body = await res.text()
+		expect(body).toContain("@mailwoman/libpostal")
+		expect(body).toContain("/parse?query=") // a clickable example query
+		expect(body).toContain("switching-from-libpostal") // docs pointer
+	})
+})

--- a/libpostal/index.ts
+++ b/libpostal/index.ts
@@ -94,6 +94,44 @@ const applyCors: RequestHandler = (req, res, next) => {
 	next()
 }
 
+/**
+ * A friendly HTML landing page for `GET /` (#1022). libpostal's own REST server has no root page, so there's no wire
+ * contract to match — this is pure courtesy: a browser visitor who pastes the bare host in gets a one-glance
+ * orientation with clickable example queries instead of Express's `Cannot GET /` 404, which reads as "the service is
+ * broken". Relative example URLs so they resolve against whatever host/port serves this.
+ */
+const ROOT_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>@mailwoman/libpostal</title>
+<style>
+:root { color-scheme: light dark }
+body { font: 16px/1.6 system-ui, -apple-system, sans-serif; max-width: 42rem; margin: 3rem auto; padding: 0 1.25rem }
+h1 { font-size: 1.3rem; margin: 0 0 .5rem }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace }
+ul { padding-left: 1.2rem }
+li { margin: .4rem 0 }
+a { color: #2563eb }
+.q { font-family: ui-monospace, SFMono-Regular, Menlo, monospace }
+footer { margin-top: 2rem; font-size: .9rem; opacity: .8 }
+</style>
+</head>
+<body>
+<h1>@mailwoman/libpostal</h1>
+<p>A libpostal-compatible <code>/parse</code> and <code>/expand</code> API, backed by a calibrated neural address parser (<code>POST</code> a JSON body, or <code>GET</code> with a query param).</p>
+<p>Try a query:</p>
+<ul>
+<li><a class="q" href="/parse?query=1600+pennsylvania+ave+washington+dc">/parse?query=1600+pennsylvania+ave+washington+dc</a></li>
+<li><a class="q" href="/parse?query=berlin+germany">/parse?query=berlin+germany</a></li>
+<li><a class="q" href="/expand?address=1600+pennsylvania+ave+nw">/expand?address=1600+pennsylvania+ave+nw</a></li>
+</ul>
+<footer><a href="https://mailwoman.sister.software/docs/concepts/switching-from-libpostal">Switching from libpostal</a> &middot; <a href="https://mailwoman.sister.software/demo">Live demo</a></footer>
+</body>
+</html>
+`
+
 /** Build the libpostal-compatible router around an injected {@link LibpostalEngine}. */
 export function createLibpostalRouter(engine: LibpostalEngine, options: LibpostalRouterOptions = {}): Router {
 	const router = Router()
@@ -101,6 +139,11 @@ export function createLibpostalRouter(engine: LibpostalEngine, options: Libposta
 	// Browser clients need CORS or their cross-origin XHR is blocked before completing (#1017).
 	if (options.cors !== false) {
 		router.use(applyCors)
+	}
+
+	// A helpful root banner instead of a bare `Cannot GET /` 404 — the first thing a browser visitor hits (#1022).
+	const root: RequestHandler = (_req, res) => {
+		res.type("html").send(ROOT_HTML)
 	}
 
 	const parse: RequestHandler = async (req, res) => {
@@ -145,6 +188,7 @@ export function createLibpostalRouter(engine: LibpostalEngine, options: Libposta
 			}
 		}
 
+	router.get("/", safe(root))
 	router.post("/parse", safe(parse))
 	router.get("/parse", safe(parse))
 	router.post("/expand", safe(expand))

--- a/nominatim/index.test.ts
+++ b/nominatim/index.test.ts
@@ -124,3 +124,15 @@ test("CORS: { cors: false } disables the headers (for a proxy that owns CORS)", 
 		expect(res.headers.get("access-control-allow-origin")).toBeNull()
 	})
 })
+
+test("root: GET / serves a friendly HTML banner, not a bare 404 (#1022)", async () => {
+	await withServer(express().use(createNominatimRouter(corsEngine)), async (base) => {
+		const res = await fetch(`${base}/`)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("content-type")).toContain("text/html")
+		const body = await res.text()
+		expect(body).toContain("@mailwoman/nominatim")
+		expect(body).toContain("/search?q=") // a clickable example query
+		expect(body).toContain("switching-from-nominatim") // docs pointer
+	})
+})

--- a/nominatim/index.ts
+++ b/nominatim/index.ts
@@ -200,6 +200,44 @@ const applyCors: RequestHandler = (req, res, next) => {
 }
 
 /**
+ * A friendly HTML landing page for `GET /` (#1022). Nominatim itself has no root page (just `/status`), so there's no
+ * wire contract to match — this is pure courtesy: a browser visitor who pastes the bare host in gets a one-glance
+ * orientation with clickable example queries instead of Express's `Cannot GET /` 404, which reads as "the service is
+ * broken". Relative example URLs so they resolve against whatever host/port serves this.
+ */
+const ROOT_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>@mailwoman/nominatim</title>
+<style>
+:root { color-scheme: light dark }
+body { font: 16px/1.6 system-ui, -apple-system, sans-serif; max-width: 42rem; margin: 3rem auto; padding: 0 1.25rem }
+h1 { font-size: 1.3rem; margin: 0 0 .5rem }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace }
+ul { padding-left: 1.2rem }
+li { margin: .4rem 0 }
+a { color: #2563eb }
+.q { font-family: ui-monospace, SFMono-Regular, Menlo, monospace }
+footer { margin-top: 2rem; font-size: .9rem; opacity: .8 }
+</style>
+</head>
+<body>
+<h1>@mailwoman/nominatim</h1>
+<p>A Nominatim-compatible geocoding API — the same <code>/search</code>, <code>/reverse</code>, <code>/lookup</code>, and <code>/status</code> contract, served from a SQLite gazetteer instead of a PostgreSQL/PostGIS import.</p>
+<p>Try a query:</p>
+<ul>
+<li><a class="q" href="/search?q=berlin&amp;format=jsonv2&amp;limit=3">/search?q=berlin&amp;format=jsonv2&amp;limit=3</a></li>
+<li><a class="q" href="/search?q=1600+pennsylvania+ave+washington+dc&amp;addressdetails=1">/search?q=1600+pennsylvania+ave+washington+dc&amp;addressdetails=1</a></li>
+<li><a class="q" href="/reverse?lat=52.52&amp;lon=13.405">/reverse?lat=52.52&amp;lon=13.405</a></li>
+</ul>
+<footer><a href="https://mailwoman.sister.software/docs/concepts/switching-from-nominatim">Switching from Nominatim</a> &middot; <a href="https://mailwoman.sister.software/demo">Live demo</a></footer>
+</body>
+</html>
+`
+
+/**
  * Build the Nominatim-compatible router around an injected {@link NominatimEngine}. Query-param parsing lives here; the
  * result _formatting_ (jsonv2 vs geojson envelope, `address` projection) is #804 and currently passes the engine's
  * results through verbatim.
@@ -210,6 +248,11 @@ export function createNominatimRouter(engine: NominatimEngine, options: Nominati
 	// Browser-embedded geocoder clients need CORS or their cross-origin XHR is blocked before completing (#1017).
 	if (options.cors !== false) {
 		router.use(applyCors)
+	}
+
+	// A helpful root banner instead of a bare `Cannot GET /` 404 — the first thing a browser visitor hits (#1022).
+	const root: RequestHandler = (_req, res) => {
+		res.type("html").send(ROOT_HTML)
 	}
 
 	const search: RequestHandler = async (req, res) => {
@@ -310,6 +353,7 @@ export function createNominatimRouter(engine: NominatimEngine, options: Nominati
 			}
 		}
 
+	router.get("/", safe(root))
 	router.get("/search", safe(search))
 	router.get("/reverse", safe(reverse))
 	router.get("/lookup", safe(lookup))

--- a/photon/index.test.ts
+++ b/photon/index.test.ts
@@ -168,3 +168,15 @@ test("CORS: { cors: false } disables the headers (for a proxy that owns CORS)", 
 		expect(res.headers.get("access-control-allow-origin")).toBeNull()
 	})
 })
+
+test("root: GET / serves a friendly HTML banner, not a bare 404 (#1022)", async () => {
+	await withServer(express().use(createPhotonRouter(engine)), async (base) => {
+		const res = await fetch(`${base}/`)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("content-type")).toContain("text/html")
+		const body = await res.text()
+		expect(body).toContain("@mailwoman/photon")
+		expect(body).toContain("/api?q=") // a clickable example query
+		expect(body).toContain("switching-from-photon") // docs pointer
+	})
+})

--- a/photon/index.ts
+++ b/photon/index.ts
@@ -132,6 +132,44 @@ const applyCors: RequestHandler = (req, res, next) => {
 }
 
 /**
+ * A friendly HTML landing page for `GET /` (#1022). Upstream komoot/photon serves no root page, so there's no wire
+ * contract to match — this is pure courtesy: a browser visitor (or an evaluator kicking the tires) who pastes the bare
+ * host in gets a one-glance orientation with clickable example queries instead of Express's `Cannot GET /` 404, which
+ * reads as "the service is broken". Relative example URLs so they resolve against whatever host/port serves this.
+ */
+const ROOT_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>@mailwoman/photon</title>
+<style>
+:root { color-scheme: light dark }
+body { font: 16px/1.6 system-ui, -apple-system, sans-serif; max-width: 42rem; margin: 3rem auto; padding: 0 1.25rem }
+h1 { font-size: 1.3rem; margin: 0 0 .5rem }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace }
+ul { padding-left: 1.2rem }
+li { margin: .4rem 0 }
+a { color: #2563eb }
+.q { font-family: ui-monospace, SFMono-Regular, Menlo, monospace }
+footer { margin-top: 2rem; font-size: .9rem; opacity: .8 }
+</style>
+</head>
+<body>
+<h1>@mailwoman/photon</h1>
+<p>A Photon-compatible autocomplete geocoding API — the same <code>/api</code> and <code>/reverse</code> contract, served from a SQLite gazetteer instead of an Elasticsearch cluster.</p>
+<p>Try a query:</p>
+<ul>
+<li><a class="q" href="/api?q=berlin&amp;limit=3">/api?q=berlin&amp;limit=3</a></li>
+<li><a class="q" href="/api?q=1600+pennsylvania+ave&amp;limit=1">/api?q=1600+pennsylvania+ave&amp;limit=1</a></li>
+<li><a class="q" href="/reverse?lat=52.52&amp;lon=13.405">/reverse?lat=52.52&amp;lon=13.405</a></li>
+</ul>
+<footer><a href="https://mailwoman.sister.software/docs/concepts/switching-from-photon">Switching from Photon</a> &middot; <a href="https://mailwoman.sister.software/demo">Live demo</a></footer>
+</body>
+</html>
+`
+
+/**
  * Build the Photon-compatible router around an injected {@link PhotonEngine}. Param parsing lives here; the feature
  * _projection_ (resolved place → {@link PhotonProperties}) is the staged work.
  */
@@ -141,6 +179,11 @@ export function createPhotonRouter(engine: PhotonEngine, options: PhotonRouterOp
 	// Browser-embedded widgets need CORS or their cross-origin XHR is blocked before the request completes (#1017).
 	if (options.cors !== false) {
 		router.use(applyCors)
+	}
+
+	// A helpful root banner instead of a bare `Cannot GET /` 404 — the first thing a browser visitor hits (#1022).
+	const root: RequestHandler = (_req, res) => {
+		res.type("html").send(ROOT_HTML)
 	}
 
 	const search: RequestHandler = async (req, res) => {
@@ -213,6 +256,7 @@ export function createPhotonRouter(engine: PhotonEngine, options: PhotonRouterOp
 			}
 		}
 
+	router.get("/", safe(root))
 	router.get("/api", safe(search))
 	router.get("/reverse", safe(reverse))
 


### PR DESCRIPTION
## What

Two small drop-in-server polish items.

### #1022 — friendly root response

The `@mailwoman/photon` / `@mailwoman/nominatim` / `@mailwoman/libpostal` routers registered only their functional routes, so `GET /` fell through to Express's default `Cannot GET /` 404. It's functionally correct (upstream komoot/photon has no root page either), but anyone who pastes the bare host into a browser — or an evaluator kicking the tires during outreach — sees "Cannot GET /" and reasonably concludes the service is broken.

Each router now serves a small friendly `GET /` banner: a minimal, self-contained HTML page with what the endpoint is, 2-3 clickable example queries (relative URLs, so they resolve against whatever host/port serves them), and links to the matching `switching-from-*` docs page + the live demo. All three drop-ins share the pattern, so the same treatment applies to each (a per-package handler wrapped in `safe()` and registered alongside the functional routes — mirroring how each package already carries its own `applyCors`). A route test per server, matching the existing HTTP-level test style.

`GET /` now serves (photon):

> **@mailwoman/photon** — a Photon-compatible autocomplete geocoding API. Try: `/api?q=berlin&limit=3`, `/api?q=1600+pennsylvania+ave&limit=1`, `/reverse?lat=52.52&lon=13.405`. Links: Switching from Photon · Live demo.

### #1011 — hosted-endpoint docs pointer (last unchecked box)

A short "Try it first" note near the top of `switching-from-photon.mdx` pointing at the hosted `https://photon.sister.software` instance, with one example query URL (`/api?q=berlin&limit=3`), in the page's own prose voice.

## Gates

- `photon` / `nominatim` / `libpostal` tests: 30 passed (3 new root-route tests)
- `yarn lint:oxlint` + `yarn lint:oxfmt` — clean
- `tsc -b` on the three packages — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)