### PR TITLE
feat(#1012): FR address-point tier from BAN — 26M rooftops close the @1km gap (37% → 88% in-BAN)

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -15,6 +15,7 @@
 				"resolver",
 				"resolver-wof-sqlite",
 				"resolver-wof-wasm",
+				"ban",
 				"classifiers",
 				"corpus",
 				"neural",

--- a/ban/README.md
+++ b/ban/README.md
@@ -1,0 +1,54 @@
+# @mailwoman/ban
+
+Base Adresse Nationale (France) rooftop ingestion. This package reads the open BAN CSV dumps
+(`adresses-<dept>.csv`, adresse.data.gouv.fr) and builds the **national FR address-point shard** on the
+same situs schema the US rooftop tier already uses — so the existing `AddressPointSqliteLookup` reads it
+with zero changes, and the resolver gains rooftop precision across France from the authoritative
+government register (26M addresses) instead of the sparse community fallback (OSM-FR, ~1.1M points).
+
+It is the French counterpart of the 50-state US situs layer (#1012). It closes the measured FR rooftop
+gap: commune resolution was already ~99% @25 km, but @1 km sat at ~37% and was _flat_ from clean to messy
+input — the flatness is the tell of a coverage ceiling, not a parse problem. BAN is the coverage.
+
+## The licensing boundary
+
+Unlike the ODbL OpenStreetMap tier, BAN is published under the **Licence Ouverte / Open Licence 2.0
+(Etalab)** — attribution only, **no share-alike**. So the built shard ships under the same terms as the
+permissive Mailwoman core (Who's On First, Overture, OpenAddresses, GeoNames); there is no lawyer sign-off
+gate. The one standing obligation is attribution:
+
+- **This package is code, and code only.** It contains no BAN bytes.
+- **Attribution rides on any result resolved through a BAN point.** The `source` on every BAN point is
+  `ban:fr`, and the resolver should surface
+  _"© les contributeurs de la Base Adresse Nationale (adresse.data.gouv.fr)"_.
+
+## Building the shard
+
+BAN's per-département dumps land under `$MAILWOMAN_DATA_ROOT/…/ban/` (or the corpus source dir). The build
+streams them — no external CLI, no DuckDB — so it is dependency-light and OOM-safe on the 26M-row national
+set.
+
+```bash
+# 1. Download the per-département dumps (or the national adresses-france.csv.gz):
+#    https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/adresses-<dept>.csv.gz
+#    → $MAILWOMAN_DATA_ROOT/ban/sources/   (or reuse an existing corpus/sources/ban)
+
+# 2. Build the national shard (writes $MAILWOMAN_DATA_ROOT/ban/address-points-fr.db, sealed 0444):
+node ban/out/scripts/build-address-point-shard.js \
+  --csv-dir $MAILWOMAN_DATA_ROOT/corpus/sources/ban --release 2026-05-18
+
+# Validate on a few départements first (transient; skips the provenance rewrite):
+node ban/out/scripts/build-address-point-shard.js --depts 48,2A,05 --out /tmp/ban-sample.db
+```
+
+The build records provenance (source URL, license, release, row count, md5) in `ban/ATTRIBUTION.json` at
+creation, seals the artifact read-only, and swaps it into place atomically — it is a new, purely-additive
+file and never touches the OSM shard beside it.
+
+## The resolution tier
+
+`BANShardProvider.for(country)` is wired into `GeocodeDeps.nationalShards`, consulted **ahead of** the OSM
+`osmShards` tier (a national authoritative register outranks the community fallback) and only for a non-US
+parse. BAN rows carry their own postcode + commune, so the lookup keys on the scoped
+(`postcode` → `locality`) probes; no bbox fall-through is needed. Interpolation for house numbers BAN
+doesn't carry is not built yet — the exact-point tier is the whole win here (BAN's density is the point).

--- a/ban/index.ts
+++ b/ban/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `@mailwoman/ban` — Base Adresse Nationale (France) rooftop address-point ingestion. The FR
+ *   counterpart of the 50-state US situs layer (#1012): the national government address register (26M
+ *   addresses) that closes the rooftop gap OSM-FR (~1.1M points) can't. PERMISSIVE CODE ONLY — this
+ *   workspace contains no BAN data bytes. It reads the open `adresses-<dept>.csv` dumps
+ *   (adresse.data.gouv.fr, Licence Ouverte/Etalab) and writes a national FR shard on the SHARED situs
+ *   schema (`@mailwoman/resolver-wof-sqlite/address-point-schema`), so the existing
+ *   `AddressPointSqliteLookup` reads it with zero changes. See `./sdk` for the ingestion surface and
+ *   `./scripts/build-address-point-shard` for the build CLI.
+ */
+
+export * from "./sdk/index.js"

--- a/ban/package.json
+++ b/ban/package.json
@@ -25,6 +25,13 @@
 		"url": "https://github.com/sister-software/mailwoman.git",
 		"directory": "ban"
 	},
+	"files": [
+		"out/**/*.js",
+		"out/**/*.js.map",
+		"out/**/*.d.ts",
+		"out/**/*.d.ts.map",
+		"README.md"
+	],
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",

--- a/ban/package.json
+++ b/ban/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@mailwoman/ban",
+	"version": "5.7.0",
+	"description": "Base Adresse Nationale (France) rooftop address-point ingestion — builds the national FR precision shard on the situs address-point schema.",
+	"keywords": [
+		"address-point",
+		"ban",
+		"france",
+		"geocoding",
+		"geospatial"
+	],
+	"homepage": "https://github.com/sister-software/mailwoman",
+	"bugs": {
+		"url": "https://github.com/sister-software/mailwoman/issues"
+	},
+	"license": "AGPL-3.0-only OR LicenseRef-Commercial",
+	"contributors": [
+		{
+			"name": "Teffen Ellis",
+			"email": "teffen@sister.software"
+		}
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sister-software/mailwoman.git",
+		"directory": "ban"
+	},
+	"type": "module",
+	"exports": {
+		"./package.json": "./package.json",
+		"./scripts/*": "./out/scripts/*.js",
+		"./sdk": "./out/sdk/index.js",
+		".": "./out/index.js"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"@mailwoman/core": "workspace:*",
+		"@mailwoman/resolver-wof-sqlite": "workspace:*",
+		"kysely": "^0.29.2",
+		"spliterator": "^3.2.0"
+	},
+	"engines": {
+		"node": ">=24.18.0"
+	}
+}

