### PR TITLE
style: green CI Lint — oxfmt pass over 9 stale files

### DIFF
--- a/docs/articles/concepts/onnx-runtime.mdx
+++ b/docs/articles/concepts/onnx-runtime.mdx
@@ -59,12 +59,8 @@ import { readFileSync } from "node:fs"
 
 const session = await InferenceSession.create(readFileSync("model.onnx"))
 
-const inputIds = new BigInt64Array([
-	/* tokenized address */
-])
-const attentionMask = new BigInt64Array([
-	/* 1s for real tokens, 0s for padding */
-])
+const inputIds = new BigInt64Array([/* tokenized address */])
+const attentionMask = new BigInt64Array([/* 1s for real tokens, 0s for padding */])
 
 const results = await session.run({
 	input_ids: new ort.Tensor("int64", inputIds, [1, seq_len]),

--- a/docs/articles/evals/2026-06-22-day-148-shipped-v4.13.0-postmortem.md
+++ b/docs/articles/evals/2026-06-22-day-148-shipped-v4.13.0-postmortem.md
@@ -5,13 +5,14 @@ _Collaborative day session, picking up where the night's [eval-coverage postmort
 ## What shipped
 
 - **🎯 v4.13.0 — `@mailwoman/*` at v1.9.1-multilocale-3order, live on npm.** The first model in the arc to lift non-FR/DE EU resolve, at zero US/FR coordinate cost. Bundled int8 verified `0b150efb` in the published tarball, provenance-attested (repo went public). Tag `v4.13.0` + `release: v4.13.0` on main.
+
   | locale | v1.8.0 (prod) | v1.9.0 (failed) | **v1.9.1 (shipped)** |
-  | --- | --: | --: | --: |
-  | IT | 79% | 63% | **92.7%** |
-  | PT | 52% | 35% | **82.0%** |
-  | PL | 53% | 39% | **62.0%** |
-  | AT | 50% | 45% | **81.3%** |
-  | CZ | 43% | 31% | **52.0%** |
+  | ------ | ------------: | --------------: | -------------------: |
+  | IT     |           79% |             63% |            **92.7%** |
+  | PT     |           52% |             35% |            **82.0%** |
+  | PL     |           53% |             39% |            **62.0%** |
+  | AT     |           50% |             45% |            **81.3%** |
+  | CZ     |           43% |             31% |            **52.0%** |
 
   Guardrails held on the metric we ship (the assembled coordinate): **US locality-match 83.4→84.1** (+0.7, 44-state holdout; 9 states gained >1pp incl. IN 68→90), **FR resolve flat / p50 1.28→1.22 km**. Three US _label-F1_ deltas (country −6.6, locality −2.2, venue −1.2) tripped the ±1pp gate but were confirmed **coordinate-invisible** by grading the coordinate.
 

--- a/docs/articles/plan/migrate-readline-to-spliterator.md
+++ b/docs/articles/plan/migrate-readline-to-spliterator.md
@@ -30,34 +30,34 @@ result as `node:readline` while adding:
 
 ## Call-site inventory
 
-| File                                                     | Pattern                                                                            | Spliterator replacement                                                                          |
+| File | Pattern | Spliterator replacement |
 | -------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----- |
-| `corpus/scripts/build-kryptonite-shard.ts:87`            | `createInterface({ input: createReadStream(jsonl, "utf8"), crlfDelay: Infinity })` | `TextSpliterator.fromAsync(jsonl)`                                                               |
-| `corpus/scripts/build-transliteration-shard.ts:116`      | same shape                                                                         | `TextSpliterator.fromAsync(jsonl)`                                                               |
-| `corpus/scripts/ingest-csv.ts:206,311`                   | CSV ingest — two passes                                                            | `CSVSpliterator.fromAsync(path, { mode: "array" })` ⚠️                                           |
-| `corpus/src/build.ts:338`                                | `streamJsonl<T>` helper                                                            | `JSONSpliterator.fromAsync<T>(path)`                                                             |
-| `corpus/src/split.ts:219`                                | shuffle-split of labeled JSONL                                                     | `JSONSpliterator.fromAsync(labeledJsonlPath)` (read phase only; write needs `createWriteStream`) |
-| `corpus/src/adapters/gnaf/adapter.ts:81`                 | pipe-delimited G-NAF                                                               | `TSVSpliterator.fromAsync` with `delimiter: "                                                    | "`    |
-| `corpus/src/adapters/openaddresses/adapter.ts:142`       | OA GeoJSONL                                                                        | `JSONSpliterator.fromAsync(adapterOpts.inputPath)`                                               |
-| `corpus/src/adapters/overture/adapter.ts:81`             | Overture JSONL                                                                     | `JSONSpliterator.fromAsync(opts.inputPath)`                                                      |
-| `corpus/src/adapters/synth-po-box/adapter.ts:94`         | synthetic PO box JSONL                                                             | `JSONSpliterator.fromAsync(options.inputPath)`                                                   |
-| `corpus/src/adapters/usgov-nad/adapter.ts:252`           | NAD GeoJSON                                                                        | `JSONSpliterator.fromAsync(join(opts.inputPath, shard))`                                         |
-| `corpus/src/shard-recipes/fr-admin-split.ts:66`          | `readCommunes` CSV                                                                 | `CSVSpliterator.fromAsync(path, { mode: "object" })`                                             |
-| `corpus/src/shard-recipes/locale.ts:220`                 | OA CSV reservoir sample                                                            | `CSVSpliterator.fromAsync(input, { mode: "array" })`                                             |
-| `corpus/src/shard-recipes/scaffold.ts:71`                | tuple JSONL → `ShardTuple`                                                         | `JSONSpliterator.fromAsync<ShardTuple>(input)`                                                   |
-| `mailwoman/commands/gazetteer/importance.tsx:131`        | gzipped TSV via `createInterface({ input: fileStream.pipe(gunzip) })`              | `TextSpliterator.fromAsync(fileStream.pipe(gunzip), { delimiter: Delimiters.Tab })`              |
-| `mailwoman/commands/gazetteer/postcode-intl.tsx:89`      | GeoNames TSV                                                                       | `TSVSpliterator.fromAsync(file)`                                                                 |
-| `mailwoman/corpus-tools/align-shard.ts:40`               | canonicalize JSONL + rewrite                                                       | `JSONSpliterator.fromAsync(args.input)` (read phase)                                             |
-| `scripts/jsonl-to-parquet.ts:159`                        | validate JSONL → DuckDB                                                            | `JSONSpliterator.fromAsync(args.input)`                                                          |
-| `scripts/eval/audit-po-box-cedex-shard.ts:156`           | JSONL audit                                                                        | `JSONSpliterator.fromAsync(opts.input)`                                                          |
-| `scripts/eval/reverse-geocode-eval.ts:105`               | JSONL eval rows                                                                    | `JSONSpliterator.fromAsync(args.eval)`                                                           |
-| `scripts/eval/gauntlet/holdout.ts:101`                   | JSONL reservoir sample                                                             | `JSONSpliterator.fromAsync(src.file)`                                                            |
-| `scripts/eval/record-matcher/train-cross-gbt.ts:146`     | CSV with manual quote handling                                                     | `CSVSpliterator.fromAsync(path, { mode: "object", enableQuoteHandling: true })`                  |
-| `scripts/eval/record-matcher/train-org-cross-gbt.ts:129` | same pattern                                                                       | same                                                                                             |
-| `tiger/sdk/fetch.ts:310`                                 | `ogr2ogr` stdout (GeoJSON per line)                                                | `JSONSpliterator.fromAsync(child.stdout)` ⚠️                                                     |
-| `tiger/sdk/redistricting.ts:122,203`                     | pipe-delimited census files                                                        | `TSVSpliterator.fromAsync(path, { delimiter: "                                                   | " })` |
-| `osm/sdk/extract.ts:127`                                 | `osmconvert` stdout                                                                | `TextSpliterator.fromAsync(proc.stdout)`                                                         |
-| `osm/sdk/street-recovery.ts:126`                         | `osmconvert` stdout                                                                | `TextSpliterator.fromAsync(proc.stdout)`                                                         |
+| `corpus/scripts/build-kryptonite-shard.ts:87` | `createInterface({ input: createReadStream(jsonl, "utf8"), crlfDelay: Infinity })` | `TextSpliterator.fromAsync(jsonl)` |
+| `corpus/scripts/build-transliteration-shard.ts:116` | same shape | `TextSpliterator.fromAsync(jsonl)` |
+| `corpus/scripts/ingest-csv.ts:206,311` | CSV ingest — two passes | `CSVSpliterator.fromAsync(path, { mode: "array" })` ⚠️ |
+| `corpus/src/build.ts:338` | `streamJsonl<T>` helper | `JSONSpliterator.fromAsync<T>(path)` |
+| `corpus/src/split.ts:219` | shuffle-split of labeled JSONL | `JSONSpliterator.fromAsync(labeledJsonlPath)` (read phase only; write needs `createWriteStream`) |
+| `corpus/src/adapters/gnaf/adapter.ts:81` | pipe-delimited G-NAF | `TSVSpliterator.fromAsync` with `delimiter: "                                                    | "` |
+| `corpus/src/adapters/openaddresses/adapter.ts:142` | OA GeoJSONL | `JSONSpliterator.fromAsync(adapterOpts.inputPath)` |
+| `corpus/src/adapters/overture/adapter.ts:81` | Overture JSONL | `JSONSpliterator.fromAsync(opts.inputPath)` |
+| `corpus/src/adapters/synth-po-box/adapter.ts:94` | synthetic PO box JSONL | `JSONSpliterator.fromAsync(options.inputPath)` |
+| `corpus/src/adapters/usgov-nad/adapter.ts:252` | NAD GeoJSON | `JSONSpliterator.fromAsync(join(opts.inputPath, shard))` |
+| `corpus/src/shard-recipes/fr-admin-split.ts:66` | `readCommunes` CSV | `CSVSpliterator.fromAsync(path, { mode: "object" })` |
+| `corpus/src/shard-recipes/locale.ts:220` | OA CSV reservoir sample | `CSVSpliterator.fromAsync(input, { mode: "array" })` |
+| `corpus/src/shard-recipes/scaffold.ts:71` | tuple JSONL → `ShardTuple` | `JSONSpliterator.fromAsync<ShardTuple>(input)` |
+| `mailwoman/commands/gazetteer/importance.tsx:131` | gzipped TSV via `createInterface({ input: fileStream.pipe(gunzip) })` | `TextSpliterator.fromAsync(fileStream.pipe(gunzip), { delimiter: Delimiters.Tab })` |
+| `mailwoman/commands/gazetteer/postcode-intl.tsx:89` | GeoNames TSV | `TSVSpliterator.fromAsync(file)` |
+| `mailwoman/corpus-tools/align-shard.ts:40` | canonicalize JSONL + rewrite | `JSONSpliterator.fromAsync(args.input)` (read phase) |
+| `scripts/jsonl-to-parquet.ts:159` | validate JSONL → DuckDB | `JSONSpliterator.fromAsync(args.input)` |
+| `scripts/eval/audit-po-box-cedex-shard.ts:156` | JSONL audit | `JSONSpliterator.fromAsync(opts.input)` |
+| `scripts/eval/reverse-geocode-eval.ts:105` | JSONL eval rows | `JSONSpliterator.fromAsync(args.eval)` |
+| `scripts/eval/gauntlet/holdout.ts:101` | JSONL reservoir sample | `JSONSpliterator.fromAsync(src.file)` |
+| `scripts/eval/record-matcher/train-cross-gbt.ts:146` | CSV with manual quote handling | `CSVSpliterator.fromAsync(path, { mode: "object", enableQuoteHandling: true })` |
+| `scripts/eval/record-matcher/train-org-cross-gbt.ts:129` | same pattern | same |
+| `tiger/sdk/fetch.ts:310` | `ogr2ogr` stdout (GeoJSON per line) | `JSONSpliterator.fromAsync(child.stdout)` ⚠️ |
+| `tiger/sdk/redistricting.ts:122,203` | pipe-delimited census files | `TSVSpliterator.fromAsync(path, { delimiter: "                                                   | " })` |
+| `osm/sdk/extract.ts:127` | `osmconvert` stdout | `TextSpliterator.fromAsync(proc.stdout)` |
+| `osm/sdk/street-recovery.ts:126` | `osmconvert` stdout | `TextSpliterator.fromAsync(proc.stdout)` |
 
 > ⚠️ denotes a call site that warrants extra care (see "Risks" below).
 

--- a/docs/research/2026-06-20-same-building-different-company.mdx
+++ b/docs/research/2026-06-20-same-building-different-company.mdx
@@ -71,9 +71,7 @@ npm install @mailwoman/registry
 ```ts
 import { resolveEntities, toMapHTML } from "@mailwoman/registry"
 
-const entities = await resolveEntities(records, {
-	/* sensible defaults */
-})
+const entities = await resolveEntities(records, {/* sensible defaults */})
 // → clustered entities, each with a coordinate, a cohesion score, and the records it merged
 ```
 

--- a/docs/superpowers/plans/2026-07-09-pastel-phase0-core-helpers-cli-kit.md
+++ b/docs/superpowers/plans/2026-07-09-pastel-phase0-core-helpers-cli-kit.md
@@ -334,9 +334,7 @@ import { createElement as h, useEffect, useState } from "react"
 
 /** The lifecycle of a command's one-shot async task. */
 export type CommandTaskState<T> =
-	| { status: "running" }
-	| { status: "done"; result: T }
-	| { status: "error"; message: string }
+	{ status: "running" } | { status: "done"; result: T } | { status: "error"; message: string }
 
 /**
  * Run a command's one-shot async task and own the exit-code discipline: rejection renders the error

--- a/nominatim/README.md
+++ b/nominatim/README.md
@@ -31,9 +31,7 @@ The package is engine-agnostic — embed it in your own server:
 import express from "express"
 import { createNominatimRouter, type NominatimEngine } from "@mailwoman/nominatim"
 
-const engine: NominatimEngine = {
-	/* search, reverse, lookup, status — backed by your Mailwoman pipeline */
-}
+const engine: NominatimEngine = {/* search, reverse, lookup, status — backed by your Mailwoman pipeline */}
 express().use(createNominatimRouter(engine)).listen(8080)
 ```
 

--- a/photon/README.md
+++ b/photon/README.md
@@ -36,9 +36,7 @@ Backed by Mailwoman's FST autocomplete tier (#190/#587) + parse → resolve.
 import express from "express"
 import { createPhotonRouter, type PhotonEngine } from "@mailwoman/photon"
 
-const engine: PhotonEngine = {
-	/* search, reverse — backed by your Mailwoman pipeline */
-}
+const engine: PhotonEngine = {/* search, reverse — backed by your Mailwoman pipeline */}
 express().use(createPhotonRouter(engine)).listen(2322)
 ```
 

--- a/query-shape/character-class.ts
+++ b/query-shape/character-class.ts
@@ -131,7 +131,7 @@ export function classifyToken(text: string): TokenCharacterClass {
 	let hasArabic = false
 	let hasPunct = false
 
-	for (let i = 0; i < text.length; ) {
+	for (let i = 0; i < text.length;) {
 		const cp = text.codePointAt(i)!
 		i += cp > 0xffff ? 2 : 1
 		const cls = classifyCodepoint(cp)

--- a/registry/tools/learned-scorer-eval.ts
+++ b/registry/tools/learned-scorer-eval.ts
@@ -365,7 +365,7 @@ export async function scorerPairwiseEval(
 		let rank = 1
 		let rankSum = 0
 
-		for (let i = 0; i < sorted.length; ) {
+		for (let i = 0; i < sorted.length;) {
 			let j = i
 
 			while (j < sorted.length && sorted[j]!.s === sorted[i]!.s) {


### PR DESCRIPTION
Main's Lint leg has been red since the a34e4f3d deps bump updated oxfmt without a reformat — which silently blocked ci:test and ci:smoke on every PR (they never executed on #1074 or #1075). Whitespace/table-padding only; the two .ts hunks are one-space removals in empty for-update clauses.

Merging this, then syncing feat/hono-api so #1075 gets a real CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)