### PR TITLE
ci: pin uv to 0.11.16 across all workflows

### DIFF
--- a/.github/workflows/publish-cargo.yml
+++ b/.github/workflows/publish-cargo.yml
@@ -52,6 +52,10 @@ jobs:
       # import-check are part of the verify gate).
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
+        with:
+          # Pinned to the lab host's uv (keep in lockstep — bump deliberately, not via "latest";
+          # silences setup-uv's could-not-determine-version fallback warning).
+          version: "0.11.16"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -61,6 +61,10 @@ jobs:
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
+        with:
+          # Pinned to the lab host's uv (keep in lockstep — bump deliberately, not via "latest";
+          # silences setup-uv's could-not-determine-version fallback warning).
+          version: "0.11.16"
 
       # The generator's Rust half runs `cargo check --examples` as part of its
       # verify gate, so the toolchain is needed even on the Python publish path.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -251,6 +251,10 @@ jobs:
       # aren't preinstalled on the runner image.
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
+        with:
+          # Pinned to the lab host's uv (keep in lockstep — bump deliberately, not via "latest";
+          # silences setup-uv's could-not-determine-version fallback warning).
+          version: "0.11.16"
 
       # `@stable` is the action's own documented usage (a tracking ref it repoints itself, not a
       # release tag) — the canonical way to pull this action, matching how the rest of this file pins

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,10 @@ jobs:
       # "command not found: uvx", exit 127).
       - name: Setup uv (ruff for lint:python)
         uses: astral-sh/setup-uv@v7
+        with:
+          # Pinned to the lab host's uv (keep in lockstep — bump deliberately, not via "latest";
+          # silences setup-uv's could-not-determine-version fallback warning).
+          version: "0.11.16"
 
       # Full repo-wide lint (oxlint incl. sister-software/no-process-globals, oxfmt --check, python
       # toolchain checks). This is THE complete gate: the pre-commit hook only lints STAGED files,


### PR DESCRIPTION
Pins `astral-sh/setup-uv` to uv 0.11.16 (the lab host's version) on all four workflows — deterministic tooling, in lockstep with local receipts, bumped deliberately instead of drifting with "latest". Silences the fallback warning observed on the first `publish-python.yml` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)