--- a/ban/scripts/build-address-point-shard.ts
+++ b/ban/scripts/build-address-point-shard.ts
@@ -1,0 +1,281 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build the national FR ROOFTOP address-point shard from the BAN `adresses-<dept>.csv` dumps
+ *   (adresse.data.gouv.fr), on the SHARED situs schema (`@mailwoman/resolver-wof-sqlite/address-point-schema`)
+ *   so the existing `AddressPointSqliteLookup` reads it with zero changes (#1012). BAN is a structured
+ *   government register — every row carries `numero`/`nom_voie`/`code_postal`/`nom_commune`/`lon`/`lat`,
+ *   so there is no OSM-style association gap: we write the exact source coordinate for every valid row.
+ *
+ *   The `rep` (repetition: bis/ter/…) is folded into the house-number key (`"8 bis"`), so a parsed
+ *   `"8 bis Rue X"` matches; plain-number rows are keyed on the bare number, unchanged. Keying uses THE
+ *   shared FR normalizer (`normalizeStreetForKeyLocale(street, "fr")`) — the identical function the
+ *   lookup tier applies at query time, so build-side and probe-side can't drift.
+ *
+ *   Build discipline (house rules): stream → positional prepared INSERT (batched) → indexes → ANALYZE →
+ *   atomic swap into place → SEAL 0444 → record md5 + provenance in `ban/ATTRIBUTION.json`. The output
+ *   is a NEW, purely-additive artifact (`ban/address-points-fr.db`); it never touches the OSM shard.
+ *
+ *   BAN is published under the Licence Ouverte / Etalab 2.0 (attribution, NO share-alike), so the built
+ *   shard ships under the same terms as the permissive core — no ODbL lawyer gate. `source = "ban:fr"`.
+ *
+ *   Usage:
+ *     node ban/out/scripts/build-address-point-shard.js \
+ *       --csv-dir $MAILWOMAN_DATA_ROOT/corpus/sources/ban --release 2026-05-18
+ *     # validate on a few départements first:
+ *     node ban/out/scripts/build-address-point-shard.js --depts 48,2A,05 --out /tmp/ban-sample.db
+ */
+
+import { createHash } from "node:crypto"
+import {
+	createReadStream,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs"
+import { dirname } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
+import { dataRootPath, sealDatabase } from "@mailwoman/core/utils"
+import {
+	ADDRESS_POINT_COLUMNS,
+	type AddressPointDatabase,
+	createAddressPointIndexes,
+	createAddressPointTable,
+} from "@mailwoman/resolver-wof-sqlite/address-point-schema"
+import {
+	canonicalizeRouteKey,
+	normalizeLocalityForKey,
+	normalizeStreetForKeyLocale,
+} from "@mailwoman/resolver-wof-sqlite/street-normalize"
+
+import { extractBANAddrPoints } from "../sdk/extract.js"
+import { BAN_ATTRIBUTION, BAN_CSV_BASE, BAN_LICENSE } from "../sdk/fetch.js"
+import { streetLocaleForBANCountry } from "../sdk/street-locale.js"
+
+interface BuildArgs {
+	country: string
+	csvDir: string
+	release: string
+	output: string
+	depts: string[] | null
+}
+
+function parse(): BuildArgs {
+	const { values } = parseArgs({
+		options: {
+			country: { type: "string" },
+			"csv-dir": { type: "string" },
+			release: { type: "string" },
+			out: { type: "string" },
+			depts: { type: "string" },
+		},
+	})
+
+	const country = (values.country ?? "fr").toLowerCase()
+	// Throws for an unsupported country — fail loud, never key with the wrong normalizer.
+	streetLocaleForBANCountry(country)
+	const csvDir = values["csv-dir"] ?? dataRootPath("corpus", "sources", "ban")
+
+	if (!existsSync(csvDir)) throw new Error(`BAN CSV dir not found: ${csvDir}`)
+	const release = values.release ?? "2026-05-18"
+	const output = values.out ?? dataRootPath("ban", `address-points-${country}.db`)
+	const depts = values.depts
+		? values.depts
+				.split(",")
+				.map((d) => d.trim())
+				.filter(Boolean)
+		: null
+
+	return { country, csvDir, release, output, depts }
+}
+
+/**
+ * Enumerate the per-département BAN dumps in `csvDir`, keyed by département code. Excludes the `merged` / `france`
+ * aggregates (they duplicate the per-département rows), and prefers an uncompressed `.csv` over a `.csv.gz` when both
+ * exist (the same dept, faster read). When `depts` is set, restricts to that list (for a fast validation build).
+ */
+function departementFiles(csvDir: string, depts: string[] | null): Map<string, string> {
+	const byDept = new Map<string, string>()
+	const wanted = depts ? new Set(depts.map((d) => d.toLowerCase())) : null
+
+	for (const name of readdirSync(csvDir).sort()) {
+		const m = /^adresses-(.+?)\.csv(\.gz)?$/.exec(name)
+
+		if (!m) continue
+		const dept = m[1]!
+
+		// The aggregate dumps double-count the per-département rows — skip them.
+		if (dept === "merged" || dept === "france") continue
+
+		if (wanted && !wanted.has(dept.toLowerCase())) continue
+
+		const path = `${csvDir}/${name}`
+		const existing = byDept.get(dept)
+
+		// Prefer the uncompressed .csv over a .csv.gz for the same dept.
+		if (!existing || (existing.endsWith(".gz") && !name.endsWith(".gz"))) {
+			byDept.set(dept, path)
+		}
+	}
+
+	return byDept
+}
+
+/** Streaming md5 of a file (never buffer a multi-GB artifact). */
+async function fileMD5(path: string): Promise<string> {
+	const hash = createHash("md5")
+
+	for await (const chunk of createReadStream(path)) {
+		hash.update(chunk as Buffer)
+	}
+
+	return hash.digest("hex")
+}
+
+async function main(): Promise<void> {
+	const args = parse()
+	const locale = streetLocaleForBANCountry(args.country)
+	const source = `ban:${args.country}`
+	const files = departementFiles(args.csvDir, args.depts)
+
+	if (files.size === 0) throw new Error(`no BAN département dumps found in ${args.csvDir}`)
+	const tmp = `${args.output}.building-${process.pid}.db`
+
+	mkdirSync(dirname(args.output), { recursive: true })
+
+	for (const sfx of ["", "-wal", "-shm"]) {
+		rmSync(tmp + sfx, { force: true })
+	}
+
+	const out = new DatabaseSync(tmp)
+	out.exec("PRAGMA page_size=8192; PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF; PRAGMA cache_size=-2000000;")
+	const kdb = new DatabaseClient<AddressPointDatabase>({ database: out })
+	await createAddressPointTable(kdb)
+
+	const insert = out.prepare(`INSERT INTO address_point VALUES (${ADDRESS_POINT_COLUMNS.map(() => "?").join(", ")})`)
+
+	let total = 0
+	let written = 0
+	let noStreet = 0
+	const BATCH = 50_000
+	const deptList = [...files.keys()].sort()
+
+	console.error(`[ban] building ${args.country} rooftop shard from ${files.size} départements in ${args.csvDir}`)
+	out.exec("BEGIN")
+
+	for (const dept of deptList) {
+		const path = files.get(dept)!
+
+		for await (const rec of extractBANAddrPoints(path)) {
+			total++
+			const streetNorm = normalizeStreetForKeyLocale(rec.street, locale)
+			const numTrim = rec.numero.trim().toLowerCase()
+
+			if (!streetNorm || !numTrim) {
+				noStreet++
+				continue
+			}
+			// Fold `rep` into the house-number key: "8" + "bis" → "8 bis" (matches a parsed "8 bis Rue X").
+			const number = rec.rep ? `${numTrim} ${rec.rep}` : numTrim
+			// Positional, in ADDRESS_POINT_COLUMNS order: street_norm, street_key, number, unit, postcode,
+			// locality_norm, street_raw, lat, lon, source, release.
+			insert.run(
+				streetNorm,
+				canonicalizeRouteKey(streetNorm),
+				number,
+				null,
+				rec.postcode,
+				rec.city ? normalizeLocalityForKey(rec.city) : null,
+				rec.street,
+				rec.lat,
+				rec.lon,
+				source,
+				args.release
+			)
+			written++
+
+			if (written % BATCH === 0) {
+				out.exec("COMMIT")
+				out.exec("BEGIN")
+
+				if (written % 2_000_000 === 0) {
+					console.error(`[ban]   ${written.toLocaleString()} written…`)
+				}
+			}
+		}
+		console.error(`[ban]   dept ${dept}: ${written.toLocaleString()} cumulative`)
+	}
+	out.exec("COMMIT")
+
+	console.error(`[ban] indexing…`)
+	await createAddressPointIndexes(kdb)
+	out.exec("ANALYZE")
+	await kdb.destroy()
+
+	// Atomic swap into place (move any prior aside first), then SEAL 0444.
+	if (existsSync(args.output)) {
+		renameSync(args.output, `${args.output}.prev`)
+	}
+
+	for (const sfx of ["-wal", "-shm"]) {
+		rmSync(args.output + sfx, { force: true })
+	}
+	renameSync(tmp, args.output)
+
+	if (existsSync(`${args.output}.prev`)) {
+		rmSync(`${args.output}.prev`, { force: true })
+	}
+	sealDatabase(args.output)
+
+	const md5 = await fileMD5(args.output)
+	const bytes = statSync(args.output).size
+
+	// Provenance manifest — additive, written at creation (house discipline). Only for a FULL national build
+	// (the fast --depts validation builds are transient and don't rewrite the record).
+	if (!args.depts) {
+		const attributionPath = dataRootPath("ban", "ATTRIBUTION.json")
+		writeFileSync(
+			attributionPath,
+			JSON.stringify(
+				{
+					artifact: `address-points-${args.country}.db`,
+					source,
+					sourceURL: BAN_CSV_BASE,
+					license: BAN_LICENSE,
+					attribution: BAN_ATTRIBUTION,
+					release: args.release,
+					departements: deptList.length,
+					totalPoints: written,
+					bytes,
+					md5,
+					builtAt: new Date().toISOString(),
+				},
+				null,
+				2
+			) + "\n"
+		)
+		console.error(`[ban] wrote ${attributionPath}`)
+	}
+
+	console.error(
+		`[ban] DONE ${args.output}\n` +
+			`      départements                     : ${deptList.length}\n` +
+			`      total source rows                : ${total.toLocaleString()}\n` +
+			`      written points                   : ${written.toLocaleString()}\n` +
+			`      skipped (no street/number)       : ${noStreet.toLocaleString()}\n` +
+			`      bytes                            : ${bytes.toLocaleString()}\n` +
+			`      md5                              : ${md5}\n` +
+			`      source                           : ${source}  release=${args.release}  license=${BAN_LICENSE}`
+	)
+}
+
+await main()

--- a/ban/sdk/ban.test.ts
+++ b/ban/sdk/ban.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The two contracts the BAN ingest must hold: (1) the extract locates its columns BY NAME off the
+ *   header (never by fixed position) and drops coordinate-less / streetless rows; (2) the provider is
+ *   FR-only and keys with the FR street locale — never a silent fold with the wrong rules. Build/probe
+ *   street-key consistency is covered by `@mailwoman/osm`'s `street-locale.test.ts` (same normalizer).
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { expect, test } from "vitest"
+
+import { extractBANAddrPoints } from "./extract.js"
+import { streetLocaleForBANCountry, supportedBANCountries } from "./street-locale.js"
+
+const HEADER =
+	"id;id_fantoir;numero;rep;nom_voie;code_postal;code_insee;nom_commune;code_insee_ancienne_commune;nom_ancienne_commune;x;y;lon;lat;type_position;alias;nom_ld;libelle_acheminement;nom_afnor;source_position;source_nom_voie;certification_commune;cad_parcelles"
+
+function fixtureCSV(rows: string[]): string {
+	const dir = mkdtempSync(join(tmpdir(), "ban-test-"))
+	const path = join(dir, "adresses-48.csv")
+	writeFileSync(path, [HEADER, ...rows].join("\n") + "\n")
+
+	return path
+}
+
+test("extract: yields the full tuple, folds rep to lower-case, skips coordinate-less rows", async () => {
+	const path = fixtureCSV([
+		"48004_x_1;;6;;Route de Pomaret;48800;48004;Altier;;;766812;6375458;3.840026;44.474983;entrée;;;;;;;1;",
+		"48005_x_2;;8;BIS;route de Laval;48310;48005;Albaret-le-Comtal;;;0;0;3.127407;44.877158;entrée;;;;;;;1;",
+		"48006_x_3;;9;;Rue Sans Coord;48000;48006;Mende;;;;;;;entrée;;;;;;;1;", // empty lon/lat → skipped
+	])
+
+	const recs = []
+
+	for await (const r of extractBANAddrPoints(path)) {
+		recs.push(r)
+	}
+
+	expect(recs).toHaveLength(2)
+	expect(recs[0]).toMatchObject({
+		numero: "6",
+		rep: null,
+		street: "Route de Pomaret",
+		postcode: "48800",
+		city: "Altier",
+	})
+	expect(recs[0]!.lat).toBeCloseTo(44.474983)
+	expect(recs[1]).toMatchObject({ numero: "8", rep: "bis" }) // uppercase BIS folded
+})
+
+test("provider: FR-only, keys with the FR street locale, throws otherwise", () => {
+	expect(supportedBANCountries()).toEqual(["fr"])
+	expect(streetLocaleForBANCountry("FR")).toBe("fr")
+	expect(() => streetLocaleForBANCountry("de")).toThrow(/No BAN street-normalization locale/)
+})

--- a/ban/sdk/extract.ts
+++ b/ban/sdk/extract.ts
@@ -1,0 +1,113 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Stream rooftop address records out of a BAN `adresses-<dept>.csv` dump (adresse.data.gouv.fr). The
+ *   dump is a `;`-delimited, header-first CSV in which EVERY row already carries the full tuple —
+ *   `numero`, `rep`, `nom_voie`, `code_postal`, `nom_commune`, `lon`/`lat` — so there is no OSM-style
+ *   "association gap" (a point with no street): BAN is a structured government register, not a
+ *   community tag soup. We stream line-by-line (the national set is 26M rows / ~5 GB uncompressed);
+ *   `.csv.gz` inputs are transparently gunzipped.
+ *
+ *   The columns are located BY NAME off the header row (never by fixed position) so a future BAN
+ *   schema addition can't silently shift the tuple. Values contain no embedded `;` (the dumps are
+ *   uniform-arity — verified 23 fields across every département), so a plain split is both correct and
+ *   fast; a literal `"` inside a field (rare) is kept verbatim, never treated as a CSV quote wrapper.
+ */
+
+import { createReadStream } from "node:fs"
+import { createGunzip } from "node:zlib"
+
+import { TextSpliterator } from "spliterator"
+
+/** One BAN address point. Every field but `rep`/`postcode`/`city` is guaranteed present by the source. */
+export interface BANAddrRecord {
+	/** `numero` — the house number (numeric in BAN; the `rep` suffix is carried separately). */
+	numero: string
+	/** `rep` — the repetition indicator (`bis`, `ter`, `quater`, `a`, `b`, …), or null when absent. */
+	rep: string | null
+	/** `nom_voie` — the street/voie name, already in full form ("Route de …", "Rue du …"). */
+	street: string
+	/** `code_postal` — the 5-digit postcode (nullable: a handful of lieu-dit rows omit it). */
+	postcode: string | null
+	/** `nom_commune` — the commune (locality) name. */
+	city: string | null
+	lon: number
+	lat: number
+}
+
+/** The BAN CSV columns this ingest reads — resolved to indices off the header row. */
+const REQUIRED_COLUMNS = ["numero", "rep", "nom_voie", "code_postal", "nom_commune", "lon", "lat"] as const
+
+type ColumnIndex = Record<(typeof REQUIRED_COLUMNS)[number], number>
+
+/** Map the header line to the indices of the columns we read; throws if the dump is missing a required column. */
+function headerIndices(header: string): ColumnIndex {
+	const cols = header.split(";").map((c) => c.trim())
+	const idx = {} as ColumnIndex
+
+	for (const name of REQUIRED_COLUMNS) {
+		const at = cols.indexOf(name)
+
+		if (at < 0) throw new Error(`BAN CSV header is missing required column "${name}" (got: ${cols.join(", ")})`)
+		idx[name] = at
+	}
+
+	return idx
+}
+
+/** A readable stream over `csvPath`, transparently gunzipping a `.csv.gz` input. */
+function openCSV(csvPath: string): NodeJS.ReadableStream {
+	const raw = createReadStream(csvPath)
+
+	return csvPath.endsWith(".gz") ? raw.pipe(createGunzip()) : raw
+}
+
+/**
+ * Stream every address point from one BAN département dump, geometry taken straight from the source `lon`/`lat`
+ * (WGS84). Rows with a non-finite coordinate or an empty `nom_voie`/`numero` are skipped (yield-side filtering is the
+ * caller's job for anything finer). The `rep` suffix is normalised to lower-case or null.
+ */
+export async function* extractBANAddrPoints(csvPath: string): AsyncGenerator<BANAddrRecord> {
+	let idx: ColumnIndex | null = null
+
+	for await (const line of TextSpliterator.fromAsync(openCSV(csvPath))) {
+		const row = typeof line === "string" ? line : String(line)
+
+		if (!row) continue
+
+		if (!idx) {
+			idx = headerIndices(row)
+			continue
+		}
+		const cols = row.split(";")
+		const numero = cols[idx.numero]?.trim()
+		const street = cols[idx.nom_voie]?.trim()
+
+		if (!numero || !street) continue
+		// Guard the empty-string trap: `Number("")` is 0 (finite), which would write a bogus (0,0) point —
+		// so require a non-empty coord string BEFORE parsing, then the finite check catches garbage.
+		const lonStr = cols[idx.lon]?.trim()
+		const latStr = cols[idx.lat]?.trim()
+
+		if (!lonStr || !latStr) continue
+		const lon = Number(lonStr)
+		const lat = Number(latStr)
+
+		if (!Number.isFinite(lon) || !Number.isFinite(lat)) continue
+		const rep = cols[idx.rep]?.trim()
+		const postcode = cols[idx.code_postal]?.trim()
+		const city = cols[idx.nom_commune]?.trim()
+
+		yield {
+			numero,
+			rep: rep ? rep.toLowerCase() : null,
+			street,
+			postcode: postcode || null,
+			city: city || null,
+			lon,
+			lat,
+		}
+	}
+}

--- a/ban/sdk/fetch.ts
+++ b/ban/sdk/fetch.ts
@@ -1,0 +1,33 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   BAN dump URLs + provenance constants. The Base Adresse Nationale publishes per-département and
+ *   national CSV exports at adresse.data.gouv.fr under the Licence Ouverte / Etalab 2.0. We pull the
+ *   per-département dumps (`adresses-<dept>.csv.gz`) — the ecosystem's default shard unit — and assemble
+ *   the national FR shard from them. These constants keep the build reproducible + the provenance
+ *   record honest (the source URL, the license, the required attribution string).
+ */
+
+/** The BAN "latest" CSV export root. */
+export const BAN_CSV_BASE = "https://adresse.data.gouv.fr/data/ban/adresses/latest/csv"
+
+/** Licence Ouverte / Etalab 2.0 — attribution, NO share-alike (unlike ODbL). */
+export const BAN_LICENSE = "Licence Ouverte / Open Licence 2.0 (Etalab)"
+
+/** The attribution string a result resolved through a BAN point must surface. */
+export const BAN_ATTRIBUTION = "© les contributeurs de la Base Adresse Nationale (adresse.data.gouv.fr)"
+
+/**
+ * The download URL of one département's BAN dump. `dept` is the INSEE département code — `01`…`95`, the Corsica codes
+ * `2A`/`2B`, or an overseas code (`971`…`976`). Pass the code exactly as BAN names the file.
+ */
+export function banDepartementURL(dept: string): string {
+	return `${BAN_CSV_BASE}/adresses-${dept}.csv.gz`
+}
+
+/** The download URL of the whole-country BAN dump (`adresses-france.csv.gz`). */
+export function banNationalURL(): string {
+	return `${BAN_CSV_BASE}/adresses-france.csv.gz`
+}

--- a/ban/sdk/index.ts
+++ b/ban/sdk/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   `@mailwoman/ban` SDK — the Base Adresse Nationale ingestion surface. PERMISSIVE CODE ONLY: this
+ *   workspace contains no BAN data bytes. It reads the open `adresses-<dept>.csv` dumps
+ *   (adresse.data.gouv.fr) and writes a national FR rooftop address-point shard on the SHARED situs
+ *   schema (`@mailwoman/resolver-wof-sqlite/address-point-schema`). BAN is published under the Licence
+ *   Ouverte / Etalab (attribution, NO share-alike), so — unlike the ODbL OSM tier — the built shard
+ *   ships under the same terms as the permissive core; only the per-row attribution obligation rides
+ *   on it. See `ban/README.md` for the licensing boundary.
+ */
+
+export * from "./fetch.js"
+export * from "./extract.js"
+export * from "./street-locale.js"
+export * from "./shard-provider.js"

--- a/ban/sdk/shard-provider.ts
+++ b/ban/sdk/shard-provider.ts
@@ -1,0 +1,71 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The BAN rooftop shard provider — the injection point the geocode cascade consults for the national
+ *   open-register precision tier (#1012), AHEAD of the community OSM tier. Given a data root, it opens
+ *   `ban/address-points-<cc>.db` with the country's street-normalization locale (so probe-side keying
+ *   matches the shard the builder wrote) and caches the open handle per country. Wire its bound `for`
+ *   into `GeocodeDeps.nationalShards`.
+ *
+ *   BAN is a French national register, so the registry is deliberately FR-only today; the shape
+ *   generalises to any other national open register (the coverage story, one country at a time).
+ */
+
+import { existsSync } from "node:fs"
+
+import { AddressPointSqliteLookup } from "@mailwoman/resolver-wof-sqlite"
+
+import { streetLocaleForBANCountry, supportedBANCountries } from "./street-locale.js"
+
+/** What the cascade needs from a BAN shard — structurally a subset of mailwoman's `StateShards`. */
+export interface BANShards {
+	addressPoints?: AddressPointSqliteLookup
+}
+
+/**
+ * Opens + caches per-country BAN rooftop lookups. A non-US geocode consults `for(country)`; the first hit for a country
+ * opens its shard (with the matching street locale) once, subsequent calls reuse it.
+ */
+export class BANShardProvider {
+	readonly #dataRoot: string
+	readonly #cache = new Map<string, BANShards>()
+
+	constructor(dataRoot: string) {
+		this.#dataRoot = dataRoot
+	}
+
+	#shardPath(countryCode: string): string {
+		return `${this.#dataRoot}/ban/address-points-${countryCode}.db`
+	}
+
+	/** Resolve the BAN shards for an ISO-3166 alpha-2 country, or `{}` when none is shipped/registered. */
+	readonly for = (country: string): BANShards => {
+		const cc = country.toLowerCase()
+		const cached = this.#cache.get(cc)
+
+		if (cached) return cached
+
+		let entry: BANShards = {}
+
+		// Only countries with a registered street locale AND an on-disk shard — never key with the wrong rules.
+		if (supportedBANCountries().includes(cc)) {
+			const path = this.#shardPath(cc)
+
+			if (existsSync(path)) {
+				entry = { addressPoints: new AddressPointSqliteLookup(path, { streetLocale: streetLocaleForBANCountry(cc) }) }
+			}
+		}
+		this.#cache.set(cc, entry)
+
+		return entry
+	}
+
+	close(): void {
+		for (const entry of this.#cache.values()) {
+			entry.addressPoints?.close()
+		}
+		this.#cache.clear()
+	}
+}

