### PR TITLE
eval parity: --weights-cache candidate grading (channel-fed, not zero-filled)

### DIFF
--- a/mailwoman/commands/eval/parity.tsx
+++ b/mailwoman/commands/eval/parity.tsx
@@ -24,6 +24,14 @@ const OptionsSchema = zod.object({
 	tokenizer: zod.string().optional().describe("Candidate tokenizer.model"),
 	card: zod.string().optional().describe("Candidate model-card.json (label vocab for --model)"),
 	fixtures: zod.string().optional().describe("Fixture JSONL override (default: the committed parity corpus)"),
+	weightsCache: zod
+		.string()
+		.optional()
+		.describe(
+			"Grade a candidate laid out package-shaped under <dir>/node_modules/@mailwoman/neural-weights-<locale> " +
+				"(feeds anchor/gazetteer/calibration siblings — PREFER over --model for candidates; the explicit-path " +
+				"branch grades a channel-starved model)"
+		),
 	failing: zod.coerce
 		.number()
 		.int()
@@ -46,6 +54,7 @@ const EvalParity: CommandComponent<typeof OptionsSchema> = ({ options }) => {
 					tokenizerPath: options.tokenizer,
 					modelCardPath: options.card,
 					fixturesPath: options.fixtures,
+					weightsCacheRoot: options.weightsCache,
 					failing: options.failing,
 				})
 			).exitCode,

--- a/mailwoman/eval-harness/parity-corpus.ts
+++ b/mailwoman/eval-harness/parity-corpus.ts
@@ -33,6 +33,13 @@ export interface ParityEvalOptions {
 	tokenizerPath?: string
 	modelCardPath?: string
 	fixturesPath?: string
+	/**
+	 * Grade a candidate laid out as a package-shaped weights dir
+	 * (`<cacheRoot>/node_modules/@mailwoman/neural-weights-<locale>`). PREFER THIS over modelPath/tokenizerPath for
+	 * candidates: the explicit-path branch feeds NO sibling channels (anchor/gazetteer/calibration) and grades a crippled
+	 * model — the #718 zero-fill trap.
+	 */
+	weightsCacheRoot?: string
 	/** List the first N disagreeing inputs per floor label. */
 	failing?: number
 }
@@ -60,6 +67,7 @@ export async function runParityEval(options: ParityEvalOptions = {}): Promise<Pa
 		modelPath: options.modelPath,
 		tokenizerPath: options.tokenizerPath,
 		modelCardPath: options.modelCardPath,
+		cacheRoot: options.weightsCacheRoot,
 	})
 
 	const tallies = new Map(PARITY_FLOORS.map((f) => [f.label, { hit: 0, total: 0, failing: [] as string[] }]))

--- a/neural/test/weights-cache.test.ts
+++ b/neural/test/weights-cache.test.ts
@@ -74,6 +74,22 @@ describe("resolveWeights cache fallback", () => {
 		)
 	})
 
+	test("an EXPLICIT cacheRoot outranks an installed package (candidate grading, en-US resolves in-repo)", () => {
+		const packageDir = join(cacheRoot, "node_modules", "@mailwoman/neural-weights-en-us")
+
+		mkdirSync(packageDir, { recursive: true })
+
+		for (const file of ["model.onnx", "tokenizer.model"]) {
+			writeFileSync(join(packageDir, file), "stub")
+		}
+
+		// The workspace package exists and resolves, but the explicit cacheRoot names the candidate.
+		const resolved = resolveWeights({ locale: "en-US", cacheRoot })
+
+		expect(resolved.source).toBe("cache:@mailwoman/neural-weights-en-us")
+		expect(resolved.modelPath).toBe(join(packageDir, "model.onnx"))
+	})
+
 	test("helpers: cache dir + package-name builder", () => {
 		expect(weightsCacheDir()).toMatch(/\.cache[/\\]mailwoman[/\\]weights$/)
 		expect(weightsPackageName("en-US")).toBe("@mailwoman/neural-weights-en-us")

--- a/neural/weights.ts
+++ b/neural/weights.ts
@@ -126,6 +126,18 @@ export function resolveWeights(opts: ResolveWeightsOpts): ResolvedWeights {
 	const locale = (opts.locale ?? "en-us").toLowerCase()
 	const packageName = weightsPackageName(locale)
 
+	const cacheDir = resolve(opts.cacheRoot ?? weightsCacheDir(), "node_modules", packageName)
+	const cacheHasBinaries = () =>
+		existsSync(resolve(cacheDir, "model.onnx")) && existsSync(resolve(cacheDir, "tokenizer.model"))
+
+	// 0. An EXPLICIT cacheRoot is authoritative — it names a candidate/package dir the caller wants
+	// graded (eval harnesses laying out a candidate bundle). In-repo the workspace weights package
+	// always resolves, so a fallback-ordered cache could never be reached for grading; the explicit
+	// override exists precisely for that. The IMPLICIT default cache stays a fallback (step 2).
+	if (opts.cacheRoot && cacheHasBinaries()) {
+		return resolveFromPackageDir(cacheDir, locale, opts, `cache:${packageName}`, tried)
+	}
+
 	// 1. Installed package (workspace or node_modules).
 	try {
 		const pkgJsonPath = req.resolve(`${packageName}/package.json`)
@@ -140,9 +152,7 @@ export function resolveWeights(opts: ResolveWeightsOpts): ResolvedWeights {
 	// 2. The user-level weights cache (npm-prefix layout written by `mailwoman parse
 	// --download-weights`, plan 3). Requires both binaries — a metadata-only cache install must NOT
 	// resolve (it would load nothing); it falls through to the actionable not-found error below.
-	const cacheDir = resolve(opts.cacheRoot ?? weightsCacheDir(), "node_modules", packageName)
-
-	if (existsSync(resolve(cacheDir, "model.onnx")) && existsSync(resolve(cacheDir, "tokenizer.model"))) {
+	if (cacheHasBinaries()) {
 		return resolveFromPackageDir(cacheDir, locale, opts, `cache:${packageName}`, tried)
 	}
 


### PR DESCRIPTION
First campaign session surfaced the #718 zero-fill trap live: grading a splice candidate via `--model` explicit paths fed no anchor/gazetteer/calibration channels, and the channel-starved numbers read as FR 20→13 / US 41→36 "regressions" that vanished entirely under package-shaped loading (tokenization-diff proved zero FR/US inputs changed; embedding old-rows byte-identical).

- `mailwoman eval parity --weights-cache <dir>` grades a candidate laid out as `<dir>/node_modules/@mailwoman/neural-weights-<locale>` with full sibling-artifact resolution.
- `resolveWeights`: an EXPLICITLY provided `cacheRoot` is now authoritative (probed before the installed package — in-repo the workspace package otherwise always wins and candidates could never be cache-graded). The implicit default cache stays a fallback; npx/guard semantics unchanged. Precedence pinned by a new test (14/14 green across weights suites).

Measured with this fix, the 12-locale tokenizer splice candidate (v3, $0, mean-init only): house_number 0.7013→0.7273, street 0.3967→0.4033, DE 24→29%, SK 0→100%, FR/US/PL byte-invariant. Splice artifacts staged on the data root; campaign notes in the session ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzDCii56StaYW7swvA41yC