### PR TITLE
feat(clients): generated Python + Rust API clients from the OpenAPI specs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,3 +78,21 @@ jobs:
       # effect — all invisible in-repo, all fatal to a fresh `npm install`.
       - name: Clean-install smoke test
         run: yarn ci:smoke
+
+  # The generated Python + Rust API clients (clients/) live OUTSIDE the yarn workspaces, so the `test`
+  # job above never touches them. This proves the composed Python package still imports and the
+  # generated Rust still compiles — i.e. the code committed under clients/ is in sync with the specs
+  # and both distributables are buildable. Neither step hits the network (compile-only for Rust).
+  clients:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+      - name: Python client — import smoke
+        working-directory: clients/python
+        run: uv run python -c "from mailwoman_client import PhotonClient, NominatimClient, LibpostalClient"
+      - name: Rust client — compile generated code
+        working-directory: clients/rust
+        run: cargo build --examples

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,18 @@ data/eval/calibration/confidences.jsonl
 .env.*
 
 corpus-python/.pytest_cache/
+
+# Generated API clients (clients/python + clients/rust) — build artifacts + caches.
+# The generated source under clients/python/mailwoman_client/{photon,nominatim,libpostal} and
+# clients/rust/openapi/ IS committed (that's the shipped client); only build output is ignored.
+**/.pytest_cache/
+**/.ruff_cache/
+clients/python/build/
+clients/python/dist/
+clients/rust/target/
+# Library crate: don't commit the lockfile (resolved per-consumer).
+clients/rust/Cargo.lock
+
 output/
 # Per-run training-output download dirs (e.g. output-v150-fr-order-s42/ — pulled from the Modal
 # volume to local during a re-gate; each holds a ~113MB model.onnx). The exact `output/` above