--- a/ban/sdk/street-locale.ts
+++ b/ban/sdk/street-locale.ts
@@ -1,0 +1,48 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Country → street-normalization-locale routing for the BAN rooftop build. The NORMALIZER itself
+ *   lives in `@mailwoman/resolver-wof-sqlite/street-normalize` (the one-function discipline — the
+ *   reader on the resolver side and the builder here must call the identical function). This module
+ *   only maps an ISO-3166 country code to the locale that selects the right per-locale rules, and
+ *   re-exports the normalizer so the BAN SDK is a self-contained surface. Kept SEPARATE from the
+ *   heavy `shard-provider.ts` (which pulls the SQLite lookup) so the pure locale contract is testable
+ *   without opening a database — mirrors `@mailwoman/osm`'s `street-locale.ts`.
+ */
+
+import { normalizeStreetForKeyLocale, type StreetLocale } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+
+export { normalizeStreetForKeyLocale, type StreetLocale }
+
+/**
+ * ISO-3166 alpha-2 (lowercase) → the street-normalization locale a BAN shard was built with. FR-only: BAN is the French
+ * national register. Adding a country here means shipping that country's national register on the shared schema AND
+ * having a matching branch in `normalizeStreetForKeyLocale` — never a silent fold with the wrong rules.
+ */
+const BAN_COUNTRY_TO_STREET_LOCALE = new Map<string, StreetLocale>([["fr", "fr"]])
+
+/**
+ * Resolve the street-normalization locale for a BAN country. Throws for an unsupported country rather than silently
+ * folding with the wrong rules — a shard built with the wrong normalizer keys every street incorrectly and looks fine
+ * until a probe misses. Add the country to {@link BAN_COUNTRY_TO_STREET_LOCALE} (and a branch in
+ * `normalizeStreetForKeyLocale`) before building its shard.
+ */
+export function streetLocaleForBANCountry(countryCode: string): StreetLocale {
+	const locale = BAN_COUNTRY_TO_STREET_LOCALE.get(countryCode.toLowerCase())
+
+	if (!locale) {
+		throw new Error(
+			`No BAN street-normalization locale registered for country "${countryCode}". ` +
+				`Add it to BAN_COUNTRY_TO_STREET_LOCALE and add the matching branch in normalizeStreetForKeyLocale before building its shard.`
+		)
+	}
+
+	return locale
+}
+
+/** The countries with a registered BAN street locale (for CLI validation / provider gating). */
+export function supportedBANCountries(): string[] {
+	return [...BAN_COUNTRY_TO_STREET_LOCALE.keys()]
+}

