### PR TITLE
docs(recipes): Phase 2d — outcome-first recipes with executed examples

### DIFF
--- a/docs/articles/recipes/batch-geocoding.md
+++ b/docs/articles/recipes/batch-geocoding.md
@@ -1,18 +1,21 @@
 ---
 title: Batch Geocoding
 id: batch-geocoding
+role: guide
+audience: product-reader
+source-of-truth: api/routes.ts, api/schema.ts, mailwoman/api-engine.ts
 ---
 
-You have a spreadsheet — ten thousand addresses, a CSV a colleague dropped in Slack, a nightly export from your CRM — and you want a coordinate for every row. Firing ten thousand individual requests works, but you'll spend most of the wall-clock time on HTTP overhead and you'll have to write the concurrency control yourself. The Mailwoman server has a bulk endpoint for exactly this.
+You have a spreadsheet — ten thousand addresses, a CSV a colleague dropped in Slack, a nightly export from your CRM — and you want a coordinate for every row. Firing ten thousand individual requests works, but you'll spend most of the wall-clock time on HTTP overhead and you'll have to write the concurrency control yourself. The Mailwoman server has a bulk endpoint for exactly this. By the time you're done here you'll have one `curl` command that turns a list of addresses into a list of coordinates, in order, with the failure cases handled.
 
 ## The endpoint
 
