### PR TITLE
docs: Phase 4 — prevent relapse (policy, CI gate, PR prompts, freshness sweep)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- What changed and why. Link the issue if one exists. -->
+
+## Docs pages touched? Confirm each line — delete this section if the PR doesn't touch docs/articles
+
+- [ ] The reader question this serves is named above — and no canonical page already owns it ([docs policy](https://github.com/sister-software/mailwoman/blob/main/docs/articles/contributing-docs.mdx)).
+- [ ] Canonical pages were updated in place; any new page answers a distinct reader question.
+- [ ] Factual claims name their source: a code path, a schema, an eval report — not recollection.
+- [ ] Captured outputs were executed, not hand-typed; release-bound numbers cite the shipped npm model.
+- [ ] Frontmatter matches the policy: `role:` where required, `status:`/`superseded-by:` on retired pages, `review-by:` considered for concept pages.

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,7 +1,9 @@
 # Build + deploy the Docusaurus docs site.
 #
-# On pull_request: build-only (catches broken links, MDX parse errors).
-# On push to main: build + deploy to GitHub Pages.
+# On pull_request: structure gate + build (catches broken links, MDX parse errors, and —
+# before any install — frontmatter/duplicate-title/orphan regressions via
+# docs/scripts/check-docs-structure.ts).
+# On push to main: same, then deploy to GitHub Pages.
 #
 # Binary assets (model.onnx, tokenizer.model, fst-en-US.bin, wof-hot.db) are
 # fetched at runtime from the HF Bucket (sister-software/mailwoman), NOT bundled
@@ -70,6 +72,15 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: yarn
+
+      # Fast structural gate (docs-architecture cleanup, Phase 4): frontmatter vocabulary +
+      # required fields, exact duplicate titles, orphan pages. Static parse over node built-ins
+      # only — no install, no build — so a structural regression fails in seconds instead of
+      # after the full Docusaurus build. Policy: docs/articles/contributing-docs.mdx.
+      # (--disable-warning: sidebars.ts is format-ambiguous — the docs workspace can't carry
+      # type:module without breaking the Docusaurus SSR bundle; see docs/scripts/package.json.)
+      - name: Docs structure checks
+        run: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON docs/scripts/check-docs-structure.ts
 
       - name: Enable Corepack (yarn 4)
         run: corepack enable

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -1,0 +1,63 @@
+# Quarterly docs freshness sweep (docs-architecture cleanup, Phase 4).
+#
+# Runs docs/scripts/list-stale-docs.ts — pages whose `review-by:` frontmatter date has
+# passed — and files the result as ONE issue titled "Docs freshness sweep", updating the
+# existing open issue in place rather than filing duplicates. Pages without `review-by:`
+# are skipped by design: the field is the opt-in that marks a page as maintained, so
+# archival evidence (eval reports, phase plans, retrospectives) is never churned.
+#
+# Quarterly = the 14th of Jan/Apr/Jul/Oct, matching the review-by cadence seeded on the
+# policy pages (first subjects come due 2026-10-14). No install, no build: the lister
+# runs on node built-ins straight off the checkout. workflow_dispatch is the manual
+# escape hatch to re-run a sweep after fixing pages.
+name: Docs freshness sweep
+
+on:
+  schedule:
+    - cron: "0 6 14 1,4,7,10 *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+# One sweep at a time, queued not cancelled: the find-then-edit/create issue lookup is not
+# atomic, so concurrent runs (a dispatch racing the cron) could each miss the other's issue
+# and double-file.
+concurrency:
+  group: docs-freshness
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: List pages past review-by
+        run: node docs/scripts/list-stale-docs.ts > sweep-body.md
+
+      - name: Open or update the sweep issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ ! -s sweep-body.md ]; then
+            echo "No pages past review-by — nothing to file."
+            exit 0
+          fi
+          existing=$(gh issue list --state open --search '"Docs freshness sweep" in:title' --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue edit "$existing" --body-file sweep-body.md
+          else
+            gh issue create --title "Docs freshness sweep" --body-file sweep-body.md
+          fi

--- a/docs/articles/concepts/README.mdx
+++ b/docs/articles/concepts/README.mdx
@@ -4,6 +4,7 @@ title: Deep dives
 role: concept
 audience: product-reader
 source-of-truth: self
+review-by: 2026-10-14
 ---
 
 # Concept deep dives

--- a/docs/articles/concepts/bio-labels.mdx
+++ b/docs/articles/concepts/bio-labels.mdx
@@ -4,6 +4,7 @@ title: BIO labels
 role: concept
 audience: product-reader
 source-of-truth: corpus-python/src/mailwoman_train/labels.py, neural-weights-en-us/model-card.json
+review-by: 2026-10-14
 tags:
   - concepts
   - neural

--- a/docs/articles/concepts/crf-decoder.mdx
+++ b/docs/articles/concepts/crf-decoder.mdx
@@ -4,6 +4,7 @@ title: CRF decoder
 role: concept
 audience: product-reader
 source-of-truth: neural/viterbi.ts, corpus-python/src/mailwoman_train/model.py, neural-weights-en-us/model-card.json
+review-by: 2026-10-14
 tags:
   - concepts
   - neural

--- a/docs/articles/concepts/data-locales-and-coverage.mdx
+++ b/docs/articles/concepts/data-locales-and-coverage.mdx
@@ -5,6 +5,7 @@ description: Which places Mailwoman can read and which it can pin to the map —
 role: concept
 audience: product-reader
 source-of-truth: plan/SCOPE.mdx, plan/reference/address-data-sources.mdx, licensing/data-provenance.md
+review-by: 2026-10-14
 ---
 
 # Data, locales, and coverage

--- a/docs/articles/concepts/fst-gazetteer-prior.mdx
+++ b/docs/articles/concepts/fst-gazetteer-prior.mdx
@@ -4,6 +4,7 @@ title: FST gazetteer prior
 role: concept
 audience: product-reader
 source-of-truth: mailwoman/runtime-pipeline.ts, mailwoman/commands/parse.tsx, resolver-wof-sqlite/street-morphology-fst-builder.ts
+review-by: 2026-10-14
 tags:
   - concepts
   - neural

--- a/docs/articles/concepts/fst-priors-as-shallow-fusion.mdx
+++ b/docs/articles/concepts/fst-priors-as-shallow-fusion.mdx
@@ -4,6 +4,7 @@ title: FST priors as shallow fusion
 role: concept
 audience: product-reader
 source-of-truth: mailwoman/runtime-pipeline.ts, mailwoman/commands/parse.tsx, neural/classifier.ts, mailwoman/eval-harness/parity-corpus.ts
+review-by: 2026-10-14
 tags:
   - concepts
   - neural

--- a/docs/articles/concepts/how-mailwoman-parses-an-address.mdx
+++ b/docs/articles/concepts/how-mailwoman-parses-an-address.mdx
@@ -5,6 +5,7 @@ description: One address followed through the whole parse — subword pieces, pe
 role: concept
 audience: product-reader
 source-of-truth: neural/classifier.ts, core/decoder/build-tree.ts, neural-weights-en-us/model-card.json, plan/reference/SCHEMA.mdx
+review-by: 2026-10-14
 ---
 
 # How Mailwoman parses an address

--- a/docs/articles/concepts/how-mailwoman-resolves-a-place.mdx
+++ b/docs/articles/concepts/how-mailwoman-resolves-a-place.mdx
@@ -5,6 +5,7 @@ description: One parsed address followed onto the map — gazetteer retrieval, c
 role: concept
 audience: product-reader
 source-of-truth: resolver/resolve.ts, core/resolver/types.ts, resolver-wof-sqlite/lookup.ts, mailwoman/geocode-core.ts
+review-by: 2026-10-14
 ---
 
 # How Mailwoman resolves a place

--- a/docs/articles/concepts/neural-classification.mdx
+++ b/docs/articles/concepts/neural-classification.mdx
@@ -4,6 +4,7 @@ title: Neural classification
 role: concept
 audience: product-reader
 source-of-truth: .github/workflows/publish.yml, how-mailwoman-parses-an-address.mdx, how-the-model-reasons.mdx
+review-by: 2026-10-14
 tags:
   - concepts
   - neural

--- a/docs/articles/concepts/quality-and-evaluation.mdx
+++ b/docs/articles/concepts/quality-and-evaluation.mdx
@@ -5,6 +5,7 @@ description: How Mailwoman grades itself — the coordinate-first grading rule, 
 role: concept
 audience: product-reader
 source-of-truth: plan/CONTRIBUTING_MODEL_WORK.mdx, evals/scores-by-version.json, plan/reference/eval-ledger.schema.json, plan/SCOPE.mdx
+review-by: 2026-10-14
 ---
 
 # Quality and evaluation

--- a/docs/articles/concepts/viterbi-and-bio-validity.mdx
+++ b/docs/articles/concepts/viterbi-and-bio-validity.mdx
@@ -4,6 +4,7 @@ title: Viterbi and BIO validity
 role: concept
 audience: product-reader
 source-of-truth: neural/viterbi.ts, corpus-python/src/mailwoman_train/labels.py
+review-by: 2026-10-14
 tags:
   - concepts
   - neural

--- a/docs/articles/concepts/what-mailwoman-is.mdx
+++ b/docs/articles/concepts/what-mailwoman-is.mdx
@@ -4,6 +4,7 @@ title: What Mailwoman is — a name for the thing we're building
 role: concept
 audience: product-reader
 source-of-truth: plan/SCOPE.mdx, plan/reference/closed-vocab-fields-model-first.mdx, plan/reference/ARCHITECTURE.mdx
+review-by: 2026-10-14
 tags:
   - concepts
   - architecture

--- a/docs/articles/contributing-docs.mdx
+++ b/docs/articles/contributing-docs.mdx
@@ -1,0 +1,97 @@
+---
+title: Contributing to the docs
+description: Page roles, required frontmatter, when a new page is warranted, and how to retire one.
+role: reference
+audience: contributor
+source-of-truth: docs/scripts/check-docs-structure.ts, docs/superpowers/plans/2026-07-14-documentation-architecture-cleanup.md
+owner: docs maintainers
+review-by: 2026-10-14
+---
+
+# Contributing to the docs
+
+The rules below are the documentation-architecture policy in its contributor-facing form. CI enforces
+the structural parts (`docs/scripts/check-docs-structure.ts`, run by the Docs workflow on every PR
+that touches the site); the editorial parts are reviewer discipline. Run the gate locally with
+`yarn workspace @mailwoman/docs lint:structure`.
+
+## Declare the page's role
+
+Every maintained page declares what kind of page it is in frontmatter, and each role has a contract:
+
+| Role        | Reader need                           | Time horizon            | Canonicality              | Required frontmatter                           |
+| ----------- | ------------------------------------- | ----------------------- | ------------------------- | ---------------------------------------------- |
+| `guide`     | accomplish a task                     | evergreen               | one preferred path        | `audience`, `prerequisites`, `verified-with`   |
+| `tutorial`  | learn by doing                        | evergreen but versioned | one learning journey      | `audience`, `prerequisites`, `verified-with`   |
+| `concept`   | understand a stable idea              | evergreen               | one explanatory home      | `audience`, `source-of-truth`, `review-by`     |
+| `reference` | look up a precise contract            | release-bound           | authoritative             | `source-of-truth`, `generated-from` or `owner` |
+| `decision`  | understand an active choice           | active until superseded | links to accepted outcome | `status`, `owner`, `superseded-by` when closed |
+| `evidence`  | inspect a result or historical record | immutable/datestamped   | cited by maintained pages | `date`, `status`, `promoted-conclusions`       |
+
+One site-specific addition: `landing`, for pure navigation surfaces (the front door, a section
+index) — required field: `audience`.
+
+You don't have to backfill `role:` onto old pages. CI requires it on the entry pages, the four
+canonical concept pages, and every recipe, and validates the vocabulary and required fields anywhere
+it's declared. Add the fields when you touch a page.
+
+## Set `status:` when a record opens or closes
+
+The page chrome (`src/theme/DocItem/Content`) renders two `status:` values above the title:
+`active-decision` for an open design record, and `superseded` — always paired with a
+`superseded-by:` link to the successor. Pages in the Archive sidebar get a dated "Historical record"
+banner automatically, no frontmatter needed. See
+[Joint consistency resolution](./plan/2026-06-29-joint-consistency-resolution.mdx) for the rendered
+chrome. Free-text `status:` values are reserved for the dated eval records (a delegated workstream);
+everywhere else the vocabulary is enforced.
+
+## New page, or update a canonical one?
+
+Four concept pages own the recurring reader questions. If your material answers one of these, extend
+the owner — don't open a parallel page:
+
+- **How does parsing work?** → [How Mailwoman parses an address](./concepts/how-mailwoman-parses-an-address.mdx)
+- **How does a parse become a coordinate?** → [How Mailwoman resolves a place](./concepts/how-mailwoman-resolves-a-place.mdx)
+- **What's covered, where, from what data?** → [Data, locales, and coverage](./concepts/data-locales-and-coverage.mdx)
+- **How good is it, and how do we know?** → [Quality and evaluation](./concepts/quality-and-evaluation.mdx)
+
+A new page needs a reader question none of these owns — name that question in the PR description.
+Contracts belong in Reference; a duplicated explanation is a future contradiction.
+
+## Retiring a page
+
+- [ ] Move its sidebar entry to the Archive section in `sidebars.ts`. The file stays where it is —
+      the URL must not change, and the Archive banner takes over from there.
+- [ ] If a successor exists, set `status: superseded` and `superseded-by:` on the retired page.
+- [ ] Repoint inbound links from maintained pages to the successor.
+- [ ] Don't touch publicness. Reorganization never changes what's published: nothing excluded from
+      the build becomes public — and nothing public gets unpublished — as a side effect of a move.
+      Promoting an internal record to the public site is its own explicit decision, per page, with
+      operator sign-off, and only for records with no internal references, no security-sensitive
+      detail, and evidentiary value (a maintained page wants to cite them). Demotion is for mistakes, not age: a page leaves the
+      public site only if it should never have been public. Dated records keep their URLs and their
+      point-in-time content.
+
+## Editorial rules
+
+- **Analog first.** The core reader is a cartography/geodata practitioner. Introduce every learned
+  mechanism through the rule-world thing it replaces — gazetteer lookup before FST prior,
+  hand-written pattern before per-token score, tie-breaking heuristics before Viterbi — and keep
+  statistical depth one link away from the entry path.
+- **Captured outputs are executed, never hand-typed.** If a page shows a command's output, run the
+  command and paste what it printed. `verified-with:` records the version you ran it against.
+- **Release-bound numbers cite the shipped npm model.** Parameter counts, sizes, and scores come
+  from the published artifacts, and they're refreshed at release time —
+  ["Step 5 — refresh the docs' release-bound numbers" in RELEASING.md](https://github.com/sister-software/mailwoman/blob/main/RELEASING.md#step-5--refresh-the-docs-release-bound-numbers).
+- **Name the property.** The word "honest" (and its cluster) stays out of prose — say what the
+  page actually claims: the eval holds out the training data, the coverage number excludes
+  interpolation. Harness identifiers (`honest-eval`, `coverage-honest`) are exempt.
+
+## What CI checks
+
+`check-docs-structure.ts` fails a PR on: an unknown `role:`/`status:` value or a missing required
+field, an exact duplicate `title:` across the published site, and a page reachable by URL but absent
+from every sidebar. Deliberate exceptions live in `docs/scripts/docs-structure-allowlist.ts`, each
+with a reason. A quarterly sweep (`.github/workflows/docs-freshness.yml`) files one "Docs freshness
+sweep" issue listing pages whose `review-by:` date has passed — pages without `review-by:` are
+never swept, so archival evidence stays untouched.

--- a/docs/articles/documentation-map.mdx
+++ b/docs/articles/documentation-map.mdx
@@ -4,6 +4,7 @@ description: What each section of the docs is for, and which ones you can treat 
 role: concept
 audience: product-reader
 source-of-truth: self
+review-by: 2026-10-14
 ---
 
 # Documentation map

--- a/docs/articles/getting-started.mdx
+++ b/docs/articles/getting-started.mdx
@@ -2,6 +2,10 @@
 sidebar_position: 2
 title: Getting started
 description: Install Mailwoman and parse your first address in about five minutes.
+role: guide
+audience: product-reader
+prerequisites: Node.js ≥24.18.0
+verified-with: mailwoman v6.1.0
 ---
 
 # Getting started

--- a/docs/articles/recipes/batch-geocoding.md
+++ b/docs/articles/recipes/batch-geocoding.md
@@ -4,6 +4,8 @@ id: batch-geocoding
 role: guide
 audience: product-reader
 source-of-truth: api/routes.ts, api/schema.ts, mailwoman/api-engine.ts
+prerequisites: a running mailwoman serve instance with gazetteer data
+verified-with: mailwoman v6.1.0
 ---
 
 You have a spreadsheet — ten thousand addresses, a CSV a colleague dropped in Slack, a nightly export from your CRM — and you want a coordinate for every row. Firing ten thousand individual requests works, but you'll spend most of the wall-clock time on HTTP overhead and you'll have to write the concurrency control yourself. The Mailwoman server has a bulk endpoint for exactly this. By the time you're done here you'll have one `curl` command that turns a list of addresses into a list of coordinates, in order, with the failure cases handled.

--- a/docs/articles/recipes/display-on-a-map.md
+++ b/docs/articles/recipes/display-on-a-map.md
@@ -4,6 +4,8 @@ id: display-on-a-map
 role: guide
 audience: product-reader
 source-of-truth: registry/resolve.ts, registry/geojson.ts, registry/map-html.ts
+prerequisites: "@mailwoman/registry, plus resolved entities to plot"
+verified-with: mailwoman v6.1.0
 ---
 
 Coordinates in a JSON array tell you the geocoder worked. They don't tell you whether the _answers_ are right — that a cluster of clinics really sits where you'd expect, that the three records you merged into one entity actually share a building. For that you need to see them on a map, and you'd rather not stand up a tile server and a frontend to glance at a few hundred points.

--- a/docs/articles/recipes/index.md
+++ b/docs/articles/recipes/index.md
@@ -3,7 +3,7 @@ sidebar_title: Overview
 title: Recipes
 sidebar_position: 0
 hide_footer: true
-role: guide
+role: landing
 audience: product-reader
 source-of-truth: self
 ---

--- a/docs/articles/recipes/multi-service-geocoding.md
+++ b/docs/articles/recipes/multi-service-geocoding.md
@@ -4,6 +4,8 @@ id: multi-service-geocoding
 role: guide
 audience: product-reader
 source-of-truth: api/schema.ts, mailwoman/geocode-core.ts
+prerequisites: a running mailwoman serve instance; a paid geocoder account for the fallback tier
+verified-with: mailwoman v6.1.0
 ---
 
 You have a table of addresses and a hosted geocoder that bills per request — every request, easy row or hard. At today's list prices that's somewhere between twenty cents and five dollars per thousand, depending on the provider and your volume. Multiply it out: a million-row table is $200 to $5,000 **per pass**, and if the table refreshes nightly, you buy it again tomorrow. The no-cost route caps you on rate instead: the public Nominatim server asks for at most one request per second, which puts the same million rows at eleven days.

--- a/docs/articles/recipes/parallel-csv-ingest.md
+++ b/docs/articles/recipes/parallel-csv-ingest.md
@@ -4,6 +4,8 @@ id: parallel-csv-ingest
 role: guide
 audience: product-reader
 source-of-truth: registry/ingest.ts, mailwoman/geocode-stream.ts, mailwoman/geocode-worker.ts
+prerequisites: "@mailwoman/registry; a CSV too big for memory; gazetteer data for the optional geocode stage"
+verified-with: mailwoman v6.1.0
 ---
 
 Someone hands you a national dataset as a single CSV — the NPPES provider registry (millions of rows), an FCC broadband availability drop, a state address export. You need every row normalized into the same shape, and ideally a coordinate on each one. Two things stand in the way: the file won't fit in memory, and geocoding a million addresses one after another takes hours. This recipe is the shape that handles both — a streaming normalize core you can hold in your head, plus an optional threaded geocode stage you bolt on only when the per-row cost earns it.

--- a/docs/articles/recipes/privacy-coordinate-rounding.md
+++ b/docs/articles/recipes/privacy-coordinate-rounding.md
@@ -4,6 +4,8 @@ id: privacy-coordinate-rounding
 role: guide
 audience: product-reader
 source-of-truth: spatial/coordinate-formats.ts
+prerequisites: "@mailwoman/spatial"
+verified-with: mailwoman v6.1.0
 ---
 
 You geocoded a customer's address and got a rooftop coordinate back — accurate to a few metres. That precision is the whole point when you're routing a driver to the door. It's a liability when you're about to store the point in an analytics table, share it with a partner, or plot a thousand customers on a public dashboard. A rooftop point _is_ the house; you usually want the neighbourhood.

--- a/docs/articles/recipes/timezones.md
+++ b/docs/articles/recipes/timezones.md
@@ -4,6 +4,8 @@ id: timezone-lookup
 role: guide
 audience: product-reader
 source-of-truth: timezone-lookup/index.ts, timezone-lookup/build.ts, timezone-lookup/cli.ts
+prerequisites: "@mailwoman/timezone-lookup (server-side, node:sqlite); a timezone-boundary-builder release to build the DB"
+verified-with: mailwoman v6.1.0
 ---
 
 You have a coordinate and you want the IANA timezone it lands in — `America/New_York`, `Asia/Tokyo`. The [`@mailwoman/timezone-lookup`](https://www.npmjs.com/package/@mailwoman/timezone-lookup) package does the point-in-polygon for you, over [timezone-boundary-builder](https://github.com/evansiroky/timezone-boundary-builder) polygons in a `node:sqlite` database. The UTC offset comes from `Intl`, so there's no tz-database dependency to keep patched.

--- a/docs/articles/recipes/un-locode-lookup.md
+++ b/docs/articles/recipes/un-locode-lookup.md
@@ -4,6 +4,8 @@ id: un-locode-lookup
 role: guide
 audience: product-reader
 source-of-truth: un-locode-lookup/index.ts, un-locode-lookup/build.ts, un-locode-lookup/cli.ts
+prerequisites: "@mailwoman/un-locode-lookup (server-side, node:sqlite); the UNECE code list to build the DB"
+verified-with: mailwoman v6.1.0
 ---
 
 A **UN/LOCODE** is the UNECE's code for a trade-and-transport location — `US NYC` for New York, `NL RTM` for Rotterdam. If you're moving freight, filing customs, or matching a shipping record to a place, you need these codes, and you usually have either a place name or a coordinate to start from. The [`@mailwoman/un-locode-lookup`](https://www.npmjs.com/package/@mailwoman/un-locode-lookup) package goes both ways, over the UNECE code list in a `node:sqlite` database.

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,8 @@
 		"build-storybook": "storybook build",
 		"clear": "docusaurus clear",
 		"docusaurus": "docusaurus",
+		"freshness-report": "node scripts/list-stale-docs.ts",
+		"lint:structure": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-docs-structure.ts",
 		"prebuild": "node ../mailwoman/out/cli.js openapi --out ./static/openapi/mailwoman.json && node ../libpostal/out/cli.js openapi --out ./static/openapi/libpostal.json && node ../photon/out/cli.js openapi --out ./static/openapi/photon.json && node ../nominatim/out/cli.js openapi --out ./static/openapi/nominatim.json",
 		"serve": "docusaurus serve --host 0.0.0.0 --port 7770",
 		"start": "docusaurus start --host 0.0.0.0 --port 7770 --no-open",

--- a/docs/scripts/check-docs-structure.ts
+++ b/docs/scripts/check-docs-structure.ts
@@ -1,0 +1,276 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Docs structural gate (docs-architecture cleanup, Phase 4). Static frontmatter parse only — no
+ *   install, no Docusaurus build — so it runs in seconds as the first step of the Docs workflow
+ *   (`.github/workflows/docs-build.yml`) and locally via
+ *   `yarn workspace @mailwoman/docs lint:structure` (or `node docs/scripts/check-docs-structure.ts`
+ *   from the repo root).
+ *
+ *   Three checks, matching the contributor policy page (`docs/articles/contributing-docs.mdx`):
+ *
+ *   1. Frontmatter validity — a page declaring `role:` must use the policy vocabulary and carry
+ *      that role's required fields; a page declaring `status:` must use the record-class chrome
+ *      vocabulary (`src/theme/DocItem/Content`). Presence is not required everywhere: validity is
+ *      enforced where declared, and `role:` itself is required on the entry pages, the canonical
+ *      concept pages, and every recipe (see ROLE_REQUIRED_PAGES).
+ *   2. Exact duplicate `title:` frontmatter across the published site.
+ *   3. Orphan pages — published docs absent from every sidebar in `docs/sidebars.ts`.
+ *
+ *   Known-intentional findings live in `docs-structure-allowlist.ts`, each with a reason. The
+ *   evals/retrospectives trees are a delegated workstream and are skipped by checks 1 and 3 (see
+ *   `isDelegatedWorkstream`).
+ */
+
+import sidebars from "../sidebars.ts"
+import { collectDocPages, type DocPage, isDelegatedWorkstream, isExcludedFromBuild } from "./docs-frontmatter.ts"
+import { allowedDuplicateTitles, allowedOrphans } from "./docs-structure-allowlist.ts"
+
+//#region Policy vocabulary
+
+/**
+ * The page-role vocabulary and each role's required frontmatter fields — the content-model table from the cleanup plan,
+ * reproduced on the policy page (`docs/articles/contributing-docs.mdx`). `landing` is the site-specific addition for
+ * pure navigation surfaces. `reference` and `decision` carry conditional requirements handled below (`generated-from`
+ * or `owner`; `superseded-by` once closed).
+ */
+const ROLE_REQUIRED_FIELDS: Record<string, string[]> = {
+	guide: ["audience", "prerequisites", "verified-with"],
+	tutorial: ["audience", "prerequisites", "verified-with"],
+	concept: ["audience", "source-of-truth", "review-by"],
+	reference: ["source-of-truth"],
+	decision: ["status", "owner"],
+	evidence: ["date", "status", "promoted-conclusions"],
+	landing: ["audience"],
+}
+
+/** The `status:` vocabulary the record-class chrome renders (`src/theme/DocItem/Content`). */
+const STATUS_VOCABULARY = new Set(["active-decision", "superseded"])
+
+/**
+ * Pages that MUST declare `role:` (relative to `docs/articles`): the front door, the entry pages, the four canonical
+ * concept pages, the docs policy itself — plus every recipe, matched by directory below.
+ */
+const ROLE_REQUIRED_PAGES = [
+	"index.mdx",
+	"getting-started.mdx",
+	"documentation-map.mdx",
+	"contributing-docs.mdx",
+	"concepts/how-mailwoman-parses-an-address.mdx",
+	"concepts/how-mailwoman-resolves-a-place.mdx",
+	"concepts/data-locales-and-coverage.mdx",
+	"concepts/quality-and-evaluation.mdx",
+]
+
+const ROLE_REQUIRED_DIRECTORIES = ["recipes/"]
+
+//#endregion
+
+//#region Check 1 — frontmatter validity
+
+function checkFrontmatter(pages: DocPage[]): string[] {
+	const failures: string[] = []
+	const checkable = pages.filter((page) => !isDelegatedWorkstream(page))
+	const byRelativePath = new Map(checkable.map((page) => [page.relativePath, page]))
+
+	for (const requiredPath of ROLE_REQUIRED_PAGES) {
+		const page = byRelativePath.get(requiredPath)
+
+		if (!page) {
+			failures.push(`${requiredPath}: page is on the role manifest but missing from docs/articles`)
+		} else if (!page.declaredKeys.has("role")) {
+			failures.push(`${requiredPath}: missing required \`role:\` frontmatter (manifest page)`)
+		}
+	}
+
+	for (const page of checkable) {
+		const inRequiredDirectory = ROLE_REQUIRED_DIRECTORIES.some((dir) => page.relativePath.startsWith(dir))
+
+		if (inRequiredDirectory && !page.declaredKeys.has("role")) {
+			failures.push(`${page.relativePath}: missing required \`role:\` frontmatter (all recipes declare one)`)
+		}
+
+		if (page.declaredKeys.has("role")) {
+			const role = page.frontmatter.get("role") ?? ""
+			const requiredFields = ROLE_REQUIRED_FIELDS[role]
+
+			if (!requiredFields) {
+				failures.push(
+					`${page.relativePath}: role \`${role}\` is not in the policy vocabulary (${Object.keys(ROLE_REQUIRED_FIELDS).join(", ")})`
+				)
+			} else {
+				for (const field of requiredFields) {
+					if (!page.declaredKeys.has(field)) {
+						failures.push(`${page.relativePath}: role \`${role}\` requires \`${field}:\` frontmatter`)
+					}
+				}
+
+				if (role === "reference" && !page.declaredKeys.has("generated-from") && !page.declaredKeys.has("owner")) {
+					failures.push(`${page.relativePath}: role \`reference\` requires \`generated-from:\` or \`owner:\``)
+				}
+			}
+		}
+
+		if (page.declaredKeys.has("status")) {
+			const status = page.frontmatter.get("status") ?? ""
+
+			if (!STATUS_VOCABULARY.has(status)) {
+				failures.push(
+					`${page.relativePath}: status \`${status}\` is not in the chrome vocabulary (${[...STATUS_VOCABULARY].join(", ")})`
+				)
+			}
+
+			if (status === "superseded" && !page.declaredKeys.has("superseded-by")) {
+				failures.push(`${page.relativePath}: status \`superseded\` requires a \`superseded-by:\` link`)
+			}
+		}
+	}
+
+	return failures
+}
+
+//#endregion
+
+//#region Check 2 — duplicate titles
+
+function checkDuplicateTitles(pages: DocPage[]): string[] {
+	const failures: string[] = []
+	const allowedTitles = new Set(allowedDuplicateTitles.map((allowance) => allowance.title))
+	const byTitle = new Map<string, string[]>()
+
+	for (const page of pages) {
+		const title = page.frontmatter.get("title")
+
+		if (!title) continue // Half the corpus titles from its first H1 — only declared titles can collide exactly.
+
+		const paths = byTitle.get(title) ?? []
+		paths.push(page.relativePath)
+		byTitle.set(title, paths)
+	}
+
+	for (const [title, paths] of byTitle) {
+		if (paths.length < 2 || allowedTitles.has(title)) continue
+
+		failures.push(`duplicate title \`${title}\`: ${paths.join(", ")}`)
+	}
+
+	return failures
+}
+
+//#endregion
+
+//#region Check 3 — orphan pages
+
+/** Recursively gather explicit doc ids and autogenerated directory roots from a sidebar item. */
+function walkSidebarItem(item: unknown, ids: Set<string>, autogeneratedDirs: Set<string>): void {
+	if (typeof item === "string") {
+		ids.add(item)
+
+		return
+	}
+
+	if (typeof item !== "object" || item === null) return
+
+	const record = item as Record<string, unknown>
+
+	if (record.type === "autogenerated" && typeof record.dirName === "string") {
+		autogeneratedDirs.add(record.dirName)
+	}
+
+	if ((record.type === "doc" || record.type === "ref") && typeof record.id === "string") {
+		ids.add(record.id)
+	}
+
+	if (record.type === "category") {
+		if (Array.isArray(record.items)) {
+			for (const child of record.items) {
+				walkSidebarItem(child, ids, autogeneratedDirs)
+			}
+		}
+
+		walkSidebarItem(record.link, ids, autogeneratedDirs)
+	}
+}
+
+function checkOrphans(pages: DocPage[]): string[] {
+	const failures: string[] = []
+	const allowedIDs = new Set(allowedOrphans.map((allowance) => allowance.id))
+	const ids = new Set<string>()
+	const autogeneratedDirs = new Set<string>()
+
+	for (const sidebar of Object.values(sidebars)) {
+		for (const item of sidebar as unknown[]) {
+			walkSidebarItem(item, ids, autogeneratedDirs)
+		}
+	}
+
+	for (const page of pages) {
+		// Autogenerated sidebars pull in every doc under their directory by file location.
+		const coveredByDirectory = [...autogeneratedDirs].some((dir) => page.relativePath.startsWith(`${dir}/`))
+
+		if (coveredByDirectory || ids.has(page.id) || allowedIDs.has(page.id)) continue
+
+		failures.push(`${page.relativePath}: reachable at /docs/ but absent from every sidebar (id \`${page.id}\`)`)
+	}
+
+	return failures
+}
+
+//#endregion
+
+const pages = await collectDocPages()
+const published = pages.filter((page) => !isExcludedFromBuild(page))
+
+const failuresByCheck: [name: string, failures: string[]][] = [
+	["Frontmatter validity", checkFrontmatter(published)],
+	["Duplicate titles", checkDuplicateTitles(published)],
+	["Orphan pages", checkOrphans(published)],
+]
+
+let failureCount = 0
+
+for (const [name, failures] of failuresByCheck) {
+	if (failures.length === 0) {
+		console.log(`✓ ${name}`)
+		continue
+	}
+
+	failureCount += failures.length
+	console.error(`✗ ${name} (${failures.length}):`)
+
+	for (const failure of failures) {
+		console.error(`  - ${failure}`)
+	}
+}
+
+// Guard the allowlists against rot: an allowance whose subject no longer exists should be removed.
+const publishedIDs = new Set(published.map((page) => page.id))
+const publishedTitles = new Set(published.map((page) => page.frontmatter.get("title")))
+
+for (const allowance of allowedOrphans) {
+	if (!publishedIDs.has(allowance.id)) {
+		failureCount += 1
+		console.error(`✗ stale allowlist entry: orphan \`${allowance.id}\` no longer exists — remove it`)
+	}
+}
+
+for (const allowance of allowedDuplicateTitles) {
+	if (!publishedTitles.has(allowance.title)) {
+		failureCount += 1
+		console.error(`✗ stale allowlist entry: duplicate title \`${allowance.title}\` no longer exists — remove it`)
+	}
+}
+
+if (failureCount > 0) {
+	console.error(
+		`\nDocs structure check FAILED (${failureCount} finding${failureCount === 1 ? "" : "s"}). ` +
+			`Policy: docs/articles/contributing-docs.mdx · allowlist: docs/scripts/docs-structure-allowlist.ts`
+	)
+	process.exit(1)
+}
+
+console.log(
+	`\nDocs structure OK — ${published.length} published pages checked (${pages.length} total under articles/).`
+)

--- a/docs/scripts/docs-frontmatter.ts
+++ b/docs/scripts/docs-frontmatter.ts
@@ -1,0 +1,136 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Shared plumbing for the docs structural checks (docs-architecture cleanup, Phase 4): walk
+ *   `docs/articles`, parse each page's frontmatter block, and derive the Docusaurus doc id. Used by
+ *   `check-docs-structure.ts` (the CI gate) and `list-stale-docs.ts` (the quarterly freshness
+ *   sweep).
+ *
+ *   The frontmatter parser is deliberately minimal — top-level `key: scalar` lines only, quotes
+ *   stripped. Nested values (`tags:` arrays, block scalars) record the key as declared but carry no
+ *   value. That covers every field the checks read (`role`, `status`, `title`, `id`, `review-by`,
+ *   …) without pulling a YAML dependency into what must stay a no-install fast path in CI.
+ */
+
+import { readdir, readFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+/** Absolute path to the docs-plugin content root (`docs/articles`). */
+export const ARTICLES_DIR = path.resolve(SCRIPT_DIR, "..", "articles")
+
+/** One `.md`/`.mdx` page under `docs/articles`. */
+export interface DocPage {
+	/** Path relative to `docs/articles`, POSIX separators — e.g. `concepts/bio-labels.mdx`. */
+	relativePath: string
+	/** Absolute filesystem path. */
+	absolutePath: string
+	/**
+	 * The Docusaurus doc id: the directory part of the file path plus the frontmatter `id:` override (which replaces only
+	 * the final segment) or the extension-less basename — e.g. `recipes/timezones.md` with `id: timezone-lookup` →
+	 * `recipes/timezone-lookup`.
+	 */
+	id: string
+	/** Top-level scalar frontmatter fields, quotes stripped. */
+	frontmatter: Map<string, string>
+	/** Every top-level frontmatter key, including keys whose values are nested/non-scalar. */
+	declaredKeys: Set<string>
+}
+
+const FRONTMATTER_KEY_PATTERN = /^([A-Za-z][A-Za-z0-9_-]*):(.*)$/
+
+/** Strip one layer of matched surrounding quotes from a scalar value. */
+function unquote(value: string): string {
+	if (value.length >= 2 && (value[0] === '"' || value[0] === "'") && value.endsWith(value[0]!)) {
+		return value.slice(1, -1)
+	}
+
+	return value
+}
+
+/**
+ * Parse the leading `---`-fenced frontmatter block of a markdown source. Returns top-level scalar fields plus the set
+ * of all declared top-level keys.
+ */
+export function parseFrontmatter(source: string): { fields: Map<string, string>; declaredKeys: Set<string> } {
+	const fields = new Map<string, string>()
+	const declaredKeys = new Set<string>()
+	const lines = source.split("\n")
+
+	if (lines[0]?.trim() !== "---") return { fields, declaredKeys }
+
+	for (let i = 1; i < lines.length; i++) {
+		const line = lines[i]!
+
+		if (line.trim() === "---") break
+
+		const match = FRONTMATTER_KEY_PATTERN.exec(line)
+
+		if (!match) continue // Nested/continuation line (indented, `- ` item, …) — not a top-level key.
+
+		const [, key, rawValue] = match
+		declaredKeys.add(key!)
+
+		const value = unquote(rawValue!.trim())
+
+		if (value) {
+			fields.set(key!, value)
+		}
+	}
+
+	return { fields, declaredKeys }
+}
+
+/** Walk `docs/articles` and parse every `.md`/`.mdx` page. */
+export async function collectDocPages(): Promise<DocPage[]> {
+	const entries = await readdir(ARTICLES_DIR, { recursive: true })
+	const pages: DocPage[] = []
+
+	for (const entry of entries.sort()) {
+		const relativePath = entry.split(path.sep).join("/")
+
+		if (!relativePath.endsWith(".md") && !relativePath.endsWith(".mdx")) continue
+
+		const absolutePath = path.join(ARTICLES_DIR, entry)
+		const { fields, declaredKeys } = parseFrontmatter(await readFile(absolutePath, "utf8"))
+
+		const directory = path.posix.dirname(relativePath)
+		const basename = path.posix.basename(relativePath).replace(/\.mdx?$/, "")
+		const idTail = fields.get("id") ?? basename
+		const id = directory === "." ? idTail : `${directory}/${idTail}`
+
+		pages.push({ relativePath, absolutePath, id, frontmatter: fields, declaredKeys })
+	}
+
+	return pages
+}
+
+/**
+ * Mirrors the docs plugin's `exclude` globs in `docs/docusaurus.config.ts` (search for `exclude:` under `path:
+ * "articles"`) — pages the build never publishes, so they can't collide or orphan on the live site. Keep the two in
+ * sync when the config's exclusions change.
+ */
+export function isExcludedFromBuild(page: DocPage): boolean {
+	if (page.relativePath.startsWith("reviews/")) return true
+
+	if (page.relativePath.startsWith("evals/")) {
+		const basename = path.posix.basename(page.relativePath)
+
+		return basename.includes("postmortem") || basename.includes("night-shift-session-report")
+	}
+
+	return false
+}
+
+/**
+ * The evals and retrospectives trees are a delegated workstream (see the coordination boundary in
+ * `docs/superpowers/plans/2026-07-14-documentation-architecture-cleanup.md`); their role/status adoption ships with its
+ * own gate. Only the duplicate-title check reads them — a title collision is site-wide by nature.
+ */
+export function isDelegatedWorkstream(page: DocPage): boolean {
+	return page.relativePath.startsWith("evals/") || page.relativePath.startsWith("retrospectives/")
+}

--- a/docs/scripts/docs-structure-allowlist.ts
+++ b/docs/scripts/docs-structure-allowlist.ts
@@ -1,0 +1,38 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Allowlists for `check-docs-structure.ts`. Every entry carries a reason — an allowance without
+ *   one is a bug, not a policy. Adding an entry here is a reviewable act: prefer fixing the page,
+ *   and allowlist only when the collision/orphan is deliberate or belongs to another workstream.
+ */
+
+/** A known-intentional exact `title:` collision. */
+export interface DuplicateTitleAllowance {
+	title: string
+	reason: string
+}
+
+/** A page deliberately reachable by URL but absent from every sidebar. */
+export interface OrphanAllowance {
+	/** The Docusaurus doc id (see `DocPage.id`). */
+	id: string
+	reason: string
+}
+
+export const allowedDuplicateTitles: DuplicateTitleAllowance[] = [
+	{
+		title: "Retrospectives",
+		reason:
+			"evals/retrospectives/index.mdx and retrospectives/README.mdx — the landing pages of two sections owned by the delegated evals/retrospectives workstream (baseline inventory §4). Resolving the collision is theirs; this gate only keeps it from growing.",
+	},
+]
+
+export const allowedOrphans: OrphanAllowance[] = [
+	{
+		id: "sotm-2026-talk-proposal",
+		reason:
+			"Deliberately un-navved conference proposal — shared by URL, kept out of every sidebar on purpose (named as such in sidebars.ts's startHere comment).",
+	},
+]

--- a/docs/scripts/list-stale-docs.ts
+++ b/docs/scripts/list-stale-docs.ts
@@ -1,0 +1,69 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Quarterly docs freshness sweep (docs-architecture cleanup, Phase 4): list maintained pages
+ *   whose `review-by:` frontmatter date has passed, as a ready-to-file Markdown issue body on
+ *   stdout. Empty output means nothing is due — the workflow
+ *   (`.github/workflows/docs-freshness.yml`) files or updates ONE "Docs freshness sweep" issue
+ *   only when there's a list to file.
+ *
+ *   Pages without `review-by:` are skipped by design: the field is the opt-in that marks a page as
+ *   maintained. Dated evidence — eval reports, phase plans, retrospectives — never carries it, so
+ *   the sweep can't churn archival records.
+ *
+ *   Run locally: `yarn workspace @mailwoman/docs freshness-report` (or
+ *   `node docs/scripts/list-stale-docs.ts` from the repo root).
+ */
+
+import { collectDocPages } from "./docs-frontmatter.ts"
+
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})/
+
+interface StalePage {
+	relativePath: string
+	reviewBy: string
+	owner: string | undefined
+}
+
+const today = new Date().toISOString().slice(0, 10)
+const stalePages: StalePage[] = []
+
+for (const page of await collectDocPages()) {
+	const reviewBy = page.frontmatter.get("review-by")
+
+	if (!reviewBy) continue // No `review-by:` = not a maintained page — skipped by design.
+
+	const match = ISO_DATE_PATTERN.exec(reviewBy)
+
+	if (!match) {
+		console.error(`warning: ${page.relativePath} has a non-ISO review-by value (\`${reviewBy}\`) — skipping`)
+		continue
+	}
+
+	const reviewDate = match[0]
+
+	// ISO dates compare correctly as strings.
+	if (reviewDate <= today) {
+		stalePages.push({
+			relativePath: page.relativePath,
+			reviewBy: reviewDate,
+			owner: page.frontmatter.get("owner") ?? page.frontmatter.get("source-of-truth"),
+		})
+	}
+}
+
+if (stalePages.length > 0) {
+	console.log(`${stalePages.length} page(s) are past their \`review-by:\` date as of ${today}.`)
+	console.log(
+		`For each: re-verify the page against its source of truth, refresh what drifted, then bump \`review-by:\` a quarter out (or retire the page — see [Contributing to the docs](https://mailwoman.sister.software/docs/contributing-docs)).\n`
+	)
+
+	for (const page of stalePages) {
+		const ownerNote = page.owner ? ` (source of truth: ${page.owner})` : ""
+		console.log(`- [ ] \`docs/articles/${page.relativePath}\` — review-by ${page.reviewBy}${ownerNote}`)
+	}
+
+	console.log(`\n_Filed by the quarterly docs-freshness workflow. Updating this issue in place is expected._`)
+}

--- a/docs/scripts/package.json
+++ b/docs/scripts/package.json
@@ -1,0 +1,4 @@
+{
+	"description": "Module-format marker only, NOT a workspace (the root workspace list is explicit). Scopes docs/scripts to ESM so plain `node docs/scripts/*.ts` runs without the MODULE_TYPELESS reparse warning — the docs workspace itself can't carry type:module because Docusaurus's CJS SSR server bundle would then load as ESM and break (`require.resolveWeak is not a function`).",
+	"type": "module"
+}

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -127,6 +127,7 @@ const sidebars: SidebarsConfig = {
 		"plan/reference/sentencepiece-uds-whitespace",
 	],
 	contribute: [
+		"contributing-docs",
 		"plan/CONTRIBUTING_MODEL_WORK",
 		"plan/reference/OPERATIONS",
 		"plan/reference/coverage-overlay",

--- a/docs/superpowers/inventory/publicness-policy.md
+++ b/docs/superpowers/inventory/publicness-policy.md
@@ -1,5 +1,7 @@
 # Archive/publicness policy — draft for agreement
 
+> **Public home (Phase 4, 2026-07-14):** this policy now lives in [`docs/articles/contributing-docs.mdx`](../../articles/contributing-docs.mdx) ("Retiring a page"); this file is the signed original, kept for provenance.
+
 _Phase 0 deliverable of the documentation-architecture cleanup. Status: **draft — needs operator sign-off** before any page moves. Once agreed, Phase 4 promotes this into the contributor-facing documentation policy._
 
 ## Principles


### PR DESCRIPTION
The final phase of the documentation-architecture cleanup: the machinery that keeps Phases 0–3 from eroding.

## What changed

- **`contributing-docs.mdx`** (leads the Contribute section): the page-role vocabulary and per-role required frontmatter, the status-chrome vocabulary with a rendered example, when a new page is justified vs updating a canonical one, and the retirement path — folding in the operator-signed publicness policy (all three promotion gates intact: no internal references, no security-sensitive detail, evidentiary value) plus the standing editorial rules (analog-first vocabulary, executed outputs only, shipped-model numbers).
- **The structure gate** (`docs/scripts/check-docs-structure.ts`): role/status vocabulary + per-role required-field validation (role required on a manifest + all recipes), site-wide duplicate-title detection, sidebar-orphan detection — each with a typed, reason-required allowlist. Node built-ins only, ~0.6 s, wired as the first step of `docs-build.yml` (type-only imports, so it runs before install) and as `yarn workspace @mailwoman/docs lint:structure`.
- **31 pre-existing violations fixed, none dodged**: review-by on the concept-role pages, true prerequisites/verified-with on the recipes (values traced to each recipe's body and the Phase 2d execution receipts — `verified-with: v6.1.0` deliberately names the version the examples were actually run against), getting-started's full guide contract.
- **PR template**: five docs checkboxes, deletable when a PR doesn't touch docs.
- **Quarterly freshness sweep** (`docs-freshness.yml`, cron Jan/Apr/Jul/Oct, `issues: write` only, concurrency-guarded): lists pages whose `review-by` has passed in ONE idempotent issue; pages without `review-by` are never swept — archival evidence doesn't churn.

## Review

Approve (opus): the reviewer built its own synthetic bad files per check class (all caught, excluded paths clean of false positives), sampled six flag resolutions and ruled every added frontmatter value truthful, verified the before-install CI placement is real (type-only imports erase), and confirmed the untouched boundary with the concurrent 6.2.0 refresh. Fix round: the dropped "no security-sensitive detail" clause restored; concurrency guard added to the sweep workflow.

Post-merge suggestion from review: one `workflow_dispatch` smoke of docs-freshness (side-effect-safe when nothing is due).

🤖 Generated with [Claude Code](https://claude.com/claude-code)