--- a/ban/tsconfig.json
+++ b/ban/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "@sister.software/tsconfig",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"emitDeclarationOnly": false,
+		"allowImportingTsExtensions": false
+	},
+	"exclude": ["./out/**/*"],
+	"references": [
+		// ---
+		{ "path": "../core" },
+		{ "path": "../resolver-wof-sqlite" }
+	]
+}

--- a/mailwoman/commands/geocode.tsx
+++ b/mailwoman/commands/geocode.tsx
@@ -45,6 +45,7 @@ import {
 	ShardProvider,
 	type GeocodeResult,
 	type ShardResolver,
+	type StateShards,
 } from "../geocode-core.js"
 import { INTERP_RADIUS_CALIBRATION } from "../interp-calibration.js"
 import { createResolverBackend, mailwomanDataRoot, resolveCandidateDBPath, wofShardPaths } from "../resolver-backend.js"
@@ -228,6 +229,18 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 				}
 			: shardProvider.for
 
+	// National open-register rooftop tier (#1012): BAN-FR ahead of the OSM tier for a non-US parse. Optional
+	// like the resolver backend above — absent `@mailwoman/ban` ⇒ no national tier (admin/OSM path unchanged),
+	// and the provider itself is a no-op when the shard isn't on disk. Keeps the CLI backend-agnostic.
+	let nationalShards: ((country: string) => StateShards) | undefined
+
+	try {
+		const { BANShardProvider } = await import("@mailwoman/ban/sdk")
+		nationalShards = new BANShardProvider(options.dataRoot).for
+	} catch {
+		nationalShards = undefined
+	}
+
 	// Coarse-placer soft country prior (#244) — opt-in. Loads the int8 model bundled in @mailwoman/core
 	// at the requested abstention threshold; a confident in-map guess feeds the resolver's anchorPosterior.
 	// The M2 open-set reject rule (reject on in-map MASS 1-P(OTHER), route on the in-map argmax) lifts in-map