--- a/clients/PUBLISHING.md
+++ b/clients/PUBLISHING.md
@@ -1,0 +1,92 @@
+# Publishing the API clients
+
+These clients are **not published yet**. The name `mailwoman-client` is available and reserved-by-intent
+on **both** registries (verified 404 on `pypi.org/pypi/mailwoman-client/json` and
+`crates.io/api/v1/crates/mailwoman-client`, 2026-07-12). This is the runbook for the first publish and
+every one after. Nothing here runs automatically — an operator runs it deliberately.
+
+Both packages version independently from the npm `@mailwoman/*` workspaces (they track the OpenAPI
+contract, not the engine release). They are not part of `yarn release` / the `publish.yml` CI flow.
+
+---
+
+## Python → PyPI (`mailwoman-client`)
+
+### One-time account setup
+
+1. Create a PyPI account at <https://pypi.org/account/register/> and enable 2FA.
+2. Pick one of the two auth routes below.
+
+### Route A — API token (simplest for the first manual publish)
+
+1. <https://pypi.org/manage/account/token/> → create a token. For the very first upload the project
+   does not exist yet, so scope the token to **"Entire account"**; after the first publish, replace it
+   with a token scoped to just the `mailwoman-client` project.
+2. Build, check, upload (verified locally — `twine check` PASSES on both artifacts):
+
+   ```bash
+   cd clients/python
+   rm -rf dist
+   uv build                        # -> dist/mailwoman_client-<v>-py3-none-any.whl + .tar.gz
+   uvx twine check dist/*          # metadata sanity
+   uvx twine upload dist/*         # username: __token__   password: pypi-AgEI...
+   ```
+
+   `uv publish --token pypi-AgEI...` (or `UV_PUBLISH_TOKEN`) is an equivalent one-shot alternative to
+   the `twine upload` line.
+
+### Route B — Trusted Publishing (recommended once a release workflow exists)
+
+PyPI Trusted Publishing (OIDC) works even though `sister-software/mailwoman` is private — it verifies a
+GitHub OIDC identity, not a public source attestation (this is the key difference from npm provenance,
+which the repo's `publish.yml` keeps off for exactly that reason). Configure a **pending publisher** at
+<https://pypi.org/manage/account/publishing/> (project `mailwoman-client`, owner `sister-software`, repo
+`mailwoman`, the workflow filename, optional environment), then a GitHub Actions job with
+`permissions: id-token: write` calls `pypa/gh-action-pypi-publish` — no token stored anywhere.
+
+### Verify
+
+```bash
+python -m venv /tmp/vv && /tmp/vv/bin/pip install mailwoman-client
+/tmp/vv/bin/python -c "from mailwoman_client import PhotonClient; print(PhotonClient.hosted()._base_url)"
+```
+
+---
+
+## Rust → crates.io (`mailwoman-client`)
+
+### One-time account setup
+
+1. Sign in at <https://crates.io/> with GitHub and confirm your email (crates.io refuses to publish until
+   the email is verified).
+2. <https://crates.io/settings/tokens> → **New Token** (scope `publish-new` + `publish-update`). Then:
+
+   ```bash
+   cargo login <crates.io-token>
+   ```
+
+### Publish
+
+`cargo package` already succeeds locally (10 files, license SPDX `AGPL-3.0-only OR LicenseRef-Commercial`
+validated). Dry-run, then publish:
+
+```bash
+cd clients/rust
+cargo publish --dry-run          # re-runs progenitor + compiles the packaged crate in isolation
+cargo publish
+```
+
+Notes:
+
+- The vendored `openapi/*.yaml` (the 3.0 down-converts) ship in the crate; `scripts/downgrade-spec.py`
+  does not, and isn't needed at build time. The `include` in `Cargo.toml` pins exactly what ships.
+- Consumers build `aws-lc-rs` (rustls' default crypto provider), which needs a **C compiler + CMake** on
+  the build host. Call this out in release notes if that's a concern for your audience.
+
+### Verify
+
+```bash
+cargo new /tmp/rr && cd /tmp/rr
+cargo add mailwoman-client tokio -F tokio/macros -F tokio/rt-multi-thread
+cargo build
+```

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,0 +1,80 @@
+# clients/
+
+Generated, typed API clients for Mailwoman's three HTTP drop-in servers — the Photon-compatible
+autocomplete API, the Nominatim-compatible geocoding API, and the libpostal-compatible parse/expand
+API. One client per language, each covering all three drop-ins:
+
+| Dir                   | Package (registry)             | Generator                                                                              |
+| --------------------- | ------------------------------ | -------------------------------------------------------------------------------------- |
+| [`python/`](./python) | `mailwoman-client` (PyPI)      | [`openapi-python-client`](https://github.com/openapi-generators/openapi-python-client) |
+| [`rust/`](./rust)     | `mailwoman-client` (crates.io) | [`progenitor`](https://github.com/oxidecomputer/progenitor)                            |
+
+These are **not** yarn workspaces — they're standalone Python / Rust projects with their own
+tooling (`ruff`, `cargo`), deliberately outside the JS monorepo (the `corpus-python/` precedent).
+Each has its own lint/format config. The root `oxfmt` gate does format the Markdown + `pyproject.toml`
+here (oxfmt covers `.md`/`.toml`), so keep those in house style; it leaves the generated `.py`/`.rs`
+and the vendored `.yaml` alone, and `oxlint` finds no JS to lint. Build artifacts (`.venv/`,
+`target/`, `*.egg-info/`, `.ruff_cache/`, `Cargo.lock`) are git-ignored; the generated source **is**
+committed (it is the shipped client).
+
+## The generated-from-spec contract
+
+The client code under `python/mailwoman_client/{photon,nominatim,libpostal}/` and the vendored specs
+under `rust/openapi/` are **generated** — do not hand-edit them; they are overwritten on regen. The
+only hand-written code is the thin ergonomics layer (`python/mailwoman_client/__init__.py`,
+`rust/src/lib.rs`): friendly client classes/constructors with a default `base_url`. To publish, see
+[`PUBLISHING.md`](./PUBLISHING.md).
+
+The source of truth is each workspace's `openapi.yaml` (`photon/`, `nominatim/`, `libpostal/` at the
+repo root), also served at `https://mailwoman.sister.software/openapi/*.yaml`.
+
+## Regenerate
+
+Run these after the specs change. Both loops read the three specs relative to the repo root.
+
+### Python (`clients/python`)
+
+`openapi-python-client` emits fully relative imports, so the three specs compose as sibling
+subpackages under one distributable with no post-processing:
+
+```bash
+cd clients/python
+for name in photon nominatim libpostal; do
+  uvx --from openapi-python-client openapi-python-client generate \
+    --path "../../$name/openapi.yaml" \
+    --meta none \
+    --output-path "mailwoman_client/$name" \
+    --overwrite
+done
+# The generator drops a .ruff_cache under each output dir — remove it.
+find mailwoman_client -name .ruff_cache -type d -prune -exec rm -rf {} +
+```
+
+### Rust (`clients/rust`)
+
+progenitor parses OpenAPI via the `openapiv3` crate, which only supports 3.0.x. The specs are 3.1,
+so regen down-converts them first (deterministic; `scripts/downgrade-spec.py`), then `cargo build`
+runs progenitor's `generate_api!` macro over the down-converted specs at compile time:
+
+```bash
+cd clients/rust
+for name in photon nominatim libpostal; do
+  uv run --with pyyaml python scripts/downgrade-spec.py "../../$name/openapi.yaml" "openapi/$name.yaml"
+done
+cargo build
+```
+
+## Smoke
+
+Both clients are verified against the hosted Photon trial endpoint (`https://photon.sister.software`):
+
+```bash
+# Python
+cd clients/python && uv run --extra dev pytest            # tests/test_smoke_live.py
+cd clients/python && uv run python examples/search_berlin.py
+
+# Rust
+cd clients/rust && cargo run --example basic
+```
+
+Both print the same three "berlin" hits (Berlin DE, Berlin CT, Berlín SV).

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,69 @@
+# mailwoman-client (Python)
+
+Typed Python clients for [Mailwoman](https://mailwoman.sister.software)'s three HTTP drop-in
+APIs, **generated from their published OpenAPI 3.1 specs** and bundled under one distributable:
+
+| Subpackage                   | Drop-in for | Endpoints                                   |
+| ---------------------------- | ----------- | ------------------------------------------- |
+| `mailwoman_client.photon`    | Photon      | `/api`, `/reverse`                          |
+| `mailwoman_client.nominatim` | Nominatim   | `/search`, `/reverse`, `/lookup`, `/status` |
+| `mailwoman_client.libpostal` | libpostal   | `/parse`, `/expand`                         |
+
+The three subpackages are generated verbatim by [`openapi-python-client`](https://github.com/openapi-generators/openapi-python-client)
+(they run their own `ruff` pass) and are **overwritten on regen** — do not hand-edit them. The
+only hand-written code is the thin ergonomics layer in `mailwoman_client/__init__.py`:
+`PhotonClient` / `NominatimClient` / `LibpostalClient`, each with a sensible default `base_url`.
+See [`../README.md`](../README.md) for the regeneration command.
+
+## Install
+
+```bash
+pip install mailwoman-client
+```
+
+Requires Python 3.10+. The only runtime dependencies are `httpx` and `attrs`.
+
+## Usage
+
+Forward-geocode against the hosted Photon trial endpoint (`https://photon.sister.software`, no
+local server needed):
+
+```python
+from mailwoman_client import PhotonClient
+from mailwoman_client.photon.api.geocoding import search
+
+client = PhotonClient.hosted()  # or PhotonClient(base_url="http://127.0.0.1:2322") to self-host
+result = search.sync(client=client, q="berlin", limit=3)
+
+for feature in result.features:
+    lon, lat = feature.geometry.coordinates
+    props = feature.properties
+    print(f"{props.name} ({props.type_}) — {lat:.4f}, {lon:.4f} [{props.country or '?'}]")
+```
+
+Verified output (against `https://photon.sister.software`):
+
+```
+Berlin (city) — 52.5015, 13.4019 [Germany]
+Berlin (city) — 41.6114, -72.7758 [United States]
+Berlín (city) — 13.5000, -88.5333 [?]
+```
+
+### Self-hosting
+
+`PhotonClient()`, `NominatimClient()`, and `LibpostalClient()` default to their local
+`serve` ports (2322 / 8080 / 8081), so they work out of the box against a self-hosted server
+(`npx @mailwoman/photon serve`, etc.). Only Photon has a hosted public trial endpoint; the
+Nominatim and libpostal drop-ins are self-host only. Point anywhere with `base_url=`.
+
+### Async
+
+Every endpoint module also exposes an `asyncio` coroutine alongside `sync`:
+
+```python
+result = await search.asyncio(client=client, q="berlin", limit=3)
+```
+
+## License
+
+AGPL-3.0-only OR LicenseRef-Commercial (see the [repository](https://github.com/sister-software/mailwoman)).

--- a/clients/python/examples/search_berlin.py
+++ b/clients/python/examples/search_berlin.py
@@ -1,0 +1,15 @@
+"""Forward-geocode "berlin" against the hosted Photon trial endpoint and print the top 3 hits.
+
+Run: ``python examples/search_berlin.py`` (from clients/python, after `pip install -e .`).
+"""
+
+from mailwoman_client import PhotonClient
+from mailwoman_client.photon.api.geocoding import search
+
+client = PhotonClient.hosted()  # https://photon.sister.software
+result = search.sync(client=client, q="berlin", limit=3)
+
+for feature in result.features:
+    lon, lat = feature.geometry.coordinates
+    props = feature.properties
+    print(f"{props.name} ({props.type_}) — {lat:.4f}, {lon:.4f} [{props.country or '?'}]")

--- a/clients/python/mailwoman_client/__init__.py
+++ b/clients/python/mailwoman_client/__init__.py
@@ -1,0 +1,88 @@
+"""mailwoman-client — typed Python clients for Mailwoman's drop-in geocoding APIs.
+
+Mailwoman ships three HTTP drop-ins — a Photon-compatible autocomplete API, a
+Nominatim-compatible geocoding API, and a libpostal-compatible parse/expand API. This
+package bundles a typed client for each, **generated from their published OpenAPI 3.1
+specs** with `openapi-python-client`, under one distributable (`mailwoman_client.photon`,
+`mailwoman_client.nominatim`, `mailwoman_client.libpostal`).
+
+The `*.photon` / `*.nominatim` / `*.libpostal` subpackages are generated verbatim — do not
+hand-edit them (they are overwritten on regen; see `clients/README.md`). Everything in this
+module is the thin, hand-written ergonomics layer over that generated code: friendly client
+classes with a sensible default `base_url`.
+
+Quick start (hosted Photon trial endpoint, no local server needed):
+
+    from mailwoman_client import PhotonClient
+    from mailwoman_client.photon.api.geocoding import search
+
+    client = PhotonClient.hosted()          # https://photon.sister.software
+    fc = search.sync(client=client, q="berlin", limit=3)
+    for feature in fc.features:
+        print(feature.properties.name, feature.geometry.coordinates)
+
+Self-hosting (`npx @mailwoman/photon serve`)? Every client defaults to its local `serve`
+port, so `PhotonClient()` / `NominatimClient()` / `LibpostalClient()` just work against a
+localhost server. Point elsewhere with `PhotonClient(base_url="http://…")`.
+"""
+
+from .libpostal.client import Client as _LibpostalBase
+from .nominatim.client import Client as _NominatimBase
+from .photon.client import Client as _PhotonBase
+
+__all__ = (
+    "PhotonClient",
+    "NominatimClient",
+    "LibpostalClient",
+    "PHOTON_HOSTED_BASE_URL",
+)
+
+#: The hosted public Photon trial endpoint (conservative rate limits). Only Photon has a
+#: hosted trial; the Nominatim and libpostal drop-ins are self-host only.
+PHOTON_HOSTED_BASE_URL = "https://photon.sister.software"
+
+
+class PhotonClient(_PhotonBase):
+    """Client for the Photon-compatible autocomplete / reverse geocoding API (`/api`, `/reverse`).
+
+    Defaults to the local `npx @mailwoman/photon serve` port (2322). Use
+    :meth:`hosted` for the public trial endpoint, or pass ``base_url=`` for anything else.
+    Call it with the generated endpoint functions, e.g.
+    ``mailwoman_client.photon.api.geocoding.search.sync(client=client, q=…)``.
+    """
+
+    DEFAULT_BASE_URL = "http://127.0.0.1:2322"
+
+    def __init__(self, base_url: str | None = None, **kwargs) -> None:
+        super().__init__(base_url=base_url or self.DEFAULT_BASE_URL, **kwargs)
+
+    @classmethod
+    def hosted(cls, **kwargs) -> "PhotonClient":
+        """Return a client pointed at the hosted public trial endpoint (:data:`PHOTON_HOSTED_BASE_URL`)."""
+        return cls(base_url=PHOTON_HOSTED_BASE_URL, **kwargs)
+
+
+class NominatimClient(_NominatimBase):
+    """Client for the Nominatim-compatible geocoding API (`/search`, `/reverse`, `/lookup`, `/status`).
+
+    Defaults to the local `npx @mailwoman/nominatim serve` port (8080). Pass ``base_url=``
+    to point elsewhere. Self-host only — there is no hosted public endpoint.
+    """
+
+    DEFAULT_BASE_URL = "http://127.0.0.1:8080"
+
+    def __init__(self, base_url: str | None = None, **kwargs) -> None:
+        super().__init__(base_url=base_url or self.DEFAULT_BASE_URL, **kwargs)
+
+
+class LibpostalClient(_LibpostalBase):
+    """Client for the libpostal-compatible parse / expand API (`/parse`, `/expand`).
+
+    Defaults to the local `npx @mailwoman/libpostal serve` port (8081). Pass ``base_url=``
+    to point elsewhere. Self-host only — there is no hosted public endpoint.
+    """
+
+    DEFAULT_BASE_URL = "http://127.0.0.1:8081"
+
+    def __init__(self, base_url: str | None = None, **kwargs) -> None:
+        super().__init__(base_url=base_url or self.DEFAULT_BASE_URL, **kwargs)

--- a/clients/python/mailwoman_client/libpostal/__init__.py
+++ b/clients/python/mailwoman_client/libpostal/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing @mailwoman/libpostal"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/clients/python/mailwoman_client/libpostal/api/__init__.py
+++ b/clients/python/mailwoman_client/libpostal/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/clients/python/mailwoman_client/libpostal/api/meta/__init__.py
+++ b/clients/python/mailwoman_client/libpostal/api/meta/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/mailwoman_client/libpostal/api/meta/get_root.py
+++ b/clients/python/mailwoman_client/libpostal/api/meta/get_root.py
@@ -1,0 +1,134 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> str | None:
+    if response.status_code == 200:
+        response_200 = response.text
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[str]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[str]:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> str | None:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[str]:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> str | None:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/libpostal/api/parsing/__init__.py
+++ b/clients/python/mailwoman_client/libpostal/api/parsing/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/mailwoman_client/libpostal/api/parsing/expand_get.py
+++ b/clients/python/mailwoman_client/libpostal/api/parsing/expand_get.py
@@ -1,0 +1,188 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.expand_response import ExpandResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    address: str | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["address"] = address
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/expand",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Error | ExpandResponse | None:
+    if response.status_code == 200:
+        response_200 = ExpandResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = Error.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Error | ExpandResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    address: str | Unset = UNSET,
+) -> Response[Error | ExpandResponse]:
+    """Expand an address (query string)
+
+     Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence
+    note).
+
+    Args:
+        address (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | ExpandResponse]
+    """
+
+    kwargs = _get_kwargs(
+        address=address,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    address: str | Unset = UNSET,
+) -> Error | ExpandResponse | None:
+    """Expand an address (query string)
+
+     Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence
+    note).
+
+    Args:
+        address (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | ExpandResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        address=address,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    address: str | Unset = UNSET,
+) -> Response[Error | ExpandResponse]:
+    """Expand an address (query string)
+
+     Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence
+    note).
+
+    Args:
+        address (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | ExpandResponse]
+    """
+
+    kwargs = _get_kwargs(
+        address=address,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    address: str | Unset = UNSET,
+) -> Error | ExpandResponse | None:
+    """Expand an address (query string)
+
+     Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence
+    note).
+
+    Args:
+        address (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | ExpandResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            address=address,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/libpostal/api/parsing/expand_post.py
+++ b/clients/python/mailwoman_client/libpostal/api/parsing/expand_post.py
@@ -1,0 +1,188 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.expand_request import ExpandRequest
+from ...models.expand_response import ExpandResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: ExpandRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/expand",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Error | ExpandResponse | None:
+    if response.status_code == 200:
+        response_200 = ExpandResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = Error.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Error | ExpandResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ExpandRequest,
+) -> Response[Error | ExpandResponse]:
+    """Expand an address (JSON body)
+
+     Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence
+    note).
+
+    Args:
+        body (ExpandRequest): An `/expand` request body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | ExpandResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ExpandRequest,
+) -> Error | ExpandResponse | None:
+    """Expand an address (JSON body)
+
+     Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence
+    note).
+
+    Args:
+        body (ExpandRequest): An `/expand` request body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | ExpandResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ExpandRequest,
+) -> Response[Error | ExpandResponse]:
+    """Expand an address (JSON body)
+
+     Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence
+    note).
+
+    Args:
+        body (ExpandRequest): An `/expand` request body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | ExpandResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ExpandRequest,
+) -> Error | ExpandResponse | None:
+    """Expand an address (JSON body)
+
+     Return the normalized + abbreviation-expanded forms of an address (deterministic; see the divergence
+    note).
+
+    Args:
+        body (ExpandRequest): An `/expand` request body.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | ExpandResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/libpostal/api/parsing/parse_get.py
+++ b/clients/python/mailwoman_client/libpostal/api/parsing/parse_get.py
@@ -1,0 +1,199 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.libpostal_component import LibpostalComponent
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    query: str | Unset = UNSET,
+    address: str | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["query"] = query
+
+    params["address"] = address
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/parse",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Error | list[LibpostalComponent] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = LibpostalComponent.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Error | list[LibpostalComponent]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    query: str | Unset = UNSET,
+    address: str | Unset = UNSET,
+) -> Response[Error | list[LibpostalComponent]]:
+    """Parse an address (query string)
+
+     Parse a free-text address into ordered labeled components.
+
+    Args:
+        query (str | Unset):
+        address (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | list[LibpostalComponent]]
+    """
+
+    kwargs = _get_kwargs(
+        query=query,
+        address=address,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    query: str | Unset = UNSET,
+    address: str | Unset = UNSET,
+) -> Error | list[LibpostalComponent] | None:
+    """Parse an address (query string)
+
+     Parse a free-text address into ordered labeled components.
+
+    Args:
+        query (str | Unset):
+        address (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | list[LibpostalComponent]
+    """
+
+    return sync_detailed(
+        client=client,
+        query=query,
+        address=address,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    query: str | Unset = UNSET,
+    address: str | Unset = UNSET,
+) -> Response[Error | list[LibpostalComponent]]:
+    """Parse an address (query string)
+
+     Parse a free-text address into ordered labeled components.
+
+    Args:
+        query (str | Unset):
+        address (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | list[LibpostalComponent]]
+    """
+
+    kwargs = _get_kwargs(
+        query=query,
+        address=address,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    query: str | Unset = UNSET,
+    address: str | Unset = UNSET,
+) -> Error | list[LibpostalComponent] | None:
+    """Parse an address (query string)
+
+     Parse a free-text address into ordered labeled components.
+
+    Args:
+        query (str | Unset):
+        address (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | list[LibpostalComponent]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            query=query,
+            address=address,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/libpostal/api/parsing/parse_post.py
+++ b/clients/python/mailwoman_client/libpostal/api/parsing/parse_post.py
@@ -1,0 +1,184 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.libpostal_component import LibpostalComponent
+from ...models.parse_request import ParseRequest
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: ParseRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/parse",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Error | list[LibpostalComponent] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = LibpostalComponent.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Error | list[LibpostalComponent]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ParseRequest,
+) -> Response[Error | list[LibpostalComponent]]:
+    """Parse an address (JSON body)
+
+     Parse a free-text address into ordered labeled components.
+
+    Args:
+        body (ParseRequest): A `/parse` request body. Provide `query` (or its alias `address`).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | list[LibpostalComponent]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ParseRequest,
+) -> Error | list[LibpostalComponent] | None:
+    """Parse an address (JSON body)
+
+     Parse a free-text address into ordered labeled components.
+
+    Args:
+        body (ParseRequest): A `/parse` request body. Provide `query` (or its alias `address`).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | list[LibpostalComponent]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ParseRequest,
+) -> Response[Error | list[LibpostalComponent]]:
+    """Parse an address (JSON body)
+
+     Parse a free-text address into ordered labeled components.
+
+    Args:
+        body (ParseRequest): A `/parse` request body. Provide `query` (or its alias `address`).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | list[LibpostalComponent]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: ParseRequest,
+) -> Error | list[LibpostalComponent] | None:
+    """Parse an address (JSON body)
+
+     Parse a free-text address into ordered labeled components.
+
+    Args:
+        body (ParseRequest): A `/parse` request body. Provide `query` (or its alias `address`).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | list[LibpostalComponent]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/libpostal/client.py
+++ b/clients/python/mailwoman_client/libpostal/client.py
@@ -1,0 +1,282 @@
+import ssl
+from typing import Any
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(
+        self, async_client: httpx.AsyncClient
+    ) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/clients/python/mailwoman_client/libpostal/errors.py
+++ b/clients/python/mailwoman_client/libpostal/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/clients/python/mailwoman_client/libpostal/models/__init__.py
+++ b/clients/python/mailwoman_client/libpostal/models/__init__.py
@@ -1,0 +1,15 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .error import Error
+from .expand_request import ExpandRequest
+from .expand_response import ExpandResponse
+from .libpostal_component import LibpostalComponent
+from .parse_request import ParseRequest
+
+__all__ = (
+    "Error",
+    "ExpandRequest",
+    "ExpandResponse",
+    "LibpostalComponent",
+    "ParseRequest",
+)

--- a/clients/python/mailwoman_client/libpostal/models/error.py
+++ b/clients/python/mailwoman_client/libpostal/models/error.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="Error")
+
+
+@_attrs_define
+class Error:
+    """A JSON error envelope.
+
+    Attributes:
+        error (str):
+    """
+
+    error: str
+
+    def to_dict(self) -> dict[str, Any]:
+        error = self.error
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "error": error,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        error = d.pop("error")
+
+        error = cls(
+            error=error,
+        )
+
+        return error

--- a/clients/python/mailwoman_client/libpostal/models/expand_request.py
+++ b/clients/python/mailwoman_client/libpostal/models/expand_request.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="ExpandRequest")
+
+
+@_attrs_define
+class ExpandRequest:
+    """An `/expand` request body.
+
+    Attributes:
+        address (str): The address to expand.
+    """
+
+    address: str
+
+    def to_dict(self) -> dict[str, Any]:
+        address = self.address
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "address": address,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        address = d.pop("address")
+
+        expand_request = cls(
+            address=address,
+        )
+
+        return expand_request

--- a/clients/python/mailwoman_client/libpostal/models/expand_response.py
+++ b/clients/python/mailwoman_client/libpostal/models/expand_response.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="ExpandResponse")
+
+
+@_attrs_define
+class ExpandResponse:
+    """The `/expand` response.
+
+    Attributes:
+        expansions (list[str]): The distinct expanded forms (original + normalized + abbreviation-expanded), order
+            preserved.
+    """
+
+    expansions: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        expansions = self.expansions
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "expansions": expansions,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        expansions = cast(list[str], d.pop("expansions"))
+
+        expand_response = cls(
+            expansions=expansions,
+        )
+
+        return expand_response

--- a/clients/python/mailwoman_client/libpostal/models/libpostal_component.py
+++ b/clients/python/mailwoman_client/libpostal/models/libpostal_component.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="LibpostalComponent")
+
+
+@_attrs_define
+class LibpostalComponent:
+    """A libpostal `parse_address` component — a label and the text span it covers, in order.
+
+    Attributes:
+        label (str): The libpostal label, e.g. `house_number`, `road`, `city`, `state`, `postcode`.
+        value (str): The text the label covers.
+    """
+
+    label: str
+    value: str
+
+    def to_dict(self) -> dict[str, Any]:
+        label = self.label
+
+        value = self.value
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "label": label,
+                "value": value,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        label = d.pop("label")
+
+        value = d.pop("value")
+
+        libpostal_component = cls(
+            label=label,
+            value=value,
+        )
+
+        return libpostal_component

--- a/clients/python/mailwoman_client/libpostal/models/parse_request.py
+++ b/clients/python/mailwoman_client/libpostal/models/parse_request.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ParseRequest")
+
+
+@_attrs_define
+class ParseRequest:
+    """A `/parse` request body. Provide `query` (or its alias `address`).
+
+    Attributes:
+        query (str | Unset): The address to parse.
+        address (str | Unset): Alias for `query`.
+    """
+
+    query: str | Unset = UNSET
+    address: str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        query = self.query
+
+        address = self.address
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if query is not UNSET:
+            field_dict["query"] = query
+        if address is not UNSET:
+            field_dict["address"] = address
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        query = d.pop("query", UNSET)
+
+        address = d.pop("address", UNSET)
+
+        parse_request = cls(
+            query=query,
+            address=address,
+        )
+
+        return parse_request

--- a/clients/python/mailwoman_client/libpostal/types.py
+++ b/clients/python/mailwoman_client/libpostal/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/clients/python/mailwoman_client/nominatim/__init__.py
+++ b/clients/python/mailwoman_client/nominatim/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing @mailwoman/nominatim"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/clients/python/mailwoman_client/nominatim/api/__init__.py
+++ b/clients/python/mailwoman_client/nominatim/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/clients/python/mailwoman_client/nominatim/api/geocoding/__init__.py
+++ b/clients/python/mailwoman_client/nominatim/api/geocoding/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/mailwoman_client/nominatim/api/geocoding/lookup.py
+++ b/clients/python/mailwoman_client/nominatim/api/geocoding/lookup.py
@@ -1,0 +1,249 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.lookup_addressdetails import LookupAddressdetails
+from ...models.lookup_format import LookupFormat
+from ...models.nominatim_feature_collection import NominatimFeatureCollection
+from ...models.nominatim_result import NominatimResult
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    osm_ids: str,
+    addressdetails: LookupAddressdetails | Unset = LookupAddressdetails.VALUE_0,
+    format_: LookupFormat | Unset = LookupFormat.JSONV2,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["osm_ids"] = osm_ids
+
+    json_addressdetails: int | Unset = UNSET
+    if not isinstance(addressdetails, Unset):
+        json_addressdetails = addressdetails.value
+
+    params["addressdetails"] = json_addressdetails
+
+    json_format_: str | Unset = UNSET
+    if not isinstance(format_, Unset):
+        json_format_ = format_.value
+
+    params["format"] = json_format_
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/lookup",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Error | list[NominatimResult] | NominatimFeatureCollection | None:
+    if response.status_code == 200:
+
+        def _parse_response_200(
+            data: object,
+        ) -> list[NominatimResult] | NominatimFeatureCollection:
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                response_200_type_0 = []
+                _response_200_type_0 = data
+                for response_200_type_0_item_data in _response_200_type_0:
+                    response_200_type_0_item = NominatimResult.from_dict(
+                        response_200_type_0_item_data
+                    )
+
+                    response_200_type_0.append(response_200_type_0_item)
+
+                return response_200_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            response_200_type_1 = NominatimFeatureCollection.from_dict(data)
+
+            return response_200_type_1
+
+        response_200 = _parse_response_200(response.json())
+
+        return response_200
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = Error.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Error | list[NominatimResult] | NominatimFeatureCollection]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    osm_ids: str,
+    addressdetails: LookupAddressdetails | Unset = LookupAddressdetails.VALUE_0,
+    format_: LookupFormat | Unset = LookupFormat.JSONV2,
+) -> Response[Error | list[NominatimResult] | NominatimFeatureCollection]:
+    """Look up known place ids
+
+     Resolve one or more OSM/place ids to result objects. Part of the router contract; not wired in the
+    bundled `serve` engine yet (answers `501`).
+
+    Args:
+        osm_ids (str):
+        addressdetails (LookupAddressdetails | Unset):  Default: LookupAddressdetails.VALUE_0.
+        format_ (LookupFormat | Unset):  Default: LookupFormat.JSONV2.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | list[NominatimResult] | NominatimFeatureCollection]
+    """
+
+    kwargs = _get_kwargs(
+        osm_ids=osm_ids,
+        addressdetails=addressdetails,
+        format_=format_,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    osm_ids: str,
+    addressdetails: LookupAddressdetails | Unset = LookupAddressdetails.VALUE_0,
+    format_: LookupFormat | Unset = LookupFormat.JSONV2,
+) -> Error | list[NominatimResult] | NominatimFeatureCollection | None:
+    """Look up known place ids
+
+     Resolve one or more OSM/place ids to result objects. Part of the router contract; not wired in the
+    bundled `serve` engine yet (answers `501`).
+
+    Args:
+        osm_ids (str):
+        addressdetails (LookupAddressdetails | Unset):  Default: LookupAddressdetails.VALUE_0.
+        format_ (LookupFormat | Unset):  Default: LookupFormat.JSONV2.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | list[NominatimResult] | NominatimFeatureCollection
+    """
+
+    return sync_detailed(
+        client=client,
+        osm_ids=osm_ids,
+        addressdetails=addressdetails,
+        format_=format_,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    osm_ids: str,
+    addressdetails: LookupAddressdetails | Unset = LookupAddressdetails.VALUE_0,
+    format_: LookupFormat | Unset = LookupFormat.JSONV2,
+) -> Response[Error | list[NominatimResult] | NominatimFeatureCollection]:
+    """Look up known place ids
+
+     Resolve one or more OSM/place ids to result objects. Part of the router contract; not wired in the
+    bundled `serve` engine yet (answers `501`).
+
+    Args:
+        osm_ids (str):
+        addressdetails (LookupAddressdetails | Unset):  Default: LookupAddressdetails.VALUE_0.
+        format_ (LookupFormat | Unset):  Default: LookupFormat.JSONV2.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | list[NominatimResult] | NominatimFeatureCollection]
+    """
+
+    kwargs = _get_kwargs(
+        osm_ids=osm_ids,
+        addressdetails=addressdetails,
+        format_=format_,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    osm_ids: str,
+    addressdetails: LookupAddressdetails | Unset = LookupAddressdetails.VALUE_0,
+    format_: LookupFormat | Unset = LookupFormat.JSONV2,
+) -> Error | list[NominatimResult] | NominatimFeatureCollection | None:
+    """Look up known place ids
+
+     Resolve one or more OSM/place ids to result objects. Part of the router contract; not wired in the
+    bundled `serve` engine yet (answers `501`).
+
+    Args:
+        osm_ids (str):
+        addressdetails (LookupAddressdetails | Unset):  Default: LookupAddressdetails.VALUE_0.
+        format_ (LookupFormat | Unset):  Default: LookupFormat.JSONV2.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | list[NominatimResult] | NominatimFeatureCollection
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            osm_ids=osm_ids,
+            addressdetails=addressdetails,
+            format_=format_,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/nominatim/api/geocoding/reverse.py
+++ b/clients/python/mailwoman_client/nominatim/api/geocoding/reverse.py
@@ -1,0 +1,318 @@
+from http import HTTPStatus
+from typing import Any, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.nominatim_feature_collection import NominatimFeatureCollection
+from ...models.nominatim_result import NominatimResult
+from ...models.reverse_addressdetails import ReverseAddressdetails
+from ...models.reverse_format import ReverseFormat
+from ...models.schema_org_place import SchemaOrgPlace
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    lat: float,
+    lon: float,
+    zoom: int | Unset = UNSET,
+    addressdetails: ReverseAddressdetails | Unset = ReverseAddressdetails.VALUE_0,
+    format_: ReverseFormat | Unset = ReverseFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["lat"] = lat
+
+    params["lon"] = lon
+
+    params["zoom"] = zoom
+
+    json_addressdetails: int | Unset = UNSET
+    if not isinstance(addressdetails, Unset):
+        json_addressdetails = addressdetails.value
+
+    params["addressdetails"] = json_addressdetails
+
+    json_format_: str | Unset = UNSET
+    if not isinstance(format_, Unset):
+        json_format_ = format_.value
+
+    params["format"] = json_format_
+
+    params["accept-language"] = accept_language
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/reverse",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace | None
+):
+    if response.status_code == 200:
+
+        def _parse_response_200(
+            data: object,
+        ) -> NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                response_200_type_0 = NominatimResult.from_dict(data)
+
+                return response_200_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                response_200_type_1 = NominatimFeatureCollection.from_dict(data)
+
+                return response_200_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                response_200_type_2 = SchemaOrgPlace.from_dict(data)
+
+                return response_200_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace,
+                data,
+            )
+
+        response_200 = _parse_response_200(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = Error.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = Error.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    lat: float,
+    lon: float,
+    zoom: int | Unset = UNSET,
+    addressdetails: ReverseAddressdetails | Unset = ReverseAddressdetails.VALUE_0,
+    format_: ReverseFormat | Unset = ReverseFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> Response[
+    Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace
+]:
+    """Reverse geocoding
+
+     Resolve a coordinate to the nearest address (point-in-polygon over the WOF admin hierarchy).
+
+    Args:
+        lat (float):
+        lon (float):
+        zoom (int | Unset):
+        addressdetails (ReverseAddressdetails | Unset):  Default: ReverseAddressdetails.VALUE_0.
+        format_ (ReverseFormat | Unset):  Default: ReverseFormat.JSONV2.
+        accept_language (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace]
+    """
+
+    kwargs = _get_kwargs(
+        lat=lat,
+        lon=lon,
+        zoom=zoom,
+        addressdetails=addressdetails,
+        format_=format_,
+        accept_language=accept_language,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    lat: float,
+    lon: float,
+    zoom: int | Unset = UNSET,
+    addressdetails: ReverseAddressdetails | Unset = ReverseAddressdetails.VALUE_0,
+    format_: ReverseFormat | Unset = ReverseFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> (
+    Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace | None
+):
+    """Reverse geocoding
+
+     Resolve a coordinate to the nearest address (point-in-polygon over the WOF admin hierarchy).
+
+    Args:
+        lat (float):
+        lon (float):
+        zoom (int | Unset):
+        addressdetails (ReverseAddressdetails | Unset):  Default: ReverseAddressdetails.VALUE_0.
+        format_ (ReverseFormat | Unset):  Default: ReverseFormat.JSONV2.
+        accept_language (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace
+    """
+
+    return sync_detailed(
+        client=client,
+        lat=lat,
+        lon=lon,
+        zoom=zoom,
+        addressdetails=addressdetails,
+        format_=format_,
+        accept_language=accept_language,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    lat: float,
+    lon: float,
+    zoom: int | Unset = UNSET,
+    addressdetails: ReverseAddressdetails | Unset = ReverseAddressdetails.VALUE_0,
+    format_: ReverseFormat | Unset = ReverseFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> Response[
+    Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace
+]:
+    """Reverse geocoding
+
+     Resolve a coordinate to the nearest address (point-in-polygon over the WOF admin hierarchy).
+
+    Args:
+        lat (float):
+        lon (float):
+        zoom (int | Unset):
+        addressdetails (ReverseAddressdetails | Unset):  Default: ReverseAddressdetails.VALUE_0.
+        format_ (ReverseFormat | Unset):  Default: ReverseFormat.JSONV2.
+        accept_language (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace]
+    """
+
+    kwargs = _get_kwargs(
+        lat=lat,
+        lon=lon,
+        zoom=zoom,
+        addressdetails=addressdetails,
+        format_=format_,
+        accept_language=accept_language,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    lat: float,
+    lon: float,
+    zoom: int | Unset = UNSET,
+    addressdetails: ReverseAddressdetails | Unset = ReverseAddressdetails.VALUE_0,
+    format_: ReverseFormat | Unset = ReverseFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> (
+    Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace | None
+):
+    """Reverse geocoding
+
+     Resolve a coordinate to the nearest address (point-in-polygon over the WOF admin hierarchy).
+
+    Args:
+        lat (float):
+        lon (float):
+        zoom (int | Unset):
+        addressdetails (ReverseAddressdetails | Unset):  Default: ReverseAddressdetails.VALUE_0.
+        format_ (ReverseFormat | Unset):  Default: ReverseFormat.JSONV2.
+        accept_language (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | NominatimFeatureCollection | NominatimResult | None | SchemaOrgPlace
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            lat=lat,
+            lon=lon,
+            zoom=zoom,
+            addressdetails=addressdetails,
+            format_=format_,
+            accept_language=accept_language,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/nominatim/api/geocoding/search.py
+++ b/clients/python/mailwoman_client/nominatim/api/geocoding/search.py
@@ -1,0 +1,444 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.nominatim_feature_collection import NominatimFeatureCollection
+from ...models.nominatim_result import NominatimResult
+from ...models.schema_org_place import SchemaOrgPlace
+from ...models.search_addressdetails import SearchAddressdetails
+from ...models.search_bounded import SearchBounded
+from ...models.search_format import SearchFormat
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    q: str | Unset = UNSET,
+    street: str | Unset = UNSET,
+    city: str | Unset = UNSET,
+    county: str | Unset = UNSET,
+    state: str | Unset = UNSET,
+    country: str | Unset = UNSET,
+    postalcode: str | Unset = UNSET,
+    countrycodes: str | Unset = UNSET,
+    limit: int | Unset = 10,
+    bounded: SearchBounded | Unset = SearchBounded.VALUE_0,
+    addressdetails: SearchAddressdetails | Unset = SearchAddressdetails.VALUE_0,
+    format_: SearchFormat | Unset = SearchFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["q"] = q
+
+    params["street"] = street
+
+    params["city"] = city
+
+    params["county"] = county
+
+    params["state"] = state
+
+    params["country"] = country
+
+    params["postalcode"] = postalcode
+
+    params["countrycodes"] = countrycodes
+
+    params["limit"] = limit
+
+    json_bounded: int | Unset = UNSET
+    if not isinstance(bounded, Unset):
+        json_bounded = bounded.value
+
+    params["bounded"] = json_bounded
+
+    json_addressdetails: int | Unset = UNSET
+    if not isinstance(addressdetails, Unset):
+        json_addressdetails = addressdetails.value
+
+    params["addressdetails"] = json_addressdetails
+
+    json_format_: str | Unset = UNSET
+    if not isinstance(format_, Unset):
+        json_format_ = format_.value
+
+    params["format"] = json_format_
+
+    params["accept-language"] = accept_language
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/search",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    Error
+    | list[NominatimResult]
+    | list[SchemaOrgPlace]
+    | NominatimFeatureCollection
+    | None
+):
+    if response.status_code == 200:
+
+        def _parse_response_200(
+            data: object,
+        ) -> list[NominatimResult] | list[SchemaOrgPlace] | NominatimFeatureCollection:
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                response_200_type_0 = []
+                _response_200_type_0 = data
+                for response_200_type_0_item_data in _response_200_type_0:
+                    response_200_type_0_item = NominatimResult.from_dict(
+                        response_200_type_0_item_data
+                    )
+
+                    response_200_type_0.append(response_200_type_0_item)
+
+                return response_200_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                response_200_type_1 = NominatimFeatureCollection.from_dict(data)
+
+                return response_200_type_1
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, list):
+                raise TypeError()
+            response_200_type_2 = []
+            _response_200_type_2 = data
+            for response_200_type_2_item_data in _response_200_type_2:
+                response_200_type_2_item = SchemaOrgPlace.from_dict(
+                    response_200_type_2_item_data
+                )
+
+                response_200_type_2.append(response_200_type_2_item)
+
+            return response_200_type_2
+
+        response_200 = _parse_response_200(response.json())
+
+        return response_200
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = Error.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    Error | list[NominatimResult] | list[SchemaOrgPlace] | NominatimFeatureCollection
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    q: str | Unset = UNSET,
+    street: str | Unset = UNSET,
+    city: str | Unset = UNSET,
+    county: str | Unset = UNSET,
+    state: str | Unset = UNSET,
+    country: str | Unset = UNSET,
+    postalcode: str | Unset = UNSET,
+    countrycodes: str | Unset = UNSET,
+    limit: int | Unset = 10,
+    bounded: SearchBounded | Unset = SearchBounded.VALUE_0,
+    addressdetails: SearchAddressdetails | Unset = SearchAddressdetails.VALUE_0,
+    format_: SearchFormat | Unset = SearchFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> Response[
+    Error | list[NominatimResult] | list[SchemaOrgPlace] | NominatimFeatureCollection
+]:
+    """Forward geocoding
+
+     Geocode a free-text `q`, or a structured (`street`/`city`/`state`/`postalcode`/`country`) query,
+    into ranked results.
+
+    Args:
+        q (str | Unset):
+        street (str | Unset):
+        city (str | Unset):
+        county (str | Unset):
+        state (str | Unset):
+        country (str | Unset):
+        postalcode (str | Unset):
+        countrycodes (str | Unset):
+        limit (int | Unset):  Default: 10.
+        bounded (SearchBounded | Unset):  Default: SearchBounded.VALUE_0.
+        addressdetails (SearchAddressdetails | Unset):  Default: SearchAddressdetails.VALUE_0.
+        format_ (SearchFormat | Unset):  Default: SearchFormat.JSONV2.
+        accept_language (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | list[NominatimResult] | list[SchemaOrgPlace] | NominatimFeatureCollection]
+    """
+
+    kwargs = _get_kwargs(
+        q=q,
+        street=street,
+        city=city,
+        county=county,
+        state=state,
+        country=country,
+        postalcode=postalcode,
+        countrycodes=countrycodes,
+        limit=limit,
+        bounded=bounded,
+        addressdetails=addressdetails,
+        format_=format_,
+        accept_language=accept_language,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    q: str | Unset = UNSET,
+    street: str | Unset = UNSET,
+    city: str | Unset = UNSET,
+    county: str | Unset = UNSET,
+    state: str | Unset = UNSET,
+    country: str | Unset = UNSET,
+    postalcode: str | Unset = UNSET,
+    countrycodes: str | Unset = UNSET,
+    limit: int | Unset = 10,
+    bounded: SearchBounded | Unset = SearchBounded.VALUE_0,
+    addressdetails: SearchAddressdetails | Unset = SearchAddressdetails.VALUE_0,
+    format_: SearchFormat | Unset = SearchFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> (
+    Error
+    | list[NominatimResult]
+    | list[SchemaOrgPlace]
+    | NominatimFeatureCollection
+    | None
+):
+    """Forward geocoding
+
+     Geocode a free-text `q`, or a structured (`street`/`city`/`state`/`postalcode`/`country`) query,
+    into ranked results.
+
+    Args:
+        q (str | Unset):
+        street (str | Unset):
+        city (str | Unset):
+        county (str | Unset):
+        state (str | Unset):
+        country (str | Unset):
+        postalcode (str | Unset):
+        countrycodes (str | Unset):
+        limit (int | Unset):  Default: 10.
+        bounded (SearchBounded | Unset):  Default: SearchBounded.VALUE_0.
+        addressdetails (SearchAddressdetails | Unset):  Default: SearchAddressdetails.VALUE_0.
+        format_ (SearchFormat | Unset):  Default: SearchFormat.JSONV2.
+        accept_language (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | list[NominatimResult] | list[SchemaOrgPlace] | NominatimFeatureCollection
+    """
+
+    return sync_detailed(
+        client=client,
+        q=q,
+        street=street,
+        city=city,
+        county=county,
+        state=state,
+        country=country,
+        postalcode=postalcode,
+        countrycodes=countrycodes,
+        limit=limit,
+        bounded=bounded,
+        addressdetails=addressdetails,
+        format_=format_,
+        accept_language=accept_language,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    q: str | Unset = UNSET,
+    street: str | Unset = UNSET,
+    city: str | Unset = UNSET,
+    county: str | Unset = UNSET,
+    state: str | Unset = UNSET,
+    country: str | Unset = UNSET,
+    postalcode: str | Unset = UNSET,
+    countrycodes: str | Unset = UNSET,
+    limit: int | Unset = 10,
+    bounded: SearchBounded | Unset = SearchBounded.VALUE_0,
+    addressdetails: SearchAddressdetails | Unset = SearchAddressdetails.VALUE_0,
+    format_: SearchFormat | Unset = SearchFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> Response[
+    Error | list[NominatimResult] | list[SchemaOrgPlace] | NominatimFeatureCollection
+]:
+    """Forward geocoding
+
+     Geocode a free-text `q`, or a structured (`street`/`city`/`state`/`postalcode`/`country`) query,
+    into ranked results.
+
+    Args:
+        q (str | Unset):
+        street (str | Unset):
+        city (str | Unset):
+        county (str | Unset):
+        state (str | Unset):
+        country (str | Unset):
+        postalcode (str | Unset):
+        countrycodes (str | Unset):
+        limit (int | Unset):  Default: 10.
+        bounded (SearchBounded | Unset):  Default: SearchBounded.VALUE_0.
+        addressdetails (SearchAddressdetails | Unset):  Default: SearchAddressdetails.VALUE_0.
+        format_ (SearchFormat | Unset):  Default: SearchFormat.JSONV2.
+        accept_language (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | list[NominatimResult] | list[SchemaOrgPlace] | NominatimFeatureCollection]
+    """
+
+    kwargs = _get_kwargs(
+        q=q,
+        street=street,
+        city=city,
+        county=county,
+        state=state,
+        country=country,
+        postalcode=postalcode,
+        countrycodes=countrycodes,
+        limit=limit,
+        bounded=bounded,
+        addressdetails=addressdetails,
+        format_=format_,
+        accept_language=accept_language,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    q: str | Unset = UNSET,
+    street: str | Unset = UNSET,
+    city: str | Unset = UNSET,
+    county: str | Unset = UNSET,
+    state: str | Unset = UNSET,
+    country: str | Unset = UNSET,
+    postalcode: str | Unset = UNSET,
+    countrycodes: str | Unset = UNSET,
+    limit: int | Unset = 10,
+    bounded: SearchBounded | Unset = SearchBounded.VALUE_0,
+    addressdetails: SearchAddressdetails | Unset = SearchAddressdetails.VALUE_0,
+    format_: SearchFormat | Unset = SearchFormat.JSONV2,
+    accept_language: str | Unset = UNSET,
+) -> (
+    Error
+    | list[NominatimResult]
+    | list[SchemaOrgPlace]
+    | NominatimFeatureCollection
+    | None
+):
+    """Forward geocoding
+
+     Geocode a free-text `q`, or a structured (`street`/`city`/`state`/`postalcode`/`country`) query,
+    into ranked results.
+
+    Args:
+        q (str | Unset):
+        street (str | Unset):
+        city (str | Unset):
+        county (str | Unset):
+        state (str | Unset):
+        country (str | Unset):
+        postalcode (str | Unset):
+        countrycodes (str | Unset):
+        limit (int | Unset):  Default: 10.
+        bounded (SearchBounded | Unset):  Default: SearchBounded.VALUE_0.
+        addressdetails (SearchAddressdetails | Unset):  Default: SearchAddressdetails.VALUE_0.
+        format_ (SearchFormat | Unset):  Default: SearchFormat.JSONV2.
+        accept_language (str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | list[NominatimResult] | list[SchemaOrgPlace] | NominatimFeatureCollection
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            q=q,
+            street=street,
+            city=city,
+            county=county,
+            state=state,
+            country=country,
+            postalcode=postalcode,
+            countrycodes=countrycodes,
+            limit=limit,
+            bounded=bounded,
+            addressdetails=addressdetails,
+            format_=format_,
+            accept_language=accept_language,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/nominatim/api/meta/__init__.py
+++ b/clients/python/mailwoman_client/nominatim/api/meta/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/mailwoman_client/nominatim/api/meta/get_root.py
+++ b/clients/python/mailwoman_client/nominatim/api/meta/get_root.py
@@ -1,0 +1,134 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> str | None:
+    if response.status_code == 200:
+        response_200 = response.text
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[str]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[str]:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> str | None:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[str]:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> str | None:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/nominatim/api/meta/status.py
+++ b/clients/python/mailwoman_client/nominatim/api/meta/status.py
@@ -1,0 +1,142 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error import Error
+from ...models.nominatim_status import NominatimStatus
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/status",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Error | NominatimStatus | None:
+    if response.status_code == 200:
+        response_200 = NominatimStatus.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 500:
+        response_500 = Error.from_dict(response.json())
+
+        return response_500
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Error | NominatimStatus]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Error | NominatimStatus]:
+    """Service status
+
+     Health check plus data version. Mirrors Nominatim's `/status?format=json`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | NominatimStatus]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Error | NominatimStatus | None:
+    """Service status
+
+     Health check plus data version. Mirrors Nominatim's `/status?format=json`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | NominatimStatus
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Error | NominatimStatus]:
+    """Service status
+
+     Health check plus data version. Mirrors Nominatim's `/status?format=json`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Error | NominatimStatus]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Error | NominatimStatus | None:
+    """Service status
+
+     Health check plus data version. Mirrors Nominatim's `/status?format=json`.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Error | NominatimStatus
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/nominatim/client.py
+++ b/clients/python/mailwoman_client/nominatim/client.py
@@ -1,0 +1,282 @@
+import ssl
+from typing import Any
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(
+        self, async_client: httpx.AsyncClient
+    ) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/clients/python/mailwoman_client/nominatim/errors.py
+++ b/clients/python/mailwoman_client/nominatim/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/clients/python/mailwoman_client/nominatim/models/__init__.py
+++ b/clients/python/mailwoman_client/nominatim/models/__init__.py
@@ -1,0 +1,71 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .error import Error
+from .lookup_addressdetails import LookupAddressdetails
+from .lookup_format import LookupFormat
+from .nominatim_address_details import NominatimAddressDetails
+from .nominatim_feature_collection import NominatimFeatureCollection
+from .nominatim_feature_collection_features_item import (
+    NominatimFeatureCollectionFeaturesItem,
+)
+from .nominatim_feature_collection_features_item_properties import (
+    NominatimFeatureCollectionFeaturesItemProperties,
+)
+from .nominatim_result import NominatimResult
+from .nominatim_status import NominatimStatus
+from .open_cage_annotations import OpenCageAnnotations
+from .open_cage_annotations_currency import OpenCageAnnotationsCurrency
+from .open_cage_annotations_dms import OpenCageAnnotationsDMS
+from .open_cage_annotations_fips import OpenCageAnnotationsFIPS
+from .open_cage_annotations_mercator import OpenCageAnnotationsMercator
+from .open_cage_annotations_nuts import OpenCageAnnotationsNUTS
+from .open_cage_annotations_nutsnuts0 import OpenCageAnnotationsNUTSNUTS0
+from .open_cage_annotations_nutsnuts1 import OpenCageAnnotationsNUTSNUTS1
+from .open_cage_annotations_nutsnuts2 import OpenCageAnnotationsNUTSNUTS2
+from .open_cage_annotations_nutsnuts3 import OpenCageAnnotationsNUTSNUTS3
+from .open_cage_annotations_sun import OpenCageAnnotationsSun
+from .open_cage_annotations_sun_rise import OpenCageAnnotationsSunRise
+from .open_cage_annotations_sun_set import OpenCageAnnotationsSunSet
+from .open_cage_annotations_timezone import OpenCageAnnotationsTimezone
+from .reverse_addressdetails import ReverseAddressdetails
+from .reverse_format import ReverseFormat
+from .schema_org_place import SchemaOrgPlace
+from .schema_org_place_address import SchemaOrgPlaceAddress
+from .schema_org_place_geo import SchemaOrgPlaceGeo
+from .search_addressdetails import SearchAddressdetails
+from .search_bounded import SearchBounded
+from .search_format import SearchFormat
+
+__all__ = (
+    "Error",
+    "LookupAddressdetails",
+    "LookupFormat",
+    "NominatimAddressDetails",
+    "NominatimFeatureCollection",
+    "NominatimFeatureCollectionFeaturesItem",
+    "NominatimFeatureCollectionFeaturesItemProperties",
+    "NominatimResult",
+    "NominatimStatus",
+    "OpenCageAnnotations",
+    "OpenCageAnnotationsCurrency",
+    "OpenCageAnnotationsDMS",
+    "OpenCageAnnotationsFIPS",
+    "OpenCageAnnotationsMercator",
+    "OpenCageAnnotationsNUTS",
+    "OpenCageAnnotationsNUTSNUTS0",
+    "OpenCageAnnotationsNUTSNUTS1",
+    "OpenCageAnnotationsNUTSNUTS2",
+    "OpenCageAnnotationsNUTSNUTS3",
+    "OpenCageAnnotationsSun",
+    "OpenCageAnnotationsSunRise",
+    "OpenCageAnnotationsSunSet",
+    "OpenCageAnnotationsTimezone",
+    "ReverseAddressdetails",
+    "ReverseFormat",
+    "SchemaOrgPlace",
+    "SchemaOrgPlaceAddress",
+    "SchemaOrgPlaceGeo",
+    "SearchAddressdetails",
+    "SearchBounded",
+    "SearchFormat",
+)

--- a/clients/python/mailwoman_client/nominatim/models/error.py
+++ b/clients/python/mailwoman_client/nominatim/models/error.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="Error")
+
+
+@_attrs_define
+class Error:
+    """A JSON error envelope.
+
+    Attributes:
+        error (str):
+    """
+
+    error: str
+
+    def to_dict(self) -> dict[str, Any]:
+        error = self.error
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "error": error,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        error = d.pop("error")
+
+        error = cls(
+            error=error,
+        )
+
+        return error

--- a/clients/python/mailwoman_client/nominatim/models/lookup_addressdetails.py
+++ b/clients/python/mailwoman_client/nominatim/models/lookup_addressdetails.py
@@ -1,0 +1,9 @@
+from enum import IntEnum
+
+
+class LookupAddressdetails(IntEnum):
+    VALUE_0 = 0
+    VALUE_1 = 1
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/nominatim/models/lookup_format.py
+++ b/clients/python/mailwoman_client/nominatim/models/lookup_format.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class LookupFormat(str, Enum):
+    GEOJSON = "geojson"
+    JSON = "json"
+    JSONLD = "jsonld"
+    JSONV2 = "jsonv2"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/nominatim/models/nominatim_address_details.py
+++ b/clients/python/mailwoman_client/nominatim/models/nominatim_address_details.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NominatimAddressDetails")
+
+
+@_attrs_define
+class NominatimAddressDetails:
+    """The structured address breakdown returned under `address` when `addressdetails=1`. Keys mirror Nominatim's OSM-
+    derived tag names.
+
+        Attributes:
+            house_number (str | Unset):
+            road (str | Unset):
+            neighbourhood (str | Unset):
+            suburb (str | Unset):
+            city (str | Unset):
+            town (str | Unset):
+            village (str | Unset):
+            county (str | Unset):
+            state (str | Unset):
+            postcode (str | Unset):
+            country (str | Unset):
+            country_code (str | Unset): ISO-3166 alpha-2, lowercased.
+    """
+
+    house_number: str | Unset = UNSET
+    road: str | Unset = UNSET
+    neighbourhood: str | Unset = UNSET
+    suburb: str | Unset = UNSET
+    city: str | Unset = UNSET
+    town: str | Unset = UNSET
+    village: str | Unset = UNSET
+    county: str | Unset = UNSET
+    state: str | Unset = UNSET
+    postcode: str | Unset = UNSET
+    country: str | Unset = UNSET
+    country_code: str | Unset = UNSET
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        house_number = self.house_number
+
+        road = self.road
+
+        neighbourhood = self.neighbourhood
+
+        suburb = self.suburb
+
+        city = self.city
+
+        town = self.town
+
+        village = self.village
+
+        county = self.county
+
+        state = self.state
+
+        postcode = self.postcode
+
+        country = self.country
+
+        country_code = self.country_code
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if house_number is not UNSET:
+            field_dict["house_number"] = house_number
+        if road is not UNSET:
+            field_dict["road"] = road
+        if neighbourhood is not UNSET:
+            field_dict["neighbourhood"] = neighbourhood
+        if suburb is not UNSET:
+            field_dict["suburb"] = suburb
+        if city is not UNSET:
+            field_dict["city"] = city
+        if town is not UNSET:
+            field_dict["town"] = town
+        if village is not UNSET:
+            field_dict["village"] = village
+        if county is not UNSET:
+            field_dict["county"] = county
+        if state is not UNSET:
+            field_dict["state"] = state
+        if postcode is not UNSET:
+            field_dict["postcode"] = postcode
+        if country is not UNSET:
+            field_dict["country"] = country
+        if country_code is not UNSET:
+            field_dict["country_code"] = country_code
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        house_number = d.pop("house_number", UNSET)
+
+        road = d.pop("road", UNSET)
+
+        neighbourhood = d.pop("neighbourhood", UNSET)
+
+        suburb = d.pop("suburb", UNSET)
+
+        city = d.pop("city", UNSET)
+
+        town = d.pop("town", UNSET)
+
+        village = d.pop("village", UNSET)
+
+        county = d.pop("county", UNSET)
+
+        state = d.pop("state", UNSET)
+
+        postcode = d.pop("postcode", UNSET)
+
+        country = d.pop("country", UNSET)
+
+        country_code = d.pop("country_code", UNSET)
+
+        nominatim_address_details = cls(
+            house_number=house_number,
+            road=road,
+            neighbourhood=neighbourhood,
+            suburb=suburb,
+            city=city,
+            town=town,
+            village=village,
+            county=county,
+            state=state,
+            postcode=postcode,
+            country=country,
+            country_code=country_code,
+        )
+
+        nominatim_address_details.additional_properties = d
+        return nominatim_address_details
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/nominatim_feature_collection.py
+++ b/clients/python/mailwoman_client/nominatim/models/nominatim_feature_collection.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.nominatim_feature_collection_features_item import (
+        NominatimFeatureCollectionFeaturesItem,
+    )
+
+
+T = TypeVar("T", bound="NominatimFeatureCollection")
+
+
+@_attrs_define
+class NominatimFeatureCollection:
+    """A GeoJSON `FeatureCollection` — the `format=geojson` envelope (RFC 7946).
+
+    Attributes:
+        type_ (Literal['FeatureCollection']):
+        features (list[NominatimFeatureCollectionFeaturesItem]):
+    """
+
+    type_: Literal["FeatureCollection"]
+    features: list[NominatimFeatureCollectionFeaturesItem]
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        features = []
+        for features_item_data in self.features:
+            features_item = features_item_data.to_dict()
+            features.append(features_item)
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+                "features": features,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.nominatim_feature_collection_features_item import (
+            NominatimFeatureCollectionFeaturesItem,
+        )
+
+        d = dict(src_dict)
+        type_ = cast(Literal["FeatureCollection"], d.pop("type"))
+        if type_ != "FeatureCollection":
+            raise ValueError(
+                f"type must match const 'FeatureCollection', got '{type_}'"
+            )
+
+        features = []
+        _features = d.pop("features")
+        for features_item_data in _features:
+            features_item = NominatimFeatureCollectionFeaturesItem.from_dict(
+                features_item_data
+            )
+
+            features.append(features_item)
+
+        nominatim_feature_collection = cls(
+            type_=type_,
+            features=features,
+        )
+
+        return nominatim_feature_collection

--- a/clients/python/mailwoman_client/nominatim/models/nominatim_feature_collection_features_item.py
+++ b/clients/python/mailwoman_client/nominatim/models/nominatim_feature_collection_features_item.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.nominatim_feature_collection_features_item_properties import (
+        NominatimFeatureCollectionFeaturesItemProperties,
+    )
+
+
+T = TypeVar("T", bound="NominatimFeatureCollectionFeaturesItem")
+
+
+@_attrs_define
+class NominatimFeatureCollectionFeaturesItem:
+    """
+    Attributes:
+        type_ (Literal['Feature']):
+        properties (NominatimFeatureCollectionFeaturesItemProperties):
+        geometry (Any): A GeoJSON geometry (the place polygon when present, else a Point).
+        bbox (list[float] | Unset): `[west, south, east, north]` (GeoJSON bbox order).
+    """
+
+    type_: Literal["Feature"]
+    properties: NominatimFeatureCollectionFeaturesItemProperties
+    geometry: Any
+    bbox: list[float] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        properties = self.properties.to_dict()
+
+        geometry = self.geometry
+
+        bbox: list[float] | Unset = UNSET
+        if not isinstance(self.bbox, Unset):
+            bbox = self.bbox
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+                "properties": properties,
+                "geometry": geometry,
+            }
+        )
+        if bbox is not UNSET:
+            field_dict["bbox"] = bbox
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.nominatim_feature_collection_features_item_properties import (
+            NominatimFeatureCollectionFeaturesItemProperties,
+        )
+
+        d = dict(src_dict)
+        type_ = cast(Literal["Feature"], d.pop("type"))
+        if type_ != "Feature":
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
+
+        properties = NominatimFeatureCollectionFeaturesItemProperties.from_dict(
+            d.pop("properties")
+        )
+
+        geometry = d.pop("geometry")
+
+        bbox = cast(list[float], d.pop("bbox", UNSET))
+
+        nominatim_feature_collection_features_item = cls(
+            type_=type_,
+            properties=properties,
+            geometry=geometry,
+            bbox=bbox,
+        )
+
+        nominatim_feature_collection_features_item.additional_properties = d
+        return nominatim_feature_collection_features_item
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/nominatim_feature_collection_features_item_properties.py
+++ b/clients/python/mailwoman_client/nominatim/models/nominatim_feature_collection_features_item_properties.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="NominatimFeatureCollectionFeaturesItemProperties")
+
+
+@_attrs_define
+class NominatimFeatureCollectionFeaturesItemProperties:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        nominatim_feature_collection_features_item_properties = cls()
+
+        nominatim_feature_collection_features_item_properties.additional_properties = d
+        return nominatim_feature_collection_features_item_properties
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/nominatim_result.py
+++ b/clients/python/mailwoman_client/nominatim/models/nominatim_result.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.nominatim_address_details import NominatimAddressDetails
+    from ..models.open_cage_annotations import OpenCageAnnotations
+
+
+T = TypeVar("T", bound="NominatimResult")
+
+
+@_attrs_define
+class NominatimResult:
+    """A Nominatim result object (the shape `geopy` and friends parse).
+
+    Attributes:
+        place_id (int | str):
+        licence (str): The attribution string for the resolved data sources.
+        lat (str): Latitude, as a string (Nominatim convention).
+        lon (str): Longitude, as a string (Nominatim convention).
+        display_name (str):
+        osm_type (str | Unset):
+        osm_id (int | str | Unset):
+        boundingbox (list[str] | Unset): `[south, north, west, east]` as strings (Nominatim convention).
+        class_ (str | Unset):
+        type_ (str | Unset):
+        importance (float | Unset):
+        place_rank (int | Unset):
+        address (NominatimAddressDetails | Unset): The structured address breakdown returned under `address` when
+            `addressdetails=1`. Keys mirror Nominatim's OSM-derived tag names.
+        geojson (Any | Unset): Present when `format=geojson` or `polygon_geojson=1` — a GeoJSON geometry.
+        annotations (OpenCageAnnotations | Unset): The OpenCage-style enrichment block, keyed and cased as OpenCage
+            documents it. A Mailwoman extension over upstream Nominatim. Only populated fields are emitted.
+    """
+
+    place_id: int | str
+    licence: str
+    lat: str
+    lon: str
+    display_name: str
+    osm_type: str | Unset = UNSET
+    osm_id: int | str | Unset = UNSET
+    boundingbox: list[str] | Unset = UNSET
+    class_: str | Unset = UNSET
+    type_: str | Unset = UNSET
+    importance: float | Unset = UNSET
+    place_rank: int | Unset = UNSET
+    address: NominatimAddressDetails | Unset = UNSET
+    geojson: Any | Unset = UNSET
+    annotations: OpenCageAnnotations | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        place_id: int | str
+        place_id = self.place_id
+
+        licence = self.licence
+
+        lat = self.lat
+
+        lon = self.lon
+
+        display_name = self.display_name
+
+        osm_type = self.osm_type
+
+        osm_id: int | str | Unset
+        if isinstance(self.osm_id, Unset):
+            osm_id = UNSET
+        else:
+            osm_id = self.osm_id
+
+        boundingbox: list[str] | Unset = UNSET
+        if not isinstance(self.boundingbox, Unset):
+            boundingbox = self.boundingbox
+
+        class_ = self.class_
+
+        type_ = self.type_
+
+        importance = self.importance
+
+        place_rank = self.place_rank
+
+        address: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.address, Unset):
+            address = self.address.to_dict()
+
+        geojson = self.geojson
+
+        annotations: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.annotations, Unset):
+            annotations = self.annotations.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "place_id": place_id,
+                "licence": licence,
+                "lat": lat,
+                "lon": lon,
+                "display_name": display_name,
+            }
+        )
+        if osm_type is not UNSET:
+            field_dict["osm_type"] = osm_type
+        if osm_id is not UNSET:
+            field_dict["osm_id"] = osm_id
+        if boundingbox is not UNSET:
+            field_dict["boundingbox"] = boundingbox
+        if class_ is not UNSET:
+            field_dict["class"] = class_
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if importance is not UNSET:
+            field_dict["importance"] = importance
+        if place_rank is not UNSET:
+            field_dict["place_rank"] = place_rank
+        if address is not UNSET:
+            field_dict["address"] = address
+        if geojson is not UNSET:
+            field_dict["geojson"] = geojson
+        if annotations is not UNSET:
+            field_dict["annotations"] = annotations
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.nominatim_address_details import NominatimAddressDetails
+        from ..models.open_cage_annotations import OpenCageAnnotations
+
+        d = dict(src_dict)
+
+        def _parse_place_id(data: object) -> int | str:
+            return cast(int | str, data)
+
+        place_id = _parse_place_id(d.pop("place_id"))
+
+        licence = d.pop("licence")
+
+        lat = d.pop("lat")
+
+        lon = d.pop("lon")
+
+        display_name = d.pop("display_name")
+
+        osm_type = d.pop("osm_type", UNSET)
+
+        def _parse_osm_id(data: object) -> int | str | Unset:
+            if isinstance(data, Unset):
+                return data
+            return cast(int | str | Unset, data)
+
+        osm_id = _parse_osm_id(d.pop("osm_id", UNSET))
+
+        boundingbox = cast(list[str], d.pop("boundingbox", UNSET))
+
+        class_ = d.pop("class", UNSET)
+
+        type_ = d.pop("type", UNSET)
+
+        importance = d.pop("importance", UNSET)
+
+        place_rank = d.pop("place_rank", UNSET)
+
+        _address = d.pop("address", UNSET)
+        address: NominatimAddressDetails | Unset
+        if isinstance(_address, Unset):
+            address = UNSET
+        else:
+            address = NominatimAddressDetails.from_dict(_address)
+
+        geojson = d.pop("geojson", UNSET)
+
+        _annotations = d.pop("annotations", UNSET)
+        annotations: OpenCageAnnotations | Unset
+        if isinstance(_annotations, Unset):
+            annotations = UNSET
+        else:
+            annotations = OpenCageAnnotations.from_dict(_annotations)
+
+        nominatim_result = cls(
+            place_id=place_id,
+            licence=licence,
+            lat=lat,
+            lon=lon,
+            display_name=display_name,
+            osm_type=osm_type,
+            osm_id=osm_id,
+            boundingbox=boundingbox,
+            class_=class_,
+            type_=type_,
+            importance=importance,
+            place_rank=place_rank,
+            address=address,
+            geojson=geojson,
+            annotations=annotations,
+        )
+
+        nominatim_result.additional_properties = d
+        return nominatim_result
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/nominatim_status.py
+++ b/clients/python/mailwoman_client/nominatim/models/nominatim_status.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NominatimStatus")
+
+
+@_attrs_define
+class NominatimStatus:
+    """The `/status` payload. `status: 0` means OK.
+
+    Attributes:
+        status (int): `0` = OK; non-zero = a fault code.
+        message (str):
+        data_updated (str | Unset): When the underlying data was last built (ISO-8601).
+    """
+
+    status: int
+    message: str
+    data_updated: str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        status = self.status
+
+        message = self.message
+
+        data_updated = self.data_updated
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "status": status,
+                "message": message,
+            }
+        )
+        if data_updated is not UNSET:
+            field_dict["data_updated"] = data_updated
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        status = d.pop("status")
+
+        message = d.pop("message")
+
+        data_updated = d.pop("data_updated", UNSET)
+
+        nominatim_status = cls(
+            status=status,
+            message=message,
+            data_updated=data_updated,
+        )
+
+        return nominatim_status

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.open_cage_annotations_currency import OpenCageAnnotationsCurrency
+    from ..models.open_cage_annotations_dms import OpenCageAnnotationsDMS
+    from ..models.open_cage_annotations_fips import OpenCageAnnotationsFIPS
+    from ..models.open_cage_annotations_mercator import OpenCageAnnotationsMercator
+    from ..models.open_cage_annotations_nuts import OpenCageAnnotationsNUTS
+    from ..models.open_cage_annotations_sun import OpenCageAnnotationsSun
+    from ..models.open_cage_annotations_timezone import OpenCageAnnotationsTimezone
+
+
+T = TypeVar("T", bound="OpenCageAnnotations")
+
+
+@_attrs_define
+class OpenCageAnnotations:
+    """The OpenCage-style enrichment block, keyed and cased as OpenCage documents it. A Mailwoman extension over upstream
+    Nominatim. Only populated fields are emitted.
+
+        Attributes:
+            dms (OpenCageAnnotationsDMS | Unset):
+            mgrs (str | Unset):
+            maidenhead (str | Unset):
+            mercator (OpenCageAnnotationsMercator | Unset):
+            geohash (str | Unset):
+            qibla (float | Unset):
+            sun (OpenCageAnnotationsSun | Unset):
+            callingcode (float | Unset):
+            currency (OpenCageAnnotationsCurrency | Unset):
+            flag (str | Unset): The country's flag emoji.
+            timezone (OpenCageAnnotationsTimezone | Unset):
+            nuts (OpenCageAnnotationsNUTS | Unset): EU NUTS region codes (when the NUTS data bundle is present).
+            un_locode (str | Unset):
+            wikidata (str | Unset):
+            fips (OpenCageAnnotationsFIPS | Unset):
+    """
+
+    dms: OpenCageAnnotationsDMS | Unset = UNSET
+    mgrs: str | Unset = UNSET
+    maidenhead: str | Unset = UNSET
+    mercator: OpenCageAnnotationsMercator | Unset = UNSET
+    geohash: str | Unset = UNSET
+    qibla: float | Unset = UNSET
+    sun: OpenCageAnnotationsSun | Unset = UNSET
+    callingcode: float | Unset = UNSET
+    currency: OpenCageAnnotationsCurrency | Unset = UNSET
+    flag: str | Unset = UNSET
+    timezone: OpenCageAnnotationsTimezone | Unset = UNSET
+    nuts: OpenCageAnnotationsNUTS | Unset = UNSET
+    un_locode: str | Unset = UNSET
+    wikidata: str | Unset = UNSET
+    fips: OpenCageAnnotationsFIPS | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        dms: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.dms, Unset):
+            dms = self.dms.to_dict()
+
+        mgrs = self.mgrs
+
+        maidenhead = self.maidenhead
+
+        mercator: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.mercator, Unset):
+            mercator = self.mercator.to_dict()
+
+        geohash = self.geohash
+
+        qibla = self.qibla
+
+        sun: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.sun, Unset):
+            sun = self.sun.to_dict()
+
+        callingcode = self.callingcode
+
+        currency: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.currency, Unset):
+            currency = self.currency.to_dict()
+
+        flag = self.flag
+
+        timezone: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.timezone, Unset):
+            timezone = self.timezone.to_dict()
+
+        nuts: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.nuts, Unset):
+            nuts = self.nuts.to_dict()
+
+        un_locode = self.un_locode
+
+        wikidata = self.wikidata
+
+        fips: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.fips, Unset):
+            fips = self.fips.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if dms is not UNSET:
+            field_dict["DMS"] = dms
+        if mgrs is not UNSET:
+            field_dict["MGRS"] = mgrs
+        if maidenhead is not UNSET:
+            field_dict["Maidenhead"] = maidenhead
+        if mercator is not UNSET:
+            field_dict["Mercator"] = mercator
+        if geohash is not UNSET:
+            field_dict["geohash"] = geohash
+        if qibla is not UNSET:
+            field_dict["qibla"] = qibla
+        if sun is not UNSET:
+            field_dict["sun"] = sun
+        if callingcode is not UNSET:
+            field_dict["callingcode"] = callingcode
+        if currency is not UNSET:
+            field_dict["currency"] = currency
+        if flag is not UNSET:
+            field_dict["flag"] = flag
+        if timezone is not UNSET:
+            field_dict["timezone"] = timezone
+        if nuts is not UNSET:
+            field_dict["NUTS"] = nuts
+        if un_locode is not UNSET:
+            field_dict["UN_LOCODE"] = un_locode
+        if wikidata is not UNSET:
+            field_dict["wikidata"] = wikidata
+        if fips is not UNSET:
+            field_dict["FIPS"] = fips
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.open_cage_annotations_currency import OpenCageAnnotationsCurrency
+        from ..models.open_cage_annotations_dms import OpenCageAnnotationsDMS
+        from ..models.open_cage_annotations_fips import OpenCageAnnotationsFIPS
+        from ..models.open_cage_annotations_mercator import OpenCageAnnotationsMercator
+        from ..models.open_cage_annotations_nuts import OpenCageAnnotationsNUTS
+        from ..models.open_cage_annotations_sun import OpenCageAnnotationsSun
+        from ..models.open_cage_annotations_timezone import OpenCageAnnotationsTimezone
+
+        d = dict(src_dict)
+        _dms = d.pop("DMS", UNSET)
+        dms: OpenCageAnnotationsDMS | Unset
+        if isinstance(_dms, Unset):
+            dms = UNSET
+        else:
+            dms = OpenCageAnnotationsDMS.from_dict(_dms)
+
+        mgrs = d.pop("MGRS", UNSET)
+
+        maidenhead = d.pop("Maidenhead", UNSET)
+
+        _mercator = d.pop("Mercator", UNSET)
+        mercator: OpenCageAnnotationsMercator | Unset
+        if isinstance(_mercator, Unset):
+            mercator = UNSET
+        else:
+            mercator = OpenCageAnnotationsMercator.from_dict(_mercator)
+
+        geohash = d.pop("geohash", UNSET)
+
+        qibla = d.pop("qibla", UNSET)
+
+        _sun = d.pop("sun", UNSET)
+        sun: OpenCageAnnotationsSun | Unset
+        if isinstance(_sun, Unset):
+            sun = UNSET
+        else:
+            sun = OpenCageAnnotationsSun.from_dict(_sun)
+
+        callingcode = d.pop("callingcode", UNSET)
+
+        _currency = d.pop("currency", UNSET)
+        currency: OpenCageAnnotationsCurrency | Unset
+        if isinstance(_currency, Unset):
+            currency = UNSET
+        else:
+            currency = OpenCageAnnotationsCurrency.from_dict(_currency)
+
+        flag = d.pop("flag", UNSET)
+
+        _timezone = d.pop("timezone", UNSET)
+        timezone: OpenCageAnnotationsTimezone | Unset
+        if isinstance(_timezone, Unset):
+            timezone = UNSET
+        else:
+            timezone = OpenCageAnnotationsTimezone.from_dict(_timezone)
+
+        _nuts = d.pop("NUTS", UNSET)
+        nuts: OpenCageAnnotationsNUTS | Unset
+        if isinstance(_nuts, Unset):
+            nuts = UNSET
+        else:
+            nuts = OpenCageAnnotationsNUTS.from_dict(_nuts)
+
+        un_locode = d.pop("UN_LOCODE", UNSET)
+
+        wikidata = d.pop("wikidata", UNSET)
+
+        _fips = d.pop("FIPS", UNSET)
+        fips: OpenCageAnnotationsFIPS | Unset
+        if isinstance(_fips, Unset):
+            fips = UNSET
+        else:
+            fips = OpenCageAnnotationsFIPS.from_dict(_fips)
+
+        open_cage_annotations = cls(
+            dms=dms,
+            mgrs=mgrs,
+            maidenhead=maidenhead,
+            mercator=mercator,
+            geohash=geohash,
+            qibla=qibla,
+            sun=sun,
+            callingcode=callingcode,
+            currency=currency,
+            flag=flag,
+            timezone=timezone,
+            nuts=nuts,
+            un_locode=un_locode,
+            wikidata=wikidata,
+            fips=fips,
+        )
+
+        open_cage_annotations.additional_properties = d
+        return open_cage_annotations
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_currency.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_currency.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsCurrency")
+
+
+@_attrs_define
+class OpenCageAnnotationsCurrency:
+    """
+    Attributes:
+        iso_code (str | Unset):
+        name (str | Unset):
+        symbol (str | Unset):
+    """
+
+    iso_code: str | Unset = UNSET
+    name: str | Unset = UNSET
+    symbol: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        iso_code = self.iso_code
+
+        name = self.name
+
+        symbol = self.symbol
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if iso_code is not UNSET:
+            field_dict["iso_code"] = iso_code
+        if name is not UNSET:
+            field_dict["name"] = name
+        if symbol is not UNSET:
+            field_dict["symbol"] = symbol
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        iso_code = d.pop("iso_code", UNSET)
+
+        name = d.pop("name", UNSET)
+
+        symbol = d.pop("symbol", UNSET)
+
+        open_cage_annotations_currency = cls(
+            iso_code=iso_code,
+            name=name,
+            symbol=symbol,
+        )
+
+        open_cage_annotations_currency.additional_properties = d
+        return open_cage_annotations_currency
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_dms.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_dms.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsDMS")
+
+
+@_attrs_define
+class OpenCageAnnotationsDMS:
+    """
+    Attributes:
+        lat (str | Unset):
+        lng (str | Unset):
+    """
+
+    lat: str | Unset = UNSET
+    lng: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        lat = self.lat
+
+        lng = self.lng
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if lat is not UNSET:
+            field_dict["lat"] = lat
+        if lng is not UNSET:
+            field_dict["lng"] = lng
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        lat = d.pop("lat", UNSET)
+
+        lng = d.pop("lng", UNSET)
+
+        open_cage_annotations_dms = cls(
+            lat=lat,
+            lng=lng,
+        )
+
+        open_cage_annotations_dms.additional_properties = d
+        return open_cage_annotations_dms
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_fips.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_fips.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsFIPS")
+
+
+@_attrs_define
+class OpenCageAnnotationsFIPS:
+    """
+    Attributes:
+        county (str | Unset):
+    """
+
+    county: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        county = self.county
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if county is not UNSET:
+            field_dict["county"] = county
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        county = d.pop("county", UNSET)
+
+        open_cage_annotations_fips = cls(
+            county=county,
+        )
+
+        open_cage_annotations_fips.additional_properties = d
+        return open_cage_annotations_fips
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_mercator.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_mercator.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsMercator")
+
+
+@_attrs_define
+class OpenCageAnnotationsMercator:
+    """
+    Attributes:
+        x (float | Unset):
+        y (float | Unset):
+    """
+
+    x: float | Unset = UNSET
+    y: float | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        x = self.x
+
+        y = self.y
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if x is not UNSET:
+            field_dict["x"] = x
+        if y is not UNSET:
+            field_dict["y"] = y
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        x = d.pop("x", UNSET)
+
+        y = d.pop("y", UNSET)
+
+        open_cage_annotations_mercator = cls(
+            x=x,
+            y=y,
+        )
+
+        open_cage_annotations_mercator.additional_properties = d
+        return open_cage_annotations_mercator
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nuts.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nuts.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.open_cage_annotations_nutsnuts0 import OpenCageAnnotationsNUTSNUTS0
+    from ..models.open_cage_annotations_nutsnuts1 import OpenCageAnnotationsNUTSNUTS1
+    from ..models.open_cage_annotations_nutsnuts2 import OpenCageAnnotationsNUTSNUTS2
+    from ..models.open_cage_annotations_nutsnuts3 import OpenCageAnnotationsNUTSNUTS3
+
+
+T = TypeVar("T", bound="OpenCageAnnotationsNUTS")
+
+
+@_attrs_define
+class OpenCageAnnotationsNUTS:
+    """EU NUTS region codes (when the NUTS data bundle is present).
+
+    Attributes:
+        nuts0 (OpenCageAnnotationsNUTSNUTS0 | Unset):
+        nuts1 (OpenCageAnnotationsNUTSNUTS1 | Unset):
+        nuts2 (OpenCageAnnotationsNUTSNUTS2 | Unset):
+        nuts3 (OpenCageAnnotationsNUTSNUTS3 | Unset):
+    """
+
+    nuts0: OpenCageAnnotationsNUTSNUTS0 | Unset = UNSET
+    nuts1: OpenCageAnnotationsNUTSNUTS1 | Unset = UNSET
+    nuts2: OpenCageAnnotationsNUTSNUTS2 | Unset = UNSET
+    nuts3: OpenCageAnnotationsNUTSNUTS3 | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        nuts0: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.nuts0, Unset):
+            nuts0 = self.nuts0.to_dict()
+
+        nuts1: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.nuts1, Unset):
+            nuts1 = self.nuts1.to_dict()
+
+        nuts2: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.nuts2, Unset):
+            nuts2 = self.nuts2.to_dict()
+
+        nuts3: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.nuts3, Unset):
+            nuts3 = self.nuts3.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if nuts0 is not UNSET:
+            field_dict["NUTS0"] = nuts0
+        if nuts1 is not UNSET:
+            field_dict["NUTS1"] = nuts1
+        if nuts2 is not UNSET:
+            field_dict["NUTS2"] = nuts2
+        if nuts3 is not UNSET:
+            field_dict["NUTS3"] = nuts3
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.open_cage_annotations_nutsnuts0 import (
+            OpenCageAnnotationsNUTSNUTS0,
+        )
+        from ..models.open_cage_annotations_nutsnuts1 import (
+            OpenCageAnnotationsNUTSNUTS1,
+        )
+        from ..models.open_cage_annotations_nutsnuts2 import (
+            OpenCageAnnotationsNUTSNUTS2,
+        )
+        from ..models.open_cage_annotations_nutsnuts3 import (
+            OpenCageAnnotationsNUTSNUTS3,
+        )
+
+        d = dict(src_dict)
+        _nuts0 = d.pop("NUTS0", UNSET)
+        nuts0: OpenCageAnnotationsNUTSNUTS0 | Unset
+        if isinstance(_nuts0, Unset):
+            nuts0 = UNSET
+        else:
+            nuts0 = OpenCageAnnotationsNUTSNUTS0.from_dict(_nuts0)
+
+        _nuts1 = d.pop("NUTS1", UNSET)
+        nuts1: OpenCageAnnotationsNUTSNUTS1 | Unset
+        if isinstance(_nuts1, Unset):
+            nuts1 = UNSET
+        else:
+            nuts1 = OpenCageAnnotationsNUTSNUTS1.from_dict(_nuts1)
+
+        _nuts2 = d.pop("NUTS2", UNSET)
+        nuts2: OpenCageAnnotationsNUTSNUTS2 | Unset
+        if isinstance(_nuts2, Unset):
+            nuts2 = UNSET
+        else:
+            nuts2 = OpenCageAnnotationsNUTSNUTS2.from_dict(_nuts2)
+
+        _nuts3 = d.pop("NUTS3", UNSET)
+        nuts3: OpenCageAnnotationsNUTSNUTS3 | Unset
+        if isinstance(_nuts3, Unset):
+            nuts3 = UNSET
+        else:
+            nuts3 = OpenCageAnnotationsNUTSNUTS3.from_dict(_nuts3)
+
+        open_cage_annotations_nuts = cls(
+            nuts0=nuts0,
+            nuts1=nuts1,
+            nuts2=nuts2,
+            nuts3=nuts3,
+        )
+
+        open_cage_annotations_nuts.additional_properties = d
+        return open_cage_annotations_nuts
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nutsnuts0.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nutsnuts0.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsNUTSNUTS0")
+
+
+@_attrs_define
+class OpenCageAnnotationsNUTSNUTS0:
+    """
+    Attributes:
+        code (str | Unset):
+    """
+
+    code: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        code = self.code
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if code is not UNSET:
+            field_dict["code"] = code
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        code = d.pop("code", UNSET)
+
+        open_cage_annotations_nutsnuts0 = cls(
+            code=code,
+        )
+
+        open_cage_annotations_nutsnuts0.additional_properties = d
+        return open_cage_annotations_nutsnuts0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nutsnuts1.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nutsnuts1.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsNUTSNUTS1")
+
+
+@_attrs_define
+class OpenCageAnnotationsNUTSNUTS1:
+    """
+    Attributes:
+        code (str | Unset):
+    """
+
+    code: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        code = self.code
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if code is not UNSET:
+            field_dict["code"] = code
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        code = d.pop("code", UNSET)
+
+        open_cage_annotations_nutsnuts1 = cls(
+            code=code,
+        )
+
+        open_cage_annotations_nutsnuts1.additional_properties = d
+        return open_cage_annotations_nutsnuts1
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nutsnuts2.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nutsnuts2.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsNUTSNUTS2")
+
+
+@_attrs_define
+class OpenCageAnnotationsNUTSNUTS2:
+    """
+    Attributes:
+        code (str | Unset):
+    """
+
+    code: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        code = self.code
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if code is not UNSET:
+            field_dict["code"] = code
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        code = d.pop("code", UNSET)
+
+        open_cage_annotations_nutsnuts2 = cls(
+            code=code,
+        )
+
+        open_cage_annotations_nutsnuts2.additional_properties = d
+        return open_cage_annotations_nutsnuts2
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nutsnuts3.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_nutsnuts3.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsNUTSNUTS3")
+
+
+@_attrs_define
+class OpenCageAnnotationsNUTSNUTS3:
+    """
+    Attributes:
+        code (str | Unset):
+    """
+
+    code: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        code = self.code
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if code is not UNSET:
+            field_dict["code"] = code
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        code = d.pop("code", UNSET)
+
+        open_cage_annotations_nutsnuts3 = cls(
+            code=code,
+        )
+
+        open_cage_annotations_nutsnuts3.additional_properties = d
+        return open_cage_annotations_nutsnuts3
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_sun.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_sun.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.open_cage_annotations_sun_rise import OpenCageAnnotationsSunRise
+    from ..models.open_cage_annotations_sun_set import OpenCageAnnotationsSunSet
+
+
+T = TypeVar("T", bound="OpenCageAnnotationsSun")
+
+
+@_attrs_define
+class OpenCageAnnotationsSun:
+    """
+    Attributes:
+        rise (OpenCageAnnotationsSunRise | Unset):
+        set_ (OpenCageAnnotationsSunSet | Unset):
+    """
+
+    rise: OpenCageAnnotationsSunRise | Unset = UNSET
+    set_: OpenCageAnnotationsSunSet | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        rise: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.rise, Unset):
+            rise = self.rise.to_dict()
+
+        set_: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.set_, Unset):
+            set_ = self.set_.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if rise is not UNSET:
+            field_dict["rise"] = rise
+        if set_ is not UNSET:
+            field_dict["set"] = set_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.open_cage_annotations_sun_rise import OpenCageAnnotationsSunRise
+        from ..models.open_cage_annotations_sun_set import OpenCageAnnotationsSunSet
+
+        d = dict(src_dict)
+        _rise = d.pop("rise", UNSET)
+        rise: OpenCageAnnotationsSunRise | Unset
+        if isinstance(_rise, Unset):
+            rise = UNSET
+        else:
+            rise = OpenCageAnnotationsSunRise.from_dict(_rise)
+
+        _set_ = d.pop("set", UNSET)
+        set_: OpenCageAnnotationsSunSet | Unset
+        if isinstance(_set_, Unset):
+            set_ = UNSET
+        else:
+            set_ = OpenCageAnnotationsSunSet.from_dict(_set_)
+
+        open_cage_annotations_sun = cls(
+            rise=rise,
+            set_=set_,
+        )
+
+        open_cage_annotations_sun.additional_properties = d
+        return open_cage_annotations_sun
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_sun_rise.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_sun_rise.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="OpenCageAnnotationsSunRise")
+
+
+@_attrs_define
+class OpenCageAnnotationsSunRise:
+    """ """
+
+    additional_properties: dict[str, float] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        open_cage_annotations_sun_rise = cls()
+
+        open_cage_annotations_sun_rise.additional_properties = d
+        return open_cage_annotations_sun_rise
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> float:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: float) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_sun_set.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_sun_set.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="OpenCageAnnotationsSunSet")
+
+
+@_attrs_define
+class OpenCageAnnotationsSunSet:
+    """ """
+
+    additional_properties: dict[str, float] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        open_cage_annotations_sun_set = cls()
+
+        open_cage_annotations_sun_set.additional_properties = d
+        return open_cage_annotations_sun_set
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> float:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: float) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_timezone.py
+++ b/clients/python/mailwoman_client/nominatim/models/open_cage_annotations_timezone.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OpenCageAnnotationsTimezone")
+
+
+@_attrs_define
+class OpenCageAnnotationsTimezone:
+    """
+    Attributes:
+        name (str | Unset):
+        offset_sec (float | Unset):
+        offset_string (str | Unset):
+    """
+
+    name: str | Unset = UNSET
+    offset_sec: float | Unset = UNSET
+    offset_string: str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        offset_sec = self.offset_sec
+
+        offset_string = self.offset_string
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if offset_sec is not UNSET:
+            field_dict["offset_sec"] = offset_sec
+        if offset_string is not UNSET:
+            field_dict["offset_string"] = offset_string
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name", UNSET)
+
+        offset_sec = d.pop("offset_sec", UNSET)
+
+        offset_string = d.pop("offset_string", UNSET)
+
+        open_cage_annotations_timezone = cls(
+            name=name,
+            offset_sec=offset_sec,
+            offset_string=offset_string,
+        )
+
+        open_cage_annotations_timezone.additional_properties = d
+        return open_cage_annotations_timezone
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/nominatim/models/reverse_addressdetails.py
+++ b/clients/python/mailwoman_client/nominatim/models/reverse_addressdetails.py
@@ -1,0 +1,9 @@
+from enum import IntEnum
+
+
+class ReverseAddressdetails(IntEnum):
+    VALUE_0 = 0
+    VALUE_1 = 1
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/nominatim/models/reverse_format.py
+++ b/clients/python/mailwoman_client/nominatim/models/reverse_format.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ReverseFormat(str, Enum):
+    GEOJSON = "geojson"
+    JSON = "json"
+    JSONLD = "jsonld"
+    JSONV2 = "jsonv2"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/nominatim/models/schema_org_place.py
+++ b/clients/python/mailwoman_client/nominatim/models/schema_org_place.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.schema_org_place_address import SchemaOrgPlaceAddress
+    from ..models.schema_org_place_geo import SchemaOrgPlaceGeo
+
+
+T = TypeVar("T", bound="SchemaOrgPlace")
+
+
+@_attrs_define
+class SchemaOrgPlace:
+    """A schema.org `Place` JSON-LD object (the `format=jsonld` projection). Only populated fields are emitted.
+
+    Attributes:
+        context (Literal['https://schema.org']):
+        type_ (Literal['Place']):
+        name (str | Unset):
+        geo (SchemaOrgPlaceGeo | Unset):
+        address (SchemaOrgPlaceAddress | Unset):
+    """
+
+    context: Literal["https://schema.org"]
+    type_: Literal["Place"]
+    name: str | Unset = UNSET
+    geo: SchemaOrgPlaceGeo | Unset = UNSET
+    address: SchemaOrgPlaceAddress | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        context = self.context
+
+        type_ = self.type_
+
+        name = self.name
+
+        geo: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.geo, Unset):
+            geo = self.geo.to_dict()
+
+        address: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.address, Unset):
+            address = self.address.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "@context": context,
+                "@type": type_,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if geo is not UNSET:
+            field_dict["geo"] = geo
+        if address is not UNSET:
+            field_dict["address"] = address
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.schema_org_place_address import SchemaOrgPlaceAddress
+        from ..models.schema_org_place_geo import SchemaOrgPlaceGeo
+
+        d = dict(src_dict)
+        context = cast(Literal["https://schema.org"], d.pop("@context"))
+        if context != "https://schema.org":
+            raise ValueError(
+                f"@context must match const 'https://schema.org', got '{context}'"
+            )
+
+        type_ = cast(Literal["Place"], d.pop("@type"))
+        if type_ != "Place":
+            raise ValueError(f"@type must match const 'Place', got '{type_}'")
+
+        name = d.pop("name", UNSET)
+
+        _geo = d.pop("geo", UNSET)
+        geo: SchemaOrgPlaceGeo | Unset
+        if isinstance(_geo, Unset):
+            geo = UNSET
+        else:
+            geo = SchemaOrgPlaceGeo.from_dict(_geo)
+
+        _address = d.pop("address", UNSET)
+        address: SchemaOrgPlaceAddress | Unset
+        if isinstance(_address, Unset):
+            address = UNSET
+        else:
+            address = SchemaOrgPlaceAddress.from_dict(_address)
+
+        schema_org_place = cls(
+            context=context,
+            type_=type_,
+            name=name,
+            geo=geo,
+            address=address,
+        )
+
+        return schema_org_place

