### PR TITLE
feat(neural-web): browser country-lexicon channel (#1104)

### DIFF
--- a/neural-web/loader.ts
+++ b/neural-web/loader.ts
@@ -15,10 +15,12 @@
 
 import {
 	type AnchorLookup,
+	type CountryLexicon,
 	type GazetteerLexicon,
 	MailwomanTokenizer,
 	NeuralAddressClassifier,
 	type NeuralAddressClassifierConfig,
+	parseCountryLexicon,
 	parseGazetteerLexicon,
 	PostcodeBinaryResolver,
 } from "@mailwoman/neural/browser"
@@ -79,6 +81,15 @@ export interface LoadFromURLsOptions {
 	 * Pass `null` to skip the fetch entirely.
 	 */
 	gazetteerLexiconURL?: string | null
+	/**
+	 * URL to the country-surface lexicon JSON (`country-surface-lexicon-v1.json`, #1104 — the in-repo source is
+	 * `data/gazetteer/country-surface-lexicon-v1.json`). Country-channel models (v6.2.0+, whose ONNX declares the
+	 * `country_features`/`country_confidence` inputs) REQUIRE this clue at inference — same zero-fill trap as the
+	 * gazetteer. Defaults to `country-surface-lexicon-v1.json` next to `modelURL`; a fetch miss does NOT throw, but a
+	 * country-trained model with no lexicon runs country-off (loud `console.error`, structurally valid). Pass `null` to
+	 * skip.
+	 */
+	countryLexiconURL?: string | null
 	/**
 	 * Channel choreography (#464, v0.9.13 postcode fix): zero the gazetteer clue on pieces adjacent to a postcode-anchor
 	 * hit. Defaults to TRUE — it pairs with the train-time half on every gazetteer-trained bundle (v4.2.0+) and is inert
@@ -146,6 +157,14 @@ export function defaultGazetteerLexiconURL(modelURL: string): string {
 }
 
 /**
+ * Default location of the country-surface lexicon (#1104): `country-surface-lexicon-v1.json` as a sibling of the model
+ * file — the release bundle lays it out beside anchor-lexicon-v1.json.
+ */
+export function defaultCountryLexiconURL(modelURL: string): string {
+	return modelURL.replace(/[^/]*$/, "country-surface-lexicon-v1.json")
+}
+
+/**
  * Convenience factory: fetch model + tokenizer, build the runner, return a classifier. The tokenizer is loaded via the
  * existing `loadFromBase64` path so this file shares zero Node-only code with `@mailwoman/neural/classifier`'s
  * `loadFromWeights`.
@@ -164,12 +183,15 @@ export async function loadNeuralClassifierFromURLs(opts: LoadFromURLsOptions): P
 
 	const gazetteerLexiconURL =
 		opts.gazetteerLexiconURL === null ? null : (opts.gazetteerLexiconURL ?? defaultGazetteerLexiconURL(opts.modelURL))
+	const countryLexiconURL =
+		opts.countryLexiconURL === null ? null : (opts.countryLexiconURL ?? defaultCountryLexiconURL(opts.modelURL))
 
-	const [modelBytes, tokenizerBytes, labels, gazetteerLexicon] = await Promise.all([
+	const [modelBytes, tokenizerBytes, labels, gazetteerLexicon, countryLexicon] = await Promise.all([
 		fetchBytes(opts.modelURL, fetchImpl),
 		fetchBytes(opts.tokenizerURL, fetchImpl),
 		opts.modelCardURL ? fetchLabelsFromModelCard(opts.modelCardURL, fetchImpl) : Promise.resolve(null),
 		gazetteerLexiconURL ? fetchGazetteerLexicon(gazetteerLexiconURL, fetchImpl) : Promise.resolve(null),
+		countryLexiconURL ? fetchCountryLexicon(countryLexiconURL, fetchImpl) : Promise.resolve(null),
 	])
 
 	const [tokenizer, runner, postcodeAnchorLookup] = await Promise.all([
@@ -191,6 +213,7 @@ export async function loadNeuralClassifierFromURLs(opts: LoadFromURLsOptions): P
 		...(labels ? { labels } : {}),
 		...(postcodeAnchorLookup ? { postcodeAnchorLookup } : {}),
 		...(gazetteerLexicon ? { gazetteerLexicon } : {}),
+		...(countryLexicon ? { countryLexicon } : {}),
 		suppressGazetteerNearPostcode: opts.suppressGazetteerNearPostcode ?? true,
 		...(conventions ? { addressSystemConventions: conventions } : {}),
 		bridgePunctuationGaps: opts.bridgePunctuationGaps ?? true,
@@ -199,6 +222,8 @@ export async function loadNeuralClassifierFromURLs(opts: LoadFromURLsOptions): P
 	warnOnUnfedTrainedChannels(runner, {
 		gazetteerLexicon,
 		gazetteerLexiconURL,
+		countryLexicon,
+		countryLexiconURL,
 		postcodeAnchorLookup,
 	})
 
@@ -217,12 +242,26 @@ function warnOnUnfedTrainedChannels(
 	fed: {
 		gazetteerLexicon: GazetteerLexicon | null
 		gazetteerLexiconURL: string | null
+		countryLexicon: CountryLexicon | null
+		countryLexiconURL: string | null
 		postcodeAnchorLookup: AnchorLookup | undefined
 	}
 ): void {
 	const inputNames = runner.inputNames
 
 	if (!inputNames) return
+
+	if (inputNames.includes("country_features") && !fed.countryLexicon) {
+		console.error(
+			"[mailwoman/neural-web] This model is country-channel-trained (its ONNX declares `country_features`) " +
+				"but no country lexicon was loaded" +
+				(fed.countryLexiconURL
+					? ` — \`country-surface-lexicon-v1.json\` could not be fetched from ${fed.countryLexiconURL}. ` +
+						"Upload the lexicon next to model.onnx, or pass `countryLexiconURL` explicitly."
+					: " — `countryLexiconURL` was explicitly disabled (null). ") +
+				" Running with zero-filled country clues: country tagging will be degraded (train/inference mismatch)."
+		)
+	}
 
 	if (inputNames.includes("gazetteer_features") && !fed.gazetteerLexicon) {
 		console.error(
@@ -263,6 +302,25 @@ async function fetchGazetteerLexicon(url: string, fetchImpl: typeof fetch): Prom
 	if (!res.ok) return null
 
 	return parseGazetteerLexicon((await res.json()) as Parameters<typeof parseGazetteerLexicon>[0])
+}
+
+/**
+ * Fetch + parse `country-surface-lexicon-v1.json` (#1104). Same contract as `fetchGazetteerLexicon`: a missing file
+ * returns null (matters iff the model declares `country_features`); a present-but-malformed lexicon throws via
+ * `parseCountryLexicon`'s validation.
+ */
+async function fetchCountryLexicon(url: string, fetchImpl: typeof fetch): Promise<CountryLexicon | null> {
+	let res: Response
+
+	try {
+		res = await fetchImpl(url)
+	} catch {
+		return null
+	}
+
+	if (!res.ok) return null
+
+	return parseCountryLexicon((await res.json()) as Parameters<typeof parseCountryLexicon>[0])
 }
 
 /**

--- a/neural-web/web-onnx-runner.ts
+++ b/neural-web/web-onnx-runner.ts
@@ -24,6 +24,7 @@
 
 import {
 	ANCHOR_FEATURE_DIM,
+	COUNTRY_FEATURE_DIM,
 	GAZETTEER_FEATURE_DIM,
 	type InferResult,
 	type NeuralRunner,
@@ -145,7 +146,8 @@ export class WebONNXRunner implements NeuralRunner {
 	async infer(
 		tokenIds: number[],
 		anchor?: { features: ReadonlyArray<ReadonlyArray<number>>; confidence: ReadonlyArray<number> },
-		gazetteer?: { features: ReadonlyArray<ReadonlyArray<number>>; confidence: ReadonlyArray<number> }
+		gazetteer?: { features: ReadonlyArray<ReadonlyArray<number>>; confidence: ReadonlyArray<number> },
+		country?: { features: ReadonlyArray<ReadonlyArray<number>>; confidence: ReadonlyArray<number> }
 	): Promise<InferResult> {
 		const session = await this.#ensureSession()
 		const seqLen = Math.min(tokenIds.length, this.fixedSeqLen)
@@ -220,6 +222,36 @@ export class WebONNXRunner implements NeuralRunner {
 				GAZETTEER_FEATURE_DIM,
 			])
 			feeds.gazetteer_confidence = new ort.Tensor("float32", new Float32Array(this.fixedSeqLen), [1, this.fixedSeqLen])
+		}
+
+		// Country-lexicon channel (#1104) — mirror of the node ONNXRunner + the gazetteer branch above.
+		// Feed the per-piece country-surface clue when supplied AND the graph declares the inputs; for
+		// country-trained models (v6.2.0+) with no lexicon, feed zeros (confidence=0 identity) so the
+		// session doesn't throw `input 'country_features' is missing in 'feeds'` — the loader warns loudly.
+		if (country && session.inputNames.includes("country_features")) {
+			const dim = country.features[0]?.length ?? 0
+			const cf = new Float32Array(this.fixedSeqLen * dim)
+			const cc = new Float32Array(this.fixedSeqLen)
+
+			for (let i = 0; i < seqLen; i++) {
+				cc[i] = country.confidence[i] ?? 0
+				const row = country.features[i]
+
+				if (row) {
+					for (let d = 0; d < dim; d++) {
+						cf[i * dim + d] = row[d] ?? 0
+					}
+				}
+			}
+			feeds.country_features = new ort.Tensor("float32", cf, [1, this.fixedSeqLen, dim])
+			feeds.country_confidence = new ort.Tensor("float32", cc, [1, this.fixedSeqLen])
+		} else if (session.inputNames.includes("country_features")) {
+			feeds.country_features = new ort.Tensor("float32", new Float32Array(this.fixedSeqLen * COUNTRY_FEATURE_DIM), [
+				1,
+				this.fixedSeqLen,
+				COUNTRY_FEATURE_DIM,
+			])
+			feeds.country_confidence = new ort.Tensor("float32", new Float32Array(this.fixedSeqLen), [1, this.fixedSeqLen])
 		}
 
 		const output = await session.run(feeds)

--- a/neural-web/web-onnx-runner.unit.test.ts
+++ b/neural-web/web-onnx-runner.unit.test.ts
@@ -19,7 +19,7 @@
  *   - The optional `locale_logits` output (v4.3.0+ locale head) surfaces as `localeLogits`.
  */
 
-import { ANCHOR_FEATURE_DIM, GAZETTEER_FEATURE_DIM } from "@mailwoman/neural/browser"
+import { ANCHOR_FEATURE_DIM, COUNTRY_FEATURE_DIM, GAZETTEER_FEATURE_DIM } from "@mailwoman/neural/browser"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const { sessionCreateMock } = vi.hoisted(() => ({ sessionCreateMock: vi.fn() }))
@@ -162,6 +162,61 @@ describe("WebONNXRunner feed construction (mocked session)", () => {
 		expect(Object.keys(feeds).sort()).toEqual(["attention_mask", "input_ids"])
 	})
 
+	// #1104 country channel — v6.2.0+ models declare `country_features`/`country_confidence`. The runner
+	// must feed them (real or zero-filled) exactly like the gazetteer channel, else ORT throws.
+	test("country-channel graph (v6.2.0+) + NO country provided → zero-filled structural fallback, not a throw", async () => {
+		const session = mockSession([
+			"input_ids",
+			"attention_mask",
+			"anchor_features",
+			"anchor_confidence",
+			"gazetteer_features",
+			"gazetteer_confidence",
+			"country_features",
+			"country_confidence",
+		])
+		const runner = await WebONNXRunner.fromBytes(new Uint8Array([1]), { useWebGPU: false })
+
+		// Pre-wiring this rejected with ORT's `input 'country_features' is missing in 'feeds'` (the v263 browser break).
+		const result = await runner.infer([5, 6, 7])
+		expect(result.logits.length).toBe(3)
+
+		const feeds = session.runCalls[0]!
+		expect(feeds.country_features!.dims).toEqual([1, SEQ, COUNTRY_FEATURE_DIM])
+		expect(feeds.country_confidence!.dims).toEqual([1, SEQ])
+		expect((feeds.country_features!.data as Float32Array).every((v) => v === 0)).toBe(true)
+		expect((feeds.country_confidence!.data as Float32Array).every((v) => v === 0)).toBe(true)
+	})
+
+	test("caller-provided country features are fed through verbatim", async () => {
+		const session = mockSession(["input_ids", "attention_mask", "country_features", "country_confidence"])
+		const runner = await WebONNXRunner.fromBytes(new Uint8Array([1]), { useWebGPU: false })
+
+		const countryRow = [1, 0] // [country_surface, country_ambiguous], featureDim = 2
+		await runner.infer([5, 6], undefined, undefined, {
+			features: [countryRow, countryRow.map(() => 0)],
+			confidence: [1, 0],
+		})
+
+		const feeds = session.runCalls[0]!
+		const cf = feeds.country_features!.data as Float32Array
+		expect(Array.from(cf.subarray(0, COUNTRY_FEATURE_DIM))).toEqual(countryRow)
+		expect(Array.from(cf.subarray(COUNTRY_FEATURE_DIM, 2 * COUNTRY_FEATURE_DIM))).toEqual([0, 0])
+		const cc = feeds.country_confidence!.data as Float32Array
+		expect(cc[0]).toBe(1)
+		expect(cc[1]).toBe(0)
+	})
+
+	test("plain graph (no country inputs) + country features provided → clue is NOT fed", async () => {
+		const session = mockSession(["input_ids", "attention_mask"])
+		const runner = await WebONNXRunner.fromBytes(new Uint8Array([1]), { useWebGPU: false })
+
+		await runner.infer([5], undefined, undefined, { features: [[1, 0]], confidence: [1] })
+
+		const feeds = session.runCalls[0]!
+		expect(Object.keys(feeds).sort()).toEqual(["attention_mask", "input_ids"])
+	})
+
 	test("locale_logits output surfaces as `localeLogits` when the graph exports it", async () => {
 		mockSession(["input_ids", "attention_mask"], { localeLogits: [0.25, 0.5, 0.125, 0.125] })
 		const runner = await WebONNXRunner.fromBytes(new Uint8Array([1]), { useWebGPU: false })
@@ -195,5 +250,17 @@ describe("defaultGazetteerLexiconURL", () => {
 		)
 		// Relative URLs stay relative.
 		expect(defaultGazetteerLexiconURL("/static/mailwoman/model.onnx")).toBe("/static/mailwoman/anchor-lexicon-v1.json")
+	})
+})
+
+describe("defaultCountryLexiconURL", () => {
+	test("derives the sibling country-surface-lexicon-v1.json beside the model URL", async () => {
+		const { defaultCountryLexiconURL } = await import("./loader.ts")
+		expect(defaultCountryLexiconURL("https://public.sister.software/mailwoman/en-us/v6.2.0/model.onnx")).toBe(
+			"https://public.sister.software/mailwoman/en-us/v6.2.0/country-surface-lexicon-v1.json"
+		)
+		expect(defaultCountryLexiconURL("/static/mailwoman/model.onnx")).toBe(
+			"/static/mailwoman/country-surface-lexicon-v1.json"
+		)
 	})
 })

--- a/neural/browser.ts
+++ b/neural/browser.ts
@@ -22,6 +22,11 @@ export * from "./postcode-binary-resolver.ts"
 // model and feeds the clue at inference (gazetteer-trained models REQUIRE it; zero-filled clues are
 // the measured train/inference mismatch — see CONTRIBUTING_MODEL_WORK.mdx "zero-fill trap").
 export * from "./gazetteer-inference.ts"
+// Browser-safe country-lexicon channel (#1104): the dedicated country soft-feed parser + feature
+// builder (`[country_surface, country_ambiguous]`). Pure JS over a JSON lexicon — the demo fetches
+// country-surface-lexicon-v1.json alongside the model and feeds it (country-channel models, v6.2.0+,
+// REQUIRE it: the ONNX declares `country_features` and zero-filled clues are the train/inference mismatch).
+export * from "./country-inference.ts"
 // Browser-safe soft-feature choreography (#718): the pure `buildSoftFeatures` that composes the
 // anchor + gazetteer channels (+ near-postcode suppression). No `fs`. The Node-only `./scorer` (which
 // constructs the ONNXRunner + reads the card/lookup/lexicon from disk) is deliberately NOT re-exported


### PR DESCRIPTION
Un-breaks in-browser loading of the v6.2.0 (v263) country-channel model and enables the R2 demo flip.

## Problem

v263's ONNX declares **required** `country_features`/`country_confidence` inputs (node feeds them). But neural-web's `WebONNXRunner.infer()` had no country branch — loading v263 in-browser threw `input 'country_features' is missing in 'feeds'`. So `neural-web@6.2.0` can't run v263, and the demo is held on v6.1.0.

## Fix (mirrors the gazetteer channel exactly)

- **`neural/browser.ts`** — re-export `./country-inference.ts` from the browser barrel (`COUNTRY_FEATURE_DIM`, `CountryLexicon`, `parseCountryLexicon`, `buildCountryFeatures`).
- **`web-onnx-runner.ts`** — `infer()` accepts a 4th `country` arg + feeds `country_features` (real when supplied + declared; **zero-fill else-if declared** — the confidence=0 identity so ORT doesn't throw). Matches the node `ONNXRunner` and the shared `NeuralRunner` contract the classifier calls.
- **`loader.ts`** — `countryLexiconURL` option + `defaultCountryLexiconURL` (sibling of `model.onnx`) + `fetchCountryLexicon`; fetches + passes `countryLexicon` to the shared classifier (which builds the features isomorphically); loud `console.error` when the model declares `country_features` but no lexicon loaded.

The feature-building stays in the shared `@mailwoman/neural` classifier — no browser reimplementation.

## Tests

- Country zero-fill un-break (the v263 break, now a structural fallback), real feed-through, plain-graph guard, `defaultCountryLexiconURL`. **11/11 neural-web unit tests pass**; `neural` + `neural-web` `tsc --noEmit` clean; oxlint/oxfmt clean.

## After merge

Ship 6.2.1 (code-only) so external browser consumers get the fix, then flip the R2 demo to v6.2.0 (with the country lexicon staged + browser e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)