@@ -263,6 +276,7 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 			classifier,
 			resolver,
 			shards,
+			...(nationalShards ? { nationalShards } : {}),
 			parsedTree,
 			...(bias.length > 0 ? { bias } : {}),
 			defaultCountry: (inferredScopeOK && resolverDefaultCountry(options, !!candidateDb)) || undefined,

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -103,9 +103,18 @@ export interface GeocodeDeps {
 	/** Per-state shard resolver. Omit for admin-only geocoding. */
 	shards?: ShardResolver
 	/**
+	 * Authoritative national open-register rooftop shards keyed by ISO-3166 alpha-2 country (#1012) — the government
+	 * address registers (BAN-FR today, 26M points). Consulted ONLY when no US per-state situs shard matched (a non-US
+	 * parse), and AHEAD of {@link osmShards}: a national register is denser + coordinate-authoritative, so it outranks the
+	 * community OSM fallback. Inject from `@mailwoman/ban`'s `BANShardProvider`; absent = no national tier. Licence
+	 * Ouverte/Etalab (permissive) — see `ban/README.md`. The shape generalises to other national registers.
+	 */
+	nationalShards?: (country: string) => StateShards
+	/**
 	 * OSM rooftop shards keyed by ISO-3166 alpha-2 country (#247) — the opt-in international precision tier. Consulted
-	 * ONLY when no US per-state situs shard matched (a non-US parse), so the US path is untouched. Inject from
-	 * `@mailwoman/osm`'s `OSMShardProvider`; absent = no OSM tier. ODbL — see `osm/README.md`.
+	 * ONLY when no US per-state situs shard matched (a non-US parse) AND no {@link nationalShards} register covered the
+	 * country, so the US path is untouched and BAN wins where it exists. Inject from `@mailwoman/osm`'s
+	 * `OSMShardProvider`; absent = no OSM tier. ODbL — see `osm/README.md`.
 	 */
 	osmShards?: (country: string) => StateShards
 	/** Country constraint passed to the resolver (e.g. `"US"`). */
@@ -499,9 +508,25 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 		}
 	}
 
