### PR TITLE
docs: Phase 3 — reference and contributor boundaries

### DIFF
--- a/docs/articles/concepts/fst-gazetteer-prior.mdx
+++ b/docs/articles/concepts/fst-gazetteer-prior.mdx
@@ -252,6 +252,6 @@ import { FSTWalker } from "@site/src/components/FSTWalker/FSTWalker"
 - [FST gazetteer LM (reference)](../plan/reference/FST_GAZETTEER_LM.mdx) — implementation phases, design decisions, locale strategy, size estimates
 - [Resolver and Who's On First](./resolver-and-wof.mdx) — the parser/resolver split and the WOF SQLite distribution this is built from
 - [Importance vs population](./importance-vs-population.mdx) — why Wikipedia importance, not population, is the right weighting signal
-- [Neural classification](./neural-classification.mdx) — the transformer + Viterbi decoder the prior plugs into
+- [How the model reasons](./how-the-model-reasons.mdx) — the transformer + Viterbi decoder the prior plugs into
 - [BIO labels](./bio-labels.mdx) — the per-token label space the prior biases
 - [WOF data pipeline](./wof-data-pipeline.mdx) — how the unified SQLite the FST is built from comes together

--- a/docs/articles/concepts/geocode-first-record-matching.mdx
+++ b/docs/articles/concepts/geocode-first-record-matching.mdx
@@ -268,3 +268,10 @@ owns the geocoder, calibrates both, and then feeds that calibrated location,
 uncertainty and all, into a Fellegi-Sunter matcher as a quality-weighted
 feature. That's either a moat or a warning, and the only way to learn which is to
 build it and grade it against real clinic data. That's the work.
+
+## See also
+
+- [Record-matcher data catalog](./record-matcher-data-catalog.md) — what each source dataset is, where it lives, and how its columns map into the matcher
+- [Record-matcher sources (reference)](../plan/reference/record-matcher-sources.md) — the machine-readable source registry the catalog narrates
+- [Choosing the dedup yardstick](./dedup-entity-truth.mdx) — why org-name, not NPI, grades the matcher's decision surface
+- [Case study: cross-registry linking](./cross-registry-linking.mdx) — the same doctor in two federal registries, matched through the geocode

--- a/docs/articles/concepts/rule-based-classifiers.mdx
+++ b/docs/articles/concepts/rule-based-classifiers.mdx
@@ -119,7 +119,7 @@ Notes:
 - **Multi-word things.** N-gram sweeps work for 2- and 3-token cases. "Saint Petersburg, FL" is fine; "Mt Tabor Forest Preserve" (a 4-token venue) is harder.
 - **Negative evidence.** Rules can say "this looks like X". They cannot easily say "this looks like X but only in the absence of Y".
 
-These weaknesses are the motivation for the neural classifier. See [Neural classification](./neural-classification.mdx).
+These weaknesses are the motivation for the neural classifier. See [How the model reasons](./how-the-model-reasons.mdx).
 
 ## How rule classifiers and the neural classifier coexist
 
@@ -145,5 +145,5 @@ This is the Ship-of-Theseus pattern. The neural classifier earns each component 
 ## See also
 
 - [What is an address?](../understanding/the-problem/what-is-an-address.mdx) — the components rule classifiers label
-- [Neural classification](./neural-classification.mdx) — the v2 alternative
+- [How the model reasons](./how-the-model-reasons.mdx) — the learned alternative, emissions through decode
 - [How it works now](../understanding/our-approach/how-it-works-now.mdx) — the hybrid in action

--- a/docs/articles/concepts/tokenization.mdx
+++ b/docs/articles/concepts/tokenization.mdx
@@ -118,4 +118,4 @@ Expand the **Subword tokens & pipeline stages** section to see per-stage word to
 
 - [What is an address?](../understanding/the-problem/what-is-an-address.mdx) — what tokens get labelled
 - [BIO labels](./bio-labels.mdx) — how subword-level labels become character-level spans
-- [Neural classification](./neural-classification.mdx) — what the model does with tokens
+- [How the model reasons](./how-the-model-reasons.mdx) — what the model does with tokens

--- a/docs/articles/concepts/wof-data-pipeline.mdx
+++ b/docs/articles/concepts/wof-data-pipeline.mdx
@@ -5,7 +5,7 @@ title: WOF data pipeline — sync, prepare, resolve
 
 # WOF data pipeline — sync, prepare, resolve
 
-Who's On First (WOF) is the gazetteer underneath Mailwoman's Stage 6 resolver. It provides place IDs, parent-child chains, placetypes, and multilingual name variants for every admin boundary on Earth. This article documents how the Mailwoman codebase ingests, normalises, and serves that data — including what's complete, what's stalled, and where the reconciler integration will eventually plug in.
+Who's On First (WOF) is the gazetteer underneath Mailwoman's Stage 6 resolver. It provides place IDs, parent-child chains, placetypes, and multilingual name variants for every admin boundary on Earth. This article documents how the Mailwoman codebase ingests, normalises, and serves that data — layer by layer, from raw GeoJSON to the queryable SQLite artifacts.
 
 If you've read [Resolver and Who's On First](./resolver-and-wof.mdx) for the runtime story, this is the build-time companion: how the data gets from raw GeoJSON on GitHub to a queryable per-placetype SQLite DB.
 