-`POST /api/batch` takes a JSON body of `{ addresses: string[] }` and returns `{ results }` in the **same order you sent them**:
+`POST /v1/batch` takes a JSON body of `{ addresses: string[] }` and returns `{ results }` in the **same order you sent them** — see the [API reference](../api.mdx#drop-in-server-specifications-openapi-31) for the full OpenAPI contract. Run against a `mailwoman serve` instance:
 
 ```bash
-curl -s localhost:3000/api/batch \
+curl -s localhost:3000/v1/batch \
   -H 'content-type: application/json' \
-  -d '{"addresses": ["350 5th Ave, New York, NY 10118", "Vienna, Austria", ""]}'
+  -d '{"addresses": ["350 5th Ave, New York, NY 10118", "Vienna, Austria"]}'
 ```
 
 ```json
@@ -20,25 +23,127 @@ curl -s localhost:3000/api/batch \
 	"results": [
 		{
 			"input": "350 5th Ave, New York, NY 10118",
-			"lat": 40.7484,
-			"lon": -73.9857,
+			"lat": 40.747773,
+			"lon": -73.985046,
 			"resolution_tier": "interpolated",
-			"...": "..."
+			"uncertainty_m": 64,
+			"locality": "New York",
+			"region": "NY",
+			"postcode": "10118",
+			"house_number": "350",
+			"street": "5th Ave",
+			"countryCode": "US",
+			"hierarchy": [
+				{
+					"tag": "locality",
+					"value": "New York",
+					"name": "New York",
+					"lat": 40.694457,
+					"lon": -73.93045,
+					"placeID": "wof:85977539"
+				},
+				{
+					"tag": "region",
+					"value": "NY",
+					"name": "New York",
+					"lat": 42.921227,
+					"lon": -75.596537,
+					"placeID": "wof:85688543"
+				}
+			],
+			"candidates": [
+				{
+					"name": "New York",
+					"tag": "region",
+					"lat": 42.921227,
+					"lon": -75.596537,
+					"countryCode": "US",
+					"placeID": "wof:85688543"
+				}
+			]
 		},
-		{ "input": "Vienna, Austria", "lat": 48.2083, "lon": 16.3725, "resolution_tier": "admin", "...": "..." },
-		{ "input": "", "error": "..." }
+		{
+			"input": "Vienna, Austria",
+			"lat": 48.20849,
+			"lon": 16.37208,
+			"resolution_tier": "admin",
+			"uncertainty_m": null,
+			"locality": "Vienna",
+			"region": null,
+			"postcode": null,
+			"house_number": null,
+			"street": null,
+			"countryCode": "AT",
+			"hierarchy": [
+				{
+					"tag": "locality",
+					"value": "Vienna",
+					"name": "Vienna",
+					"lat": 48.20849,
+					"lon": 16.37208,
+					"placeID": "wof:9000000038140"
+				}
+			],
+			"candidates": [
+				{
+					"name": "Vienna",
+					"tag": "locality",
+					"lat": 48.20849,
+					"lon": 16.37208,
+					"countryCode": "AT",
+					"placeID": "wof:9000000038140"
+				},
+				{
+					"name": "Wien",
+					"tag": "locality",
+					"lat": 48.2083537,
+					"lon": 16.3725042,
+					"countryCode": "AT",
+					"placeID": "wof:8000000584878"
+				}
+			]
+		}
 	]
 }
 ```
 
-Order is the contract that makes the bulk path usable: zip the `results` array straight back onto your input rows by index, no join key required.
+Order is the contract that makes the bulk path usable: zip the `results` array straight back onto your input rows by index, no join key required. The second row's `hierarchy`/`candidates` carry both "Vienna" and "Wien": the German endonym is a distinct WOF place record for the same city, and the candidate list surfaces it as a runner-up.
 
-## One bad row never fails the batch
+## Rows fail independently
 
-The third address above was empty, so its slot carries an `{ input, error }` instead of a coordinate. That's the whole isolation model — a row that throws is caught and parked in its own slot, and the other 9 999 rows still come back. So the one check you can't skip is per-row:
+Most malformed input doesn't error at all: an address with no recognizable component (an empty string, say) resolves fine, every field lands `null`, and the tier settles at `admin`. What throws is a row that overruns the classifier's token budget. The model tokenizes to a fixed 128-token window, and a row that blows past it — a CSV escaping bug that concatenated an entire delivery note into the address column, for instance — throws deep inside the classifier instead of truncating gracefully. Batch isolation exists for exactly that case: a row that throws is caught and parked in its own `{ input, error }` slot, and the rest of the batch still comes back.
+
+```bash
+# the second "address" is a 106-word, 600+ character delivery note that a CSV
+# escaping bug dumped into the address column — shown truncated below (…)
+curl -s localhost:3000/v1/batch \
+  -H 'content-type: application/json' \
+  -d '{"addresses": ["350 5th Ave, New York, NY 10118", "123 Main St, Springfield, IL 62701 -- customer requested delivery instructions: please leave the package behind the blue recycling bin near the side door, not the front porch, because the front porch floods during rain …"]}'
+```
+
+```json
+{
+	"results": [
+		{
+			"input": "350 5th Ave, New York, NY 10118",
+			"lat": 40.747773,
+			"lon": -73.985046,
+			"resolution_tier": "interpolated"
+		},
+		{
+			"input": "123 Main St, Springfield, IL 62701 -- customer requested delivery instructions: please leave the package behind the blue recycling bin near the side door, not the front porch, because the front porch floods during rain …",
+			"error": "Cannot read properties of undefined (reading '0')"
+		}
+	]
+}
+```
+
+(Both the input and output above are truncated with `…` for the docs. The real 106-word string runs another 400-odd characters, and the server echoes it back verbatim in the error slot.)
+
+So the one check you can't skip is per-row:
 
 ```ts
-const res = await fetch("http://localhost:3000/api/batch", {
+const res = await fetch("http://localhost:3000/v1/batch", {
 	method: "POST",
 	headers: { "content-type": "application/json" },
 	body: JSON.stringify({ addresses }),

--- a/docs/articles/recipes/display-on-a-map.md
+++ b/docs/articles/recipes/display-on-a-map.md
@@ -1,11 +1,14 @@
 ---
 title: Displaying Results on a Map
 id: display-on-a-map
+role: guide
+audience: product-reader
+source-of-truth: registry/resolve.ts, registry/geojson.ts, registry/map-html.ts
 ---
 
 Coordinates in a JSON array tell you the geocoder worked. They don't tell you whether the _answers_ are right — that a cluster of clinics really sits where you'd expect, that the three records you merged into one entity actually share a building. For that you need to see them on a map, and you'd rather not stand up a tile server and a frontend to glance at a few hundred points.
 
-`@mailwoman/registry` renders a self-contained map for you. You hand it resolved entities; it hands back a single HTML file you open in a browser.
+`@mailwoman/registry` renders a self-contained map for you. You hand it resolved entities; it hands back a single HTML file you open in a browser. By the end you'll have a `map.html` you can open locally or serve from anywhere. [Geocode-first record matching](../concepts/geocode-first-record-matching.mdx) covers how `resolveEntities` gets from raw records to the entities this recipe maps.
 
 ## From records to a map
 

--- a/docs/articles/recipes/index.md
+++ b/docs/articles/recipes/index.md
@@ -3,6 +3,17 @@ sidebar_title: Overview
 title: Recipes
 sidebar_position: 0
 hide_footer: true
+role: guide
+audience: product-reader
+source-of-truth: self
 ---
 
-Whether you are a developer, data scientist, or just someone interested in geospatial data, the `@mailwoman` packages provide a variety of tools to help you work with geographic information. This section contains recipes and examples for using these packages effectively.
+Task-oriented walkthroughs for jobs people actually show up with: geocode a table, put the results on a map, keep a coordinate private. Each one states what you'll have by the end and links the reference or concept page it builds on.
+
+- **[Batch geocoding](./batch-geocoding.md)** — turn a list of addresses into a list of coordinates with one bulk request, with per-row error isolation so one bad row never sinks the batch.
+- **[Displaying results on a map](./display-on-a-map.md)** — render resolved entities to a self-contained `map.html` you can open in a browser, from the same data you'd export as GeoJSON for QGIS.
+- **[The free first pass](./multi-service-geocoding.md)** — run Mailwoman locally as a no-cost first geocoding pass, and spend a paid API's budget only on the residual it couldn't pin well enough.
+- **[Ingesting giant CSVs](./parallel-csv-ingest.md)** — stream a multi-gigabyte CSV into normalized records on one thread, then thread only the geocoding stage that's actually expensive.
+- **[Coarsening a coordinate for privacy](./privacy-coordinate-rounding.md)** — round or geohash a rooftop coordinate down to neighbourhood-level precision before it lands in an analytics table or a public dashboard.
+- **[Looking up a timezone](./timezones.md)** — resolve a coordinate to its IANA timezone over a self-built point-in-polygon database.
+- **[UN/LOCODE lookup](./un-locode-lookup.md)** — resolve a place name or coordinate to its UN/LOCODE trade-and-transport code, and back.

--- a/docs/articles/recipes/multi-service-geocoding.md
+++ b/docs/articles/recipes/multi-service-geocoding.md
@@ -1,20 +1,23 @@
 ---
 title: The Free First Pass
 id: multi-service-geocoding
+role: guide
+audience: product-reader
+source-of-truth: api/schema.ts, mailwoman/geocode-core.ts
 ---
 
 You have a table of addresses and a hosted geocoder that bills per request — every request, easy row or hard. At today's list prices that's somewhere between twenty cents and five dollars per thousand, depending on the provider and your volume. Multiply it out: a million-row table is $200 to $5,000 **per pass**, and if the table refreshes nightly, you buy it again tomorrow. The no-cost route caps you on rate instead: the public Nominatim server asks for at most one request per second, which puts the same million rows at eleven days.
 
 None of that is a complaint about the services. OpenCage wraps aggregated open data in a pleasant API with friendly storage terms; Google's rooftop coverage is hard to beat; the public Nominatim instance is a donation to the commons that deserves the gentle use its policy asks for. The waste is on your side of the wire: most rows in a real table are ordinary, well-formed addresses that don't need a premium answer, and each one bills like the hard ones.
 
-So don't send them. Run Mailwoman on your own hardware as the first pass over everything, and spend money only on the residual — the rows the free pass couldn't pin well enough for your use case. What makes the cascade practical is that Mailwoman's result tells you, per row, how good its answer is.
+So don't send them. Run Mailwoman on your own hardware as the first pass over everything, and spend money only on the residual — the rows the free pass couldn't pin well enough for your use case. By the end of this recipe you'll have that cascade wired up: geocode everything locally first, then route only what the free pass couldn't pin well enough to a paid API. What makes it practical is that Mailwoman's result tells you, per row, how good its answer is.
 
 ## Pass one: everything, locally
 
 Geocode the whole table against your own server. [Batch geocoding](./batch-geocoding.md) covers the endpoint; [Ingesting giant CSVs](./parallel-csv-ingest.md) covers the streaming path for files that don't fit in memory.
 
 ```ts
-const res = await fetch("http://localhost:3000/api/batch", {
+const res = await fetch("http://localhost:3000/v1/batch", {
 	method: "POST",
 	headers: { "content-type": "application/json" },
 	body: JSON.stringify({ addresses }),
@@ -26,7 +29,7 @@ A local pass costs CPU time and nothing else, so "geocode all of it, twice if yo
 
 ## The routing decision
 
-Every result carries a `resolution_tier` plus a calibrated `uncertainty_m` radius. The tier is one of `address_point` (a rooftop or parcel point), `interpolated` (a house-number estimate along the street), or `admin` (a locality or region centroid). Together they are the routing decision, made explicit per row. Partition on it:
+Every result carries a `resolution_tier` plus a calibrated `uncertainty_m` radius. The tier is one of `address_point` (a rooftop or parcel point), `interpolated` (a house-number estimate along the street), `street` (a street centroid: the query named a street but no house number), or `admin` (a locality or region centroid) — see the [API reference](../api.mdx#drop-in-server-specifications-openapi-31) for the full response shape. Together they are the routing decision, made explicit per row. Partition on it:
 
 ```ts
 const kept = []

--- a/docs/articles/recipes/parallel-csv-ingest.md
+++ b/docs/articles/recipes/parallel-csv-ingest.md
@@ -1,6 +1,9 @@
 ---
 title: Ingesting Giant CSVs
 id: parallel-csv-ingest
+role: guide
+audience: product-reader
+source-of-truth: registry/ingest.ts, mailwoman/geocode-stream.ts, mailwoman/geocode-worker.ts
 ---
 
 Someone hands you a national dataset as a single CSV — the NPPES provider registry (millions of rows), an FCC broadband availability drop, a state address export. You need every row normalized into the same shape, and ideally a coordinate on each one. Two things stand in the way: the file won't fit in memory, and geocoding a million addresses one after another takes hours. This recipe is the shape that handles both — a streaming normalize core you can hold in your head, plus an optional threaded geocode stage you bolt on only when the per-row cost earns it.
@@ -46,7 +49,7 @@ import { normalizeCSV } from "@mailwoman/registry"
 import { geocodeStream } from "mailwoman/geocode-stream"
 
 const geocode = {
-	wofDbPath: "/data/wof/admin-global-priority.db",
+	wofDBPath: "/data/wof/admin-global-priority.db",
 	dataRoot: "/data",
 	locale: "en-US",
 	country: "US",
@@ -96,3 +99,5 @@ If your gazetteer fits in RAM, or you've sharded it across disks, your curve wil
 ## When to stop at `normalize`
 
 Not every ingest needs a coordinate. If you're loading records to dedupe by name and org, or to join on an ID, the address never gets geocoded — so there's no heavy stage to thread, and `normalizeCSV` on its own is the whole job. Reaching for `geocodeStream` there would only add worker overhead to microsecond work, the exact loss from two sections ago. Thread the stage that earns it; leave the cheap one alone.
+
+Once you have geocoded `SourceRecord`s, [Geocode-first record matching](../concepts/geocode-first-record-matching.mdx) covers the dedup/entity-resolution step this ingest usually feeds, and [Displaying results on a map](./display-on-a-map.md) covers turning the output into a map you can eyeball.

--- a/docs/articles/recipes/privacy-coordinate-rounding.md
+++ b/docs/articles/recipes/privacy-coordinate-rounding.md
@@ -1,6 +1,9 @@
 ---
 title: Coarsening a Coordinate for Privacy
 id: privacy-coordinate-rounding
+role: guide
+audience: product-reader
+source-of-truth: spatial/coordinate-formats.ts
 ---
 
 You geocoded a customer's address and got a rooftop coordinate back — accurate to a few metres. That precision is the whole point when you're routing a driver to the door. It's a liability when you're about to store the point in an analytics table, share it with a partner, or plot a thousand customers on a public dashboard. A rooftop point _is_ the house; you usually want the neighbourhood.
@@ -39,7 +42,7 @@ A geohash encodes a coordinate as a string where every character you drop widens
 ```ts
 import { toGeohash } from "@mailwoman/spatial"
 
-toGeohash(40.7484, -73.9857) // precision 9 ≈ 4.8 m: "dr5ru7p4n"
+toGeohash(40.7484, -73.9857) // precision 9 ≈ 4.8 m: "dr5ru6j28"
 toGeohash(40.7484, -73.9857, 5) // ≈ 4.9 km: "dr5ru"
 ```
 
@@ -53,4 +56,4 @@ toGeohash(40.7484, -73.9857, 5) // ≈ 4.9 km: "dr5ru"
 
 Because the cell boundaries are fixed, every address inside `dr5ru` shares the prefix — you can group, join, or count by the truncated string and know that two records in the same cell really are neighbours. Store the geohash, not the point, and the precision you didn't keep is precision you can't leak.
 
-One thing to name plainly: coarsening is one-way by design, but it is not anonymity. A precision-6 cell over a rural address can still hold exactly one house. If the guarantee you need is "this point cannot be traced to a person," coarsening is a layer, not the whole answer — pair it with aggregation thresholds (suppress any cell with fewer than _k_ records) before anything goes public.
+One thing to name plainly: coarsening is one-way by design, but it is not anonymity. A precision-6 cell over a rural address can still hold exactly one house. If the guarantee you need is "this point cannot be traced to a person," coarsening is a layer, not the whole answer — pair it with aggregation thresholds (suppress any cell with fewer than _k_ records) before anything goes public. See [Privacy policy & legal posture](../licensing/privacy.md) for where Mailwoman's own data-handling design sits relative to this.

--- a/docs/articles/recipes/timezones.md
+++ b/docs/articles/recipes/timezones.md
@@ -1,6 +1,9 @@
 ---
 title: Looking up a Timezone
 id: timezone-lookup
+role: guide
+audience: product-reader
+source-of-truth: timezone-lookup/index.ts, timezone-lookup/build.ts, timezone-lookup/cli.ts
 ---
 
 You have a coordinate and you want the IANA timezone it lands in — `America/New_York`, `Asia/Tokyo`. The [`@mailwoman/timezone-lookup`](https://www.npmjs.com/package/@mailwoman/timezone-lookup) package does the point-in-polygon for you, over [timezone-boundary-builder](https://github.com/evansiroky/timezone-boundary-builder) polygons in a `node:sqlite` database. The UTC offset comes from `Intl`, so there's no tz-database dependency to keep patched.
@@ -19,12 +22,14 @@ That's a one-time step. The `.db` is an immutable artifact — build it in CI, s
 
 ## CLI usage
 
-Hand it a latitude and longitude:
+Hand it a latitude and longitude. A leading `--` is required before a negative longitude, or the CLI's flag parser reads `-74.0060` as an unknown option and errors:
 
 ```bash
-npx @mailwoman/timezone-lookup --db timezone.db 40.7128 -74.0060
-# {"timezone":"America/New_York","offsetSec":-18000}
+npx @mailwoman/timezone-lookup --db timezone.db -- 40.7128 -74.0060
+# {"timezone":"America/New_York","offsetSec":-14400}
 ```
+
+(The offset is the current UTC offset for that timezone: `-14400` is EDT in July, `-18000` for EST outside daylight saving.)
 
 ## Programmatic usage
 

--- a/docs/articles/recipes/un-locode-lookup.md
+++ b/docs/articles/recipes/un-locode-lookup.md
@@ -1,6 +1,9 @@
 ---
 title: UN/LOCODE Lookup
 id: un-locode-lookup
+role: guide
+audience: product-reader
+source-of-truth: un-locode-lookup/index.ts, un-locode-lookup/build.ts, un-locode-lookup/cli.ts
 ---
 
 A **UN/LOCODE** is the UNECE's code for a trade-and-transport location — `US NYC` for New York, `NL RTM` for Rotterdam. If you're moving freight, filing customs, or matching a shipping record to a place, you need these codes, and you usually have either a place name or a coordinate to start from. The [`@mailwoman/un-locode-lookup`](https://www.npmjs.com/package/@mailwoman/un-locode-lookup) package goes both ways, over the UNECE code list in a `node:sqlite` database.
@@ -17,13 +20,13 @@ npx @mailwoman/un-locode-lookup build --csv code-list.csv --out un-locode.db
 
 ## CLI usage
 
-By country and place name, or by nearest coordinate:
+By country and place name, or by nearest coordinate. The coordinate form needs a leading `--` before the negative longitude, or the CLI's flag parser reads `-74.0060` as an unknown option:
 
 ```bash
 npx @mailwoman/un-locode-lookup --db un-locode.db --country NL --name "Rotterdam"
 # {"unLocode":"NL RTM"}
 
-npx @mailwoman/un-locode-lookup --db un-locode.db --near 40.7128 -74.0060
+npx @mailwoman/un-locode-lookup --db un-locode.db -- 40.7128 -74.0060
 # {"unLocode":"US NYC"}
 ```
 


### PR DESCRIPTION
Phase 2d of the documentation-architecture cleanup: every Use-Mailwoman recipe now states its outcome up front, and every code block was executed against a live `mailwoman serve` + real gazetteer/timezone/UN-LOCODE databases before shipping. 8 files, recipes/ only.

## Real breakage found and fixed (9 fixes, ~20 examples verified)

- **Dead endpoint**: `/api/batch` no longer exists; the live route is `/v1/batch` (review re-confirmed: 404 vs 200 against a running server).
- **Factually false claim rebuilt around verified behavior**: the batch-isolation section claimed empty-string rows trigger `{input, error}` — they resolve fine with nulls. The real trigger is a row overrunning the model's 128-token window; the section now shows that, with genuinely captured JSON (review reproduced the exact error string live).
- **Two CLI examples crashed as written**: negative-longitude positionals need the `--` separator (`timezone-lookup`/`un-locode-lookup`); a `--near` flag that no longer exists; both re-run clean in review.
- Also: stale geohash sample output, missing `street` in the `resolution_tier` enum (now all 4 values per `api/schema.ts`), `wofDbPath` → `wofDBPath` (verified by running `geocodeStream` end to end).

`recipes/index.md` went from an 8-line stub to a curated landing — one line and one concrete outcome per recipe. All 8 pages carry the content-model frontmatter and cross-link their API/concept homes.

Disclosed non-executions (fallback evidence in the work report): the OpenCage external call (no API key; shape verified against OpenCage's current docs) and the worker-throughput benchmark table (corroborated against the source module's docstring rather than re-swept).

## Review

Task review: SPEC pass on all requirements; the three highest-stakes fixes independently re-verified live; quality approved with no fix items. Build green under `onBrokenLinks: "throw"`.

Minor out-of-scope flag from review, queued for the receipts sweep: `/api/batch` still appears in a code comment at `mailwoman/api-engine.ts:8-10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)