-	// OSM international rooftop tier (#247): only when no US situs shard matched (a non-US parse). An explicit
-	// defaultCountry wins; otherwise the coarse placer's country. Bbox fall-through is ON for OSM — its points
-	// often carry no postcode/locality tag, so the resolved locality's box scopes the (street, number) probe.
+	// National open-register rooftop tier (#1012): a non-US parse first consults an authoritative government
+	// address register (BAN-FR today) AHEAD of OSM — it's denser + coordinate-authoritative. BAN rows carry
+	// their own postcode + commune, so the scoped (postcode → locality) probes suffice; no bbox fall-through.
+	if (!addressPoints) {
+		const country = (deps.defaultCountry ?? placedCountry)?.toLowerCase()
+
+		if (country && country !== "us") {
+			const national = deps.nationalShards?.(country)
+
+			if (national?.addressPoints) {
+				addressPoints = national.addressPoints
+			}
+		}
+	}
+
+	// OSM international rooftop tier (#247): the community fallback, only when neither a US situs shard nor a
+	// national register (above) covered the country. An explicit defaultCountry wins; otherwise the coarse
+	// placer's country. Bbox fall-through is ON for OSM — its points often carry no postcode/locality tag, so
+	// the resolved locality's box scopes the (street, number) probe.
 	if (!addressPoints) {
 		const country = (deps.defaultCountry ?? placedCountry)?.toLowerCase()
 

--- a/mailwoman/test/geocode-core-national-shard.test.ts
+++ b/mailwoman/test/geocode-core-national-shard.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Unit tests for the national open-register rooftop tier wiring in `geocodeAddress` (#1012, BAN-FR).
+ *   Fakes the classifier + resolver so the test captures the `ResolveOpts` the cascade hands the
+ *   resolver — no WOF / weights / shards / 7 GB BAN db needed. Pins the tier contract:
+ *
+ *   - a non-US parse consults `nationalShards` (BAN) AHEAD of `osmShards` — BAN wins where it covers;
+ *   - BAN carries its own postcode + commune, so it sets NO bbox fall-through (unlike the OSM tier);
+ *   - when no national register covers the country, the cascade falls through to the OSM tier;
+ *   - a US parse never consults BAN (the US situs path owns address points);
+ *   - absent `nationalShards`, the cascade is byte-stable — the tier is purely additive.
+ */
+
+import type { AddressTree } from "@mailwoman/core/decoder"
+import type { AddressPointLookup, ResolveOpts, Resolver } from "@mailwoman/resolver"
+import { describe, expect, test, vi } from "vitest"
+
+import { geocodeAddress, type GeocodeClassifier, type StateShards } from "../geocode-core.js"
+
+/** A classifier that returns a fixed tree (no region → admin-only path, no US situs shards needed). */
+function fakeClassifier(tree: AddressTree): GeocodeClassifier {
+	return { parse: vi.fn(async () => tree) }
+}
+
+/** A resolver that records the ResolveOpts it was handed and echoes the tree back. */
+function captureResolver(): { resolver: Resolver; seen: ResolveOpts[] } {
+	const seen: ResolveOpts[] = []
+	const resolver: Resolver = {
+		resolveTree: vi.fn(async (tree, opts) => {
+			seen.push(opts ?? {})
+
+			return tree
+		}),
+	}
+
+	return { resolver, seen }
+}
+
+const emptyTree: AddressTree = { raw: "x", roots: [] }
+
+/** A sentinel address-point lookup — the cascade only assigns it to `opts.addressPoints`, never calls `find`. */
+const sentinel = (): AddressPointLookup => ({ find: vi.fn(() => null) })
+const banLookup = sentinel()
+const osmLookup = sentinel()
+const frRegister = (c: string): StateShards => (c === "fr" ? { addressPoints: banLookup } : {})
+
+describe("geocodeAddress — national (BAN) rooftop tier wiring (#1012)", () => {
+	test("BAN wins over OSM for a non-US parse (consulted AHEAD of the OSM tier)", async () => {
+		const { resolver, seen } = captureResolver()
+		await geocodeAddress("12 rue de la Paix, Paris", {
+			classifier: fakeClassifier(emptyTree),
+			resolver,
+			placeCountry: false,
+			defaultCountry: "FR",
+			nationalShards: frRegister,
+			osmShards: (c) => (c === "fr" ? { addressPoints: osmLookup } : {}),
+		})
+		expect(seen[0]?.addressPoints).toBe(banLookup)
+		// BAN rows carry their own postcode + commune → the scoped probes suffice; no bbox fall-through.
+		expect(seen[0]?.addressPointBboxFallback).toBeUndefined()
+	})
+
+	test("falls through to the OSM tier when no national register covers the country", async () => {
+		const { resolver, seen } = captureResolver()
+		await geocodeAddress("Hauptstraße 5, Berlin", {
+			classifier: fakeClassifier(emptyTree),
+			resolver,
+			placeCountry: false,
+			defaultCountry: "DE",
+			nationalShards: frRegister, // FR-only register → no DE coverage
+			osmShards: (c) => (c === "de" ? { addressPoints: osmLookup } : {}),
+		})
+		expect(seen[0]?.addressPoints).toBe(osmLookup)
+		// The OSM tier's points carry no scope tag, so its bbox fall-through IS enabled.
+		expect(seen[0]?.addressPointBboxFallback).toBe(true)
+	})
+
+	test("a US parse never consults BAN (the US situs path owns address points)", async () => {
+		const { resolver, seen } = captureResolver()
+		const nationalShards = vi.fn((_c: string): StateShards => ({ addressPoints: banLookup }))
+		await geocodeAddress("350 5th Ave, New York, NY 10118", {
+			classifier: fakeClassifier(emptyTree),
+			resolver,
+			placeCountry: false,
+			defaultCountry: "US",
+			nationalShards,
+		})
+		expect(nationalShards).not.toHaveBeenCalled()
+		expect(seen[0]?.addressPoints).toBeUndefined()
+	})
+
+	test("absent nationalShards ⇒ byte-stable: the OSM tier serves FR unchanged (pre-#1012 behavior)", async () => {
+		const { resolver, seen } = captureResolver()
+		await geocodeAddress("12 rue de la Paix, Paris", {
+			classifier: fakeClassifier(emptyTree),
+			resolver,
+			placeCountry: false,
+			defaultCountry: "FR",
+			osmShards: (c) => (c === "fr" ? { addressPoints: osmLookup } : {}),
+		})
+		expect(seen[0]?.addressPoints).toBe(osmLookup)
+		expect(seen[0]?.addressPointBboxFallback).toBe(true)
+	})
+})

--- a/mailwoman/tsconfig.json
+++ b/mailwoman/tsconfig.json
@@ -19,6 +19,7 @@
 		{ "path": "../phrase-grouper" },
 		{ "path": "../query-shape" },
 		{ "path": "../registry" },
-		{ "path": "../resolver-wof-sqlite" }
+		{ "path": "../resolver-wof-sqlite" },
+		{ "path": "../ban" }
 	]
 }

