### PR TITLE
docs: OpenAPI 3.1 specs for the photon/nominatim/libpostal drop-ins (redocly-validated)

### DIFF
--- a/docs/articles/api.mdx
+++ b/docs/articles/api.mdx
@@ -239,3 +239,21 @@ The full `ComponentTag` union (source of truth: `core/types/component.ts`):
 | `cedex`              | FR postal routing      | `CEDEX 08`         |
 
 The current neural model (v0.4.0) emits 10 of these: country, region, locality, dependent_locality, postcode, subregion, cedex, venue, street, house_number. The remaining tags are rule-classifier-only.
+
+## Drop-in server specifications (OpenAPI 3.1)
+
+The three HTTP drop-ins each ship a machine-readable [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0.html) specification — the endpoints, query parameters, response shapes, the schema.org `jsonld` variants, and the documented divergences from each upstream. Point Swagger UI, Redoc, a client generator, or a contract test at them.
+
+| Drop-in                                                                     | Endpoints                                   | Specification                                          |
+| --------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------- |
+| [`@mailwoman/photon`](https://www.npmjs.com/package/@mailwoman/photon)       | `/api`, `/reverse`                          | [photon.yaml](pathname:///openapi/photon.yaml)         |
+| [`@mailwoman/nominatim`](https://www.npmjs.com/package/@mailwoman/nominatim) | `/search`, `/reverse`, `/lookup`, `/status` | [nominatim.yaml](pathname:///openapi/nominatim.yaml)   |
+| [`@mailwoman/libpostal`](https://www.npmjs.com/package/@mailwoman/libpostal) | `/parse`, `/expand`                         | [libpostal.yaml](pathname:///openapi/libpostal.yaml)   |
+
+The source of truth for each is `openapi.yaml` at the workspace root; the copies above are published as static site assets. All three validate against the OpenAPI standard with zero errors under [Redocly CLI](https://redocly.com/docs/cli):
+
+```bash
+npx --yes @redocly/cli@latest lint photon/openapi.yaml
+npx --yes @redocly/cli@latest lint nominatim/openapi.yaml
+npx --yes @redocly/cli@latest lint libpostal/openapi.yaml
+```

--- a/docs/static/openapi/libpostal.yaml
+++ b/docs/static/openapi/libpostal.yaml
@@ -1,0 +1,268 @@
+# @mailwoman/libpostal — OpenAPI 3.1 specification
+#
+# The libpostal-compatible parse/expand HTTP drop-in (/parse, /expand) served by
+# `npx @mailwoman/libpostal serve`. Wire shapes taken verbatim from libpostal/index.ts +
+# libpostal/cli.ts.
+#
+# Validate (Redocly CLI 2.38.0, zero errors):
+#   cd libpostal && npx --yes @redocly/cli@latest lint openapi.yaml
+
+openapi: 3.1.0
+
+info:
+  title: "@mailwoman/libpostal"
+  version: 5.10.1
+  summary: libpostal-compatible address parse / expand API.
+  description: >
+    A drop-in replacement for [libpostal](https://github.com/openvenues/libpostal)'s REST
+    server — the same `/parse` (`parse_address`) and `/expand` (`expand_address`) contract,
+    backed by Mailwoman's calibrated neural address parser. The lowest-dependency drop-in:
+    `/parse` needs no gazetteer, just the model.
+
+
+    **Drop-in compatibility.** `/parse` returns an ordered array of `{ label, value }`
+    components, mapping Mailwoman's `ComponentTag` classifications onto libpostal's OSM-derived
+    labels (`street`→`road`, `locality`→`city`, `region`→`state`, …). Unmapped classifications
+    pass through unchanged.
+
+
+    **Known divergences from upstream libpostal.**
+
+    - `/expand` is deterministic. Mailwoman's normalization is rule-based, so `/expand` returns
+      the original string plus its normalized + abbreviation-expanded forms — one canonical
+      alternative set, not libpostal's probabilistic multi-variant hypothesis expansion.
+    - `GET /` serves a friendly HTML banner; libpostal's own REST server has no root page.
+
+
+    **Request forms.** Both `/parse` and `/expand` accept `GET` (with a query-string parameter)
+    and `POST` (with a JSON body). The `serve` CLI reads query-string parameters directly; mount
+    a JSON body parser (e.g. `express.json()`) to accept `POST` JSON bodies.
+
+
+    **CORS.** Permissive CORS is on by default (`Access-Control-Allow-Origin: *`, and a `204`
+    answer to preflight `OPTIONS` — the `POST /parse` preflight needs it). Disable with
+    `serve --no-cors` when a reverse proxy already owns the headers.
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+    identifier: AGPL-3.0-only
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+
+externalDocs:
+  description: Switching from libpostal (setup, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-libpostal
+
+servers:
+  - url: http://{host}:{port}
+    description: Self-hosted server (`npx @mailwoman/libpostal serve`).
+    variables:
+      host:
+        default: 127.0.0.1
+        description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+      port:
+        default: "8081"
+        description: The port passed to `serve --port` (default 8081).
+
+# These endpoints require no authentication (self-host); declared explicitly for tooling.
+security: []
+
+tags:
+  - name: parsing
+    description: Address parsing and expansion endpoints.
+  - name: meta
+    description: Non-parsing informational endpoints.
+
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+      tags: [meta]
+      responses:
+        "200":
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /parse:
+    get:
+      operationId: parseGet
+      summary: Parse an address (query string)
+      description: Parse a free-text address into ordered labeled components.
+      tags: [parsing]
+      parameters:
+        - name: query
+          in: query
+          description: The address to parse. `address` is accepted as an alias.
+          required: false
+          schema: { type: string }
+        - name: address
+          in: query
+          description: Alias for `query`.
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          $ref: "#/components/responses/ParseResult"
+        "400":
+          $ref: "#/components/responses/MissingQuery"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      operationId: parsePost
+      summary: Parse an address (JSON body)
+      description: Parse a free-text address into ordered labeled components.
+      tags: [parsing]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ParseRequest" }
+            example: { query: "1600 Pennsylvania Ave NW, Washington DC 20500" }
+      responses:
+        "200":
+          $ref: "#/components/responses/ParseResult"
+        "400":
+          $ref: "#/components/responses/MissingQuery"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /expand:
+    get:
+      operationId: expandGet
+      summary: Expand an address (query string)
+      description: Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence note).
+      tags: [parsing]
+      parameters:
+        - name: address
+          in: query
+          description: The address to expand.
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          $ref: "#/components/responses/ExpandResult"
+        "400":
+          $ref: "#/components/responses/MissingAddress"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+    post:
+      operationId: expandPost
+      summary: Expand an address (JSON body)
+      description: Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence note).
+      tags: [parsing]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ExpandRequest" }
+            example: { address: "1600 pennsylvania ave nw" }
+      responses:
+        "200":
+          $ref: "#/components/responses/ExpandResult"
+        "400":
+          $ref: "#/components/responses/MissingAddress"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+components:
+  responses:
+    ParseResult:
+      description: The ordered libpostal components.
+      content:
+        application/json:
+          schema:
+            type: array
+            items: { $ref: "#/components/schemas/LibpostalComponent" }
+          example:
+            - { label: house_number, value: "1600" }
+            - { label: road, value: Pennsylvania Ave NW }
+            - { label: city, value: Washington }
+            - { label: state, value: DC }
+            - { label: postcode, value: "20500" }
+    ExpandResult:
+      description: The deterministic expansion set.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ExpandResponse" }
+          example:
+            expansions:
+              - "1600 pennsylvania ave nw"
+              - "1600 pennsylvania avenue northwest"
+    MissingQuery:
+      description: The required `query` (or `address`) parameter is missing.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "query is required" }
+    MissingAddress:
+      description: The required `address` parameter is missing.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "address is required" }
+    InternalError:
+      description: An unexpected engine fault. Returns a clean JSON error, never a stack trace.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "internal error" }
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "expand not implemented" }
+
+  schemas:
+    ParseRequest:
+      type: object
+      description: A `/parse` request body. Provide `query` (or its alias `address`).
+      properties:
+        query: { type: string, description: The address to parse. }
+        address: { type: string, description: Alias for `query`. }
+      additionalProperties: false
+
+    ExpandRequest:
+      type: object
+      description: An `/expand` request body.
+      required: [address]
+      properties:
+        address: { type: string, description: The address to expand. }
+      additionalProperties: false
+
+    LibpostalComponent:
+      type: object
+      description: A libpostal `parse_address` component — a label and the text span it covers, in order.
+      required: [label, value]
+      properties:
+        label: { type: string, description: "The libpostal label, e.g. `house_number`, `road`, `city`, `state`, `postcode`." }
+        value: { type: string, description: The text the label covers. }
+      additionalProperties: false
+
+    ExpandResponse:
+      type: object
+      description: The `/expand` response.
+      required: [expansions]
+      properties:
+        expansions:
+          type: array
+          description: The distinct expanded forms (original + normalized + abbreviation-expanded), order preserved.
+          items: { type: string }
+      additionalProperties: false
+
+    Error:
+      type: object
+      description: A JSON error envelope.
+      required: [error]
+      properties:
+        error: { type: string }
+      additionalProperties: false

