### PR TITLE
fix(#981): geocode-core applies the query-shape emission prior — path convergence, byte-stable

### DIFF
--- a/mailwoman/geocode-core.test.ts
+++ b/mailwoman/geocode-core.test.ts
@@ -11,9 +11,15 @@
  */
 
 import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { computeQueryShape } from "@mailwoman/query-shape"
 import { describe, expect, it } from "vitest"
 
-import { countryFromPostcodeFormat, extractGeocodeResult } from "./geocode-core.js"
+import {
+	countryFromPostcodeFormat,
+	extractGeocodeResult,
+	type GeocodeClassifier,
+	parseForGeocode,
+} from "./geocode-core.js"
 
 describe("countryFromPostcodeFormat (#928)", () => {
 	it("matches GB postcodes (spaced and unspaced)", () => {
@@ -186,5 +192,66 @@ describe("extractGeocodeResult — ranked candidates for limit>1 (#1016)", () =>
 			],
 		}
 		expect(extractGeocodeResult("berlin", tree).candidates).toHaveLength(1)
+	})
+})
+
+describe("parseForGeocode — query-shape emission prior (#981)", () => {
+	type ParseOpts = Parameters<GeocodeClassifier["parse"]>[1]
+
+	/**
+	 * A recording classifier: captures the opts geocode-core hands the model. Lets us assert the query-shape prior the
+	 * runtime pipeline applies (`core/pipeline/runtime-pipeline.ts` → `safeClassify`) now reaches the geocode path too —
+	 * without loading a real model.
+	 */
+	function recordingClassifier(): { classifier: GeocodeClassifier; calls: Array<{ text: string; opts?: ParseOpts }> } {
+		const calls: Array<{ text: string; opts?: ParseOpts }> = []
+		const classifier: GeocodeClassifier = {
+			parse(text, opts) {
+				calls.push({ text, opts })
+
+				return Promise.resolve({ raw: text, roots: [] })
+			},
+		}
+
+		return { classifier, calls }
+	}
+
+	it("passes a queryShape computed on the exact model input (converges with the runtime pipeline)", async () => {
+		const { classifier, calls } = recordingClassifier()
+		await parseForGeocode("Damrak 1, 1012 LG Amsterdam", { classifier })
+
+		expect(calls).toHaveLength(1)
+		const { text, opts } = calls[0]!
+		expect(opts?.queryShape).toBeDefined()
+		// The shape must be the one computeQueryShape derives from the SAME text handed to the model.
+		expect(opts!.queryShape).toEqual(computeQueryShape(text))
+	})
+
+	it("carries the known-format hit that biases B-postcode (the belt reaches the geocode path)", async () => {
+		const { classifier, calls } = recordingClassifier()
+		await parseForGeocode("Damrak 1, 1012 LG Amsterdam", { classifier })
+
+		const formats = calls[0]!.opts!.queryShape!.knownFormats.map((f) => f.format)
+		expect(formats).toContain("nl_postcode")
+	})
+
+	it("is an empty-format shape for the bare street+city class — nothing for the prior to bias (#981 falsified)", async () => {
+		const { classifier, calls } = recordingClassifier()
+		await parseForGeocode("Wetstraat, Brussel", { classifier })
+
+		const qs = calls[0]!.opts!.queryShape!
+		// The Wetstraat/Rue-de-la-Loi cross-border class: no known postcode format, no region abbreviation, so
+		// buildEmissionPriors returns an all-zeros matrix — the emission prior CANNOT move it. That class needs a
+		// lexical country prior, not this belt.
+		expect(qs.knownFormats).toHaveLength(0)
+		expect(qs.regionAbbreviations ?? []).toHaveLength(0)
+	})
+
+	it("computes the shape over the raw input when normalizeInput is false", async () => {
+		const { classifier, calls } = recordingClassifier()
+		await parseForGeocode("Damrak 1, 1012 LG Amsterdam", { classifier, normalizeInput: false })
+
+		expect(calls[0]!.text).toBe("Damrak 1, 1012 LG Amsterdam")
+		expect(calls[0]!.opts!.queryShape).toEqual(computeQueryShape("Damrak 1, 1012 LG Amsterdam"))
 	})
 })

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -28,6 +28,7 @@ import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
 import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { hardCountryFor, isBareLocalityTree } from "@mailwoman/core/pipeline"
 import { normalize } from "@mailwoman/normalize"