@@ -26,16 +26,11 @@ WOF GitHub repos                     Per-placetype SQLite DBs
 │ • Placetype     │     │ • glob *.geojson │
 │   .prepare()    │     │ • Piscina batch  │
 └─────────────────┘     │ • pluckSpec      │
-                        │ • write to DB    │ ← stalled here
+                        │ • write to DB    │
                         └──────────────────┘
 ```
 
-**Status (updated 2026-05-26):**
-
-- **sync** works end-to-end. Clones WOF repos, filters via `--repos`, calls `Placetype.prepare()` to load the hierarchy.
-- **prepare** writes to per-placetype SQLite mini-DBs via `PlacetypeDataSource`. The Redis target was removed.
-- **build-unified-wof** ([#176](https://github.com/sister-software/mailwoman/pull/176)) — standalone script that reads 293K GeoJSON files from cloned repos and produces a unified SQLite (spr, names, concordances, place_population tables) in 43 seconds. Uses `spliterator`'s `asyncParallelIterator` for bounded-concurrency file reads. This unified SQLite replaces the geocode.earth pre-built download as the FST builder and resolver input.
-- **build-importance** — post-processing step that downloads Nominatim's `wikimedia-importance.csv.gz`, joins through WOF concordances, and writes a `place_importance` table into the unified SQLite.
+**Status (updated 2026-07-14):** every stage below shipped and matured — the unified admin gazetteer is now built, verified, and sealed end-to-end by the [`mailwoman gazetteer` CLI](https://github.com/sister-software/mailwoman/tree/main/mailwoman/commands/gazetteer) (`gazetteer build admin`: WOF ingest → Overture divisions → GeoNames folds → enrich → FTS → verify gate → seal), which absorbed the standalone `build-unified-wof` and `build-importance` scripts described in this article's history.
 
 ## Layer by layer
 

--- a/docs/articles/documentation-map.mdx
+++ b/docs/articles/documentation-map.mdx
@@ -13,7 +13,7 @@ The switcher at the top of every docs page has nine sections. Here's what each o
 - **Start here** — the front door: install, your first parse, current status, releases, and how to contribute.
 - **Use Mailwoman** — task-oriented recipes: batch geocoding, CSV ingest, timezone lookups, and the rest.
 - **Understand** — the why and how: the problem Mailwoman solves, why address parsing is hard, the alternatives, our approach, and concept deep dives.
-- **Reference** — the contracts a build depends on: [the current scope declaration](./plan/SCOPE.mdx), [the `ComponentTag` schema](./plan/reference/SCHEMA.mdx), the runtime pipeline stages, and the other lookup docs kept in sync with the code.
+- **Reference** — the contracts a build depends on: [Current scope & roadmap](./plan/SCOPE.mdx), [the `ComponentTag` schema](./plan/reference/SCHEMA.mdx), the runtime pipeline stages, and the other lookup docs kept in sync with the code. The roadmap question routes here — the Archive's plan directory is history, not the plan of record.
 - **Contribute** — runbooks for working on the model, the training data, and operations, if you're extending Mailwoman itself.
 - **Archive** — closed engineering records: dated plans, phase-by-phase build history, and superseded reference docs, kept for provenance.
 - **Eval reports** — per-model score reports and parity scorecards.

--- a/docs/articles/plan/2026-06-29-joint-consistency-resolution.mdx
+++ b/docs/articles/plan/2026-06-29-joint-consistency-resolution.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 60
 title: Joint-consistency resolution — reading an address through the hermeneutic circle
+status: active-decision
 tags:
   - plan
   - architecture

--- a/docs/articles/plan/2026-07-03-exonym-prominence.mdx
+++ b/docs/articles/plan/2026-07-03-exonym-prominence.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Design note: exonym prominence in the exact tier (the Åbo problem)"
 description: The name-exact vs alias-exact sub-tier meets bilingual official names — three candidate rules, one recommendation, no implementation yet.
+status: active-decision
 ---
 
 # Exonym prominence in the exact tier

--- a/docs/articles/plan/SCOPE.mdx
+++ b/docs/articles/plan/SCOPE.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: Scope — what mailwoman is now
+sidebar_label: Current scope & roadmap
 description: The current scope declaration — locale tiers, the two workstreams, the standing invariants, and where the live roadmap actually lives.
 ---
 

--- a/docs/articles/status.mdx
+++ b/docs/articles/status.mdx
@@ -6,7 +6,10 @@ description: What ships today, what's behind a flag, and what's still experiment
 
 # Status
 
-This page is the single source of truth for what works in Mailwoman right now.
+This page is the single source of truth for what works in Mailwoman right now. For where the
+project is going — locale tiers, workstreams, standing invariants — see
+[Current scope & roadmap](./plan/SCOPE.mdx); the Archive's plan directory is history, not the
+roadmap.
 
 :::info[Verified as of 2026-07-14 — release 6.1.0]
 The current npm release is **6.1.0** (`npm view mailwoman version`; `git tag` confirms `v6.1.0`), a

--- a/docs/articles/understanding/our-approach/how-it-works-now.mdx
+++ b/docs/articles/understanding/our-approach/how-it-works-now.mdx
@@ -76,7 +76,7 @@ Two kinds of classifier run in parallel:
 
 **Rule classifiers** (from Mailwoman v1): `house_number`, `postcode`, `whos_on_first`, `street_prefix`, `street_suffix`, and others. Deterministic, dictionary/regex-based. Correct for the bounded cases they cover.
 
-**Neural classifier**: a 9-million-parameter encoder-only transformer trained from scratch on Mailwoman's corpus. Emits per-token BIO labels using a 21-class vocabulary (country, region, locality, postcode, street, house_number, venue, and associated `I-` and `B-` variants). See [Neural classification](../../concepts/neural-classification.mdx).
+**Neural classifier**: a 9-million-parameter encoder-only transformer trained from scratch on Mailwoman's corpus. Emits per-token BIO labels using a 21-class vocabulary (country, region, locality, postcode, street, house_number, venue, and associated `I-` and `B-` variants). See [How the model reasons](../../concepts/how-the-model-reasons.mdx).
 
 The v0.5.0 classifier (Thread C-s) adds two architectural changes gated behind config flags:
 

--- a/docs/articles/understanding/our-approach/the-staged-pipeline.mdx
+++ b/docs/articles/understanding/our-approach/the-staged-pipeline.mdx
@@ -64,7 +64,7 @@ The interfaces between stages matter as much as the stages themselves. Each hand
 
 ## Stage 3 — Token classify (transformer encoder)
 
-**What it does.** The current Mailwoman model. Subword tokenizer + 6-layer transformer encoder + 21 BIO output head per token. Detailed in [Neural classification](../../concepts/neural-classification.mdx).
+**What it does.** The current Mailwoman model. Subword tokenizer + 6-layer transformer encoder + 21 BIO output head per token. Detailed in [How the model reasons](../../concepts/how-the-model-reasons.mdx).
 
 **Failures it owns.**
 

--- a/docs/articles/understanding/why-its-hard/addresses-that-break-geocoders.mdx
+++ b/docs/articles/understanding/why-its-hard/addresses-that-break-geocoders.mdx
@@ -116,7 +116,7 @@ Quebec Grill, Quebec City
 
 What breaks: a dictionary-based locality classifier (the standard Pelias approach) fires on `"London"` in `"London Drugs"` and on `"Paris"` in `"Paris Cafe"`. Now the parser has two locality proposals — one for the venue's name and one for the actual locality — and the solver may pick the wrong one.
 
-This is the bitter-lesson case for address parsing. A rule classifier cannot tell the difference; it needs context. A transformer encoder ([Neural classification](../../concepts/neural-classification.mdx)) sees the whole sentence and can learn that `"Paris"` followed by `"Cafe"` is part of a `venue` span, while `"Paris"` preceded by a comma and followed by `"Ontario"` is a `locality` span. The "Buffalo, NY / Buffalo Wild Wings, Buffalo, NY" pair is in Mailwoman's adversarial eval set for exactly this reason.
+This is the bitter-lesson case for address parsing. A rule classifier cannot tell the difference; it needs context. A transformer encoder ([How the model reasons](../../concepts/how-the-model-reasons.mdx)) sees the whole sentence and can learn that `"Paris"` followed by `"Cafe"` is part of a `venue` span, while `"Paris"` preceded by a comma and followed by `"Ontario"` is a `locality` span. The "Buffalo, NY / Buffalo Wild Wings, Buffalo, NY" pair is in Mailwoman's adversarial eval set for exactly this reason.
 
 Four field specimens, contributed by a conference attendee in Paris (July 2026) — all real venues, all with the toponym pointing the wrong way:
 
@@ -263,5 +263,5 @@ A geocoder that handles half of these well is already useful. A geocoder that ha
 
 - [What is an address?](../the-problem/what-is-an-address.mdx) — the data model these failure modes operate against
 - [Rule-based classifiers](../../concepts/rule-based-classifiers.mdx) — what regex-and-dictionary approaches can and cannot do
-- [Neural classification](../../concepts/neural-classification.mdx) — why a transformer encoder helps with the context-dependent cases
+- [How the model reasons](../../concepts/how-the-model-reasons.mdx) — why a transformer encoder helps with the context-dependent cases
 - [Resolver and Who's On First](../../concepts/resolver-and-wof.mdx) — how the candidate-search side handles ambiguity

--- a/docs/src/theme/DocItem/Content/index.tsx
+++ b/docs/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,108 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Wraps `@theme-original/DocItem/Content` to mount the record-class chrome (docs-architecture
+ *   cleanup, Phase 3) above every doc title, so a reader can tell a contract from an active
+ *   decision from a historical record without the page author hand-editing banners:
+ *
+ *   - Docs rendered from the `archive` sidebar (see sidebars.ts) get an automatic "Historical
+ *     record" banner, dated when a YYYY-MM-DD date is derivable from the doc id
+ *     (`plan/2026-06-14-…`) or a `date:` frontmatter field.
+ *   - Docs with a `status:` frontmatter field from the maintained vocabulary (`active-decision`,
+ *     `superseded` — the content-model table in
+ *     docs/superpowers/plans/2026-07-14-documentation-architecture-cleanup.md) render a status
+ *     line; an optional `superseded-by:` field (a site-relative URL, e.g. `/docs/plan/SCOPE`)
+ *     renders as a link when present. Free-text `status:` values (some dated eval reports carry
+ *     them, and evals/retrospectives are a delegated workstream) deliberately render nothing.
+ *
+ *   Hand-written banners on individual pages (ARCHITECTURE.mdx, how-it-will-work.mdx, …) carry
+ *   page specifics and stay in the page body; this chrome only marks the record class, stays a
+ *   couple of lines tall, and inherits both color themes through Infima's `alert` classes.
+ */
+
+import Link from "@docusaurus/Link"
+import { useDoc, useDocsSidebar } from "@docusaurus/plugin-content-docs/client"
+import Content from "@theme-original/DocItem/Content"
+import type { Props } from "@theme/DocItem/Content"
+import clsx from "clsx"
+import type { ReactNode } from "react"
+
+import styles from "./styles.module.css"
+
+const ISO_DATE_PATTERN = /(\d{4}-\d{2}-\d{2})/
+
+/** Display labels for the `status:` frontmatter vocabulary. Unknown values render no chrome. */
+const STATUS_LABELS: Record<string, string> = {
+	"active-decision": "Active decision",
+	superseded: "Superseded",
+}
+
+/** Taglines rendered after the status label. */
+const STATUS_TAGLINES: Record<string, string> = {
+	"active-decision": "An open design decision — current until a successor supersedes it.",
+}
+
+/**
+ * The doc's display date: an explicit `date:` frontmatter field wins, else the dated-id filename convention
+ * (`plan/2026-06-14-arbitration-layer-spec`).
+ */
+function useRecordDate(): string | undefined {
+	const { metadata, frontMatter } = useDoc()
+	// `DocFrontMatter` types only the Docusaurus-owned fields; the record-class fields are
+	// site-specific pass-throughs, so they're read as `unknown` and narrowed.
+	const explicit: unknown = (frontMatter as Record<string, unknown>).date
+
+	// YAML parses an unquoted `date: 2026-06-14` into a Date object, a quoted one into a string.
+	if (explicit instanceof Date) return explicit.toISOString().slice(0, 10)
+
+	if (typeof explicit === "string" && ISO_DATE_PATTERN.test(explicit)) return explicit
+
+	return ISO_DATE_PATTERN.exec(metadata.id)?.[1]
+}
+
+function DocRecordChrome(): ReactNode {
+	const { frontMatter } = useDoc()
+	const sidebar = useDocsSidebar()
+	const date = useRecordDate()
+
+	// Archive-sidebar docs are historical records by construction — no frontmatter required.
+	if (sidebar?.name === "archive") {
+		return (
+			<aside className={clsx("alert", "alert--warning", styles.recordChrome)} role="note">
+				<strong>Historical record{date ? ` · ${date}` : ""}.</strong> Preserved as written, not maintained. For the
+				current state, see <Link to="/docs/plan/SCOPE">Current scope &amp; roadmap</Link>.
+			</aside>
+		)
+	}
+
+	const status: unknown = (frontMatter as Record<string, unknown>).status
+
+	if (typeof status !== "string" || !(status in STATUS_LABELS)) return null
+
+	const supersededBy: unknown = (frontMatter as Record<string, unknown>)["superseded-by"]
+	const tagline = STATUS_TAGLINES[status]
+
+	return (
+		<aside className={clsx("alert", "alert--info", styles.recordChrome)} role="note">
+			<strong>{STATUS_LABELS[status]}.</strong>
+			{tagline ? <> {tagline}</> : null}
+			{typeof supersededBy === "string" && supersededBy.length > 0 ? (
+				<>
+					{" "}
+					Superseded by <Link to={supersededBy}>{supersededBy}</Link>.
+				</>
+			) : null}
+		</aside>
+	)
+}
+
+export default function ContentWrapper(props: Props): ReactNode {
+	return (
+		<>
+			<DocRecordChrome />
+			<Content {...props} />
+		</>
+	)
+}

--- a/docs/src/theme/DocItem/Content/styles.module.css
+++ b/docs/src/theme/DocItem/Content/styles.module.css
@@ -1,0 +1,14 @@
+/**
+ * Record-class chrome (see ./index.tsx). The Infima `alert alert--warning|info` classes carry the
+ * light/dark palette; this module only slims the banner down from admonition scale to chrome
+ * scale — smaller type, tighter padding, no shadow — so it reads as page metadata, not content.
+ */
+
+.recordChrome {
+	--ifm-alert-padding-vertical: 0.5rem;
+	--ifm-alert-padding-horizontal: 0.75rem;
+	--ifm-alert-shadow: none;
+
+	margin-bottom: 1.25rem;
+	font-size: 0.875rem;
+}


### PR DESCRIPTION
Phase 3 of the documentation-architecture cleanup. Exit criterion — a reader can distinguish an API/schema contract, an active decision, and a historical record from page chrome within one screen — verified met in review with per-class screenshots.

## What changed

- **Automatic status chrome** (`docs/src/theme/DocItem/Content/` wrapper, swizzle-safe): every doc in the Archive sidebar renders a dated "Historical record" banner with zero per-page edits; pages carrying `status:` frontmatter from the maintained vocabulary render a status line (`active-decision` now live on the two open design specs; `superseded`/`superseded-by` implemented for the docs policy to use). Free-text statuses on delegated eval pages render nothing by construction. Light + dark verified; hand-bannered pages don't double-stack.
- **Generated contracts**: audit confirmed #1086 already retired the hand-copied OpenAPI yamls in favor of prebuild emission from the compiled surface CLIs — verified end-to-end (zero tracked spec files, emission works) and deliberately left alone.
- **"Current scope & roadmap"** is now an explicit entry: `SCOPE.mdx` leads Reference under that label, and the docs map + status page route the roadmap question there instead of the plan directory.
- **Three exit-report receipts**: `wof-data-pipeline.mdx`'s "stalled" status block replaced with the gazetteer-CLI reality; the record-matching flagship got its See-also cluster; the last 8 depth-promising links into the `neural-classification` stub repointed.

## Review

SPEC pass on all items (opus review: TSX read line-by-line, screenshots inspected, build re-run green, repoint grep clean). Three logged follow-ups, all adjudicated acceptable-with-note: the component's pinned SCOPE link, the not-yet-exercised `superseded` path, undated banners on archive pages without derivable dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)