--- a/clients/python/mailwoman_client/nominatim/models/schema_org_place_address.py
+++ b/clients/python/mailwoman_client/nominatim/models/schema_org_place_address.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SchemaOrgPlaceAddress")
+
+
+@_attrs_define
+class SchemaOrgPlaceAddress:
+    """
+    Attributes:
+        type_ (Literal['PostalAddress']):
+        street_address (str | Unset):
+        post_office_box_number (str | Unset):
+        address_locality (str | Unset):
+        address_region (str | Unset):
+        postal_code (str | Unset):
+        address_country (str | Unset): ISO-3166 alpha-2 (uppercased).
+    """
+
+    type_: Literal["PostalAddress"]
+    street_address: str | Unset = UNSET
+    post_office_box_number: str | Unset = UNSET
+    address_locality: str | Unset = UNSET
+    address_region: str | Unset = UNSET
+    postal_code: str | Unset = UNSET
+    address_country: str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        street_address = self.street_address
+
+        post_office_box_number = self.post_office_box_number
+
+        address_locality = self.address_locality
+
+        address_region = self.address_region
+
+        postal_code = self.postal_code
+
+        address_country = self.address_country
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "@type": type_,
+            }
+        )
+        if street_address is not UNSET:
+            field_dict["streetAddress"] = street_address
+        if post_office_box_number is not UNSET:
+            field_dict["postOfficeBoxNumber"] = post_office_box_number
+        if address_locality is not UNSET:
+            field_dict["addressLocality"] = address_locality
+        if address_region is not UNSET:
+            field_dict["addressRegion"] = address_region
+        if postal_code is not UNSET:
+            field_dict["postalCode"] = postal_code
+        if address_country is not UNSET:
+            field_dict["addressCountry"] = address_country
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["PostalAddress"], d.pop("@type"))
+        if type_ != "PostalAddress":
+            raise ValueError(f"@type must match const 'PostalAddress', got '{type_}'")
+
+        street_address = d.pop("streetAddress", UNSET)
+
+        post_office_box_number = d.pop("postOfficeBoxNumber", UNSET)
+
+        address_locality = d.pop("addressLocality", UNSET)
+
+        address_region = d.pop("addressRegion", UNSET)
+
+        postal_code = d.pop("postalCode", UNSET)
+
+        address_country = d.pop("addressCountry", UNSET)
+
+        schema_org_place_address = cls(
+            type_=type_,
+            street_address=street_address,
+            post_office_box_number=post_office_box_number,
+            address_locality=address_locality,
+            address_region=address_region,
+            postal_code=postal_code,
+            address_country=address_country,
+        )
+
+        return schema_org_place_address