--- a/docs/static/openapi/nominatim.yaml
+++ b/docs/static/openapi/nominatim.yaml
@@ -1,0 +1,516 @@
+# @mailwoman/nominatim — OpenAPI 3.1 specification
+#
+# The Nominatim-compatible HTTP geocoding drop-in (/search, /reverse, /lookup, /status)
+# served by `npx @mailwoman/nominatim serve`. Wire shapes taken verbatim from
+# nominatim/index.ts + nominatim/cli.ts.
+#
+# Validate (Redocly CLI 2.38.0, zero errors):
+#   cd nominatim && npx --yes @redocly/cli@latest lint openapi.yaml
+
+openapi: 3.1.0
+
+info:
+  title: "@mailwoman/nominatim"
+  version: 5.10.1
+  summary: Nominatim-compatible HTTP geocoding API.
+  description: >
+    A drop-in replacement for [Nominatim](https://nominatim.org) — the same `/search`,
+    `/reverse`, `/lookup`, and `/status` contract, returning `jsonv2` result objects (and
+    `geojson` / `jsonld` on request), served from a SQLite gazetteer over the Mailwoman
+    engine instead of a PostgreSQL/PostGIS `osm2pgsql` import.
+
+
+    **Drop-in compatibility.** Point an existing Nominatim client (`geopy`, …) at this server
+    and forward + reverse geocoding work unchanged. Result objects carry the fields Nominatim
+    clients parse — `place_id`, `licence`, `lat`, `lon`, `display_name`, `boundingbox`,
+    `class`, `type`, `importance`, and the `address` breakdown when `addressdetails=1`.
+
+
+    **Known divergences from upstream Nominatim.**
+
+    - Every result carries an OpenCage-style `annotations` block (coordinate formats, country
+      flag, calling code, currency, and — when their data bundles are present — IANA timezone,
+      UN/LOCODE, and EU NUTS codes). Plain Nominatim returns none of these.
+    - `format=jsonld` is a Mailwoman extension (not in upstream Nominatim): it re-serializes
+      each result as a [schema.org `Place`](https://schema.org/Place) JSON-LD object. `jsonv2`
+      stays the default.
+    - `/lookup` is part of the router contract but is not wired in the bundled `serve` engine
+      yet, so it answers `501`.
+    - `licence` reports the Mailwoman data sources (Who's On First, Overture Maps,
+      OpenAddresses, US Census TIGER), not OSM/ODbL.
+    - `GET /` serves a friendly HTML banner; Nominatim itself has only `/status`.
+
+
+    **CORS.** Permissive CORS is on by default (`Access-Control-Allow-Origin: *`, and a `204`
+    answer to preflight `OPTIONS`). Disable with `serve --no-cors` when a reverse proxy already
+    owns the headers.
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+    identifier: AGPL-3.0-only
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+
+externalDocs:
+  description: Switching from Nominatim (setup, hosted data, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-nominatim
+
+servers:
+  - url: http://{host}:{port}
+    description: Self-hosted server (`npx @mailwoman/nominatim serve`).
+    variables:
+      host:
+        default: 127.0.0.1
+        description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+      port:
+        default: "8080"
+        description: The port passed to `serve --port` (default 8080).
+
+# These endpoints require no authentication (self-host); declared explicitly for tooling.
+security: []
+
+tags:
+  - name: geocoding
+    description: Forward, reverse, and id-based geocoding endpoints.
+  - name: meta
+    description: Health and informational endpoints.
+
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+      tags: [meta]
+      responses:
+        "200":
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /search:
+    get:
+      operationId: search
+      summary: Forward geocoding
+      description: >
+        Geocode a free-text `q`, or a structured (`street`/`city`/`state`/`postalcode`/`country`)
+        query, into ranked results.
+      tags: [geocoding]
+      parameters:
+        - name: q
+          in: query
+          description: Free-text query. Mutually exclusive with the structured parameters.
+          required: false
+          schema: { type: string }
+        - name: street
+          in: query
+          description: Structured query — street (with optional house number).
+          required: false
+          schema: { type: string }
+        - name: city
+          in: query
+          description: Structured query — city.
+          required: false
+          schema: { type: string }
+        - name: county
+          in: query
+          description: Structured query — county.
+          required: false
+          schema: { type: string }
+        - name: state
+          in: query
+          description: Structured query — state / region.
+          required: false
+          schema: { type: string }
+        - name: country
+          in: query
+          description: Structured query — country.
+          required: false
+          schema: { type: string }
+        - name: postalcode
+          in: query
+          description: Structured query — postal code.
+          required: false
+          schema: { type: string }
+        - name: countrycodes
+          in: query
+          description: >
+            Comma-separated ISO-3166 alpha-2 codes restricting results to those countries
+            (Nominatim semantics — a hard restriction; the first is applied as the country
+            constraint).
+          required: false
+          schema: { type: string }
+        - $ref: "#/components/parameters/Limit"
+        - name: bounded
+          in: query
+          description: Restrict results to the viewbox (`1`) or not (`0`).
+          required: false
+          schema: { type: integer, enum: [0, 1], default: 0 }
+        - $ref: "#/components/parameters/AddressDetails"
+        - $ref: "#/components/parameters/Format"
+        - $ref: "#/components/parameters/AcceptLanguage"
+      responses:
+        "200":
+          description: >
+            An array of result objects (`jsonv2`/`json`), a GeoJSON `FeatureCollection`
+            (`geojson`), or an array of schema.org `Place` objects (`jsonld`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items: { $ref: "#/components/schemas/NominatimResult" }
+                  - $ref: "#/components/schemas/NominatimFeatureCollection"
+                  - type: array
+                    items: { $ref: "#/components/schemas/SchemaOrgPlace" }
+              example:
+                - place_id: 240087473
+                  licence: "Data © Who's On First, Overture Maps, OpenAddresses, US Census TIGER"
+                  lat: "38.8977"
+                  lon: "-77.0365"
+                  display_name: "1600, Pennsylvania Avenue NW, Washington, DC, 20500, United States"
+                  class: place
+                  type: house
+                  address:
+                    house_number: "1600"
+                    road: Pennsylvania Avenue NW
+                    city: Washington
+                    state: DC
+                    postcode: "20500"
+                    country: United States
+                    country_code: us
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /reverse:
+    get:
+      operationId: reverse
+      summary: Reverse geocoding
+      description: Resolve a coordinate to the nearest address (point-in-polygon over the WOF admin hierarchy).
+      tags: [geocoding]
+      parameters:
+        - name: lat
+          in: query
+          description: Latitude to reverse geocode.
+          required: true
+          schema: { type: number, format: double, minimum: -90, maximum: 90 }
+        - name: lon
+          in: query
+          description: Longitude to reverse geocode.
+          required: true
+          schema: { type: number, format: double, minimum: -180, maximum: 180 }
+        - name: zoom
+          in: query
+          description: Level of detail (Nominatim zoom, 0–18).
+          required: false
+          schema: { type: integer, minimum: 0, maximum: 18 }
+        - $ref: "#/components/parameters/AddressDetails"
+        - $ref: "#/components/parameters/Format"
+        - $ref: "#/components/parameters/AcceptLanguage"
+      responses:
+        "200":
+          description: >
+            A single result object (`jsonv2`/`json`), a GeoJSON `FeatureCollection`
+            (`geojson`), or a schema.org `Place` (`jsonld`). Returns JSON `null` when nothing
+            resolves.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/NominatimResult"
+                  - $ref: "#/components/schemas/NominatimFeatureCollection"
+                  - $ref: "#/components/schemas/SchemaOrgPlace"
+                  - type: "null"
+        "400":
+          description: "`lat`/`lon` are missing or out of range."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+              example: { error: "lat and lon are required" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /lookup:
+    get:
+      operationId: lookup
+      summary: Look up known place ids
+      description: >
+        Resolve one or more OSM/place ids to result objects. Part of the router contract; not
+        wired in the bundled `serve` engine yet (answers `501`).
+      tags: [geocoding]
+      parameters:
+        - name: osm_ids
+          in: query
+          description: Comma-separated place ids to look up.
+          required: true
+          schema: { type: string }
+        - $ref: "#/components/parameters/AddressDetails"
+        - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: An array of result objects (`jsonv2`/`json`) or a GeoJSON `FeatureCollection` (`geojson`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items: { $ref: "#/components/schemas/NominatimResult" }
+                  - $ref: "#/components/schemas/NominatimFeatureCollection"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /status:
+    get:
+      operationId: status
+      summary: Service status
+      description: Health check plus data version. Mirrors Nominatim's `/status?format=json`.
+      tags: [meta]
+      responses:
+        "200":
+          description: "Service status. `status: 0` means OK."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/NominatimStatus" }
+              example: { status: 0, message: OK }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  parameters:
+    Limit:
+      name: limit
+      in: query
+      description: Maximum number of results to return.
+      required: false
+      schema: { type: integer, minimum: 1, default: 10 }
+    AddressDetails:
+      name: addressdetails
+      in: query
+      description: Include a structured `address` breakdown (`1`) or not (`0`). Forced on for `format=jsonld`.
+      required: false
+      schema: { type: integer, enum: [0, 1], default: 0 }
+    Format:
+      name: format
+      in: query
+      description: >
+        Output serialization. `jsonv2` (default) and `json` return result objects; `geojson`
+        returns a `FeatureCollection`; `jsonld` (a Mailwoman extension) returns schema.org
+        `Place` JSON-LD.
+      required: false
+      schema:
+        type: string
+        enum: [jsonv2, json, geojson, jsonld]
+        default: jsonv2
+    AcceptLanguage:
+      name: accept-language
+      in: query
+      description: Preferred result language(s) (BCP-47), as a query parameter.
+      required: false
+      schema: { type: string }
+
+  responses:
+    InternalError:
+      description: An unexpected engine fault. Returns a clean JSON error, never a stack trace.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "internal error" }
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "lookup not implemented (see #805)" }
+
+  schemas:
+    NominatimResult:
+      type: object
+      description: A Nominatim result object (the shape `geopy` and friends parse).
+      required: [place_id, licence, lat, lon, display_name]
+      properties:
+        place_id: { type: [integer, string] }
+        licence: { type: string, description: The attribution string for the resolved data sources. }
+        osm_type: { type: string }
+        osm_id: { type: [integer, string] }
+        lat: { type: string, description: "Latitude, as a string (Nominatim convention)." }
+        lon: { type: string, description: "Longitude, as a string (Nominatim convention)." }
+        display_name: { type: string }
+        boundingbox:
+          type: array
+          description: "`[south, north, west, east]` as strings (Nominatim convention)."
+          minItems: 4
+          maxItems: 4
+          items: { type: string }
+        class: { type: string }
+        type: { type: string }
+        importance: { type: number }
+        place_rank: { type: integer }
+        address: { $ref: "#/components/schemas/NominatimAddressDetails" }
+        geojson:
+          description: Present when `format=geojson` or `polygon_geojson=1` — a GeoJSON geometry.
+        annotations: { $ref: "#/components/schemas/OpenCageAnnotations" }
+      additionalProperties: true
+
+    NominatimAddressDetails:
+      type: object
+      description: The structured address breakdown returned under `address` when `addressdetails=1`. Keys mirror Nominatim's OSM-derived tag names.
+      properties:
+        house_number: { type: string }
+        road: { type: string }
+        neighbourhood: { type: string }
+        suburb: { type: string }
+        city: { type: string }
+        town: { type: string }
+        village: { type: string }
+        county: { type: string }
+        state: { type: string }
+        postcode: { type: string }
+        country: { type: string }
+        country_code: { type: string, description: "ISO-3166 alpha-2, lowercased." }
+      additionalProperties:
+        type: string
+
+    NominatimStatus:
+      type: object
+      description: "The `/status` payload. `status: 0` means OK."
+      required: [status, message]
+      properties:
+        status: { type: integer, description: "`0` = OK; non-zero = a fault code." }
+        message: { type: string }
+        data_updated: { type: string, description: When the underlying data was last built (ISO-8601). }
+      additionalProperties: false
+
+    NominatimFeatureCollection:
+      type: object
+      description: A GeoJSON `FeatureCollection` — the `format=geojson` envelope (RFC 7946).
+      externalDocs:
+        description: GeoJSON (RFC 7946)
+        url: https://www.rfc-editor.org/rfc/rfc7946
+      required: [type, features]
+      properties:
+        type: { const: FeatureCollection }
+        features:
+          type: array
+          items:
+            type: object
+            required: [type, properties, geometry]
+            properties:
+              type: { const: Feature }
+              properties: { type: object, additionalProperties: true }
+              geometry:
+                description: A GeoJSON geometry (the place polygon when present, else a Point).
+              bbox:
+                type: array
+                description: "`[west, south, east, north]` (GeoJSON bbox order)."
+                minItems: 4
+                maxItems: 4
+                items: { type: number }
+            additionalProperties: true
+      additionalProperties: false
+
+    OpenCageAnnotations:
+      type: object
+      description: >
+        The OpenCage-style enrichment block, keyed and cased as OpenCage documents it. A
+        Mailwoman extension over upstream Nominatim. Only populated fields are emitted.
+      externalDocs:
+        description: OpenCage annotations
+        url: https://opencagedata.com/api#annotations
+      properties:
+        DMS:
+          type: object
+          properties:
+            lat: { type: string }
+            lng: { type: string }
+        MGRS: { type: string }
+        Maidenhead: { type: string }
+        Mercator:
+          type: object
+          properties:
+            x: { type: number }
+            y: { type: number }
+        geohash: { type: string }
+        qibla: { type: number }
+        sun:
+          type: object
+          properties:
+            rise: { type: object, additionalProperties: { type: number } }
+            set: { type: object, additionalProperties: { type: number } }
+        callingcode: { type: number }
+        currency:
+          type: object
+          properties:
+            iso_code: { type: string }
+            name: { type: string }
+            symbol: { type: string }
+        flag: { type: string, description: The country's flag emoji. }
+        timezone:
+          type: object
+          properties:
+            name: { type: string }
+            offset_sec: { type: number }
+            offset_string: { type: string }
+        NUTS:
+          type: object
+          description: EU NUTS region codes (when the NUTS data bundle is present).
+          properties:
+            NUTS0: { type: object, properties: { code: { type: string } } }
+            NUTS1: { type: object, properties: { code: { type: string } } }
+            NUTS2: { type: object, properties: { code: { type: string } } }
+            NUTS3: { type: object, properties: { code: { type: string } } }
+        UN_LOCODE: { type: string }
+        wikidata: { type: string }
+        FIPS:
+          type: object
+          properties:
+            county: { type: string }
+      additionalProperties: true
+
+    SchemaOrgPlace:
+      type: object
+      description: A schema.org `Place` JSON-LD object (the `format=jsonld` projection). Only populated fields are emitted.
+      externalDocs:
+        description: schema.org Place
+        url: https://schema.org/Place
+      required: ["@context", "@type"]
+      properties:
+        "@context": { const: "https://schema.org" }
+        "@type": { const: Place }
+        name: { type: string }
+        geo:
+          type: object
+          required: ["@type", latitude, longitude]
+          properties:
+            "@type": { const: GeoCoordinates }
+            latitude: { type: number }
+            longitude: { type: number }
+          additionalProperties: false
+        address:
+          type: object
+          required: ["@type"]
+          properties:
+            "@type": { const: PostalAddress }
+            streetAddress: { type: string }
+            postOfficeBoxNumber: { type: string }
+            addressLocality: { type: string }
+            addressRegion: { type: string }
+            postalCode: { type: string }
+            addressCountry: { type: string, description: "ISO-3166 alpha-2 (uppercased)." }
+          additionalProperties: false
+      additionalProperties: false
+
+    Error:
+      type: object
+      description: A JSON error envelope.
+      required: [error]
+      properties:
+        error: { type: string }
+      additionalProperties: false

--- a/docs/static/openapi/photon.yaml
+++ b/docs/static/openapi/photon.yaml
@@ -1,0 +1,376 @@
+# @mailwoman/photon — OpenAPI 3.1 specification
+#
+# The Photon-compatible autocomplete / reverse geocoding drop-in (GeoJSON FeatureCollection
+# over /api + /reverse) served by `npx @mailwoman/photon serve`. Wire shapes taken verbatim
+# from photon/index.ts + photon/cli.ts.
+#
+# Validate (Redocly CLI 2.38.0, zero errors):
+#   cd photon && npx --yes @redocly/cli@latest lint openapi.yaml
+
+openapi: 3.1.0
+
+info:
+  title: "@mailwoman/photon"
+  version: 5.10.1
+  summary: Photon-compatible autocomplete / type-ahead geocoding API.
+  description: >
+    A drop-in replacement for [Photon](https://github.com/komoot/photon) — the same `/api`
+    (forward / autocomplete) and `/reverse` contract, returning GeoJSON `FeatureCollection`s,
+    served from a SQLite gazetteer over the Mailwoman engine instead of an Elasticsearch cluster.
+
+
+    **Drop-in compatibility.** Point an existing Photon client (`leaflet-control-geocoder`,
+    `@openrunner/photon-geocoder`, …) at this server and forward + reverse geocoding work
+    unchanged. Every response is a GeoJSON `FeatureCollection` of `Point` features
+    (RFC 7946), and each feature's `properties` carry the OSM-derived key names a Photon
+    client reads (`osm_key`, `osm_value`, `type`, `name`, `housenumber`, `street`, `city`,
+    `state`, `country`, `countrycode`, …).
+
+
+    **Known divergences from upstream Photon.**
+
+    - `format=jsonld` is a Mailwoman extension (not in upstream Photon): it re-serializes the
+      *same* resolved places as an array of [schema.org `Place`](https://schema.org/Place)
+      JSON-LD objects. The native GeoJSON `FeatureCollection` stays the default.
+    - Results are ranked by the Mailwoman resolver (population-first candidate scoring with an
+      optional proximity re-rank), not Photon's Elasticsearch relevance model — ordering can
+      differ. The dedicated prefix-first FST autocomplete front is a refinement still in flight.
+    - `GET /` serves a friendly HTML banner; upstream Photon has no root page.
+
+
+    **CORS.** Permissive CORS is on by default (`Access-Control-Allow-Origin: *`, and a `204`
+    answer to preflight `OPTIONS`), matching upstream Photon — browser-embedded map widgets
+    need it. Disable with `serve --no-cors` when a reverse proxy already owns the headers.
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+    identifier: AGPL-3.0-only
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+
+externalDocs:
+  description: Switching from Photon (setup, hosted data, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-photon
+
+servers:
+  - url: https://photon.sister.software
+    description: Hosted public trial endpoint (conservative rate limits).
+  - url: http://{host}:{port}
+    description: Local self-hosted server (`npx @mailwoman/photon serve`).
+    variables:
+      host:
+        default: 127.0.0.1
+        description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+      port:
+        default: "2322"
+        description: The port passed to `serve --port` (default 2322).
+
+# These endpoints require no authentication (public / self-host); declared explicitly for tooling.
+security: []
+
+tags:
+  - name: geocoding
+    description: Forward (autocomplete) and reverse geocoding endpoints.
+  - name: meta
+    description: Non-geocoding informational endpoints.
+
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+      tags: [meta]
+      responses:
+        "200":
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /api:
+    get:
+      operationId: search
+      summary: Forward / autocomplete geocoding
+      description: >
+        Parse and resolve a free-text query into ranked places, returning a GeoJSON
+        `FeatureCollection` (or a schema.org `Place[]` when `format=jsonld`).
+      tags: [geocoding]
+      parameters:
+        - $ref: "#/components/parameters/Query"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Lang"
+        - name: lat
+          in: query
+          description: Latitude of a proximity bias (soft re-rank). Only applied when `lon` is also present.
+          required: false
+          schema: { type: number, format: double, minimum: -90, maximum: 90 }
+        - name: lon
+          in: query
+          description: Longitude of a proximity bias (soft re-rank). Only applied when `lat` is also present.
+          required: false
+          schema: { type: number, format: double, minimum: -180, maximum: 180 }
+        - name: osm_tag
+          in: query
+          description: Filter results by OSM tag (repeatable). Photon `key`, `key:value`, or `:value` syntax.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+        - name: layer
+          in: query
+          description: Filter results by layer (repeatable), e.g. `city`, `street`, `house`.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+        - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: >
+            A GeoJSON `FeatureCollection` of ranked `Point` features (default), or — when
+            `format=jsonld` — an array of schema.org `Place` objects.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/PhotonFeatureCollection"
+                  - type: array
+                    items: { $ref: "#/components/schemas/SchemaOrgPlace" }
+              example:
+                type: FeatureCollection
+                features:
+                  - type: Feature
+                    geometry:
+                      type: Point
+                      coordinates: [13.405, 52.52]
+                    properties:
+                      osm_key: place
+                      osm_value: city
+                      type: city
+                      name: Berlin
+                      state: Berlin
+                      country: Germany
+                      countrycode: de
+        "400":
+          description: The required `q` parameter is missing.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorFeatureCollection" }
+              example: { type: FeatureCollection, features: [], message: "q is required" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /reverse:
+    get:
+      operationId: reverse
+      summary: Reverse geocoding
+      description: >
+        Resolve a coordinate to the nearest place(s), returning a GeoJSON `FeatureCollection`
+        (or a schema.org `Place[]` when `format=jsonld`).
+      tags: [geocoding]
+      parameters:
+        - name: lat
+          in: query
+          description: Latitude to reverse geocode.
+          required: true
+          schema: { type: number, format: double, minimum: -90, maximum: 90 }
+        - name: lon
+          in: query
+          description: Longitude to reverse geocode.
+          required: true
+          schema: { type: number, format: double, minimum: -180, maximum: 180 }
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Lang"
+        - name: radius
+          in: query
+          description: Optional search radius (km) around the coordinate.
+          required: false
+          schema: { type: number, format: double, minimum: 0 }
+        - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: >
+            A GeoJSON `FeatureCollection` for the nearest place(s) (default), or — when
+            `format=jsonld` — an array of schema.org `Place` objects.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/PhotonFeatureCollection"
+                  - type: array
+                    items: { $ref: "#/components/schemas/SchemaOrgPlace" }
+        "400":
+          description: "`lat`/`lon` are missing or out of range."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorFeatureCollection" }
+              example: { type: FeatureCollection, features: [], message: "lat and lon are required" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+components:
+  parameters:
+    Query:
+      name: q
+      in: query
+      description: The free-text query to geocode (e.g. `1600 pennsylvania ave`).
+      required: true
+      schema: { type: string, minLength: 1 }
+    Limit:
+      name: limit
+      in: query
+      description: Maximum number of features to return.
+      required: false
+      schema: { type: integer, minimum: 1, default: 15 }
+    Lang:
+      name: lang
+      in: query
+      description: Preferred result language (BCP-47 / ISO code).
+      required: false
+      schema: { type: string }
+    Format:
+      name: format
+      in: query
+      description: >
+        Output serialization. Omit for the native GeoJSON `FeatureCollection`. `jsonld`
+        (a Mailwoman extension) returns an array of schema.org `Place` objects instead.
+      required: false
+      schema:
+        type: string
+        enum: [jsonld]
+
+  responses:
+    InternalError:
+      description: An unexpected engine fault. Returns an empty `FeatureCollection` with a message, never a stack trace.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorFeatureCollection" }
+          example: { type: FeatureCollection, features: [], message: "internal error" }
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorFeatureCollection" }
+          example: { type: FeatureCollection, features: [], message: "search not implemented" }
+
+  schemas:
+    PhotonFeatureCollection:
+      type: object
+      description: A GeoJSON `FeatureCollection` of Photon result features (RFC 7946).
+      externalDocs:
+        description: GeoJSON (RFC 7946)
+        url: https://www.rfc-editor.org/rfc/rfc7946
+      required: [type, features]
+      properties:
+        type: { const: FeatureCollection }
+        features:
+          type: array
+          items: { $ref: "#/components/schemas/PhotonFeature" }
+      additionalProperties: false
+
+    PhotonFeature:
+      type: object
+      description: A GeoJSON `Point` feature carrying Photon properties.
+      required: [type, geometry, properties]
+      properties:
+        type: { const: Feature }
+        geometry: { $ref: "#/components/schemas/PointGeometry" }
+        properties: { $ref: "#/components/schemas/PhotonProperties" }
+      additionalProperties: false
+
+    PointGeometry:
+      type: object
+      description: A GeoJSON `Point` geometry — `coordinates` are `[longitude, latitude]`.
+      required: [type, coordinates]
+      properties:
+        type: { const: Point }
+        coordinates:
+          type: array
+          description: "`[longitude, latitude]` (RFC 7946 position order)."
+          minItems: 2
+          maxItems: 3
+          items: { type: number }
+      additionalProperties: false
+
+    PhotonProperties:
+      type: object
+      description: >
+        OSM-derived feature properties, populated from the resolved place. `osm_key`,
+        `osm_value`, and `type` are always present so a Photon client never dereferences
+        `undefined`. Unlisted keys may also appear.
+      properties:
+        osm_id: { type: [integer, string] }
+        osm_type: { type: string }
+        osm_key: { type: string, description: "OSM key, e.g. `place`, `highway`, `building`." }
+        osm_value: { type: string, description: "OSM value, e.g. `city`, `house`, `residential`." }
+        type: { type: string, description: "Photon place type, e.g. `city`, `street`, `house`, `country`." }
+        name: { type: string }
+        housenumber: { type: string }
+        street: { type: string }
+        postcode: { type: string }
+        city: { type: string }
+        district: { type: string }
+        county: { type: string }
+        state: { type: string }
+        country: { type: string }
+        countrycode: { type: string, description: "ISO-3166 alpha-2, lowercased." }
+        extent:
+          type: array
+          description: "Bounding box `[minLon, maxLat, maxLon, minLat]` (Photon convention)."
+          minItems: 4
+          maxItems: 4
+          items: { type: number }
+      additionalProperties: true
+
+    ErrorFeatureCollection:
+      type: object
+      description: An empty `FeatureCollection` with a human-readable `message` — the shape every Photon error uses.
+      required: [type, features, message]
+      properties:
+        type: { const: FeatureCollection }
+        features:
+          type: array
+          items: { $ref: "#/components/schemas/PhotonFeature" }
+        message: { type: string }
+      additionalProperties: false
+
+    SchemaOrgPlace:
+      type: object
+      description: A schema.org `Place` JSON-LD object (the `format=jsonld` projection). Only populated fields are emitted.
+      externalDocs:
+        description: schema.org Place
+        url: https://schema.org/Place
+      required: ["@context", "@type"]
+      properties:
+        "@context": { const: "https://schema.org" }
+        "@type": { const: Place }
+        name: { type: string }
+        geo:
+          type: object
+          required: ["@type", latitude, longitude]
+          properties:
+            "@type": { const: GeoCoordinates }
+            latitude: { type: number }
+            longitude: { type: number }
+          additionalProperties: false
+        address:
+          type: object
+          required: ["@type"]
+          properties:
+            "@type": { const: PostalAddress }
+            streetAddress: { type: string }
+            postOfficeBoxNumber: { type: string }
+            addressLocality: { type: string }
+            addressRegion: { type: string }
+            postalCode: { type: string }
+            addressCountry: { type: string, description: "ISO-3166 alpha-2 (uppercased)." }
+          additionalProperties: false
+      additionalProperties: false

--- a/libpostal/openapi.yaml
+++ b/libpostal/openapi.yaml
@@ -1,0 +1,268 @@
+# @mailwoman/libpostal — OpenAPI 3.1 specification
+#
+# The libpostal-compatible parse/expand HTTP drop-in (/parse, /expand) served by
+# `npx @mailwoman/libpostal serve`. Wire shapes taken verbatim from libpostal/index.ts +
+# libpostal/cli.ts.
+#
+# Validate (Redocly CLI 2.38.0, zero errors):
+#   cd libpostal && npx --yes @redocly/cli@latest lint openapi.yaml
+
+openapi: 3.1.0
+
+info:
+  title: "@mailwoman/libpostal"
+  version: 5.10.1
+  summary: libpostal-compatible address parse / expand API.
+  description: >
+    A drop-in replacement for [libpostal](https://github.com/openvenues/libpostal)'s REST
+    server — the same `/parse` (`parse_address`) and `/expand` (`expand_address`) contract,
+    backed by Mailwoman's calibrated neural address parser. The lowest-dependency drop-in:
+    `/parse` needs no gazetteer, just the model.
+
+
+    **Drop-in compatibility.** `/parse` returns an ordered array of `{ label, value }`
+    components, mapping Mailwoman's `ComponentTag` classifications onto libpostal's OSM-derived
+    labels (`street`→`road`, `locality`→`city`, `region`→`state`, …). Unmapped classifications
+    pass through unchanged.
+
+
+    **Known divergences from upstream libpostal.**
+
+    - `/expand` is deterministic. Mailwoman's normalization is rule-based, so `/expand` returns
+      the original string plus its normalized + abbreviation-expanded forms — one canonical
+      alternative set, not libpostal's probabilistic multi-variant hypothesis expansion.
+    - `GET /` serves a friendly HTML banner; libpostal's own REST server has no root page.
+
+
+    **Request forms.** Both `/parse` and `/expand` accept `GET` (with a query-string parameter)
+    and `POST` (with a JSON body). The `serve` CLI reads query-string parameters directly; mount
+    a JSON body parser (e.g. `express.json()`) to accept `POST` JSON bodies.
+
+
+    **CORS.** Permissive CORS is on by default (`Access-Control-Allow-Origin: *`, and a `204`
+    answer to preflight `OPTIONS` — the `POST /parse` preflight needs it). Disable with
+    `serve --no-cors` when a reverse proxy already owns the headers.
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+    identifier: AGPL-3.0-only
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+
+externalDocs:
+  description: Switching from libpostal (setup, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-libpostal
+
+servers:
+  - url: http://{host}:{port}
+    description: Self-hosted server (`npx @mailwoman/libpostal serve`).
+    variables:
+      host:
+        default: 127.0.0.1
+        description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+      port:
+        default: "8081"
+        description: The port passed to `serve --port` (default 8081).
+
+# These endpoints require no authentication (self-host); declared explicitly for tooling.
+security: []
+
+tags:
+  - name: parsing
+    description: Address parsing and expansion endpoints.
+  - name: meta
+    description: Non-parsing informational endpoints.
+
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+      tags: [meta]
+      responses:
+        "200":
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /parse:
+    get:
+      operationId: parseGet
+      summary: Parse an address (query string)
+      description: Parse a free-text address into ordered labeled components.
+      tags: [parsing]
+      parameters:
+        - name: query
+          in: query
+          description: The address to parse. `address` is accepted as an alias.
+          required: false
+          schema: { type: string }
+        - name: address
+          in: query
+          description: Alias for `query`.
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          $ref: "#/components/responses/ParseResult"
+        "400":
+          $ref: "#/components/responses/MissingQuery"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      operationId: parsePost
+      summary: Parse an address (JSON body)
+      description: Parse a free-text address into ordered labeled components.
+      tags: [parsing]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ParseRequest" }
+            example: { query: "1600 Pennsylvania Ave NW, Washington DC 20500" }
+      responses:
+        "200":
+          $ref: "#/components/responses/ParseResult"
+        "400":
+          $ref: "#/components/responses/MissingQuery"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /expand:
+    get:
+      operationId: expandGet
+      summary: Expand an address (query string)
+      description: Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence note).
+      tags: [parsing]
+      parameters:
+        - name: address
+          in: query
+          description: The address to expand.
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          $ref: "#/components/responses/ExpandResult"
+        "400":
+          $ref: "#/components/responses/MissingAddress"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+    post:
+      operationId: expandPost
+      summary: Expand an address (JSON body)
+      description: Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence note).
+      tags: [parsing]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ExpandRequest" }
+            example: { address: "1600 pennsylvania ave nw" }
+      responses:
+        "200":
+          $ref: "#/components/responses/ExpandResult"
+        "400":
+          $ref: "#/components/responses/MissingAddress"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+components:
+  responses:
+    ParseResult:
+      description: The ordered libpostal components.
+      content:
+        application/json:
+          schema:
+            type: array
+            items: { $ref: "#/components/schemas/LibpostalComponent" }
+          example:
+            - { label: house_number, value: "1600" }
+            - { label: road, value: Pennsylvania Ave NW }
+            - { label: city, value: Washington }
+            - { label: state, value: DC }
+            - { label: postcode, value: "20500" }
+    ExpandResult:
+      description: The deterministic expansion set.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ExpandResponse" }
+          example:
+            expansions:
+              - "1600 pennsylvania ave nw"
+              - "1600 pennsylvania avenue northwest"
+    MissingQuery:
+      description: The required `query` (or `address`) parameter is missing.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "query is required" }
+    MissingAddress:
+      description: The required `address` parameter is missing.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "address is required" }
+    InternalError:
+      description: An unexpected engine fault. Returns a clean JSON error, never a stack trace.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "internal error" }
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "expand not implemented" }
+
+  schemas:
+    ParseRequest:
+      type: object
+      description: A `/parse` request body. Provide `query` (or its alias `address`).
+      properties:
+        query: { type: string, description: The address to parse. }
+        address: { type: string, description: Alias for `query`. }
+      additionalProperties: false
+
+    ExpandRequest:
+      type: object
+      description: An `/expand` request body.
+      required: [address]
+      properties:
+        address: { type: string, description: The address to expand. }
+      additionalProperties: false
+
+    LibpostalComponent:
+      type: object
+      description: A libpostal `parse_address` component — a label and the text span it covers, in order.
+      required: [label, value]
+      properties:
+        label: { type: string, description: "The libpostal label, e.g. `house_number`, `road`, `city`, `state`, `postcode`." }
+        value: { type: string, description: The text the label covers. }
+      additionalProperties: false
+
+    ExpandResponse:
+      type: object
+      description: The `/expand` response.
+      required: [expansions]
+      properties:
+        expansions:
+          type: array
+          description: The distinct expanded forms (original + normalized + abbreviation-expanded), order preserved.
+          items: { type: string }
+      additionalProperties: false
+
+    Error:
+      type: object
+      description: A JSON error envelope.
+      required: [error]
+      properties:
+        error: { type: string }
+      additionalProperties: false

--- a/libpostal/package.json
+++ b/libpostal/package.json
@@ -14,7 +14,8 @@
 		"out/**/*.js.map",
 		"out/**/*.d.ts",
 		"out/**/*.d.ts.map",
-		"README.md"
+		"README.md",
+		"openapi.yaml"
 	],
 	"type": "module",
 	"exports": {

--- a/nominatim/openapi.yaml
+++ b/nominatim/openapi.yaml
@@ -1,0 +1,516 @@
+# @mailwoman/nominatim — OpenAPI 3.1 specification
+#
+# The Nominatim-compatible HTTP geocoding drop-in (/search, /reverse, /lookup, /status)
+# served by `npx @mailwoman/nominatim serve`. Wire shapes taken verbatim from
+# nominatim/index.ts + nominatim/cli.ts.
+#
+# Validate (Redocly CLI 2.38.0, zero errors):
+#   cd nominatim && npx --yes @redocly/cli@latest lint openapi.yaml
+
+openapi: 3.1.0
+
+info:
+  title: "@mailwoman/nominatim"
+  version: 5.10.1
+  summary: Nominatim-compatible HTTP geocoding API.
+  description: >
+    A drop-in replacement for [Nominatim](https://nominatim.org) — the same `/search`,
+    `/reverse`, `/lookup`, and `/status` contract, returning `jsonv2` result objects (and
+    `geojson` / `jsonld` on request), served from a SQLite gazetteer over the Mailwoman
+    engine instead of a PostgreSQL/PostGIS `osm2pgsql` import.
+
+
+    **Drop-in compatibility.** Point an existing Nominatim client (`geopy`, …) at this server
+    and forward + reverse geocoding work unchanged. Result objects carry the fields Nominatim
+    clients parse — `place_id`, `licence`, `lat`, `lon`, `display_name`, `boundingbox`,
+    `class`, `type`, `importance`, and the `address` breakdown when `addressdetails=1`.
+
+
+    **Known divergences from upstream Nominatim.**
+
+    - Every result carries an OpenCage-style `annotations` block (coordinate formats, country
+      flag, calling code, currency, and — when their data bundles are present — IANA timezone,
+      UN/LOCODE, and EU NUTS codes). Plain Nominatim returns none of these.
+    - `format=jsonld` is a Mailwoman extension (not in upstream Nominatim): it re-serializes
+      each result as a [schema.org `Place`](https://schema.org/Place) JSON-LD object. `jsonv2`
+      stays the default.
+    - `/lookup` is part of the router contract but is not wired in the bundled `serve` engine
+      yet, so it answers `501`.
+    - `licence` reports the Mailwoman data sources (Who's On First, Overture Maps,
+      OpenAddresses, US Census TIGER), not OSM/ODbL.
+    - `GET /` serves a friendly HTML banner; Nominatim itself has only `/status`.
+
+
+    **CORS.** Permissive CORS is on by default (`Access-Control-Allow-Origin: *`, and a `204`
+    answer to preflight `OPTIONS`). Disable with `serve --no-cors` when a reverse proxy already
+    owns the headers.
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+    identifier: AGPL-3.0-only
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+
+externalDocs:
+  description: Switching from Nominatim (setup, hosted data, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-nominatim
+
+servers:
+  - url: http://{host}:{port}
+    description: Self-hosted server (`npx @mailwoman/nominatim serve`).
+    variables:
+      host:
+        default: 127.0.0.1
+        description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+      port:
+        default: "8080"
+        description: The port passed to `serve --port` (default 8080).
+
+# These endpoints require no authentication (self-host); declared explicitly for tooling.
+security: []
+
+tags:
+  - name: geocoding
+    description: Forward, reverse, and id-based geocoding endpoints.
+  - name: meta
+    description: Health and informational endpoints.
+
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+      tags: [meta]
+      responses:
+        "200":
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /search:
+    get:
+      operationId: search
+      summary: Forward geocoding
+      description: >
+        Geocode a free-text `q`, or a structured (`street`/`city`/`state`/`postalcode`/`country`)
+        query, into ranked results.
+      tags: [geocoding]
+      parameters:
+        - name: q
+          in: query
+          description: Free-text query. Mutually exclusive with the structured parameters.
+          required: false
+          schema: { type: string }
+        - name: street
+          in: query
+          description: Structured query — street (with optional house number).
+          required: false
+          schema: { type: string }
+        - name: city
+          in: query
+          description: Structured query — city.
+          required: false
+          schema: { type: string }
+        - name: county
+          in: query
+          description: Structured query — county.
+          required: false
+          schema: { type: string }
+        - name: state
+          in: query
+          description: Structured query — state / region.
+          required: false
+          schema: { type: string }
+        - name: country
+          in: query
+          description: Structured query — country.
+          required: false
+          schema: { type: string }
+        - name: postalcode
+          in: query
+          description: Structured query — postal code.
+          required: false
+          schema: { type: string }
+        - name: countrycodes
+          in: query
+          description: >
+            Comma-separated ISO-3166 alpha-2 codes restricting results to those countries
+            (Nominatim semantics — a hard restriction; the first is applied as the country
+            constraint).
+          required: false
+          schema: { type: string }
+        - $ref: "#/components/parameters/Limit"
+        - name: bounded
+          in: query
+          description: Restrict results to the viewbox (`1`) or not (`0`).
+          required: false
+          schema: { type: integer, enum: [0, 1], default: 0 }
+        - $ref: "#/components/parameters/AddressDetails"
+        - $ref: "#/components/parameters/Format"
+        - $ref: "#/components/parameters/AcceptLanguage"
+      responses:
+        "200":
+          description: >
+            An array of result objects (`jsonv2`/`json`), a GeoJSON `FeatureCollection`
+            (`geojson`), or an array of schema.org `Place` objects (`jsonld`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items: { $ref: "#/components/schemas/NominatimResult" }
+                  - $ref: "#/components/schemas/NominatimFeatureCollection"
+                  - type: array
+                    items: { $ref: "#/components/schemas/SchemaOrgPlace" }
+              example:
+                - place_id: 240087473
+                  licence: "Data © Who's On First, Overture Maps, OpenAddresses, US Census TIGER"
+                  lat: "38.8977"
+                  lon: "-77.0365"
+                  display_name: "1600, Pennsylvania Avenue NW, Washington, DC, 20500, United States"
+                  class: place
+                  type: house
+                  address:
+                    house_number: "1600"
+                    road: Pennsylvania Avenue NW
+                    city: Washington
+                    state: DC
+                    postcode: "20500"
+                    country: United States
+                    country_code: us
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /reverse:
+    get:
+      operationId: reverse
+      summary: Reverse geocoding
+      description: Resolve a coordinate to the nearest address (point-in-polygon over the WOF admin hierarchy).
+      tags: [geocoding]
+      parameters:
+        - name: lat
+          in: query
+          description: Latitude to reverse geocode.
+          required: true
+          schema: { type: number, format: double, minimum: -90, maximum: 90 }
+        - name: lon
+          in: query
+          description: Longitude to reverse geocode.
+          required: true
+          schema: { type: number, format: double, minimum: -180, maximum: 180 }
+        - name: zoom
+          in: query
+          description: Level of detail (Nominatim zoom, 0–18).
+          required: false
+          schema: { type: integer, minimum: 0, maximum: 18 }
+        - $ref: "#/components/parameters/AddressDetails"
+        - $ref: "#/components/parameters/Format"
+        - $ref: "#/components/parameters/AcceptLanguage"
+      responses:
+        "200":
+          description: >
+            A single result object (`jsonv2`/`json`), a GeoJSON `FeatureCollection`
+            (`geojson`), or a schema.org `Place` (`jsonld`). Returns JSON `null` when nothing
+            resolves.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/NominatimResult"
+                  - $ref: "#/components/schemas/NominatimFeatureCollection"
+                  - $ref: "#/components/schemas/SchemaOrgPlace"
+                  - type: "null"
+        "400":
+          description: "`lat`/`lon` are missing or out of range."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+              example: { error: "lat and lon are required" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /lookup:
+    get:
+      operationId: lookup
+      summary: Look up known place ids
+      description: >
+        Resolve one or more OSM/place ids to result objects. Part of the router contract; not
+        wired in the bundled `serve` engine yet (answers `501`).
+      tags: [geocoding]
+      parameters:
+        - name: osm_ids
+          in: query
+          description: Comma-separated place ids to look up.
+          required: true
+          schema: { type: string }
+        - $ref: "#/components/parameters/AddressDetails"
+        - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: An array of result objects (`jsonv2`/`json`) or a GeoJSON `FeatureCollection` (`geojson`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items: { $ref: "#/components/schemas/NominatimResult" }
+                  - $ref: "#/components/schemas/NominatimFeatureCollection"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /status:
+    get:
+      operationId: status
+      summary: Service status
+      description: Health check plus data version. Mirrors Nominatim's `/status?format=json`.
+      tags: [meta]
+      responses:
+        "200":
+          description: "Service status. `status: 0` means OK."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/NominatimStatus" }
+              example: { status: 0, message: OK }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  parameters:
+    Limit:
+      name: limit
+      in: query
+      description: Maximum number of results to return.
+      required: false
+      schema: { type: integer, minimum: 1, default: 10 }
+    AddressDetails:
+      name: addressdetails
+      in: query
+      description: Include a structured `address` breakdown (`1`) or not (`0`). Forced on for `format=jsonld`.
+      required: false
+      schema: { type: integer, enum: [0, 1], default: 0 }
+    Format:
+      name: format
+      in: query
+      description: >
+        Output serialization. `jsonv2` (default) and `json` return result objects; `geojson`
+        returns a `FeatureCollection`; `jsonld` (a Mailwoman extension) returns schema.org
+        `Place` JSON-LD.
+      required: false
+      schema:
+        type: string
+        enum: [jsonv2, json, geojson, jsonld]
+        default: jsonv2
+    AcceptLanguage:
+      name: accept-language
+      in: query
+      description: Preferred result language(s) (BCP-47), as a query parameter.
+      required: false
+      schema: { type: string }
+
+  responses:
+    InternalError:
+      description: An unexpected engine fault. Returns a clean JSON error, never a stack trace.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "internal error" }
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+          example: { error: "lookup not implemented (see #805)" }
+
+  schemas:
+    NominatimResult:
+      type: object
+      description: A Nominatim result object (the shape `geopy` and friends parse).
+      required: [place_id, licence, lat, lon, display_name]
+      properties:
+        place_id: { type: [integer, string] }
+        licence: { type: string, description: The attribution string for the resolved data sources. }
+        osm_type: { type: string }
+        osm_id: { type: [integer, string] }
+        lat: { type: string, description: "Latitude, as a string (Nominatim convention)." }
+        lon: { type: string, description: "Longitude, as a string (Nominatim convention)." }
+        display_name: { type: string }
+        boundingbox:
+          type: array
+          description: "`[south, north, west, east]` as strings (Nominatim convention)."
+          minItems: 4
+          maxItems: 4
+          items: { type: string }
+        class: { type: string }
+        type: { type: string }
+        importance: { type: number }
+        place_rank: { type: integer }
+        address: { $ref: "#/components/schemas/NominatimAddressDetails" }
+        geojson:
+          description: Present when `format=geojson` or `polygon_geojson=1` — a GeoJSON geometry.
+        annotations: { $ref: "#/components/schemas/OpenCageAnnotations" }
+      additionalProperties: true
+
+    NominatimAddressDetails:
+      type: object
+      description: The structured address breakdown returned under `address` when `addressdetails=1`. Keys mirror Nominatim's OSM-derived tag names.
+      properties:
+        house_number: { type: string }
+        road: { type: string }
+        neighbourhood: { type: string }
+        suburb: { type: string }
+        city: { type: string }
+        town: { type: string }
+        village: { type: string }
+        county: { type: string }
+        state: { type: string }
+        postcode: { type: string }
+        country: { type: string }
+        country_code: { type: string, description: "ISO-3166 alpha-2, lowercased." }
+      additionalProperties:
+        type: string
+
+    NominatimStatus:
+      type: object
+      description: "The `/status` payload. `status: 0` means OK."
+      required: [status, message]
+      properties:
+        status: { type: integer, description: "`0` = OK; non-zero = a fault code." }
+        message: { type: string }
+        data_updated: { type: string, description: When the underlying data was last built (ISO-8601). }
+      additionalProperties: false
+
+    NominatimFeatureCollection:
+      type: object
+      description: A GeoJSON `FeatureCollection` — the `format=geojson` envelope (RFC 7946).
+      externalDocs:
+        description: GeoJSON (RFC 7946)
+        url: https://www.rfc-editor.org/rfc/rfc7946
+      required: [type, features]
+      properties:
+        type: { const: FeatureCollection }
+        features:
+          type: array
+          items:
+            type: object
+            required: [type, properties, geometry]
+            properties:
+              type: { const: Feature }
+              properties: { type: object, additionalProperties: true }
+              geometry:
+                description: A GeoJSON geometry (the place polygon when present, else a Point).
+              bbox:
+                type: array
+                description: "`[west, south, east, north]` (GeoJSON bbox order)."
+                minItems: 4
+                maxItems: 4
+                items: { type: number }
+            additionalProperties: true
+      additionalProperties: false
+
+    OpenCageAnnotations:
+      type: object
+      description: >
+        The OpenCage-style enrichment block, keyed and cased as OpenCage documents it. A
+        Mailwoman extension over upstream Nominatim. Only populated fields are emitted.
+      externalDocs:
+        description: OpenCage annotations
+        url: https://opencagedata.com/api#annotations
+      properties:
+        DMS:
+          type: object
+          properties:
+            lat: { type: string }
+            lng: { type: string }
+        MGRS: { type: string }
+        Maidenhead: { type: string }
+        Mercator:
+          type: object
+          properties:
+            x: { type: number }
+            y: { type: number }
+        geohash: { type: string }
+        qibla: { type: number }
+        sun:
+          type: object
+          properties:
+            rise: { type: object, additionalProperties: { type: number } }
+            set: { type: object, additionalProperties: { type: number } }
+        callingcode: { type: number }
+        currency:
+          type: object
+          properties:
+            iso_code: { type: string }
+            name: { type: string }
+            symbol: { type: string }
+        flag: { type: string, description: The country's flag emoji. }
+        timezone:
+          type: object
+          properties:
+            name: { type: string }
+            offset_sec: { type: number }
+            offset_string: { type: string }
+        NUTS:
+          type: object
+          description: EU NUTS region codes (when the NUTS data bundle is present).
+          properties:
+            NUTS0: { type: object, properties: { code: { type: string } } }
+            NUTS1: { type: object, properties: { code: { type: string } } }
+            NUTS2: { type: object, properties: { code: { type: string } } }
+            NUTS3: { type: object, properties: { code: { type: string } } }
+        UN_LOCODE: { type: string }
+        wikidata: { type: string }
+        FIPS:
+          type: object
+          properties:
+            county: { type: string }
+      additionalProperties: true
+
+    SchemaOrgPlace:
+      type: object
+      description: A schema.org `Place` JSON-LD object (the `format=jsonld` projection). Only populated fields are emitted.
+      externalDocs:
+        description: schema.org Place
+        url: https://schema.org/Place
+      required: ["@context", "@type"]
+      properties:
+        "@context": { const: "https://schema.org" }
+        "@type": { const: Place }
+        name: { type: string }
+        geo:
+          type: object
+          required: ["@type", latitude, longitude]
+          properties:
+            "@type": { const: GeoCoordinates }
+            latitude: { type: number }
+            longitude: { type: number }
+          additionalProperties: false
+        address:
+          type: object
+          required: ["@type"]
+          properties:
+            "@type": { const: PostalAddress }
+            streetAddress: { type: string }
+            postOfficeBoxNumber: { type: string }
+            addressLocality: { type: string }
+            addressRegion: { type: string }
+            postalCode: { type: string }
+            addressCountry: { type: string, description: "ISO-3166 alpha-2 (uppercased)." }
+          additionalProperties: false
+      additionalProperties: false
+
+    Error:
+      type: object
+      description: A JSON error envelope.
+      required: [error]
+      properties:
+        error: { type: string }
+      additionalProperties: false

--- a/nominatim/package.json
+++ b/nominatim/package.json
@@ -14,7 +14,8 @@
 		"out/**/*.js.map",
 		"out/**/*.d.ts",
 		"out/**/*.d.ts.map",
-		"README.md"
+		"README.md",
+		"openapi.yaml"
 	],
 	"type": "module",
 	"exports": {

--- a/photon/openapi.yaml
+++ b/photon/openapi.yaml
@@ -1,0 +1,376 @@
+# @mailwoman/photon — OpenAPI 3.1 specification
+#
+# The Photon-compatible autocomplete / reverse geocoding drop-in (GeoJSON FeatureCollection
+# over /api + /reverse) served by `npx @mailwoman/photon serve`. Wire shapes taken verbatim
+# from photon/index.ts + photon/cli.ts.
+#
+# Validate (Redocly CLI 2.38.0, zero errors):
+#   cd photon && npx --yes @redocly/cli@latest lint openapi.yaml
+
+openapi: 3.1.0
+
+info:
+  title: "@mailwoman/photon"
+  version: 5.10.1
+  summary: Photon-compatible autocomplete / type-ahead geocoding API.
+  description: >
+    A drop-in replacement for [Photon](https://github.com/komoot/photon) — the same `/api`
+    (forward / autocomplete) and `/reverse` contract, returning GeoJSON `FeatureCollection`s,
+    served from a SQLite gazetteer over the Mailwoman engine instead of an Elasticsearch cluster.
+
+
+    **Drop-in compatibility.** Point an existing Photon client (`leaflet-control-geocoder`,
+    `@openrunner/photon-geocoder`, …) at this server and forward + reverse geocoding work
+    unchanged. Every response is a GeoJSON `FeatureCollection` of `Point` features
+    (RFC 7946), and each feature's `properties` carry the OSM-derived key names a Photon
+    client reads (`osm_key`, `osm_value`, `type`, `name`, `housenumber`, `street`, `city`,
+    `state`, `country`, `countrycode`, …).
+
+
+    **Known divergences from upstream Photon.**
+
+    - `format=jsonld` is a Mailwoman extension (not in upstream Photon): it re-serializes the
+      *same* resolved places as an array of [schema.org `Place`](https://schema.org/Place)
+      JSON-LD objects. The native GeoJSON `FeatureCollection` stays the default.
+    - Results are ranked by the Mailwoman resolver (population-first candidate scoring with an
+      optional proximity re-rank), not Photon's Elasticsearch relevance model — ordering can
+      differ. The dedicated prefix-first FST autocomplete front is a refinement still in flight.
+    - `GET /` serves a friendly HTML banner; upstream Photon has no root page.
+
+
+    **CORS.** Permissive CORS is on by default (`Access-Control-Allow-Origin: *`, and a `204`
+    answer to preflight `OPTIONS`), matching upstream Photon — browser-embedded map widgets
+    need it. Disable with `serve --no-cors` when a reverse proxy already owns the headers.
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+    identifier: AGPL-3.0-only
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+
+externalDocs:
+  description: Switching from Photon (setup, hosted data, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-photon
+
+servers:
+  - url: https://photon.sister.software
+    description: Hosted public trial endpoint (conservative rate limits).
+  - url: http://{host}:{port}
+    description: Local self-hosted server (`npx @mailwoman/photon serve`).
+    variables:
+      host:
+        default: 127.0.0.1
+        description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+      port:
+        default: "2322"
+        description: The port passed to `serve --port` (default 2322).
+
+# These endpoints require no authentication (public / self-host); declared explicitly for tooling.
+security: []
+
+tags:
+  - name: geocoding
+    description: Forward (autocomplete) and reverse geocoding endpoints.
+  - name: meta
+    description: Non-geocoding informational endpoints.
+
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+      tags: [meta]
+      responses:
+        "200":
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+
+  /api:
+    get:
+      operationId: search
+      summary: Forward / autocomplete geocoding
+      description: >
+        Parse and resolve a free-text query into ranked places, returning a GeoJSON
+        `FeatureCollection` (or a schema.org `Place[]` when `format=jsonld`).
+      tags: [geocoding]
+      parameters:
+        - $ref: "#/components/parameters/Query"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Lang"
+        - name: lat
+          in: query
+          description: Latitude of a proximity bias (soft re-rank). Only applied when `lon` is also present.
+          required: false
+          schema: { type: number, format: double, minimum: -90, maximum: 90 }
+        - name: lon
+          in: query
+          description: Longitude of a proximity bias (soft re-rank). Only applied when `lat` is also present.
+          required: false
+          schema: { type: number, format: double, minimum: -180, maximum: 180 }
+        - name: osm_tag
+          in: query
+          description: Filter results by OSM tag (repeatable). Photon `key`, `key:value`, or `:value` syntax.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+        - name: layer
+          in: query
+          description: Filter results by layer (repeatable), e.g. `city`, `street`, `house`.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+        - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: >
+            A GeoJSON `FeatureCollection` of ranked `Point` features (default), or — when
+            `format=jsonld` — an array of schema.org `Place` objects.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/PhotonFeatureCollection"
+                  - type: array
+                    items: { $ref: "#/components/schemas/SchemaOrgPlace" }
+              example:
+                type: FeatureCollection
+                features:
+                  - type: Feature
+                    geometry:
+                      type: Point
+                      coordinates: [13.405, 52.52]
+                    properties:
+                      osm_key: place
+                      osm_value: city
+                      type: city
+                      name: Berlin
+                      state: Berlin
+                      country: Germany
+                      countrycode: de
+        "400":
+          description: The required `q` parameter is missing.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorFeatureCollection" }
+              example: { type: FeatureCollection, features: [], message: "q is required" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+  /reverse:
+    get:
+      operationId: reverse
+      summary: Reverse geocoding
+      description: >
+        Resolve a coordinate to the nearest place(s), returning a GeoJSON `FeatureCollection`
+        (or a schema.org `Place[]` when `format=jsonld`).
+      tags: [geocoding]
+      parameters:
+        - name: lat
+          in: query
+          description: Latitude to reverse geocode.
+          required: true
+          schema: { type: number, format: double, minimum: -90, maximum: 90 }
+        - name: lon
+          in: query
+          description: Longitude to reverse geocode.
+          required: true
+          schema: { type: number, format: double, minimum: -180, maximum: 180 }
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Lang"
+        - name: radius
+          in: query
+          description: Optional search radius (km) around the coordinate.
+          required: false
+          schema: { type: number, format: double, minimum: 0 }
+        - $ref: "#/components/parameters/Format"
+      responses:
+        "200":
+          description: >
+            A GeoJSON `FeatureCollection` for the nearest place(s) (default), or — when
+            `format=jsonld` — an array of schema.org `Place` objects.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/PhotonFeatureCollection"
+                  - type: array
+                    items: { $ref: "#/components/schemas/SchemaOrgPlace" }
+        "400":
+          description: "`lat`/`lon` are missing or out of range."
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorFeatureCollection" }
+              example: { type: FeatureCollection, features: [], message: "lat and lon are required" }
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "501":
+          $ref: "#/components/responses/NotImplemented"
+
+components:
+  parameters:
+    Query:
+      name: q
+      in: query
+      description: The free-text query to geocode (e.g. `1600 pennsylvania ave`).
+      required: true
+      schema: { type: string, minLength: 1 }
+    Limit:
+      name: limit
+      in: query
+      description: Maximum number of features to return.
+      required: false
+      schema: { type: integer, minimum: 1, default: 15 }
+    Lang:
+      name: lang
+      in: query
+      description: Preferred result language (BCP-47 / ISO code).
+      required: false
+      schema: { type: string }
+    Format:
+      name: format
+      in: query
+      description: >
+        Output serialization. Omit for the native GeoJSON `FeatureCollection`. `jsonld`
+        (a Mailwoman extension) returns an array of schema.org `Place` objects instead.
+      required: false
+      schema:
+        type: string
+        enum: [jsonld]
+
+  responses:
+    InternalError:
+      description: An unexpected engine fault. Returns an empty `FeatureCollection` with a message, never a stack trace.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorFeatureCollection" }
+          example: { type: FeatureCollection, features: [], message: "internal error" }
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorFeatureCollection" }
+          example: { type: FeatureCollection, features: [], message: "search not implemented" }
+
+  schemas:
+    PhotonFeatureCollection:
+      type: object
+      description: A GeoJSON `FeatureCollection` of Photon result features (RFC 7946).
+      externalDocs:
+        description: GeoJSON (RFC 7946)
+        url: https://www.rfc-editor.org/rfc/rfc7946
+      required: [type, features]
+      properties:
+        type: { const: FeatureCollection }
+        features:
+          type: array
+          items: { $ref: "#/components/schemas/PhotonFeature" }
+      additionalProperties: false
+
+    PhotonFeature:
+      type: object
+      description: A GeoJSON `Point` feature carrying Photon properties.
+      required: [type, geometry, properties]
+      properties:
+        type: { const: Feature }
+        geometry: { $ref: "#/components/schemas/PointGeometry" }
+        properties: { $ref: "#/components/schemas/PhotonProperties" }
+      additionalProperties: false
+
+    PointGeometry:
+      type: object
+      description: A GeoJSON `Point` geometry — `coordinates` are `[longitude, latitude]`.
+      required: [type, coordinates]
+      properties:
+        type: { const: Point }
+        coordinates:
+          type: array
+          description: "`[longitude, latitude]` (RFC 7946 position order)."
+          minItems: 2
+          maxItems: 3
+          items: { type: number }
+      additionalProperties: false
+
+    PhotonProperties:
+      type: object
+      description: >
+        OSM-derived feature properties, populated from the resolved place. `osm_key`,
+        `osm_value`, and `type` are always present so a Photon client never dereferences
+        `undefined`. Unlisted keys may also appear.
+      properties:
+        osm_id: { type: [integer, string] }
+        osm_type: { type: string }
+        osm_key: { type: string, description: "OSM key, e.g. `place`, `highway`, `building`." }
+        osm_value: { type: string, description: "OSM value, e.g. `city`, `house`, `residential`." }
+        type: { type: string, description: "Photon place type, e.g. `city`, `street`, `house`, `country`." }
+        name: { type: string }
+        housenumber: { type: string }
+        street: { type: string }
+        postcode: { type: string }
+        city: { type: string }
+        district: { type: string }
+        county: { type: string }
+        state: { type: string }
+        country: { type: string }
+        countrycode: { type: string, description: "ISO-3166 alpha-2, lowercased." }
+        extent:
+          type: array
+          description: "Bounding box `[minLon, maxLat, maxLon, minLat]` (Photon convention)."
+          minItems: 4
+          maxItems: 4
+          items: { type: number }
+      additionalProperties: true
+
+    ErrorFeatureCollection:
+      type: object
+      description: An empty `FeatureCollection` with a human-readable `message` — the shape every Photon error uses.
+      required: [type, features, message]
+      properties:
+        type: { const: FeatureCollection }
+        features:
+          type: array
+          items: { $ref: "#/components/schemas/PhotonFeature" }
+        message: { type: string }
+      additionalProperties: false
+
+    SchemaOrgPlace:
+      type: object
+      description: A schema.org `Place` JSON-LD object (the `format=jsonld` projection). Only populated fields are emitted.
+      externalDocs:
+        description: schema.org Place
+        url: https://schema.org/Place
+      required: ["@context", "@type"]
+      properties:
+        "@context": { const: "https://schema.org" }
+        "@type": { const: Place }
+        name: { type: string }
+        geo:
+          type: object
+          required: ["@type", latitude, longitude]
+          properties:
+            "@type": { const: GeoCoordinates }
+            latitude: { type: number }
+            longitude: { type: number }
+          additionalProperties: false
+        address:
+          type: object
+          required: ["@type"]
+          properties:
+            "@type": { const: PostalAddress }
+            streetAddress: { type: string }
+            postOfficeBoxNumber: { type: string }
+            addressLocality: { type: string }
+            addressRegion: { type: string }
+            postalCode: { type: string }
+            addressCountry: { type: string, description: "ISO-3166 alpha-2 (uppercased)." }
+          additionalProperties: false
+      additionalProperties: false

--- a/photon/package.json
+++ b/photon/package.json
@@ -14,7 +14,8 @@
 		"out/**/*.js.map",
 		"out/**/*.d.ts",
 		"out/**/*.d.ts.map",
-		"README.md"
+		"README.md",
+		"openapi.yaml"
 	],
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
## What

Machine-readable **OpenAPI 3.1** specifications for the three HTTP drop-in servers — DPG-submission evidence of adherence to the OpenAPI open standard (machine-validatable).

| Drop-in | Endpoints | Spec | Redocly lint |
| --- | --- | --- | --- |
| `@mailwoman/photon` | `/api`, `/reverse` | `photon/openapi.yaml` | ✅ 0 errors |
| `@mailwoman/nominatim` | `/search`, `/reverse`, `/lookup`, `/status` | `nominatim/openapi.yaml` | ✅ 0 errors |
| `@mailwoman/libpostal` | `/parse`, `/expand` | `libpostal/openapi.yaml` | ✅ 0 errors |

Wire shapes are taken verbatim from each router (`{photon,nominatim,libpostal}/index.ts` + `cli.ts`): GeoJSON `FeatureCollection`s for photon, `jsonv2` result objects + `geojson` envelope for nominatim, ordered `[{label,value}]` for libpostal, the `format=jsonld` schema.org `Place` variants, and the nominatim OpenCage-style `annotations` block. Descriptions are honest about drop-in compatibility and the known upstream divergences (jsonld/annotations extensions, deterministic `/expand`, `/lookup` `501`, `licence` sources, courtesy `GET /` banner). CORS defaults noted.

`servers`: photon lists the hosted trial endpoint `https://photon.sister.software` plus a self-host template; nominatim/libpostal use self-host templates only.

## Validation

All three validate under **Redocly CLI 2.38.0** with **zero errors** (the command is recorded in each file's header comment):

```bash
npx --yes @redocly/cli@latest lint photon/openapi.yaml
npx --yes @redocly/cli@latest lint nominatim/openapi.yaml
npx --yes @redocly/cli@latest lint libpostal/openapi.yaml
```

The remaining lint output is a handful of benign `operation-4xx-response` **warnings** on informational endpoints (`GET /`, `/status`, `/search`, `/lookup`) that genuinely return no 4xx — not errors.

## Docs

- Copies published as static site assets under `docs/static/openapi/` (byte-identical to the workspace sources; md5-verified).
- New **"Drop-in server specifications (OpenAPI 3.1)"** section in `docs/articles/api.mdx` linking all three (via the `pathname://` static-asset protocol, so the `onBrokenLinks: throw` build is safe) plus the validation command.
- Live URLs after deploy: `https://mailwoman.sister.software/openapi/{photon,nominatim,libpostal}.yaml`.

## Packaging

Each spec is added to its workspace's npm `files` array (next to the already-shipped `README.md`) so `npm pack` includes it. This is a static workspace-root asset — it does **not** touch the `exports`/`publishConfig.exports` dual-map (that governs importable module entries, not shipped files), so it is trivially correct per AGENTS.md.

## Gates

- Redocly validation clean ×3 (sources + static copies, 6/6 valid).
- No runtime code changed — only `openapi.yaml` specs, `package.json` `files` arrays, `api.mdx`, and static copies. `oxfmt --check` clean on the three edited `package.json` files; no `.ts`/JS/Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5qDbkGN3xs2XDvyK52qPT