--- a/nominatim/cli.ts
+++ b/nominatim/cli.ts
@@ -151,6 +151,10 @@ async function serve(): Promise<void> {
 	const backend = createResolverBackend(resolverMod, { wofPaths, candidateDb })
 	const resolver = createWOFResolver(backend)
 	const shards = new ShardProvider(resolverMod, mailwomanDataRoot())
+	// National open-register rooftop tier (#1012): BAN-FR ahead of the OSM tier for a non-US parse. A no-op
+	// when the shard isn't on disk (existsSync-gated inside the provider), so the endpoint degrades cleanly.
+	const { BANShardProvider } = await import("@mailwoman/ban/sdk")
+	const banShards = new BANShardProvider(mailwomanDataRoot())
 	// NOT a geocode country constraint. The default-on #244 placer already routes the query's country
 	// (Berlin→DE, Boston→US) and `defaultCountry` is a HARD override that beats it (geocode-core.ts:102),
 	// so forcing "US" resolved every non-US query to its US namesake (Berlin→Berlin NH). We let the
@@ -195,6 +199,7 @@ async function serve(): Promise<void> {
 				classifier,
 				resolver,
 				shards: shards.for,
+				nationalShards: banShards.for,
 				defaultCountry: userCountry,
 			})
 

--- a/nominatim/package.json
+++ b/nominatim/package.json
@@ -26,6 +26,7 @@
 	},
 	"dependencies": {
 		"@mailwoman/annotations": "workspace:*",
+		"@mailwoman/ban": "workspace:*",
 		"@mailwoman/codex": "workspace:*",
 		"@mailwoman/neural": "workspace:*",
 		"@mailwoman/nuts-lookup": "workspace:*",

--- a/nominatim/tsconfig.json
+++ b/nominatim/tsconfig.json
@@ -8,6 +8,7 @@
 	"include": ["./**/*"],
 	"exclude": ["./out/**/*", "./**/*.test.ts", "./**/*.test.tsx"],
 	"references": [
+		{ "path": "../ban" },
 		{ "path": "../annotations" },
 		{ "path": "../codex" },
 		{ "path": "../spatial" },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"spatial",
 		"tiger",
 		"osm",
+		"ban",
 		"cartographer",
 		"codex",
 		"classifiers",

--- a/photon/cli.ts
+++ b/photon/cli.ts
@@ -85,6 +85,10 @@ async function serve(): Promise<void> {
 	const backend = createResolverBackend(resolverMod, { wofPaths, candidateDb })
 	const resolver = createWOFResolver(backend)
 	const shards = new ShardProvider(resolverMod, mailwomanDataRoot())
+	// National open-register rooftop tier (#1012): BAN-FR ahead of the OSM tier for a non-US parse. A no-op
+	// when the shard isn't on disk (existsSync-gated inside the provider), so the endpoint degrades cleanly.
+	const { BANShardProvider } = await import("@mailwoman/ban/sdk")
+	const banShards = new BANShardProvider(mailwomanDataRoot())
 	const reverseGeo = adminDBPath ? new resolverMod.WOFReverseGeocoder({ adminDBPath }) : undefined
 
 	const engine: PhotonEngine = {
@@ -99,7 +103,13 @@ async function serve(): Promise<void> {
 			// No country constraint: the default-on #244 placer routes the query's country (Berlin→DE,
 			// Boston→US). Forcing "US" here is a HARD override (geocode-core.ts:102) that resolved every
 			// non-US query to its US namesake — wrong for a global autocomplete front.
-			const result = await geocodeAddress(query, { classifier, resolver, shards: shards.for, bias })
+			const result = await geocodeAddress(query, {
+				classifier,
+				resolver,
+				shards: shards.for,
+				nationalShards: banShards.for,
+				bias,
+			})
 
 			if (result.lat == null || result.lon == null) return photonCollection([])
 			// #1014: decorate from the RESOLVED gazetteer place — proper-cased ancestry names (`hierarchy[].name`,

--- a/photon/package.json
+++ b/photon/package.json
@@ -25,6 +25,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@mailwoman/ban": "workspace:*",
 		"@mailwoman/codex": "workspace:*",
 		"@mailwoman/neural": "workspace:*",
 		"@mailwoman/resolver": "workspace:*",

--- a/photon/tsconfig.json
+++ b/photon/tsconfig.json
@@ -8,6 +8,7 @@
 	"include": ["./**/*"],
 	"exclude": ["./out/**/*", "./**/*.test.ts", "./**/*.test.tsx"],
 	"references": [
+		{ "path": "../ban" },
 		{ "path": "../codex" },
 		{ "path": "../neural" },
 		{ "path": "../resolver" },

--- a/scripts/smoke-clean-install.ts
+++ b/scripts/smoke-clean-install.ts
@@ -39,6 +39,7 @@ const WORKSPACES: Record<string, string> = {
 	"@mailwoman/core": "core",
 	"@mailwoman/spatial": "spatial",
 	"@mailwoman/resolver": "resolver",
+	"@mailwoman/ban": "ban",
 	"@mailwoman/codex": "codex",
 	"@mailwoman/classifiers": "classifiers",
 	"@mailwoman/kind-classifier": "kind-classifier",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
 		{ "path": "./spatial" },
 		{ "path": "./tiger" },
 		{ "path": "./osm" },
+		{ "path": "./ban" },
 		{ "path": "./cartographer" },
 		{ "path": "./codex" },
 		{ "path": "./classifiers" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4641,6 +4641,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@mailwoman/ban@workspace:*, @mailwoman/ban@workspace:ban":
+  version: 0.0.0-use.local
+  resolution: "@mailwoman/ban@workspace:ban"
+  dependencies:
+    "@mailwoman/core": "workspace:*"
+    "@mailwoman/resolver-wof-sqlite": "workspace:*"
+    kysely: "npm:^0.29.2"
+    spliterator: "npm:^3.2.0"
+  languageName: unknown
+  linkType: soft
+
 "@mailwoman/cartographer@workspace:*, @mailwoman/cartographer@workspace:cartographer":
   version: 0.0.0-use.local
   resolution: "@mailwoman/cartographer@workspace:cartographer"
@@ -4852,6 +4863,7 @@ __metadata:
   resolution: "@mailwoman/nominatim@workspace:nominatim"
   dependencies:
     "@mailwoman/annotations": "workspace:*"
+    "@mailwoman/ban": "workspace:*"
     "@mailwoman/codex": "workspace:*"
     "@mailwoman/neural": "workspace:*"
     "@mailwoman/nuts-lookup": "workspace:*"
@@ -4899,6 +4911,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mailwoman/photon@workspace:photon"
   dependencies:
+    "@mailwoman/ban": "workspace:*"
     "@mailwoman/codex": "workspace:*"
     "@mailwoman/neural": "workspace:*"
     "@mailwoman/resolver": "workspace:*"


### PR DESCRIPTION
Closes #1012.

Ingests the **Base Adresse Nationale** (France's national government address register, 26 M addresses) as the FR rooftop address-point tier — the French counterpart of the 50-state US situs layer. Closes the measured FR rooftop gap: commune resolution was already ~99 % @25 km, but @1 km sat flat at ~37 % from clean → messy input. That flatness is the tell of a **coverage** ceiling (OSM-FR ≈ 1.1 M points), not a parse problem. BAN is the coverage.

## Artifact provenance (already built — credit to the prior session)

The expensive 6.9 GB shard was built by a prior session that was killed mid-task by a connection drop. This PR inherits and completes that work; the artifact is treated as an immutable, verified input.

| field | value |
|---|---|
| path | `$MAILWOMAN_DATA_ROOT/ban/address-points-fr.db` |
| bytes | 6,963,167,232 (sealed `0444`) |
| md5 | `b570ccee687f28b527577f5dc1a17dbc` (re-verified this session) |
| source | `ban:fr`, release `2026-05-18` |
| license | Licence Ouverte / Open Licence 2.0 (Etalab) — attribution, **no** share-alike |
| points | 26,041,013 written / 26,041,013 source rows (0 skipped) across 101 départements |
| provenance | `ban/ATTRIBUTION.json` beside the db (source URL, license, release, row count, md5) |

**Recipe (verbatim, reproduces the artifact):**

```bash
node ban/out/scripts/build-address-point-shard.js \
  --csv-dir $MAILWOMAN_DATA_ROOT/corpus/sources/ban --release 2026-05-18
```

The build is **code-only** — this workspace contains no BAN data bytes. It streams the per-département dumps (no external CLI, no DuckDB — OOM-safe on 26 M rows), keys on the SHARED situs schema + FR street normalizer, then: stream → positional prepared INSERT → indexes → ANALYZE → atomic swap → seal `0444` → provenance manifest. Purely additive; never touches the OSM shard beside it.

## Salvage verdict (unreviewed mid-task code, reviewed + fixed)

The prior session's `ban/` workspace + the `geocode-core.ts` cascade were high quality and mirror `@mailwoman/osm` faithfully. **Kept** the extract (column-by-name, empty-coord trap, gunzip, `rep`-fold), the build discipline, the provider shape, and the cascade (BAN ahead of OSM, no bbox fall-through). **Fixed one conformance deviation**: the salvage folded the pure country→locale routing into the heavy `shard-provider.ts`; `@mailwoman/osm` keeps that in a separate `street-locale.ts` so the locale contract is testable without opening a 7 GB SQLite handle. Split it out to match (`ban/sdk/street-locale.ts`), which also keeps `ban.test.ts` off the SQLite import graph.

## Ladder wiring

`geocode-core.ts` — a non-US parse consults the national register (`nationalShards`) **ahead of** the OSM tier: a government register is denser + coordinate-authoritative, so it outranks the community fallback. BAN rows carry their own postcode + commune, so the scoped `(postcode → locality)` probes suffice — **no** bbox fall-through (unlike OSM). The branch is inert without an injected `nationalShards`, so the change is purely additive.

Injected the provider alongside the US situs `shards` in the FR geocoding entrypoints (mirrors the US address_point wiring): **`photon`** + **`nominatim`** (the FR-capable drop-in APIs — already SQLite-committed, so `@mailwoman/ban` is a consistent dep + reference) and the **`mailwoman geocode` CLI** (kept backend-agnostic via a tsconfig reference + optional dynamic import, exactly how the resolver backend is treated). Each is a no-op when the shard isn't on disk. The live endpoint is unaffected until a redeploy.

Deferred as a follow-up (same optional-backend pattern, low marginal value beyond the primary path): `GeocodeRouter` (native server bundle) + `geocode-worker`/`registry` (record matcher).

## Interpolation fallback

**Not built** (exact-point tier only). BAN carries no house-number ranges, and its density is the win — 300/340 panel addresses hit an exact BAN point. A street-centroid / interpolation tier is what the Oslandia street-only panel would need; noted for follow-up.

## Gates (before → after)

### (a) FR rooftop — Addok/BAN panel, n=340, scoped FR

| arm | metric | BEFORE (OSM only) | AFTER (OSM+BAN) |
|---|---|---|---|
| ARM1 clean | @1 km | 37.4 % | **87.9 %** |
| ARM1 clean | p50 | 1.34 km | **0.00 km** |
| ARM2 messy | @1 km | 35.6 % | **60.9 %** |
| ARM2 messy (rooftop classes) | @1 km | 37.5 % | **78.8 %** |
| clean tier mix | address_point | 22 / 340 | **300 / 340** |

**⚠ Circularity caveat (stated honestly):** the panel's ground truth **is** BAN's own coordinate (validated against OpenAddresses-FR, itself BAN-derived), and the new tier **is** BAN. So the honest claim is *"resolves to BAN's rooftop when the address is in BAN"* — **not** "37 % → 88 % against independent truth."

**Independent spot-check (counters the circularity):** 14 FR rooftops compared to **Nominatim** (independent, OSM-derived, non-BAN): **13/14 within 200 m** (median ~30 m; the one outlier 688 m is a rural *chemin*). BAN's coordinates independently agree with a non-BAN geocoder, so the @1 km lift is real rooftop precision.

### (b) Oslandia 8 voies — 0/8 → **0/8** (unchanged, expected)

7 of the 8 are **street-only** queries (no house number: "Place Bellecour, Lyon", "Rue de la République, Marseille"…) — an address-**point** layer cannot fire without a house number; those need the (unbuilt) interpolation/street-centroid tier. The 1 case with a house number ("55 rue du Faubourg Saint-Honoré, 75008 Paris") misses for a characterized reason: **the neural parser truncates the trailing accented character** — street parsed as "du Faubourg Saint-**Honor**", so the key `rue du faubourg saint honor` misses BAN's `rue du faubourg saint honore`. BAN **holds the exact rooftop** (55 → 48.87063, 2.316931). Upstream span-boundary issue (#727-class), independent of this tier.

### (c) Gauntlet self-check — VERDICT **PASS**

`node scripts/eval/gauntlet/run.ts` → regression 27/27 gated (2 tracked), metamorphic PASS (5 tracked xfails). Model md5 `ea785a70` matches the card (the #1024 guard held). Weights untouched (md5 guard active).

### (d) Non-FR byte-stability — **22/22 identical (0 moved)**

22 US + non-FR queries run through `geocodeAddress` without vs. with the BAN `nationalShards` tier: byte-identical result (lat/lon/tier/countryCode/hierarchy). BAN is FR-only and never consulted for a US parse. The gauntlet US cases are unchanged (PASS above). FR positive control ("2 Rue Piltepois, 62160 Aix-Noulette") correctly moves `admin` → `address_point` at BAN's rooftop (Δtruth 0 m).

---

Do **not** publish; the demo repoint is a separate release-time step. The 26 M-row shard is additive and provenance-pinned; the same pipeline generalizes to other national open registers, one country at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5qDbkGN3xs2XDvyK52qPT
