### PR TITLE
docs: Phase 2f — receipts sweep (six verified stale-claim fixes)

### DIFF
--- a/docs/articles/concepts/onnx-runtime.mdx
+++ b/docs/articles/concepts/onnx-runtime.mdx
@@ -125,6 +125,6 @@ A few subtle issues come up during ONNX export:
 
 ## See also
 
-- [Neural classification](./neural-classification.mdx) — what the ONNX graph implements
+- [How the model reasons](./how-the-model-reasons.mdx) — the encoder computation the ONNX graph exports
 - [Training pipeline](./training-pipeline.mdx) — where the ONNX file comes from
 - [CRF decoder](./crf-decoder.mdx) — the part that is _not_ in the ONNX graph (yet)

--- a/docs/articles/concepts/resolver-and-wof.mdx
+++ b/docs/articles/concepts/resolver-and-wof.mdx
@@ -91,13 +91,13 @@ Mailwoman's resolver drops any candidate whose coordinates are `(0, 0)` from res
 
 ## What the resolver does not do
 
-- **Address-point lookup.** Given `"350 5th Ave, New York"`, the resolver returns the centroid of New York City, not the precise rooftop of 350 5th Ave. Rooftop-precision geocoding requires a different dataset (commercial address-point databases) and is out of scope for the open Mailwoman pipeline.
+- **Rooftop precision outside the covered registers.** Where an address-point shard exists, the resolver returns the exact address point, not a locality centroid, at 1 m reported uncertainty: the US situs layer (~125M points, built from NAD and OpenAddresses) and the French BAN register (26M points) are the two live shards today. Outside that coverage, the ladder falls back to interpolation, then a street or admin centroid. [How Mailwoman resolves a place](./how-mailwoman-resolves-a-place.mdx) walks the full precision ladder and what each rung promises.
 - **Reverse geocoding.** "What place is at coordinates (40.7128, -74.0060)?" is a separate query shape. The R\*Tree index supports it but the public Mailwoman API does not expose a reverse-geocode endpoint today.
 - **Routing.** "How do I get from A to B?" is a graph problem on the road network, not a gazetteer query.
 
 ## Where this lives in the code
 
-- **Server resolver:** `resolver-wof-sqlite/` (uses `better-sqlite3`)
+- **Server resolver:** `resolver-wof-sqlite/` (uses `node:sqlite`)
 - **Browser resolver:** `resolver-wof-wasm/` (uses `@sqlite.org/sqlite-wasm`)
 - **Slim builder:** `corpus/scripts/build-wof-slim.ts`
 - **Demo integration:** `docs/src/pages/demo/index.tsx` (the cascade + the `FailureDiagnostic` panel)
@@ -106,4 +106,5 @@ Mailwoman's resolver drops any candidate whose coordinates are `(0, 0)` from res
 ## See also
 
 - [What is an address?](../understanding/the-problem/what-is-an-address.mdx) — the components the resolver receives
+- [How Mailwoman resolves a place](./how-mailwoman-resolves-a-place.mdx) — the full walk from parsed components to a coordinate, including the precision ladder
 - [How it works now](../understanding/our-approach/how-it-works-now.mdx) — where the resolver fits in the live demo flow

--- a/docs/articles/concepts/tokenization.mdx
+++ b/docs/articles/concepts/tokenization.mdx
@@ -41,20 +41,16 @@ The neural classifier works with **subwords**. Instead of treating "New" and "Ne
 
 Why subwords? Two reasons:
 
