### PR TITLE
feat(#1042): FR street-centroid tier derived from BAN — voies 0/8→7/8

### DIFF
--- a/ban/scripts/build-street-centroid-shard.ts
+++ b/ban/scripts/build-street-centroid-shard.ts
@@ -1,0 +1,268 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Build the DERIVED street-centroid shard (`ban/street-centroids-<cc>.db`, #1042) from the SEALED
+ *   rooftop address-point shard (`ban/address-points-<cc>.db`, #1012). No new data source: it is a
+ *   `GROUP BY street` roll-up of the register we already ingested — one row per (street_norm, postcode,
+ *   commune) carrying the street's CENTROID + bounding-box EXTENT + member-point count. The output feeds
+ *   `StreetCentroidSqliteLookup`, the street-level tier for a street-only query (a thoroughfare with NO
+ *   house number) that no address-POINT tier can serve by definition.
+ *
+ *   The commune is the arrondissement-STRIPPED base commune (`stripArrondissement` — BAN names
+ *   Paris/Lyon/Marseille rows per arrondissement, but a query names the base commune); the aggregation
+ *   groups on the full `locality_norm` and emits the base, so a rare (street, postcode, base) collision
+ *   across two arrondissements is merged harmlessly by the reader's weighted aggregate.
+ *
+ *   The SEALED input is opened READ-ONLY and NEVER modified. Build discipline (house rules): aggregate
+ *   in SQLite → stream via `.iterate()` → positional prepared INSERT (batched) into a staging DB →
+ *   indexes → ANALYZE → atomic swap into place → SEAL 0444 → record md5 + the derivation provenance in
+ *   `ban/street-centroids-<cc>.ATTRIBUTION.json`. Purely additive; it never touches the rooftop shard.
+ *
+ *   Usage:
+ *     node ban/out/scripts/build-street-centroid-shard.js            # fr, default paths
+ *     node ban/out/scripts/build-street-centroid-shard.js --country fr --out /tmp/sc-fr.db
+ */
+
+import { createHash } from "node:crypto"
+import {
+	createReadStream,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs"
+import { dirname } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
+
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
+import { dataRootPath, sealDatabase } from "@mailwoman/core/utils"
+import {
+	createStreetCentroidIndexes,
+	createStreetCentroidTable,
+	STREET_CENTROID_COLUMNS,
+	type StreetCentroidDatabase,
+} from "@mailwoman/resolver-wof-sqlite/street-centroid-schema"
+import { stripArrondissement } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+
+import { BAN_ATTRIBUTION, BAN_CSV_BASE, BAN_LICENSE } from "../sdk/fetch.js"
+import { streetLocaleForBANCountry } from "../sdk/street-locale.js"
+
+interface BuildArgs {
+	country: string
+	source: string
+	release: string
+	output: string
+}
+
+function parse(): BuildArgs {
+	const { values } = parseArgs({
+		options: {
+			country: { type: "string" },
+			source: { type: "string" },
+			release: { type: "string" },
+			out: { type: "string" },
+		},
+	})
+
+	const country = (values.country ?? "fr").toLowerCase()
+	// Throws for an unsupported country — fail loud, never derive a tier keyed with the wrong locale rules.
+	streetLocaleForBANCountry(country)
+	const source = values.source ?? dataRootPath("ban", `address-points-${country}.db`)
+
+	if (!existsSync(source)) throw new Error(`sealed BAN rooftop shard not found: ${source} (build it via #1012 first)`)
+	const release = values.release ?? "2026-05-18"
+	const output = values.out ?? dataRootPath("ban", `street-centroids-${country}.db`)
+
+	return { country, source, release, output }
+}
+
+/** Streaming md5 of a file (never buffer a multi-GB artifact). */
+async function fileMD5(path: string): Promise<string> {
+	const hash = createHash("md5")
+
+	for await (const chunk of createReadStream(path)) {
+		hash.update(chunk as Buffer)
+	}
+
+	return hash.digest("hex")
+}
+
+/** The md5 the #1012 build recorded for the sealed rooftop input, for the derivation provenance chain. */
+function sourceMD5(country: string): string | null {
+	try {
+		const rec = JSON.parse(readFileSync(dataRootPath("ban", "ATTRIBUTION.json"), "utf8")) as {
+			artifact?: string
+			md5?: string
+		}
+
+		return rec.artifact === `address-points-${country}.db` ? (rec.md5 ?? null) : null
+	} catch {
+		return null
+	}
+}
+
+async function main(): Promise<void> {
+	const args = parse()
+	const source = `ban:${args.country}`
+	const tmp = `${args.output}.building-${process.pid}.db`
+
+	mkdirSync(dirname(args.output), { recursive: true })
+
+	for (const sfx of ["", "-wal", "-shm"]) {
+		rmSync(tmp + sfx, { force: true })
+	}
+
+	// The SEALED input — READ-ONLY, immutable; register the base-commune folder as a scalar SQL function.
+	const src = new DatabaseSync(args.source, { readOnly: true })
+
+	src.function("ban_base_commune", { deterministic: true }, (loc: unknown): string =>
+		typeof loc === "string" && loc ? stripArrondissement(loc) : ""
+	)
+
+	const out = new DatabaseSync(tmp)
+
+	out.exec("PRAGMA page_size=8192; PRAGMA journal_mode=OFF; PRAGMA synchronous=OFF; PRAGMA cache_size=-1000000;")
+	const kdb = new DatabaseClient<StreetCentroidDatabase>({ database: out })
+
+	await createStreetCentroidTable(kdb)
+
+	const insert = out.prepare(
+		`INSERT INTO street_centroid VALUES (${STREET_CENTROID_COLUMNS.map(() => "?").join(", ")})`
+	)
+
+	// GROUP BY the sealed rooftop points into per-(street, postcode, commune) roll-ups. AVG(lat/lon) over the group's
+	// member points is the exact centroid; MIN/MAX is the extent; COUNT is the weight for the reader's cross-group mean.
+	// The base commune is emitted per group (2.2M calls), NOT per source row.
+	const agg = src.prepare(
+		`SELECT street_norm,
+		        postcode,
+		        ban_base_commune(locality_norm) AS locality_base,
+		        AVG(lat) AS lat, AVG(lon) AS lon,
+		        MIN(lat) AS min_lat, MAX(lat) AS max_lat, MIN(lon) AS min_lon, MAX(lon) AS max_lon,
+		        COUNT(*) AS n,
+		        MIN(street_raw) AS street_raw
+		 FROM address_point
+		 GROUP BY street_norm, postcode, locality_norm`
+	)
+
+	let written = 0
+	const BATCH = 50_000
+
+	console.error(`[ban] deriving ${args.country} street-centroid tier from ${args.source}`)
+	out.exec("BEGIN")
+
+	for (const row of agg.iterate() as Iterable<{
+		street_norm: string
+		postcode: string | null
+		locality_base: string
+		lat: number
+		lon: number
+		min_lat: number
+		max_lat: number
+		min_lon: number
+		max_lon: number
+		n: number
+		street_raw: string
+	}>) {
+		// Positional, in STREET_CENTROID_COLUMNS order.
+		insert.run(
+			row.street_norm,
+			row.postcode,
+			row.locality_base,
+			row.lat,
+			row.lon,
+			row.min_lat,
+			row.max_lat,
+			row.min_lon,
+			row.max_lon,
+			row.n,
+			row.street_raw,
+			source,
+			args.release
+		)
+		written++
+
+		if (written % BATCH === 0) {
+			out.exec("COMMIT")
+			out.exec("BEGIN")
+
+			if (written % 500_000 === 0) {
+				console.error(`[ban]   ${written.toLocaleString()} streets…`)
+			}
+		}
+	}
+	out.exec("COMMIT")
+	src.close()
+
+	console.error(`[ban] indexing…`)
+	await createStreetCentroidIndexes(kdb)
+	out.exec("ANALYZE")
+	await kdb.destroy()
+
+	// Atomic swap into place (move any prior aside first), then SEAL 0444.
+	if (existsSync(args.output)) {
+		renameSync(args.output, `${args.output}.prev`)
+	}
+
+	for (const sfx of ["-wal", "-shm"]) {
+		rmSync(args.output + sfx, { force: true })
+	}
+	renameSync(tmp, args.output)
+
+	if (existsSync(`${args.output}.prev`)) {
+		rmSync(`${args.output}.prev`, { force: true })
+	}
+	sealDatabase(args.output)
+
+	const md5 = await fileMD5(args.output)
+	const bytes = statSync(args.output).size
+	const srcMD5 = sourceMD5(args.country)
+
+	// Provenance manifest — additive, written at creation (house discipline). Records the DERIVATION chain: this
+	// artifact is derived from the sealed #1012 rooftop shard, itself derived from the BAN release.
+	const attributionPath = dataRootPath("ban", `street-centroids-${args.country}.ATTRIBUTION.json`)
+
+	writeFileSync(
+		attributionPath,
+		JSON.stringify(
+			{
+				artifact: `street-centroids-${args.country}.db`,
+				derivedFrom: {
+					artifact: `address-points-${args.country}.db`,
+					source,
+					release: args.release,
+					md5: srcMD5,
+					note: `derived from ${source} release=${args.release}${srcMD5 ? ` (md5 ${srcMD5.slice(0, 8)})` : ""}`,
+				},
+				source,
+				sourceURL: BAN_CSV_BASE,
+				license: BAN_LICENSE,
+				attribution: BAN_ATTRIBUTION,
+				release: args.release,
+				streets: written,
+				bytes,
+				md5,
+				builtAt: new Date().toISOString(),
+			},
+			null,
+			2
+		) + "\n"
+	)
+	console.error(`[ban] wrote ${attributionPath}`)
+
+	console.error(
+		`[ban] DONE ${args.output}\n` +
+			`      streets (rows)                   : ${written.toLocaleString()}\n` +
+			`      bytes                            : ${bytes.toLocaleString()}\n` +
+			`      md5                              : ${md5}\n` +
+			`      derived from                     : address-points-${args.country}.db${srcMD5 ? ` (md5 ${srcMD5.slice(0, 8)})` : ""}  release=${args.release}`
+	)
+}
+
+await main()

--- a/ban/sdk/shard-provider.ts
+++ b/ban/sdk/shard-provider.ts
@@ -15,13 +15,15 @@
 
 import { existsSync } from "node:fs"
 
-import { AddressPointSqliteLookup } from "@mailwoman/resolver-wof-sqlite"
+import { AddressPointSqliteLookup, StreetCentroidSqliteLookup } from "@mailwoman/resolver-wof-sqlite"
 
 import { streetLocaleForBANCountry, supportedBANCountries } from "./street-locale.js"
 
 /** What the cascade needs from a BAN shard — structurally a subset of mailwoman's `StateShards`. */
 export interface BANShards {
 	addressPoints?: AddressPointSqliteLookup
+	/** The #1042 derived street-centroid tier — a `GROUP BY street` roll-up, for a street-only query (no house number). */
+	streetCentroids?: StreetCentroidSqliteLookup
 }
 
 /**
@@ -40,6 +42,10 @@ export class BANShardProvider {
 		return `${this.#dataRoot}/ban/address-points-${countryCode}.db`
 	}
 
+	#streetCentroidPath(countryCode: string): string {
+		return `${this.#dataRoot}/ban/street-centroids-${countryCode}.db`
+	}
+
 	/** Resolve the BAN shards for an ISO-3166 alpha-2 country, or `{}` when none is shipped/registered. */
 	readonly for = (country: string): BANShards => {
 		const cc = country.toLowerCase()
@@ -47,14 +53,21 @@ export class BANShardProvider {
 
 		if (cached) return cached
 
-		let entry: BANShards = {}
+		const entry: BANShards = {}
 
 		// Only countries with a registered street locale AND an on-disk shard — never key with the wrong rules.
 		if (supportedBANCountries().includes(cc)) {
+			const locale = streetLocaleForBANCountry(cc)
 			const path = this.#shardPath(cc)
 
 			if (existsSync(path)) {
-				entry = { addressPoints: new AddressPointSqliteLookup(path, { streetLocale: streetLocaleForBANCountry(cc) }) }
+				entry.addressPoints = new AddressPointSqliteLookup(path, { streetLocale: locale })
+			}
+			// The #1042 derived street tier — purely additive, opened only when its artifact is on disk.
+			const streetPath = this.#streetCentroidPath(cc)
+
+			if (existsSync(streetPath)) {
+				entry.streetCentroids = new StreetCentroidSqliteLookup(streetPath, { streetLocale: locale })
 			}
 		}
 		this.#cache.set(cc, entry)
@@ -65,6 +78,7 @@ export class BANShardProvider {
 	close(): void {
 		for (const entry of this.#cache.values()) {
 			entry.addressPoints?.close()
+			entry.streetCentroids?.close()
 		}
 		this.#cache.clear()
 	}

--- a/core/resolver/index.ts
+++ b/core/resolver/index.ts
@@ -24,4 +24,6 @@ export type {
 	ResolvedPlace,
 	Resolver,
 	ResolverBackend,
+	StreetCentroidHit,
+	StreetCentroidLookup,
 } from "./types.js"

--- a/core/resolver/types.ts
+++ b/core/resolver/types.ts
@@ -206,6 +206,31 @@ export interface InterpolationLookup {
 	find(query: { street: string; number: string; postcode?: string }): InterpolatedPointHit | null
 }
 
+/**
+ * One street-CENTROID hit (#1042) — the street-level tier BELOW the exact address-point tier and ABOVE admin-centroid
+ * resolution. A street's centroid + an honest extent-derived radius, for a street-only query (no house number) that an
+ * address-point tier cannot serve by definition. Derived from a national register's rooftop points
+ * (`street-centroids-<cc>.db`, a `GROUP BY street` roll-up). `uncertaintyM` prices the coarseness (half the street's
+ * bbox diagonal) so a consumer never mistakes it for a rooftop.
+ */
+export interface StreetCentroidHit {
+	lat: number
+	lon: number
+	/** Honest coarse radius in METERS — half the street's bounding-box diagonal. */
+	uncertaintyM: number
+	source: string
+	release: string
+}
+
+/**
+ * Street-centroid lookup (#1042). Like {@link AddressPointLookup}, implementations own their normalization (the shared
+ * `resolver-wof-sqlite/street-normalize.ts`); core depends only on this contract. Scoped by `postcode` (preferred) or
+ * `locality` (the base commune) — NO house number: this is the street-only tier.
+ */
+export interface StreetCentroidLookup {
+	find(query: { street: string; postcode?: string; locality?: string }): StreetCentroidHit | null
+}
+
 export interface ResolveOpts {
 	/**
 	 * Hard cap on how many backend lookups one tree may issue. Default 10. Prevents a tree with dozens of candidate nodes
@@ -335,6 +360,30 @@ export interface ResolveOpts {
 	 * docs/articles/evals/2026-06-14-interp-radius-calibration.md.
 	 */
 	interpolationRadiusCalibration?: number
+	/**
+	 * Street-centroid tier (#1042): consulted for a STREET-ONLY query (a street/thoroughfare with NO house number) that
+	 * neither the address-point nor the interpolation tier can serve. On a hit, injects/stamps a resolved `street` node
+	 * carrying the street's centroid under a DISTINCT metadata key (`street_centroid`, `resolution_tier: "street"`,
+	 * `uncertainty_m`) — never `address_point`/`interpolated_point`, so a consumer reading the exact keys never gets a
+	 * coarse centroid mislabeled as a rooftop. The thoroughfare + commune are recovered raw-text-first (the FR no-street
+	 * class mis-parses the thoroughfare as a locality — #901 composition-insensitive), so the tier rides the model where
+	 * it works and recovers where it fails.
+	 *
+	 * A COUNTRY-KEYED PROVIDER (not a bare lookup) because the country signal for a street-only query is unreliable
+	 * BEFORE resolution: a bare thoroughfare ("Avenue des Champs-Élysées, Paris") is a bare-locality tree the placer is
+	 * skipped on, and the placer mis-routes some French streets ("Rue Sainte-Catherine" → IT). So the tier probes a UNION
+	 * of candidate countries — {@link streetCountryHints} (pre-resolution: defaultCountry + the ungated placer) PLUS the
+	 * countries the tree actually RESOLVED to — and the exact (street, base-commune) match is itself the country filter.
+	 * Opt-in; absent = byte-stable. Never fires when a house number is present (rooftop tiers untouched) or when a
+	 * street-level coordinate already resolved.
+	 */
+	streetCentroids?: (country: string) => StreetCentroidLookup | undefined
+	/**
+	 * Ordered pre-resolution country hints for the {@link streetCentroids} tier — the caller's defaultCountry and the
+	 * (ungated) coarse-placer country. The tier unions these with the resolved-tree countries. Absent = only the resolved
+	 * countries are tried.
+	 */
+	streetCountryHints?: readonly string[]
 	/**
 	 * Span-rescore tier (#370). When the tree resolved nothing, recover a dropped/fragmented locality from the raw text:
 	 * enumerate raw-token spans, exact-match the same-country gazetteer (longest-wins + postcode-consistency gate), and

--- a/mailwoman/geocode-core.ts
+++ b/mailwoman/geocode-core.ts
@@ -29,7 +29,13 @@ import { decodeAsJSON } from "@mailwoman/core/decoder"
 import { hardCountryFor, isBareLocalityTree } from "@mailwoman/core/pipeline"
 import { normalize } from "@mailwoman/normalize"
 import { computeQueryShape, type QueryShape } from "@mailwoman/query-shape"
-import type { AddressPointLookup, InterpolationLookup, ResolveOpts, Resolver } from "@mailwoman/resolver"
+import type {
+	AddressPointLookup,
+	InterpolationLookup,
+	ResolveOpts,
+	Resolver,
+	StreetCentroidLookup,
+} from "@mailwoman/resolver"
 
 import { type DataReleaseManifest, readReleaseManifest, resolveShardPath } from "./data-release.js"
 import { loadDefaultPlaceCountry, type PlaceCountryFn } from "./default-placer.js"
@@ -37,13 +43,14 @@ import { interpCalibrationForRegion, type InterpCalibrationTable } from "./inter
 import { recognizeUSRegions } from "./region-recognition.js"
 
 /**
- * The resolution tier that produced the coordinate. `address_point` > `interpolated` > `admin`.
+ * The resolution tier that produced the coordinate. `address_point` > `interpolated` > `street` > `admin`.
  *
  * - `address_point` — rooftop / parcel centroid; uncertainty_m is a small floor (~1 m)
  * - `interpolated` — house-number estimate; uncertainty_m is honest (calibrated bracket span)
+ * - `street` — street centroid for a street-only query (#1042); uncertainty_m is half the street's bbox diagonal
  * - `admin` — admin centroid; uncertainty_m is null (no sub-locality estimate available)
  */
-export type ResolutionTier = "address_point" | "interpolated" | "admin"
+export type ResolutionTier = "address_point" | "interpolated" | "street" | "admin"
 
 export interface GeocodeResult {
 	input: string
@@ -88,6 +95,13 @@ export interface GeocodeResult {
 export interface StateShards {
 	addressPoints?: AddressPointLookup
 	interpolation?: InterpolationLookup
+	/**
+	 * Derived street-centroid tier (#1042) — a `GROUP BY street` roll-up of a national register's rooftop points, keyed
+	 * for a street-only query (no house number). Supplied today only by `@mailwoman/ban`'s `BANShardProvider` for FR (the
+	 * US per-state {@link ShardProvider} never opens one), so the tier is FR-only in practice and every non-FR path stays
+	 * byte-stable. Consulted BELOW the address-point/interpolation tiers, ABOVE admin.
+	 */
+	streetCentroids?: StreetCentroidLookup
 }
 
 /** Resolve the situs/interpolation shards for a state slug (e.g. `"tx"`). `null` slug → no shards. */
@@ -474,6 +488,14 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	// The placer's country (in-map, non-OTHER) — reused below to select an OSM rooftop shard for a non-US parse.
 	let placedCountry: string | null = null
 
+	// The placer's prediction, computed ONCE and UNGATED (so it's available even for a bare-locality tree, where the
+	// #912 lever below deliberately withholds it from the anchor). Reused by that lever AND by the #1042 street tier's
+	// country hint (a bare thoroughfare "Avenue des Champs-Élysées, Paris" is a bare-locality tree — the only reliable
+	// FR signal there is this ungated placer). Byte-stable: the anchor/hardCountry logic stays gated exactly as before.
+	const placerResult = placeCountry ? placeCountry(parseInput) : null
+	const streetPlacerCountry =
+		placerResult?.country && placerResult.country !== "OTHER" ? placerResult.country.toLowerCase() : null
+
 	// #928: a distinctive postcode FORMAT outranks the language-based placer (which conflates GB/US → US
 	// namesakes). When gated on and no explicit defaultCountry, set the country prior from the parsed
 	// postcode's format; the placer block below then no-ops via its `!opts.anchorPosterior` guard. Confidence
@@ -503,8 +525,8 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 	// #912 lever 1: the placer abstains on a single bare locality — OOD input, and the wrong soft
 	// posterior overrides the resolver's better-informed exact-tier/population ranking (see
 	// isBareLocalityTree). Explicit defaultCountry / anchorPosterior from the caller are untouched.
-	if (placeCountry && !isBareLocalityTree(tree)) {
-		const placed = placeCountry(parseInput)
+	if (placeCountry && placerResult && !isBareLocalityTree(tree)) {
+		const placed = placerResult
 		placedCountry = placed.country && placed.country !== "OTHER" ? placed.country : null
 
 		if (placed.country && placed.country !== "OTHER" && !opts.anchorPosterior) {
@@ -561,6 +583,29 @@ export async function geocodeAddress(input: string, deps: GeocodeDeps): Promise<
 
 	if (addressPoints) {
 		opts.addressPoints = addressPoints
+	}
+
+	// National street-centroid tier (#1042): wire the country-keyed street-centroid PROVIDER (BAN-FR today) + the
+	// pre-resolution country hints so a STREET-ONLY query (no house number) — which no rooftop tier can serve — gets a
+	// street-level coordinate instead of the commune centroid. The resolver's applyStreetCentroid self-gates on
+	// no-house-number (a numbered query is byte-identical) and unions these hints with the RESOLVED-tree countries,
+	// because the pre-resolution country of a bare thoroughfare is unreliable (bare-locality tree / placer mis-route).
+	// US never supplies a street shard, so `provider("us")` is undefined and the US path stays byte-stable.
+	if (deps.nationalShards) {
+		const provider = deps.nationalShards
+
+		opts.streetCentroids = (country: string) => provider(country).streetCentroids
+		const hints: string[] = []
+
+		for (const c of [deps.defaultCountry?.toLowerCase(), placedCountry?.toLowerCase(), streetPlacerCountry]) {
+			if (c && !hints.includes(c)) {
+				hints.push(c)
+			}
+		}
+
+		if (hints.length > 0) {
+			opts.streetCountryHints = hints
+		}
 	}
 
 	if (interpolation) {
@@ -621,6 +666,19 @@ export function extractGeocodeResult(input: string, tree: AddressTree): GeocodeR
 			lat = ip.lat
 			lon = ip.lon
 			tier = "interpolated"
+			uncertaintyM = (streetNode.metadata["uncertainty_m"] as number | undefined) ?? null
+		}
+	}
+
+	// Street-centroid tier (#1042): below rooftop/interp, above admin. Only reached for a street-only query the
+	// exact tiers couldn't serve (they require a house number), so this never displaces a rooftop coordinate.
+	if (tier !== "address_point" && tier !== "interpolated" && streetNode?.metadata?.["resolution_tier"] === "street") {
+		const sc = streetNode.metadata["street_centroid"] as { lat: number; lon: number } | undefined
+
+		if (sc) {
+			lat = sc.lat
+			lon = sc.lon
+			tier = "street"
 			uncertaintyM = (streetNode.metadata["uncertainty_m"] as number | undefined) ?? null
 		}
 	}

--- a/mailwoman/server/GeocodeRouter.ts
+++ b/mailwoman/server/GeocodeRouter.ts
@@ -249,13 +249,15 @@ const resolveTreeHandler: RequestHandler = async (req, res) => {
 }
 
 /** Pull the street node's resolution tier (if any) for the metric — mirrors extractGeocodeResult. */
-function collectStreetTier(node: AddressTree["roots"][number]): Array<"address_point" | "interpolated" | "admin"> {
-	const out: Array<"address_point" | "interpolated" | "admin"> = []
+function collectStreetTier(
+	node: AddressTree["roots"][number]
+): Array<"address_point" | "interpolated" | "street" | "admin"> {
+	const out: Array<"address_point" | "interpolated" | "street" | "admin"> = []
 
 	if (node.tag === "street") {
 		const tier = node.metadata?.["resolution_tier"]
 
-		if (tier === "address_point" || tier === "interpolated") {
+		if (tier === "address_point" || tier === "interpolated" || tier === "street") {
 			out.push(tier)
 		}
 	}

--- a/mailwoman/server/metrics.test.ts
+++ b/mailwoman/server/metrics.test.ts
@@ -68,7 +68,7 @@ test("recordGeocode: counts total, partitions by tier, and tallies errors separa
 	const g = metricsSnapshot().geocode
 	expect(g.total).toBe(5) // every call, errors included
 	expect(g.errors).toBe(1)
-	expect(g.tiers).toEqual({ address_point: 2, interpolated: 1, admin: 1 })
+	expect(g.tiers).toEqual({ address_point: 2, interpolated: 1, street: 0, admin: 1 })
 })
 
 test("recordGeocode: an error still records its latency in the reservoir", () => {
@@ -79,7 +79,7 @@ test("recordGeocode: an error still records its latency in the reservoir", () =>
 	expect(g.latency_samples).toBe(1)
 	expect(g.latency_ms?.max).toBe(99)
 	expect(g.errors).toBe(1)
-	expect(g.tiers).toEqual({ address_point: 0, interpolated: 0, admin: 0 })
+	expect(g.tiers).toEqual({ address_point: 0, interpolated: 0, street: 0, admin: 0 })
 })
 
 test("__resetMetricsForTest: clears counters and the reservoir", () => {

--- a/mailwoman/server/metrics.ts
+++ b/mailwoman/server/metrics.ts
@@ -18,7 +18,7 @@ const MAX_SAMPLES = 2048
 const latencies: number[] = []
 let writeIdx = 0
 
-const tierCounts: Record<ResolutionTier, number> = { address_point: 0, interpolated: 0, admin: 0 }
+const tierCounts: Record<ResolutionTier, number> = { address_point: 0, interpolated: 0, street: 0, admin: 0 }
 let total = 0
 let errors = 0
 const startedAt = Date.now()
@@ -88,6 +88,7 @@ export function __resetMetricsForTest(): void {
 	writeIdx = 0
 	tierCounts.address_point = 0
 	tierCounts.interpolated = 0
+	tierCounts.street = 0
 	tierCounts.admin = 0
 	total = 0
 	errors = 0

--- a/mailwoman/test/geocode-core-national-shard.test.ts
+++ b/mailwoman/test/geocode-core-national-shard.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type { AddressTree } from "@mailwoman/core/decoder"
-import type { AddressPointLookup, ResolveOpts, Resolver } from "@mailwoman/resolver"
+import type { AddressPointLookup, ResolveOpts, Resolver, StreetCentroidLookup } from "@mailwoman/resolver"
 import { describe, expect, test, vi } from "vitest"
 
 import { geocodeAddress, type GeocodeClassifier, type StateShards } from "../geocode-core.js"
@@ -90,6 +90,36 @@ describe("geocodeAddress — national (BAN) rooftop tier wiring (#1012)", () => 
 		})
 		expect(nationalShards).not.toHaveBeenCalled()
 		expect(seen[0]?.addressPoints).toBeUndefined()
+	})
+
+	test("wires the street-centroid provider + FR hint for a non-US parse (#1042)", async () => {
+		const { resolver, seen } = captureResolver()
+		const streetLookup: StreetCentroidLookup = { find: vi.fn(() => null) }
+		await geocodeAddress("Place Bellecour, Lyon", {
+			classifier: fakeClassifier(emptyTree),
+			resolver,
+			placeCountry: false,
+			defaultCountry: "FR",
+			nationalShards: (c) => (c === "fr" ? { streetCentroids: streetLookup } : {}),
+		})
+		// A country-keyed PROVIDER (not a bare lookup): resolves the FR shard, undefined for a country BAN lacks.
+		expect(typeof seen[0]?.streetCentroids).toBe("function")
+		expect(seen[0]?.streetCentroids?.("fr")).toBe(streetLookup)
+		expect(seen[0]?.streetCentroids?.("de")).toBeUndefined()
+		// The pre-resolution hint carries the country the tier's union starts from.
+		expect(seen[0]?.streetCountryHints).toContain("fr")
+	})
+
+	test("absent nationalShards ⇒ no street-centroid tier (byte-stable, #1042)", async () => {
+		const { resolver, seen } = captureResolver()
+		await geocodeAddress("Place Bellecour, Lyon", {
+			classifier: fakeClassifier(emptyTree),
+			resolver,
+			placeCountry: false,
+			defaultCountry: "FR",
+		})
+		expect(seen[0]?.streetCentroids).toBeUndefined()
+		expect(seen[0]?.streetCountryHints).toBeUndefined()
 	})
 
 	test("absent nationalShards ⇒ byte-stable: the OSM tier serves FR unchanged (pre-#1012 behavior)", async () => {

--- a/mailwoman/test/health-router.test.ts
+++ b/mailwoman/test/health-router.test.ts
@@ -45,7 +45,7 @@ describe("metrics recorder", () => {
 		const s = metricsSnapshot()
 		expect(s.geocode.total).toBe(4)
 		expect(s.geocode.errors).toBe(1)
-		expect(s.geocode.tiers).toEqual({ address_point: 1, interpolated: 1, admin: 1 })
+		expect(s.geocode.tiers).toEqual({ address_point: 1, interpolated: 1, street: 0, admin: 1 })
 		expect(s.geocode.latency_samples).toBe(4)
 		expect(s.geocode.latency_ms).not.toBeNull()
 		expect(s.geocode.latency_ms!.max).toBe(30)

--- a/record/address.ts
+++ b/record/address.ts
@@ -27,10 +27,11 @@ export interface GeoCoordinate {
 
 /**
  * The resolution tier that produced a coordinate, mirroring mailwoman's geocoder (`address_point` > `interpolated` >
- * `admin`). Kept as a local plain union so this package stays decoupled from the heavy geocoder runtime; a
- * `GeocodeResult.resolution_tier` maps in directly.
+ * `street` > `admin`). Kept as a local plain union so this package stays decoupled from the heavy geocoder runtime; a
+ * `GeocodeResult.resolution_tier` maps in directly. (`street` = a street centroid for a street-only query, #1042 —
+ * coarser than a house-number estimate, finer than an admin centroid.)
  */
-export type ResolutionTier = "address_point" | "interpolated" | "admin"
+export type ResolutionTier = "address_point" | "interpolated" | "street" | "admin"
 
 /** One resolved admin-hierarchy ancestor (most specific first), for spelling-invariant blocking. */
 export interface HierarchyNode {

--- a/resolver-wof-sqlite/index.ts
+++ b/resolver-wof-sqlite/index.ts
@@ -95,6 +95,13 @@ export {
 export { AddressPointInterpolator } from "./address-point-interpolation.js"
 export { AddressPointSqliteLookup } from "./address-point.js"
 export {
+	STREET_CENTROID_COLUMNS,
+	createStreetCentroidIndexes,
+	createStreetCentroidTable,
+} from "./street-centroid-schema.js"
+export type { StreetCentroidDatabase, StreetCentroidTable } from "./street-centroid-schema.js"
+export { StreetCentroidSqliteLookup } from "./street-centroid.js"
+export {
 	StreetInterpolator,
 	type InterpolatedHit,
 	type InterpolationMethod,

--- a/resolver-wof-sqlite/package.json
+++ b/resolver-wof-sqlite/package.json
@@ -45,6 +45,7 @@
 		"./candidate-schema": "./out/candidate-schema.js",
 		"./postal-city-alias-schema": "./out/postal-city-alias-schema.js",
 		"./address-point-schema": "./out/address-point-schema.js",
+		"./street-centroid-schema": "./out/street-centroid-schema.js",
 		"./street-segment-schema": "./out/street-segment-schema.js"
 	},
 	"publishConfig": {

--- a/resolver-wof-sqlite/street-centroid-schema.ts
+++ b/resolver-wof-sqlite/street-centroid-schema.ts
@@ -1,0 +1,109 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Typed schema for the DERIVED STREET-CENTROID shard (`street-centroids-<cc>.db`, built by
+ *   `ban/scripts/build-street-centroid-shard.ts` — the #1042 street-level tier behind "street-only
+ *   FR queries deserve a street-level answer"). The shard is a `GROUP BY street` roll-up of the
+ *   sealed rooftop address-point shard: one row per (street, postcode, commune) carrying the street's
+ *   CENTROID + bounding-box EXTENT + member-point count. No new data source — a derived artifact.
+ *
+ *   Single source of truth for the columns shared by the BUILDER (a positional prepared INSERT for
+ *   throughput) and the READER ({@link StreetCentroidSqliteLookup}), so a column rename in one is a
+ *   compile error in the other — the same discipline as `address-point-schema.ts`.
+ *
+ *   Probe scopes (most-selective first): by `postcode`, else by `locality_base` (the
+ *   arrondissement-stripped commune — see `stripArrondissement`; BAN names Paris/Lyon/Marseille rows
+ *   per arrondissement, but a query names the base commune). The reader WEIGHTED-aggregates across the
+ *   matched rows (by `point_count`) so a locality-scope probe returns the street's grand centroid over
+ *   every postcode/arrondissement it spans.
+ */
+
+import type { Kysely } from "kysely"
+
+/**
+ * One street roll-up. `(street_norm, postcode, locality_base)` is unique. `lat`/`lon` are the UNWEIGHTED mean of the
+ * group's member address points (each source row = one point), so a cross-group weighted mean (`SUM(lat*point_count) /
+ * SUM(point_count)`) reconstructs the grand centroid. `min_/max_lat/lon` are the group's extent (the reader turns the
+ * bbox diagonal into an honest `uncertainty_m`).
+ */
+export interface StreetCentroidTable {
+	/** Shared `normalizeStreetForKeyLocale` of the street — the build/query-consistent probe key. */
+	street_norm: string
+	/** The 5-digit postcode of this group, or null when the source row carried none. */
+	postcode: string | null
+	/** Arrondissement-stripped commune (`stripArrondissement(normalizeLocalityForKey(commune))`) — the fallback scope. */
+	locality_base: string
+	/** Weighted-mean centroid latitude of the street's member points. */
+	lat: number
+	/** Weighted-mean centroid longitude of the street's member points. */
+	lon: number
+	min_lat: number
+	max_lat: number
+	min_lon: number
+	max_lon: number
+	/** Member address-point count — the weight for a cross-group centroid aggregate. */
+	point_count: number
+	/** A representative street name as it appeared in the source (display / debugging). */
+	street_raw: string
+	/** Provenance: the register this street was derived from (e.g. `ban:fr`). */
+	source: string
+	/** The pinned data release the underlying points came from. */
+	release: string
+}
+
+/** The street-centroid database schema for `new DatabaseClient<StreetCentroidDatabase>(...)`. */
+export interface StreetCentroidDatabase {
+	street_centroid: StreetCentroidTable
+}
+
+/**
+ * The `street_centroid` columns in INSERT order. The builder's positional prepared statement derives its placeholder
+ * list from this, so the positional order can't drift from the DDL / the reader.
+ */
+export const STREET_CENTROID_COLUMNS = [
+	"street_norm",
+	"postcode",
+	"locality_base",
+	"lat",
+	"lon",
+	"min_lat",
+	"max_lat",
+	"min_lon",
+	"max_lon",
+	"point_count",
+	"street_raw",
+	"source",
+	"release",
+] as const
+
+/** Create the `street_centroid` table — called before the streaming bulk load. */
+export async function createStreetCentroidTable(db: Kysely<StreetCentroidDatabase>): Promise<void> {
+	await db.schema
+		.createTable("street_centroid")
+		.addColumn("street_norm", "text", (c) => c.notNull())
+		.addColumn("postcode", "text")
+		.addColumn("locality_base", "text", (c) => c.notNull())
+		.addColumn("lat", "real", (c) => c.notNull())
+		.addColumn("lon", "real", (c) => c.notNull())
+		.addColumn("min_lat", "real", (c) => c.notNull())
+		.addColumn("max_lat", "real", (c) => c.notNull())
+		.addColumn("min_lon", "real", (c) => c.notNull())
+		.addColumn("max_lon", "real", (c) => c.notNull())
+		.addColumn("point_count", "integer", (c) => c.notNull())
+		.addColumn("street_raw", "text", (c) => c.notNull())
+		.addColumn("source", "text", (c) => c.notNull())
+		.addColumn("release", "text", (c) => c.notNull())
+		.execute()
+}
+
+/** Create the two probe indexes the reader relies on (postcode-scope, locality-base-scope). */
+export async function createStreetCentroidIndexes(db: Kysely<StreetCentroidDatabase>): Promise<void> {
+	await db.schema.createIndex("idx_sc_postcode").on("street_centroid").columns(["postcode", "street_norm"]).execute()
+	await db.schema
+		.createIndex("idx_sc_locality")
+		.on("street_centroid")
+		.columns(["locality_base", "street_norm"])
+		.execute()
+}

--- a/resolver-wof-sqlite/street-centroid.test.ts
+++ b/resolver-wof-sqlite/street-centroid.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the #1042 street-centroid tier: the shared `stripArrondissement` folder and the
+ *   `StreetCentroidSqliteLookup` reader. Seeds a temp-file `street_centroid` fixture (the schema the
+ *   `ban/scripts/build-street-centroid-shard.ts` roll-up writes) and asserts postcode-scope probing,
+ *   base-commune probing, arrondissement folding, the cross-row WEIGHTED centroid aggregate, the
+ *   extent-derived uncertainty, and the exact-match miss.
+ */
+
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { DatabaseClient } from "@mailwoman/core/kysley/client"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+import { type StreetCentroidDatabase, createStreetCentroidTable } from "./street-centroid-schema.js"
+import { StreetCentroidSqliteLookup } from "./street-centroid.js"
+import { stripArrondissement } from "./street-normalize.js"
+
+interface Seed {
+	street_norm: string
+	postcode: string | null
+	locality_base: string
+	lat: number
+	lon: number
+	min_lat: number
+	max_lat: number
+	min_lon: number
+	max_lon: number
+	point_count: number
+}
+
+/** Seed a temp-file `street_centroid` shard and return its path (the reader opens by path, read-only). */
+async function seedShard(rows: Seed[]): Promise<string> {
+	const path = join(mkdtempSync(join(tmpdir(), "sc-test-")), "street-centroids.db")
+	const db = new DatabaseSync(path)
+	const kdb = new DatabaseClient<StreetCentroidDatabase>({ database: db })
+	await createStreetCentroidTable(kdb)
+	const ins = db.prepare(
+		`INSERT INTO street_centroid
+		 (street_norm, postcode, locality_base, lat, lon, min_lat, max_lat, min_lon, max_lon, point_count, street_raw, source, release)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ban:fr', '2026-05-18')`
+	)
+
+	for (const r of rows) {
+		ins.run(
+			r.street_norm,
+			r.postcode,
+			r.locality_base,
+			r.lat,
+			r.lon,
+			r.min_lat,
+			r.max_lat,
+			r.min_lon,
+			r.max_lon,
+			r.point_count,
+			r.street_norm
+		)
+	}
+	db.close()
+
+	return path
+}
+
+describe("stripArrondissement", () => {
+	it("strips a trailing French arrondissement designator to the base commune", () => {
+		expect(stripArrondissement("paris 8e arrondissement")).toBe("paris")
+		expect(stripArrondissement("lyon 1er arrondissement")).toBe("lyon")
+		expect(stripArrondissement("marseille 10e arrondissement")).toBe("marseille")
+	})
+
+	it("is a no-op for every other commune", () => {
+		expect(stripArrondissement("bordeaux")).toBe("bordeaux")
+		expect(stripArrondissement("le touquet paris plage")).toBe("le touquet paris plage")
+		expect(stripArrondissement("")).toBe("")
+	})
+})
+
+describe("StreetCentroidSqliteLookup", () => {
+	let lookup: StreetCentroidSqliteLookup
+
+	beforeAll(async () => {
+		const path = await seedShard([
+			// "Place Bellecour" split across two arrondissement/postcode rows, both base-commune "lyon". The
+			// weighted centroid over the two rows weights by point_count (10 @ lon 4.83, 30 @ lon 4.85).
+			{
+				street_norm: "place bellecour",
+				postcode: "69002",
+				locality_base: "lyon",
+				lat: 45.757,
+				lon: 4.83,
+				min_lat: 45.756,
+				max_lat: 45.758,
+				min_lon: 4.829,
+				max_lon: 4.831,
+				point_count: 10,
+			},
+			{
+				street_norm: "place bellecour",
+				postcode: "69289",
+				locality_base: "lyon",
+				lat: 45.759,
+				lon: 4.85,
+				min_lat: 45.758,
+				max_lat: 45.76,
+				min_lon: 4.849,
+				max_lon: 4.851,
+				point_count: 30,
+			},
+			// A plain non-arrondissement commune.
+			{
+				street_norm: "cours de lintendance",
+				postcode: "33000",
+				locality_base: "bordeaux",
+				lat: 44.842,
+				lon: -0.577,
+				min_lat: 44.841,
+				max_lat: 44.843,
+				min_lon: -0.579,
+				max_lon: -0.575,
+				point_count: 65,
+			},
+		])
+		lookup = new StreetCentroidSqliteLookup(path, { streetLocale: "fr" })
+	})
+
+	afterAll(() => {
+		lookup.close()
+	})
+
+	it("probes by postcode and returns the single-row centroid", () => {
+		const hit = lookup.find({ street: "Cours de l'Intendance", postcode: "33000" })
+		expect(hit).not.toBeNull()
+		expect(hit!.lat).toBeCloseTo(44.842, 3)
+		expect(hit!.lon).toBeCloseTo(-0.577, 3)
+		expect(hit!.source).toBe("ban:fr")
+		expect(hit!.release).toBe("2026-05-18")
+		expect(hit!.uncertaintyM).toBeGreaterThan(0)
+	})
+
+	it("probes by base commune, folding a query arrondissement, and WEIGHTED-aggregates across rows", () => {
+		// (10 @ 4.83 + 30 @ 4.85) / 40 = 4.845 — the point-count-weighted centroid, not the plain mean 4.84.
+		const hit = lookup.find({ street: "Place Bellecour", locality: "Lyon 2e Arrondissement" })
+		expect(hit).not.toBeNull()
+		expect(hit!.lon).toBeCloseTo(4.845, 4)
+		expect(hit!.lat).toBeCloseTo((45.757 * 10 + 45.759 * 30) / 40, 5)
+	})
+
+	it("folds the FR street normalizer on both sides (apostrophe/accents)", () => {
+		// "Cours de l'Intendance" and its normalized key agree by construction.
+		expect(lookup.find({ street: "cours de l'intendance", locality: "Bordeaux" })).not.toBeNull()
+	})
+
+	it("returns null on an exact-match miss (unknown street or wrong commune)", () => {
+		expect(lookup.find({ street: "Place Bellecour", locality: "Paris" })).toBeNull()
+		expect(lookup.find({ street: "Rue Inconnue", locality: "Lyon" })).toBeNull()
+		expect(lookup.find({ street: "Place Bellecour", postcode: "75001" })).toBeNull()
+	})
+})

--- a/resolver-wof-sqlite/street-centroid.ts
+++ b/resolver-wof-sqlite/street-centroid.ts
@@ -1,0 +1,124 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   SQLite implementation of core's `StreetCentroidLookup` (#1042): the street-level tier BELOW the
+ *   exact address-point tier and ABOVE admin-centroid resolution. Given a street name (no house
+ *   number) plus a postcode/commune scope, it returns the street's CENTROID + an honest extent-derived
+ *   uncertainty from the derived `street-centroids-<cc>.db` roll-up.
+ *
+ *   Query-side normalization is THE shared normalizer (`street-normalize.ts`), selected per the shard's
+ *   `streetLocale`, so build-side and probe-side keys agree by construction. The commune scope folds
+ *   through `normalizeLocalityForKey` + `stripArrondissement` (BAN names Paris/Lyon/Marseille per
+ *   arrondissement; a query names the base commune).
+ *
+ *   Scope order is most-selective first: `postcode`, then the base commune. Each scope WEIGHTED-
+ *   aggregates (by `point_count`) across the matched rows in SQL, so a commune-scope probe returns the
+ *   street's grand centroid over every postcode/arrondissement it spans — one row, one hit. Matching is
+ *   exact-after-normalization only (no fuzzy street matching in this tier).
+ */
+
+import { DatabaseSync } from "node:sqlite"
+
+import type { StreetCentroidHit, StreetCentroidLookup } from "@mailwoman/resolver"
+
+import { hasTable } from "./sqlite-utils.js"
+import {
+	normalizeLocalityForKey,
+	normalizeStreetForKeyLocale,
+	type StreetLocale,
+	stripArrondissement,
+} from "./street-normalize.js"
+
+/** The weighted-centroid + extent + provenance an aggregate probe projects. `lat` is null when nothing matched. */
+interface AggRow {
+	lat: number | null
+	lon: number | null
+	min_lat: number | null
+	max_lat: number | null
+	min_lon: number | null
+	max_lon: number | null
+	source: string | null
+	release: string | null
+}
+
+/** Weighted-centroid aggregate over a WHERE-filtered set. `SUM(coord*n)/SUM(n)` reconstructs the grand centroid. */
+const AGG_SELECT =
+	"SUM(lat * point_count) / SUM(point_count) AS lat, " +
+	"SUM(lon * point_count) / SUM(point_count) AS lon, " +
+	"MIN(min_lat) AS min_lat, MAX(max_lat) AS max_lat, MIN(min_lon) AS min_lon, MAX(max_lon) AS max_lon, " +
+	"MAX(source) AS source, MAX(release) AS release"
+
+/** Half the bbox diagonal, in METERS — an honest coarse radius for a street centroid. */
+function extentRadiusM(minLat: number, maxLat: number, minLon: number, maxLon: number): number {
+	const R = 6_371_000
+	const toRad = (d: number): number => (d * Math.PI) / 180
+	const dLat = toRad(maxLat - minLat)
+	const dLon = toRad(maxLon - minLon)
+	const midLat = toRad((minLat + maxLat) / 2)
+	const a = Math.sin(dLat / 2) ** 2 + Math.cos(midLat) ** 2 * Math.sin(dLon / 2) ** 2
+	const diag = 2 * R * Math.asin(Math.min(1, Math.sqrt(a)))
+
+	return Math.round(diag / 2)
+}
+
+export class StreetCentroidSqliteLookup implements StreetCentroidLookup {
+	readonly #db: DatabaseSync
+	readonly #locale: StreetLocale
+	readonly #byPostcode: ReturnType<DatabaseSync["prepare"]> | undefined
+	readonly #byLocality: ReturnType<DatabaseSync["prepare"]> | undefined
+
+	/**
+	 * @param dbPath Shard path.
+	 * @param opts.streetLocale The street-normalization locale this shard was BUILT with — must match, or every key
+	 *   misses. Defaults to `"fr"` (BAN is the French national register; the tier is FR-only today).
+	 */
+	constructor(dbPath: string, opts: { streetLocale?: StreetLocale } = {}) {
+		this.#db = new DatabaseSync(dbPath, { readOnly: true })
+		this.#locale = opts.streetLocale ?? "fr"
+
+		// Degrade gracefully on an empty/tableless shard (interrupted build, stray 0-byte file): with no
+		// `street_centroid` table this lookup is a no-op miss, not a crash (mirrors the address-point reader).
+		if (hasTable(this.#db, "street_centroid")) {
+			this.#byPostcode = this.#db.prepare(
+				`SELECT ${AGG_SELECT} FROM street_centroid WHERE postcode = ? AND street_norm = ?`
+			)
+			this.#byLocality = this.#db.prepare(
+				`SELECT ${AGG_SELECT} FROM street_centroid WHERE locality_base = ? AND street_norm = ?`
+			)
+		}
+	}
+
+	find(query: { street: string; postcode?: string; locality?: string }): StreetCentroidHit | null {
+		if (!this.#byPostcode || !this.#byLocality) return null
+		const streetNorm = normalizeStreetForKeyLocale(query.street, this.#locale)
+
+		if (!streetNorm) return null
+
+		let row: AggRow | undefined
+
+		if (query.postcode?.trim()) {
+			row = this.#byPostcode.get(query.postcode.trim(), streetNorm) as AggRow | undefined
+		}
+
+		if ((!row || row.lat == null) && query.locality?.trim()) {
+			const base = stripArrondissement(normalizeLocalityForKey(query.locality))
+			row = this.#byLocality.get(base, streetNorm) as AggRow | undefined
+		}
+
+		if (!row || row.lat == null || row.lon == null) return null
+
+		return {
+			lat: row.lat,
+			lon: row.lon,
+			uncertaintyM: extentRadiusM(row.min_lat!, row.max_lat!, row.min_lon!, row.max_lon!),
+			source: row.source ?? "",
+			release: row.release ?? "",
+		}
+	}
+
+	close(): void {
+		this.#db.close()
+	}
+}

--- a/resolver-wof-sqlite/street-normalize.ts
+++ b/resolver-wof-sqlite/street-normalize.ts
@@ -235,6 +235,22 @@ export function normalizeLocalityForKey(locality: string): string {
 }
 
 /**
+ * Strip a trailing French arrondissement designator from a FOLDED commune key ("paris 8e arrondissement" → "paris",
+ * "lyon 1er arrondissement" → "lyon", "marseille 10e arrondissement" → "marseille"). Paris, Lyon and Marseille are the
+ * only French communes subdivided into _arrondissements municipaux_; a national register (BAN) names each row per
+ * arrondissement, but a query names the base commune ("Place Bellecour, Lyon", never "…, Lyon 2e"). Applied on BOTH
+ * sides of the #1042 street-centroid key — build-side (deriving the `locality_base` column) and query-side (folding the
+ * probe commune) — so the two agree by construction (the one-function discipline). Input must already be folded
+ * (lower-case, diacritic-stripped); a no-op for every other commune. Returns the input unchanged if the strip would
+ * empty it.
+ */
+export function stripArrondissement(localityNorm: string): string {
+	const stripped = localityNorm.replace(/\s+\d+(?:er|e)\s+arrondissement$/, "").trim()
+
+	return stripped || localityNorm
+}
+
+/**
  * Strip a locality QUALIFIER for a query-side fallback — when an OA locality's exact normalized name misses the
  * gazetteer's canonical name, retry with the qualifier removed. OA address data carries disambiguating qualifiers the
  * gazetteer's canonical name omits: Austrian `Kraubath/Mur` and `Hart b.Graz` → `Hart`; Swiss `Lenk im Simmental` →

--- a/resolver/resolve.test.ts
+++ b/resolver/resolve.test.ts
@@ -15,6 +15,7 @@ import type {
 	InterpolationLookup,
 	ResolvedPlace,
 	ResolverBackend,
+	StreetCentroidLookup,
 } from "@mailwoman/core/resolver"
 import { expandPlacetypeFilter } from "@mailwoman/core/resolver"
 import { describe, expect, test, vi } from "vitest"
@@ -977,5 +978,134 @@ describe("resolveTree — interpolation tier (#483)", () => {
 		const noHn = tree("Main St", [node("street", "Main St", 0, 7)])
 		await resolver.resolveTree(noHn, { interpolation: spy })
 		expect(called).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Street-centroid tier (#1042) — the street-only rung between interp and admin.
+// ---------------------------------------------------------------------------
+
+/** A fake street-centroid lookup that hits only for known (normalized street, commune) pairs. */
+function fakeStreetCentroids(
+	entries: Array<{ street: string; commune: string; lat: number; lon: number }>,
+	onCall?: () => void
+): StreetCentroidLookup {
+	// Mirror the FR normalizer's apostrophe/hyphen handling: strip apostrophes GLUED ("l'intendance" →
+	// "lintendance"), hyphens → space ("Sainte-Catherine" → "sainte catherine").
+	const key = (s: string, c: string) =>
+		`${s
+			.toLowerCase()
+			.replace(/['’]/g, "")
+			.replace(/-/g, " ")
+			.replace(/\s+/g, " ")
+			.trim()}|${c.toLowerCase().trim()}`
+	const map = new Map(entries.map((e) => [key(e.street, e.commune), e]))
+
+	return {
+		find: (q) => {
+			onCall?.()
+			const commune = q.locality ?? q.postcode ?? ""
+			const e = map.get(key(q.street, commune))
+
+			return e ? { lat: e.lat, lon: e.lon, uncertaintyM: 120, source: "ban:fr", release: "2026-05-18" } : null
+		},
+	}
+}
+
+/** A FR-only provider (mirrors BANShardProvider: only `fr` yields a lookup). */
+const frProvider = (lookup: StreetCentroidLookup) => (country: string) => (country === "fr" ? lookup : undefined)
+
+/** Pull the street node's stamped street-centroid tier out of a resolved tree, if any. */
+function streetTier(t: AddressTree): AddressNode | undefined {
+	const stack = [...t.roots]
+
+	while (stack.length) {
+		const n = stack.pop()!
+
+		if (n.tag === "street" && n.metadata?.["resolution_tier"] === "street") return n
+		stack.push(...n.children)
+	}
+
+	return undefined
+}
+
+describe("resolveTree — street-centroid tier (#1042)", () => {
+	test("recovers a thoroughfare the model mis-parsed as a locality (via the FR country hint)", async () => {
+		const lookup = fakeStreetCentroids([{ street: "place bellecour", commune: "Lyon", lat: 45.7576, lon: 4.8317 }])
+		const resolver = createWOFResolver(new FakeResolverBackend(FIXTURE_PLACES))
+		// The FR no-street parse shape: thoroughfare tagged `locality`, commune tagged `region`.
+		const input = tree("Place Bellecour, Lyon", [
+			node("locality", "Place Bellecour", 0, 15),
+			node("region", "Lyon", 17, 21),
+		])
+		const out = await resolver.resolveTree(input, { streetCentroids: frProvider(lookup), streetCountryHints: ["fr"] })
+		const street = streetTier(out)
+		expect(street).toBeDefined()
+		expect(street!.metadata!["street_centroid"]).toMatchObject({ lat: 45.7576, lon: 4.8317, source: "ban:fr" })
+		expect(street!.metadata!["uncertainty_m"]).toBe(120)
+	})
+
+	test("recovers the commune from the raw comma-split when the parse dropped it", async () => {
+		const lookup = fakeStreetCentroids([
+			{ street: "rue sainte catherine", commune: "Bordeaux", lat: 44.8364, lon: -0.5736 },
+		])
+		const resolver = createWOFResolver(new FakeResolverBackend(FIXTURE_PLACES))
+		// Garbled parse (the real "Rue Sainte-Catherine, Bordeaux" shape): street present, commune lost.
+		const input = tree("Rue Sainte-Catherine, Bordeaux", [
+			node("locality", "e", 0, 1),
+			node("street", "Rue Sainte-Catherine", 0, 20),
+		])
+		const out = await resolver.resolveTree(input, { streetCentroids: frProvider(lookup), streetCountryHints: ["fr"] })
+		const street = streetTier(out)
+		expect(street?.metadata?.["street_centroid"]).toMatchObject({ lat: 44.8364, lon: -0.5736 })
+	})
+
+	test("unions the RESOLVED-tree country when no hint pins it (placer mis-route recovery)", async () => {
+		// Commune resolves to France (so `resolver_country: FR` is stamped) but NO pre-resolution hint says FR.
+		const places: ResolvedPlace[] = [
+			{ id: 1, name: "Bordeaux", placetype: "locality", country: "FR", lat: 44.84, lon: -0.58, score: 9 },
+		]
+		const lookup = fakeStreetCentroids([
+			{ street: "cours de lintendance", commune: "Bordeaux", lat: 44.8419, lon: -0.5772 },
+		])
+		const resolver = createWOFResolver(new FakeResolverBackend(places))
+		const input = tree("Cours de l'Intendance, Bordeaux", [
+			node("locality", "Cours de l'Intendance", 0, 21),
+			node("locality", "Bordeaux", 23, 31),
+		])
+		const out = await resolver.resolveTree(input, { streetCentroids: frProvider(lookup) /* no hints */ })
+		expect(streetTier(out)?.metadata?.["street_centroid"]).toMatchObject({ lat: 44.8419, lon: -0.5772 })
+	})
+
+	test("never fires when a house number is present (rooftop tiers' domain)", async () => {
+		let called = false
+		const lookup = fakeStreetCentroids([{ street: "rue de rivoli", commune: "Paris", lat: 1, lon: 2 }], () => {
+			called = true
+		})
+		const resolver = createWOFResolver(new FakeResolverBackend(FIXTURE_PLACES))
+		const input = tree("10 Rue de Rivoli, Paris", [
+			node("house_number", "10", 0, 2),
+			node("street", "Rue de Rivoli", 3, 16),
+			node("locality", "Paris", 18, 23),
+		])
+		const out = await resolver.resolveTree(input, { streetCentroids: frProvider(lookup), streetCountryHints: ["fr"] })
+		expect(called).toBe(false)
+		expect(streetTier(out)).toBeUndefined()
+	})
+
+	test("no matching country → the lookup is never consulted (byte-stable)", async () => {
+		let called = false
+		const lookup = fakeStreetCentroids([{ street: "place bellecour", commune: "Lyon", lat: 1, lon: 2 }], () => {
+			called = true
+		})
+		const resolver = createWOFResolver(new FakeResolverBackend(FIXTURE_PLACES))
+		const input = tree("Main Street, Springfield", [
+			node("street", "Main Street", 0, 11),
+			node("locality", "Springfield", 13, 24),
+		])
+		// Hint is US; provider only serves `fr` — so no lookup is opened.
+		const out = await resolver.resolveTree(input, { streetCentroids: frProvider(lookup), streetCountryHints: ["us"] })
+		expect(called).toBe(false)
+		expect(streetTier(out)).toBeUndefined()
 	})
 })

--- a/resolver/resolve.ts
+++ b/resolver/resolve.ts
@@ -26,6 +26,7 @@ import {
 	type ResolveOpts,
 	type Resolver,
 	type ResolverBackend,
+	type StreetCentroidLookup,
 } from "@mailwoman/core/resolver"
 import { haversineKm } from "@mailwoman/spatial"
 
@@ -293,6 +294,248 @@ function applyInterpolation(roots: AddressNode[], lookup: InterpolationLookup, r
 		interpolation_method: hit.method,
 		...(hit.parityMatched !== undefined ? { parity_matched: hit.parityMatched } : {}),
 		...(hit.bracket !== undefined ? { interpolation_bracket: hit.bracket } : {}),
+	}
+}
+
+/**
+ * French thoroughfare (voie) type tokens — the leading word that marks a street-only span as a THOROUGHFARE rather than
+ * a place name ("Place Bellecour", "Cours de l'Intendance", "Quai des Bateliers"). Used by the #1042 street-centroid
+ * tier to recognize a thoroughfare that the model mis-parsed as a `locality` (the FR no-street class, #901).
+ * Deliberately generous — a false positive simply misses the exact street-centroid lookup and no-ops; the lookup is the
+ * real gate.
+ */
+const FR_VOIE_TYPES: ReadonlySet<string> = new Set([
+	"rue",
+	"ruelle",
+	"venelle",
+	"avenue",
+	"av",
+	"ave",
+	"boulevard",
+	"bd",
+	"bld",
+	"bvd",
+	"boul",
+	"place",
+	"pl",
+	"cours",
+	"quai",
+	"impasse",
+	"imp",
+	"allee",
+	"all",
+	"chemin",
+	"ch",
+	"che",
+	"passage",
+	"pas",
+	"square",
+	"sq",
+	"faubourg",
+	"fg",
+	"fbg",
+	"route",
+	"rte",
+	"esplanade",
+	"promenade",
+	"sentier",
+	"sente",
+	"villa",
+	"cite",
+	"hameau",
+	"montee",
+	"chaussee",
+	"traverse",
+	"mail",
+	"clos",
+	"voie",
+	"quartier",
+	"lotissement",
+	"residence",
+	"rond",
+])
+
+/** Fold to lower-case, diacritic-stripped, punctuation-free tokens — mirrors `street-normalize.ts`'s `fold`. */
+function foldVoieTokens(s: string): string[] {
+	return s
+		.normalize("NFKD")
+		.replace(/[̀-ͯ]/g, "")
+		.toLowerCase()
+		.replace(/[.,'’]/g, "")
+		.replace(/-/g, " ")
+		.split(/\s+/)
+		.filter(Boolean)
+}
+
+/** Does a string START with a French thoroughfare type token ("Rue …", "Place …")? */
+function isVoieShaped(s: string): boolean {
+	const first = foldVoieTokens(s)[0]
+
+	return first !== undefined && FR_VOIE_TYPES.has(first)
+}
+
+/** Push `v` (trimmed, non-empty, deduped, capped) onto `list`. */
+function pushCandidate(list: string[], v: string | undefined, cap: number): void {
+	const t = v?.trim()
+
+	if (t && list.length < cap && !list.includes(t)) {
+		list.push(t)
+	}
+}
+
+/**
+ * Street-centroid tier (#1042): the street-level rung BELOW the exact/interpolation tiers and ABOVE admin-centroid
+ * resolution. For a STREET-ONLY query (a thoroughfare with NO house number), stamp the street's centroid onto a
+ * `street` node so a consumer gets a street-level coordinate instead of the commune centroid (or a wrong namesake).
+ *
+ * The FR no-street class mis-parses the thoroughfare — "Place Bellecour, Lyon" parses `region=Lyon`, `locality="Place
+ * Bellecour"`; "Avenue des Champs-Élysées" truncates — so this recovers the thoroughfare + commune RAW-TEXT-first (the
+ * same substrate as span-rescore), preferring parsed nodes and falling back to the comma-split raw query. A
+ * thoroughfare is recognized by its leading voie type ({@link isVoieShaped}); the commune is any non-voie span. Every
+ * (thoroughfare, commune) pair is probed against the exact street-centroid lookup, first hit wins — a false candidate
+ * simply misses. Additive only: fires ONLY when no house number is present (rooftop tiers untouched) and no
+ * street-level coordinate already resolved, and never alters admin resolution.
+ */
+function applyStreetCentroid(
+	roots: AddressNode[],
+	raw: string,
+	provider: (country: string) => StreetCentroidLookup | undefined,
+	hints: readonly string[]
+): void {
+	let streetNode: AddressNode | undefined
+	let houseNumber = false
+	let postcode: string | undefined
+	const adminValues: string[] = [] // region / locality values, in tree order (thoroughfare and commune both hide here)
+	const resolvedCountries: string[] = [] // countries the tree actually resolved to — a post-resolution country hint
+	const stack = [...roots]
+
+	while (stack.length > 0) {
+		const n = stack.pop()!
+
+		if (n.tag === "house_number") {
+			houseNumber = true
+		}
+
+		if (n.tag === "street" && !streetNode) {
+			streetNode = n
+		}
+
+		// Never shadow a real street-level coordinate the exact/interp tiers already stamped.
+		if (n.metadata?.["resolution_tier"] === "address_point" || n.metadata?.["resolution_tier"] === "interpolated") {
+			return
+		}
+
+		if (!postcode && n.tag === "postcode" && n.value.trim()) {
+			postcode = n.value.trim()
+		}
+
+		if ((n.tag === "region" || n.tag === "locality" || n.tag === "dependent_locality") && n.value.trim()) {
+			adminValues.push(n.value.trim())
+		}
+		const rc = (n.metadata?.["resolver_country"] as string | undefined)?.trim().toLowerCase()
+
+		if (rc && !resolvedCountries.includes(rc)) {
+			resolvedCountries.push(rc)
+		}
+		stack.push(...n.children)
+	}
+
+	if (houseNumber) return // street-only tier — a numbered address is the rooftop tiers' job
+
+	// Candidate countries: pre-resolution hints (defaultCountry + ungated placer) then the resolved countries. BAN is
+	// FR-only, so a non-FR candidate simply yields no lookup; the exact (street, base-commune) match is the real filter.
+	const countries: string[] = []
+
+	for (const c of [...hints, ...resolvedCountries]) {
+		const cc = c?.trim().toLowerCase()
+
+		if (cc && !countries.includes(cc)) {
+			countries.push(cc)
+		}
+	}
+	const lookups = countries.map((c) => provider(c)).filter((l): l is StreetCentroidLookup => l != null)
+
+	if (lookups.length === 0) return
+
+	const rawSegments = raw
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean)
+	const CAP = 5
+
+	// Thoroughfare candidates (parsed-first, then raw): the assembled street node, any voie-shaped parsed value, any
+	// voie-shaped raw comma-segment. The parse often truncates these (Champs-Élysées → "Avenue des Champs"), so the raw
+	// segment is the recovery — a candidate that misses just advances to the next.
+	const thoroughfares: string[] = []
+
+	if (streetNode) {
+		pushCandidate(thoroughfares, assembleStreetValue(streetNode), CAP)
+	}
+
+	for (const v of adminValues) {
+		if (isVoieShaped(v)) {
+			pushCandidate(thoroughfares, v, CAP)
+		}
+	}
+
+	for (const s of rawSegments) {
+		if (isVoieShaped(s)) {
+			pushCandidate(thoroughfares, s, CAP)
+		}
+	}
+
+	if (thoroughfares.length === 0) return
+
+	// Commune candidates: non-voie parsed admin values, then non-voie raw segments (a truncated/garbled parse loses the
+	// commune — "Rue de la République, Marseille" parses `locality="e"` — so the raw "Marseille" is the recovery).
+	const communes: string[] = []
+
+	for (const v of adminValues) {
+		if (!isVoieShaped(v)) {
+			pushCandidate(communes, v, CAP)
+		}
+	}
+
+	for (const s of rawSegments) {
+		if (!isVoieShaped(s) && !thoroughfares.includes(s)) {
+			pushCandidate(communes, s, CAP)
+		}
+	}
+
+	for (const lookup of lookups) {
+		for (const street of thoroughfares) {
+			let hit = postcode ? lookup.find({ street, postcode }) : null
+
+			for (let i = 0; !hit && i < communes.length; i++) {
+				hit = lookup.find({ street, locality: communes[i]! })
+			}
+
+			if (!hit) continue
+
+			const target =
+				streetNode ??
+				(() => {
+					const injected: AddressNode = {
+						tag: "street",
+						value: street,
+						start: 0,
+						end: 0,
+						confidence: 0.5,
+						children: [],
+					}
+					roots.push(injected)
+
+					return injected
+				})()
+			target.metadata = {
+				...target.metadata,
+				street_centroid: { lat: hit.lat, lon: hit.lon, source: hit.source, release: hit.release },
+				resolution_tier: "street",
+				uncertainty_m: hit.uncertaintyM,
+			}
+
+			return
+		}
 	}
 }
 
@@ -834,6 +1077,15 @@ class WOFResolver implements Resolver {
 		// US path). Explicit opt-OUT via `spanRescore: false`; byte-stable then.
 		if (opts.spanRescore !== false) {
 			await applySpanRescore(newRoots, tree.raw, this.#backend, opts)
+		}
+
+		// Street-centroid tier (#1042): LAST, after span-rescore, so it can (a) union the span-rescore-recovered
+		// country into its FR/national country hints (a placer-misrouted street — "Rue Sainte-Catherine" → IT — leaves
+		// admin unresolved, and only span-rescore recovers the FR country signal) and (b) override a coarse recovered
+		// locality with the exact street centroid. Self-gates on no house number + no existing street-level tier, so a
+		// rooftop query is untouched; byte-stable when opts.streetCentroids absent.
+		if (opts.streetCentroids) {
+			applyStreetCentroid(newRoots, tree.raw, opts.streetCentroids, opts.streetCountryHints ?? [])
 		}
 
 		return { raw: tree.raw, roots: newRoots }


### PR DESCRIPTION
Closes #1042.

Street-only FR queries — `Place Bellecour, Lyon`, `Avenue des Champs-Élysées, Paris`, `Cours de l'Intendance, Bordeaux` — had **no coordinate tier**. An address-POINT tier needs a house number, so 7 of the 8 Oslandia voies-panel queries fell to the commune centroid (or a wrong namesake): **0/8 within 1 km**.

This adds a **street-centroid tier DERIVED from the sealed #1012 BAN rooftop shard** — no new data source. A `GROUP BY street` roll-up of `address-points-fr.db` (26 M rows) → 2.2 M street rows, each carrying the street's **weighted centroid + bbox extent + member-point count**.

## Artifact provenance (derived, sealed; not committed — data)

| field | value |
|---|---|
| path | `$MAILWOMAN_DATA_ROOT/ban/street-centroids-fr.db` |
| rows | 2,195,655 |
| bytes | 463,052,800 (sealed `0444`) |
| md5 | `931fe6b82be15e6d27805aa54531f56c` |
| derived from | `ban:fr` release `2026-05-18` (md5 `b570ccee`, `address-points-fr.db`) |
| build | ~32 s, code-only; streams the sealed input **READ-ONLY**, never modifies it |
| provenance | `ban/street-centroids-fr.ATTRIBUTION.json` beside the db (derivation chain + md5) |

**Recipe (verbatim, reproduces the artifact):**

```bash
node ban/out/scripts/build-street-centroid-shard.js
```

The build is **code-only** (this workspace ships no BAN bytes): register the arrondissement-fold as a scalar SQL function on the sealed read-only input → `GROUP BY street_norm, postcode, locality_norm` aggregate → stream via `.iterate()` → positional prepared INSERT (batched) → indexes → `ANALYZE` → atomic swap → seal `0444` → provenance manifest. Purely additive; it never touches the rooftop shard.

## Ladder

A street-only FR parse (a thoroughfare with **NO house number**) consults the street tier **LAST** (after span-rescore), below the rooftop/interp tiers and above admin. The FR no-street class mis-parses the thoroughfare as a `locality` (#901, composition-insensitive), so the tier recovers the thoroughfare + commune **raw-text-first** (span-rescore's substrate) and probes a **UNION of country signals** — pre-resolution hints (`defaultCountry` + the ungated placer) plus the resolved-tree countries — because the placer mis-routes some French streets (`Rue Sainte-Catherine` → IT, 0.98) and skips bare-locality trees (`Avenue des Champs-Élysées`). The **exact `(street, base-commune)` match is the real country filter.** Paris/Lyon/Marseille fold through `stripArrondissement` (BAN names rows per arrondissement; a query names the base commune). The reader stays **sync-by-interface** (raw prepared statements); the DDL goes through the shared Kysely schema builder.

## Gates

| gate | before | after |
|---|---|---|
| **8-voies panel** (≤1 km) | 0/8 | **7/8** |
| FR rooftop panel | — | **byte-identical** (numbered queries never touch the tier) |
| non-FR / US | — | **byte-identical** (US never supplies a street shard) |
| gauntlet | — | **PASS** (regression 27/27, metamorphic all gated held) |

The 8th voie (`55 rue du Faubourg Saint-Honoré, 75008 Paris`) carries a house number → the address-point tier's domain, unchanged by this PR.

Per-query (measured through the exact photon serve path):

```
[street] Place Bellecour, Lyon              0.03 km
[street] Rue de la République, Marseille    0.94 km
[street] Avenue des Champs-Élysées, Paris   0.33 km
[street] Cours de l'Intendance, Bordeaux    0.12 km
[street] Rue Sainte-Catherine, Bordeaux     0.19 km
[street] Place du Capitole, Toulouse        0.05 km
[street] Quai des Bateliers, Strasbourg     0.14 km
```

## Decoration (#1041)

`resolution_tier: "street"` surfaces on `GeocodeResult` (+ `metadata.street_centroid`, `uncertainty_m` = half the street's bbox diagonal). Photon's `type:street` projection **already exists** (`FORWARD_TAG_PROJECTION`) and rides on **#1041**'s `address_point → house` decoration rework — which carries the resolved street node into the `places` block for both tiers.

**Merge order:** independent of #1041 — no conflict either way. #1041 is an open issue (no PR in flight); this PR adds only the tier + the `resolution_tier` value, leaving the Photon property projection to #1041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5qDbkGN3xs2XDvyK52qPT
