### PR TITLE
feat(#444): FR diacritic vocab-splice — training-free path FALSIFIED for FR streets (NO-PROMOTE)

### DIFF
--- a/corpus-python/src/mailwoman_train/tokenizer_splice.py
+++ b/corpus-python/src/mailwoman_train/tokenizer_splice.py
@@ -365,7 +365,9 @@ def mean_init_onnx_embeddings(
         recon = np.clip(np.round(emb[old_vocab - 1] / scale) + zp, 0, 255).astype(q.dtype)
         mism = int((recon != q[old_vocab - 1]).sum())
         if mism > emb.shape[1] // 20:  # allow a few rounding-boundary ticks, not a wholesale mismatch
-            raise AssertionError(f"int8 quant-inverse mismatch on row {old_vocab - 1}: {mism}/{emb.shape[1]} — scale/zp wrong?")
+            raise AssertionError(
+                f"int8 quant-inverse mismatch on row {old_vocab - 1}: {mism}/{emb.shape[1]} — scale/zp wrong?"
+            )
         q_new = np.clip(np.round(new_rows / scale) + zp, 0, 255).astype(q.dtype)
         grown_q = np.concatenate([q, q_new], axis=0)
         qi[qname].CopyFrom(numpy_helper.from_array(grown_q, name=qname))

--- a/corpus-python/src/mailwoman_train/tokenizer_splice.py
+++ b/corpus-python/src/mailwoman_train/tokenizer_splice.py
@@ -284,6 +284,97 @@ def mean_init_embeddings(
     return old_vocab, new_vocab
 
 
+def _fvt_rows(base_tokenizer: Path, spliced_tokenizer: Path, emb):  # -> np.ndarray
+    """The FVT mean-init rows for the spliced-in pieces, computed from an existing embedding matrix.
+
+    Mirrors the mean-init in ``mean_init_embeddings`` (the pytorch state-dict path) exactly, on numpy so
+    the ONNX-graph path can reuse it: each new row = the mean of the OLD tokenizer's constituent-piece
+    embeddings for that piece's surface, global mean if the surface has no in-vocab constituents.
+    ``emb`` is the old [old_vocab, hidden] matrix as a numpy array.
+    """
+    import numpy as np
+
+    spliced = sp_pb2.ModelProto()
+    spliced.ParseFromString(spliced_tokenizer.read_bytes())
+    new_vocab = len(spliced.pieces)
+    old_vocab, hidden = emb.shape
+    if new_vocab < old_vocab:
+        raise ValueError(f"spliced vocab {new_vocab} < embedding vocab {old_vocab} — wrong tokenizer?")
+
+    old_sp = spm.SentencePieceProcessor(model_file=str(base_tokenizer))
+    emb_mean = emb.mean(0)
+    new_rows = np.empty((new_vocab - old_vocab, hidden), dtype=emb.dtype)
+    for idx in range(old_vocab, new_vocab):
+        surface = spliced.pieces[idx].piece.replace("▁", " ")
+        constituents = [i for i in old_sp.encode(surface, out_type=int) if i < old_vocab]
+        new_rows[idx - old_vocab] = emb[constituents].mean(0) if constituents else emb_mean
+    return new_rows, old_vocab, new_vocab
+
+
+def mean_init_onnx_embeddings(
+    fp32_onnx: Path,
+    base_tokenizer: Path,
+    spliced_tokenizer: Path,
+    out_fp32: Path,
+    *,
+    int8_onnx: Path | None = None,
+    out_int8: Path | None = None,
+    emb_name: str = "inner.token_embeddings.weight",
+) -> tuple[int, int]:
+    """Expand an EXPORTED ONNX model's token_embeddings to the spliced vocab (FVT mean-init), in place.
+
+    This is the local, checkpoint-free twin of ``mean_init_embeddings``. The prior nsplice ran mean-init
+    on the Modal volume where the training ``pytorch_model.bin`` lived, then re-exported ONNX. When only
+    the shipped ONNX is on hand, the SAME surgery is exact on the graph: in this BIO token-classifier the
+    ONLY vocab-dependent tensor is ``inner.token_embeddings.weight`` (the label head is [hidden, num_labels],
+    independent of vocab), so growing that one initializer and mean-initing the new rows is byte-for-byte what
+    a re-export would produce. Every other node — encoder, CRF, anchor/gaz heads — is untouched, which is why
+    source/other-locale inference stays byte-identical (their input_ids never index the appended rows).
+
+    fp32: read the float initializer, append the FVT rows. int8 (optional): the embedding is stored as a
+    per-tensor-quantized ``<emb>_quantized`` (uint8) + scalar ``_scale`` / ``_zero_point``; the new rows are
+    quantized with the SAME params (round(x/scale)+zp, clamped) — means of existing rows lie inside the
+    existing value range, so no re-calibration is needed. Returns (old_vocab, new_vocab).
+    """
+    import numpy as np
+    import onnx
+    from onnx import numpy_helper
+
+    m = onnx.load(str(fp32_onnx))
+    inits = {i.name: i for i in m.graph.initializer}
+    if emb_name not in inits:
+        raise KeyError(f"{emb_name} not in {fp32_onnx} initializers: {sorted(inits)[:8]}…")
+    emb = numpy_helper.to_array(inits[emb_name])
+    new_rows, old_vocab, new_vocab = _fvt_rows(base_tokenizer, spliced_tokenizer, emb)
+    grown = np.concatenate([emb, new_rows], axis=0)
+    inits[emb_name].CopyFrom(numpy_helper.from_array(grown, name=emb_name))
+    out_fp32.parent.mkdir(parents=True, exist_ok=True)
+    onnx.save(m, str(out_fp32))
+
+    if int8_onnx is not None and out_int8 is not None:
+        mi = onnx.load(str(int8_onnx))
+        qi = {i.name: i for i in mi.graph.initializer}
+        qname, sname, zname = f"{emb_name}_quantized", f"{emb_name}_scale", f"{emb_name}_zero_point"
+        for req in (qname, sname, zname):
+            if req not in qi:
+                raise KeyError(f"{req} not in {int8_onnx} initializers: {sorted(qi)[:8]}…")
+        q = numpy_helper.to_array(qi[qname])
+        scale = float(numpy_helper.to_array(qi[sname]))
+        zp = int(numpy_helper.to_array(qi[zname]))
+        # Sanity: the quant inverse must reproduce an existing quantized row from its fp32 source.
+        recon = np.clip(np.round(emb[old_vocab - 1] / scale) + zp, 0, 255).astype(q.dtype)
+        mism = int((recon != q[old_vocab - 1]).sum())
+        if mism > emb.shape[1] // 20:  # allow a few rounding-boundary ticks, not a wholesale mismatch
+            raise AssertionError(f"int8 quant-inverse mismatch on row {old_vocab - 1}: {mism}/{emb.shape[1]} — scale/zp wrong?")
+        q_new = np.clip(np.round(new_rows / scale) + zp, 0, 255).astype(q.dtype)
+        grown_q = np.concatenate([q, q_new], axis=0)
+        qi[qname].CopyFrom(numpy_helper.from_array(grown_q, name=qname))
+        out_int8.parent.mkdir(parents=True, exist_ok=True)
+        onnx.save(mi, str(out_int8))
+
+    return old_vocab, new_vocab
+
+
 def _main() -> None:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = ap.add_subparsers(dest="cmd", required=True)
@@ -294,6 +385,15 @@ def _main() -> None:
     bt.add_argument("--base-tokenizer", type=Path, required=True)
     bt.add_argument("--out-tokenizer", type=Path, required=True)
     bt.add_argument("--vocab-size", type=int, default=24_000)
+    bt.add_argument(
+        "--per-file-cap",
+        type=int,
+        default=400_000,
+        help="rows read per OA CSV before breaking. The CZ/PL/Nordic recipes had many small "
+        "per-region dumps, so 400k/file sampled the whole country; FR ships ONE giant "
+        "fr/countrywide.csv, so a low cap reads only the top departments — raise it (or feed a "
+        "pre-sampled national extract) to keep the diacritic-piece corpus geographically fair.",
+    )
     bt.add_argument("--work-dir", type=Path, default=Path("out/bsplice-work"))
     bt.add_argument(
         "--trained-samples",
@@ -323,12 +423,28 @@ def _main() -> None:
     mi.add_argument("--spliced-tokenizer", type=Path, required=True)
     mi.add_argument("--out-dir", type=Path, required=True)
 
+    oi = sub.add_parser(
+        "onnx-mean-init",
+        help="expand an EXPORTED ONNX model's token_embeddings to the spliced vocab (checkpoint-free)",
+    )
+    oi.add_argument("--fp32-onnx", type=Path, required=True)
+    oi.add_argument("--base-tokenizer", type=Path, required=True)
+    oi.add_argument("--spliced-tokenizer", type=Path, required=True)
+    oi.add_argument("--out-fp32", type=Path, required=True)
+    oi.add_argument("--int8-onnx", type=Path, default=None)
+    oi.add_argument("--out-int8", type=Path, default=None)
+
     args = ap.parse_args()
     if args.cmd == "build-tokenizer":
         args.work_dir.mkdir(parents=True, exist_ok=True)
         corpus = args.work_dir / "slavic-corpus.txt"
         n = build_slavic_corpus(
-            args.oa_root, args.locales.split(","), corpus, extra_text=args.extra_text, extra_repeat=args.extra_repeat
+            args.oa_root,
+            args.locales.split(","),
+            corpus,
+            per_file_cap=args.per_file_cap,
+            extra_text=args.extra_text,
+            extra_repeat=args.extra_repeat,
         )
         print(f"corpus: {n} lines")
         sp_model = train_diacritic_sp(corpus, args.work_dir / "slavic-sp", vocab_size=args.vocab_size)
@@ -348,6 +464,18 @@ def _main() -> None:
     elif args.cmd == "mean-init":
         old_v, new_v = mean_init_embeddings(args.checkpoint, args.base_tokenizer, args.spliced_tokenizer, args.out_dir)
         print(f"expanded token_embeddings {old_v} -> {new_v}; wrote {args.out_dir}")
+    elif args.cmd == "onnx-mean-init":
+        old_v, new_v = mean_init_onnx_embeddings(
+            args.fp32_onnx,
+            args.base_tokenizer,
+            args.spliced_tokenizer,
+            args.out_fp32,
+            int8_onnx=args.int8_onnx,
+            out_int8=args.out_int8,
+        )
+        print(f"expanded ONNX token_embeddings {old_v} -> {new_v}; wrote {args.out_fp32}")
+        if args.out_int8:
+            print(f"  int8 twin written {args.out_int8}")
 
 
 if __name__ == "__main__":

--- a/scripts/eval/fr-accent-mangle-rate.ts
+++ b/scripts/eval/fr-accent-mangle-rate.ts
@@ -32,9 +32,9 @@
  *       --n 1500
  */
 
-import { parseArgs } from "node:util"
 import { resolve } from "node:path"
 import { DatabaseSync } from "node:sqlite"
+import { parseArgs } from "node:util"
 
 import { createScorer, type NeuralAddressClassifier } from "@mailwoman/neural"
 import { normalizeStreetForKeyLocale } from "@mailwoman/resolver-wof-sqlite/street-normalize"
@@ -76,7 +76,9 @@ function streetInfo(tree: { roots: readonly Node[] }): { key: string; spans: num
 	while (stack.length) {
 		const n = stack.pop()!
 
-		if (STREET_TAGS.has(n.tag) && n.value.trim()) { parts.push({ value: n.value.trim(), start: n.start, end: n.end }) }
+		if (STREET_TAGS.has(n.tag) && n.value.trim()) {
+			parts.push({ value: n.value.trim(), start: n.start, end: n.end })
+		}
 		stack.push(...(n.children as Node[]))
 	}
 
@@ -86,7 +88,9 @@ function streetInfo(tree: { roots: readonly Node[] }): { key: string; spans: num
 	let prevEnd = -100
 
 	for (const p of parts) {
-		if (p.start - prevEnd > 2) { spans++ }
+		if (p.start - prevEnd > 2) {
+			spans++
+		}
 		prevEnd = p.end
 	}
 
@@ -135,36 +139,60 @@ for (const r of sample) {
 	if (bMangled) {
 		base.mangled++
 
-		if (b.spans > 1) { base.fragmented++ }
-		else { base.truncation++ }
+		if (b.spans > 1) {
+			base.fragmented++
+		} else {
+			base.truncation++
+		}
 	}
 
 	if (cMangled) {
 		cand.mangled++
 
-		if (c.spans > 1) { cand.fragmented++ }
-		else { cand.truncation++ }
+		if (c.spans > 1) {
+			cand.fragmented++
+		} else {
+			cand.truncation++
+		}
 	}
 
 	if (bMangled && !cMangled) {
 		flippedToHit++
 
-		if (examples.length < 12) { examples.push(`  ✓ "${r.street_raw}"  base→"${b.key}"  cand→"${c.key}"  (want "${want}")`) }
+		if (examples.length < 12) {
+			examples.push(`  ✓ "${r.street_raw}"  base→"${b.key}"  cand→"${c.key}"  (want "${want}")`)
+		}
 	}
 }
 
 const pct = (x: number) => ((x / sample.length) * 100).toFixed(1)
 
 console.log(`\n=== #444 FR accent-mangle rate (n=${sample.length} distinct accented BAN streets, rowid-ordered) ===`)
-console.log(`  BASELINE (shipped): mangled ${base.mangled}/${sample.length} (${pct(base.mangled)}%)  [frag ${base.fragmented} / trunc ${base.truncation}]`)
-console.log(`  CANDIDATE (splice): mangled ${cand.mangled}/${sample.length} (${pct(cand.mangled)}%)  [frag ${cand.fragmented} / trunc ${cand.truncation}]`)
-console.log(`  Δ mangle rate: ${pct(base.mangled)}% → ${pct(cand.mangled)}%  (${(((cand.mangled - base.mangled) / sample.length) * 100).toFixed(1)}pp)`)
+console.log(
+	`  BASELINE (shipped): mangled ${base.mangled}/${sample.length} (${pct(base.mangled)}%)  [frag ${base.fragmented} / trunc ${base.truncation}]`
+)
+console.log(
+	`  CANDIDATE (splice): mangled ${cand.mangled}/${sample.length} (${pct(cand.mangled)}%)  [frag ${cand.fragmented} / trunc ${cand.truncation}]`
+)
+console.log(
+	`  Δ mangle rate: ${pct(base.mangled)}% → ${pct(cand.mangled)}%  (${(((cand.mangled - base.mangled) / sample.length) * 100).toFixed(1)}pp)`
+)
 console.log(`  address_point MISS→HIT (base mangled, cand intact): ${flippedToHit}`)
 
 // --- Named #444 datapoints: parse both arms + probe the BAN address_point tier directly (MISS→HIT + coord) ---
 const datapoints = [
-	{ q: "55 Rue du Faubourg Saint-Honoré, 75008 Paris", number: "55", postcode: "75008", street_norm: "rue du faubourg saint honore" },
-	{ q: "10 Avenue des Champs-Élysées, 75008 Paris", number: "10", postcode: "75008", street_norm: "avenue des champs elysees" },
+	{
+		q: "55 Rue du Faubourg Saint-Honoré, 75008 Paris",
+		number: "55",
+		postcode: "75008",
+		street_norm: "rue du faubourg saint honore",
+	},
+	{
+		q: "10 Avenue des Champs-Élysées, 75008 Paris",
+		number: "10",
+		postcode: "75008",
+		street_norm: "avenue des champs elysees",
+	},
 	{ q: "1 Place René Cassin, 75001 Paris", number: "1", postcode: "75001", street_norm: "place rene cassin" },
 	{ q: "1 Rue de la République, 13001 Marseille", number: "1", postcode: "13001", street_norm: "rue de la republique" },
 ]
@@ -174,7 +202,7 @@ console.log(`\n--- named #444 datapoints (parse key + direct BAN address_point p
 for (const d of datapoints) {
 	const b = streetInfo(await baseline.parse(d.q, { postcodeRepair: true, normalizeCase: true }))
 	const c = streetInfo(await candidate.parse(d.q, { postcodeRepair: true, normalizeCase: true }))
-	const hit = (key: string) => (probe.get(d.postcode, key, d.number) as { lat: number; lon: number } | undefined)
+	const hit = (key: string) => probe.get(d.postcode, key, d.number) as { lat: number; lon: number } | undefined
 	const bh = hit(b.key)
 	const ch = hit(c.key)
 	console.log(`  "${d.q}"  (BAN holds street_norm="${d.street_norm}")`)
@@ -184,6 +212,8 @@ for (const d of datapoints) {
 
 console.log(`\nsample MISS→HIT flips:`)
 
-for (const e of examples) { console.log(e) }
+for (const e of examples) {
+	console.log(e)
+}
 
 db.close()

--- a/scripts/eval/fr-accent-mangle-rate.ts
+++ b/scripts/eval/fr-accent-mangle-rate.ts
@@ -1,0 +1,189 @@
+/**
+ * @copyright Sister Software.
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #444 — the FR accent-mangle rate, as a SAVED, reproducible harness (the 2026-07-09 issue comment
+ *   measured "13.4% of accented FR streets get a mangled street key" with an inline diagnostic that was
+ *   never committed — this is that diagnostic, tracked).
+ *
+ *   The metric. The BAN address-point tier (`AddressPointSqliteLookup.find`) keys a query on
+ *   `normalizeStreetForKeyLocale(parsedStreetSpan, "fr")` and matches `street_norm` exactly. Build-side
+ *   and probe-side share that ONE normalizer, so a pure accent folds identically on both sides — the ONLY
+ *   way a probe misses is the PARSER emitting a different street string (dropping/fragmenting an accented
+ *   char). So: draw a rowid-ordered (non-alphabetical, fair) sample of distinct accented BAN streets, parse
+ *   a realistic `number street, postcode locality` address for each, fold the parsed street span, and count
+ *   rows whose folded key != the stored `street_norm`. That count IS the address-point-tier accent gap, and
+ *   it is entirely upstream of the keying.
+ *
+ *   Two arms, each a full (model, tokenizer, card) trio via {@link createScorer} so anchor/gazetteer soft-feeds
+ *   are wired identically — the ONLY variables are the ONNX + the vocab. Never compares parse-F1 across
+ *   tokenizer versions; it grades the COORDINATE-relevant street key + a direct address-point DB probe
+ *   (MISS→HIT) on the named #444 datapoints.
+ *
+ *   Run (baseline = shipped v5.4.0 int8 + v0.7.1-nsplice; candidate = FR-splice v240 int8 + v0.8.0-fr-nsplice):
+ *     node scripts/eval/fr-accent-mangle-rate.ts \
+ *       --base-model  $MAILWOMAN_DATA_ROOT/models/candidates/v230-nl-postcode/model-int8.onnx \
+ *       --base-tokenizer $MAILWOMAN_DATA_ROOT/models/tokenizer/v0.7.1-nsplice/tokenizer.model \
+ *       --base-card   neural-weights-en-us/model-card.json \
+ *       --cand-model  $MAILWOMAN_DATA_ROOT/models/candidates/v240-fr-nsplice/model-int8.onnx \
+ *       --cand-tokenizer $MAILWOMAN_DATA_ROOT/models/tokenizer/v0.8.0-fr-nsplice/tokenizer.model \
+ *       --cand-card   $MAILWOMAN_DATA_ROOT/models/candidates/v240-fr-nsplice/model-card.json \
+ *       --n 1500
+ */
+
+import { parseArgs } from "node:util"
+import { resolve } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { createScorer, type NeuralAddressClassifier } from "@mailwoman/neural"
+import { normalizeStreetForKeyLocale } from "@mailwoman/resolver-wof-sqlite/street-normalize"
+import { mailwomanDataRoot } from "mailwoman/resolver-backend"
+
+const STREET_TAGS = new Set(["street", "street_prefix", "street_suffix"])
+
+const { values } = parseArgs({
+	options: {
+		"base-model": { type: "string" },
+		"base-tokenizer": { type: "string" },
+		"base-card": { type: "string", default: "neural-weights-en-us/model-card.json" },
+		"cand-model": { type: "string" },
+		"cand-tokenizer": { type: "string" },
+		"cand-card": { type: "string" },
+		db: { type: "string", default: `${mailwomanDataRoot()}/ban/address-points-fr.db` },
+		n: { type: "string", default: "1500" },
+	},
+	strict: true,
+})
+
+const N = Number(values.n)
+
+function req(name: string): string {
+	const v = values[name as keyof typeof values] as string | undefined
+
+	if (!v) throw new Error(`--${name} is required`)
+
+	return resolve(v)
+}
+
+type Node = { tag: string; value: string; start: number; end: number; children: readonly Node[] }
+
+/** The folded street key + the number of contiguous street spans (a gap > 2 chars ⇒ the span fragmented). */
+function streetInfo(tree: { roots: readonly Node[] }): { key: string; spans: number } {
+	const parts: Array<{ value: string; start: number; end: number }> = []
+	const stack: Node[] = [...tree.roots]
+
+	while (stack.length) {
+		const n = stack.pop()!
+
+		if (STREET_TAGS.has(n.tag) && n.value.trim()) { parts.push({ value: n.value.trim(), start: n.start, end: n.end }) }
+		stack.push(...(n.children as Node[]))
+	}
+
+	parts.sort((a, b) => a.start - b.start)
+
+	let spans = 0
+	let prevEnd = -100
+
+	for (const p of parts) {
+		if (p.start - prevEnd > 2) { spans++ }
+		prevEnd = p.end
+	}
+
+	return { key: normalizeStreetForKeyLocale(parts.map((p) => p.value).join(" "), "fr"), spans }
+}
+
+async function load(model: string, tokenizer: string, card: string): Promise<NeuralAddressClassifier> {
+	return createScorer({ modelPath: model, tokenizerPath: tokenizer, modelCardPath: card, locale: "en-us" })
+}
+
+const baseline = await load(req("base-model"), req("base-tokenizer"), req("base-card"))
+const candidate = await load(req("cand-model"), req("cand-tokenizer"), req("cand-card"))
+
+const db = new DatabaseSync(resolve(values.db!), { readOnly: true })
+
+// Distinct accented streets, rowid-ordered (fair, non-alphabetical). GLOB '*[^ -~]*' = any char outside
+// printable ASCII (0x20–0x7e) ⇒ an accented/diacritic char.
+const sample = db
+	.prepare(
+		`SELECT street_raw, street_norm, number, postcode, locality_norm FROM address_point
+		 WHERE street_raw GLOB '*[^ -~]*' GROUP BY street_norm ORDER BY rowid LIMIT ?`
+	)
+	.all(N) as Array<{ street_raw: string; street_norm: string; number: string; postcode: string; locality_norm: string }>
+
+const probe = db.prepare(
+	`SELECT lat, lon FROM address_point WHERE postcode = ? AND street_norm = ? AND number = ? LIMIT 1`
+)
+
+type Tally = { mangled: number; fragmented: number; truncation: number }
+const tally = (): Tally => ({ mangled: 0, fragmented: 0, truncation: 0 })
+const base = tally()
+const cand = tally()
+let flippedToHit = 0 // base mangled → cand intact (address_point MISS → HIT)
+
+const examples: string[] = []
+
+for (const r of sample) {
+	const want = r.street_norm
+	const q = `${r.number} ${r.street_raw}, ${r.postcode} ${r.locality_norm}`
+	const b = streetInfo(await baseline.parse(q, { postcodeRepair: true, normalizeCase: true }))
+	const c = streetInfo(await candidate.parse(q, { postcodeRepair: true, normalizeCase: true }))
+
+	const bMangled = b.key !== want
+	const cMangled = c.key !== want
+
+	if (bMangled) {
+		base.mangled++
+
+		if (b.spans > 1) { base.fragmented++ }
+		else { base.truncation++ }
+	}
+
+	if (cMangled) {
+		cand.mangled++
+
+		if (c.spans > 1) { cand.fragmented++ }
+		else { cand.truncation++ }
+	}
+
+	if (bMangled && !cMangled) {
+		flippedToHit++
+
+		if (examples.length < 12) { examples.push(`  ✓ "${r.street_raw}"  base→"${b.key}"  cand→"${c.key}"  (want "${want}")`) }
+	}
+}
+
+const pct = (x: number) => ((x / sample.length) * 100).toFixed(1)
+
+console.log(`\n=== #444 FR accent-mangle rate (n=${sample.length} distinct accented BAN streets, rowid-ordered) ===`)
+console.log(`  BASELINE (shipped): mangled ${base.mangled}/${sample.length} (${pct(base.mangled)}%)  [frag ${base.fragmented} / trunc ${base.truncation}]`)
+console.log(`  CANDIDATE (splice): mangled ${cand.mangled}/${sample.length} (${pct(cand.mangled)}%)  [frag ${cand.fragmented} / trunc ${cand.truncation}]`)
+console.log(`  Δ mangle rate: ${pct(base.mangled)}% → ${pct(cand.mangled)}%  (${(((cand.mangled - base.mangled) / sample.length) * 100).toFixed(1)}pp)`)
+console.log(`  address_point MISS→HIT (base mangled, cand intact): ${flippedToHit}`)
+
+// --- Named #444 datapoints: parse both arms + probe the BAN address_point tier directly (MISS→HIT + coord) ---
+const datapoints = [
+	{ q: "55 Rue du Faubourg Saint-Honoré, 75008 Paris", number: "55", postcode: "75008", street_norm: "rue du faubourg saint honore" },
+	{ q: "10 Avenue des Champs-Élysées, 75008 Paris", number: "10", postcode: "75008", street_norm: "avenue des champs elysees" },
+	{ q: "1 Place René Cassin, 75001 Paris", number: "1", postcode: "75001", street_norm: "place rene cassin" },
+	{ q: "1 Rue de la République, 13001 Marseille", number: "1", postcode: "13001", street_norm: "rue de la republique" },
+]
+
+console.log(`\n--- named #444 datapoints (parse key + direct BAN address_point probe) ---`)
+
+for (const d of datapoints) {
+	const b = streetInfo(await baseline.parse(d.q, { postcodeRepair: true, normalizeCase: true }))
+	const c = streetInfo(await candidate.parse(d.q, { postcodeRepair: true, normalizeCase: true }))
+	const hit = (key: string) => (probe.get(d.postcode, key, d.number) as { lat: number; lon: number } | undefined)
+	const bh = hit(b.key)
+	const ch = hit(c.key)
+	console.log(`  "${d.q}"  (BAN holds street_norm="${d.street_norm}")`)
+	console.log(`    base:  key="${b.key}"  ${bh ? `HIT ${bh.lat},${bh.lon}` : "MISS"}`)
+	console.log(`    cand:  key="${c.key}"  ${ch ? `HIT ${ch.lat},${ch.lon}` : "MISS"}`)
+}
+
+console.log(`\nsample MISS→HIT flips:`)
+
+for (const e of examples) { console.log(e) }
+
+db.close()

--- a/scripts/eval/gauntlet/harness.ts
+++ b/scripts/eval/gauntlet/harness.ts
@@ -13,7 +13,7 @@ import { createHash } from "node:crypto"
 import { existsSync, readFileSync } from "node:fs"
 import { resolve } from "node:path"
 
-import { NeuralAddressClassifier } from "@mailwoman/neural"
+import { createScorer, NeuralAddressClassifier } from "@mailwoman/neural"
 import { OSMShardProvider } from "@mailwoman/osm/sdk"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { type GeocodeResult, geocodeAddress, ShardProvider } from "mailwoman/geocode-core"
@@ -54,8 +54,17 @@ function assertShippedModelMatchesCard(materializedMd5: string): void {
 /**
  * Build the geocode deps. `modelPath` swaps ONLY the ONNX (same tokenizer/card/anchor/gazetteer soft-feed), so the
  * held-out gate can grade a candidate against production fairly; omit it for the shipped default.
+ *
+ * `tokenizerPath` (+ optional `modelCardPath`) additionally swaps the VOCAB — required to grade a tokenizer-SPLICE
+ * candidate (#444/#884/#912), whose model has extra embedding rows a plain `modelPath` swap can never exercise (the
+ * shipped tokenizer emits no ids for the new pieces, so the candidate would score byte-identical to production and the
+ * splice would be invisible). When a tokenizer is given the classifier is built via `createScorer` (which wires the
+ * anchor + gazetteer soft-feeds the model requires); pair it with the matching shipped trio on the production side so
+ * the ONLY variables are the ONNX + the vocab (see holdout.ts).
  */
-export async function buildGauntletDeps(opts: { modelPath?: string } = {}): Promise<GauntletDeps> {
+export async function buildGauntletDeps(
+	opts: { modelPath?: string; tokenizerPath?: string; modelCardPath?: string } = {}
+): Promise<GauntletDeps> {
 	const resolverMod = await import("@mailwoman/resolver-wof-sqlite")
 	// Transparency: stamp the model under test so a stale dev symlink (the d6812bc7 trap — the default
 	// loadFromWeights symlink can point at an old training base, not the shipped model) is never silent.
@@ -71,13 +80,20 @@ export async function buildGauntletDeps(opts: { modelPath?: string } = {}): Prom
 		// shipped default must match the model-card's files_md5 (the card is the source of truth). A `--candidate`
 		// run intentionally grades a different artifact, so it is exempt. This gate is wired as the release
 		// before:release step (RELEASING.md), so failing here guards BOTH the gate and the ship.
-		if (!opts.modelPath) {
+		if (!opts.modelPath && !opts.tokenizerPath) {
 			assertShippedModelMatchesCard(md5)
 		}
 	}
-	const classifier = opts.modelPath
-		? await NeuralAddressClassifier.loadFromWeights({ locale: "en-US", modelPath: resolve(opts.modelPath) })
-		: await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
+	const classifier = opts.tokenizerPath
+		? await createScorer({
+				modelPath: resolve(opts.modelPath ?? "neural-weights-en-us/model.onnx"),
+				tokenizerPath: resolve(opts.tokenizerPath),
+				modelCardPath: resolve(opts.modelCardPath ?? "neural-weights-en-us/model-card.json"),
+				locale: "en-us",
+			})
+		: opts.modelPath
+			? await NeuralAddressClassifier.loadFromWeights({ locale: "en-US", modelPath: resolve(opts.modelPath) })
+			: await NeuralAddressClassifier.loadFromWeights({ locale: "en-US" })
 	const resolver = createWOFResolver(
 		createResolverBackend(resolverMod, { wofPaths: wofShardPaths().filter(existsSync) })
 	)

--- a/scripts/eval/gauntlet/holdout.ts
+++ b/scripts/eval/gauntlet/holdout.ts
@@ -15,6 +15,7 @@
 
 import { parseArgs } from "node:util"
 
+import { resolveWeights } from "@mailwoman/neural"
 import { haversineKm } from "@mailwoman/spatial"
 import { mailwomanDataRoot } from "mailwoman/resolver-backend"
 import { TextSpliterator } from "spliterator"
@@ -23,14 +24,25 @@ import { buildGauntletDeps, type GauntletDeps } from "./harness.ts"
 
 // Loose scan parity with the retired scripts/lib/cli-args helpers: unknown flags tolerated.
 const { values: rawValues } = parseArgs({
-	options: { candidate: { type: "string" }, n: { type: "string" }, source: { type: "string" } },
+	options: {
+		candidate: { type: "string" },
+		n: { type: "string" },
+		source: { type: "string" },
+		// A tokenizer-SPLICE candidate (#444/#884/#912) ships a NEW vocab; grading it needs the candidate
+		// tokenizer (+ card) paired with the candidate model. Production is then also run through the SHIPPED
+		// trio (createScorer both sides) so the only variables are the ONNX + the vocab. Omit for a model-only bump.
+		tokenizer: { type: "string" },
+		card: { type: "string" },
+	},
 	strict: false,
 	allowPositionals: true,
 })
 // Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
-const values = rawValues as { candidate?: string; n?: string; source?: string }
+const values = rawValues as { candidate?: string; n?: string; source?: string; tokenizer?: string; card?: string }
 const N = Number(values["n"] || "300")
 const CANDIDATE = values["candidate"] || ""
+const CAND_TOKENIZER = values["tokenizer"] || ""
+const CAND_CARD = values["card"] || ""
 const SOURCE = (values["source"] || "fr").toLowerCase()
 const TOLS = [0.1, 0.5, 5] as const // rooftop / street / locality (km)
 const GATE_TOL = 5 // the z-test runs at the locality bucket (the dominant resolvable tier)
@@ -163,11 +175,23 @@ console.error(`[gauntlet/holdout] drawing ${N} fresh ${src.label} addresses…`)
 const sample = await draw(N)
 console.error(`[gauntlet/holdout] scoring production vs candidate on the SAME ${sample.length} addresses…`)
 
-const prodDeps = await buildGauntletDeps({})
+// A splice candidate (--tokenizer given) swaps the vocab, so production must ALSO run through the SHIPPED
+// (model, tokenizer, card) trio via createScorer — otherwise the two sides have different anchor/gazetteer
+// wiring and the z-test is confounded. resolveWeights gives the shipped trio for the production side.
+const shipped = CAND_TOKENIZER ? resolveWeights({ locale: "en-us" }) : null
+const prodDeps = await buildGauntletDeps(
+	shipped
+		? { modelPath: shipped.modelPath, tokenizerPath: shipped.tokenizerPath, modelCardPath: shipped.modelCardPath }
+		: {}
+)
 const prod = await score(prodDeps, sample)
 prodDeps.close()
 
-const candDeps = await buildGauntletDeps({ modelPath: CANDIDATE })
+const candDeps = await buildGauntletDeps(
+	CAND_TOKENIZER
+		? { modelPath: CANDIDATE, tokenizerPath: CAND_TOKENIZER, modelCardPath: CAND_CARD || undefined }
+		: { modelPath: CANDIDATE }
+)
 const cand = await score(candDeps, sample)
 candDeps.close()
 

--- a/scripts/eval/gauntlet/metamorphic.ts
+++ b/scripts/eval/gauntlet/metamorphic.ts
@@ -42,7 +42,7 @@ const { values: rawValues } = parseArgs({
 	allowPositionals: true,
 })
 // Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
-const values = rawValues as { model?: string }
+const values = rawValues as { model?: string; tokenizer?: string; card?: string }
 const INV_EPSILON_KM = 0.001 // 1m — same address, identical resolution expected.
 const DIR_NEAR_KM = 5 // dropping the postcode may lose the rooftop, but must still land in the right area.
 const BAND_NEAR_KM = 5 // a corrupted surface may shift the parse, but must stay within the tolerance band.

--- a/scripts/eval/gauntlet/metamorphic.ts
+++ b/scripts/eval/gauntlet/metamorphic.ts
@@ -34,7 +34,10 @@ import { buildGauntletDeps, runOne } from "./harness.ts"
 
 // Loose scan parity with the retired scripts/lib/cli-args helpers: unknown flags tolerated.
 const { values: rawValues } = parseArgs({
-	options: { model: { type: "string" } },
+	// `tokenizer`/`card`: a tokenizer-SPLICE candidate (#444/#884/#912) needs its new vocab paired with the
+	// model, or the new embedding rows stay dormant (shipped tokenizer emits no ids for them) and the splice
+	// is invisible to this layer. Model-only bumps omit them.
+	options: { model: { type: "string" }, tokenizer: { type: "string" }, card: { type: "string" } },
 	strict: false,
 	allowPositionals: true,
 })
@@ -293,7 +296,15 @@ const dropPostcode = (s: string) =>
 		.replace(/\s+/g, " ")
 		.trim()
 
-const deps = await buildGauntletDeps(values["model"] || "" ? { modelPath: values["model"] || "" } : {})
+const deps = await buildGauntletDeps(
+	values["model"] || ""
+		? {
+				modelPath: values["model"] || "",
+				...(values["tokenizer"] ? { tokenizerPath: values["tokenizer"] as string } : {}),
+				...(values["card"] ? { modelCardPath: values["card"] as string } : {}),
+			}
+		: {}
+)
 
 interface Tally {
 	checks: number

--- a/scripts/eval/gauntlet/regression.ts
+++ b/scripts/eval/gauntlet/regression.ts
@@ -32,7 +32,7 @@ const { values: rawValues } = parseArgs({
 	allowPositionals: true,
 })
 // Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
-const values = rawValues as { model?: string }
+const values = rawValues as { model?: string; tokenizer?: string; card?: string }
 const DEFAULT_TOL_M = 5000
 
 /** Map an expect_components key to the assembled-result field it asserts. */

--- a/scripts/eval/gauntlet/regression.ts
+++ b/scripts/eval/gauntlet/regression.ts
@@ -24,7 +24,10 @@ import type { GauntletDatabase } from "./schema.ts"
 
 // Loose scan parity with the retired scripts/lib/cli-args helpers: unknown flags tolerated.
 const { values: rawValues } = parseArgs({
-	options: { model: { type: "string" } },
+	// `tokenizer`/`card`: a tokenizer-SPLICE candidate (#444/#884/#912) needs its new vocab paired with the
+	// model, or the new embedding rows stay dormant (shipped tokenizer emits no ids for them) and the splice
+	// is invisible to this layer. Model-only bumps omit them.
+	options: { model: { type: "string" }, tokenizer: { type: "string" }, card: { type: "string" } },
 	strict: false,
 	allowPositionals: true,
 })
@@ -85,7 +88,15 @@ function checkCase(c: (typeof cases)[number], r: GauntletResult): string[] {
 	return issues
 }
 
-const deps = await buildGauntletDeps(values["model"] || "" ? { modelPath: values["model"] || "" } : {})
+const deps = await buildGauntletDeps(
+	values["model"] || ""
+		? {
+				modelPath: values["model"] || "",
+				...(values["tokenizer"] ? { tokenizerPath: values["tokenizer"] as string } : {}),
+				...(values["card"] ? { modelCardPath: values["card"] as string } : {}),
+			}
+		: {}
+)
 const fails: string[] = [] // status=pass that failed → BLOCK
 const tracked: string[] = [] // known_fail / improvement_target still failing → report, non-blocking
 const newlyPassing: string[] = [] // tracked case that now passes → promote it (anti-rot)

--- a/scripts/eval/gauntlet/run.ts
+++ b/scripts/eval/gauntlet/run.ts
@@ -22,15 +22,24 @@ import { parseArgs } from "node:util"
 
 // Loose scan parity with the retired scripts/lib/cli-args helpers: unknown flags tolerated.
 const { values: rawValues } = parseArgs({
-	options: { candidate: { type: "string" }, source: { type: "string" } },
+	options: {
+		candidate: { type: "string" },
+		source: { type: "string" },
+		// A tokenizer-SPLICE candidate (#444/#884/#912) ships a new vocab — forward it so the held-out layer
+		// pairs the candidate model with the candidate tokenizer (and runs production through the shipped trio).
+		tokenizer: { type: "string" },
+		card: { type: "string" },
+	},
 	strict: false,
 	allowPositionals: true,
 })
 // Typed view: strict:false loosens TS inference, but declared options always parse to their schema type.
-const values = rawValues as { candidate?: string; source?: string }
+const values = rawValues as { candidate?: string; source?: string; tokenizer?: string; card?: string }
 const candidate = values["candidate"] || ""
 const source = values["source"] || "fr"
-const modelArgs = candidate ? ["--model", candidate] : []
+const tokenizer = values["tokenizer"] || ""
+const card = values["card"] || ""
+const modelArgs = candidate ? ["--model", candidate, ...(tokenizer ? ["--tokenizer", tokenizer] : []), ...(card ? ["--card", card] : [])] : []
 
 interface Layer {
 	name: string
@@ -45,7 +54,15 @@ const layers: Layer[] = [
 if (candidate) {
 	layers.push({
 		name: "held-out",
-		argv: ["scripts/eval/gauntlet/holdout.ts", "--candidate", candidate, "--source", source],
+		argv: [
+			"scripts/eval/gauntlet/holdout.ts",
+			"--candidate",
+			candidate,
+			"--source",
+			source,
+			...(tokenizer ? ["--tokenizer", tokenizer] : []),
+			...(card ? ["--card", card] : []),
+		],
 	})
 } else {
 	console.log("[gauntlet] no --candidate → skipping the held-out generalization layer (self-check mode)")

--- a/scripts/eval/gauntlet/run.ts
+++ b/scripts/eval/gauntlet/run.ts
@@ -39,7 +39,9 @@ const candidate = values["candidate"] || ""
 const source = values["source"] || "fr"
 const tokenizer = values["tokenizer"] || ""
 const card = values["card"] || ""
-const modelArgs = candidate ? ["--model", candidate, ...(tokenizer ? ["--tokenizer", tokenizer] : []), ...(card ? ["--card", card] : [])] : []
+const modelArgs = candidate
+	? ["--model", candidate, ...(tokenizer ? ["--tokenizer", tokenizer] : []), ...(card ? ["--card", card] : [])]
+	: []
 
 interface Layer {
 	name: string


### PR DESCRIPTION
## What this is

The training-free FR diacritic **vocab-splice** from the #444 model-fix spec — the same `nsplice`
mechanism shipped for CZ/PL/SK/SI (#884) and Nordic (#912 lever-4): train an OA-FR SentencePiece
unigram, splice **only** its diacritic-bearing pieces into the vocab (English tokenizes byte-identically
by construction), and FVT mean-init the new embedding rows. No retrain, no promotion, no HF upload.

**Headline: the training-free path is FALSIFIED for FR *streets*.** It fixes some accented streets
(Honoré, Painlevé, Libération) and — surprisingly — *improves* accented **locality** resolution, but it
**net-regresses the #444 street-key target** and introduces a new failure mode. The tokenizer is sound;
the real fix is a **retrain** on this vocab (#901/#727), for which the staged artifacts are the inputs.

## Why it fails for FR streets (the mechanism)

For CZ/PL/Nordic, the isolated diacritic piece (`á`, `å`) was tagged `O`, and merging it into a word piece
fixed the fragmentation. For FR, the model was trained **from scratch on v0.7.1** with abundant FR `é→O`,
so `é` carries a *strong, well-trained* `O` signal. The FVT mean-init of a merged piece —
`E(▁René) = mean(E[▁Ren], E[é])` — inherits that `O` pull, so the **whole** merged token tags `O` and the
word drops entirely (`Place René Cassin` → `place cassin`) — *worse* than the baseline dropping just the é
(`place ren cassin`). Mean-init-only can't teach the merged FR street pieces; that needs gradient steps.

## Gate table (all re-derived under the correct labels, byte-provenanced; never copied across tokenizer versions)

| gate | baseline (shipped v5.4.0 int8 + v0.7.1-nsplice) | candidate (v240-fr-nsplice int8 + v0.8.0-fr-nsplice) | verdict |
| --- | --- | --- | --- |
| **Mangle rate** — n=1500 accented BAN streets (int8) | 23.5% (frag 13 / trunc 340) | **26.4%** (frag 101 / trunc 295) | **+2.9pp WORSE** |
| Mangle rate — fp32 (not int8 noise) | 23.6% | 26.4% | +2.8pp WORSE |
| — 64 MISS→HIT flips vs 107 new breaks | — | net −43 | fixes < regressions |
| **Honoré** `55 Rue du Faubourg Saint-Honoré, 75008` | key `…saint honor` → MISS | key `…saint honore` → **HIT 48.87063, 2.316931** | ✅ FIXED |
| Champs-Élysées | `…champs lysees` MISS | `…champs lysees` MISS | unchanged (É-after-hyphen still isolates) |
| René Cassin | `place ren cassin` MISS | `place cassin` MISS | ❌ WORSE (whole `▁René` → O) |
| **Gauntlet held-out FR** ≤5km z-test (n=400) | 312 hit / 379 resolved | 345 hit / 392 resolved | **z=+3.05 PASS** (locality better) |
| — Gauntlet FR ≤0.1km rooftop (n=400) | 15 | 16 | FLAT (target tier no net gain) |
| **Gauntlet held-out US** ≤5km (n=250) | 228 | 228 | **z=0.00 PASS** (byte-identical) |
| Non-FR tokenizer byte-identity — ES / DE(at) / EN spot list | — | **0 shift** | ✅ |
| Non-FR tokenizer sweep — 26k OA rows | — | 155 (0.596%) | é/ê/ô neighbors (CH/PT/CZ/SK/DK/IS); cf. prior art 0.35% |
| #900 codepoint-overlap gate | — | report written, EU accents accepted | ✅ |

The gauntlet held-out **locality** z=+3.05 (two independent draws both positive; candidate resolves +13/400)
is real but *incidental*: accented **commune** names de-fragment (`Génas` `▁G|é|nas`→`▁G|énas`, `Nîmes`→`▁Nîmes`,
`Béziers`→`▁Béziers`, `Orléans`→`▁Orléans`). The **rooftop** tier the change targeted is flat, and the
street-key metric regresses — so the coordinate is non-inferior-to-better while the change misses its purpose.

## Staged artifacts (beside canonical; nothing overwritten, immutable dirs per #945)

- `$MAILWOMAN_DATA_ROOT/models/tokenizer/v0.8.0-fr-nsplice/tokenizer.model` — md5 `04995524cceb4d2bf689e77338f80de2` (66319 pieces = 63913 + 2406 FR); `+ tokenizer.overlap-report.json`
- `$MAILWOMAN_DATA_ROOT/models/candidates/v240-fr-nsplice/model.onnx` (fp32) — md5 `3991bc296f3014d30ab3bf304851a91e`
- `$MAILWOMAN_DATA_ROOT/models/candidates/v240-fr-nsplice/model-int8.onnx` — md5 `f8ede0c7d40c9539991e8802d09beea5`
- `$MAILWOMAN_DATA_ROOT/models/candidates/v240-fr-nsplice/model-card.json` — md5 `b97962b9f892ee77e689589e64353322` (+ `MANIFEST.md` with verbatim build commands)

Source bases (unchanged): tokenizer `v0.7.1-nsplice` `8e1cab7c…`; model `v230-nl-postcode` fp32 `0e41ead5…` / int8 (shipped) `ea785a70…`.

## Code

- **`corpus-python/…/tokenizer_splice.py`** — `--per-file-cap` (one giant `fr/countrywide.csv` needs it, unlike the CZ/PL multi-file case) + **`onnx-mean-init`** (checkpoint-free ONNX embedding expansion for fp32+int8, same FVT math as `mean_init_embeddings`, int8 quant-inverse self-check). Existing splice-gate tests still pass.
- **`scripts/eval/fr-accent-mangle-rate.ts`** — the #444 mangle-rate metric as a **saved, reproducible** harness (the issue's inline diagnostic was never committed).
- **`scripts/eval/gauntlet/{run,holdout,harness,regression,metamorphic}.ts`** — `--candidate-tokenizer`/`--card` thread so the held-out z-test can grade a tokenizer-**splice** (both sides via `createScorer`, production on the shipped trio). A model-only `--candidate` swap leaves the new embedding rows dormant and the splice invisible. This also grades the coming FR retrain.

## Recommendation: **NO-PROMOTE**

The training-free splice misses its own target (accent street-key / rooftop) and adds René-class whole-token
drops. Do **not** ship it as-is. The **tokenizer** is validated (US byte-identical, non-FR-safe, commune
de-fragmentation) — hand it + the mean-init candidate to a **retrain / init_from fine-tune** on
`v0.8.0-fr-nsplice` (#901/#727), which would capture the locality win *and* fix the street class *and*
eliminate the René regression. Falsification of the training-free shortcut for FR — valid per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5qDbkGN3xs2XDvyK52qPT