-1. **Vocabulary size is bounded.** A word-level tokenizer trained on a multi-million-row corpus needs a vocabulary of millions of words. A subword tokenizer hits the same coverage with a 16,000-piece vocabulary by sharing pieces between words.
+1. **Vocabulary size is bounded.** A word-level tokenizer trained on a multi-million-row corpus needs a vocabulary of millions of words. A subword tokenizer hits the same coverage with a 73,143-piece vocabulary by sharing pieces between words.
 2. **Unseen words are handled gracefully.** "Pennsyvana" (a typo for "Pennsylvania") would be a complete unknown to a word-level tokenizer. A subword tokenizer breaks it into pieces it has seen — `["▁Penn", "syv", "ana"]` — and the model can still extract meaning.
 
 Mailwoman uses [SentencePiece](https://github.com/google/sentencepiece), an open-source subword tokenizer library originally from Google. The specific algorithm is **unigram language model** tokenization, which tends to produce slightly more linguistically-aware splits than the BPE alternative.
 
-Mailwoman's tokenizer was trained from scratch on the corpus. The current shipping version is **v0.1.0** (16K vocab); a new **A1 tokenizer** (48K vocab, multi-script) is validated and waiting for the CE-only classifier train to complete.
+Mailwoman's tokenizer started from a from-scratch SentencePiece unigram build. Since then it has grown through targeted vocabulary splices rather than full retrains: new diacritic-bearing pieces are trained on the affected locale's own corpus, then spliced into the existing vocabulary. Every spliced piece contains a codepoint absent from the base languages' text, so it can never match an English or French span; splicing in new coverage can't silently change how an already-shipping locale tokenizes. The added embedding rows are mean-initialized from their old-tokenizer constituents before a short fine-tune gives them real gradient.
 
-| Version           | Vocab  | Character coverage | Training data                                             | Status                                                         |
-| ----------------- | ------ | ------------------ | --------------------------------------------------------- | -------------------------------------------------------------- |
-| v0.1.0 (shipping) | 16,000 | 99.95%             | 1M US + 1M FR from `corpus-v0.1.1`                        | In production                                                  |
-| A1 (validated)    | 48,000 | 99.99%             | 500K US + 500K FR + 73K multi-script from `corpus-v0.4.0` | Trained; byte-fallback 36.7%→18.2%; pending classifier weights |
+The **shipping tokenizer is v0.9.0-multisplice** (73,143 pieces, byte fallback on): the base vocabulary plus a French diacritic splice (v0.8.0-fr-nsplice, +2,406 pieces) and a further splice adding Czech, Polish, Slovak, and Slovenian diacritic coverage among other locales ([#884](https://github.com/sister-software/mailwoman/issues/884), shipped v5.1.0). See [Which languages Mailwoman handles well](./language-support.mdx) for the fertility story that made the splice necessary; French's accent fragmentation is the canonical example.
 
 - **Special tokens:** `[UNK]` (unknown), `[PAD]` (padding), `[BOS]` / `[EOS]` (beginning/end of sequence)
-- **A1 additions:** 2,110 user-defined symbols (US state codes, postcode literal formats, country abbreviations) to prevent byte-fallback on known address tokens. See [`tokenizer-a0-baseline.md`](../plan/reference/tokenizer-a0-baseline.mdx) for the A0→A1 measurement story.
 
 ```mermaid
 flowchart LR
@@ -103,9 +99,9 @@ The byte fallback comes from SentencePiece's `byte_fallback: true` setting in th
 
 ## Where this lives in the code
 
-- **Word tokenizer (rules):** the v1 core, around `core/tokenize/`
-- **Subword tokenizer (neural):** `neural/tokenizer.ts` + the trained model at `packages/neural-weights-en-us/tokenizer.model`
-- **Training:** `corpus-python/scripts/train_tokenizer.py` (run once, output committed to `/data/models/tokenizer/v0.1.0/`)
+- **Word tokenizer (rules):** the v1 core, around `core/tokenization/`
+- **Subword tokenizer (neural):** `neural/tokenizer.ts` + the trained model at `neural-weights-en-us/tokenizer.model`
+- **Training:** `corpus-python/src/mailwoman_train/tokenizer_splice.py` (the shipping tokenizer is built by splicing new diacritic coverage into the existing vocab, not a full retrain); output lives under `$MAILWOMAN_DATA_ROOT/models/tokenizer/v0.9.0-multisplice/`
 
 ## See it in action
 

--- a/docs/articles/concepts/training-pipeline.mdx
+++ b/docs/articles/concepts/training-pipeline.mdx
@@ -152,5 +152,5 @@ Both packages (en-us, fr-fr) get bumped to a new npm version (v3.0.0 for the Tie
 ## See also
 
 - [Corpus construction](./corpus-construction.mdx) — Stages 1–4 in more detail
-- [Neural classification](./neural-classification.mdx) — what the model itself is
+- [How the model reasons](./how-the-model-reasons.mdx) — what the trained model actually does with a token
 - [ONNX runtime](./onnx-runtime.mdx) — what happens after ship

--- a/docs/articles/understanding/our-approach/how-it-will-work.mdx
+++ b/docs/articles/understanding/our-approach/how-it-will-work.mdx
@@ -14,6 +14,12 @@ tags:
 
 # How it will work — the near future
 
+:::info[Historical planning document]
+
+This is a roadmap snapshot, current as of May 2026. For current state, see [the scope declaration](../../plan/SCOPE.mdx), [How Mailwoman parses an address](../../concepts/how-mailwoman-parses-an-address.mdx), and [How Mailwoman resolves a place](../../concepts/how-mailwoman-resolves-a-place.mdx).
+
+:::
+
 This article describes where Mailwoman is heading. The work is tracked in GitHub issues and the [`plan/`](../../plan/README.mdx) directory. Status is current as of May 2026.
 
 ## What shipped: v0.4.0 through v0.5.0 scaffolding

--- a/docs/articles/understanding/our-approach/why-a-neural-parser.mdx
+++ b/docs/articles/understanding/our-approach/why-a-neural-parser.mdx
@@ -152,7 +152,7 @@ The direction is not in question. The question is whether the current training a
 ## See also
 
 - [How it works now](./how-it-works-now.mdx) — the current rule + neural hybrid in detail
-- [Neural classification](../../concepts/neural-classification.mdx) — the transformer architecture deep dive
+- [How the model reasons](../../concepts/how-the-model-reasons.mdx) — the transformer architecture deep dive
 - [The knowledge ladder](./the-knowledge-ladder.mdx) — the staged pipeline decomposition
 - [The tokenization tautology](../why-its-hard/the-tokenization-tautology.mdx) — why rules hit a ceiling
 - [The case for simple geocoders](../alternatives/the-case-for-simple-geocoders.mdx) — the strongest argument for the alternative

--- a/mailwoman/api-engine.ts
+++ b/mailwoman/api-engine.ts
@@ -4,11 +4,12 @@
  * @author Teffen Ellis, et al.
  *
  *   The wired {@link MailwomanAPIEngine} for `mailwoman serve` (Phase 4b, the Hono cutover). Ports the
- *   former express `server/`'s handler bodies — `GeocodeRouter.getDeps` + its `/api/geocode`,
- *   `/api/batch`, `/api/resolve-tree`, `/api/reload` handlers, `AddressRouter`'s `/parse` handler, and
- *   `HealthRouter`'s `/health` data block — onto the engine-agnostic `@mailwoman/api` contract
- *   (`/v1/parse`, `/v1/geocode`, `/v1/batch`, `/v1/resolve`, `/v1/reload`). `mailwoman/server/` is
- *   deleted (Task 2) — this file is its sole successor, a fresh port rather than a thin wrapper.
+ *   former express `server/`'s handler bodies — `GeocodeRouter.getDeps` + its retired `/api/geocode`,
+ *   `/api/batch`, `/api/resolve-tree`, `/api/reload` handlers, `AddressRouter`'s retired `/parse`
+ *   handler, and `HealthRouter`'s `/health` data block — onto the engine-agnostic `@mailwoman/api`
+ *   contract's live routes (`/v1/parse`, `/v1/geocode`, `/v1/batch`, `/v1/resolve`, `/v1/reload`).
+ *   `mailwoman/server/` is deleted (Task 2) — this file is its sole successor, a fresh port rather
+ *   than a thin wrapper.
  *
  *   `createServeEngine` builds the shared stack ONCE, at boot, instead of express's lazy
  *   first-request memoized promise — the CLI's `serve` command awaits it before listening, so a


### PR DESCRIPTION
Phase 2f of the documentation-architecture cleanup: the six stale-claim receipts accumulated across Phase 2 reviews, each fixed against verified current ground truth.

1. **`concepts/tokenization.mdx`** — 16K-vocab/v0.1.0 claims → the shipped 6.1.0 card (vocab 73,143, tokenizer `v0.9.0-multisplice`), plus stale code paths corrected. Per the operator ruling, docs cite the shipped npm model; review confirmed exact match against `model-card.json` and `npm view` (6.1.0).
2. **`concepts/resolver-and-wof.mdx`** (18 inbound) — surgical: `better-sqlite3` → `node:sqlite` (per actual imports); the "rooftop out of scope" claim — contradicted live in two prior reviews — replaced with the real coverage-scoped rooftop story, cross-linked with the resolution flagship.
3. **`understanding/our-approach/how-it-will-work.mdx`** — dated historical-record banner (ARCHITECTURE.mdx pattern), body untouched.
4. **Three anchor repoints** — links that promised "the transformer architecture deep dive" but landed on the neural-classification transition stub now point at `how-the-model-reasons.mdx`.
5. **`mailwoman/api-engine.ts`** — comment-only: the retired `/api/batch` → live `/v1/batch` mapping made unambiguous.
6. Do-not-touch list respected — diff is exactly the seven named files.

Review: SPEC pass on all six receipts (independently re-verified against model card, source imports, and link targets); quality approved, no fix round. Build green under `onBrokenLinks: "throw"`.

Follow-ups already queued in the 6.1.0 numbers-refresh task: the parse flagship's now-stale vocab/params, and `why-a-neural-parser.mdx`'s own dated roadmap section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)