+import { computeQueryShape, type QueryShape } from "@mailwoman/query-shape"
 import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } from "@mailwoman/resolver"
 
 import { type DataReleaseManifest, readReleaseManifest, resolveShardPath } from "./data-release.js"
@@ -94,7 +95,10 @@ export type ShardResolver = (stateSlug: string | null) => StateShards
 
 /** The minimal classifier surface the cascade needs (a `NeuralAddressClassifier` satisfies it). */
 export interface GeocodeClassifier {
-	parse(text: string, opts?: { postcodeRepair?: boolean; normalizeCase?: boolean }): Promise<AddressTree>
+	parse(
+		text: string,
+		opts?: { postcodeRepair?: boolean; normalizeCase?: boolean; queryShape?: QueryShape }
+	): Promise<AddressTree>
 }
 
 export interface GeocodeDeps {
@@ -399,8 +403,23 @@ export async function parseForGeocode(
 	const parseInput =
 		deps.normalizeInput === false ? input : normalize(input, { expandAbbreviations: true, locale: "und" }).normalized
 
+	// #981: apply the query-shape emission prior the runtime pipeline applies (core/pipeline/runtime-pipeline.ts:336
+	// `computeQueryShape` → `safeClassify` → parse with `queryShape`). Without it the geocode path — the drop-in
+	// servers (nominatim/photon `/api`) + the geocode CLI — diverged from the pipeline: a detected known-format span
+	// (`nl_postcode` → `B-postcode`, …) or a US region abbreviation never biased the emissions here. Computed on
+	// `parseInput` (the exact text handed to the model), matching the pipeline (which computes it on the normalized
+	// text, before the classifier's internal case-normalization). It is a NO-OP whenever the shape carries no known
+	// format and no region abbreviation (the bare `street, city` class) — `buildEmissionPriors` returns an all-zeros
+	// matrix — so both bare-form and well-formed inputs are byte-stable; it earns its keep only on the ambiguous
+	// digit-span / region-abbrev cases the model isn't already confident about.
+	const queryShape = computeQueryShape(parseInput)
+
 	return recognizeUSRegions(
-		await deps.classifier.parse(parseInput, { postcodeRepair: true, normalizeCase: deps.normalizeCase ?? true })
+		await deps.classifier.parse(parseInput, {
+			postcodeRepair: true,
+			normalizeCase: deps.normalizeCase ?? true,
+			queryShape,
+		})
 	)
 }
 


### PR DESCRIPTION
Fixes #981.

## Characterization (file:line)

`classifier.parse` applies the query-shape emission prior (`buildEmissionPriors` — the `FORMAT_TO_LABEL` postcode/`po_box` bias **and** the region-abbreviation → `B-locality` bias) **only when passed `opts.queryShape`** (`neural/classifier.ts:495`).

- The **runtime pipeline** computes it and threads it through: `core/pipeline/runtime-pipeline.ts:336` `computeQueryShape` → `safeClassify` (`:569`) → `classifier.parse(text, { queryShape, … })`. Prior applied.
- **geocode-core** — the geocode CLI + the nominatim/photon `/api` drop-ins (`photon/cli.ts:102`, `nominatim/cli.ts:194` → `geocodeAddress`) — called `parseForGeocode` → `classifier.parse(parseInput, { postcodeRepair, normalizeCase })` at `mailwoman/geocode-core.ts:403` with **no `queryShape`**, and never imported `computeQueryShape`. Prior skipped.

## Why it was skipped — accident, not deliberate

Incidental omission. The geocode-core header deliberately bypasses the runtime *pipeline* (its reconcile stage merges `street` into `house_number`, dropping the street node the coordinate tiers need, #566) — but says nothing about the query-shape prior. The belt was wired into the classifier (#973) and the pipeline consumes it (#924); the raw `classifier.parse` in `parseForGeocode` was simply written without threading the shape. No comment or design note excludes it. Converging is correct (defense-in-depth: a future format entry or a less-confident model would otherwise silently miss the belt on the served path).

## The fix (converged, not copied)

`parseForGeocode` computes `computeQueryShape(parseInput)` on the exact text handed to the model and passes it to `classifier.parse` — the same `computeQueryShape` from `@mailwoman/query-shape` the pipeline uses (no duplicated logic). `GeocodeClassifier.parse` gains the structural `queryShape?: QueryShape` opt. Single call site.

## Measured effect — BOTH parse paths, 30-query probe

Config: bundled placer + hardPlaceCountry + postcodeCountryPrior default-on (the live `/api` config), production-faithful with anchor + gazetteer fed. **A = no queryShape (pre-fix)**, **B = +queryShape (post-fix)**.

| Class | n | parse diffs | resolved-country diffs | coord diffs |
|---|---|---|---|---|
| **Bare street+city, no postcode** (Wetstraat/Rue-de-la-Loi; BE/FR/DE/NL) | 20 | **0/20** | **0/20** | **0/20** |
| **Postcode-carrying controls** (NL/BE/DE/GB/US/FR/CA) | 10 | **0/10** | **0/10** | **0/10** |

The prior moves nothing on this probe. Two structural reasons:

1. **Bare-form class:** no known postcode format + no region abbreviation → `buildEmissionPriors` returns an **all-zeros matrix** (`neural/query-shape-prior.ts:112`). The emission prior *cannot* touch this class — there is nothing to bias.
2. **Well-formed controls:** the model already labels the postcode/region tokens correctly, so the confidence-scaled +0.9..1.0 nudge toward `B-postcode` never flips the argmax. Consistent with #981's own assessment ("for well-formed input the model is already correct, so the prior is largely a no-op").

## Wetstraat hypothesis — FALSIFIED (stated plainly)

The suspicion (from #994) that this missing prior contributes to bare no-postcode queries resolving cross-border — `Wetstraat, Brussel` → Netherlands, `Rue de la Loi, Bruxelles` → Butembo CD — **does not hold**. The query-shape emission prior is provably inert on that class (empty shape → zero matrix). Those misroutes are a **resolver-side country-selection** problem; the fix is a **lexical country prior** (a whole-string BE/FR/NL signal that survives the absence of a postcode), not this emission belt. This PR still lands because the path divergence is a real bug worth closing on consistency grounds — it just isn't the Wetstraat lever.

## Gate

**Gauntlet self-check — `VERDICT: PASS — clear to ship`** (anchor + gazetteer fed):

```
════════════════ GAUNTLET ════════════════
  ✓ PASS  regression      (27/27 gated cases pass, 2 tracked)
  ✓ PASS  metamorphic     (INV 53/53, DIR 3/3, BAND 16/21 + 5 tracked xfails)
VERDICT: PASS — clear to ship
```

- The regression layer is **byte-identical before/after** this change (verified by reverting geocode-core.ts to `origin/main`, recompiling, and re-running — same pass/fail set), confirming zero coordinate movement.
- Unit tests: 4 new cases in `mailwoman/geocode-core.test.ts` (17 total pass) — assert the shape reaches the model, matches `computeQueryShape` of the exact input, carries the `nl_postcode` hit on `Damrak 1, 1012 LG`, and is empty for `Wetstraat, Brussel` (the falsified class, documented in the test).
- `yarn compile` green across all workspaces (nominatim/photon consumers of `GeocodeClassifier` typecheck), `yarn lint` all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)