### PR TITLE
docs: v263 recaptures + Step 5 checklist upgrades from its first field run

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -412,12 +412,34 @@ against the real shipped weights, not a staging candidate:
    `docs/src/components/AboutDemo/AboutDemo.tsx`),
    `docs/articles/understanding/our-approach/from-pelias-to-mailwoman.mdx`, and
    `docs/articles/status.mdx` + `docs/articles/releases.mdx` (params, vocab size, int8/fp32 size —
-   byte-verify each against the artifact; don't trust the prose you're replacing).
+   byte-verify each against **the model card** `neural-weights-en-us/model-card.json`
+   (`architecture`, `format`, `files_md5`); don't trust the prose you're replacing. A fine-tune off
+   the same lineage often changes NONE of these — confirm via the card rather than assuming drift.
+   These are a **different measurement** from the npm package download/unpacked size quoted in
+   `getting-started.mdx` — get those from the registry, never by arithmetic: `npm view
+@mailwoman/neural-weights-en-us@<version> dist.unpackedSize` for the unpacked figure, and a
+   `curl -r 0-0` range-request (`content-range: bytes 0-0/<total>`) against the tarball URL for the
+   compressed download figure.
 2. **Re-run the docs' captured CLI examples** (`mailwoman parse`, `mailwoman geocode`, the
    `/v1/batch` curl captures) against the newly-promoted weights, and refresh only the output blocks
    whose real bytes changed — byte-exact, leave unchanged blocks and surrounding prose untouched.
-3. **Run the `mailwoman eval ledger-append` command** the promotion gate printed on its PASS output,
-   so `evals/scores-by-version.json` picks up the new row.
+   **On a fresh worktree/host, `link-dev-weights.ts` linking `model.onnx`/`tokenizer.model` is not
+   enough** — a model whose card `requires` an anchor/gazetteer/country channel also needs
+   `anchor-lexicon-v1.json` + `country-surface-lexicon-v1.json` (copy from this repo's own
+   `data/gazetteer/`) and any `postcode-<cc>.bin` in the weights package dir, or the capture runs
+   silently degraded through the legacy rule-only fallback (no error — a stderr banner names each
+   missing channel; if you don't see one, you didn't check hard enough). Re-verify the md5 guard
+   passes with no `#397 guard` error before trusting a capture.
+   **If the demo is deliberately held back on an older model** (its runtime doesn't yet feed a new
+   required input channel — see the 6.2.0 precedent below), the demo's own captured screenshots/text
+   stay on the OLD version; only the library/CLI/server captures move to the new one. Say so
+   explicitly in `status.mdx` rather than letting the version mismatch read as an oversight.
+3. **Check `evals/scores-by-version.json` for the new version's row** (`mailwoman eval
+ledger-append`, printed by the promotion gate on its PASS output, is what writes it) — but that
+   command is the OPERATOR's to run, from the session that held the gate's PASS output. If your task
+   is a docs-only refresh and you don't have that output in hand, don't fabricate or backfill the
+   row: verify presence/absence in the ledger and report it, and flag any still-missing prior
+   version's row you notice along the way (they accumulate silently otherwise).
 
 `status.mdx` and `releases.mdx` change together or not at all (each page says so) — a model
 promotion always touches both: a new row on the releases matrix, a re-verified banner on status.

--- a/docs/articles/concepts/how-mailwoman-resolves-a-place.mdx
+++ b/docs/articles/concepts/how-mailwoman-resolves-a-place.mdx
@@ -42,7 +42,7 @@ You can watch the decoration land on the same tree the parsing page ended with (
 ```xml
 <address raw="413 S 8th St, Springfield, IL 62701">
 	<region start="27" end="29" conf="0.92" src="resolver:region:85688697" lat="40.124199" lon="-89.148632" place="wof:85688697">IL
-		<locality start="14" end="25" conf="0.94" src="resolver:locality:85940429" lat="39.770987" lon="-89.653852" place="wof:85940429">Springfield
+		<locality start="14" end="25" conf="0.95" src="resolver:locality:85940429" lat="39.770987" lon="-89.653852" place="wof:85940429">Springfield
 			<street start="6" end="9" conf="0.94">8th
 				<house_number start="0" end="3" conf="0.89">413</house_number>
 				<street_prefix start="4" end="5" conf="0.96">S</street_prefix>

--- a/docs/articles/getting-started.mdx
+++ b/docs/articles/getting-started.mdx
@@ -60,7 +60,7 @@ Output:
 region: "NY" (confidence: 0.93)
   locality: "New York" (confidence: 0.89)
     street: "5th" (confidence: 0.95)
-      house_number: "350" (confidence: 0.87)
+      house_number: "350" (confidence: 0.88)
       street_suffix: "Ave" (confidence: 0.95)
     postcode: "10118" (confidence: 0.92)
 ```

--- a/neural-weights-en-us/.gitignore
+++ b/neural-weights-en-us/.gitignore
@@ -9,3 +9,7 @@
 # WOF postcode shard + data/gazetteer/, not committed (mirrors model.onnx/tokenizer.model).
 /postcode-*.bin
 /anchor-lexicon-v1.json
+
+# The #1104 country soft-feed channel's lexicon artifact (same treatment as anchor-lexicon-v1.json
+# above — copied from data/gazetteer/ at dev-link/publish time, not committed here).
+/country-surface-lexicon-v1.json


### PR DESCRIPTION
Slimmed after main moved to 6.2.1: the operator's own status/releases rewrite for 6.2.1 superseded this branch's 6.2.0 versions of those pages (including the demo-hold language — the hold is lifted). What survives is everything main still lacked:

- **Two byte-verified v263 output recaptures** — `getting-started` house_number 0.87→0.88, resolve-flagship locality 0.94→0.95. Captured against md5-verified v263 weights and independently re-run in review; 6.2.1 ships the same v263 model, so they hold.
- **RELEASING.md Step 5 upgrades from its first field run**: model-card numbers vs npm-registry package sizes are different measurements (with the exact registry commands); the fresh-worktree trap where linked weights without the anchor/country lexicon artifacts capture silently degraded output; wording for the deliberate demo-hold case; and the ledger-append split-actor reality — the docs task verifies the row's presence, the operator's gate session writes it.
- The `country-surface-lexicon-v1.json` workspace `.gitignore` entry (same treatment as the anchor lexicon).

Ledger status from the run, still true: neither 6.1.0 nor 6.2.0 (nor 6.2.1) has a `scores-by-version.json` row — flagged in #1117.

Original review: accept (byte-level re-verification); the two cosmetic nits it raised applied to since-superseded status.mdx text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)