### PR TITLE
fix(#1041): rooftop results decorate house-grade — address_point → type:house + housenumber/street

### DIFF
--- a/mailwoman/geocode-core.test.ts
+++ b/mailwoman/geocode-core.test.ts
@@ -195,6 +195,78 @@ describe("extractGeocodeResult — ranked candidates for limit>1 (#1016)", () =>
 	})
 })
 
+describe("extractGeocodeResult — parsed house-grade fields (#1041)", () => {
+	// A rooftop parse of "123 East Sheldon Rd 75001 Paris": the street node is stamped `address_point`, and its
+	// name-bearing subtree (prefix + base + suffix) plus the house_number nest under it (per the containment schema).
+	const rooftopTree = (tier: "address_point" | "interpolated" | "admin"): AddressTree => ({
+		raw: "123 east sheldon rd 75001 paris",
+		roots: [
+			node({
+				tag: "street",
+				value: "Sheldon",
+				start: 9,
+				end: 16,
+				metadata:
+					tier === "address_point"
+						? { resolution_tier: "address_point", address_point: { lat: 48.8548, lon: 2.3451 } }
+						: tier === "interpolated"
+							? {
+									resolution_tier: "interpolated",
+									interpolated_point: { lat: 48.8548, lon: 2.3451 },
+									uncertainty_m: 40,
+								}
+							: undefined,
+				children: [
+					node({ tag: "house_number", value: "123", start: 0, end: 3 }),
+					node({ tag: "street_prefix", value: "East", start: 4, end: 8 }),
+					node({ tag: "street_suffix", value: "Rd", start: 17, end: 19 }),
+				],
+			}),
+			node({
+				tag: "locality",
+				value: "paris",
+				lat: 48.8566,
+				lon: 2.3522,
+				metadata: { resolver_name: "Paris", resolver_country: "FR" },
+			}),
+			node({ tag: "postcode", value: "75001" }),
+		],
+	})
+
+	it("surfaces the parsed house number + FULL reassembled street on a rooftop (address_point) result", () => {
+		const r = extractGeocodeResult("123 East Sheldon Rd 75001 Paris", rooftopTree("address_point"))
+		expect(r.resolution_tier).toBe("address_point")
+		expect(r.house_number).toBe("123")
+		expect(r.street).toBe("East Sheldon Rd") // prefix + base + suffix, span-ordered — not the bare "Sheldon"
+		expect(r.lat).toBe(48.8548) // the rooftop coordinate won
+		expect(r.postcode).toBe("75001")
+	})
+
+	it("surfaces the same house-grade fields on an interpolated result", () => {
+		const r = extractGeocodeResult("123 East Sheldon Rd 75001 Paris", rooftopTree("interpolated"))
+		expect(r.resolution_tier).toBe("interpolated")
+		expect(r.house_number).toBe("123")
+		expect(r.street).toBe("East Sheldon Rd")
+	})
+
+	it("still carries the parsed spans on an admin-tier fallback (the consumer gates on the tier, not their presence)", () => {
+		const r = extractGeocodeResult("123 East Sheldon Rd 75001 Paris", rooftopTree("admin"))
+		expect(r.resolution_tier).toBe("admin") // no address_point/interpolated metadata → admin centroid
+		expect(r.house_number).toBe("123") // populated regardless of tier — informational
+		expect(r.street).toBe("East Sheldon Rd")
+	})
+
+	it("is null for both when the parse found no street / house number (a bare locality query)", () => {
+		const tree: AddressTree = {
+			raw: "berlin",
+			roots: [node({ tag: "locality", value: "Berlin", lat: 52.5, lon: 13.4 })],
+		}
+		const r = extractGeocodeResult("berlin", tree)
+		expect(r.house_number).toBeNull()
+		expect(r.street).toBeNull()
+	})
+})
+
 describe("parseForGeocode — query-shape emission prior (#981)", () => {
 	type ParseOpts = Parameters<GeocodeClassifier["parse"]>[1]
 

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -56,6 +56,16 @@ export interface GeocodeResult {
 	region: string | null
 	postcode: string | null
 	/**
+	 * The PARSED house number + full street name (reassembled from the street subtree — prefix + base + suffix, since
+	 * `street.value` alone is the bare base span), or null when the parse found neither. #1041 — lets a forward consumer
+	 * that resolved to a house-number-grade coordinate (the `address_point` / `interpolated` {@link resolution_tier})
+	 * render the result HOUSE-GRADE (`type: house` + `housenumber`/`street`, matching upstream Photon) instead of
+	 * mislabeling a rooftop as its admin locality. Populated regardless of tier (they are the parsed spans); the consumer
+	 * gates the house-grade rendering on the tier so an admin-only fallback is never dressed up as a rooftop.
+	 */
+	house_number: string | null
+	street: string | null
+	/**
 	 * ISO-3166 alpha-2 of the resolved place (the gazetteer/candidate country of the deepest resolved node), or null.
 	 * #1014 — lets a forward consumer fill `country`/`countrycode` without a full ancestry walk (the candidate backend
 	 * carries the country code even when it has no `ancestors()` table).
@@ -583,6 +593,31 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 }
 
 /**
+ * Street-name component tags — the name-bearing subtree of a `street` node (`street.value` alone is the bare base:
+ * "Sheldon" for "East Sheldon Rd"). Mirrors the resolver's `assembleStreetValue`; used to surface the FULL parsed
+ * street on the result so a house-grade forward consumer renders "Boulevard du Palais", not just "Palais". #1041.
+ */
+const STREET_NAME_TAGS = new Set(["street", "street_prefix", "street_prefix_particle", "street_suffix"])
+
+/** Reassemble the full parsed street name from a street node's name-bearing subtree, ordered by span offset. #1041. */
+function assembleStreetName(streetNode: AddressNode): string {
+	const parts: AddressNode[] = []
+	const stack = [streetNode]
+
+	while (stack.length > 0) {
+		const n = stack.pop()!
+
+		if (STREET_NAME_TAGS.has(n.tag) && n.value.trim()) {
+			parts.push(n)
+		}
+		stack.push(...n.children)
+	}
+	parts.sort((a, b) => a.start - b.start)
+
+	return parts.map((n) => n.value.trim()).join(" ")
+}
+
+/**
  * Walk the resolved tree and extract the geocode result: the street node's address-point / interpolation coordinate
  * (whichever tier won), else the best admin centroid (locality → region → country).
  */
@@ -661,6 +696,11 @@ export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeR
 	const locality = allNodes.find((n) => n.tag === "locality" || n.tag === "dependent_locality")?.value?.trim() || null
 	const region = allNodes.find((n) => n.tag === "region")?.value?.trim() || null
 	const postcode = allNodes.find((n) => n.tag === "postcode")?.value?.trim() || null
+
+	// #1041: the parsed house number + full street name, so a house-grade forward consumer (photon `/api`) can decorate a
+	// rooftop / interpolated result with `housenumber`/`street` (matching upstream Photon) instead of the admin locality.
+	const houseNumber = allNodes.find((n) => n.tag === "house_number")?.value?.trim() || null
+	const street = streetNode ? assembleStreetName(streetNode) || null : null
 
 	const HIERARCHY_TAGS = ["locality", "dependent_locality", "subregion", "region", "country"]
 	const hierarchy = allNodes
@@ -752,6 +792,8 @@ export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeR
 		locality,
 		region,
 		postcode,
+		house_number: houseNumber,
+		street,
 		countryCode,
 		hierarchy,
 		candidates,

--- a/nominatim/cli.ts
+++ b/nominatim/cli.ts
@@ -205,6 +205,15 @@ async function serve(): Promise<void> {
 
 			if (result.lat == null || result.lon == null) return []
 			const resolved = forwardToResolved(result)
+
+			// #1041: a rooftop (`address_point`) / house-number-estimate (`interpolated`) tier is HOUSE-GRADE — tag the
+			// result `class: place` / `type: house` (upstream Nominatim's own class/type for a house), so a client that
+			// keys on `class`/`type`/`addresstype` treats it as a building, not an untyped admin hit. The admin tier
+			// (a locality centroid) carries no class/type here, as before.
+			if (result.resolution_tier === "address_point" || result.resolution_tier === "interpolated") {
+				resolved.category = "place"
+				resolved.type = "house"
+			}
 			// Recover the street the resolver drops, so addressdetails + display_name carry it.
 			const { houseNumber, road } = await streetParts(parser, query)
 

--- a/photon/cli.ts
+++ b/photon/cli.ts
@@ -117,12 +117,17 @@ async function serve(): Promise<void> {
 			// Photon clients don't TypeError. The candidate backend fills only the locality (no ancestors() table),
 			// so state/county come through only on an ancestry-capable backend — country still lands from the code.
 			const country = matchCountry(result.countryCode)
+			// #1041: a rooftop (`address_point`) or house-number-estimate (`interpolated`) tier is HOUSE-GRADE — carry the
+			// parsed housenumber + street so photonForwardProperties decorates it `type: house` (matching upstream Photon)
+			// instead of inheriting the admin locality's `type: city`. The admin tier (a locality centroid) never does.
+			const houseGrade = result.resolution_tier === "address_point" || result.resolution_tier === "interpolated"
 			const primary: PhotonForwardInput = {
 				lat: result.lat,
 				lon: result.lon,
 				postcode: result.postcode,
 				country: country ? { name: country.canonical, code: country.iso2 } : undefined,
 				places: result.hierarchy.map((h) => ({ tag: h.tag, name: h.name })),
+				...(houseGrade ? { house: { number: result.house_number, street: result.street } } : {}),
 			}
 			// #1016: candidates[0] is the primary itself; its ranked alternatives (Springfield MA/IL/…) become the
 			// extra features, up to the requested `limit`. Each alternative is a single resolved place.

--- a/photon/index.test.ts
+++ b/photon/index.test.ts
@@ -105,6 +105,69 @@ test("forward: a street-primary result names the street and types as street", ()
 	expect(props.type).toBe("street")
 })
 
+// #1041 — a rooftop / interpolated result must render HOUSE-GRADE. Upstream komoot/photon labels a bare
+// residential address point `{osm_key:"place", osm_value:"house", type:"house", housenumber, street}` with NO
+// `name` (verified against photon.komoot.io). Without this a rooftop inherits the admin ancestry's `type:city`
+// and a client zooms to city scale on a doorstep match.
+
+test("forward: a house-grade (rooftop) result decorates type:house + housenumber/street (#1041)", () => {
+	const props = photonForwardProperties({
+		lat: 48.8548,
+		lon: 2.3451,
+		postcode: "75001",
+		country: { name: "France", code: "FR" },
+		// The resolved ancestry is still locality→…; the `house` marker overrides the schema to house-grade.
+		places: [{ tag: "locality", name: "Paris" }],
+		house: { number: "8", street: "Boulevard du Palais" },
+	})
+	// Matches upstream komoot/photon's bare address point.
+	expect(props.type).toBe("house")
+	expect(props.osm_key).toBe("place")
+	expect(props.osm_value).toBe("house")
+	expect(props.housenumber).toBe("8")
+	expect(props.street).toBe("Boulevard du Palais")
+	// name is dropped (upstream has none for a bare address point; keeping the city here would double it in the
+	// QGIS FLF label "Paris 8 Boulevard du Palais Paris 75001").
+	expect(props.name).toBeUndefined()
+	// The admin fields the ancestry filled are retained — a house result still carries city/postcode/country.
+	expect(props.city).toBe("Paris")
+	expect(props.postcode).toBe("75001")
+	expect(props.country).toBe("France")
+	expect(props.countrycode).toBe("fr")
+})
+
+test("forward: WITHOUT `house`, the same locality resolution stays type:city (no false rooftop) (#1041)", () => {
+	const props = photonForwardProperties({ lat: 48.8566, lon: 2.3522, places: [{ tag: "locality", name: "Paris" }] })
+	expect(props.type).toBe("city")
+	expect(props.name).toBe("Paris")
+	expect(props.housenumber).toBeUndefined()
+	expect(props.street).toBeUndefined()
+})
+
+test("forward: house-grade with a missing parsed street/number still types house (fields just omitted) (#1041)", () => {
+	const props = photonForwardProperties({
+		lat: 48.8548,
+		lon: 2.3451,
+		places: [{ tag: "locality", name: "Paris" }],
+		house: { number: "8", street: null },
+	})
+	expect(props.type).toBe("house")
+	expect(props.housenumber).toBe("8")
+	expect(props.street).toBeUndefined() // null street → field simply absent, never "null"
+})
+
+test("photonForwardFeature: a house-grade input renders a type:house Point Feature (#1041)", () => {
+	const f = photonForwardFeature({
+		lat: 48.8548,
+		lon: 2.3451,
+		places: [{ tag: "locality", name: "Paris" }],
+		house: { number: "8", street: "Boulevard du Palais" },
+	})
+	expect(f.geometry.coordinates).toEqual([2.3451, 48.8548])
+	expect(f.properties.type).toBe("house")
+	expect(f.properties.housenumber).toBe("8")
+})
+
 test("photonOSMTags: maps place tiers to the Photon osm schema, with a safe fallback", () => {
 	expect(photonOSMTags("locality")).toEqual({ osm_key: "place", osm_value: "city", type: "city" })
 	expect(photonOSMTags("localadmin")).toEqual({ osm_key: "place", osm_value: "city", type: "city" }) // reverse placetype

--- a/photon/index.ts
+++ b/photon/index.ts
@@ -286,6 +286,16 @@ export interface PhotonForwardInput {
 	country?: { name?: string; code?: string } | null
 	/** Resolved admin ancestry, most-specific first, each carrying the gazetteer's canonical name (not the parsed span). */
 	places: ReadonlyArray<{ tag: string; name: string }>
+	/**
+	 * A HOUSE-GRADE result (#1041): set only when the resolver produced a specific building coordinate — the
+	 * `address_point` (rooftop) or `interpolated` tier fired, NOT an admin centroid. {@link photonForwardProperties} then
+	 * re-tags the schema `osm_key: place` / `osm_value: house` / `type: house` and surfaces the parsed `housenumber` +
+	 * `street`, matching upstream komoot/photon's own bare-address-point shape (verified against `photon.komoot.io`: a
+	 * residential rooftop returns `{osm_key:"place", osm_value:"house", type:"house", housenumber, street}` with NO
+	 * `name`). Absent → the result keeps its admin-ancestry schema. Without it a rooftop reads as `type: city` and a
+	 * client zooms to city scale (or paints a city marker) on a doorstep match — the #1041 regression.
+	 */
+	house?: { number?: string | null; street?: string | null } | null
 }
 
 /**
@@ -359,6 +369,29 @@ export function photonForwardProperties(input: PhotonForwardInput): PhotonProper
 
 	if (input.country?.code) {
 		props.countrycode = input.country.code.toLowerCase()
+	}
+
+	// #1041: house-grade override. A rooftop / interpolated coordinate is a BUILDING, not the admin locality the
+	// ancestry above would label it — re-tag the schema so a Photon client renders (and zooms to) a house, and surface
+	// the parsed housenumber + street. Matches upstream komoot/photon's bare address point (osm_key:place, osm_value:
+	// house, type:house, with housenumber + street and NO name). Drop the admin-derived `name` — else the QGIS FLF label
+	// (name + housenumber + street + city + postcode) doubles the city ("Paris 8 Boulevard du Palais Paris 75001"). The
+	// city/state/postcode/country the ancestry filled stay put (upstream carries them on a house result too).
+	if (input.house) {
+		props.osm_key = "place"
+		props.osm_value = "house"
+		props.type = "house"
+		delete props.name
+		const number = input.house.number?.trim()
+		const street = input.house.street?.trim()
+
+		if (number) {
+			props.housenumber = number
+		}
+
+		if (street) {
+			props.street = street
+		}
 	}
 
 	return props


### PR DESCRIPTION
## Problem

The #1012 BAN `address_point` tier fires through the live photon serve path — `'8 Boulevard du Palais, 75001 Paris'` → tier `address_point`, `[2.3451, 48.8548]` (BAN's rooftop) — but the Photon `properties` block mislabeled it `type: city` / `name: <city>`, with **no** `housenumber`/`street`. A client sees a rooftop coordinate labeled as a city hit and the QGIS locator zooms to city scale on a rooftop match.

**Root cause:** `extractGeocodeResult`'s `hierarchy` only carries locality→country (street/house_number aren't hierarchy tags), so the #1014 projection took `places[0]` = the locality → `type: city`.

## Fix (decoration only — coordinate byte-stable)

- **`geocode-core`** — surface the *parsed* house number + full reassembled street name (prefix + base + suffix; `street.value` alone is the bare base) on `GeocodeResult`, populated regardless of tier.
- **`photon`** — a house-grade input (the `address_point` / `interpolated` tier) re-tags the schema `osm_key: place` / `osm_value: house` / `type: house` and carries `housenumber` + `street`, dropping the admin-derived `name`. This matches upstream komoot/photon's own bare address point (verified against `photon.komoot.io`: a residential rooftop returns `{osm_key:"place", osm_value:"house", type:"house", housenumber, street}` with **no** `name`). The admin tier (a locality centroid) keeps `type: city`, so an admin fallback is never dressed up as a rooftop.
- **`nominatim`** — same gap: forward results carried no `class`/`type`; a house-grade tier now tags `class: place` / `type: house` (its `addressdetails` already carried `house_number`/`road`).
- **`/reverse`** — unchanged: the `WOFReverseGeocoder` is a PIP over admin polygons and never returns an address-point tier, so there is nothing house-grade to decorate (scope note).

## Upstream evidence (komoot/photon)

A plain residential rooftop query returns:
```json
{ "osm_key": "place", "osm_value": "house", "type": "house",
  "housenumber": "8", "street": "Boulevard du Palais",
  "city": "Paris", "postcode": "75001", "country": "France" }
```
(no `name` field — `name` appears only for named POIs). We match this exactly.

## Verification

- **Live serve** (free port, BAN shard): `/api?q=8 Boulevard du Palais, 75001 Paris` now returns `type:house`, `osm_key:place`, `osm_value:house`, `housenumber:8`, `street:"Boulevard du Palais"`, coordinate `[2.345141, 48.854843]` — the same rooftop coordinate as before the fix (decoration-only). A plain `Paris` query still returns `type:city`.
- **Real clients (contract):**
  - `@openrunner/photon-geocoder@1.2.13` (jsdom): `showResults()` does not throw, `getIconType("place")` is clean, line 1 renders the **street** "Boulevard du Palais" (not the city "Paris" — the pre-fix mislabel).
  - QGIS French Locator Filter (`PhotonGeocoder._result_from_json` replica): groups as `house`, zooms to building scale (2000, not city 25000), label `"8 Boulevard du Palais Paris 75001"` with no doubled city.
- **Unit tests:** new coverage in `geocode-core.test.ts` (parsed house-grade fields across tiers) + `photon/index.test.ts` (house-grade projection). `yarn test` green for the affected workspaces; lint + oxfmt clean.
- **Coordinate byte-stability:** the diff is 224 insertions / 0 deletions — no coordinate/parse logic touched. The gauntlet metamorphic layer held INV 53/53 (≤1m); the regression layer's 4 failures (DC 1.93km, Beirut 10160.76km, Zurich 8044.16km, Springfield region) reproduce **byte-identically** on `origin/main` with the same local dev weights — they are the known anchor-OFF/gazetteer-OFF dev-weights degradation, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)