### PR TITLE
ci(clients): environment-bound publish workflows for the provisioned pypi/cargo environments

### DIFF
--- a/.github/workflows/publish-cargo.yml
+++ b/.github/workflows/publish-cargo.yml
@@ -1,0 +1,84 @@
+# Publish the generated Rust API client (`mailwoman-client`) to crates.io.
+#
+# Credential: the `CARGO_REGISTRY_TOKEN` secret stored in the `cargo` GitHub
+# environment (operator-provisioned) — declaring `environment: cargo` on the
+# job is what makes that secret resolvable here; it is NOT a repo-level secret.
+#
+# The client is regenerated from `main` at dispatch time — its version syncs to
+# `mailwoman/package.json`, so ALWAYS dispatch this AFTER the npm release it
+# should match (crates.io permanently reserves a published version; a
+# client-only fix rides the next release train — see RELEASING.md "Client
+# packages"). Joins the `publish` concurrency group so a dispatch can't race an
+# in-flight npm release into generating at a mid-bump version.
+name: Publish Rust client
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish-cargo:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Resolves CARGO_REGISTRY_TOKEN from the environment's secrets.
+    environment: cargo
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Version syncs to mailwoman/package.json on main (main-only release
+          # flow by construction — same rationale as publish.yml's clients job).
+          ref: main
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Enable Corepack (yarn 4)
+        run: corepack enable
+
+      # uv is needed by the generator's Python half (uv build + wheel
+      # import-check are part of the verify gate).
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Compile
+        run: yarn compile
+
+      # Full generate + verify — a failure stops the publish before anything
+      # reaches crates.io.
+      - name: Generate + verify API clients
+        run: node mailwoman/out/cli.js clients generate
+
+      # Token-presence guard first: a readable ::error:: beats cargo's 401.
+      # No --no-verify / --allow-dirty — both verified unnecessary (vendored
+      # specs are in Cargo.toml's include list; clients-build/ is gitignored,
+      # so cargo's dirty check ignores it). See publish.yml's retired inline
+      # publish step (git history) for the original verification notes.
+      - name: Publish to crates.io
+        working-directory: clients-build/rust
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: | # shell
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN is not resolvable — is it still set in the 'cargo' GitHub environment?"
+            exit 1
+          fi
+          cargo publish

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,87 @@
+# Publish the generated Python API client (`mailwoman-client`) to PyPI via
+# Trusted Publishing (OIDC) — no token secret anywhere.
+#
+# THE FILENAME IS LOAD-BEARING: PyPI's Trusted Publisher configuration binds to
+# this exact workflow path (`.github/workflows/publish-python.yml`) plus the
+# `pypi` GitHub environment declared on the job below. Renaming this file (or
+# the environment) silently breaks the OIDC exchange until the PyPI-side
+# publisher config is updated to match. The pending-publisher project name on
+# PyPI must be `mailwoman-client` (what `mailwoman clients generate` stamps
+# into the generated pyproject).
+#
+# The client is regenerated from `main` at dispatch time — its version syncs to
+# `mailwoman/package.json`, so ALWAYS dispatch this AFTER the npm release it
+# should match (see RELEASING.md "Client packages": PyPI rejects a re-upload of
+# an already-published version, so a client-only fix rides the next release
+# train). Joins the `publish` concurrency group so a dispatch can't race an
+# in-flight npm release into generating at a mid-bump version.
+name: Publish Python client
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  # Mints the OIDC token PyPI's Trusted Publisher verifies. Scoped to this
+  # workflow only — the main publish.yml's clients job deliberately has no
+  # id-token permission (it never publishes).
+  id-token: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish-python:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # The GitHub environment PyPI's Trusted Publisher config expects to see in
+    # the OIDC claims. No secrets live in it — the trust IS the credential.
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The generated client's version syncs to mailwoman/package.json on
+          # main (same rationale as publish.yml's clients job — the release
+          # flow is main-only by construction).
+          ref: main
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Enable Corepack (yarn 4)
+        run: corepack enable
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      # The generator's Rust half runs `cargo check --examples` as part of its
+      # verify gate, so the toolchain is needed even on the Python publish path.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Compile
+        run: yarn compile
+
+      # Full generate + verify (8 spec emissions, openapi-python-client, uv
+      # build + wheel import-check, cargo check) — a failure here stops the
+      # publish before anything reaches PyPI.
+      - name: Generate + verify API clients
+        run: node mailwoman/out/cli.js clients generate
+
+      # `--trusted-publishing always` fails loud if the OIDC exchange doesn't
+      # happen (e.g. the PyPI-side publisher config drifted from this
+      # file/environment) instead of falling back to prompting for a token.
+      - name: Publish to PyPI (Trusted Publishing)
+        working-directory: clients-build/python
+        run: uv publish --trusted-publishing always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,13 +29,12 @@
 # Python + Rust API clients (`mailwoman clients generate` — Phase 5 Task 4)
 # against whatever `mailwoman/package.json` reads on `main` at that point (the
 # just-bumped version on a real run, unchanged on a dry run) and uploads both
-# as workflow artifacts on EVERY dispatch. It only pushes to PyPI/crates.io
-# when the operator opts in via the `publish_clients` input AND the run is not
-# a dry run — see RELEASING.md "Client packages" for the one-time registry
-# provisioning this requires (PyPI + crates.io accounts, `PYPI_API_TOKEN` +
-# `CARGO_REGISTRY_TOKEN` secrets). Additive only: this job never runs before
-# or blocks `publish`, and default-false `publish_clients` means an ordinary
-# dispatch behaves exactly as before this job existed.
+# as workflow artifacts on EVERY dispatch — inspection copies only. This
+# workflow NEVER publishes clients: registry publishing lives in the two
+# environment-bound workflows `publish-python.yml` (PyPI Trusted Publishing,
+# `pypi` environment — PyPI's trust binds to that exact filename) and
+# `publish-cargo.yml` (`cargo` environment's CARGO_REGISTRY_TOKEN secret),
+# dispatched separately by the operator. See RELEASING.md "Client packages".
 name: NPM Publish
 
 on:
@@ -53,11 +52,6 @@ on:
         type: boolean
       publish_only:
         description: "Finish a partial release: skip release-it's version bump/tag (already done) and just publish each workspace at its current version via OIDC (--tolerate-republish). Use when a prior run bumped+tagged but failed mid-publish."
-        required: false
-        default: false
-        type: boolean
-      publish_clients:
-        description: "Publish generated API clients to PyPI/crates.io (requires PYPI_API_TOKEN + CARGO_REGISTRY_TOKEN secrets; provision accounts first — see RELEASING.md)"
         required: false
         default: false
         type: boolean
@@ -211,20 +205,18 @@ jobs:
           fi
           echo "All workspaces published."
 
-  # Regenerate + (optionally) publish the Python + Rust API clients (Phase 5 Task 4). Additive: this
-  # job never gates or reshapes `publish` above — it only starts once that job has already succeeded
-  # (`needs: publish`), so it can't turn a working npm release red, and a run where `publish_clients`
-  # stays at its default `false` behaves exactly like this workflow did before this job existed
-  # (artifacts still build every dispatch — see below — but nothing leaves the runner).
+  # Regenerate the Python + Rust API clients (Phase 5 Task 4) as INSPECTION ARTIFACTS — this job
+  # never publishes anything (registry publishing = publish-python.yml / publish-cargo.yml, each
+  # bound to its GitHub environment). Additive: it only starts once `publish` has already succeeded
+  # (`needs: publish`), so it can't turn a working npm release red.
   clients:
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # NOTE: this job occupies the workflow-level `publish` concurrency group even when
-    # `publish_clients=false` (artifact generation always runs on dispatch). A follow-up dispatch —
-    # notably the `publish_only` recovery path — queues behind it for the cold setup+generate leg.
-    # During an incident: cancel THIS job from the Actions UI (safe — it publishes nothing when
-    # ungated) to free the queue immediately.
+    # NOTE: this job occupies the workflow-level `publish` concurrency group (artifact generation
+    # always runs on dispatch). A follow-up dispatch — notably the `publish_only` recovery path —
+    # queues behind it for the cold setup+generate leg. During an incident: cancel THIS job from the
+    # Actions UI (always safe — it publishes nothing) to free the queue immediately.
     # Least privilege: this job doesn't push commits/tags (unlike `publish`) and doesn't use npm's
     # OIDC Trusted Publishing, so it needs neither `contents: write` nor `id-token: write`.
     permissions:
@@ -302,46 +294,3 @@ jobs:
           path: clients-build/mailwoman-client-rust.tar.gz
           if-no-files-found: error
 
-      # Gated on the operator's explicit opt-in AND excludes dry runs — `dry_run=true` means "preview,
-      # don't actually publish", and letting `publish_clients=true` slip a REAL PyPI upload through a
-      # preview run would violate that contract even though the brief only specified the
-      # `publish_clients` gate. `inputs.publish_clients`/`inputs.dry_run` are used bare (no `== 'true'`
-      # string compare) to match how `dry_run`/`publish_only` are already read elsewhere in this file
-      # (`!inputs.dry_run`, `inputs.publish_only && !inputs.dry_run`) — workflow_dispatch `type:
-      # boolean` inputs are real booleans in the `inputs` context, not strings.
-      #
-      # The token-presence check runs as the first thing inside the step (not a separate step) so a
-      # missing secret fails with one readable `::error::` line instead of `uv publish`/`cargo
-      # publish`'s own cryptic 401, matching the pattern the "Fetch weight binaries" step above already
-      # uses for its own precondition checks.
-      - name: Publish Python client to PyPI
-        if: ${{ inputs.publish_clients && !inputs.dry_run }}
-        working-directory: clients-build/python
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: | # shell
-          if [ -z "${UV_PUBLISH_TOKEN}" ]; then
-            echo "::error::publish_clients=true but the PYPI_API_TOKEN secret is not set. Provision a PyPI account + token (or Trusted Publisher) first — see RELEASING.md 'Client packages'."
-            exit 1
-          fi
-          uv publish
-
-      # No `--no-verify`: verified locally (Task 4) that `cargo publish`'s default isolated verify
-      # build — which packages the crate into `target/package/`, a COPY separate from the working
-      # tree — successfully finds the vendored `openapi/*.json` specs there (they're in Cargo.toml's
-      # `include` list) and rebuilds cleanly. No `--allow-dirty` either: also verified locally that
-      # `cargo publish --dry-run` raises no dirty-working-tree warning even though `clients-build/`
-      # sits inside this git repository, because every file under it is gitignored (`/clients-build/`
-      # in `.gitignore`) and cargo's dirty check reads git status, which omits ignored paths by
-      # default — there's nothing to override.
-      - name: Publish Rust client to crates.io
-        if: ${{ inputs.publish_clients && !inputs.dry_run }}
-        working-directory: clients-build/rust
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: | # shell
-          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
-            echo "::error::publish_clients=true but the CARGO_REGISTRY_TOKEN secret is not set. Provision a crates.io account + token first — see RELEASING.md 'Client packages'."
-            exit 1
-          fi
-          cargo publish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -521,68 +521,66 @@ fetches at runtime (`docs-build.yml` bundles no binaries). So the whole release 
 
 ## Client packages
 
-`publish.yml` carries a second job, `clients`, that runs after `publish` succeeds. It regenerates the
-Python (`mailwoman-client` on PyPI) and Rust (`mailwoman-client` on crates.io) API clients — typed
-wrappers over the Photon / Nominatim / libpostal drop-ins plus the native `/v1/*` surface, generated
-from the OpenAPI documents those surfaces already emit. See `docs/articles/api.mdx` "Client libraries"
-for what they are and how to use them; this section is the release-operator's view.
+Three workflows share the client story. `publish.yml`'s `clients` job (runs after `publish` succeeds)
+regenerates the Python (`mailwoman-client` on PyPI) and Rust (`mailwoman-client` on crates.io) API
+clients — typed wrappers over the Photon / Nominatim / libpostal drop-ins plus the native `/v1/*`
+surface, generated from the OpenAPI documents those surfaces already emit — and uploads them as
+**inspection artifacts only**. Registry publishing lives in two dedicated, environment-bound,
+manually-dispatched workflows: **`publish-python.yml`** (PyPI Trusted Publishing / OIDC, `pypi`
+environment — PyPI's trust binds to that exact filename, so never rename it without updating the
+PyPI-side publisher config) and **`publish-cargo.yml`** (`cargo` environment, whose
+`CARGO_REGISTRY_TOKEN` environment secret is the credential). See `docs/articles/api.mdx` "Client
+libraries" for what the clients are; this section is the release-operator's view.
 
-> **Incident note:** the `clients` job holds the workflow's `publish` concurrency slot even when
-> `publish_clients=false`, so a `publish_only` recovery dispatch queues behind its setup+generate leg
-> (minutes, cold). If you're mid-incident, cancel the running `clients` job from the Actions UI first —
-> it publishes nothing when ungated, and cancelling frees the queue immediately.
+> **Sequencing — do not publish clients before the next npm release.** The generated clients stamp
+> `mailwoman/package.json`'s version and document the `/v1` + emitted-spec surfaces, which exist on
+> `main` but in **no published npm release yet** (the Hono migration ships in the next release, a
+> MAJOR). Dispatching either publish workflow before that release would claim the current version
+> number on PyPI/crates.io for a client describing endpoints nobody can install — and both registries
+> permanently burn published version numbers. First client publish = right after the next npm release.
 
-### Artifacts always build; the registry push is gated
+> **Incident note:** the `clients` job holds the workflow's `publish` concurrency slot, so a
+> `publish_only` recovery dispatch queues behind its setup+generate leg (minutes, cold). If you're
+> mid-incident, cancel the running `clients` job from the Actions UI first — it publishes nothing,
+> ever, and cancelling frees the queue immediately. (The two client-publish workflows join the same
+> `publish` concurrency group by design, so they can't race a release into a mid-bump version.)
+
+### Artifacts always build; publishing is its own dispatch
 
 Every dispatch of `publish.yml` — including a `dry_run` — regenerates both clients and uploads them as
 workflow artifacts (`mailwoman-client-python`: the wheel + sdist; `mailwoman-client-rust`: a tarball of
 the assembled crate). That half runs unconditionally: it's the same local, receipt-verified pipeline as
 `mailwoman clients generate` (below), so a broken generator or a spec that drifted out from under
-`progenitor`/`openapi-python-client` fails the job and shows up in every PR-adjacent dispatch, not just
-the runs where someone remembers to check.
+`progenitor`/`openapi-python-client` fails the job and shows up on every dispatch, not just the runs
+where someone remembers to check. Nothing in `publish.yml` ever reaches a registry.
 
-Actually publishing those artifacts to PyPI/crates.io is a separate, explicit opt-in: the
-`publish_clients` workflow-dispatch input (boolean, default `false`). Leaving it `false` — the default —
-means an ordinary release behaves exactly as it did before this job existed; nothing reaches either
-registry. Set it `true` only once the one-time provisioning below is done, and never on a `dry_run`
-(the job refuses to publish on a dry run regardless of `publish_clients`, since "preview, don't actually
-publish" should mean that for every side effect a dispatch can have, not just the npm one).
+To actually publish, dispatch the dedicated workflow(s) from the Actions UI — each regenerates from
+`main` and publishes its half:
 
-### Operator TODO — one-time registry provisioning
+- **Python → PyPI:** run `Publish Python client` (`publish-python.yml`). Auth is Trusted Publishing —
+  the job's `pypi` environment + this filename are what PyPI verifies in the OIDC claims; there is no
+  token anywhere. `uv publish --trusted-publishing always` fails loud if the PyPI-side publisher
+  config drifts from the file/environment names.
+- **Rust → crates.io:** run `Publish Rust client` (`publish-cargo.yml`). Auth is the
+  `CARGO_REGISTRY_TOKEN` secret in the `cargo` GitHub environment (not a repo-level secret — the
+  job's `environment: cargo` declaration is what makes it resolvable).
 
-Nothing below is done yet. `publish_clients: true` will fail closed (a readable `::error::`, not a bare 401) until both are in place:
+### Registry provisioning — state as of 2026-07-12
 
-1. **PyPI** — create an account at <https://pypi.org/account/register/>, enable 2FA, and mint an
-   **account-scoped** API token (<https://pypi.org/manage/account/token/>, scope "Entire account" —
-   not a project-scoped token, which can't be minted until the project exists). Unlike a project token,
-   an account-scoped token CAN create a brand-new project on its first publish, so either:
-   - publish the first release **locally** — `UV_PUBLISH_TOKEN=<token> uv publish` from
-     `clients-build/python/`, after a checkout that already ran `mailwoman clients generate`; or
-   - store that same account-scoped token as the repo secret `PYPI_API_TOKEN` and let the existing
-     `clients` CI job do it — its "Publish Python client to PyPI" step already runs plain `uv publish`
-     against `UV_PUBLISH_TOKEN`, no other wiring required for a token-based first publish.
+Provisioned by the operator:
 
-   Once `mailwoman-client` exists on PyPI, swap `PYPI_API_TOKEN` for a narrower **project-scoped**
-   token for routine releases.
+- **`pypi` GitHub environment** (no secrets — OIDC only) + a PyPI Trusted Publisher configured against
+  `publish-python.yml`. Before the first dispatch, double-check the PyPI-side pending-publisher entry:
+  project name must be **`mailwoman-client`** (what the generator stamps), repository
+  `sister-software/mailwoman`, workflow filename `publish-python.yml`, and — if the publisher config
+  names an environment — it must say `pypi` (the job declares it either way; a mismatch fails the OIDC
+  exchange with a readable PyPI error).
+- **`cargo` GitHub environment** carrying `CARGO_REGISTRY_TOKEN`. crates.io has no pre-claim step —
+  the first successful `cargo publish` creates the crate. Confirm the crates.io account email is
+  verified (crates.io refuses publishes until it is).
 
-   Trusted Publishing (OIDC, no token in the repo at all) is a **future enhancement**, not something
-   already wired: the `clients` job requests only `permissions: contents: read`, and its publish step
-   is a bare `uv publish`. Adding it would mean granting the job `id-token: write`, registering a PyPI
-   Trusted Publisher (repo `sister-software/mailwoman`, workflow `.github/workflows/publish.yml`, job
-   `clients`), and switching the step to `uv publish --trusted-publishing automatic`. None of that
-   exists today — as shipped, `publish_clients: true` fails closed on a missing `PYPI_API_TOKEN`, not
-   on missing OIDC.
-
-2. **crates.io** — sign in at <https://crates.io/> with GitHub, verify the account email (crates.io
-   refuses to publish until it's verified), create a token at
-   <https://crates.io/settings/tokens> (scopes `publish-new` + `publish-update`), and store it as the
-   repo secret `CARGO_REGISTRY_TOKEN`. crates.io has no separate "claim the name first" step —
-   `cargo publish` creates the crate on its first successful run, token-authenticated, so CI can do the
-   first publish itself once the secret exists.
-3. **Both names were still free as of 2026-07-12** (404 on `pypi.org/pypi/mailwoman-client/json` and
-   `crates.io/api/v1/crates/mailwoman-client`) — reserved by intent, not yet claimed. Claim them before
-   they're gone; nothing else in this repo depends on the name, but a squatted `mailwoman-client` on
-   either registry would force a rename across both client packages, their docs, and this runbook.
+Both registry names (`mailwoman-client` on PyPI and crates.io) were unclaimed as of 2026-07-12 —
+reserved by intent, not yet claimed. The first dispatches claim them.
 
 ### Version sync — a client-only fix can't republish alone
 
@@ -621,7 +619,8 @@ never be used to validate a real change — the verify step is the entire point.
   already does at runtime.
 - **`mailwoman release hf` is still hand-invoked** — staging the model to HF (and bumping `releases.json`)
   is a separate manual command after the npm release, not part of `yarn release`.
-- **Client-package registry provisioning** — see "Client packages" above. The `clients` CI job builds
-  and artifacts the Python/Rust clients on every dispatch already; it can't publish either until the
-  operator provisions the PyPI + crates.io accounts and secrets.
+- **Client-package first publish** — provisioning is DONE (see "Client packages" above: `pypi` +
+  `cargo` environments, Trusted Publisher bound to `publish-python.yml`). What remains is dispatching
+  `publish-python.yml` + `publish-cargo.yml` once — AFTER the next npm release, per the sequencing
+  note above.
 - **Changelog generation** — release-it can emit one via the `@release-it/conventional-changelog` plugin. Not configured yet because commit messages haven't standardized on Conventional Commits.


### PR DESCRIPTION
The operator provisioned GitHub environments: `pypi` (OIDC-only — PyPI Trusted Publisher bound to the `publish-python.yml` filename) and `cargo` (`CARGO_REGISTRY_TOKEN`). This reworks the client-publish topology shipped in #1086 to match:

- `publish.yml`'s `clients` job is now **artifacts-only** (the `publish_clients` input and both token-gated publish steps removed) — inspection copies on every dispatch, zero registry access.
- New **`publish-python.yml`**: `environment: pypi`, `id-token: write`, `uv publish --trusted-publishing always` (fails loud if the OIDC exchange breaks). The filename is load-bearing — PyPI's trust binds to it.
- New **`publish-cargo.yml`**: `environment: cargo`, token guard, `cargo publish`.
- Both join the `publish` concurrency group (no racing an in-flight release into a mid-bump version); both regenerate + fully verify before publishing.
- RELEASING.md rewritten to the provisioned state, with the sequencing rule made loud: **no client publish before the next (major) npm release** — the clients document `/v1` surfaces that exist on main but in no published npm package yet.

Reviewed (7-point topology check: OIDC scoping, environment secret resolution, surgery completeness, concurrency, checkout refs, doc/YAML parity, toolchain) — all pass; the plan doc's original token-based design remains as a point-in-time record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)