--- a/clients/python/mailwoman_client/nominatim/models/schema_org_place_geo.py
+++ b/clients/python/mailwoman_client/nominatim/models/schema_org_place_geo.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="SchemaOrgPlaceGeo")
+
+
+@_attrs_define
+class SchemaOrgPlaceGeo:
+    """
+    Attributes:
+        type_ (Literal['GeoCoordinates']):
+        latitude (float):
+        longitude (float):
+    """
+
+    type_: Literal["GeoCoordinates"]
+    latitude: float
+    longitude: float
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        latitude = self.latitude
+
+        longitude = self.longitude
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "@type": type_,
+                "latitude": latitude,
+                "longitude": longitude,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["GeoCoordinates"], d.pop("@type"))
+        if type_ != "GeoCoordinates":
+            raise ValueError(f"@type must match const 'GeoCoordinates', got '{type_}'")
+
+        latitude = d.pop("latitude")
+
+        longitude = d.pop("longitude")
+
+        schema_org_place_geo = cls(
+            type_=type_,
+            latitude=latitude,
+            longitude=longitude,
+        )
+
+        return schema_org_place_geo

--- a/clients/python/mailwoman_client/nominatim/models/search_addressdetails.py
+++ b/clients/python/mailwoman_client/nominatim/models/search_addressdetails.py
@@ -1,0 +1,9 @@
+from enum import IntEnum
+
+
+class SearchAddressdetails(IntEnum):
+    VALUE_0 = 0
+    VALUE_1 = 1
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/nominatim/models/search_bounded.py
+++ b/clients/python/mailwoman_client/nominatim/models/search_bounded.py
@@ -1,0 +1,9 @@
+from enum import IntEnum
+
+
+class SearchBounded(IntEnum):
+    VALUE_0 = 0
+    VALUE_1 = 1
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/nominatim/models/search_format.py
+++ b/clients/python/mailwoman_client/nominatim/models/search_format.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class SearchFormat(str, Enum):
+    GEOJSON = "geojson"
+    JSON = "json"
+    JSONLD = "jsonld"
+    JSONV2 = "jsonv2"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/nominatim/types.py
+++ b/clients/python/mailwoman_client/nominatim/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/clients/python/mailwoman_client/photon/__init__.py
+++ b/clients/python/mailwoman_client/photon/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing @mailwoman/photon"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/clients/python/mailwoman_client/photon/api/__init__.py
+++ b/clients/python/mailwoman_client/photon/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/clients/python/mailwoman_client/photon/api/geocoding/__init__.py
+++ b/clients/python/mailwoman_client/photon/api/geocoding/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/mailwoman_client/photon/api/geocoding/reverse.py
+++ b/clients/python/mailwoman_client/photon/api/geocoding/reverse.py
@@ -1,0 +1,294 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_feature_collection import ErrorFeatureCollection
+from ...models.photon_feature_collection import PhotonFeatureCollection
+from ...models.reverse_format import ReverseFormat
+from ...models.schema_org_place import SchemaOrgPlace
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    lat: float,
+    lon: float,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    radius: float | Unset = UNSET,
+    format_: ReverseFormat | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["lat"] = lat
+
+    params["lon"] = lon
+
+    params["limit"] = limit
+
+    params["lang"] = lang
+
+    params["radius"] = radius
+
+    json_format_: str | Unset = UNSET
+    if not isinstance(format_, Unset):
+        json_format_ = format_.value
+
+    params["format"] = json_format_
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/reverse",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection | None:
+    if response.status_code == 200:
+
+        def _parse_response_200(
+            data: object,
+        ) -> list[SchemaOrgPlace] | PhotonFeatureCollection:
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                response_200_type_0 = PhotonFeatureCollection.from_dict(data)
+
+                return response_200_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, list):
+                raise TypeError()
+            response_200_type_1 = []
+            _response_200_type_1 = data
+            for response_200_type_1_item_data in _response_200_type_1:
+                response_200_type_1_item = SchemaOrgPlace.from_dict(
+                    response_200_type_1_item_data
+                )
+
+                response_200_type_1.append(response_200_type_1_item)
+
+            return response_200_type_1
+
+        response_200 = _parse_response_200(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorFeatureCollection.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 500:
+        response_500 = ErrorFeatureCollection.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = ErrorFeatureCollection.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    lat: float,
+    lon: float,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    radius: float | Unset = UNSET,
+    format_: ReverseFormat | Unset = UNSET,
+) -> Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]:
+    """Reverse geocoding
+
+     Resolve a coordinate to the nearest place(s), returning a GeoJSON `FeatureCollection` (or a
+    schema.org `Place[]` when `format=jsonld`).
+
+    Args:
+        lat (float):
+        lon (float):
+        limit (int | Unset):  Default: 15.
+        lang (str | Unset):
+        radius (float | Unset):
+        format_ (ReverseFormat | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]
+    """
+
+    kwargs = _get_kwargs(
+        lat=lat,
+        lon=lon,
+        limit=limit,
+        lang=lang,
+        radius=radius,
+        format_=format_,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    lat: float,
+    lon: float,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    radius: float | Unset = UNSET,
+    format_: ReverseFormat | Unset = UNSET,
+) -> ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection | None:
+    """Reverse geocoding
+
+     Resolve a coordinate to the nearest place(s), returning a GeoJSON `FeatureCollection` (or a
+    schema.org `Place[]` when `format=jsonld`).
+
+    Args:
+        lat (float):
+        lon (float):
+        limit (int | Unset):  Default: 15.
+        lang (str | Unset):
+        radius (float | Unset):
+        format_ (ReverseFormat | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection
+    """
+
+    return sync_detailed(
+        client=client,
+        lat=lat,
+        lon=lon,
+        limit=limit,
+        lang=lang,
+        radius=radius,
+        format_=format_,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    lat: float,
+    lon: float,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    radius: float | Unset = UNSET,
+    format_: ReverseFormat | Unset = UNSET,
+) -> Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]:
+    """Reverse geocoding
+
+     Resolve a coordinate to the nearest place(s), returning a GeoJSON `FeatureCollection` (or a
+    schema.org `Place[]` when `format=jsonld`).
+
+    Args:
+        lat (float):
+        lon (float):
+        limit (int | Unset):  Default: 15.
+        lang (str | Unset):
+        radius (float | Unset):
+        format_ (ReverseFormat | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]
+    """
+
+    kwargs = _get_kwargs(
+        lat=lat,
+        lon=lon,
+        limit=limit,
+        lang=lang,
+        radius=radius,
+        format_=format_,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    lat: float,
+    lon: float,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    radius: float | Unset = UNSET,
+    format_: ReverseFormat | Unset = UNSET,
+) -> ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection | None:
+    """Reverse geocoding
+
+     Resolve a coordinate to the nearest place(s), returning a GeoJSON `FeatureCollection` (or a
+    schema.org `Place[]` when `format=jsonld`).
+
+    Args:
+        lat (float):
+        lon (float):
+        limit (int | Unset):  Default: 15.
+        lang (str | Unset):
+        radius (float | Unset):
+        format_ (ReverseFormat | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            lat=lat,
+            lon=lon,
+            limit=limit,
+            lang=lang,
+            radius=radius,
+            format_=format_,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/photon/api/geocoding/search.py
+++ b/clients/python/mailwoman_client/photon/api/geocoding/search.py
@@ -1,0 +1,332 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_feature_collection import ErrorFeatureCollection
+from ...models.photon_feature_collection import PhotonFeatureCollection
+from ...models.schema_org_place import SchemaOrgPlace
+from ...models.search_format import SearchFormat
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    q: str,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    lat: float | Unset = UNSET,
+    lon: float | Unset = UNSET,
+    osm_tag: list[str] | Unset = UNSET,
+    layer: list[str] | Unset = UNSET,
+    format_: SearchFormat | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["q"] = q
+
+    params["limit"] = limit
+
+    params["lang"] = lang
+
+    params["lat"] = lat
+
+    params["lon"] = lon
+
+    json_osm_tag: list[str] | Unset = UNSET
+    if not isinstance(osm_tag, Unset):
+        json_osm_tag = osm_tag
+
+    params["osm_tag"] = json_osm_tag
+
+    json_layer: list[str] | Unset = UNSET
+    if not isinstance(layer, Unset):
+        json_layer = layer
+
+    params["layer"] = json_layer
+
+    json_format_: str | Unset = UNSET
+    if not isinstance(format_, Unset):
+        json_format_ = format_.value
+
+    params["format"] = json_format_
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection | None:
+    if response.status_code == 200:
+
+        def _parse_response_200(
+            data: object,
+        ) -> list[SchemaOrgPlace] | PhotonFeatureCollection:
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                response_200_type_0 = PhotonFeatureCollection.from_dict(data)
+
+                return response_200_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            if not isinstance(data, list):
+                raise TypeError()
+            response_200_type_1 = []
+            _response_200_type_1 = data
+            for response_200_type_1_item_data in _response_200_type_1:
+                response_200_type_1_item = SchemaOrgPlace.from_dict(
+                    response_200_type_1_item_data
+                )
+
+                response_200_type_1.append(response_200_type_1_item)
+
+            return response_200_type_1
+
+        response_200 = _parse_response_200(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorFeatureCollection.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 500:
+        response_500 = ErrorFeatureCollection.from_dict(response.json())
+
+        return response_500
+
+    if response.status_code == 501:
+        response_501 = ErrorFeatureCollection.from_dict(response.json())
+
+        return response_501
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    q: str,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    lat: float | Unset = UNSET,
+    lon: float | Unset = UNSET,
+    osm_tag: list[str] | Unset = UNSET,
+    layer: list[str] | Unset = UNSET,
+    format_: SearchFormat | Unset = UNSET,
+) -> Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]:
+    """Forward / autocomplete geocoding
+
+     Parse and resolve a free-text query into ranked places, returning a GeoJSON `FeatureCollection` (or
+    a schema.org `Place[]` when `format=jsonld`).
+
+    Args:
+        q (str):
+        limit (int | Unset):  Default: 15.
+        lang (str | Unset):
+        lat (float | Unset):
+        lon (float | Unset):
+        osm_tag (list[str] | Unset):
+        layer (list[str] | Unset):
+        format_ (SearchFormat | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]
+    """
+
+    kwargs = _get_kwargs(
+        q=q,
+        limit=limit,
+        lang=lang,
+        lat=lat,
+        lon=lon,
+        osm_tag=osm_tag,
+        layer=layer,
+        format_=format_,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    q: str,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    lat: float | Unset = UNSET,
+    lon: float | Unset = UNSET,
+    osm_tag: list[str] | Unset = UNSET,
+    layer: list[str] | Unset = UNSET,
+    format_: SearchFormat | Unset = UNSET,
+) -> ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection | None:
+    """Forward / autocomplete geocoding
+
+     Parse and resolve a free-text query into ranked places, returning a GeoJSON `FeatureCollection` (or
+    a schema.org `Place[]` when `format=jsonld`).
+
+    Args:
+        q (str):
+        limit (int | Unset):  Default: 15.
+        lang (str | Unset):
+        lat (float | Unset):
+        lon (float | Unset):
+        osm_tag (list[str] | Unset):
+        layer (list[str] | Unset):
+        format_ (SearchFormat | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection
+    """
+
+    return sync_detailed(
+        client=client,
+        q=q,
+        limit=limit,
+        lang=lang,
+        lat=lat,
+        lon=lon,
+        osm_tag=osm_tag,
+        layer=layer,
+        format_=format_,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    q: str,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    lat: float | Unset = UNSET,
+    lon: float | Unset = UNSET,
+    osm_tag: list[str] | Unset = UNSET,
+    layer: list[str] | Unset = UNSET,
+    format_: SearchFormat | Unset = UNSET,
+) -> Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]:
+    """Forward / autocomplete geocoding
+
+     Parse and resolve a free-text query into ranked places, returning a GeoJSON `FeatureCollection` (or
+    a schema.org `Place[]` when `format=jsonld`).
+
+    Args:
+        q (str):
+        limit (int | Unset):  Default: 15.
+        lang (str | Unset):
+        lat (float | Unset):
+        lon (float | Unset):
+        osm_tag (list[str] | Unset):
+        layer (list[str] | Unset):
+        format_ (SearchFormat | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection]
+    """
+
+    kwargs = _get_kwargs(
+        q=q,
+        limit=limit,
+        lang=lang,
+        lat=lat,
+        lon=lon,
+        osm_tag=osm_tag,
+        layer=layer,
+        format_=format_,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    q: str,
+    limit: int | Unset = 15,
+    lang: str | Unset = UNSET,
+    lat: float | Unset = UNSET,
+    lon: float | Unset = UNSET,
+    osm_tag: list[str] | Unset = UNSET,
+    layer: list[str] | Unset = UNSET,
+    format_: SearchFormat | Unset = UNSET,
+) -> ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection | None:
+    """Forward / autocomplete geocoding
+
+     Parse and resolve a free-text query into ranked places, returning a GeoJSON `FeatureCollection` (or
+    a schema.org `Place[]` when `format=jsonld`).
+
+    Args:
+        q (str):
+        limit (int | Unset):  Default: 15.
+        lang (str | Unset):
+        lat (float | Unset):
+        lon (float | Unset):
+        osm_tag (list[str] | Unset):
+        layer (list[str] | Unset):
+        format_ (SearchFormat | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorFeatureCollection | list[SchemaOrgPlace] | PhotonFeatureCollection
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            q=q,
+            limit=limit,
+            lang=lang,
+            lat=lat,
+            lon=lon,
+            osm_tag=osm_tag,
+            layer=layer,
+            format_=format_,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/photon/api/meta/__init__.py
+++ b/clients/python/mailwoman_client/photon/api/meta/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/clients/python/mailwoman_client/photon/api/meta/get_root.py
+++ b/clients/python/mailwoman_client/photon/api/meta/get_root.py
@@ -1,0 +1,134 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> str | None:
+    if response.status_code == 200:
+        response_200 = response.text
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[str]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[str]:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> str | None:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[str]:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> str | None:
+    """Landing page
+
+     A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET /` 404).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/clients/python/mailwoman_client/photon/client.py
+++ b/clients/python/mailwoman_client/photon/client.py
@@ -1,0 +1,282 @@
+import ssl
+from typing import Any
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(
+        self, async_client: httpx.AsyncClient
+    ) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/clients/python/mailwoman_client/photon/errors.py
+++ b/clients/python/mailwoman_client/photon/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/clients/python/mailwoman_client/photon/models/__init__.py
+++ b/clients/python/mailwoman_client/photon/models/__init__.py
@@ -1,0 +1,25 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .error_feature_collection import ErrorFeatureCollection
+from .photon_feature import PhotonFeature
+from .photon_feature_collection import PhotonFeatureCollection
+from .photon_properties import PhotonProperties
+from .point_geometry import PointGeometry
+from .reverse_format import ReverseFormat
+from .schema_org_place import SchemaOrgPlace
+from .schema_org_place_address import SchemaOrgPlaceAddress
+from .schema_org_place_geo import SchemaOrgPlaceGeo
+from .search_format import SearchFormat
+
+__all__ = (
+    "ErrorFeatureCollection",
+    "PhotonFeature",
+    "PhotonFeatureCollection",
+    "PhotonProperties",
+    "PointGeometry",
+    "ReverseFormat",
+    "SchemaOrgPlace",
+    "SchemaOrgPlaceAddress",
+    "SchemaOrgPlaceGeo",
+    "SearchFormat",
+)

--- a/clients/python/mailwoman_client/photon/models/error_feature_collection.py
+++ b/clients/python/mailwoman_client/photon/models/error_feature_collection.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.photon_feature import PhotonFeature
+
+
+T = TypeVar("T", bound="ErrorFeatureCollection")
+
+
+@_attrs_define
+class ErrorFeatureCollection:
+    """An empty `FeatureCollection` with a human-readable `message` — the shape every Photon error uses.
+
+    Attributes:
+        type_ (Literal['FeatureCollection']):
+        features (list[PhotonFeature]):
+        message (str):
+    """
+
+    type_: Literal["FeatureCollection"]
+    features: list[PhotonFeature]
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        features = []
+        for features_item_data in self.features:
+            features_item = features_item_data.to_dict()
+            features.append(features_item)
+
+        message = self.message
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+                "features": features,
+                "message": message,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.photon_feature import PhotonFeature
+
+        d = dict(src_dict)
+        type_ = cast(Literal["FeatureCollection"], d.pop("type"))
+        if type_ != "FeatureCollection":
+            raise ValueError(
+                f"type must match const 'FeatureCollection', got '{type_}'"
+            )
+
+        features = []
+        _features = d.pop("features")
+        for features_item_data in _features:
+            features_item = PhotonFeature.from_dict(features_item_data)
+
+            features.append(features_item)
+
+        message = d.pop("message")
+
+        error_feature_collection = cls(
+            type_=type_,
+            features=features,
+            message=message,
+        )
+
+        return error_feature_collection

--- a/clients/python/mailwoman_client/photon/models/photon_feature.py
+++ b/clients/python/mailwoman_client/photon/models/photon_feature.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.photon_properties import PhotonProperties
+    from ..models.point_geometry import PointGeometry
+
+
+T = TypeVar("T", bound="PhotonFeature")
+
+
+@_attrs_define
+class PhotonFeature:
+    """A GeoJSON `Point` feature carrying Photon properties.
+
+    Attributes:
+        type_ (Literal['Feature']):
+        geometry (PointGeometry): A GeoJSON `Point` geometry — `coordinates` are `[longitude, latitude]`.
+        properties (PhotonProperties): OSM-derived feature properties, populated from the resolved place. `osm_key`,
+            `osm_value`, and `type` are always present so a Photon client never dereferences `undefined`. Unlisted keys may
+            also appear.
+    """
+
+    type_: Literal["Feature"]
+    geometry: PointGeometry
+    properties: PhotonProperties
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        geometry = self.geometry.to_dict()
+
+        properties = self.properties.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+                "geometry": geometry,
+                "properties": properties,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.photon_properties import PhotonProperties
+        from ..models.point_geometry import PointGeometry
+
+        d = dict(src_dict)
+        type_ = cast(Literal["Feature"], d.pop("type"))
+        if type_ != "Feature":
+            raise ValueError(f"type must match const 'Feature', got '{type_}'")
+
+        geometry = PointGeometry.from_dict(d.pop("geometry"))
+
+        properties = PhotonProperties.from_dict(d.pop("properties"))
+
+        photon_feature = cls(
+            type_=type_,
+            geometry=geometry,
+            properties=properties,
+        )
+
+        return photon_feature

--- a/clients/python/mailwoman_client/photon/models/photon_feature_collection.py
+++ b/clients/python/mailwoman_client/photon/models/photon_feature_collection.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.photon_feature import PhotonFeature
+
+
+T = TypeVar("T", bound="PhotonFeatureCollection")
+
+
+@_attrs_define
+class PhotonFeatureCollection:
+    """A GeoJSON `FeatureCollection` of Photon result features (RFC 7946).
+
+    Attributes:
+        type_ (Literal['FeatureCollection']):
+        features (list[PhotonFeature]):
+    """
+
+    type_: Literal["FeatureCollection"]
+    features: list[PhotonFeature]
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        features = []
+        for features_item_data in self.features:
+            features_item = features_item_data.to_dict()
+            features.append(features_item)
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+                "features": features,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.photon_feature import PhotonFeature
+
+        d = dict(src_dict)
+        type_ = cast(Literal["FeatureCollection"], d.pop("type"))
+        if type_ != "FeatureCollection":
+            raise ValueError(
+                f"type must match const 'FeatureCollection', got '{type_}'"
+            )
+
+        features = []
+        _features = d.pop("features")
+        for features_item_data in _features:
+            features_item = PhotonFeature.from_dict(features_item_data)
+
+            features.append(features_item)
+
+        photon_feature_collection = cls(
+            type_=type_,
+            features=features,
+        )
+
+        return photon_feature_collection

--- a/clients/python/mailwoman_client/photon/models/photon_properties.py
+++ b/clients/python/mailwoman_client/photon/models/photon_properties.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="PhotonProperties")
+
+
+@_attrs_define
+class PhotonProperties:
+    """OSM-derived feature properties, populated from the resolved place. `osm_key`, `osm_value`, and `type` are always
+    present so a Photon client never dereferences `undefined`. Unlisted keys may also appear.
+
+        Attributes:
+            osm_id (int | str | Unset):
+            osm_type (str | Unset):
+            osm_key (str | Unset): OSM key, e.g. `place`, `highway`, `building`.
+            osm_value (str | Unset): OSM value, e.g. `city`, `house`, `residential`.
+            type_ (str | Unset): Photon place type, e.g. `city`, `street`, `house`, `country`.
+            name (str | Unset):
+            housenumber (str | Unset):
+            street (str | Unset):
+            postcode (str | Unset):
+            city (str | Unset):
+            district (str | Unset):
+            county (str | Unset):
+            state (str | Unset):
+            country (str | Unset):
+            countrycode (str | Unset): ISO-3166 alpha-2, lowercased.
+            extent (list[float] | Unset): Bounding box `[minLon, maxLat, maxLon, minLat]` (Photon convention).
+    """
+
+    osm_id: int | str | Unset = UNSET
+    osm_type: str | Unset = UNSET
+    osm_key: str | Unset = UNSET
+    osm_value: str | Unset = UNSET
+    type_: str | Unset = UNSET
+    name: str | Unset = UNSET
+    housenumber: str | Unset = UNSET
+    street: str | Unset = UNSET
+    postcode: str | Unset = UNSET
+    city: str | Unset = UNSET
+    district: str | Unset = UNSET
+    county: str | Unset = UNSET
+    state: str | Unset = UNSET
+    country: str | Unset = UNSET
+    countrycode: str | Unset = UNSET
+    extent: list[float] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        osm_id: int | str | Unset
+        if isinstance(self.osm_id, Unset):
+            osm_id = UNSET
+        else:
+            osm_id = self.osm_id
+
+        osm_type = self.osm_type
+
+        osm_key = self.osm_key
+
+        osm_value = self.osm_value
+
+        type_ = self.type_
+
+        name = self.name
+
+        housenumber = self.housenumber
+
+        street = self.street
+
+        postcode = self.postcode
+
+        city = self.city
+
+        district = self.district
+
+        county = self.county
+
+        state = self.state
+
+        country = self.country
+
+        countrycode = self.countrycode
+
+        extent: list[float] | Unset = UNSET
+        if not isinstance(self.extent, Unset):
+            extent = self.extent
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if osm_id is not UNSET:
+            field_dict["osm_id"] = osm_id
+        if osm_type is not UNSET:
+            field_dict["osm_type"] = osm_type
+        if osm_key is not UNSET:
+            field_dict["osm_key"] = osm_key
+        if osm_value is not UNSET:
+            field_dict["osm_value"] = osm_value
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if name is not UNSET:
+            field_dict["name"] = name
+        if housenumber is not UNSET:
+            field_dict["housenumber"] = housenumber
+        if street is not UNSET:
+            field_dict["street"] = street
+        if postcode is not UNSET:
+            field_dict["postcode"] = postcode
+        if city is not UNSET:
+            field_dict["city"] = city
+        if district is not UNSET:
+            field_dict["district"] = district
+        if county is not UNSET:
+            field_dict["county"] = county
+        if state is not UNSET:
+            field_dict["state"] = state
+        if country is not UNSET:
+            field_dict["country"] = country
+        if countrycode is not UNSET:
+            field_dict["countrycode"] = countrycode
+        if extent is not UNSET:
+            field_dict["extent"] = extent
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_osm_id(data: object) -> int | str | Unset:
+            if isinstance(data, Unset):
+                return data
+            return cast(int | str | Unset, data)
+
+        osm_id = _parse_osm_id(d.pop("osm_id", UNSET))
+
+        osm_type = d.pop("osm_type", UNSET)
+
+        osm_key = d.pop("osm_key", UNSET)
+
+        osm_value = d.pop("osm_value", UNSET)
+
+        type_ = d.pop("type", UNSET)
+
+        name = d.pop("name", UNSET)
+
+        housenumber = d.pop("housenumber", UNSET)
+
+        street = d.pop("street", UNSET)
+
+        postcode = d.pop("postcode", UNSET)
+
+        city = d.pop("city", UNSET)
+
+        district = d.pop("district", UNSET)
+
+        county = d.pop("county", UNSET)
+
+        state = d.pop("state", UNSET)
+
+        country = d.pop("country", UNSET)
+
+        countrycode = d.pop("countrycode", UNSET)
+
+        extent = cast(list[float], d.pop("extent", UNSET))
+
+        photon_properties = cls(
+            osm_id=osm_id,
+            osm_type=osm_type,
+            osm_key=osm_key,
+            osm_value=osm_value,
+            type_=type_,
+            name=name,
+            housenumber=housenumber,
+            street=street,
+            postcode=postcode,
+            city=city,
+            district=district,
+            county=county,
+            state=state,
+            country=country,
+            countrycode=countrycode,
+            extent=extent,
+        )
+
+        photon_properties.additional_properties = d
+        return photon_properties
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/clients/python/mailwoman_client/photon/models/point_geometry.py
+++ b/clients/python/mailwoman_client/photon/models/point_geometry.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="PointGeometry")
+
+
+@_attrs_define
+class PointGeometry:
+    """A GeoJSON `Point` geometry — `coordinates` are `[longitude, latitude]`.
+
+    Attributes:
+        type_ (Literal['Point']):
+        coordinates (list[float]): `[longitude, latitude]` (RFC 7946 position order).
+    """
+
+    type_: Literal["Point"]
+    coordinates: list[float]
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        coordinates = self.coordinates
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "type": type_,
+                "coordinates": coordinates,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["Point"], d.pop("type"))
+        if type_ != "Point":
+            raise ValueError(f"type must match const 'Point', got '{type_}'")
+
+        coordinates = cast(list[float], d.pop("coordinates"))
+
+        point_geometry = cls(
+            type_=type_,
+            coordinates=coordinates,
+        )
+
+        return point_geometry

--- a/clients/python/mailwoman_client/photon/models/reverse_format.py
+++ b/clients/python/mailwoman_client/photon/models/reverse_format.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ReverseFormat(str, Enum):
+    JSONLD = "jsonld"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/photon/models/schema_org_place.py
+++ b/clients/python/mailwoman_client/photon/models/schema_org_place.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.schema_org_place_address import SchemaOrgPlaceAddress
+    from ..models.schema_org_place_geo import SchemaOrgPlaceGeo
+
+
+T = TypeVar("T", bound="SchemaOrgPlace")
+
+
+@_attrs_define
+class SchemaOrgPlace:
+    """A schema.org `Place` JSON-LD object (the `format=jsonld` projection). Only populated fields are emitted.
+
+    Attributes:
+        context (Literal['https://schema.org']):
+        type_ (Literal['Place']):
+        name (str | Unset):
+        geo (SchemaOrgPlaceGeo | Unset):
+        address (SchemaOrgPlaceAddress | Unset):
+    """
+
+    context: Literal["https://schema.org"]
+    type_: Literal["Place"]
+    name: str | Unset = UNSET
+    geo: SchemaOrgPlaceGeo | Unset = UNSET
+    address: SchemaOrgPlaceAddress | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        context = self.context
+
+        type_ = self.type_
+
+        name = self.name
+
+        geo: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.geo, Unset):
+            geo = self.geo.to_dict()
+
+        address: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.address, Unset):
+            address = self.address.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "@context": context,
+                "@type": type_,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if geo is not UNSET:
+            field_dict["geo"] = geo
+        if address is not UNSET:
+            field_dict["address"] = address
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.schema_org_place_address import SchemaOrgPlaceAddress
+        from ..models.schema_org_place_geo import SchemaOrgPlaceGeo
+
+        d = dict(src_dict)
+        context = cast(Literal["https://schema.org"], d.pop("@context"))
+        if context != "https://schema.org":
+            raise ValueError(
+                f"@context must match const 'https://schema.org', got '{context}'"
+            )
+
+        type_ = cast(Literal["Place"], d.pop("@type"))
+        if type_ != "Place":
+            raise ValueError(f"@type must match const 'Place', got '{type_}'")
+
+        name = d.pop("name", UNSET)
+
+        _geo = d.pop("geo", UNSET)
+        geo: SchemaOrgPlaceGeo | Unset
+        if isinstance(_geo, Unset):
+            geo = UNSET
+        else:
+            geo = SchemaOrgPlaceGeo.from_dict(_geo)
+
+        _address = d.pop("address", UNSET)
+        address: SchemaOrgPlaceAddress | Unset
+        if isinstance(_address, Unset):
+            address = UNSET
+        else:
+            address = SchemaOrgPlaceAddress.from_dict(_address)
+
+        schema_org_place = cls(
+            context=context,
+            type_=type_,
+            name=name,
+            geo=geo,
+            address=address,
+        )
+
+        return schema_org_place

--- a/clients/python/mailwoman_client/photon/models/schema_org_place_address.py
+++ b/clients/python/mailwoman_client/photon/models/schema_org_place_address.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SchemaOrgPlaceAddress")
+
+
+@_attrs_define
+class SchemaOrgPlaceAddress:
+    """
+    Attributes:
+        type_ (Literal['PostalAddress']):
+        street_address (str | Unset):
+        post_office_box_number (str | Unset):
+        address_locality (str | Unset):
+        address_region (str | Unset):
+        postal_code (str | Unset):
+        address_country (str | Unset): ISO-3166 alpha-2 (uppercased).
+    """
+
+    type_: Literal["PostalAddress"]
+    street_address: str | Unset = UNSET
+    post_office_box_number: str | Unset = UNSET
+    address_locality: str | Unset = UNSET
+    address_region: str | Unset = UNSET
+    postal_code: str | Unset = UNSET
+    address_country: str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        street_address = self.street_address
+
+        post_office_box_number = self.post_office_box_number
+
+        address_locality = self.address_locality
+
+        address_region = self.address_region
+
+        postal_code = self.postal_code
+
+        address_country = self.address_country
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "@type": type_,
+            }
+        )
+        if street_address is not UNSET:
+            field_dict["streetAddress"] = street_address
+        if post_office_box_number is not UNSET:
+            field_dict["postOfficeBoxNumber"] = post_office_box_number
+        if address_locality is not UNSET:
+            field_dict["addressLocality"] = address_locality
+        if address_region is not UNSET:
+            field_dict["addressRegion"] = address_region
+        if postal_code is not UNSET:
+            field_dict["postalCode"] = postal_code
+        if address_country is not UNSET:
+            field_dict["addressCountry"] = address_country
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["PostalAddress"], d.pop("@type"))
+        if type_ != "PostalAddress":
+            raise ValueError(f"@type must match const 'PostalAddress', got '{type_}'")
+
+        street_address = d.pop("streetAddress", UNSET)
+
+        post_office_box_number = d.pop("postOfficeBoxNumber", UNSET)
+
+        address_locality = d.pop("addressLocality", UNSET)
+
+        address_region = d.pop("addressRegion", UNSET)
+
+        postal_code = d.pop("postalCode", UNSET)
+
+        address_country = d.pop("addressCountry", UNSET)
+
+        schema_org_place_address = cls(
+            type_=type_,
+            street_address=street_address,
+            post_office_box_number=post_office_box_number,
+            address_locality=address_locality,
+            address_region=address_region,
+            postal_code=postal_code,
+            address_country=address_country,
+        )
+
+        return schema_org_place_address

--- a/clients/python/mailwoman_client/photon/models/schema_org_place_geo.py
+++ b/clients/python/mailwoman_client/photon/models/schema_org_place_geo.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="SchemaOrgPlaceGeo")
+
+
+@_attrs_define
+class SchemaOrgPlaceGeo:
+    """
+    Attributes:
+        type_ (Literal['GeoCoordinates']):
+        latitude (float):
+        longitude (float):
+    """
+
+    type_: Literal["GeoCoordinates"]
+    latitude: float
+    longitude: float
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        latitude = self.latitude
+
+        longitude = self.longitude
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "@type": type_,
+                "latitude": latitude,
+                "longitude": longitude,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = cast(Literal["GeoCoordinates"], d.pop("@type"))
+        if type_ != "GeoCoordinates":
+            raise ValueError(f"@type must match const 'GeoCoordinates', got '{type_}'")
+
+        latitude = d.pop("latitude")
+
+        longitude = d.pop("longitude")
+
+        schema_org_place_geo = cls(
+            type_=type_,
+            latitude=latitude,
+            longitude=longitude,
+        )
+
+        return schema_org_place_geo

--- a/clients/python/mailwoman_client/photon/models/search_format.py
+++ b/clients/python/mailwoman_client/photon/models/search_format.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class SearchFormat(str, Enum):
+    JSONLD = "jsonld"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/clients/python/mailwoman_client/photon/types.py
+++ b/clients/python/mailwoman_client/photon/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,65 @@
+[project]
+name = "mailwoman-client"
+version = "0.1.0"
+description = "Typed Python clients for Mailwoman's Photon / Nominatim / libpostal drop-in geocoding APIs, generated from their OpenAPI 3.1 specs."
+readme = "README.md"
+license = { text = "AGPL-3.0-only OR LicenseRef-Commercial" }
+requires-python = ">=3.10"
+authors = [{ name = "Sister Software", email = "contact@sister.software" }]
+keywords = ["geocoding", "photon", "nominatim", "libpostal", "openapi", "mailwoman", "address"]
+
+# The generated code (mailwoman_client/{photon,nominatim,libpostal}) needs only httpx (the
+# transport) + attrs (the models). No dateutil — none of the three specs carry a date/datetime
+# format. Pins mirror openapi-python-client's own runtime floor.
+dependencies = ["httpx>=0.23,<0.29", "attrs>=22.2.0"]
+
+classifiers = [
+	"Development Status :: 4 - Beta",
+	"Intended Audience :: Developers",
+	"License :: OSI Approved :: GNU Affero General Public License v3",
+	"Operating System :: OS Independent",
+	"Programming Language :: Python :: 3",
+	"Programming Language :: Python :: 3.10",
+	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
+	"Topic :: Scientific/Engineering :: GIS",
+	"Topic :: Software Development :: Libraries :: Python Modules",
+	"Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://mailwoman.sister.software"
+Documentation = "https://mailwoman.sister.software/docs"
+Repository = "https://github.com/sister-software/mailwoman"
+Issues = "https://github.com/sister-software/mailwoman/issues"
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "ruff==0.15.20"]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["mailwoman_client*"]
+
+[tool.setuptools.package-data]
+# Ship the PEP 561 marker so consumers' type-checkers see the generated types.
+mailwoman_client = ["py.typed"]
+
+# Ruff — the Python analog of the repo's oxlint + oxfmt setup, mirroring corpus-python's config.
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+src = ["mailwoman_client", "tests"]
+# The three drop-in subpackages are GENERATED verbatim by openapi-python-client (which runs its
+# own ruff pass) and are overwritten on regen — don't lint/format them as hand-maintained code.
+extend-exclude = ["mailwoman_client/photon", "mailwoman_client/nominatim", "mailwoman_client/libpostal"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+docstring-code-format = true

--- a/clients/python/tests/test_smoke_live.py
+++ b/clients/python/tests/test_smoke_live.py
@@ -1,0 +1,31 @@
+"""Live smoke test for the generated Photon client against the hosted trial endpoint.
+
+Hits https://photon.sister.software (the public trial server) and asserts the typed client
+round-trips a real forward-geocoding query. Network-dependent; skipped automatically if the
+endpoint is unreachable, so it never fails a hermetic CI leg.
+
+Run just this: ``pytest tests/test_smoke_live.py``.
+"""
+
+import httpx
+import pytest
+from mailwoman_client import PhotonClient
+from mailwoman_client.photon.api.geocoding import search
+from mailwoman_client.photon.models import PhotonFeatureCollection
+
+
+def test_photon_search_berlin_hosted() -> None:
+    client = PhotonClient.hosted()
+    try:
+        result = search.sync(client=client, q="berlin", limit=3)
+    except httpx.HTTPError as exc:  # network flake / endpoint down — don't fail hermetic CI
+        pytest.skip(f"hosted endpoint unreachable: {exc}")
+
+    assert isinstance(result, PhotonFeatureCollection)
+    assert result.type_ == "FeatureCollection"
+    assert len(result.features) == 3
+    first = result.features[0]
+    # `type` is guaranteed present on every Photon feature (osm_key/osm_value/type always set).
+    assert first.properties.type_ == "city"
+    # A GeoJSON Point carries [lon, lat].
+    assert len(first.geometry.coordinates) == 2

--- a/clients/python/uv.lock
+++ b/clients/python/uv.lock
@@ -1,0 +1,268 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "mailwoman-client"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "attrs" },
+    { name = "httpx" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "attrs", specifier = ">=22.2.0" },
+    { name = "httpx", specifier = ">=0.23,<0.29" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "mailwoman-client"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+description = "Typed Rust clients for Mailwoman's Photon / Nominatim / libpostal drop-in geocoding APIs, generated from their OpenAPI 3.1 specs."
+license = "AGPL-3.0-only OR LicenseRef-Commercial"
+repository = "https://github.com/sister-software/mailwoman"
+homepage = "https://mailwoman.sister.software"
+documentation = "https://docs.rs/mailwoman-client"
+readme = "README.md"
+keywords = ["geocoding", "photon", "nominatim", "libpostal", "openapi"]
+categories = ["api-bindings", "science::geo"]
+# The vendored specs + the src are all that ship; nothing else is needed to build.
+include = ["src/**/*", "openapi/*.yaml", "examples/**/*", "README.md"]
+
+[dependencies]
+# progenitor's generate_api! proc-macro synthesizes the client at compile time from the vendored
+# spec; the generated code calls into progenitor::progenitor_client (re-exported by progenitor,
+# so no separate progenitor-client dep). reqwest MUST match the version progenitor 0.14 uses
+# (0.13) — a second reqwest in the graph makes the generated client fail to typecheck.
+progenitor = "0.14"
+# rustls (not native-tls) so the crate builds without a system OpenSSL / pkg-config — portable
+# for consumers and CI. default-features=false drops the native-tls default.
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+futures-core = "0.3"
+bytes = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -1,0 +1,79 @@
+# mailwoman-client (Rust)
+
+Typed Rust clients for [Mailwoman](https://mailwoman.sister.software)'s three HTTP drop-in APIs,
+**generated at compile time** by [`progenitor`](https://github.com/oxidecomputer/progenitor) from
+their OpenAPI specs, exposed as three modules of one crate:
+
+| Module                        | Drop-in for | Endpoints                                   |
+| ----------------------------- | ----------- | ------------------------------------------- |
+| `mailwoman_client::photon`    | Photon      | `/api`, `/reverse`                          |
+| `mailwoman_client::nominatim` | Nominatim   | `/search`, `/reverse`, `/lookup`, `/status` |
+| `mailwoman_client::libpostal` | libpostal   | `/parse`, `/expand`                         |
+
+Each module runs `progenitor::generate_api!` over a vendored spec under `openapi/`. The only
+hand-written code is the thin constructor layer in `src/lib.rs` (`photon_hosted()`,
+`photon_local()`, `nominatim_local()`, `libpostal_local()` — clients pre-pointed at the hosted
+trial or the local `serve` ports). See [`../README.md`](../README.md) for the regen command.
+
+> **Note on the spec version.** progenitor parses OpenAPI via the `openapiv3` crate, which only
+> understands 3.0.x. Mailwoman's published specs are 3.1, so the regen pipeline down-converts them
+> (`scripts/downgrade-spec.py`) before generation; the vendored `openapi/*.yaml` are the 3.0
+> derivatives. This is documented and deterministic — not a hand-written client.
+
+## Add it
+
+```toml
+[dependencies]
+mailwoman-client = "0.1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+The transport is `reqwest` with **rustls** (no system OpenSSL). rustls' default crypto provider is
+`aws-lc-rs`, which builds a small C library — a C compiler and CMake must be on the build host.
+
+## Usage
+
+```rust
+use std::num::NonZeroU64;
+use mailwoman_client::photon::types::{SearchQ, SearchResponse};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = mailwoman_client::photon_hosted(); // https://photon.sister.software
+    let q: SearchQ = "berlin".parse()?;
+
+    // progenitor's positional interface sorts params alphabetically:
+    // search(format, lang, lat, layer, limit, lon, osm_tag, q)
+    let response = client
+        .search(None, None, None, None, NonZeroU64::new(3), None, None, &q)
+        .await?;
+
+    if let SearchResponse::PhotonFeatureCollection(fc) = response.into_inner() {
+        for feature in &fc.features {
+            let [lon, lat] = [feature.geometry.coordinates[0], feature.geometry.coordinates[1]];
+            let name = feature.properties.name.as_deref().unwrap_or("?");
+            println!("{name} — {lat:.4}, {lon:.4}");
+        }
+    }
+    Ok(())
+}
+```
+
+`cargo run --example basic` runs exactly this. Verified output (against `https://photon.sister.software`):
+
+```
+Berlin (city) — 52.5015, 13.4019 [Germany]
+Berlin (city) — 41.6114, -72.7758 [United States]
+Berlín (city) — 13.5000, -88.5333 [?]
+```
+
+### Self-hosting
+
+`photon_local()` / `nominatim_local()` / `libpostal_local()` point at the local `serve` ports
+(2322 / 8080 / 8081). For any other host, construct the module client directly:
+`mailwoman_client::nominatim::Client::new("http://…")`. Only Photon has a hosted public trial
+endpoint; the Nominatim and libpostal drop-ins are self-host only.
+
+## License
+
+AGPL-3.0-only OR LicenseRef-Commercial (see the [repository](https://github.com/sister-software/mailwoman)).

--- a/clients/rust/examples/basic.rs
+++ b/clients/rust/examples/basic.rs
@@ -1,0 +1,38 @@
+//! Forward-geocode "berlin" against the hosted Photon trial endpoint and print the top 3 hits.
+//!
+//! Run: `cargo run --example basic` (hits https://photon.sister.software).
+//!
+//! Note the alphabetical parameter order — progenitor's positional interface sorts an operation's
+//! parameters by name, so `search` takes `(format, lang, lat, layer, limit, lon, osm_tag, q)`.
+
+use std::num::NonZeroU64;
+
+use mailwoman_client::photon::types::{SearchQ, SearchResponse};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = mailwoman_client::photon_hosted(); // https://photon.sister.software
+    let q: SearchQ = "berlin".parse().expect("non-empty query");
+
+    let response = client
+        .search(None, None, None, None, NonZeroU64::new(3), None, None, &q)
+        .await?;
+
+    let features = match response.into_inner() {
+        SearchResponse::PhotonFeatureCollection(fc) => fc.features,
+        SearchResponse::Array(_) => unreachable!("GeoJSON is the default; JSON-LD needs format=jsonld"),
+    };
+
+    for feature in &features {
+        let coords = &feature.geometry.coordinates; // [lon, lat]
+        let props = &feature.properties;
+        let name = props.name.as_deref().unwrap_or("?");
+        let kind = props.type_.as_deref().unwrap_or("?");
+        let country = props.country.as_deref().unwrap_or("?");
+        println!("{name} ({kind}) — {:.4}, {:.4} [{country}]", coords[1], coords[0]);
+    }
+
+    assert_eq!(features.len(), 3, "expected 3 features");
+    assert_eq!(features[0].properties.type_.as_deref(), Some("city"));
+    Ok(())
+}

--- a/clients/rust/openapi/libpostal.yaml
+++ b/clients/rust/openapi/libpostal.yaml
@@ -1,0 +1,279 @@
+# GENERATED — do not edit. 3.0.3 down-convert of the published 3.1 spec.
+# Produced by clients/rust/scripts/downgrade-spec.py (see clients/README.md).
+openapi: 3.0.3
+info:
+  title: '@mailwoman/libpostal'
+  version: 5.10.1
+  description: "A drop-in replacement for [libpostal](https://github.com/openvenues/libpostal)'s REST\
+    \ server — the same `/parse` (`parse_address`) and `/expand` (`expand_address`) contract, backed by\
+    \ Mailwoman's calibrated neural address parser. The lowest-dependency drop-in: `/parse` needs no gazetteer,\
+    \ just the model.\n\n**Drop-in compatibility.** `/parse` returns an ordered array of `{ label, value\
+    \ }` components, mapping Mailwoman's `ComponentTag` classifications onto libpostal's OSM-derived labels\
+    \ (`street`→`road`, `locality`→`city`, `region`→`state`, …). Unmapped classifications pass through\
+    \ unchanged.\n\n**Known divergences from upstream libpostal.**\n- `/expand` is deterministic. Mailwoman's\
+    \ normalization is rule-based, so `/expand` returns\n  the original string plus its normalized + abbreviation-expanded\
+    \ forms — one canonical\n  alternative set, not libpostal's probabilistic multi-variant hypothesis\
+    \ expansion.\n- `GET /` serves a friendly HTML banner; libpostal's own REST server has no root page.\n\
+    \n**Request forms.** Both `/parse` and `/expand` accept `GET` (with a query-string parameter) and\
+    \ `POST` (with a JSON body). The `serve` CLI reads query-string parameters directly; mount a JSON\
+    \ body parser (e.g. `express.json()`) to accept `POST` JSON bodies.\n\n**CORS.** Permissive CORS is\
+    \ on by default (`Access-Control-Allow-Origin: *`, and a `204` answer to preflight `OPTIONS` — the\
+    \ `POST /parse` preflight needs it). Disable with `serve --no-cors` when a reverse proxy already owns\
+    \ the headers.\n"
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+externalDocs:
+  description: Switching from libpostal (setup, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-libpostal
+servers:
+- url: http://{host}:{port}
+  description: Self-hosted server (`npx @mailwoman/libpostal serve`).
+  variables:
+    host:
+      default: 127.0.0.1
+      description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+    port:
+      default: '8081'
+      description: The port passed to `serve --port` (default 8081).
+security: []
+tags:
+- name: parsing
+  description: Address parsing and expansion endpoints.
+- name: meta
+  description: Non-parsing informational endpoints.
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET
+        /` 404).
+      tags:
+      - meta
+      responses:
+        '200':
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+  /parse:
+    get:
+      operationId: parseGet
+      summary: Parse an address (query string)
+      description: Parse a free-text address into ordered labeled components.
+      tags:
+      - parsing
+      parameters:
+      - name: query
+        in: query
+        description: The address to parse. `address` is accepted as an alias.
+        required: false
+        schema:
+          type: string
+      - name: address
+        in: query
+        description: Alias for `query`.
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/ParseResult'
+        '400':
+          $ref: '#/components/responses/MissingQuery'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    post:
+      operationId: parsePost
+      summary: Parse an address (JSON body)
+      description: Parse a free-text address into ordered labeled components.
+      tags:
+      - parsing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParseRequest'
+            example:
+              query: 1600 Pennsylvania Ave NW, Washington DC 20500
+      responses:
+        '200':
+          $ref: '#/components/responses/ParseResult'
+        '400':
+          $ref: '#/components/responses/MissingQuery'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /expand:
+    get:
+      operationId: expandGet
+      summary: Expand an address (query string)
+      description: Return the normalized + abbreviation-expanded forms of an address (deterministic; see
+        the divergence note).
+      tags:
+      - parsing
+      parameters:
+      - name: address
+        in: query
+        description: The address to expand.
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/ExpandResult'
+        '400':
+          $ref: '#/components/responses/MissingAddress'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+    post:
+      operationId: expandPost
+      summary: Expand an address (JSON body)
+      description: Return the normalized + abbreviation-expanded forms of an address (deterministic; see
+        the divergence note).
+      tags:
+      - parsing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExpandRequest'
+            example:
+              address: 1600 pennsylvania ave nw
+      responses:
+        '200':
+          $ref: '#/components/responses/ExpandResult'
+        '400':
+          $ref: '#/components/responses/MissingAddress'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+components:
+  responses:
+    ParseResult:
+      description: The ordered libpostal components.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/LibpostalComponent'
+          example:
+          - label: house_number
+            value: '1600'
+          - label: road
+            value: Pennsylvania Ave NW
+          - label: city
+            value: Washington
+          - label: state
+            value: DC
+          - label: postcode
+            value: '20500'
+    ExpandResult:
+      description: The deterministic expansion set.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ExpandResponse'
+          example:
+            expansions:
+            - 1600 pennsylvania ave nw
+            - 1600 pennsylvania avenue northwest
+    MissingQuery:
+      description: The required `query` (or `address`) parameter is missing.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: query is required
+    MissingAddress:
+      description: The required `address` parameter is missing.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: address is required
+    InternalError:
+      description: An unexpected engine fault. Returns a clean JSON error, never a stack trace.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: internal error
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: expand not implemented
+  schemas:
+    ParseRequest:
+      type: object
+      description: A `/parse` request body. Provide `query` (or its alias `address`).
+      properties:
+        query:
+          type: string
+          description: The address to parse.
+        address:
+          type: string
+          description: Alias for `query`.
+      additionalProperties: false
+    ExpandRequest:
+      type: object
+      description: An `/expand` request body.
+      required:
+      - address
+      properties:
+        address:
+          type: string
+          description: The address to expand.
+      additionalProperties: false
+    LibpostalComponent:
+      type: object
+      description: A libpostal `parse_address` component — a label and the text span it covers, in order.
+      required:
+      - label
+      - value
+      properties:
+        label:
+          type: string
+          description: The libpostal label, e.g. `house_number`, `road`, `city`, `state`, `postcode`.
+        value:
+          type: string
+          description: The text the label covers.
+      additionalProperties: false
+    ExpandResponse:
+      type: object
+      description: The `/expand` response.
+      required:
+      - expansions
+      properties:
+        expansions:
+          type: array
+          description: The distinct expanded forms (original + normalized + abbreviation-expanded), order
+            preserved.
+          items:
+            type: string
+      additionalProperties: false
+    Error:
+      type: object
+      description: A JSON error envelope.
+      required:
+      - error
+      properties:
+        error:
+          type: string
+      additionalProperties: false

--- a/clients/rust/openapi/nominatim.yaml
+++ b/clients/rust/openapi/nominatim.yaml
@@ -1,0 +1,655 @@
+# GENERATED — do not edit. 3.0.3 down-convert of the published 3.1 spec.
+# Produced by clients/rust/scripts/downgrade-spec.py (see clients/README.md).
+openapi: 3.0.3
+info:
+  title: '@mailwoman/nominatim'
+  version: 5.10.1
+  description: "A drop-in replacement for [Nominatim](https://nominatim.org) — the same `/search`, `/reverse`,\
+    \ `/lookup`, and `/status` contract, returning `jsonv2` result objects (and `geojson` / `jsonld` on\
+    \ request), served from a SQLite gazetteer over the Mailwoman engine instead of a PostgreSQL/PostGIS\
+    \ `osm2pgsql` import.\n\n**Drop-in compatibility.** Point an existing Nominatim client (`geopy`, …)\
+    \ at this server and forward + reverse geocoding work unchanged. Result objects carry the fields Nominatim\
+    \ clients parse — `place_id`, `licence`, `lat`, `lon`, `display_name`, `boundingbox`, `class`, `type`,\
+    \ `importance`, and the `address` breakdown when `addressdetails=1`.\n\n**Known divergences from upstream\
+    \ Nominatim.**\n- Every result carries an OpenCage-style `annotations` block (coordinate formats,\
+    \ country\n  flag, calling code, currency, and — when their data bundles are present — IANA timezone,\n\
+    \  UN/LOCODE, and EU NUTS codes). Plain Nominatim returns none of these.\n- `format=jsonld` is a Mailwoman\
+    \ extension (not in upstream Nominatim): it re-serializes\n  each result as a [schema.org `Place`](https://schema.org/Place)\
+    \ JSON-LD object. `jsonv2`\n  stays the default.\n- `/lookup` is part of the router contract but is\
+    \ not wired in the bundled `serve` engine\n  yet, so it answers `501`.\n- `licence` reports the Mailwoman\
+    \ data sources (Who's On First, Overture Maps,\n  OpenAddresses, US Census TIGER), not OSM/ODbL.\n\
+    - `GET /` serves a friendly HTML banner; Nominatim itself has only `/status`.\n\n**CORS.** Permissive\
+    \ CORS is on by default (`Access-Control-Allow-Origin: *`, and a `204` answer to preflight `OPTIONS`).\
+    \ Disable with `serve --no-cors` when a reverse proxy already owns the headers.\n"
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+externalDocs:
+  description: Switching from Nominatim (setup, hosted data, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-nominatim
+servers:
+- url: http://{host}:{port}
+  description: Self-hosted server (`npx @mailwoman/nominatim serve`).
+  variables:
+    host:
+      default: 127.0.0.1
+      description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+    port:
+      default: '8080'
+      description: The port passed to `serve --port` (default 8080).
+security: []
+tags:
+- name: geocoding
+  description: Forward, reverse, and id-based geocoding endpoints.
+- name: meta
+  description: Health and informational endpoints.
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET
+        /` 404).
+      tags:
+      - meta
+      responses:
+        '200':
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+  /search:
+    get:
+      operationId: search
+      summary: Forward geocoding
+      description: 'Geocode a free-text `q`, or a structured (`street`/`city`/`state`/`postalcode`/`country`)
+        query, into ranked results.
+
+        '
+      tags:
+      - geocoding
+      parameters:
+      - name: q
+        in: query
+        description: Free-text query. Mutually exclusive with the structured parameters.
+        required: false
+        schema:
+          type: string
+      - name: street
+        in: query
+        description: Structured query — street (with optional house number).
+        required: false
+        schema:
+          type: string
+      - name: city
+        in: query
+        description: Structured query — city.
+        required: false
+        schema:
+          type: string
+      - name: county
+        in: query
+        description: Structured query — county.
+        required: false
+        schema:
+          type: string
+      - name: state
+        in: query
+        description: Structured query — state / region.
+        required: false
+        schema:
+          type: string
+      - name: country
+        in: query
+        description: Structured query — country.
+        required: false
+        schema:
+          type: string
+      - name: postalcode
+        in: query
+        description: Structured query — postal code.
+        required: false
+        schema:
+          type: string
+      - name: countrycodes
+        in: query
+        description: 'Comma-separated ISO-3166 alpha-2 codes restricting results to those countries (Nominatim
+          semantics — a hard restriction; the first is applied as the country constraint).
+
+          '
+        required: false
+        schema:
+          type: string
+      - $ref: '#/components/parameters/Limit'
+      - name: bounded
+        in: query
+        description: Restrict results to the viewbox (`1`) or not (`0`).
+        required: false
+        schema:
+          type: integer
+          enum:
+          - 0
+          - 1
+          default: 0
+      - $ref: '#/components/parameters/AddressDetails'
+      - $ref: '#/components/parameters/Format'
+      - $ref: '#/components/parameters/AcceptLanguage'
+      responses:
+        '200':
+          description: 'An array of result objects (`jsonv2`/`json`), a GeoJSON `FeatureCollection` (`geojson`),
+            or an array of schema.org `Place` objects (`jsonld`).
+
+            '
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/NominatimResult'
+                - $ref: '#/components/schemas/NominatimFeatureCollection'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/SchemaOrgPlace'
+              example:
+              - place_id: 240087473
+                licence: Data © Who's On First, Overture Maps, OpenAddresses, US Census TIGER
+                lat: '38.8977'
+                lon: '-77.0365'
+                display_name: 1600, Pennsylvania Avenue NW, Washington, DC, 20500, United States
+                class: place
+                type: house
+                address:
+                  house_number: '1600'
+                  road: Pennsylvania Avenue NW
+                  city: Washington
+                  state: DC
+                  postcode: '20500'
+                  country: United States
+                  country_code: us
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+  /reverse:
+    get:
+      operationId: reverse
+      summary: Reverse geocoding
+      description: Resolve a coordinate to the nearest address (point-in-polygon over the WOF admin hierarchy).
+      tags:
+      - geocoding
+      parameters:
+      - name: lat
+        in: query
+        description: Latitude to reverse geocode.
+        required: true
+        schema:
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+      - name: lon
+        in: query
+        description: Longitude to reverse geocode.
+        required: true
+        schema:
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+      - name: zoom
+        in: query
+        description: Level of detail (Nominatim zoom, 0–18).
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          maximum: 18
+      - $ref: '#/components/parameters/AddressDetails'
+      - $ref: '#/components/parameters/Format'
+      - $ref: '#/components/parameters/AcceptLanguage'
+      responses:
+        '200':
+          description: 'A single result object (`jsonv2`/`json`), a GeoJSON `FeatureCollection` (`geojson`),
+            or a schema.org `Place` (`jsonld`). Returns JSON `null` when nothing resolves.
+
+            '
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/NominatimResult'
+                - $ref: '#/components/schemas/NominatimFeatureCollection'
+                - $ref: '#/components/schemas/SchemaOrgPlace'
+                nullable: true
+        '400':
+          description: '`lat`/`lon` are missing or out of range.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: lat and lon are required
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+  /lookup:
+    get:
+      operationId: lookup
+      summary: Look up known place ids
+      description: 'Resolve one or more OSM/place ids to result objects. Part of the router contract;
+        not wired in the bundled `serve` engine yet (answers `501`).
+
+        '
+      tags:
+      - geocoding
+      parameters:
+      - name: osm_ids
+        in: query
+        description: Comma-separated place ids to look up.
+        required: true
+        schema:
+          type: string
+      - $ref: '#/components/parameters/AddressDetails'
+      - $ref: '#/components/parameters/Format'
+      responses:
+        '200':
+          description: An array of result objects (`jsonv2`/`json`) or a GeoJSON `FeatureCollection` (`geojson`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/NominatimResult'
+                - $ref: '#/components/schemas/NominatimFeatureCollection'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+  /status:
+    get:
+      operationId: status
+      summary: Service status
+      description: Health check plus data version. Mirrors Nominatim's `/status?format=json`.
+      tags:
+      - meta
+      responses:
+        '200':
+          description: 'Service status. `status: 0` means OK.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NominatimStatus'
+              example:
+                status: 0
+                message: OK
+        '500':
+          $ref: '#/components/responses/InternalError'
+components:
+  parameters:
+    Limit:
+      name: limit
+      in: query
+      description: Maximum number of results to return.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        default: 10
+    AddressDetails:
+      name: addressdetails
+      in: query
+      description: Include a structured `address` breakdown (`1`) or not (`0`). Forced on for `format=jsonld`.
+      required: false
+      schema:
+        type: integer
+        enum:
+        - 0
+        - 1
+        default: 0
+    Format:
+      name: format
+      in: query
+      description: 'Output serialization. `jsonv2` (default) and `json` return result objects; `geojson`
+        returns a `FeatureCollection`; `jsonld` (a Mailwoman extension) returns schema.org `Place` JSON-LD.
+
+        '
+      required: false
+      schema:
+        type: string
+        enum:
+        - jsonv2
+        - json
+        - geojson
+        - jsonld
+        default: jsonv2
+    AcceptLanguage:
+      name: accept-language
+      in: query
+      description: Preferred result language(s) (BCP-47), as a query parameter.
+      required: false
+      schema:
+        type: string
+  responses:
+    InternalError:
+      description: An unexpected engine fault. Returns a clean JSON error, never a stack trace.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: internal error
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error: 'lookup not implemented (see #805)'
+  schemas:
+    NominatimResult:
+      type: object
+      description: A Nominatim result object (the shape `geopy` and friends parse).
+      required:
+      - place_id
+      - licence
+      - lat
+      - lon
+      - display_name
+      properties:
+        place_id: {}
+        licence:
+          type: string
+          description: The attribution string for the resolved data sources.
+        osm_type:
+          type: string
+        osm_id: {}
+        lat:
+          type: string
+          description: Latitude, as a string (Nominatim convention).
+        lon:
+          type: string
+          description: Longitude, as a string (Nominatim convention).
+        display_name:
+          type: string
+        boundingbox:
+          type: array
+          description: '`[south, north, west, east]` as strings (Nominatim convention).'
+          minItems: 4
+          maxItems: 4
+          items:
+            type: string
+        class:
+          type: string
+        type:
+          type: string
+        importance:
+          type: number
+        place_rank:
+          type: integer
+        address:
+          $ref: '#/components/schemas/NominatimAddressDetails'
+        geojson:
+          description: Present when `format=geojson` or `polygon_geojson=1` — a GeoJSON geometry.
+        annotations:
+          $ref: '#/components/schemas/OpenCageAnnotations'
+      additionalProperties: true
+    NominatimAddressDetails:
+      type: object
+      description: The structured address breakdown returned under `address` when `addressdetails=1`.
+        Keys mirror Nominatim's OSM-derived tag names.
+      properties:
+        house_number:
+          type: string
+        road:
+          type: string
+        neighbourhood:
+          type: string
+        suburb:
+          type: string
+        city:
+          type: string
+        town:
+          type: string
+        village:
+          type: string
+        county:
+          type: string
+        state:
+          type: string
+        postcode:
+          type: string
+        country:
+          type: string
+        country_code:
+          type: string
+          description: ISO-3166 alpha-2, lowercased.
+      additionalProperties:
+        type: string
+    NominatimStatus:
+      type: object
+      description: 'The `/status` payload. `status: 0` means OK.'
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: integer
+          description: '`0` = OK; non-zero = a fault code.'
+        message:
+          type: string
+        data_updated:
+          type: string
+          description: When the underlying data was last built (ISO-8601).
+      additionalProperties: false
+    NominatimFeatureCollection:
+      type: object
+      description: A GeoJSON `FeatureCollection` — the `format=geojson` envelope (RFC 7946).
+      externalDocs:
+        description: GeoJSON (RFC 7946)
+        url: https://www.rfc-editor.org/rfc/rfc7946
+      required:
+      - type
+      - features
+      properties:
+        type:
+          enum:
+          - FeatureCollection
+        features:
+          type: array
+          items:
+            type: object
+            required:
+            - type
+            - properties
+            - geometry
+            properties:
+              type:
+                enum:
+                - Feature
+              properties:
+                type: object
+                additionalProperties: true
+              geometry:
+                description: A GeoJSON geometry (the place polygon when present, else a Point).
+              bbox:
+                type: array
+                description: '`[west, south, east, north]` (GeoJSON bbox order).'
+                minItems: 4
+                maxItems: 4
+                items:
+                  type: number
+            additionalProperties: true
+      additionalProperties: false
+    OpenCageAnnotations:
+      type: object
+      description: 'The OpenCage-style enrichment block, keyed and cased as OpenCage documents it. A Mailwoman
+        extension over upstream Nominatim. Only populated fields are emitted.
+
+        '
+      externalDocs:
+        description: OpenCage annotations
+        url: https://opencagedata.com/api#annotations
+      properties:
+        DMS:
+          type: object
+          properties:
+            lat:
+              type: string
+            lng:
+              type: string
+        MGRS:
+          type: string
+        Maidenhead:
+          type: string
+        Mercator:
+          type: object
+          properties:
+            x:
+              type: number
+            y:
+              type: number
+        geohash:
+          type: string
+        qibla:
+          type: number
+        sun:
+          type: object
+          properties:
+            rise:
+              type: object
+              additionalProperties:
+                type: number
+            set:
+              type: object
+              additionalProperties:
+                type: number
+        callingcode:
+          type: number
+        currency:
+          type: object
+          properties:
+            iso_code:
+              type: string
+            name:
+              type: string
+            symbol:
+              type: string
+        flag:
+          type: string
+          description: The country's flag emoji.
+        timezone:
+          type: object
+          properties:
+            name:
+              type: string
+            offset_sec:
+              type: number
+            offset_string:
+              type: string
+        NUTS:
+          type: object
+          description: EU NUTS region codes (when the NUTS data bundle is present).
+          properties:
+            NUTS0:
+              type: object
+              properties:
+                code:
+                  type: string
+            NUTS1:
+              type: object
+              properties:
+                code:
+                  type: string
+            NUTS2:
+              type: object
+              properties:
+                code:
+                  type: string
+            NUTS3:
+              type: object
+              properties:
+                code:
+                  type: string
+        UN_LOCODE:
+          type: string
+        wikidata:
+          type: string
+        FIPS:
+          type: object
+          properties:
+            county:
+              type: string
+      additionalProperties: true
+    SchemaOrgPlace:
+      type: object
+      description: A schema.org `Place` JSON-LD object (the `format=jsonld` projection). Only populated
+        fields are emitted.
+      externalDocs:
+        description: schema.org Place
+        url: https://schema.org/Place
+      required:
+      - '@context'
+      - '@type'
+      properties:
+        '@context':
+          enum:
+          - https://schema.org
+        '@type':
+          enum:
+          - Place
+        name:
+          type: string
+        geo:
+          type: object
+          required:
+          - '@type'
+          - latitude
+          - longitude
+          properties:
+            '@type':
+              enum:
+              - GeoCoordinates
+            latitude:
+              type: number
+            longitude:
+              type: number
+          additionalProperties: false
+        address:
+          type: object
+          required:
+          - '@type'
+          properties:
+            '@type':
+              enum:
+              - PostalAddress
+            streetAddress:
+              type: string
+            postOfficeBoxNumber:
+              type: string
+            addressLocality:
+              type: string
+            addressRegion:
+              type: string
+            postalCode:
+              type: string
+            addressCountry:
+              type: string
+              description: ISO-3166 alpha-2 (uppercased).
+          additionalProperties: false
+      additionalProperties: false
+    Error:
+      type: object
+      description: A JSON error envelope.
+      required:
+      - error
+      properties:
+        error:
+          type: string
+      additionalProperties: false

--- a/clients/rust/openapi/photon.yaml
+++ b/clients/rust/openapi/photon.yaml
@@ -1,0 +1,467 @@
+# GENERATED — do not edit. 3.0.3 down-convert of the published 3.1 spec.
+# Produced by clients/rust/scripts/downgrade-spec.py (see clients/README.md).
+openapi: 3.0.3
+info:
+  title: '@mailwoman/photon'
+  version: 5.10.1
+  description: "A drop-in replacement for [Photon](https://github.com/komoot/photon) — the same `/api`\
+    \ (forward / autocomplete) and `/reverse` contract, returning GeoJSON `FeatureCollection`s, served\
+    \ from a SQLite gazetteer over the Mailwoman engine instead of an Elasticsearch cluster.\n\n**Drop-in\
+    \ compatibility.** Point an existing Photon client (`leaflet-control-geocoder`, `@openrunner/photon-geocoder`,\
+    \ …) at this server and forward + reverse geocoding work unchanged. Every response is a GeoJSON `FeatureCollection`\
+    \ of `Point` features (RFC 7946), and each feature's `properties` carry the OSM-derived key names\
+    \ a Photon client reads (`osm_key`, `osm_value`, `type`, `name`, `housenumber`, `street`, `city`,\
+    \ `state`, `country`, `countrycode`, …).\n\n**Known divergences from upstream Photon.**\n- `format=jsonld`\
+    \ is a Mailwoman extension (not in upstream Photon): it re-serializes the\n  *same* resolved places\
+    \ as an array of [schema.org `Place`](https://schema.org/Place)\n  JSON-LD objects. The native GeoJSON\
+    \ `FeatureCollection` stays the default.\n- Results are ranked by the Mailwoman resolver (population-first\
+    \ candidate scoring with an\n  optional proximity re-rank), not Photon's Elasticsearch relevance model\
+    \ — ordering can\n  differ. The dedicated prefix-first FST autocomplete front is a refinement still\
+    \ in flight.\n- `GET /` serves a friendly HTML banner; upstream Photon has no root page.\n\n**CORS.**\
+    \ Permissive CORS is on by default (`Access-Control-Allow-Origin: *`, and a `204` answer to preflight\
+    \ `OPTIONS`), matching upstream Photon — browser-embedded map widgets need it. Disable with `serve\
+    \ --no-cors` when a reverse proxy already owns the headers.\n"
+  license:
+    name: AGPL-3.0-only OR LicenseRef-Commercial
+  contact:
+    name: Sister Software
+    url: https://mailwoman.sister.software
+externalDocs:
+  description: Switching from Photon (setup, hosted data, divergences)
+  url: https://mailwoman.sister.software/docs/concepts/switching-from-photon
+servers:
+- url: https://photon.sister.software
+  description: Hosted public trial endpoint (conservative rate limits).
+- url: http://{host}:{port}
+  description: Local self-hosted server (`npx @mailwoman/photon serve`).
+  variables:
+    host:
+      default: 127.0.0.1
+      description: The host `serve` binds (default 0.0.0.0; reach it at 127.0.0.1).
+    port:
+      default: '2322'
+      description: The port passed to `serve --port` (default 2322).
+security: []
+tags:
+- name: geocoding
+  description: Forward (autocomplete) and reverse geocoding endpoints.
+- name: meta
+  description: Non-geocoding informational endpoints.
+paths:
+  /:
+    get:
+      operationId: getRoot
+      summary: Landing page
+      description: A friendly HTML banner with clickable example queries (in place of a bare `Cannot GET
+        /` 404).
+      tags:
+      - meta
+      responses:
+        '200':
+          description: HTML landing page.
+          content:
+            text/html:
+              schema:
+                type: string
+  /api:
+    get:
+      operationId: search
+      summary: Forward / autocomplete geocoding
+      description: 'Parse and resolve a free-text query into ranked places, returning a GeoJSON `FeatureCollection`
+        (or a schema.org `Place[]` when `format=jsonld`).
+
+        '
+      tags:
+      - geocoding
+      parameters:
+      - $ref: '#/components/parameters/Query'
+      - $ref: '#/components/parameters/Limit'
+      - $ref: '#/components/parameters/Lang'
+      - name: lat
+        in: query
+        description: Latitude of a proximity bias (soft re-rank). Only applied when `lon` is also present.
+        required: false
+        schema:
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+      - name: lon
+        in: query
+        description: Longitude of a proximity bias (soft re-rank). Only applied when `lat` is also present.
+        required: false
+        schema:
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+      - name: osm_tag
+        in: query
+        description: Filter results by OSM tag (repeatable). Photon `key`, `key:value`, or `:value` syntax.
+        required: false
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+      - name: layer
+        in: query
+        description: Filter results by layer (repeatable), e.g. `city`, `street`, `house`.
+        required: false
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+      - $ref: '#/components/parameters/Format'
+      responses:
+        '200':
+          description: 'A GeoJSON `FeatureCollection` of ranked `Point` features (default), or — when
+            `format=jsonld` — an array of schema.org `Place` objects.
+
+            '
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/PhotonFeatureCollection'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/SchemaOrgPlace'
+              example:
+                type: FeatureCollection
+                features:
+                - type: Feature
+                  geometry:
+                    type: Point
+                    coordinates:
+                    - 13.405
+                    - 52.52
+                  properties:
+                    osm_key: place
+                    osm_value: city
+                    type: city
+                    name: Berlin
+                    state: Berlin
+                    country: Germany
+                    countrycode: de
+        '400':
+          description: The required `q` parameter is missing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorFeatureCollection'
+              example:
+                type: FeatureCollection
+                features: []
+                message: q is required
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+  /reverse:
+    get:
+      operationId: reverse
+      summary: Reverse geocoding
+      description: 'Resolve a coordinate to the nearest place(s), returning a GeoJSON `FeatureCollection`
+        (or a schema.org `Place[]` when `format=jsonld`).
+
+        '
+      tags:
+      - geocoding
+      parameters:
+      - name: lat
+        in: query
+        description: Latitude to reverse geocode.
+        required: true
+        schema:
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+      - name: lon
+        in: query
+        description: Longitude to reverse geocode.
+        required: true
+        schema:
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+      - $ref: '#/components/parameters/Limit'
+      - $ref: '#/components/parameters/Lang'
+      - name: radius
+        in: query
+        description: Optional search radius (km) around the coordinate.
+        required: false
+        schema:
+          type: number
+          format: double
+          minimum: 0
+      - $ref: '#/components/parameters/Format'
+      responses:
+        '200':
+          description: 'A GeoJSON `FeatureCollection` for the nearest place(s) (default), or — when `format=jsonld`
+            — an array of schema.org `Place` objects.
+
+            '
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/PhotonFeatureCollection'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/SchemaOrgPlace'
+        '400':
+          description: '`lat`/`lon` are missing or out of range.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorFeatureCollection'
+              example:
+                type: FeatureCollection
+                features: []
+                message: lat and lon are required
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+components:
+  parameters:
+    Query:
+      name: q
+      in: query
+      description: The free-text query to geocode (e.g. `1600 pennsylvania ave`).
+      required: true
+      schema:
+        type: string
+        minLength: 1
+    Limit:
+      name: limit
+      in: query
+      description: Maximum number of features to return.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        default: 15
+    Lang:
+      name: lang
+      in: query
+      description: Preferred result language (BCP-47 / ISO code).
+      required: false
+      schema:
+        type: string
+    Format:
+      name: format
+      in: query
+      description: 'Output serialization. Omit for the native GeoJSON `FeatureCollection`. `jsonld` (a
+        Mailwoman extension) returns an array of schema.org `Place` objects instead.
+
+        '
+      required: false
+      schema:
+        type: string
+        enum:
+        - jsonld
+  responses:
+    InternalError:
+      description: An unexpected engine fault. Returns an empty `FeatureCollection` with a message, never
+        a stack trace.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorFeatureCollection'
+          example:
+            type: FeatureCollection
+            features: []
+            message: internal error
+    NotImplemented:
+      description: The backing engine method is not wired for this deployment.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorFeatureCollection'
+          example:
+            type: FeatureCollection
+            features: []
+            message: search not implemented
+  schemas:
+    PhotonFeatureCollection:
+      type: object
+      description: A GeoJSON `FeatureCollection` of Photon result features (RFC 7946).
+      externalDocs:
+        description: GeoJSON (RFC 7946)
+        url: https://www.rfc-editor.org/rfc/rfc7946
+      required:
+      - type
+      - features
+      properties:
+        type:
+          enum:
+          - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/PhotonFeature'
+      additionalProperties: false
+    PhotonFeature:
+      type: object
+      description: A GeoJSON `Point` feature carrying Photon properties.
+      required:
+      - type
+      - geometry
+      - properties
+      properties:
+        type:
+          enum:
+          - Feature
+        geometry:
+          $ref: '#/components/schemas/PointGeometry'
+        properties:
+          $ref: '#/components/schemas/PhotonProperties'
+      additionalProperties: false
+    PointGeometry:
+      type: object
+      description: A GeoJSON `Point` geometry — `coordinates` are `[longitude, latitude]`.
+      required:
+      - type
+      - coordinates
+      properties:
+        type:
+          enum:
+          - Point
+        coordinates:
+          type: array
+          description: '`[longitude, latitude]` (RFC 7946 position order).'
+          minItems: 2
+          maxItems: 3
+          items:
+            type: number
+      additionalProperties: false
+    PhotonProperties:
+      type: object
+      description: 'OSM-derived feature properties, populated from the resolved place. `osm_key`, `osm_value`,
+        and `type` are always present so a Photon client never dereferences `undefined`. Unlisted keys
+        may also appear.
+
+        '
+      properties:
+        osm_id: {}
+        osm_type:
+          type: string
+        osm_key:
+          type: string
+          description: OSM key, e.g. `place`, `highway`, `building`.
+        osm_value:
+          type: string
+          description: OSM value, e.g. `city`, `house`, `residential`.
+        type:
+          type: string
+          description: Photon place type, e.g. `city`, `street`, `house`, `country`.
+        name:
+          type: string
+        housenumber:
+          type: string
+        street:
+          type: string
+        postcode:
+          type: string
+        city:
+          type: string
+        district:
+          type: string
+        county:
+          type: string
+        state:
+          type: string
+        country:
+          type: string
+        countrycode:
+          type: string
+          description: ISO-3166 alpha-2, lowercased.
+        extent:
+          type: array
+          description: Bounding box `[minLon, maxLat, maxLon, minLat]` (Photon convention).
+          minItems: 4
+          maxItems: 4
+          items:
+            type: number
+      additionalProperties: true
+    ErrorFeatureCollection:
+      type: object
+      description: An empty `FeatureCollection` with a human-readable `message` — the shape every Photon
+        error uses.
+      required:
+      - type
+      - features
+      - message
+      properties:
+        type:
+          enum:
+          - FeatureCollection
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/PhotonFeature'
+        message:
+          type: string
+      additionalProperties: false
+    SchemaOrgPlace:
+      type: object
+      description: A schema.org `Place` JSON-LD object (the `format=jsonld` projection). Only populated
+        fields are emitted.
+      externalDocs:
+        description: schema.org Place
+        url: https://schema.org/Place
+      required:
+      - '@context'
+      - '@type'
+      properties:
+        '@context':
+          enum:
+          - https://schema.org
+        '@type':
+          enum:
+          - Place
+        name:
+          type: string
+        geo:
+          type: object
+          required:
+          - '@type'
+          - latitude
+          - longitude
+          properties:
+            '@type':
+              enum:
+              - GeoCoordinates
+            latitude:
+              type: number
+            longitude:
+              type: number
+          additionalProperties: false
+        address:
+          type: object
+          required:
+          - '@type'
+          properties:
+            '@type':
+              enum:
+              - PostalAddress
+            streetAddress:
+              type: string
+            postOfficeBoxNumber:
+              type: string
+            addressLocality:
+              type: string
+            addressRegion:
+              type: string
+            postalCode:
+              type: string
+            addressCountry:
+              type: string
+              description: ISO-3166 alpha-2 (uppercased).
+          additionalProperties: false
+      additionalProperties: false

--- a/clients/rust/scripts/downgrade-spec.py
+++ b/clients/rust/scripts/downgrade-spec.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Down-convert an OpenAPI 3.1 spec to 3.0.3 for progenitor.
+
+progenitor 0.14 parses OpenAPI via the `openapiv3` crate, which only understands 3.0.x. Our
+published specs are 3.1, so this script rewrites the handful of 3.1-only constructs the specs
+actually use into their 3.0 equivalents. It is deterministic and lossless for our purposes:
+
+  - `openapi: 3.1.x`            -> `openapi: 3.0.3`
+  - `info.summary`             -> dropped (3.0 Info has no `summary`)
+  - `info.license.identifier`  -> dropped (3.0 License has no SPDX `identifier`)
+  - `const: X`                 -> `enum: [X]`
+  - `type: [T, "null"]`        -> `type: T` + `nullable: true`
+  - `type: [A, B, ...]`        -> `type` removed (an untyped/any schema; a union of concrete
+                                  types has no single-`type` 3.0 form)
+  - a `{type: "null"}` entry in `oneOf`/`anyOf` -> entry removed + `nullable: true` on the parent
+
+This is the ONE derived step in the Rust regen pipeline; see clients/README.md. Do not hand-edit
+the vendored `openapi/*.yaml` — they are this script's output.
+
+Usage: downgrade-spec.py <input-3.1.yaml> <output-3.0.yaml>
+"""
+
+import sys
+
+import yaml
+
+
+def downgrade(node):
+    """Recursively rewrite a parsed OpenAPI node in place, returning the rewritten node."""
+    if isinstance(node, list):
+        return [downgrade(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    # const -> single-value enum
+    if "const" in node:
+        node["enum"] = [node.pop("const")]
+
+    # multi-type arrays (3.1) -> single type + nullable, or drop when it's a real union
+    t = node.get("type")
+    if isinstance(t, list):
+        non_null = [x for x in t if x != "null"]
+        has_null = "null" in t
+        if len(non_null) == 1:
+            node["type"] = non_null[0]
+        else:
+            # a union of >1 concrete types has no single-`type` 3.0 form: leave it untyped (any)
+            node.pop("type", None)
+        if has_null:
+            node["nullable"] = True
+
+    # a `{type: "null"}` member of oneOf/anyOf -> drop it, mark the parent nullable
+    for combiner in ("oneOf", "anyOf"):
+        if isinstance(node.get(combiner), list):
+            kept = [s for s in node[combiner] if s != {"type": "null"}]
+            if len(kept) != len(node[combiner]):
+                node["nullable"] = True
+            node[combiner] = kept
+
+    return {k: downgrade(v) for k, v in node.items()}
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__)
+        return 2
+    src, dst = sys.argv[1], sys.argv[2]
+    with open(src, encoding="utf-8") as fh:
+        spec = yaml.safe_load(fh)
+
+    spec["openapi"] = "3.0.3"
+    info = spec.get("info", {})
+    info.pop("summary", None)
+    if isinstance(info.get("license"), dict):
+        info["license"].pop("identifier", None)
+
+    spec = downgrade(spec)
+
+    with open(dst, "w", encoding="utf-8") as fh:
+        fh.write("# GENERATED — do not edit. 3.0.3 down-convert of the published 3.1 spec.\n")
+        fh.write("# Produced by clients/rust/scripts/downgrade-spec.py (see clients/README.md).\n")
+        yaml.safe_dump(spec, fh, sort_keys=False, allow_unicode=True, width=100)
+    print(f"wrote {dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,0 +1,62 @@
+//! Typed Rust clients for Mailwoman's three HTTP drop-in geocoding APIs.
+//!
+//! Each submodule is generated at compile time by [`progenitor`]'s `generate_api!` proc-macro
+//! from the OpenAPI 3.1 spec vendored under `openapi/` — nothing here is hand-written except the
+//! thin default-`base_url` constructors below. Regenerate by refreshing the vendored specs (see
+//! `clients/README.md`); there is no code to hand-edit.
+//!
+//! ```no_run
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = mailwoman_client::photon_hosted();
+//! let fc = client.search().q("berlin").limit(3).send().await?;
+//! for feature in &fc.features {
+//!     println!("{:?}", feature.properties);
+//! }
+//! # Ok(()) }
+//! ```
+
+/// Photon-compatible autocomplete / reverse geocoding client (`/api`, `/reverse`).
+pub mod photon {
+    progenitor::generate_api!("openapi/photon.yaml");
+}
+
+/// Nominatim-compatible geocoding client (`/search`, `/reverse`, `/lookup`, `/status`).
+pub mod nominatim {
+    progenitor::generate_api!("openapi/nominatim.yaml");
+}
+
+/// libpostal-compatible parse / expand client (`/parse`, `/expand`).
+pub mod libpostal {
+    progenitor::generate_api!("openapi/libpostal.yaml");
+}
+
+/// The hosted public Photon trial endpoint (conservative rate limits). Only Photon has a hosted
+/// trial; the Nominatim and libpostal drop-ins are self-host only.
+pub const PHOTON_HOSTED_BASE_URL: &str = "https://photon.sister.software";
+
+/// Default local `npx @mailwoman/photon serve` base URL.
+pub const PHOTON_LOCAL_BASE_URL: &str = "http://127.0.0.1:2322";
+/// Default local `npx @mailwoman/nominatim serve` base URL.
+pub const NOMINATIM_LOCAL_BASE_URL: &str = "http://127.0.0.1:8080";
+/// Default local `npx @mailwoman/libpostal serve` base URL.
+pub const LIBPOSTAL_LOCAL_BASE_URL: &str = "http://127.0.0.1:8081";
+
+/// A Photon client pointed at the hosted public trial endpoint ([`PHOTON_HOSTED_BASE_URL`]).
+pub fn photon_hosted() -> photon::Client {
+    photon::Client::new(PHOTON_HOSTED_BASE_URL)
+}
+
+/// A Photon client pointed at a local `serve` server ([`PHOTON_LOCAL_BASE_URL`]).
+pub fn photon_local() -> photon::Client {
+    photon::Client::new(PHOTON_LOCAL_BASE_URL)
+}
+
+/// A Nominatim client pointed at a local `serve` server ([`NOMINATIM_LOCAL_BASE_URL`]).
+pub fn nominatim_local() -> nominatim::Client {
+    nominatim::Client::new(NOMINATIM_LOCAL_BASE_URL)
+}
+
+/// A libpostal client pointed at a local `serve` server ([`LIBPOSTAL_LOCAL_BASE_URL`]).
+pub fn libpostal_local() -> libpostal::Client {
+    libpostal::Client::new(LIBPOSTAL_LOCAL_BASE_URL)
+}


### PR DESCRIPTION
Rung 1 of the multi-language story: typed **Python** and **Rust** clients for Mailwoman's three HTTP drop-ins (Photon / Nominatim / libpostal), **generated from the published OpenAPI 3.1 specs** with a thin ergonomics layer. Scope discipline held: generated clients + small convenience wrappers, no hand-written SDK surface.

## Names

`mailwoman-client` — verified **available** on both registries (HTTP 404): PyPI (`/pypi/mailwoman-client/json`) and crates.io (`/api/v1/crates/mailwoman-client` → "does not exist"). No fallback needed.

## Placement

Follows the `corpus-python/` precedent — a top-level `clients/` dir with standalone Python + Rust projects (not yarn workspaces). Generated code **is** committed (it's the shipped client); build artifacts are git-ignored. `oxlint` finds no JS to lint; `oxfmt` formats the Markdown + `pyproject.toml` (kept in house style) and leaves the generated `.py`/`.rs`/`.yaml` alone.

## Python — `clients/python` (PyPI `mailwoman-client`)

- `openapi-python-client`, `--meta none`: one distributable `mailwoman_client` with `photon`/`nominatim`/`libpostal` sibling subpackages. The generator emits fully **relative** imports, so the three compose with zero post-processing.
- Hand-written `__init__.py` exposes `PhotonClient` / `NominatimClient` / `LibpostalClient` with default local `serve` base_urls, plus `PhotonClient.hosted()` for the public trial endpoint.
- Honest metadata (AGPL-3.0-only OR LicenseRef-Commercial, project URLs, classifiers, `py.typed`); own `ruff` config excluding the generated subpackages.
- **Verified**: live smoke vs `https://photon.sister.software` (berlin, limit 3 → 3 features, `type=city`); wheel builds (89 files, all subpackages + `py.typed`); `twine check` PASS; `ruff` clean.

## Rust — `clients/rust` (crates.io `mailwoman-client`)

- `progenitor` `generate_api!` — one crate, three modules (`photon`/`nominatim`/`libpostal`).
- **What fought us**: progenitor's `openapiv3` parser is **3.0-only** and rejects the specs' 3.1 constructs (`openapi: 3.1.0`, `type: [integer, string]`, `type: null`). The named fallback (openapi-generator) needs Java, which isn't on this box (and non-interactive sudo is unavailable). Resolution: a deterministic 3.1→3.0 down-convert (`scripts/downgrade-spec.py`) runs in regen; the vendored `openapi/*.yaml` are the 3.0 derivatives. Also pinned `reqwest` to 0.13 (progenitor 0.14's version) with **rustls** to avoid a second reqwest and system OpenSSL.
- **Verified**: `cargo build`, `clippy` clean, `cargo run --example basic` runs **live** (same 3 berlin hits), `cargo package` OK (license SPDX validates, 10 files).

## Also

- Lean `clients` CI job in `test.yml` (Python import smoke + Rust compile — no network).
- `.gitignore` for the new build artifacts.
- `clients/README.md` (verbatim regen commands) and `clients/PUBLISHING.md` (the exact PyPI + crates.io publish steps the operator runs).

**Not published** to any registry. **Do not merge** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5qDbkGN3xs2XDvyK52qPT