### PR TITLE
train(#444): v241 fr-nsplice init_from fine-tune config

### DIFF
--- a/corpus-python/modal/train_remote.py
+++ b/corpus-python/modal/train_remote.py
@@ -1407,6 +1407,88 @@ def mean_init_nsplice():
 
 
 @app.function(
+    image=training_image,
+    volumes={VOL_MOUNT: vol},
+    secrets=[r2_secret],
+    timeout=1800,
+)
+def sync_v241_fr_nsplice():
+    """#444 — stage the FR-diacritic init_from FINE-TUNE (the #1047 falsification's principled fix).
+    Pulls the v0.8.0-fr-nsplice tokenizer (v0.7.1's 63913 + 2406 FR diacritic pieces from OA-FR street/
+    city text; md5 04995524…, #900 overlap gate PASS, US byte-identical) + refreshes the training code/
+    config (v2.4.1-fr-nsplice-ft.yaml). The v230-nl-postcode (v5.4.0) step-005000 base checkpoint, the
+    v0.10.1-nl-postcode corpus, and the v0.7.1-nsplice base tokenizer are already on the volume from the
+    v5.4.0 chain — not re-synced. Prints a container-side isfile verify block AFTER vol.commit() (the
+    `modal volume put` blind-spot doesn't apply here — writes go through container rclone + commit)."""
+    import shutil
+    import subprocess
+
+    print("Syncing v0.8.0-fr-nsplice tokenizer + code/config from R2...")
+    vol.reload()
+    R = "--low-level-retries 30 --retries 8 --transfers 8 --checkers 16"
+    commands = [
+        f"rclone copy :s3:{BUCKET}/corpus-python/src/ {VOL_MOUNT}/corpus-python/src/ {R}",
+        f"rclone copy :s3:{BUCKET}/models/tokenizer/v0.8.0-fr-nsplice/ {VOL_MOUNT}/models/tokenizer/v0.8.0-fr-nsplice/ {R}",
+    ]
+    for i, cmd in enumerate(commands):
+        print(f"[{i + 1}/{len(commands)}] {cmd[:90]}...")
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"rclone failed: {result.stderr[:300]}")
+    pyc = f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/__pycache__"
+    if os.path.isdir(pyc):
+        shutil.rmtree(pyc)
+    vol.commit()
+    for check, path in [
+        ("v2.4.1 config", f"{VOL_MOUNT}/corpus-python/src/mailwoman_train/configs/v2.4.1-fr-nsplice-ft.yaml"),
+        ("fr-nsplice tokenizer", f"{VOL_MOUNT}/models/tokenizer/v0.8.0-fr-nsplice/tokenizer.model"),
+        ("v0.7.1 base tokenizer", f"{VOL_MOUNT}/models/tokenizer/v0.7.1-nsplice/tokenizer.model"),
+        (
+            "v230 base ckpt",
+            f"{VOL_MOUNT}/output-v230-nl-postcode-full-s42/checkpoints/step-005000/pytorch_model.bin",
+        ),
+        (
+            "corpus train dir",
+            f"{VOL_MOUNT}/corpus/versioned/v0.10.1-nl-postcode/corpus-v0.10.1-nl-postcode/train",
+        ),
+    ]:
+        ok = os.path.isfile(path) or os.path.isdir(path)
+        print(f"  {check} present:", ok)
+
+
+@app.function(
+    image=training_image,
+    volumes={VOL_MOUNT: vol},
+    timeout=1200,
+)
+def mean_init_fr_nsplice():
+    """#444: expand the shipped v230-nl-postcode (v5.4.0) step-005000 checkpoint's token_embeddings to
+    the v0.8.0-fr-nsplice vocab (FVT mean-init — the pytorch-checkpoint twin of the onnx-mean-init that
+    produced the staged v240 candidate; identical FVT math). Writes /data/models/fr-nsplice-expanded,
+    the init_from base for v2.4.1-fr-nsplice-ft. Prints old→new vocab (expect 63913 → 66319) and a
+    container-side isfile verify of the written checkpoint AFTER vol.commit()."""
+    import sys
+
+    sys.path.insert(0, "/data/corpus-python/src")
+    from pathlib import Path
+
+    from mailwoman_train.tokenizer_splice import mean_init_embeddings
+
+    vol.reload()
+    out = Path(f"{VOL_MOUNT}/models/fr-nsplice-expanded")
+    old_v, new_v = mean_init_embeddings(
+        Path(f"{VOL_MOUNT}/output-v230-nl-postcode-full-s42/checkpoints/step-005000"),
+        Path(f"{VOL_MOUNT}/models/tokenizer/v0.7.1-nsplice/tokenizer.model"),
+        Path(f"{VOL_MOUNT}/models/tokenizer/v0.8.0-fr-nsplice/tokenizer.model"),
+        out,
+    )
+    vol.commit()
+    print(f"mean-init done: {old_v} -> {new_v} rows; {out} committed")
+    print("  pytorch_model.bin present:", os.path.isfile(out / "pytorch_model.bin"))
+    print("  config.json present:", os.path.isfile(out / "config.json"))
+
+
+@app.function(
     volumes={VOL_MOUNT: vol},
     image=training_image,
     timeout=600,

--- a/corpus-python/src/mailwoman_train/configs/v2.4.1-fr-nsplice-ft.yaml
+++ b/corpus-python/src/mailwoman_train/configs/v2.4.1-fr-nsplice-ft.yaml
@@ -1,0 +1,197 @@
+# v2.4.1-fr-nsplice-ft (#444) — THE PRINCIPLED FR-DIACRITIC FIX: an init_from FINE-TUNE that gives the
+# merged FR diacritic pieces gradient steps, the retrain the #1047 falsification specified.
+#
+# WHY (the #1047 mechanism finding): the training-free vocab-splice that fixed CZ/PL/SK/SI (#884) and
+# Nordic (#912 lever-4) is FALSIFIED for FR STREETS. The en-US line was trained FROM SCRATCH on v0.7.1
+# with abundant FR `é→O`, so `é` carries a strong, well-trained O-signal. FVT mean-init of a merged FR
+# piece — E(▁René) = mean(E[▁Ren], E[é]) — INHERITS that O pull, so the whole merged token tags O and
+# the word drops (`Place René Cassin` → `place cassin`), NET-worse than the baseline dropping just the é
+# (mangle 23.5%→26.4%). Mean-init-only can't teach the merged pieces; that needs GRADIENT STEPS. This
+# config supplies them: init_from the mean-init candidate, fine-tune on the v0.8.0-fr-nsplice vocab.
+#
+# THE RECIPE = v2.3.0-nl-postcode-full (the shipped v5.4.0 lineage) VERBATIM, with EXACTLY these deltas:
+#   1. tokenizer_dir  → v0.8.0-fr-nsplice (v0.7.1's 63913 + 2406 FR diacritic pieces; md5 04995524…,
+#      #900 overlap gate PASS, US byte-identical by construction).
+#   2. init_from      → /data/models/fr-nsplice-expanded — the v230-nl-postcode (v5.4.0) step-005000
+#      checkpoint's token_embeddings FVT mean-init-expanded 63913→66319 (mean_init_fr_nsplice, the
+#      pytorch-checkpoint twin of the onnx-mean-init that produced the staged v240 candidate; same FVT
+#      math, so the init is numerically the v240 mean-init candidate as a trainable checkpoint).
+#   3. SCHEDULE → the vocab-splice fine-tune schedule established across v1.9.7/v1.9.8/v1.9.9/v2.1.0
+#      (init_from a mean-init-expanded ckpt, fresh optimizer): constant lr 5.0e-5, warmup 200, 12000
+#      steps, eval/save every 2000. NOT v230's same-vocab lr 1e-5 (that fine-tune had no new rows to
+#      move); the new FR rows must overcome the inherited O-signal, and 5e-5 is THE splice-adaptation LR.
+#   4. output_dir/run name → v241 (FRESH dir; init_from READS v230's checkpoints, never overwrites).
+# Everything else — the v0.10.1-nl-postcode corpus (699 shards), all source/country weights, the model
+# config (crf_loss_weight 0.0; conventions loss-mask absent=OFF), anchor/gaz knobs, class_weights, seed
+# 42, batch 128, bf16 — is v230-VERBATIM, so the SPLICED VOCAB + its gradient steps are the only variable.
+#
+# GATE when it lands (operator reviews; do NOT auto-promote): mangle rate < 23.5% baseline (the #444
+# metric, scripts/eval/fr-accent-mangle-rate.ts); Honoré + René repros flip to HIT; gauntlet held-out FR
+# + US z-tests via --candidate + --candidate-tokenizer v0.8.0-fr-nsplice (a model-only swap leaves the
+# new rows dormant); non-FR byte-stability. NaN protocol: if the first checkpoints are NaN/inf, stop.
+data:
+  # v230's corpus VERBATIM (v0.10.1-nl-postcode = the v0.10.0 boundary-family base + synth-nl-postcode,
+  # 699 shards). Stored as raw text + char-offset spans → RE-TOKENIZED through the spliced tokenizer at
+  # load, so the FR diacritic pieces actually fire and receive gradient. No corpus rebuild needed.
+  corpus_dir: /data/corpus/versioned/v0.10.1-nl-postcode/corpus-v0.10.1-nl-postcode
+  tokenizer_dir: /data/models/tokenizer/v0.8.0-fr-nsplice
+  max_length: 128
+  country_weights: # VERBATIM from v1.9.3a3 (22 countries) — no new locales (surgical).
+    US: 1.0
+    FR: 1.0
+    DE: 1.0
+    ES: 1.0
+    IT: 1.0
+    NL: 1.0
+    PT: 1.0
+    BE: 1.0
+    PL: 1.0
+    AT: 1.0
+    CH: 1.0
+    CZ: 1.0
+    DK: 1.0
+    NO: 1.0
+    SE: 1.0
+    FI: 1.0
+    IE: 1.0
+    GB: 1.0
+    SK: 1.0
+    SI: 1.0
+    HR: 1.0
+    HU: 1.0
+    AU: 1.0
+  source_weights: # VERBATIM from v1.9.3a3 + the one new fr-bare-street shard.
+    wof-admin: 2.0
+    wof-postalcode: 2.0
+    ban: 3.0
+    tiger: 4.0
+    usgov-nppes: 2.0
+    usgov-hrsa-fqhc: 2.0
+    usgov-imls-pls: 2.0
+    usgov-nad: 1.0
+    state-ia-contractors: 2.0
+    state-tx-notaries: 1.5
+    state-ny-notaries: 2.0
+    deepseek-kryptonite: 3.0
+    synth-intersection: 1.0
+    synth-german: 6.0
+    synth-fr-order: 3.0
+    synth-fr-admin-split: 6.0
+    synth-unit: 1.5
+    synth-po-box-cedex: 1.5
+    synth-affix: 2.0
+    synth-country: 2.0
+    overture: 3.0
+    gnaf: 6.0
+    synth-anchor-absorption: 6.0
+    # #251 NEW: the bare-no-postcode FR street shard. 6.0 = targeted-fix precedent.
+    synth-fr-bare-street: 12.0
+    synth-si-bare-village: 12.0 # the family, balanced polarity
+    synth-no-street-led: 12.0
+    synth-cz-pcfirst-preposition: 12.0
+    synth-nl-postcode: 6.0 # #924 the NL digits-first postcode fix
+  train_rows_per_epoch: 1000000
+  val_rows: 4096
+  coarse_filter: true
+  augment_directional_prob: 0.3
+  augment_region_prob: 0.3
+  augment_glue_prob: 0.25
+  anchor_lookup_path: /data/anchor/pilot-anchor-lookup.json
+  gazetteer_lexicon_path: /data/gazetteer/anchor-lexicon-v1.json
+  gazetteer_choreography: true
+  affix_relabel_lexicon_path: /data/gazetteer/affix-relabel-lexicon-v1.json
+  anchor_paint_mode: shaped
+  anchor_value_mode: posterior_latlon
+
+model: # VERBATIM from v1.9.3a3.
+  hidden_size: 384
+  num_hidden_layers: 6
+  num_attention_heads: 6
+  intermediate_size: 1536
+  max_position_embeddings: 128
+  type_vocab_size: 1
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  use_crf: true
+  crf_loss_weight: 0.0
+  crf_normalization: per_sequence
+  label_smoothing: 0.1
+  use_locale_conditioning: true
+  locale_loss_weight: 0.3
+  use_postcode_anchor: true
+  use_gazetteer_anchor: true
+  gazetteer_feature_dim: 5
+  class_weights:
+    O: 0.5
+    B-country: 3.5
+    I-country: 3.5
+    B-region: 1.5
+    I-region: 1.5
+    B-locality: 2.0
+    I-locality: 2.0
+    B-dependent_locality: 0.3
+    I-dependent_locality: 0.3
+    B-postcode: 1.5
+    I-postcode: 1.5
+    B-subregion: 0.3
+    I-subregion: 0.3
+    B-cedex: 1.0
+    I-cedex: 1.0
+    B-venue: 1.5
+    I-venue: 1.5
+    B-street: 2.0
+    I-street: 2.0
+    B-house_number: 1.5
+    I-house_number: 1.5
+    B-street_prefix: 1.5
+    I-street_prefix: 1.5
+    B-street_suffix: 1.5
+    I-street_suffix: 1.5
+    B-unit: 1.5
+    I-unit: 1.5
+    B-po_box: 1.5
+    I-po_box: 1.5
+    B-intersection_a: 1.0
+    I-intersection_a: 1.0
+    B-intersection_b: 1.0
+    I-intersection_b: 1.0
+  use_phrase_priors: true
+  phrase_feature_dim: 10
+
+train: # #444 vocab-splice INIT_FROM FINE-TUNE (the v1.9.7/v2.1.0 idiom: fresh optimizer over the
+  # mean-init-expanded checkpoint; --resume auto on a FRESH output_dir resolves to no checkpoint → honors
+  # init_from, loading model weights only). NOT a from-scratch run and NOT a resume.
+  output_dir: /data/output-v241-fr-nsplice-ft-s42/checkpoints
+  seed: 42
+  # The v230 (v5.4.0) step-005000 embeddings FVT mean-init-expanded to the v0.8.0-fr-nsplice vocab
+  # (66319 rows). mean_init_fr_nsplice writes this on the volume; = the staged v240 candidate as a
+  # trainable pytorch checkpoint. The new FR rows now receive gradient instead of inheriting é's O-signal.
+  init_from: /data/models/fr-nsplice-expanded
+  batch_size: 128
+  eval_batch_size: 128
+  grad_accum_steps: 1
+  # 5.0e-5 = the vocab-splice fine-tune LR (v1.9.7/v1.9.8/v1.9.9/v2.1.0), 5× v230's same-vocab 1e-5 —
+  # the mean-init FR rows must MOVE off the inherited O-signal; drift on the trained encoder/US is
+  # guarded by the US byte-identity + non-inferiority gate. Constant schedule, warmup 200.
+  learning_rate: 5.0e-5
+  weight_decay: 0.01
+  warmup_steps: 200
+  grad_clip_norm: 1.0
+  # 12000 steps, eval/save every 2000 (6 gated checkpoints) — the fuller splice-fine-tune length
+  # (v1.9.8/v2.1.0); FR overcomes a STRONGER O-prior than the CZ/PL/Nordic splices. ~1/8 the from-scratch
+  # 100k schedule → a short fine-tune. Operator gates the best checkpoint when it lands (no auto-promote).
+  max_steps: 12000
+  eval_every_steps: 2000
+  save_every_steps: 2000
+  log_every_steps: 50
+  precision: bf16
+  num_workers: 0
+  csv_log_path: "{output_dir}/../train_log.csv"
+  lr_schedule: constant
+  gazetteer_curriculum: false
+  trackio_project: mailwoman
+  trackio_run_name: v2.4.1-fr-nsplice-ft-s42
+
+eval:
+  golden_dir: /data/eval/golden/v0.1.2
+  val_jsonl: ""

--- a/corpus-python/src/mailwoman_train/trackio_logging.py
+++ b/corpus-python/src/mailwoman_train/trackio_logging.py
@@ -136,7 +136,10 @@ def _run_config(cfg: Any) -> dict[str, Any]:
     return {
         # Human-readable legend shown in the run's config panel — so a viewer who isn't
         # steeped in the metrics knows how to read the charts (esp. the blank/gap ones).
-        "_legend": (
+        # NB: the key must NOT start with "_" — current trackio reserves the "_" prefix and
+        # raises "Config key '_legend' is reserved" from init(), which trackio_logging.py catches
+        # and silently downgrades the whole run to CSV-only (no Space dashboard). Plain "legend".
+        "legend": (
             "f1.<tag> = token-level F1 for that address component on the val set (higher is better). "
             "support.<tag> = how many val examples contain that component. A MISSING/BLANK f1.<tag> "
             "chart means support.<tag> = 0 — the val sample has no examples of that tag, so F1 is "


### PR DESCRIPTION
## What this is

The principled fix the #1047 falsification specified: an **init_from fine-tune** on the validated
`v0.8.0-fr-nsplice` tokenizer, so the merged FR diacritic pieces receive **gradient steps** instead of
inheriting é's well-trained `O`-signal.

#1047 proved the *training-free* vocab-splice net-**regresses** FR streets (mangle 23.5% → 26.4%): FVT
mean-init of a merged FR piece — `E(▁René) = mean(E[▁Ren], E[é])` — inherits é's strong `O` pull, so the
whole `▁René` token tags `O` and the word drops entirely. Mean-init alone can't teach the merged pieces;
that needs training. This config supplies it, with the staged tokenizer + mean-init candidate as inputs.

**Run launched, NOT merged.** Operator gates the candidate when it lands (do not auto-promote).

## The config = v2.3.0-nl-postcode-full VERBATIM, four deltas

`v2.4.1-fr-nsplice-ft.yaml` copies the shipped v5.4.0 lineage (v230) and changes ONLY:

| knob | v230 | v241 | why |
| --- | --- | --- | --- |
| `tokenizer_dir` | v0.7.1-nsplice (63913) | **v0.8.0-fr-nsplice** (66319 = +2406 FR) | the spliced vocab, #900 gate PASS, US byte-identical |
| `init_from` | v220 step-100000 | **/data/models/fr-nsplice-expanded** | v230 step-005000 embeddings FVT mean-init-expanded to the spliced vocab = the staged v240 candidate as a trainable pytorch ckpt |
| `learning_rate` | 1e-5 (same-vocab FT) | **5.0e-5** | the vocab-splice fine-tune LR (v1.9.7/v1.9.8/v1.9.9/v2.1.0); the new FR rows must move off the inherited O-signal |
| schedule | 5000 steps, warmup 1000, eval 500 | **12000 steps, warmup 200, eval/save 2000** | the fuller splice-fine-tune length; FR overcomes a stronger O-prior than the CZ/PL/Nordic splices |

Everything else — corpus (`v0.10.1-nl-postcode`, raw-text → **re-tokenized through the spliced tokenizer
at load**, so the FR pieces actually fire and get gradient), all source/country weights, model config
(`crf_loss_weight 0.0`; conventions loss-mask absent = OFF), anchor/gaz knobs, class_weights, seed 42,
batch 128, bf16 — is v230-verbatim. The spliced vocab + its gradient steps are the only variable.

## Staging (train_remote.py)

- **`sync_v241_fr_nsplice`** — R2 → volume (code + the v0.8.0-fr-nsplice tokenizer), with a container-side
  `os.path.isfile` verify block after `vol.commit()` (the `modal volume put` blind-spot doesn't apply —
  writes go through container rclone + commit). Mirrors `sync_nsplice`.
- **`mean_init_fr_nsplice`** — the pytorch-checkpoint twin of the `onnx-mean-init` that produced the v240
  candidate (same FVT math via `mean_init_embeddings`): v230 step-005000 → `/data/models/fr-nsplice-expanded`,
  **63913 → 66319 rows**. Mirrors `mean_init_nsplice`.

## Drive-by fix: `trackio_logging.py` `_legend` → `legend`

Current `trackio` reserves the `_` key prefix and raises `Config key '_legend' is reserved` from `init()`,
which `init_tracker` catches and silently downgrades **every run** to CSV-only (no Space dashboard). The
first launch hit exactly this. Renamed the config-panel legend key to `legend`; the relaunch streams to
the Space.

## Launch status (verified started)

- App `ap-ksD3u5OGcrUdjv1bIOGwDL` on A100-SXM4-40GB, `--config v2.4.1-fr-nsplice-ft.yaml --resume auto`.
- `--resume auto` on the fresh v241 output dir resolves to no checkpoint → honors `init_from`:
  `[init_from] loaded encoder from /data/models/fr-nsplice-expanded (missing=0 unexpected=0)`.
- Loss finite + decreasing (0.7314 → 0.6922 by step 200); warmup ramps to 5e-5 then constant; ~6 steps/s
  → 12000 steps ≈ 33 min. NaN protocol: clean.
- Trackio streaming → https://huggingface.co/spaces/sister-software/mailwoman-trackio (run `v2.4.1-fr-nsplice-ft-s42`).

## Gate when it lands (operator, no auto-promote)

Mangle rate < 23.5% baseline (`scripts/eval/fr-accent-mangle-rate.ts`); Honoré + René repros flip to HIT;
gauntlet held-out FR + US z-tests via `--candidate` **and** `--candidate-tokenizer v0.8.0-fr-nsplice` (a
model-only swap leaves the new rows dormant); non-FR byte-stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5qDbkGN3xs2XDvyK52qPT