### PR TITLE
feat(#1052): schema.org Place/PostalAddress JSON-LD output — toSchemaOrg() + --format jsonld + endpoint param

### DIFF
--- a/annotations/index.test.ts
+++ b/annotations/index.test.ts
@@ -6,7 +6,15 @@
 
 import { expect, test } from "vitest"
 
-import { type AnnotationSet, type Annotator, composeAnnotators, toNative, toOpenCage } from "./index.ts"
+import {
+	type AnnotationSet,
+	type Annotator,
+	composeAnnotators,
+	composeStreetAddress,
+	toNative,
+	toOpenCage,
+	toSchemaOrg,
+} from "./index.ts"
 
 test("composeAnnotators: merges partial results from multiple annotators", async () => {
 	const coords: Annotator = () => ({ geohash: "dqcjqcp84", mgrs: "18SUJ23480647" })
@@ -70,4 +78,67 @@ test("toOpenCage: omits unpopulated fields", () => {
 test("toNative: returns the native set unchanged", () => {
 	const set: AnnotationSet = { geohash: "x", callingCode: 44 }
 	expect(toNative(set)).toEqual(set)
+})
+
+// schema.org Place / PostalAddress / GeoCoordinates JSON-LD projection (#1052)
+
+test("composeStreetAddress: collapses housenumber + street + unit into one number-first line", () => {
+	expect(composeStreetAddress({ houseNumber: "8", street: "Boulevard du Palais" })).toBe("8 Boulevard du Palais")
+	// The lossy collapse: unit rides the same opaque string (schema.org has no unit slot).
+	expect(composeStreetAddress({ houseNumber: "350", street: "5th Ave", unit: "Apt 4B" })).toBe("350 5th Ave Apt 4B")
+	// Blank parts drop out; an all-empty input is "".
+	expect(composeStreetAddress({ street: "5th Ave" })).toBe("5th Ave")
+	expect(composeStreetAddress({ houseNumber: "  ", street: "" })).toBe("")
+})
+
+test("toSchemaOrg: full Place with geo + PostalAddress, ISO-3166 alpha-2 country (uppercased)", () => {
+	const place = toSchemaOrg({
+		lat: 48.8556,
+		lon: 2.3448,
+		streetAddress: "8 Boulevard du Palais",
+		locality: "Paris",
+		region: "Île-de-France",
+		postalCode: "75001",
+		countryCode: "fr", // lowercase in → uppercase out
+	})
+
+	expect(place["@context"]).toBe("https://schema.org")
+	expect(place["@type"]).toBe("Place")
+	expect(place.geo).toEqual({ "@type": "GeoCoordinates", latitude: 48.8556, longitude: 2.3448 })
+	expect(place.address).toEqual({
+		"@type": "PostalAddress",
+		streetAddress: "8 Boulevard du Palais",
+		addressLocality: "Paris",
+		addressRegion: "Île-de-France",
+		postalCode: "75001",
+		addressCountry: "FR",
+	})
+})
+
+test("toSchemaOrg: omits absent fields entirely (never null)", () => {
+	const place = toSchemaOrg({ lat: 40.0, lon: -75.0, locality: "Philadelphia", countryCode: "US" })
+
+	expect(place.name).toBeUndefined()
+	expect(place.address?.streetAddress).toBeUndefined()
+	expect(place.address?.postalCode).toBeUndefined()
+	expect(place.address?.addressRegion).toBeUndefined()
+	// No null-valued keys anywhere in the JSON.
+	expect(JSON.stringify(place)).not.toContain("null")
+	expect(place.address).toEqual({ "@type": "PostalAddress", addressLocality: "Philadelphia", addressCountry: "US" })
+})
+
+test("toSchemaOrg: geo omitted when the coordinate is missing / non-finite", () => {
+	expect(toSchemaOrg({ lat: null, lon: null, locality: "Nowhere" }).geo).toBeUndefined()
+	expect(toSchemaOrg({ lat: Number.NaN, lon: 2, locality: "Nowhere" }).geo).toBeUndefined()
+	// An address with no fields at all yields a bare Place (no `address` key).
+	expect(toSchemaOrg({ lat: 1, lon: 2 }).address).toBeUndefined()
+})
+
+test("toSchemaOrg: PO box maps to postOfficeBoxNumber; name carries a venue", () => {
+	const place = toSchemaOrg({ lat: 38.9, lon: -77.0, name: "The White House", poBox: "12345", countryCode: "us" })
+
+	expect(place.name).toBe("The White House")
+	expect(place.address?.postOfficeBoxNumber).toBe("12345")
+	expect(place.address?.streetAddress).toBeUndefined()
+	expect(place.address?.addressCountry).toBe("US")
 })

--- a/annotations/index.ts
+++ b/annotations/index.ts
@@ -256,3 +256,127 @@ export function toOpenCage(set: AnnotationSet): OpenCageAnnotations {
 export function toNative(set: AnnotationSet): AnnotationSet {
 	return set
 }
+
+// ---------------------------------------------------------------------------
+// schema.org Place / PostalAddress / GeoCoordinates — a JSON-LD OUTPUT projection (#1052)
+// ---------------------------------------------------------------------------
+
+/**
+ * A schema.org [`GeoCoordinates`](https://schema.org/GeoCoordinates) node — the resolved coordinate, embedded under a
+ * {@link SchemaOrgPlace}'s `geo`.
+ */
+export interface SchemaOrgGeoCoordinates {
+	"@type": "GeoCoordinates"
+	latitude: number
+	longitude: number
+}
+
+/**
+ * A schema.org [`PostalAddress`](https://schema.org/PostalAddress) node. Only populated fields are emitted (never
+ * `null`). `streetAddress` is a single opaque line — the house-number/street/unit distinction is intentionally
+ * collapsed (schema.org has no structured slots for them). `addressCountry` is ISO-3166 alpha-2.
+ */
+export interface SchemaOrgPostalAddress {
+	"@type": "PostalAddress"
+	streetAddress?: string
+	postOfficeBoxNumber?: string
+	addressLocality?: string
+	addressRegion?: string
+	postalCode?: string
+	/** ISO-3166 alpha-2 (e.g. `"FR"`). */
+	addressCountry?: string
+}
+
+/**
+ * A schema.org [`Place`](https://schema.org/Place) node with an embedded `PostalAddress` + `GeoCoordinates` — the
+ * JSON-LD projection returned by {@link toSchemaOrg}. Its `@context` makes the object valid linked data on its own.
+ */
+export interface SchemaOrgPlace {
+	"@context": "https://schema.org"
+	"@type": "Place"
+	name?: string
+	geo?: SchemaOrgGeoCoordinates
+	address?: SchemaOrgPostalAddress
+}
+
+/**
+ * The neutral resolved-address input {@link toSchemaOrg} serializes. Every field is optional; an absent field is omitted
+ * from the output entirely (no `null`s). Mirrors the {@link OpenCageAnnotations} precedent: one native shape, a
+ * dedicated serializer per wire format.
+ */
+export interface SchemaOrgInput {
+	lat?: number | null
+	lon?: number | null
+	/** The resolved POI / venue name, when one exists. Omitted for a bare street address. */
+	name?: string
+	/**
+	 * The rendered street line (house number + street + unit) as ONE string. Compose it with the locale-aware
+	 * `@mailwoman/formatter` (`formatAddress`) where available, or {@link composeStreetAddress} for a plain join.
+	 */
+	streetAddress?: string
+	/** PO box number, when the address is a PO box (→ `postOfficeBoxNumber`). */
+	poBox?: string
+	locality?: string
+	region?: string
+	postalCode?: string
+	/** ISO-3166 alpha-2 (any case); emitted uppercased as `addressCountry`. */
+	countryCode?: string
+}
+
+/**
+ * Collapse parsed street parts into one opaque `streetAddress` line — the schema.org lossy-by-design collapse (house
+ * number + street + unit → a single space-joined string). Parts are number-FIRST, correct for the shipped en-US / fr-FR
+ * tiers; callers with `@mailwoman/formatter` render locale-aware (e.g. de-DE number-last) instead. Blank parts are
+ * dropped; an all-empty input yields `""`.
+ */
+export function composeStreetAddress(parts: { houseNumber?: string; street?: string; unit?: string }): string {
+	return [parts.houseNumber, parts.street, parts.unit]
+		.map((p) => p?.trim())
+		.filter(Boolean)
+		.join(" ")
+}
+
+/**
+ * Serialize a resolved address into a schema.org `Place` JSON-LD object — `Place { geo: GeoCoordinates, address:
+ * PostalAddress }` (#1052). An OUTPUT PROJECTION, lossy by design: `streetAddress` is one opaque string, and
+ * tiers/confidence/provenance don't fit the core vocabulary, so they're dropped rather than shoehorned into an
+ * extension property. Only populated fields are emitted — absent fields are omitted entirely (never `null`).
+ * `addressCountry` is ISO-3166 alpha-2 (uppercased). `geo` is emitted only when both coordinates are finite; the
+ * `address` block only when at least one address field is present.
+ */
+export function toSchemaOrg(input: SchemaOrgInput): SchemaOrgPlace {
+	const place: SchemaOrgPlace = { "@context": "https://schema.org", "@type": "Place" }
+
+	if (input.name?.trim()) {
+		place.name = input.name.trim()
+	}
+
+	if (input.lat != null && input.lon != null && Number.isFinite(input.lat) && Number.isFinite(input.lon)) {
+		place.geo = { "@type": "GeoCoordinates", latitude: input.lat, longitude: input.lon }
+	}
+
+	const address: SchemaOrgPostalAddress = { "@type": "PostalAddress" }
+	let hasField = false
+
+	const assign = (key: Exclude<keyof SchemaOrgPostalAddress, "@type">, value: string | undefined): void => {
+		const trimmed = value?.trim()
+
+		if (trimmed) {
+			address[key] = trimmed
+			hasField = true
+		}
+	}
+
+	assign("streetAddress", input.streetAddress)
+	assign("postOfficeBoxNumber", input.poBox)
+	assign("addressLocality", input.locality)
+	assign("addressRegion", input.region)
+	assign("postalCode", input.postalCode)
+	assign("addressCountry", input.countryCode?.toUpperCase())
+
+	if (hasField) {
+		place.address = address
+	}
+
+	return place
+}

--- a/mailwoman/commands/geocode.test.ts
+++ b/mailwoman/commands/geocode.test.ts
@@ -191,6 +191,41 @@ describe.skipIf(!hasCLICompiled || !hasWOFDb || !hasTxShards)(`geocode integrati
 		expect(stdout).toMatch(/resolution_tier/)
 		expect(stdout).toMatch(/coordinate/)
 	}, 60_000)
+
+	test("--format=jsonld emits a valid schema.org Place JSON-LD object (#1052)", () => {
+		const stdout = execFileSync(
+			process.execPath,
+			[
+				CLI_PATH,
+				"geocode",
+				TX_ADDRESS,
+				`--resolve-db=${wofPath}`,
+				`--address-points-db=${TX_ADDRESS_POINTS_DB}`,
+				`--interpolation-db=${TX_INTERPOLATION_DB}`,
+				"--format=jsonld",
+			],
+			{ encoding: "utf8", timeout: 60_000 }
+		)
+
+		const place = JSON.parse(stdout) as {
+			"@context": string
+			"@type": string
+			geo?: { "@type": string; latitude: number; longitude: number }
+			address?: { "@type": string; streetAddress?: string; addressRegion?: string; addressCountry?: string }
+		}
+
+		expect(place["@context"]).toBe("https://schema.org")
+		expect(place["@type"]).toBe("Place")
+		// A street-level TX geocode carries a coordinate and a PostalAddress with the street line + ISO country.
+		expect(place.geo?.["@type"]).toBe("GeoCoordinates")
+		expect(place.geo?.latitude).toBeGreaterThan(29.5)
+		expect(place.geo?.latitude).toBeLessThan(31.5)
+		expect(place.address?.["@type"]).toBe("PostalAddress")
+		expect(place.address?.streetAddress).toMatch(/Flower Hill/i)
+		expect(place.address?.addressCountry).toBe("US")
+		// Lossy by design: no resolution tier / uncertainty / candidates leak into the JSON-LD.
+		expect(stdout).not.toMatch(/resolution_tier|uncertainty_m|candidates/)
+	}, 60_000)
 })
 
 /**

--- a/mailwoman/commands/geocode.tsx
+++ b/mailwoman/commands/geocode.tsx
@@ -29,9 +29,11 @@
 import { existsSync } from "node:fs"
 
 import { Spinner } from "@inkjs/ui"
+import { type SchemaOrgPlace, toSchemaOrg } from "@mailwoman/annotations"
 import { CoarsePlacer } from "@mailwoman/core/coarse-placer"
 import { $public } from "@mailwoman/core/env"
 import { isBareLocalityTree } from "@mailwoman/core/pipeline"
+import { formatAddress } from "@mailwoman/formatter"
 import { NeuralAddressClassifier } from "@mailwoman/neural"
 import { createWOFResolver } from "@mailwoman/resolver"
 import { Text } from "ink"
@@ -140,10 +142,13 @@ const OptionsSchema = zod.object({
 			"Abstention threshold for --place-country: below this calibrated confidence the prior is skipped. Default 0.9."
 		),
 	format: zod
-		.enum(["json", "text"])
+		.enum(["json", "text", "jsonld"])
 		.optional()
 		.default("json")
-		.describe('Output format. "json" (default) emits a machine-readable object; "text" prints a human summary.'),
+		.describe(
+			'Output format. "json" (default) emits the native machine-readable result; "text" prints a human summary; ' +
+				'"jsonld" emits a schema.org Place/PostalAddress/GeoCoordinates JSON-LD object (the web\'s native address format).'
+		),
 })
 
 // ---------------------------------------------------------------------------
@@ -289,13 +294,49 @@ async function runGeocode(input: string, options: zod.infer<typeof OptionsSchema
 			placeCountry: placer ? (t: string) => placer.predict(t) : false,
 		})
 
-		return options.format === "text" ? formatText(result) : JSON.stringify(result, null, 2)
+		if (options.format === "text") return formatText(result)
+
+		if (options.format === "jsonld") return JSON.stringify(geocodeToSchemaOrg(result), null, 2)
+
+		return JSON.stringify(result, null, 2)
 	} finally {
 		explicitAp?.close()
 		explicitIp?.close()
 		shardProvider.close()
 		lookup.close()
 	}
+}
+
+// ---------------------------------------------------------------------------
+// schema.org JSON-LD projection (#1052)
+// ---------------------------------------------------------------------------
+
+/**
+ * Project a {@link GeocodeResult} into a schema.org `Place` JSON-LD object (`--format jsonld`, #1052). `streetAddress`
+ * is rendered locale-aware by `@mailwoman/formatter` (house number placement follows the resolved country); the rest of
+ * the mapping (locality/region/postcode/ISO country → PostalAddress; coordinate → GeoCoordinates) lives in
+ * `@mailwoman/annotations`' {@link toSchemaOrg}. Lossy by design: tiers/uncertainty/candidates don't fit the vocabulary
+ * and are dropped.
+ */
+function geocodeToSchemaOrg(result: GeocodeResult): SchemaOrgPlace {
+	const streetAddress = formatAddress(
+		{
+			...(result.house_number ? { house_number: result.house_number } : {}),
+			...(result.street ? { street: result.street } : {}),
+		},
+		result.countryCode ?? "US",
+		{ separator: " " }
+	)
+
+	return toSchemaOrg({
+		lat: result.lat,
+		lon: result.lon,
+		streetAddress: streetAddress || undefined,
+		locality: result.locality ?? undefined,
+		region: result.region ?? undefined,
+		postalCode: result.postcode ?? undefined,
+		countryCode: result.countryCode ?? undefined,
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/mailwoman/package.json
+++ b/mailwoman/package.json
@@ -156,11 +156,13 @@
 	"dependencies": {
 		"@fragaria/address-formatter": "^6.7.1",
 		"@inkjs/ui": "^2.0.0",
+		"@mailwoman/annotations": "workspace:*",
 		"@mailwoman/ban": "workspace:*",
 		"@mailwoman/classifiers": "workspace:*",
 		"@mailwoman/codex": "workspace:*",
 		"@mailwoman/core": "workspace:*",
 		"@mailwoman/corpus": "workspace:*",
+		"@mailwoman/formatter": "workspace:*",
 		"@mailwoman/kind-classifier": "workspace:*",
 		"@mailwoman/locale-gate": "workspace:*",
 		"@mailwoman/neural": "workspace:*",

--- a/nominatim/index.test.ts
+++ b/nominatim/index.test.ts
@@ -6,6 +6,7 @@
 
 import type { AddressInfo } from "node:net"
 
+import type { SchemaOrgPlace } from "@mailwoman/annotations"
 import express from "express"
 import { expect, test } from "vitest"
 
@@ -13,6 +14,7 @@ import {
 	createNominatimRouter,
 	MAILWOMAN_LICENCE,
 	type NominatimEngine,
+	nominatimResultToSchemaOrg,
 	type ResolvedAddress,
 	toFeatureCollection,
 	toNominatimResult,
@@ -85,6 +87,55 @@ test("toNominatimResult: carries class/type/importance/boundingbox when present"
 	expect(r.type).toBe("government")
 	expect(r.importance).toBe(0.8)
 	expect(r.boundingbox).toEqual(["38.89", "38.90", "-77.04", "-77.03"])
+})
+
+// #1052 — schema.org Place/PostalAddress/GeoCoordinates JSON-LD as an alternate output format (`format=jsonld`).
+
+test("nominatimResultToSchemaOrg: projects a result's address into a schema.org Place (#1052)", () => {
+	const place = nominatimResultToSchemaOrg(toNominatimResult(dc, { addressdetails: true }))
+
+	expect(place["@context"]).toBe("https://schema.org")
+	expect(place["@type"]).toBe("Place")
+	expect(place.geo).toEqual({ "@type": "GeoCoordinates", latitude: 38.8977, longitude: -77.0365 })
+	expect(place.address?.["@type"]).toBe("PostalAddress")
+	expect(place.address?.streetAddress).toBe("1600 Pennsylvania Ave NW")
+	expect(place.address?.addressLocality).toBe("Washington")
+	expect(place.address?.addressRegion).toBe("DC")
+	expect(place.address?.postalCode).toBe("20500")
+	expect(place.address?.addressCountry).toBe("US") // country_code "us" → uppercased alpha-2
+})
+
+// Echoes params.addressdetails into the result so the route test also proves the router FORCES it for jsonld.
+const jsonldEngine: NominatimEngine = {
+	search: async (params) => [toNominatimResult(dc, { addressdetails: params.addressdetails })],
+	reverse: async (params) => toNominatimResult(dc, { addressdetails: params.addressdetails }),
+}
+
+test("route: /search?format=jsonld returns schema.org Place[] and forces addressdetails (#1052)", async () => {
+	await withServer(express().use(createNominatimRouter(jsonldEngine)), async (base) => {
+		const res = await fetch(`${base}/search?q=1600+pennsylvania+ave&format=jsonld`)
+		expect(res.status).toBe(200)
+		const body = (await res.json()) as SchemaOrgPlace[]
+		expect(Array.isArray(body)).toBe(true)
+		const place = body[0]!
+		expect(place["@type"]).toBe("Place")
+		// jsonld forced addressdetails on (the client did not pass it), so the PostalAddress is fully populated.
+		expect(place.address?.streetAddress).toBe("1600 Pennsylvania Ave NW")
+		expect(place.address?.addressLocality).toBe("Washington")
+		expect(place.address?.addressCountry).toBe("US")
+	})
+})
+
+test("route: /reverse?format=jsonld returns a single schema.org Place (#1052)", async () => {
+	await withServer(express().use(createNominatimRouter(jsonldEngine)), async (base) => {
+		const res = await fetch(`${base}/reverse?lat=38.8977&lon=-77.0365&format=jsonld`)
+		expect(res.status).toBe(200)
+		const place = (await res.json()) as SchemaOrgPlace
+		expect(place["@context"]).toBe("https://schema.org")
+		expect(place["@type"]).toBe("Place")
+		expect(place.address?.addressLocality).toBe("Washington")
+		expect(place.address?.addressCountry).toBe("US")
+	})
 })
 
 const corsEngine: NominatimEngine = { status: async () => ({ status: 0, message: "OK" }) }

--- a/nominatim/index.ts
+++ b/nominatim/index.ts
@@ -15,11 +15,19 @@
  *   `/reverse`, #805 `/lookup` + `/status`. Routes whose engine method is absent answer `501`.
  */
 
-import type { OpenCageAnnotations } from "@mailwoman/annotations"
+import {
+	composeStreetAddress,
+	type OpenCageAnnotations,
+	type SchemaOrgPlace,
+	toSchemaOrg,
+} from "@mailwoman/annotations"
 import { type RequestHandler, Router } from "express"
 
-/** Output serialization formats Nominatim supports. `jsonv2` is the modern default. */
-export type NominatimFormat = "jsonv2" | "json" | "geojson"
+/**
+ * Output serialization formats Nominatim supports. `jsonv2` is the modern default. `jsonld` is the Mailwoman extension
+ * (#1052) — schema.org `Place` JSON-LD, not part of upstream Nominatim.
+ */
+export type NominatimFormat = "jsonv2" | "json" | "geojson" | "jsonld"
 
 /**
  * The structured address breakdown returned under `address` when `addressdetails=1`. Keys mirror Nominatim's
@@ -121,7 +129,7 @@ export interface NominatimEngine {
 const DEFAULT_LIMIT = 10
 
 function parseFormat(raw: unknown): NominatimFormat {
-	return raw === "geojson" || raw === "json" ? raw : "jsonv2"
+	return raw === "geojson" || raw === "json" || raw === "jsonld" ? raw : "jsonv2"
 }
 
 function parseBool(raw: unknown): boolean {
@@ -273,12 +281,21 @@ export function createNominatimRouter(engine: NominatimEngine, options: Nominati
 			countrycodes: asString(q["countrycodes"])?.split(","),
 			limit: Number(q["limit"] ?? DEFAULT_LIMIT) || DEFAULT_LIMIT,
 			bounded: parseBool(q["bounded"]),
-			addressdetails: parseBool(q["addressdetails"]),
+			// #1052: jsonld projects the address breakdown into a PostalAddress, so it needs the details block.
+			addressdetails: parseBool(q["addressdetails"]) || q["format"] === "jsonld",
 			format: parseFormat(q["format"]),
 			acceptLanguage: asString(q["accept-language"]),
 		}
 		const results = await engine.search(params)
-		res.json(params.format === "geojson" ? toFeatureCollection(results) : results)
+
+		if (params.format === "geojson") {
+			res.json(toFeatureCollection(results))
+		} else if (params.format === "jsonld") {
+			// #1052: re-serialize the SAME results as schema.org `Place[]`; jsonv2 stays the default.
+			res.json(results.map(nominatimResultToSchemaOrg))
+		} else {
+			res.json(results)
+		}
 	}
 
 	const reverse: RequestHandler = async (req, res) => {
@@ -306,12 +323,21 @@ export function createNominatimRouter(engine: NominatimEngine, options: Nominati
 			lat,
 			lon,
 			zoom: q["zoom"] != null ? Number(q["zoom"]) : undefined,
-			addressdetails: parseBool(q["addressdetails"]),
+			// #1052: jsonld projects the address breakdown into a PostalAddress, so it needs the details block.
+			addressdetails: parseBool(q["addressdetails"]) || q["format"] === "jsonld",
 			format: parseFormat(q["format"]),
 			acceptLanguage: asString(q["accept-language"]),
 		}
 		const result = await engine.reverse(params)
-		res.json(params.format === "geojson" ? toFeatureCollection(result ? [result] : []) : result)
+
+		if (params.format === "geojson") {
+			res.json(toFeatureCollection(result ? [result] : []))
+		} else if (params.format === "jsonld") {
+			// #1052: a single reverse hit → one schema.org `Place` (or null when unresolved).
+			res.json(result ? nominatimResultToSchemaOrg(result) : null)
+		} else {
+			res.json(result)
+		}
 	}
 
 	const lookup: RequestHandler = async (req, res) => {
@@ -436,4 +462,25 @@ export function toNominatimResult(r: ResolvedAddress, opts: { addressdetails?: b
 	}
 
 	return result
+}
+
+/**
+ * Project a Nominatim result into a schema.org `Place` JSON-LD object (`format=jsonld`, #1052) — the OUTPUT-format
+ * projection. Reads the result's `address` breakdown (populated because the router forces `addressdetails` for
+ * `jsonld`) plus the coordinate, re-serializing the SAME resolved place. `streetAddress` is the plain
+ * house-number-first join (house_number + road); `addressCountry` is ISO-3166 alpha-2 (uppercased).
+ */
+export function nominatimResultToSchemaOrg(r: NominatimResult): SchemaOrgPlace {
+	const a = r.address ?? {}
+	const streetAddress = composeStreetAddress({ houseNumber: a.house_number, street: a.road })
+
+	return toSchemaOrg({
+		lat: r.lat ? Number(r.lat) : null,
+		lon: r.lon ? Number(r.lon) : null,
+		streetAddress: streetAddress || undefined,
+		locality: a.city ?? a.town ?? a.village,
+		region: a.state,
+		postalCode: a.postcode,
+		countryCode: a.country_code,
+	})
 }

--- a/photon/index.test.ts
+++ b/photon/index.test.ts
@@ -6,11 +6,14 @@
 
 import type { AddressInfo } from "node:net"
 
+import type { SchemaOrgPlace } from "@mailwoman/annotations"
 import express from "express"
 import { expect, test } from "vitest"
 
 import {
 	createPhotonRouter,
+	photonFeature,
+	photonFeatureToSchemaOrg,
 	photonForwardCollection,
 	photonForwardFeature,
 	type PhotonForwardInput,
@@ -241,6 +244,95 @@ test("photonForwardFeature: wraps properties as a Point Feature at [lon, lat]", 
 	expect(f.type).toBe("Feature")
 	expect(f.geometry).toEqual({ type: "Point", coordinates: [13.4, 52.5] })
 	expect(f.properties.city).toBe("Berlin")
+})
+
+// #1052 — schema.org Place/PostalAddress/GeoCoordinates JSON-LD as an alternate output format (`format=jsonld`).
+
+test("photonFeatureToSchemaOrg: projects a house feature into a schema.org Place (#1052)", () => {
+	const feature = photonForwardFeature({
+		lat: 48.8548,
+		lon: 2.3451,
+		postcode: "75001",
+		country: { name: "France", code: "FR" },
+		places: [{ tag: "locality", name: "Paris" }],
+		house: { number: "8", street: "Boulevard du Palais" },
+	})
+	const place = photonFeatureToSchemaOrg(feature)
+
+	expect(place["@context"]).toBe("https://schema.org")
+	expect(place["@type"]).toBe("Place")
+	expect(place.geo).toEqual({ "@type": "GeoCoordinates", latitude: 48.8548, longitude: 2.3451 })
+	expect(place.address?.["@type"]).toBe("PostalAddress")
+	expect(place.address?.streetAddress).toBe("8 Boulevard du Palais")
+	expect(place.address?.addressLocality).toBe("Paris")
+	expect(place.address?.postalCode).toBe("75001")
+	expect(place.address?.addressCountry).toBe("FR") // ISO-3166 alpha-2, uppercased
+})
+
+const jsonldEngine: PhotonEngine = {
+	search: async () =>
+		photonForwardCollection(
+			{
+				primary: {
+					lat: 48.8548,
+					lon: 2.3451,
+					postcode: "75001",
+					country: { name: "France", code: "FR" },
+					places: [{ tag: "locality", name: "Paris" }],
+					house: { number: "8", street: "Boulevard du Palais" },
+				},
+				alternatives: [],
+			},
+			1
+		),
+	reverse: async () => ({
+		type: "FeatureCollection",
+		features: [
+			photonFeature(2.3522, 48.8566, {
+				osm_key: "place",
+				osm_value: "city",
+				type: "city",
+				name: "Paris",
+				city: "Paris",
+				countrycode: "fr",
+			}),
+		],
+	}),
+}
+
+test("route: /reverse?format=jsonld returns schema.org Place[] JSON-LD (#1052)", async () => {
+	await withServer(express().use(createPhotonRouter(jsonldEngine)), async (base) => {
+		const res = await fetch(`${base}/reverse?lat=48.8566&lon=2.3522&format=jsonld`)
+		expect(res.status).toBe(200)
+		const body = (await res.json()) as SchemaOrgPlace[]
+		expect(Array.isArray(body)).toBe(true)
+		const place = body[0]!
+		expect(place["@context"]).toBe("https://schema.org")
+		expect(place["@type"]).toBe("Place")
+		expect(place.name).toBe("Paris")
+		expect(place.address?.addressLocality).toBe("Paris")
+		expect(place.address?.addressCountry).toBe("FR")
+	})
+})
+
+test("route: /api?format=jsonld returns schema.org Place[] JSON-LD; default stays GeoJSON (#1052)", async () => {
+	await withServer(express().use(createPhotonRouter(jsonldEngine)), async (base) => {
+		const res = await fetch(`${base}/api?q=8+boulevard+du+palais&format=jsonld`)
+		expect(res.status).toBe(200)
+		const body = (await res.json()) as SchemaOrgPlace[]
+		expect(Array.isArray(body)).toBe(true)
+		const place = body[0]!
+		expect(place["@context"]).toBe("https://schema.org")
+		expect(place["@type"]).toBe("Place")
+		expect(place.address?.["@type"]).toBe("PostalAddress")
+		expect(place.address?.streetAddress).toBe("8 Boulevard du Palais")
+		expect(place.address?.addressCountry).toBe("FR")
+		expect(place.geo?.latitude).toBeCloseTo(48.8548)
+
+		// The native GeoJSON FeatureCollection stays the default (no format param).
+		const def = (await (await fetch(`${base}/api?q=x`)).json()) as { type: string }
+		expect(def.type).toBe("FeatureCollection")
+	})
 })
 
 test("CORS: permissive Access-Control-Allow-Origin on responses (upstream Photon parity)", async () => {

--- a/photon/index.ts
+++ b/photon/index.ts
@@ -14,6 +14,7 @@
  *   / the Photon child); routes whose engine method is absent answer `501`.
  */
 
+import { composeStreetAddress, type SchemaOrgPlace, toSchemaOrg } from "@mailwoman/annotations"
 import { type RequestHandler, Router } from "express"
 
 /**
@@ -209,7 +210,10 @@ export function createPhotonRouter(engine: PhotonEngine, options: PhotonRouterOp
 			osmTag: asStringArray(q["osm_tag"]),
 			layer: asStringArray(q["layer"]),
 		}
-		res.json(await engine.search(params))
+		const collection = await engine.search(params)
+		// #1052: `format=jsonld` re-serializes the SAME FeatureCollection as schema.org `Place[]` JSON-LD;
+		// the native GeoJSON FeatureCollection stays the default.
+		res.json(asString(q["format"]) === "jsonld" ? photonToSchemaOrg(collection) : collection)
 	}
 
 	const reverse: RequestHandler = async (req, res) => {
@@ -240,7 +244,9 @@ export function createPhotonRouter(engine: PhotonEngine, options: PhotonRouterOp
 			lang: asString(q["lang"]),
 			radius: q["radius"] != null ? Number(q["radius"]) : undefined,
 		}
-		res.json(await engine.reverse(params))
+		const collection = await engine.reverse(params)
+		// #1052: `format=jsonld` re-serializes the reverse FeatureCollection as schema.org `Place[]` JSON-LD.
+		res.json(asString(q["format"]) === "jsonld" ? photonToSchemaOrg(collection) : collection)
 	}
 
 	// Safety net: malformed input or an engine fault returns an empty FeatureCollection, never a crash.
@@ -441,4 +447,32 @@ export function photonForwardCollection(result: PhotonForwardResult, limit: numb
 	}
 
 	return photonCollection(features)
+}
+
+/**
+ * Project a Photon `Feature` into a schema.org `Place` JSON-LD object (`format=jsonld`, #1052) — the OUTPUT-format
+ * projection. Reads the feature's already-decorated {@link PhotonProperties} (housenumber/street/city/state/postcode/
+ * countrycode + the coordinate), so it stays a pure re-serialization of the SAME resolved place the FeatureCollection
+ * carries. `streetAddress` is the plain house-number-first join (the light router has no locale formatter).
+ */
+export function photonFeatureToSchemaOrg(feature: PhotonFeature): SchemaOrgPlace {
+	const p = feature.properties
+	const [lon, lat] = feature.geometry.coordinates
+	const streetAddress = composeStreetAddress({ houseNumber: p.housenumber, street: p.street })
+
+	return toSchemaOrg({
+		lat,
+		lon,
+		name: p.name,
+		streetAddress: streetAddress || undefined,
+		locality: p.city,
+		region: p.state,
+		postalCode: p.postcode,
+		countryCode: p.countrycode,
+	})
+}
+
+/** Project a whole Photon `FeatureCollection` into an array of schema.org `Place` objects (`format=jsonld`). #1052. */
+export function photonToSchemaOrg(collection: PhotonFeatureCollection): SchemaOrgPlace[] {
+	return collection.features.map(photonFeatureToSchemaOrg)
 }

--- a/photon/package.json
+++ b/photon/package.json
@@ -36,6 +36,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@mailwoman/annotations": "workspace:*",
 		"@mailwoman/ban": "workspace:*",
 		"@mailwoman/codex": "workspace:*",
 		"@mailwoman/neural": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4911,6 +4911,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mailwoman/photon@workspace:photon"
   dependencies:
+    "@mailwoman/annotations": "workspace:*"
     "@mailwoman/ban": "workspace:*"
     "@mailwoman/codex": "workspace:*"
     "@mailwoman/neural": "workspace:*"
@@ -16782,11 +16783,13 @@ __metadata:
   dependencies:
     "@fragaria/address-formatter": "npm:^6.7.1"
     "@inkjs/ui": "npm:^2.0.0"
+    "@mailwoman/annotations": "workspace:*"
     "@mailwoman/ban": "workspace:*"
     "@mailwoman/classifiers": "workspace:*"
     "@mailwoman/codex": "workspace:*"
     "@mailwoman/core": "workspace:*"
     "@mailwoman/corpus": "workspace:*"
+    "@mailwoman/formatter": "workspace:*"
     "@mailwoman/kind-classifier": "workspace:*"
     "@mailwoman/locale-gate": "workspace:*"
     "@mailwoman/neural": "workspace:*"


### PR DESCRIPTION
Closes #1052.

schema.org [`Place`](https://schema.org/Place) / [`PostalAddress`](https://schema.org/PostalAddress) / [`GeoCoordinates`](https://schema.org/GeoCoordinates) JSON-LD as an **output projection** — the web's de-facto address interchange, for CMS/SEO/knowledge-graph pipelines. Lossy by design (per the issue): `streetAddress` is one opaque line, and tiers/confidence/provenance are dropped rather than shoehorned into an extension property. `addressCountry` is ISO-3166 alpha-2. Absent fields are omitted entirely (never `null`).

## Surfaces covered

- **`@mailwoman/annotations`** — `toSchemaOrg()` + `composeStreetAddress()`, beside the `toOpenCage()` precedent. Pure serializer over a neutral resolved-address shape (no `@mailwoman/*` runtime dep); one native shape, a serializer per wire format.
- **CLI** — `mailwoman geocode --format jsonld`. `streetAddress` is rendered locale-aware by `@mailwoman/formatter` (house-number placement follows the resolved country: `de-DE` number-last, `en-US`/`fr-FR` number-first).
- **Photon drop-in** — `format=jsonld` on `/api` + `/reverse` (native GeoJSON `FeatureCollection` stays the default). Re-serializes the same FeatureCollection to `Place[]`.
- **Nominatim drop-in** — `format=jsonld` on `/search` + `/reverse` (jsonv2 stays the default). `jsonld` forces `addressdetails` so the `PostalAddress` is populated; `/search` → `Place[]`, `/reverse` → a single `Place`.

## Local smoke — Photon, `format=jsonld`, `8 Boulevard du Palais, 75001 Paris`

`curl "http://127.0.0.1:8899/api?q=8 Boulevard du Palais, 75001 Paris&format=jsonld&limit=1"` (candidate gazetteer + BAN-FR rooftop tier, `$MAILWOMAN_DATA_ROOT`):

```json
[
    {
        "@context": "https://schema.org",
        "@type": "Place",
        "geo": {
            "@type": "GeoCoordinates",
            "latitude": 48.854843,
            "longitude": 2.345141
        },
        "address": {
            "@type": "PostalAddress",
            "streetAddress": "8 Boulevard du Palais",
            "addressLocality": "Paris",
            "postalCode": "75001",
            "addressCountry": "FR"
        }
    }
]
```

CLI, `mailwoman geocode "350 5th Ave, New York, NY 10118" --format jsonld` (formatter-rendered street line):

```json
{
  "@context": "https://schema.org",
  "@type": "Place",
  "geo": { "@type": "GeoCoordinates", "latitude": 40.747773, "longitude": -73.985046 },
  "address": {
    "@type": "PostalAddress",
    "streetAddress": "350 5th Ave",
    "addressLocality": "New York",
    "addressRegion": "NY",
    "postalCode": "10118",
    "addressCountry": "US"
  }
}
```

## Scope

**Zero coordinate logic — the diff touches no resolver / parser / `geocode-core` path.** It re-serializes the SAME resolved place each surface already produces, so no gauntlet is needed. Changed: `annotations/`, `photon/`, `nominatim/`, the CLI `geocode` command, and two `package.json` dep additions (`@mailwoman/annotations` → photon; `@mailwoman/annotations` + `@mailwoman/formatter` → mailwoman).

## Gates

- `yarn compile` (tsc -b) green.
- Affected tests green: annotations (11), photon (22), nominatim (13), CLI geocode (7, incl. the DB-gated `--format=jsonld` integration test).
- `yarn lint` (oxlint + oxfmt) clean on the changed files.

## Tests

- **Unit** (`annotations`): field presence/omission, no-nulls, ISO-3166 alpha-2 uppercasing, `geo` omitted on missing/non-finite coords, PO-box → `postOfficeBoxNumber`, and the `streetAddress` lossy collapse (house# + street + unit).
- **Route** (one per endpoint touched): photon `/api` + `/reverse`, nominatim `/search` + `/reverse` — structural JSON-LD assertions in-test (no external validator calls in CI). The nominatim `/search` test also proves the router forces `addressdetails` for `jsonld`.

## Follow-ups deferred

- **Endpoint `streetAddress`** uses a plain house-number-first join (the light router packages carry no locale formatter); the CLI is locale-aware via `@mailwoman/formatter`. Unifying endpoints on the formatter is a cheap v2 if a non-number-first locale needs it.
- **`name` / `postOfficeBoxNumber`** are supported in `toSchemaOrg` but populated only where a venue name / PO box is already surfaced (photon carries `name`); threading PO-box + venue through `GeocodeResult` is out of scope here.
- **`addressCountry` on the endpoints** follows each engine's existing country derivation — a candidate-backed result whose hierarchy omits the country tag omits `addressCountry` (correct omit-absent; photon fills it from `GeocodeResult.countryCode`).
- **CI contract tests** against schema.org's validator + Google Rich Results (the issue's #1014/#1016 lesson) — left as a follow-up; in-repo tests assert the shape structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
