### PR TITLE
docs(concepts): Phase 2c — consolidation pass behind the flagship explainer

### DIFF
--- a/docs/articles/concepts/README.mdx
+++ b/docs/articles/concepts/README.mdx
@@ -1,74 +1,25 @@
 ---
 sidebar_position: 1
 title: Deep dives
+role: concept
+audience: product-reader
+source-of-truth: self
 ---
 
 # Concept deep dives
 
-This track has one article per concept. The articles are independent — read them in any order. If you are new to Mailwoman, read [`understanding/`](../understanding/README.mdx) first.
+Fifty articles, one per concept. Each is independent — read them in any order. If you want the problem framed before the solution, read [`understanding/`](../understanding/README.mdx) first.
 
-## Suggested reading order
+New to Mailwoman? Start with [How Mailwoman parses an address](./how-mailwoman-parses-an-address.mdx) for the walkthrough — one address, followed through the whole parse — then [What Mailwoman is](./what-mailwoman-is.mdx) for the product boundary: what the system claims to do, and what it deliberately doesn't. Everything else here is a deep dive behind one of those two pages.
 
-A useful order if you want to follow the data and code from input to output:
+## The clusters
 
-1. [Tokenization](./tokenization.mdx) — splitting strings into tokens
-2. [Rule-based classifiers](./rule-based-classifiers.mdx) — the Mailwoman v1 approach
-3. [BIO labels](./bio-labels.mdx) — how the neural model marks spans
-4. [Neural classification](./neural-classification.mdx) — what a transformer encoder does
-5. [CRF decoder](./crf-decoder.mdx) — fixing structurally-invalid label sequences
-6. [Training pipeline](./training-pipeline.mdx) — from corpus to model file
-7. [Corpus construction](./corpus-construction.mdx) — how the training data is built
-8. [ONNX runtime](./onnx-runtime.mdx) — running the model in production
-9. [Resolver and Who's On First](./resolver-and-wof.mdx) — turning labels into coordinates
-
-Additional articles:
-
-- [Joint decoding walkthrough](./joint-decoding-walkthrough.mdx) — how the reconciler picks coherent interpretations
-- [Reconcile empty-parse bonus](./reconcile-empty-parse-bonus.mdx) — handling the "model gives up" failure mode
-- [Dual-role places](./dual-role-places.mdx) — completing the dropped locality of a city-state or capital-seat province
-- [Synthetic corpus validation](./synthetic-corpus-validation.mdx) — how we validate LLM-generated training data
-- [DeepSeek reasoning budget](./deepseek-reasoning-budget.mdx) — the adversarial corpus generation pipeline
-- [Staged pipeline contract](./staged-pipeline-contract.mdx) — implementer-facing TypeScript contracts
-
-Articles moved to [`understanding/`](../understanding/README.mdx) in May 2026:
-
-- [What is an address?](../understanding/the-problem/what-is-an-address.mdx) — now at Tier 1 position 8
-- [Addresses that break geocoders](../understanding/why-its-hard/addresses-that-break-geocoders.mdx) — now at Tier 1 position 9
-- [The knowledge ladder](../understanding/our-approach/the-knowledge-ladder.mdx) — now at Tier 1 position 14
-- [The staged pipeline](../understanding/our-approach/the-staged-pipeline.mdx) — now at Tier 1 position 15
-
-## Dependency map
-
-Some concepts assume others:
-
-```mermaid
-flowchart TD
-    A[Tokenization]
-    B[Rule-based classifiers]
-    C[BIO labels]
-    D[Neural classification]
-    E[CRF decoder]
-    F[Training pipeline]
-    G[Corpus construction]
-    H[ONNX runtime]
-    I[Resolver and WOF]
-    A --> C
-    C --> D
-    D --> E
-    D --> F
-    F --> G
-    F --> H
-```
-
-You can short-circuit: if you know what a transformer is, skip directly to [CRF decoder](./crf-decoder.mdx). If you want a tour of the training side, jump to [Training pipeline](./training-pipeline.mdx).
+- **Parsing internals** — tokenization, BIO labels, the Viterbi decoder, the FST priors, attention. What happens between a raw string and a labeled tree. Start at [How the model reasons](./how-the-model-reasons.mdx).
+- **Training and corpus** — how the training data gets built, validated, and turned into a model. Start at [Training pipeline](./training-pipeline.mdx).
+- **Resolver and gazetteer** — turning labeled spans into coordinates against Who's On First. Start at [Resolver and Who's On First](./resolver-and-wof.mdx).
+- **Record matching** — geocode-first entity resolution for messy records with no shared ID. Start at [Geocode-first record matching](./geocode-first-record-matching.mdx).
+- **Switching guides** — coming from Pelias, libpostal, Nominatim, Photon, or OpenCage? These map the differences directly, starting with [How Mailwoman compares](./how-mailwoman-compares.mdx).
 
 ## Article shape
 
