### PR TITLE
docs: front-door delta — link fixes, rooftop tier, drop-in servers, footer links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,7 @@ By making a contribution to this project, I certify that:
 
 ## Prerequisites
 
-- **Node ≥ 22.5.1.** The runtime uses `node:sqlite`, which landed in 22.5. The
-  repo itself is developed on Node 26.
+- **Node ≥ 24.18.0** (the published `engines` floor). The repo itself is developed on Node 26.
 - **Yarn 4** via Corepack — don't install Yarn globally.
 - **git**, and a POSIX-ish shell for the helper scripts.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <a href="https://mailwoman.sister.software/demo"><strong>Live demo</strong></a> ·
   <a href="https://mailwoman.sister.software">Docs & blog</a> ·
-  <a href="https://mailwoman.sister.software/articles/getting-started/">Getting started</a>
+  <a href="https://mailwoman.sister.software/docs/getting-started/">Getting started</a>
 </p>
 
 <p align="center">
@@ -34,8 +34,8 @@ classification over a 33-label schema. It is **not** an LLM and nothing about it
 generative — boring NER, which is the point for short, structured strings.
 
 It runs in Node.js and the browser, with no Elasticsearch and no multi-gigabyte libpostal
-install. The model is about 30 MB and resolves admin/postcode coordinates from a SQLite
-gazetteer.
+install. The model is about 30 MB and resolves coordinates from a SQLite gazetteer at the finest
+tier available — admin, postcode, street, or rooftop (US and French national registers).
 
 ```bash
 npx mailwoman parse "1600 Amphitheatre Parkway, Mountain View, CA 94043"
@@ -120,6 +120,22 @@ began as a fork of Pelias Parser and ships wire-compatible drop-ins for the othe
 | Autocomplete / type-ahead     | ✓ (Photon-compatible API)       | ✗                  | ✗                          | ✓                              |
 | Annotations (tz, currency, …) | ✓ OpenCage-style block          | ✗                  | ✗                          | ✗                              |
 
+## Drop-in servers
+
+Migrating off Nominatim, Photon, or libpostal? Each has a compatible server — same wire
+contract, from a SQLite file instead of a cluster. A hosted Photon-compatible endpoint is
+live for evaluation:
+
+```bash
+curl "https://photon.sister.software/api?q=berlin&limit=3"   # hosted — nothing to install
+npx @mailwoman/photon    serve   # Photon-compatible    /api, /reverse
+npx @mailwoman/nominatim serve   # Nominatim-compatible /search, /reverse, /status
+npx @mailwoman/libpostal serve   # libpostal-compatible /parse, /expand
+```
+
+OpenAPI 3.1 specifications for all three ship in each package and at
+[mailwoman.sister.software/openapi](https://mailwoman.sister.software/openapi/photon.yaml).
+
 ## How it works
 
 The problem splits in two:
@@ -136,7 +152,7 @@ The confidence numbers the parser returns are calibrated probabilities, not heur
 scores: when it says `0.88`, it is right about 88% of the time.
 
 For the longer version, read [What Mailwoman
-Is](https://mailwoman.sister.software/articles/concepts/what-mailwoman-is/).
+Is](https://mailwoman.sister.software/docs/concepts/what-mailwoman-is/).
 
 ## Locale coverage
 
@@ -177,6 +193,12 @@ Mailwoman is dual-licensed:
   for network services, your source.
 - **A commercial license** for closed-source/commercial use without the AGPL's source-sharing
   obligation. Contact `teffen@sister.software`.
+
+Release notes live in the [release matrix](https://mailwoman.sister.software/docs/releases/);
+what we do and don't collect is stated plainly in the
+[privacy policy](https://mailwoman.sister.software/docs/licensing/privacy/); funders and sponsors
+can read our machine-readable [funding.json](https://mailwoman.sister.software/funding.json).
+Report security vulnerabilities privately per [`SECURITY.md`](./SECURITY.md).
 
 Portions of Mailwoman derived from [Pelias Parser](https://github.com/pelias/parser) remain
 under the MIT license, and Mailwoman bundles third-party data under its own terms. See

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,9 +20,9 @@ We're happy to credit you in the release notes if you'd like.
 
 ## Supported versions
 
-Mailwoman is pre-1.0 in spirit even though the npm version is 4.x — the public
+Mailwoman is pre-1.0 in spirit even though the npm version is 5.x — the public
 API is still settling. Security fixes land on the **latest published minor**
-(`4.x`). We don't backport to older minors; upgrading forward is the supported
+(`5.x`). We don't backport to older minors; upgrading forward is the supported
 path.
 
 ## Scope


### PR DESCRIPTION
Rebuilt as a DELTA on top of the operator's P0 front door (f609dead + follow-ups). What this adds to yours:

1. **Two live 404s fixed**: the site serves `/docs/…`, not `/articles/…` — getting-started (header nav) + what-mailwoman-is links repointed and verified 200.
2. **Rooftop undersell corrected**: the intro said 'admin/postcode coordinates' — we ship street + rooftop tiers (US + FR registers) since 5.8–5.10.
3. **Drop-in servers section**: the hosted endpoint curl + the three `npx … serve` lines + OpenAPI spec links — the migration story was otherwise only implied by the capability matrix.
4. **Footer links**: release matrix, privacy policy, funding.json, SECURITY.md pointer.
5. **SECURITY.md**: supported versions 4.x → 5.x. **CONTRIBUTING.md**: Node floor updated to match the published `engines` (>=24.18.0; it said ≥22.5.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5qDbkGN3xs2XDvyK52qPT