-Each article is about 5–10 minutes to read, with:
-
-- A short motivation: why this concept matters in Mailwoman.
-- An explanation that defines its terms on first use.
-- A diagram where structure helps (built with [mermaid](https://mermaid.js.org/)).
-- A short code-or-data example.
-- Pointers into the source code for readers who want to go further.
-- A "See also" list.
+Each article is about 5–10 minutes to read, with a short motivation, an explanation that defines its terms on first use, a diagram where structure helps, a short code-or-data example, pointers into the source for readers who want to go further, and a "See also" list.

--- a/docs/articles/concepts/bio-labels.mdx
+++ b/docs/articles/concepts/bio-labels.mdx
@@ -1,6 +1,9 @@
 ---
 sidebar_position: 6
 title: BIO labels
+role: concept
+audience: product-reader
+source-of-truth: corpus-python/src/mailwoman_train/labels.py, neural-weights-en-us/model-card.json
 tags:
   - concepts
   - neural
@@ -11,7 +14,7 @@ tags:
 
 BIO labelling is the trick that lets a token classifier (which decides one token at a time) emit **spans** (groups of consecutive tokens that mean one thing together). It is the standard approach for sequence labelling tasks in NLP — Named Entity Recognition, part-of-speech tagging, address parsing.
 
-This article explains the scheme, why it works, and a failure mode that Mailwoman v3.0.0 specifically fixes.
+This article explains the scheme, why it works, and a failure mode (the orphan-I) that motivated the decode-time fix covered in [How Mailwoman parses an address](./how-mailwoman-parses-an-address.mdx#decoding-a-valid-sequence-and-building-the-tree). For the full walkthrough of a parse, start there; this page is the deep dive on the label space itself.
 
 ## The scheme
 
@@ -34,7 +37,7 @@ The span "Saint Petersburg" is signalled by one `B-locality` followed by one `I-
 
 ## The full Mailwoman vocabulary
 
-Mailwoman v3.0.0 uses 21 BIO labels:
+The current active set (Stage 3, shipped since v0.6.0) has 16 component tags, each split into `{B-, I-}` plus one shared `O` — 16 × 2 + 1 = 33 BIO labels, matching `neural-weights-en-us/model-card.json`'s `num_labels: 33`:
 
 | label                                          | example token                          |
 | ---------------------------------------------- | -------------------------------------- |
@@ -47,15 +50,21 @@ Mailwoman v3.0.0 uses 21 BIO labels:
 | `B-subregion`, `I-subregion`                   | `"Brooklyn"`                           |
 | `B-cedex`, `I-cedex`                           | `"CEDEX"` `"08"` (FR-specific)         |
 | `B-venue`, `I-venue`                           | `"Wrigley"` `"Field"`                  |
-| `B-street`, `I-street`                         | `"5th"` `"Ave"`                        |
+| `B-street`, `I-street`                         | `"5th"` (the street's base name)       |
 | `B-house_number`, `I-house_number`             | `"350"`, `"10"` `"bis"`                |
+| `B-street_prefix`, `I-street_prefix`           | `"SE"` (directional, before the name)  |
+| `B-street_suffix`, `I-street_suffix`           | `"St"`, `"Ave"` (the street type)      |
+| `B-unit`, `I-unit`                             | `"Apt"` `"3"`                          |
+| `B-po_box`, `I-po_box`                         | `"PO"` `"Box"` `"4"`                   |
+| `B-intersection_a`, `I-intersection_a`         | `"5th"` `"Ave"` (first cross street)   |
+| `B-intersection_b`, `I-intersection_b`         | `"42nd"` `"St"` (second cross street)  |
 
-10 tags × `{B-, I-}` + `O` = 21 labels. The neural model's final classifier layer has 21 outputs and the model picks the highest-probability label for each token.
+The neural model's final classifier layer has 33 outputs; the model picks a score for every label at every position (an [emission](./how-mailwoman-parses-an-address.mdx#scoring-every-piece)), and the decoder — not raw per-token argmax — turns those scores into a label sequence.
 
 In code:
 
 ```ts
-const STAGE2_TAGS = [
+const STAGE3_TAGS = [
 	"country",
 	"region",
 	"locality",
@@ -66,11 +75,17 @@ const STAGE2_TAGS = [
 	"venue",
 	"street",
 	"house_number",
+	"street_prefix",
+	"street_suffix",
+	"unit",
+	"po_box",
+	"intersection_a",
+	"intersection_b",
 ]
-const STAGE2_BIO_LABELS = ["O", ...STAGE2_TAGS.flatMap((t) => [`B-${t}`, `I-${t}`])]
+const STAGE3_BIO_LABELS = ["O", ...STAGE3_TAGS.flatMap((t) => [`B-${t}`, `I-${t}`])]
 ```
 
-(The first 7 tags — through `cedex` — are the original "Tier 1" coarse vocabulary; the last 3 are the "Tier 2" expansion added in v3.0.0. Historically called "Stage 1/2" — see PHASE_2_training.md for the terminology note.)
+The last 6 tags — `street_prefix` through `intersection_b` — are the Stage 3 expansion, shipped in v0.6.0: decomposing the monolithic `street` tag into prefix/base/suffix and adding `unit`, `po_box`, and paired intersection tags. `labels.py` keeps the earlier Stage 1 and Stage 2 vocabularies (7 and 10 tags) defined alongside Stage 3 so historical checkpoints and eval reports can still be diffed against older label sets — but Stage 3 is what every current training config and shipped model uses.
 
 ## The orphan-I problem
 
@@ -90,34 +105,25 @@ What happens when the decoder reconstructs the span? Depending on how it handles
 
 Neither is what the data actually wants. The data wants `B-locality, I-locality`.
 
-## How Mailwoman v3.0.0 fixes this
+## How Mailwoman fixes this
 
-The fix is the **CRF decoder** — see [CRF decoder](./crf-decoder.mdx) for the full story. In short:
+The fix is decode-time, not learned. A fixed **BIO-validity table** pins the impossible transitions — `O → I-X`, `B-X → I-Y` where `X ≠ Y` — to negative infinity, and the **Viterbi algorithm** searches for the highest-scoring label sequence that respects the table, rather than picking each token's label independently. The orphan-I is structurally excluded: there's no valid path through it.
 
-- During training, the CRF learns a transition matrix between every pair of labels. Some transitions are pinned to negative infinity: `O → I-X` is impossible, `B-X → I-Y` (where `X ≠ Y`) is impossible.
-- During decoding, the CRF runs the **Viterbi algorithm**: find the highest-probability sequence of labels that obeys every transition rule. The orphan-I is structurally excluded.
-
-The result: a model that is uncertain about "Saint" between `O` and `B-locality` will still produce a structurally valid sequence at decode time. "Saint Petersburg" comes out as one locality span.
+The result: a model that is uncertain about "Saint" between `O` and `B-locality` will still produce a structurally valid sequence at decode time. "Saint Petersburg" comes out as one locality span. See [CRF decoder](./crf-decoder.mdx) for why this is narrower than a full learned CRF, and what that page's name still refers to.
 
 ```mermaid
 flowchart LR
-    subgraph A[Without CRF — per-token argmax]
+    subgraph A[Per-token argmax — no validity check]
         A1["Saint → O"]
         A2["Petersburg → I-locality"]
         A3["Result: 'Petersburg' (orphan-I dropped)"]
     end
-    subgraph B[With CRF — Viterbi decode]
+    subgraph B[Viterbi over the BIO-validity table]
         B1["Saint → B-locality"]
         B2["Petersburg → I-locality"]
         B3["Result: 'Saint Petersburg'"]
     end
 ```
-
-## A subtlety the v3.0.0 ship caught
-
-The training-time CRF and the production-time decoder must agree. v3.0.0 trained with CRF and evaluated with CRF Viterbi, so the eval reports the structurally-valid metrics. But the JavaScript runtime in `@mailwoman/neural` still uses per-token argmax. The "Saint Petersburg" win is therefore only half-real today — the underlying probabilities are better (because the model learned with the CRF as a structural prior), but the runtime decoding does not exploit them fully.
-
-v0.4.0 ([issue #116](https://github.com/sister-software/mailwoman/issues/116)) ports the Viterbi loop to JavaScript and exports the transition matrix in the ONNX bundle.
 
 ## The other reason BIO works well
 
@@ -131,11 +137,10 @@ This pattern is one of the most-tested approaches in NLP. CoNLL-2003 (the canoni
 
 ## Where this lives in the code
 
-- **Label vocabulary:** `corpus-python/src/mailwoman_train/labels.py` (`STAGE2_BIO_LABELS`, `ACTIVE_BIO_LABELS`)
+- **Label vocabulary:** `corpus-python/src/mailwoman_train/labels.py` (`STAGE3_BIO_LABELS`, `ACTIVE_BIO_LABELS`)
 - **TypeScript mirror:** `core/types/component.ts` (`BIO_LABELS`)
 - **Training-time alignment:** `corpus/src/align.ts` (turns `(raw, components)` into per-token BIO labels)
-- **Inference-time decoding:** `neural/decoder.ts` (per-token argmax today; Viterbi in v0.4.0)
-- **CRF transition mask:** `corpus-python/src/mailwoman_train/crf.py` (`build_bio_transition_mask`)
+- **Inference-time decoding:** `neural/viterbi.ts` (`buildBIOTransitionMask`, `viterbi`) — see [CRF decoder](./crf-decoder.mdx)
 
 ## See it in action
 
@@ -150,6 +155,7 @@ Expand the **BIO labels** section to see the word-level BIO label breakdown for 
 
 ## See also
 
+- [How Mailwoman parses an address](./how-mailwoman-parses-an-address.mdx) — the full parse this label space plugs into
 - [CRF decoder](./crf-decoder.mdx) — the structural-validity layer
 - [Tokenization](./tokenization.mdx) — what gets labelled
 - [Training pipeline](./training-pipeline.mdx) — how BIO labels become training data

--- a/docs/articles/concepts/crf-decoder.mdx
+++ b/docs/articles/concepts/crf-decoder.mdx
@@ -1,6 +1,9 @@
 ---
 sidebar_position: 8
 title: CRF decoder
+role: concept
+audience: product-reader
+source-of-truth: neural/viterbi.ts, corpus-python/src/mailwoman_train/model.py, neural-weights-en-us/model-card.json
 tags:
   - concepts
   - neural
@@ -10,123 +13,29 @@ tags:
 
 # CRF decoder
 
-A **Conditional Random Field (CRF)** is a structured-prediction layer that sits on top of a per-token classifier and finds the best **whole-sequence** assignment of labels, subject to learnable transition rules between consecutive labels.
+A **Conditional Random Field (CRF)** is a structured-prediction layer that finds the best **whole-sequence** label assignment instead of picking each token's label independently. Mailwoman's model card carries `crf_at_inference: true` — but what that flag names today is narrower than the textbook CRF: a Viterbi search over a frozen, hand-coded validity table, with no learned transition scores anywhere in the loop. This page explains what ships, and how it got here.
 
-Mailwoman added a CRF decoder in v3.0.0 to solve the [orphan-I problem](./bio-labels.mdx#the-orphan-i-problem) — the "Saint Petersburg → Petersburg" clipping bug.
+## What ships
 
-## Why a CRF, not just argmax
+Per-token argmax can produce structurally invalid label sequences — an `I-locality` with no `B-locality` before it, the "Saint Petersburg → Petersburg" clipping bug. The fix Mailwoman ships is a **BIO-validity table**: `X → O` and `X → B-Y` are always allowed, `X → I-Y` is allowed only when `X` is `B-Y` or `I-Y`, and a sequence may never open on an `I-`. Invalid transitions score `-∞`; valid ones score `0`. The **Viterbi algorithm** then finds the highest-scoring label sequence that respects the table, considering the whole sequence at once rather than one token at a time.
 
-Without a CRF, the model picks the highest-probability label at each position independently. Because the labels are picked independently, the resulting sequence can be structurally invalid (an `I-locality` with no preceding `B-locality`, for example).
+That table is not learned. It's built once from the label vocabulary and never updated during training — a hard grammatical constraint, not a statistical preference. There is no transition matrix with real-valued scores like "`B-postcode` usually follows `B-region`"; the shipped decoder has no opinion on which valid transitions are common, only on which are legal. The model card's `crf_at_inference: true` refers to this Viterbi-over-structural-mask pass. It's already a strict improvement over raw argmax — orphan continuations can't survive it — just narrower than a full learned CRF.
 
-A CRF fixes this by:
+## Why there's no learned CRF
 
-1. Learning a **transition score** for every pair of adjacent labels. Some transitions can be pinned to negative infinity, making them impossible. Mailwoman pins all the BIO-invalid transitions (`O → I-X`, `B-X → I-Y` where tags differ, `B-X → I-X` valid, etc.).
-2. At decode time, finding the **highest-scoring whole sequence** — not the highest-scoring sequence of individual choices. This is the **Viterbi algorithm**.
-
-The result: every sequence the model can emit is structurally valid. There is no `I-X` without a matching `B-X` before it.
-
-## A worked example
-
-Input: `"Saint Petersburg, FL"`. The model's per-token outputs (raw softmax probabilities) might look like:
-
-| token        | B-locality | I-locality | B-region | I-region | O    |
-| ------------ | ---------- | ---------- | -------- | -------- | ---- |
-| `Saint`      | 0.40       | 0.10       | 0.05     | 0.00     | 0.45 |
-| `Petersburg` | 0.20       | 0.65       | 0.05     | 0.00     | 0.10 |
-| `,`          | 0.00       | 0.00       | 0.00     | 0.00     | 1.00 |
-| `FL`         | 0.05       | 0.00       | 0.90     | 0.00     | 0.05 |
-
-**Per-token argmax** picks the best label at each position: `O, I-locality, O, B-region`. This is invalid because `O → I-locality` is forbidden. A strict decoder drops "Saint", yielding `"Petersburg"` as the locality.
-
-**CRF Viterbi** instead searches for the best whole sequence. The transition `O → I-locality` is impossible, so the Viterbi search rules out any sequence containing it. The next-best candidates:
-
-- `B-locality, I-locality, O, B-region` — score 0.40 × 0.65 × 1.00 × 0.90 = **0.234**
-- `O, B-locality, O, B-region` — score 0.45 × 0.20 × 1.00 × 0.90 = **0.081**
-
-The first wins. "Saint Petersburg" comes out as one locality span, even though the model was uncertain about "Saint".
-
-## The transition mask
-
-Mailwoman's BIO transition mask is built from these rules:
-
-- **`X → O`** is always valid (any tag can transition to "outside").
-- **`X → B-Y`** is always valid (any tag can start a new entity).
-- **`X → I-Y`** is valid only if `X` is `B-Y` or `I-Y` (the previous tag must be a matching `B-` or `I-`).
-- **Sequence start → `I-X`** is invalid (cannot start on inside-tag).
-
-Invalid transitions are set to `-inf` in the transition matrix. The transition mask is a **frozen** parameter — never updated during training — so the structural rules are guarantees, not hopes.
-
-```mermaid
-graph LR
-    subgraph Valid
-        O[O] -->|"→"| O
-        O -->|"→"| BL[B-loc]
-        BL -->|"→"| IL[I-loc]
-        IL -->|"→"| IL
-        IL -->|"→"| O
-        IL -->|"→"| BR[B-region]
-    end
-    subgraph Invalid
-        O2[O] -.->|"× forbidden"| IL2[I-loc]
-        BL2[B-loc] -.->|"× forbidden"| IR[I-region]
-    end
-```
-
-## What the CRF learns
-
-On top of the frozen structural mask, the CRF has **learnable** transition scores. These are real-valued, not yes/no. The model learns patterns like:
-
-- `B-postcode` after `B-region` is common in US addresses (`"NY 10118"`).
-- `B-locality` after `B-locality` is rare unless separated by `O` (a comma).
-- `B-house_number` at the start of the sequence is much more common than at the end.
-
-These soft priors get baked into the transition matrix during training. They help the Viterbi search prefer sequences that look like real addresses.
-
-The matrix is small: 21 × 21 + 21 + 21 = 483 learnable scalars (the transition matrix plus start- and end-transition vectors). Negligible compared to the encoder's 8.87 million parameters.
-
-## How training works with a CRF
-
-Without a CRF, the loss is **cross-entropy per token**: for each position, compare the model's softmax over labels to the gold label, and average. The model is rewarded for getting each position right on its own.
-
-With a CRF, the loss is **negative log-likelihood of the gold sequence under the CRF**:
-
-```
-loss = -log P(gold_sequence | emissions)
-     = -log(score(gold) / sum-over-all-paths(score(path)))
-```
-
-The numerator is easy: just look up the score the CRF gives the gold sequence. The denominator requires summing over all possible sequences, which the **forward algorithm** does efficiently in O(seq_len × num_labels²) time.
-
-Backpropagation through the forward algorithm trains both the encoder weights AND the CRF transition scores. The encoder is encouraged to emit per-token outputs that, combined with the CRF transitions, give the gold sequence the highest score.
-
-## The v3.0.0 instability
-
-Mailwoman v3.0.0 shipped with the CRF, but training was harder than expected. The agent who shipped it documented the issue at length:
-
-- The CRF's NLL is **per-sequence and unbounded** — its magnitude is O(sequence length × log num_labels), roughly 10–100 per training example.
-- The per-token cross-entropy is **per-token and log-bounded** — roughly 3 per token at random init, dropping to under 1 with training.
-- Summing the two at equal weight let CRF gradients dominate CE gradients, destabilizing training.
-
-The v3.0.0 fix was to hand-weight the CRF NLL down: `loss = ce + 0.05 × crf_nll`. This worked but was fragile — four iterations of LR/weight tuning before training stayed stable past warmup.
-
-v0.4.0 ([issue #116](https://github.com/sister-software/mailwoman/issues/116)) replaces the hand-weight with **per-token CRF NLL normalization** — dividing the CRF loss by the sequence length. The two terms then have comparable magnitudes naturally, and the hand-tuning goes away.
-
-## The runtime gap (resolved in v0.4.0)
-
-Originally, the CRF was used during training and in the Python evaluation script, but the JavaScript production runtime used per-token argmax — not Viterbi. This meant the model's emissions improved from CRF-aware training, but the runtime couldn't exploit the trained transition matrix.
-
-As of v0.4.0 (shipped 2026-05-23), the Viterbi decoder has been ported to JavaScript: `neural/viterbi.ts` with a frozen BIO structural transition mask. The mask is hand-encoded from the label vocabulary — no retraining required. This makes orphan-I sequences (like `Saint → Petersburg` being split) structurally impossible at the JavaScript runtime, regardless of which weights are loaded. Composes additively with learned CRF transitions when a future weights release ships them.
+Mailwoman v3.0.0 shipped with a trainable CRF: a learned transition matrix, backpropagated jointly with the per-token cross-entropy loss. That dual loss was unstable — the CRF's sequence-level negative log-likelihood dwarfed the per-token CE loss, and summing them at a fixed weight let CRF gradients destabilize the encoder. v0.4.0 replaced the hand-tuned weight with per-token normalization, which helped but didn't end the story: the recipe first went CE-only (`crf_loss_weight: 0.0`) at v0.5.0, reactivation attempts for the Stage 3 label set diverged three more times, and after a last labeled fp32-precision diagnostic run (v0.6.2, briefly back at `crf_loss_weight: 0.5` to isolate the NaN cause), every config from v0.6.3 on has stayed at `0.0` — today's included. At zero weight, `model.py`'s CRF forward-backward pass never fires; the module sits in the graph but gets no gradient, and training falls through to CE-only. The full diagnostic story is in [Dual-loss curvature conflict](./dual-loss-curvature-conflict.mdx); this page only needed the outcome.
 
 ## Where this lives in the code
 
-- **CRF implementation:** `corpus-python/src/mailwoman_train/crf.py` (`LinearChainCRF`, ~250 lines, hand-rolled to match the encoder's hand-rolled style)
-- **Transition mask construction:** `build_bio_transition_mask` in the same file
-- **Training-time use:** `corpus-python/src/mailwoman_train/model.py` (`MailwomanCoarseEncoder.forward` computes both CE and CRF NLL when in training mode)
-- **Inference-time use (Python):** `MailwomanCoarseEncoder.predict` calls `crf.viterbi_decode`
-- **Inference-time use (JavaScript):** `neural/viterbi.ts` — shipped v0.4.0 (2026-05-23) with frozen BIO structural mask
-- **Future:** learned CRF transitions from a future weights release, composable with the existing structural mask
+- **Structural mask + Viterbi (JavaScript, shipped):** `neural/viterbi.ts`
+- **Training-time loss gate:** `corpus-python/src/mailwoman_train/model.py` — CRF forward/backward only runs when `crf_loss_weight > 0`, which every config from v0.6.3 on leaves at `0.0`
+- **Model card flags:** `neural-weights-en-us/model-card.json` — `crf_at_training: false`, `crf_at_inference: true`
+
+For the decode step in the context of a full parse, see [How Mailwoman parses an address](./how-mailwoman-parses-an-address.mdx#decoding-a-valid-sequence-and-building-the-tree).
 
 ## See it in action
+
+The demo below shows the general argmax-vs-Viterbi idea using an example transition matrix with soft preferences like `+1.5`, to make the mechanism easy to follow. The shipped decoder's actual table only carries `0` and `-∞` — no soft scores.
 
 import { CRFDiff } from "@site/src/components/CRFDiff/CRFDiff"
 
@@ -134,6 +43,7 @@ import { CRFDiff } from "@site/src/components/CRFDiff/CRFDiff"
 
 ## See also
 
-- [BIO labels](./bio-labels.mdx) — the labels the CRF operates over
-- [Neural classification](./neural-classification.mdx) — the encoder whose outputs the CRF decodes
-- [Training pipeline](./training-pipeline.mdx) — where the CRF's transition scores get learned
+- [BIO labels](./bio-labels.mdx) — the label space the decoder validates against
+- [Viterbi and BIO validity](./viterbi-and-bio-validity.mdx) — the decode algorithm in more depth
+- [Dual-loss curvature conflict](./dual-loss-curvature-conflict.mdx) — why learned CRF training was abandoned
+- [How Mailwoman parses an address](./how-mailwoman-parses-an-address.mdx) — the full parse this step is one part of

--- a/docs/articles/concepts/fst-gazetteer-prior.mdx
+++ b/docs/articles/concepts/fst-gazetteer-prior.mdx
@@ -1,6 +1,9 @@
 ---
 sidebar_position: 21
 title: FST gazetteer prior
+role: concept
+audience: product-reader
+source-of-truth: mailwoman/runtime-pipeline.ts, mailwoman/commands/parse.tsx, resolver-wof-sqlite/street-morphology-fst-builder.ts
 tags:
   - concepts
   - neural
@@ -14,7 +17,7 @@ tags:
 
 The FST (finite-state transducer) gazetteer prior is the structure that lets the neural classifier benefit from everything Who's On First already knows. The neural model knows grammar; the gazetteer knows places. The FST is the bridge — pre-computed at build time so the classifier can consult it at inference time without paying gazetteer-lookup costs per token.
 
-This article explains the idea behind it, the build-time vs query-time split that makes it cheap, and how it slots into the rest of the pipeline.
+This article explains the idea behind it, the build-time vs query-time split that makes it cheap, and how it slots into the rest of the pipeline. It's also the reference for what's actually wired into production: `mailwoman parse` builds this admin FST from a WOF SQLite database and threads it through `createRuntimePipeline`. The mechanism generalizes past admin data — the same shallow-fusion pattern speech recognition uses to blend a learned model with world knowledge at decode time; see [FST priors as shallow fusion](./fst-priors-as-shallow-fusion.mdx) for that framing and for the street-morphology FST, which exists but isn't wired into the runtime pipeline yet.
 
 ## "If you knew this, you'd know that..."
 
@@ -232,7 +235,7 @@ The FST is one node in a longer pipeline of cached work. The unified SQLite is a
 ## What the FST does not do
 
 - **It does not resolve.** It tells the classifier which spans _could_ be places. Producing a single canonical place ID + coordinates is the resolver's job (see [Resolver and Who's On First](./resolver-and-wof.mdx)).
-- **It does not handle streets.** v1 ships admin-only (countries, regions, localities, postcodes). Streets would add ~3-5M unique names and require metro-area sharding for the browser; tracked as Phase 2+ in [`FST_GAZETTEER_LM.md`](../plan/reference/FST_GAZETTEER_LM.mdx).
+- **It does not carry individual street names.** This FST ships admin-only (countries, regions, localities, postcodes). A gazetteer of specific street names (`"5th Avenue"`, `"Rue de Rivoli"` as named entities) would add ~3-5M unique names and require metro-area sharding for the browser; still tracked as Phase 2+ in [`FST_GAZETTEER_LM.md`](../plan/reference/FST_GAZETTEER_LM.mdx). That's a different, much smaller thing from the street-**morphology** FST — generic street-type vocabulary (`avenue`, `road`, `rue`), not specific names — which does exist; see [FST priors as shallow fusion](./fst-priors-as-shallow-fusion.mdx#the-morphology-fst) for what it covers and its current wiring status.
 - **It does not override the model.** The bias is additive and capped. If the model is confident the input says "Paris, TX," the FST prior on French Paris doesn't change the outcome.
 
 ## See it in action

--- a/docs/articles/concepts/fst-priors-as-shallow-fusion.mdx
+++ b/docs/articles/concepts/fst-priors-as-shallow-fusion.mdx
@@ -1,6 +1,9 @@
 ---
 sidebar_position: 28
 title: FST priors as shallow fusion
+role: concept
+audience: product-reader
+source-of-truth: mailwoman/runtime-pipeline.ts, mailwoman/commands/parse.tsx, neural/classifier.ts, mailwoman/eval-harness/parity-corpus.ts
 tags:
   - concepts
   - neural
@@ -20,9 +23,15 @@ a foreign address pattern.
 The FST priors fix this by giving the model world knowledge at inference
 time. They're an instance of **shallow fusion** — the same architectural
 pattern modern automatic speech recognition uses to blend acoustic models
-with language models. This article explains the shallow-fusion analogy and
-how the two FSTs in mailwoman (admin + morphology) compose with the
-encoder's emissions.
+with language models. This article explains the shallow-fusion analogy,
+and — since the two FSTs Mailwoman defines are at different stages of
+being wired up — is precise about which one runs where. The **admin FST**
+is wired into the production runtime pipeline and the CLI today. The
+**morphology FST** exists as a built artifact and runs in eval harnesses;
+it isn't wired into the default runtime pipeline yet. [FST gazetteer
+prior](./fst-gazetteer-prior.mdx) is the full reference for the admin
+FST's mechanics; this page is the framing plus the morphology-FST detail
+that page doesn't cover.
 
 ## The shallow-fusion pattern
 
@@ -65,6 +74,8 @@ final_emissions = encoder_logits + queryShape_bias + admin_fst_bias + morphology
 viterbi_path = viterbi(final_emissions, transitions_mask)
 ```
 
+This is the full picture the classifier supports — `morphology_fst_bias` is a real term the code can add. In a default `mailwoman parse`, it's zero, because nothing wires the morphology FST in yet (see above); `admin_fst_bias` is the one live by default.
+
 The biases are capped at 3.0 logits (per the
 [FST gazetteer prior](./fst-gazetteer-prior.mdx) design). A confident
 encoder decision (raw logit > 5) is not overridden by a 3-logit bias.
@@ -73,44 +84,38 @@ bias is decisive.
 
 ## The admin FST
 
-Pre-computed at build time from the WOF SQLite gazetteer. For each
-WOF placetype (`country`, `region`, `county`, `locality`, `borough`,
-`neighbourhood`, `postalcode`, `campus`, `dependency`) and each
-country in scope, every place name is tokenized and inserted into a
-trie. Terminal states carry `PlaceEntry` records:
+Pre-computed at build time from the WOF SQLite gazetteer: every place
+name (`country`, `region`, `county`, `locality`, `borough`,
+`neighbourhood`, `postalcode`, `campus`, `dependency`) tokenized into a
+trie, with a positive bias toward the matching placetype's BIO labels
+and a negative bias against competing tags (`B-street`,
+`B-house_number`, `B-venue`) on the same tokens, capped at 3.0 logits.
+[FST gazetteer prior](./fst-gazetteer-prior.mdx) has the full build,
+the `PlaceEntry` shape, and worked examples — that's the reference for
+this FST; this page just needed the shape of it for the analogy above.
 
-```
-PlaceEntry {
-  wofID,          // unique place ID in WOF
-  placetype,      // 'locality' | 'region' | ...
-  name,           // canonical name
-  parentChain,    // [country_id, region_id, ...] for context
-  importance,     // Wikipedia-based ranking [0..1]
-  lat, lon
-}
-```
-
-At inference, the matcher walks token sequences through the trie. When
-a sequence ends at an accepting state, the prior generates a positive
-bias toward the matching placetype's BIO labels (`B-locality` for a
-locality match, etc.) AND a negative bias against competing tags on
-those same tokens (`B-street`, `B-house_number`, `B-venue`).
-
-The full design is in
-[FST gazetteer prior](./fst-gazetteer-prior.mdx). Key constants:
-
-- 3.0 logit cap
-- Suppression on `B/I-street`, `B/I-house_number`, `B/I-venue` for matched admin tokens
-- Suppression scale 1.5x
+This is the FST that's actually wired into production: `mailwoman parse`
+builds it from the WOF SQLite database whenever one is available
+(`tryBuildFST` in `mailwoman/commands/parse.tsx`) and passes it into
+`createRuntimePipeline({ fst, ... })`, which threads it through to the
+classifier as `opts.fst`.
 
 ## The morphology FST
 
-Built later (v0.6.3 work). Reads libpostal's `street_types.txt`
-dictionaries — 60 locales, ~1700 canonical street-typing affixes
-(`Street`, `Avenue`, `Road`, `Boulevard`, `Lane`, `rue`, `Calle`,
-`Straße`, etc.) — and indexes them in a trie. Variants of the same
-canonical (`avenue|av|ave|aven|...`) all point to the same `PlaceEntry`
-with `placetype: "street_affix"`.
+Built later (v0.6.3 work) but not yet wired the same way. Reads
+libpostal's `street_types.txt` dictionaries — 60 locales, ~1700
+canonical street-typing affixes (`Street`, `Avenue`, `Road`,
+`Boulevard`, `Lane`, `rue`, `Calle`, `Straße`, etc.) — and indexes them
+in a trie. Variants of the same canonical (`avenue|av|ave|aven|...`)
+all point to the same `PlaceEntry` with `placetype: "street_affix"`.
+The builder (`resolver-wof-sqlite/street-morphology-fst-builder.ts`)
+and the classifier-side hook (`neural/classifier.ts`'s
+`opts.fstStreetMorphology`) both exist and are exercised in the parity
+eval harness (`mailwoman/eval-harness/parity-corpus.ts`). What's
+missing is the production wire: `createRuntimePipeline` and the CLI
+have no `fstStreetMorphology` option today, so this prior doesn't run
+in a default `mailwoman parse`. Everything below describes the
+mechanism as built and eval-tested, not the shipped default path.
 
 The prior is a TWO-pass bias:
 

--- a/docs/articles/concepts/neural-classification.mdx
+++ b/docs/articles/concepts/neural-classification.mdx
@@ -1,6 +1,9 @@
 ---
 sidebar_position: 7
 title: Neural classification
+role: concept
+audience: product-reader
+source-of-truth: .github/workflows/publish.yml, how-mailwoman-parses-an-address.mdx, how-the-model-reasons.mdx
 tags:
   - concepts
   - neural
@@ -9,98 +12,17 @@ tags:
 
 # Neural classification
 
-The neural classifier is a small **transformer encoder** that reads an address as a sequence of tokens and emits one [BIO label](../concepts/bio-labels.mdx) for each token. This article explains what a transformer encoder is, what makes Mailwoman's specific model the shape it is, and what the model is and is not capable of.
+This page used to be the primary explanation of Mailwoman's transformer encoder. It's been superseded — [How the model reasons](./how-the-model-reasons.mdx) says so in its own See Also, and this page's numbers had drifted out of date besides. Rather than maintain two competing descriptions of the same architecture, here's where to go instead:
 
-## What a transformer encoder does
+- **Want the whole parse, one address end to end?** [How Mailwoman parses an address](./how-mailwoman-parses-an-address.mdx) is the flagship walkthrough — tokens through spans through the decoded tree.
+- **Want the emissions-level detail — how the encoder scores each piece, and how priors nudge those scores?** [How the model reasons](./how-the-model-reasons.mdx) is the deep dive.
+- **Want the exact tag union the model emits?** [The component schema reference](../plan/reference/SCHEMA.mdx) is the single source of truth.
 
-A transformer encoder takes a list of input tokens and produces a list of output **vectors** (one per token). Each output vector is a numerical representation of "what this token means in the context of the whole sequence".
-
-This is different from older models that processed tokens one at a time. The defining trick of the transformer is **self-attention**: every token gets to look at every other token in the sequence, and learn how much each one matters to its own representation.
-
-Take this input: `"Saint Petersburg, FL"`. After tokenization (let's pretend each word is one token), the encoder receives 4 tokens. Before the encoder runs, each token's representation is just its embedding (a look-up vector from a learned table). After the encoder runs:
-
-- `"Saint"` has been updated to know it is right next to `"Petersburg"`.
-- `"Petersburg"` has been updated to know it is preceded by `"Saint"`.
-- `"FL"` has been updated to know there is a `","` between it and the locality.
-
-The classifier head on top then takes each updated vector and predicts a BIO label for that token. Because the vector for `"Saint"` knows about `"Petersburg"`, the model can label `"Saint"` as `B-locality` (a locality that continues into the next token).
-
-## The Mailwoman model geometry
-
-Mailwoman's encoder is intentionally small. Real-world geocoding does not need a model with billions of parameters; the task is narrow.
-
-| dimension           | value         | what it controls                                             |
-| ------------------- | ------------- | ------------------------------------------------------------ |
-| hidden size         | 256           | width of each token's vector                                 |
-| layers              | 6             | how many times the self-attention + feed-forward pair stacks |
-| attention heads     | 4             | how many parallel attention computations per layer           |
-| feed-forward dim    | 1024          | width of the inner feed-forward layer                        |
-| max sequence length | 128           | longest input the model can see                              |
-| total parameters    | ~8.87 million | the file size proxy                                          |
-
-For comparison: GPT-3 has 175 billion parameters, BERT-base has 110 million. Mailwoman's encoder is about 1/12 the size of BERT-base. We do not need more; address parsing is not a problem that scales with model size beyond a certain point.
-
-```mermaid
-flowchart TD
-    A["Input tokens<br>['▁Saint', '▁Petersburg', ',', '▁FL']"]
-    A --> E["Token embeddings + position embeddings<br>(256-dim each)"]
-    E --> L1["Encoder block 1<br>(self-attention + FFN)"]
-    L1 --> L2["Encoder block 2"]
-    L2 --> L3["..."]
-    L3 --> L6["Encoder block 6"]
-    L6 --> C["Per-token classifier head<br>(linear, 256 → 21)"]
-    C --> O["21-class softmax per token"]
-    O --> CRF["CRF Viterbi decode"]
-    CRF --> F["Best BIO label sequence"]
-```
-
-The CRF layer at the bottom is covered in [CRF decoder](./crf-decoder.mdx).
-
-## Why we hand-rolled the encoder block
-
-Most teams use `transformers.BertForTokenClassification` from Hugging Face. Mailwoman doesn't. The reason is hardware: the lab's training GPU is an AMD Radeon 780M (gfx1103 architecture). Two specific incompatibilities forced a hand-rolled implementation:
-
-1. **Flash-attention crashes on this GPU.** The Hugging Face default attention kernel is `flash` or `mem-efficient`, both of which crash on gfx1103 in bf16 mode. We force `math` SDPA (the slowest but most compatible kernel) and never use the fused attention path.
-2. **`nn.TransformerEncoderLayer`'s fused forward hangs at batch ≥ 128.** Same root cause — fused kernels for transformer blocks make assumptions the gfx1103 firmware does not honour. We use individual `nn.MultiheadAttention` + `nn.LayerNorm` + linear FFN ops instead.
-
-The result is a hand-rolled `MailwomanCoarseEncoder` class in `corpus-python/src/mailwoman_train/model.py`. The arithmetic is identical to BERT-base's encoder block; only the implementation differs. The cost is some readability; the benefit is the model trains at all on the hardware we have.
-
-## Self-attention in 90 seconds
-
-The math of self-attention is simple. For each token, the encoder:
-
-1. Computes three vectors from the token's representation: a **query** `Q`, a **key** `K`, and a **value** `V`. These come from three learned linear projections.
-2. Computes a similarity score between this token's query and every token's key: `score[i, j] = Q[i] · K[j]`.
-3. Normalizes the scores into a probability distribution via softmax across `j`.
-4. Computes the output for token `i` as a weighted sum of the values: `output[i] = sum over j of softmax_score[i, j] · V[j]`.
-
-The "attention" is the softmax probabilities: each token decides how much attention to pay to every other token, and updates its own representation accordingly. **Multi-head** attention runs this computation in parallel several times (4, in Mailwoman) and concatenates the results — each "head" can learn to attend to different patterns (e.g. one head learns positional patterns, another learns punctuation-related patterns).
-
-The feed-forward layer that follows each attention layer is a straightforward 2-layer MLP applied independently to each token. It does the per-token transformation that attention does not.
-
-## What this model is capable of
-
-- **Context-aware labelling.** Multi-word components ("Saint Petersburg"), tokens that look like multiple things ("Buffalo"), and components in unusual orders all work because the encoder sees the whole sequence.
-- **Graceful handling of typos and casing.** Subword tokenization plus distributed representations mean "Pennsyvana Ave" is not completely unfamiliar to the model.
-- **Locale-specific patterns.** Trained on en-US + fr-FR data, the model has internalized the conventions of both.
-
-## What this model is not capable of
-
-- **Generating text.** This is an **encoder-only** model. It cannot write addresses; it can only label them.
-- **Cross-locale generalization.** A model trained on en-US + fr-FR addresses will not parse Japanese addresses well. Each new locale needs its own training run and its own weights package.
-- **Free-text understanding.** "I live near the corner of 5th and Main, just past the Starbucks" is conversational, not address-shaped. The model is trained on structured addresses and will struggle with prose.
-- **Resolving.** The model labels parts of a string. It does not look anything up. That job belongs to the [resolver](./resolver-and-wof.mdx).
-
-## Where this lives in the code
-
-- **Model implementation:** `corpus-python/src/mailwoman_train/model.py` (`MailwomanCoarseEncoder`)
-- **Training entry point:** `corpus-python/src/mailwoman_train/train.py`
-- **Inference (TypeScript):** `neural/classifier.ts`, `neural-web/web-onnx-runner.ts` (browser path)
-- **The exported model file:** `packages/neural-weights-en-us/model.onnx` (about 25 MB int8-quantized)
+One correction, since old copies of the outdated claim are still linked from elsewhere: Mailwoman trains **one** model on a combined corpus, not a separate model per locale. The `@mailwoman/neural-weights-en-us` and `@mailwoman/neural-weights-fr-fr` packages currently ship the identical binary — the publish workflow copies the en-us artifacts into the fr-fr package. Locale-specific weights are future work, not something shipped today.
 
 ## See also
 
-- [BIO labels](./bio-labels.mdx) — what the model outputs
-- [CRF decoder](./crf-decoder.mdx) — what sits on top of the encoder
+- [CRF decoder](./crf-decoder.mdx) — the decode step downstream of the encoder
+- [BIO labels](./bio-labels.mdx) — what the encoder outputs
 - [ONNX runtime](./onnx-runtime.mdx) — how the model runs in production
 - [Training pipeline](./training-pipeline.mdx) — how the model gets its weights

--- a/docs/articles/concepts/viterbi-and-bio-validity.mdx
+++ b/docs/articles/concepts/viterbi-and-bio-validity.mdx
@@ -1,6 +1,9 @@
 ---
 sidebar_position: 29
 title: Viterbi and BIO validity
+role: concept
+audience: product-reader
+source-of-truth: neural/viterbi.ts, corpus-python/src/mailwoman_train/labels.py
 tags:
   - concepts
   - neural
@@ -21,8 +24,10 @@ after a `B-X` (begin of the same tag) or another `I-X`. The sequence
 in the middle of a span with no begin.
 
 The Viterbi decoder enforces this grammar globally. This article
-explains how, why it matters, and how learned CRF transitions
-(coming in v0.6.4) extend the picture.
+explains how, why it matters, and why no learned CRF transitions
+ship alongside it today — see [CRF decoder](./crf-decoder.mdx) for
+the short version, and [How Mailwoman parses an address](./how-mailwoman-parses-an-address.mdx#decoding-a-valid-sequence-and-building-the-tree)
+for this step in the context of a full parse.
 
 ## The BIO label space
 
@@ -83,18 +88,12 @@ best_path = argmax over all valid sequences s of (
 ```
 
 The emission scores come from the encoder + priors. The transition
-scores come from:
-
-1. **The structural BIO mask** (always present): `-∞` for invalid
-   transitions, 0 for valid ones. Hard constraint.
-2. **Learned CRF transitions** (optional, when shipped): a learned
-   matrix of `transition_logit[from_label][to_label]`. Soft preference
-   for common label-pair transitions vs rare ones.
-
-In v0.6.x today, only the structural mask is active (the
-[fp32-CRF diagnostic](../evals/model-versions/2026-05-28-fp32-crf-diagnostic.mdx)
-confirmed the bf16-CRF NaN issue; v0.6.4 will enable learned CRF
-transitions with the fp32 fix).
+scores come from a single source today: **the structural BIO mask**
+(always present) — `-∞` for invalid transitions, `0` for valid ones.
+That's the whole matrix. There's no second, learned layer of transition
+scores stacked on top of it; see [CRF decoder](./crf-decoder.mdx) for
+why — CRF training was tried, destabilized repeatedly, and has been
+permanently disabled (CE-only) since v0.6.3.
 
 The output is a valid label sequence that maximizes the total score.
 Per-token argmaxes that violate BIO are replaced with the
@@ -141,59 +140,62 @@ Consider: `B-region → B-locality` is structurally valid. So is
 always followed by `postcode` (`MA 02101`), not another locality. The
 structural mask treats both as equally allowed.
 
-Learned CRF transitions encode the statistical preference. After
-training, the transition matrix would have higher score for
-`B-region → B-postcode` than for `B-region → B-locality`. The Viterbi
-pass would then prefer the more common sequence.
+A learned transition matrix could in principle encode that statistical
+preference — after training, it would score `B-region → B-postcode`
+higher than `B-region → B-locality`, and Viterbi would prefer the more
+common sequence. Mailwoman doesn't ship one. Viterbi runs on emission
+scores alone, which is what ships today. It works well enough because
+the encoder's emissions already carry most of the sequencing signal
+via attention — a learned transition layer would be an additive
+refinement on top of that, not a replacement for it.
 
-Without learned CRF, Viterbi just falls back on emission scores —
-which is what we ship today. It works because the encoder emissions
-already encode most of the sequencing signal via attention. The CRF
-would be additive improvement, not a replacement for the encoder.
+## Why there's no learned CRF
 
-## Why learned CRF was disabled in v0.6.x
+Mailwoman tried this. A trainable CRF shipped in v3.0.0, and Stage 3's
+33×33 transition matrix (masked `-∞` entries) was re-attempted more
+than once — including a run that hit NaN gradients traced to bf16
+precision on the masked `logsumexp`, described in the
+[fp32-CRF diagnostic](../evals/model-versions/2026-05-28-fp32-crf-diagnostic.mdx).
+Every attempt after v0.4.0's loss-scale fix still diverged, three times
+over. The recipe first went CE-only (`crf_loss_weight: 0.0`) at v0.5.0,
+and apart from those labeled diagnostic reactivations (the v0.6.2 fp32
+probe), every config from v0.6.3 on has stayed at `0.0` — the current
+one included. [Dual-loss curvature
+conflict](./dual-loss-curvature-conflict.mdx) has the full diagnostic
+story of why the two losses fought instead of cooperating. There's no
+active plan to revisit it — the structural mask alone already buys the
+concrete win (no orphan-I), and the encoder's attention covers most of
+the rest.
 
-The
-2026-05-28 night-shift postmortem
-captured the story: enabling learned CRF transitions in Stage 3 (33×33
-transition matrix with masked `-∞` entries) caused NaN gradients
-twice during training. The
-[fp32-CRF diagnostic](../evals/model-versions/2026-05-28-fp32-crf-diagnostic.mdx)
-identified the root cause: bf16 precision is insufficient for the
-masked `logsumexp` over `-∞` entries. The fix is to run just the CRF
-forward in fp32 while the rest of the model stays bf16 — `crf_fp32:
-true` in the v0.6.4 yaml.
+## What a learned CRF would buy (if one ever ships)
 
-v0.6.3 ships without learned CRF (CE-only). v0.6.4 will turn it on.
-
-## What CRF buys (and what it doesn't)
-
-CRF buys soft transition preferences that the encoder didn't pick up
-strongly from training data. Examples:
+A learned transition layer would add soft transition preferences on
+top of the hard structural mask. For example:
 
 - `B-house_number` is almost always followed by `B-street` or `O,
-B-street`. CRF can encode this preference.
+B-street` — a learned matrix could encode that preference.
 - `B-postcode` rarely precedes anything (it's usually the last
-  component). CRF can encode "B-postcode → O" preference.
+  component) — `B-postcode → O` could get a boost.
 - `B-street_prefix → B-street` is common; `B-street_prefix →
-B-locality` is rare. CRF can rank these.
+B-locality` is rare — a learned matrix could rank these apart.
 
-CRF doesn't buy:
+It would not buy:
 
 - Better encoder representations. The encoder is the upstream learner;
-  CRF is downstream.
+  a CRF layer is downstream of it, not a substitute for it.
 - Handling of novel patterns. If a sequence isn't represented well in
-  training, CRF has no opinion.
-- Inference speed. CRF Viterbi over learned transitions is slightly
-  slower than the structural-mask-only version (matrix lookups per
+  training, a transition matrix has no opinion either.
+- Inference speed. Viterbi over a learned matrix is marginally slower
+  than the structural-mask-only version (one more score lookup per
   transition).
 
 ## Decoder modes
 
 The `parse()` API accepts a `decode` option:
 
-- `"viterbi"` (default): full Viterbi with BIO mask + (optional) CRF
-  transitions. Produces structurally valid sequences.
+- `"viterbi"` (default): full Viterbi over the BIO validity mask — no
+  learned transitions ship, so this is the mask alone. Produces
+  structurally valid sequences.
 - `"argmax"`: per-token argmax with no sequence consideration. Faster
   but produces invalid sequences. Used in ablation studies to measure
   how much Viterbi contributes vs how much is in the encoder.
@@ -203,12 +205,15 @@ uses `"viterbi"`.
 
 ## See also
 
+- [How Mailwoman parses an address](./how-mailwoman-parses-an-address.mdx) —
+  the full parse this step plugs into
 - [How the model reasons](./how-the-model-reasons.mdx) — the central
   pipeline doc
 - [Attention and bidirectional context](./attention-and-bidirectional-context.mdx) — what's UPSTREAM of Viterbi
 - [FST priors as shallow fusion](./fst-priors-as-shallow-fusion.mdx) —
   the additive biases on the emissions Viterbi consumes
-- [fp32-CRF diagnostic](../evals/model-versions/2026-05-28-fp32-crf-diagnostic.mdx) —
-  why learned CRF was disabled in v0.6.x and how v0.6.4 brings it back
+- [CRF decoder](./crf-decoder.mdx) — the short version of this page
+- [Dual-loss curvature conflict](./dual-loss-curvature-conflict.mdx) —
+  why learned CRF training was abandoned
 - [BIO labels](./bio-labels.mdx) — the per-tag label space (existing
   reference)

--- a/docs/articles/concepts/what-mailwoman-is.mdx
+++ b/docs/articles/concepts/what-mailwoman-is.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 title: What Mailwoman is — a name for the thing we're building
 tags:
   - concepts

--- a/docs/articles/index.mdx
+++ b/docs/articles/index.mdx
@@ -20,10 +20,10 @@ Install it, parse your first address, and read the output. About five minutes.
 
 ## I want to understand how this works
 
-Mailwoman splits the parsing problem into a staged pipeline: each stage owns one kind of
-knowledge, instead of asking a single model to learn everything at once.
+Follow one address through the whole parse — subword pieces, per-label scores, gazetteer
+priors, decoding, and the component tree the resolver receives.
 
-**[The knowledge ladder →](./understanding/our-approach/the-knowledge-ladder.mdx)**
+**[How Mailwoman parses an address →](./concepts/how-mailwoman-parses-an-address.mdx)**
 
 ## I want to understand the problem
 

--- a/docs/articles/understanding/our-approach/from-pelias-to-mailwoman.mdx
+++ b/docs/articles/understanding/our-approach/from-pelias-to-mailwoman.mdx
@@ -38,10 +38,10 @@ This worked, but it ran into the same limit every rule-based parser hits: the lo
 
 Mailwoman v2 — what you are reading docs for — keeps the rule classifiers but adds a **neural classifier** alongside them. Both run; both produce candidate labels; a per-component **policy** decides which one's vote counts more for each address component type. The migration is gradual on purpose: rules stay until the neural classifier's metrics prove it does better.
 
-The neural classifier is a small transformer model (about 9 million parameters — see [`concepts/neural-classification.md`](../../concepts/neural-classification.mdx)) trained on a 677-million-row corpus built from many open data sources. It ships in two pieces:
+The neural classifier is a small transformer model (about 34M parameters in the current weights — see [`concepts/how-mailwoman-parses-an-address.md`](../../concepts/how-mailwoman-parses-an-address.mdx)) trained on a corpus built from many open data sources and rebuilt many times over — see [`concepts/training-pipeline.md`](../../concepts/training-pipeline.mdx) for how it's constructed. It ships in two pieces:
 
 - `@mailwoman/neural` — the runtime that loads the model and runs inference (works in Node.js and the browser).
-- `@mailwoman/neural-weights-en-us` and `@mailwoman/neural-weights-fr-fr` — the model files (one per locale).
+- `@mailwoman/neural-weights-en-us` and `@mailwoman/neural-weights-fr-fr` — the model files. Two npm packages, but one trained model today: the publish workflow copies the en-us artifacts into the fr-fr package. Locale-specific weights are future work.
 
 The Pelias side of the equation — the gazetteer + resolver — is also evolving. Mailwoman now ships its own resolver against Who's On First as a SQLite database, both server-side and in the browser via WebAssembly. See [`concepts/resolver-and-wof.md`](../../concepts/resolver-and-wof.mdx).
 
@@ -50,7 +50,7 @@ The Pelias side of the equation — the gazetteer + resolver — is also evolvin
 - **The two-job split.** Parse, then resolve. Same as Pelias. Same as every modern geocoder.
 - **The output shape.** Mailwoman emits parsed components with confidence scores and offsets, the same surface a Pelias consumer would expect.
 - **The CLI ergonomics.** `mailwoman parse <input>` is the entry point.
-- **Multi-locale design.** Mailwoman ships separate weight packages per locale (en-us, fr-fr) and the architecture is built around the idea that locales are first-class (see [`plan/reference/ARCHITECTURE.md`](../../plan/reference/ARCHITECTURE.mdx)).
+- **Multi-locale packaging.** Mailwoman ships a separate weights package per locale (en-us, fr-fr) — a packaging boundary for a locale to get its own trained weights without a breaking change, even though today both packages carry the same model (see [`plan/reference/ARCHITECTURE.md`](../../plan/reference/ARCHITECTURE.mdx)).
 
 ## What we deliberately do differently: no span left behind
 

--- a/docs/articles/understanding/the-problem/what-is-an-address.mdx
+++ b/docs/articles/understanding/the-problem/what-is-an-address.mdx
@@ -99,7 +99,7 @@ Four ways to write the same address. The parser has to handle all of them, and t
 
 **5. Different locales have different rules.**
 
-US addresses put the postcode after the region. French addresses put it before the locality. Japanese addresses are essentially the reverse of European ones — country first, then prefecture, then municipality, then a building number. Mailwoman's model is per-locale (separate weights for en-US and fr-FR; Japan is a planned future locale) precisely because there is no universal address grammar.
+US addresses put the postcode after the region. French addresses put it before the locality. Japanese addresses are essentially the reverse of European ones — country first, then prefecture, then municipality, then a building number. Mailwoman's model is trained on a combined multi-country corpus rather than a universal template, precisely because there is no universal address grammar; Japan today is resolver-route only, with no parser training claim (see [the scope declaration](../../plan/SCOPE.mdx) for the current locale tiers).
 
 ## The adversarial cases
 

--- a/docs/src/components/AboutDemo/AboutDemo.tsx
+++ b/docs/src/components/AboutDemo/AboutDemo.tsx
@@ -31,10 +31,10 @@ const AboutDemoInner: React.FC = () => {
 				<section className={styles.section}>
 					<h3 className={styles.sectionHeading}>Neural model</h3>
 					<p>
-						A 29.3M-parameter BERT-style encoder classifies each token into one of 33 BIO labels covering 16 address
+						A 33.9M-parameter BERT-style encoder classifies each token into one of 33 BIO labels covering 16 address
 						components (street, house number, unit, locality, region, postcode, venue, country, intersection, etc.). It
 						runs entirely in your browser via <strong>onnxruntime-web</strong> (WebGPU with WASM SIMD fallback). The
-						model ships as a 29.8 MB int8-quantized ONNX bundle; fp32 weights are also available for higher accuracy.
+						model ships as a 36.8 MB int8-quantized ONNX bundle; fp32 weights are also available for higher accuracy.
 					</p>
 				</section>
 

--- a/docs/src/components/CRFDiff/CRFDiff.tsx
+++ b/docs/src/components/CRFDiff/CRFDiff.tsx
@@ -29,6 +29,11 @@ import styles from "./styles.module.css"
  * From → to B-locality I-locality O ────────────────────────────────────────── B-locality -2.0 +1.5 0 I-locality -1.0
  * +2.0 0 O +0.5 -∞ +1.0
  *
+ * ILLUSTRATIVE, not shipped: the soft scores (+1.5, +2.0, …) show what a learned transition matrix would look like.
+ * Mailwoman's shipped decoder uses only the structural BIO mask (0 for valid transitions, −∞ for invalid) — no learned
+ * transition scores train or ship (first CE-only at v0.5.0, permanent from v0.6.3 on; see
+ * docs/articles/concepts/crf-decoder.mdx). The −∞ row is the part that matches production.
+ *
  * Key insight:
  *
  * - B-locality → I-locality (+1.5) is strongly preferred over B-locality → B-locality (-2.0), so Viterbi chains "Saint"
@@ -124,7 +129,10 @@ export const CRFDiff: React.FC = () => {
 			{/* Transition matrix */}
 			<div className={styles.matrixSection}>
 				<div className={styles.decodeLabel}>
-					Transition scores <span style={{ fontWeight: 400, fontSize: "0.75rem" }}>(additive log-prob, learned)</span>
+					Transition scores{" "}
+					<span style={{ fontWeight: 400, fontSize: "0.75rem" }}>
+						(additive log-prob — illustrative: what a learned transition matrix would look like, not what ships)
+					</span>
 				</div>
 				<table className={styles.matrix}>
 					<thead>
@@ -148,7 +156,8 @@ export const CRFDiff: React.FC = () => {
 				</table>
 				<div className={`${styles.note}`} style={{ marginTop: "0.5rem" }}>
 					Green = allowed transition · Blue = strongly preferred · Red = structurally forbidden (−∞). The Viterbi path
-					(B → I) scores +1.5; the argmax path (B → B) scores −2.0, so Viterbi wins by 3.5 log-prob.
+					(B → I) scores +1.5; the argmax path (B → B) scores −2.0, so Viterbi wins by 3.5 log-prob. The soft scores are
+					hypothetical — Mailwoman's shipped table carries only 0 and −∞.
 				</div>
 			</div>
 		</div>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -75,7 +75,7 @@ function Gallery(): ReactNode {
 							<h3 className={styles.cardTitle}>Geocode on-device</h3>
 							<p className={styles.cardBody}>
 								Resolve an address to a real coordinate with no server, no API key, and no query leaving the machine. A
-								29.8 MB model and a byte-ranged global gazetteer do it in the tab.
+								36.8 MB model and a byte-ranged global gazetteer do it in the tab.
 							</p>
 							<code className={styles.cardTransform}>"350 5th Ave, New York" → 40.7484, -73.9857 · rooftop</code>
 							<p className={styles.cardLinks}>


### PR DESCRIPTION
Phase 2c of the documentation-architecture cleanup: with the parsing flagship merged (#1107), this retires or corrects everything it supersedes. 14 files, net −189 lines, no page deleted, no URL removed.

## What changed

- **Fork page**: the "how this works" door now points at the flagship (knowledge-ladder keeps 21 inbound links from maintained pages — no orphan).
- **CRF cluster corrected against what ships**: `crf-decoder.mdx` rewritten (433 words: Viterbi over a hand-coded validity table, `crf_at_training: false`, exact CE-only chronology incl. the v0.6.2 fp32 diagnostic reactivation before permanent 0.0 from v0.6.3); `bio-labels.mdx` and `viterbi-and-bio-validity.mdx` re-anchored to the 33-label/16-tag reality; the `CRFDiff` component no longer labels its illustrative matrix "learned" (it renders in two pages, so the fix lives in the component).
- **`neural-classification.mdx` → transition page** (~230 words): it declared itself superseded while holding 13 inbound links; those now route to the flagship, `how-the-model-reasons`, and SCHEMA.
- **FST pages de-duplicated with wiring verified**: the admin FST is wired into `createRuntimePipeline` (via `tryBuildFST`); the street-morphology FST exists only in eval harnesses (`CreateRuntimePipelineOpts` has no such field) — both pages now say so. Review endorsed keeping both pages and trimming the duplicate section rather than stubbing the deeper one.
- **Per-locale-model claims fixed in living pages** (`from-pelias-to-mailwoman`, `what-is-an-address`), including the leftover ~9M-params claim → ~34M per the model card, and the corpus-v0.3.0-era row-count dropped rather than swapped for an uncommitted number.
- **Homepage + AboutDemo**: stale 29.8 MB / params figures → 36.8 MB (`int8_size_mb`, byte-verified) and 33.9M.
- `concepts/README.mdx` refreshed to route by need; `what-mailwoman-is` explicitly `sidebar_position: 2`.

## Review

Task review: SPEC pass on all ten items; 9 of the 13 stale-claims receipts resolved (3 correctly deferred to dated/orphaned pages, 1 — `tokenization.mdx` — out of scope by design, queued). Three fix-round items applied and verified. Build green twice under `onBrokenLinks: "throw"`.

## Queued for a receipts-sweep follow-up (not here)

`tokenization.mdx` 16K-vocab claim · `resolver-and-wof.mdx` (better-sqlite3, address-point "out of scope") · `how-it-will-work.mdx` archive-status ambiguity · three pages whose anchor text oversells the neural-classification stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)