### PR TITLE
feat(eval): gate --weights-cache (package-shaped) + ledger backfill 6.0–6.2

### DIFF
--- a/docs/articles/evals/2026-07-14-v263-country-channel-result.md
+++ b/docs/articles/evals/2026-07-14-v263-country-channel-result.md
@@ -11,18 +11,20 @@ v261 documented-exception decision — because the region delta is a per-tag reg
 
 ## Grade (package-shaped throughout — `--weights-cache`, never `--model` alone, #718)
 
-| Gate                                                  | shipped (v261 / 6.1.0) | v263                         | verdict                                                            |
-| ----------------------------------------------------- | ---------------------- | ---------------------------- | ------------------------------------------------------------------ |
-| **PRIMARY — golden country recall**                   | 190/224 = **84.8%**    | 200/224 = **89.3%**          | ✓ +4.5pp — clears the 88.6% v241 bar; fixes 19, breaks 9 (net +10) |
-| **GUARD — real-postal country recall** (falsifier)    | 3/4                    | 3/4                          | ✓ identical                                                        |
-| **GUARD — hallucination** (300 real no-country rows)  | 1%                     | 1%                           | ✓ identical                                                        |
-| **NON-INF — held-out US coordinate** (300 FDIC, ≤5km) | 279                    | 278 (z −0.16)                | ✓ PASS — not significantly worse                                   |
-| **NON-INF — held-out FR coordinate** (300 BAN, ≤5km)  | 281                    | 280 (z −0.17)                | ✓ PASS                                                             |
-| **gauntlet regression + metamorphic**                 | PASS                   | PASS (same 6 tracked xfails) | ✓                                                                  |
-| **per-tag region** (golden, exact-match)              | 556 fails              | 580 fails                    | ⚠ **+24 — the trade**                                              |
+| Gate                                                  | shipped (v261 / 6.1.0) | v263                         | verdict                                                             |
+| ----------------------------------------------------- | ---------------------- | ---------------------------- | ------------------------------------------------------------------- |
+| **PRIMARY — golden country recall**                   | 190/224 = **84.8%**    | 200/224 = **89.3%**          | ✓ +4.5pp — clears the 88.6% v241 bar; fixes 19, breaks 9 (net +10)  |
+| **GUARD — real-postal country recall** (falsifier)    | 3/4                    | 3/4                          | ✓ identical                                                         |
+| **GUARD — hallucination** (300 real no-country rows)  | 1%                     | 1%                           | ✓ identical                                                         |
+| **NON-INF — held-out US coordinate** (300 FDIC, ≤5km) | 279                    | 278 (z −0.16)                | ✓ PASS — not significantly worse                                    |
+| **NON-INF — held-out FR coordinate** (300 BAN, ≤5km)  | 281                    | 280 (z −0.17)                | ✓ PASS                                                              |
+| **gauntlet regression + metamorphic**                 | PASS                   | PASS (same 6 tracked xfails) | ✓                                                                   |
+| **per-tag region** (golden, exact-match)              | 556 fails              | 580 fails                    | ⚠ **+24 — the region trade**                                        |
+| **country-homograph** F1 (real, n=54)                 | 89.8 (country-OFF)     | **82.6** (country-ON)        | ⚠ **−7.2pp — the homograph trade** (surfaced by the ledger tooling) |
 
-Country/postcode/hn/street/locality per-tag deltas on golden are small (country −10; postcode +6, street
-+5, locality +4, hn +2); aggregate label-fails 1805 → 1835 (+30), dominated by region.
+Country/postcode/hn/street/locality per-tag deltas on golden are small (postcode +6, street +5, locality
++4, hn +2); aggregate label-fails 1805 → 1835 (+30), dominated by region. Note the two country lenses
+disagree by design — see the two trade sections below.
 
 ## The region trade — real, but coordinate-invisible
 
@@ -37,6 +39,26 @@ z-test on 300 fresh real US/FDIC and 300 fresh real FR/BAN addresses — is flat
 −0.17, PASS). The golden region misses are on redundant-trailing-country formats that real-address draws
 don't emphasize; the resolver still pins those without the region. This is the same class as v261's
 documented country exception, in the opposite tag: a per-tag delta that the coordinate does not see.
+
+## The homograph trade — the country channel cuts both ways (surfaced 2026-07-14 by the ledger tooling)
+
+The `--weights-cache` promotion-gate path added for the ledger backfill graded v263 package-shaped on the
+`country-homograph-real` probe (n=54) and exposed a **second, country-side** trade the golden grade above
+did not measure. v263's country channel is a 2-dim `[country_surface, country_ambiguous]` feature; the
+`country_ambiguous` bit is a learnable false-positive guard for homograph surfaces (a country name that is
+also a US state, a city, or a common word). It works — but on this all-homographs-are-countries test it is
+_too_ conservative: v263 (country-ON) misses exactly three rows country-OFF emits — **Georgia** (US state),
+**Jordan** (given name), **Jamaica** (NYC neighborhood) — and gains none, so country F1 drops **89.8 → 82.6**.
+
+This is the mirror image of the WOF-admin win. On the leading-long-form WOF-admin distribution (golden, the
+#1104 target) the channel _lifts_ country recall 84.8→89.3%; on the trailing-homograph distribution it
+_trades_ recall for precision. The net is coordinate-invisible — the held-out coordinate z-test passed on
+both locales, and the `country_ambiguous` guard's whole purpose is fewer false "Georgia → country" emissions
+on real mixed input, which the homograph-recall test cannot credit. It does not change the v263 ship
+(coordinate is the ship gate, #566), but it sharpens the country story: **v263 helps admin-hierarchy country
+and trades a little homograph-country recall for homograph precision.** A future tune could soften the
+guard (a lower `country_ambiguous` weight) if the homograph-recall lens is judged to matter more than the
+precision it buys. Recorded in `evals/scores-by-version.json` (the 6.2.0 row's `us.country_homograph`).
 
 ## The decision — operator's, per the v261 precedent
 

--- a/evals/scores-by-version.json
+++ b/evals/scores-by-version.json
@@ -711,6 +711,129 @@
 				}
 			},
 			"notes": "Promoted 2026-07-09 via the gauntlet battery (mangle 23.5→17.7% int8, Honoré+René repros, held-out FR z=+0.90 / US z=+0.29 — table on #444); this promotion-gate run executed post-hoc for the ledger per the re-anchor discipline. Tokenizer v0.8.0-fr-nsplice (spliced; training-free path falsified first, #1047). Clears the int8 homograph floor outright (85.1 vs 83.3) — the 5.3.0/5.4.0 adjudicated int8-delta exception is no longer needed. [graded_artifact=int8; gate=v2.3.0-nl-postcode; out-dir=/tmp/claude-1000/-home-lab-Projects-mailwoman/fc0a4401-3bda-4fa5-b4b9-4031dda9cbeb/scratchpad/gate-v241-ledger]"
+		},
+		{
+			"run_id": "hono-api-cutover-6-0-0",
+			"model_version": "6.0.0",
+			"model_path": "@mailwoman/neural-weights-en-us@6.0.0",
+			"corpus_version": "corpus-v0.10.1-nl-postcode",
+			"corpus_sha256": "see the shipped model-card corpus_version (practiced-shape pointer, not a digest)",
+			"eval_set_version": "promotion-gate battery (v2.3.0-nl-postcode): golden v0.1.2 + real-OOD + arena perturb",
+			"eval_set_sha256": "per-file, see data/eval/external",
+			"trained_at": "2026-07-09",
+			"hardware": "NVIDIA A100-SXM4-40GB (Modal cloud)",
+			"training_steps": 12000,
+			"training_wall_clock_seconds": 0,
+			"metrics": {
+				"us": {
+					"postcode": 96.5,
+					"country_homograph": 85.1,
+					"micro": 87.5,
+					"locality": 78.3,
+					"region": 90.7,
+					"street": 82.6,
+					"street_prefix": 98,
+					"street_suffix": 94.9,
+					"unit": 97,
+					"po_box_real": 89.8,
+					"intersection_real": 100
+				},
+				"fr": {
+					"postcode": 99.2,
+					"house_number": 98.8,
+					"region": 50.2,
+					"cedex_real": 93.3
+				},
+				"de": {
+					"native_locality_anchor_on": 91.3
+				},
+				"arena": {
+					"perturb": 81
+				}
+			},
+			"notes": "Code-only Hono API-surface cutover (#1084/#1085); the trained model is UNCHANGED from 5.9.0 (v2.4.1-fr-nsplice-ft, v241) — its model-card stayed at 5.9.0. Metrics carried from the 5.9.0 row, not re-graded (a model-unchanged code release produces byte-identical parses). See releases.mdx."
+		},
+		{
+			"run_id": "v2-6-1-span-boundary-full-20260714",
+			"model_version": "6.1.0",
+			"model_path": "@mailwoman/neural-weights-en-us@6.1.0",
+			"corpus_version": "v257 fragment-campaign corpus (shard-v5) re-tokenized through v0.9.0-multisplice; span-boundary aux head from BIO labels.",
+			"corpus_sha256": "see the shipped model-card corpus_version (practiced-shape pointer, not a digest)",
+			"eval_set_version": "promotion-gate battery (v5.3.0-family): golden v0.1.2 + real-OOD + arena perturb",
+			"eval_set_sha256": "per-file, see data/eval/external",
+			"trained_at": "2026-07-14",
+			"hardware": "NVIDIA A100-SXM4-40GB (Modal cloud)",
+			"training_steps": 8000,
+			"training_wall_clock_seconds": 0,
+			"metrics": {
+				"us": {
+					"postcode": 96.9,
+					"country_homograph": 89.8,
+					"micro": 87.2,
+					"locality": 78.7,
+					"region": 90.4,
+					"street": 81.7,
+					"street_prefix": 98,
+					"street_suffix": 94.9,
+					"unit": 97,
+					"po_box_real": 88.8,
+					"intersection_real": 100
+				},
+				"fr": {
+					"postcode": 98.9,
+					"house_number": 96.5,
+					"region": 47.2,
+					"cedex_real": 87.6
+				},
+				"de": {
+					"native_locality_anchor_on": 91.5
+				},
+				"arena": {
+					"perturb": 80
+				}
+			},
+			"notes": "POST-HOC ledger measurement (package-shaped, eval gate --weights-cache). v261 (#727 stage-1 span-boundary) shipped on the gauntlet COORDINATE gate + operator-approved documented country cosmetic exception (#1104), NOT this v5.3.0-family parity gate. One floor-fail, coordinate-invisible (operator-excepted): fr.postcode 98.9<99.2 — a small FR-postcode dip shared across the multisplice/fragment line, held-out FR coordinate flat. country_homograph 89.x PASSES (v261 has no country channel). See releases.mdx 6.1.0 row. OPERATOR-EXCEPTED CHECKS (adjudicated at the promote fork, see the gate spec's revision comment): fr.postcode. [graded_artifact=fp32; gate=v5.3.0-family; out-dir=/tmp/claude-1000/-home-lab-Projects-mailwoman/68bebf18-8fe3-4263-ae64-70c79a08f97c/scratchpad/gate-v261-610]"
+		},
+		{
+			"run_id": "v2-6-3-country-channel-20260714",
+			"model_version": "6.2.0",
+			"model_path": "@mailwoman/neural-weights-en-us@6.2.0",
+			"corpus_version": "v257 fragment-campaign corpus (shard-v5) — UNCHANGED from v261; the country channel paints features on existing rows from the country-surface lexicon at encode time (no new shard).",
+			"corpus_sha256": "see the shipped model-card corpus_version (practiced-shape pointer, not a digest)",
+			"eval_set_version": "promotion-gate battery (v5.3.0-family): golden v0.1.2 + real-OOD + arena perturb",
+			"eval_set_sha256": "per-file, see data/eval/external",
+			"trained_at": "2026-07-14",
+			"hardware": "NVIDIA A100-SXM4-40GB (Modal cloud)",
+			"training_steps": 8000,
+			"training_wall_clock_seconds": 0,
+			"metrics": {
+				"us": {
+					"postcode": 96.7,
+					"country_homograph": 82.6,
+					"micro": 87.1,
+					"locality": 78.5,
+					"region": 90,
+					"street": 81.9,
+					"street_prefix": 98,
+					"street_suffix": 94.9,
+					"unit": 97,
+					"po_box_real": 88.9,
+					"intersection_real": 100
+				},
+				"fr": {
+					"postcode": 98.8,
+					"house_number": 96.5,
+					"region": 44.2,
+					"cedex_real": 87.8
+				},
+				"de": {
+					"native_locality_anchor_on": 91.4
+				},
+				"arena": {
+					"perturb": 80
+				}
+			},
+			"notes": "POST-HOC ledger measurement (package-shaped, eval gate --weights-cache). v263 shipped on the gauntlet COORDINATE gate + operator-approved documented per-tag trades, NOT this v5.3.0-family parity gate. Two floor-fails, both coordinate-invisible (operator-excepted): us.country_homograph 82.6<83.3 (the country channel's ambiguity guard over-suppresses homograph countries Georgia/Jordan/Jamaica — trades homograph recall for precision) and fr.postcode 98.8<99.2. The channel LIFTS WOF-admin/golden country recall 84.8->89.3% (the #1104 target); held-out US/FR coordinate flat (z -0.16/-0.17). See 2026-07-14-v263-country-channel-result.md. OPERATOR-EXCEPTED CHECKS (adjudicated at the promote fork, see the gate spec's revision comment): us.country_homograph_f1, fr.postcode. [graded_artifact=fp32; gate=v5.3.0-family; out-dir=/tmp/claude-1000/-home-lab-Projects-mailwoman/68bebf18-8fe3-4263-ae64-70c79a08f97c/scratchpad/gate-v263-620]"
 		}
 	]
 }

--- a/mailwoman/commands/eval/gate.tsx
+++ b/mailwoman/commands/eval/gate.tsx
@@ -33,6 +33,12 @@ const OptionsSchema = zod.object({
 		.string()
 		.optional()
 		.describe("Gazetteer lexicon JSON (default data/gazetteer/anchor-lexicon-v1.json)"),
+	weightsCache: zod
+		.string()
+		.optional()
+		.describe(
+			"Package-shaped candidate weights dir (<root>/node_modules/@mailwoman/neural-weights-en-us) — #718-safe, feeds anchor+gazetteer+country via loadFromWeights; the only correct grade for a country-channel model (v6.2.0+). Alternative to --model."
+		),
 	outDir: zod.string().optional().describe("Battery output dir (default /tmp/gate-<label>-<hhmm>)"),
 })
 

--- a/mailwoman/eval-harness/promotion-gate.ts
+++ b/mailwoman/eval-harness/promotion-gate.ts
@@ -48,7 +48,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
-import { basename, dirname } from "node:path"
+import { basename, dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { $public } from "@mailwoman/core/env"
@@ -86,6 +86,12 @@ export interface PromotionGateOptions {
 	card?: string
 	/** Gazetteer lexicon JSON. Default `data/gazetteer/anchor-lexicon-v1.json`. */
 	gazetteerLexicon?: string
+	/**
+	 * Package-shaped candidate weights dir `<root>/node_modules/@mailwoman/neural-weights-en-us` — the #718-safe path
+	 * that feeds anchor+gazetteer+country via loadFromWeights, the only in-distribution grade for a country-channel model
+	 * (v6.2.0+). Alternative to --model/--int8; takes precedence.
+	 */
+	weightsCache?: string
 	/** Battery output dir. Default `/tmp/gate-<label>-<hhmm>`. */
 	outDir?: string
 }
@@ -130,8 +136,18 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 	const GAZ = options.gazetteerLexicon ?? "data/gazetteer/anchor-lexicon-v1.json"
 	const LK = dataRootPath("anchor", "pilot-anchor-lookup.json")
 
-	if (!MODEL || !GATE) {
-		console.error("✗ --model and --gate required")
+	// PACKAGE-SHAPED (#718-safe): when --weights-cache is set, the graded artifact + its tokenizer/card
+	// are the cache's own siblings. The metric probes load it via loadFromWeights (feeding anchor +
+	// gazetteer + COUNTRY — the only in-distribution grade for a country-channel model); the
+	// country-orthogonal downstream legs (preset / cascade / arena / fr-recall / mask) stay on the
+	// explicit --model path against these EFF_TOK/EFF_CARD siblings.
+	const WC = options.weightsCache ?? ""
+	const WC_MODEL = WC ? resolve(WC, "node_modules/@mailwoman/neural-weights-en-us/model.onnx") : ""
+	const EFF_TOK = WC ? resolve(WC, "node_modules/@mailwoman/neural-weights-en-us/tokenizer.model") : TOK
+	const EFF_CARD = WC ? resolve(WC, "node_modules/@mailwoman/neural-weights-en-us/model-card.json") : CARD
+
+	if (!GATE || (!MODEL && !WC)) {
+		console.error("✗ --gate and one of --model / --weights-cache required")
 
 		return 2
 	}
@@ -146,10 +162,12 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 	mkdirSync(OUT_DIR, { recursive: true })
 
 	// --- lore guard: tokenizer comparability -----------------------------------
-	const card = JSON.parse(readFileSync(CARD, "utf8")) as ModelCard
+	const card = JSON.parse(readFileSync(EFF_CARD, "utf8")) as ModelCard
 	const CARD_TOK = card.training.tokenizer_version
 
-	if (!TOK.includes(CARD_TOK)) {
+	// Skipped for --weights-cache: loadFromWeights pairs the package's own tokenizer + card internally,
+	// so the (unused) explicit TOK path won't contain the card's version string.
+	if (!WC && !TOK.includes(CARD_TOK)) {
 		console.error(
 			`✗ tokenizer path '${TOK}' does not contain card tokenizer_version '${CARD_TOK}' — F1 would be incomparable`
 		)
@@ -184,40 +202,53 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 		return r.stdout.trim().split(/\s+/)[0] ?? ""
 	}
 
-	const modelDql = await dql(MODEL)
-	const provLines = [
-		`graded at ${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}`,
-		`MODEL  ${await md5(MODEL)}  dql=${modelDql}  ${MODEL}`,
-	]
-	let int8Dql = ""
+	// --weights-cache: one artifact (the shipped package int8) — log its provenance, skip the
+	// fp32/int8 dual-artifact assertions (they exist for the --model fp32 + --int8 sibling flow).
+	if (WC) {
+		const wcDql = await dql(WC_MODEL)
+		const provenance =
+			[
+				`graded at ${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}`,
+				`WEIGHTS-CACHE  ${await md5(WC_MODEL)}  dql=${wcDql}  ${WC_MODEL}`,
+			].join("\n") + "\n"
+		writeFileSync(`${OUT_DIR}/provenance.txt`, provenance)
+		process.stdout.write(provenance)
+	} else {
+		const modelDql = await dql(MODEL)
+		const provLines = [
+			`graded at ${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}`,
+			`MODEL  ${await md5(MODEL)}  dql=${modelDql}  ${MODEL}`,
+		]
+		let int8Dql = ""
 
-	if (INT8) {
-		int8Dql = await dql(INT8)
-		provLines.push(`INT8   ${await md5(INT8)}  dql=${int8Dql}  ${INT8}`)
-	}
-	const provenance = provLines.join("\n") + "\n"
-	writeFileSync(`${OUT_DIR}/provenance.txt`, provenance) // tee → file …
-	process.stdout.write(provenance)
+		if (INT8) {
+			int8Dql = await dql(INT8)
+			provLines.push(`INT8   ${await md5(INT8)}  dql=${int8Dql}  ${INT8}`)
+		}
+		const provenance = provLines.join("\n") + "\n"
+		writeFileSync(`${OUT_DIR}/provenance.txt`, provenance) // tee → file …
+		process.stdout.write(provenance)
 
-	//                       … and stdout
+		//                       … and stdout
 
-	if (modelDql !== "0") {
-		console.error(`✗ --model '${MODEL}' carries int8 quant nodes — it is not an fp32 artifact`)
-
-		return 2
-	}
-
-	if (INT8) {
-		if (int8Dql === "0") {
-			console.error(`✗ --int8 '${INT8}' has no quant nodes — it is not a quantized artifact`)
+		if (modelDql !== "0") {
+			console.error(`✗ --model '${MODEL}' carries int8 quant nodes — it is not an fp32 artifact`)
 
 			return 2
 		}
 
-		if ((await md5(MODEL)) === (await md5(INT8))) {
-			console.error("✗ --model and --int8 are byte-identical — one is mislabeled")
+		if (INT8) {
+			if (int8Dql === "0") {
+				console.error(`✗ --int8 '${INT8}' has no quant nodes — it is not a quantized artifact`)
 
-			return 2
+				return 2
+			}
+
+			if ((await md5(MODEL)) === (await md5(INT8))) {
+				console.error("✗ --model and --int8 are byte-identical — one is mislabeled")
+
+				return 2
+			}
 		}
 	}
 
@@ -242,48 +273,62 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 		BRIDGE_MODE = "1"
 	}
 
-	const shipModel = INT8 || MODEL
+	const shipModel = WC ? WC_MODEL : INT8 || MODEL
 
 	const runBattery = async (m: string, tag: string): Promise<void> => {
 		console.log(`== battery [${tag}] ${m} ==`)
+		// Package-shaped (#718): the metric probes (which support --weights-cache) load ALL channels —
+		// anchor + gazetteer + COUNTRY — from the package. The country-orthogonal de-order watch lens
+		// stays on the explicit path against the cache siblings (EFF_TOK/EFF_CARD); m = WC_MODEL when WC.
+		const plFlags = WC
+			? ["--weights-cache", WC]
+			: ["--model", m, "--tokenizer", TOK, "--model-card", CARD, "--model-anchor-lookup", String(LK)]
+		const probeFlags = WC ? ["--weights-cache", WC] : ["--model", m]
 		const perLocale =
-			await $`node scripts/eval/per-locale-f1.ts --model ${m} --tokenizer ${TOK} --model-card ${CARD} --model-anchor-lookup ${LK} ${GAZ_ARGS} --out-json ${`${OUT_DIR}/${tag}-per-locale.json`}`
+			await $`node scripts/eval/per-locale-f1.ts ${plFlags} ${GAZ_ARGS} --out-json ${`${OUT_DIR}/${tag}-per-locale.json`}`
 		writeFileSync(`${OUT_DIR}/${tag}-per-locale.md`, perLocale.stdout)
 		const affix =
-			await $`node scripts/eval/score-affix.ts --model ${m} ${GAZ_ARGS} --json ${`${OUT_DIR}/${tag}-affix.json`}`
+			await $`node scripts/eval/score-affix.ts ${probeFlags} ${GAZ_ARGS} --json ${`${OUT_DIR}/${tag}-affix.json`}`
 		writeFileSync(`${OUT_DIR}/${tag}-affix.md`, affix.stdout)
 		const unit =
-			await $`node scripts/eval/score-affix.ts --model ${m} --file data/eval/external/unit-real-designators.jsonl ${GAZ_ARGS} --json ${`${OUT_DIR}/${tag}-unit.json`}`
+			await $`node scripts/eval/score-affix.ts ${probeFlags} --file data/eval/external/unit-real-designators.jsonl ${GAZ_ARGS} --json ${`${OUT_DIR}/${tag}-unit.json`}`
 		writeFileSync(`${OUT_DIR}/${tag}-unit.md`, unit.stdout)
 		const country =
-			await $`node scripts/eval/score-country-homograph.ts --model ${m} ${GAZ_ARGS} --suppress-gaz-near-postcode --json ${`${OUT_DIR}/${tag}-country.json`}`
+			await $`node scripts/eval/score-country-homograph.ts ${probeFlags} ${GAZ_ARGS} --suppress-gaz-near-postcode --json ${`${OUT_DIR}/${tag}-country.json`}`
 		writeFileSync(`${OUT_DIR}/${tag}-country.md`, country.stdout)
 		// v4.4.0 floors: po_box/cedex (the coverage-shard val) + intersections (real TIGER crossings).
 		const pobox =
-			await $`node scripts/eval/score-affix.ts --model ${m} --file data/eval/external/po-box-cedex-val.jsonl ${GAZ_ARGS} --json ${`${OUT_DIR}/${tag}-pobox.json`}`
+			await $`node scripts/eval/score-affix.ts ${probeFlags} --file data/eval/external/po-box-cedex-val.jsonl ${GAZ_ARGS} --json ${`${OUT_DIR}/${tag}-pobox.json`}`
 		writeFileSync(`${OUT_DIR}/${tag}-pobox.md`, pobox.stdout)
 		const intersection =
-			await $`node scripts/eval/score-affix.ts --model ${m} --file data/eval/external/intersection-real.jsonl ${GAZ_ARGS} --json ${`${OUT_DIR}/${tag}-intersection.json`}`
+			await $`node scripts/eval/score-affix.ts ${probeFlags} --file data/eval/external/intersection-real.jsonl ${GAZ_ARGS} --json ${`${OUT_DIR}/${tag}-intersection.json`}`
 		writeFileSync(`${OUT_DIR}/${tag}-intersection.md`, intersection.stdout)
 		// Watch lenses (v4.4.0+, recorded not floored — one release of history before promotion, #488):
 		const watchVt =
-			await $`node scripts/eval/score-affix.ts --model ${m} --file data/eval/external/intersection-golden-vt.jsonl ${GAZ_ARGS}`
+			await $`node scripts/eval/score-affix.ts ${probeFlags} --file data/eval/external/intersection-golden-vt.jsonl ${GAZ_ARGS}`
 		writeFileSync(`${OUT_DIR}/${tag}-watch-intersection-vt.md`, watchVt.stdout)
 		const watchGlue =
-			await $`node scripts/eval/score-affix.ts --model ${m} --file data/eval/external/glue-rows-perturb.jsonl ${GAZ_ARGS}`
+			await $`node scripts/eval/score-affix.ts ${probeFlags} --file data/eval/external/glue-rows-perturb.jsonl ${GAZ_ARGS}`
 		writeFileSync(`${OUT_DIR}/${tag}-watch-glue.md`, watchGlue.stdout)
 		// de-order-eval tolerates its own non-zero regression exit (it wrote a valid report) — nothrow,
 		// combine stdout+stderr like the bash `> … 2>&1 || true`.
 		const deorder = await $({
 			nothrow: true,
-		})`node scripts/eval/de-order-eval.ts --model ${m} --card ${CARD} --tokenizer ${TOK} --anchor-lookup ${LK} --out ${`${OUT_DIR}/${tag}-deorder`}`
+		})`node scripts/eval/de-order-eval.ts --model ${m} --card ${EFF_CARD} --tokenizer ${EFF_TOK} --anchor-lookup ${LK} --out ${`${OUT_DIR}/${tag}-deorder`}`
 		writeFileSync(`${OUT_DIR}/${tag}-deorder.md`, `${deorder.stdout}${deorder.stderr}`)
 	}
 
-	await runBattery(MODEL, "fp32")
+	// --weights-cache grades the single shipped package (int8) in the primary slot; the verdict reads
+	// the `fp32-*` files (its primary-artifact slot) with withInt8=false. The --model path keeps the
+	// fp32 + optional int8 dual-artifact flow.
+	if (WC) {
+		await runBattery(WC_MODEL, "fp32")
+	} else {
+		await runBattery(MODEL, "fp32")
 
-	if (INT8) {
-		await runBattery(INT8, "int8")
+		if (INT8) {
+			await runBattery(INT8, "int8")
+		}
 	}
 	// In-process since the eval-harness migration (was `node scripts/eval/demo-preset-compare.ts`);
 	// same capture: the report lines land in presets.md, a failure is tolerated like the old child's
@@ -308,7 +353,7 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 	if (existsSync(HOT_DB)) {
 		const cascade = await $({
 			nothrow: true,
-		})`node scripts/eval/demo-cascade-smoke.ts --db ${HOT_DB} --stage-dir ${HOT_STAGE} --model ${shipModel} --tokenizer ${TOK} --card ${CARD} --gazetteer-lexicon ${GAZ} --json ${`${OUT_DIR}/cascade-smoke.json`}`
+		})`node scripts/eval/demo-cascade-smoke.ts --db ${HOT_DB} --stage-dir ${HOT_STAGE} --model ${shipModel} --tokenizer ${EFF_TOK} --card ${EFF_CARD} --gazetteer-lexicon ${GAZ} --json ${`${OUT_DIR}/cascade-smoke.json`}`
 		writeFileSync(`${OUT_DIR}/cascade-smoke.md`, cascade.stdout)
 
 		if (cascade.exitCode !== 0) {
@@ -334,9 +379,9 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 			"--model",
 			shipModel,
 			"--tokenizer",
-			TOK,
+			EFF_TOK,
 			"--model-card",
-			CARD,
+			EFF_CARD,
 			"--gazetteer-lexicon",
 			GAZ,
 			"--anchor-lookup",
@@ -367,7 +412,7 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 		const bare = await $({
 			nothrow: true,
 			env: childEnv(),
-		})`node scripts/diagnostic/fr-parse-recall.ts --model ${shipModel} --tokenizer ${TOK} --model-card ${CARD} --floor ${String(bareStreetFloor)} --json ${`${OUT_DIR}/fr-bare-street.json`}`
+		})`node scripts/diagnostic/fr-parse-recall.ts --model ${shipModel} --tokenizer ${EFF_TOK} --model-card ${EFF_CARD} --floor ${String(bareStreetFloor)} --json ${`${OUT_DIR}/fr-bare-street.json`}`
 		writeFileSync(`${OUT_DIR}/fr-bare-street.md`, `${bare.stdout}${bare.stderr}`)
 
 		if (bare.exitCode !== 0) {
@@ -397,8 +442,8 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 			const mask = await maskRegressionGate(
 				{
 					model: shipModel,
-					tokenizer: TOK,
-					modelCard: CARD,
+					tokenizer: EFF_TOK,
+					modelCard: EFF_CARD,
 					anchorLookup: String(LK),
 					gazetteerLexicon: GAZ,
 					json: `${OUT_DIR}/mask-regression.json`,
@@ -455,7 +500,7 @@ export async function runPromotionGate(options: PromotionGateOptions): Promise<n
 			`  node mailwoman/out/cli.js eval ledger-append \\\n` +
 			`    --out-dir ${OUT_DIR} --model-version <npm-semver> \\\n` +
 			`    --run-id ${LABEL.replace(/[^a-z0-9-]/g, "-")}-${shipDate.replaceAll("-", "")} \\\n` +
-			`    --model-path "@mailwoman/neural-weights-en-us@<npm-semver>" --card ${CARD}`
+			`    --model-path "@mailwoman/neural-weights-en-us@<npm-semver>" --card ${EFF_CARD}`
 	)
 
 	return 0

--- a/scripts/eval/per-locale-f1.ts
+++ b/scripts/eval/per-locale-f1.ts
@@ -74,6 +74,7 @@ const DEFAULT_GAZETTEER_LEXICON = "data/gazetteer/anchor-lexicon-v1.json"
 interface Args {
 	goldenDir: string
 	files: string[]
+	weightsCache?: string
 	modelPath?: string
 	tokenizerPath?: string
 	modelCardPath?: string
@@ -107,6 +108,7 @@ function parseArgs(): Args {
 			"out-json": { type: "string" },
 			"suppress-gaz-near-postcode": { type: "boolean" },
 			tokenizer: { type: "string" },
+			"weights-cache": { type: "string" },
 		},
 		strict: false,
 		allowPositionals: true,
@@ -121,6 +123,10 @@ function parseArgs(): Args {
 			.split(",")
 			.map((s) => s.trim())
 			.filter(Boolean)
+	}
+
+	if (values["weights-cache"] != null) {
+		out.weightsCache = values["weights-cache"] as string
 	}
 
 	if (values["model"] != null) {
@@ -342,10 +348,18 @@ async function main(): Promise<void> {
 
 	let neural: NeuralAddressClassifier
 
-	// FOOTGUN GUARD: if ANY custom-model flag is set, ALL THREE are required. Previously a missing
-	// --tokenizer silently fell back to the DEFAULT shipped weights, so --model was ignored and two
-	// different checkpoints scored byte-identical. Refuse to guess; fail loud.
-	if (args.modelPath || args.tokenizerPath || args.modelCardPath) {
+	// PACKAGE-SHAPED (#718-safe): `--weights-cache <root>` loads model + tokenizer + card + ALL soft
+	// channels (anchor + gazetteer + country) from `<root>/node_modules/@mailwoman/neural-weights-en-us`
+	// via loadFromWeights, exactly as production does — the only way to grade a country-channel model
+	// (v6.2.0+) in-distribution. Mirrors the gauntlet + `eval parity --weights-cache`. Takes precedence
+	// over the explicit --model path.
+	if (args.weightsCache) {
+		console.error(`Weights:    package-shaped from ${args.weightsCache} (loadFromWeights cacheRoot)`)
+		neural = await NeuralAddressClassifier.loadFromWeights({ locale: "en-US", cacheRoot: args.weightsCache })
+	} else if (args.modelPath || args.tokenizerPath || args.modelCardPath) {
+		// FOOTGUN GUARD: if ANY custom-model flag is set, ALL THREE are required. Previously a missing
+		// --tokenizer silently fell back to the DEFAULT shipped weights, so --model was ignored and two
+		// different checkpoints scored byte-identical. Refuse to guess; fail loud.
 		if (!args.modelPath || !args.tokenizerPath || !args.modelCardPath) {
 			throw new Error(
 				"--model requires --tokenizer AND --model-card together (refusing to silently fall back to " +

--- a/scripts/eval/score-affix.ts
+++ b/scripts/eval/score-affix.ts
@@ -21,6 +21,7 @@ const { values: rawValues } = parseArgs({
 		model: { type: "string" },
 		"bridge-gaps": { type: "boolean" },
 		"suppress-gaz-near-postcode": { type: "boolean" },
+		"weights-cache": { type: "string" },
 	},
 	strict: false,
 	allowPositionals: true,
@@ -34,6 +35,7 @@ const values = rawValues as {
 	model?: string
 	"bridge-gaps"?: boolean
 	"suppress-gaz-near-postcode"?: boolean
+	"weights-cache"?: string
 }
 const TOK = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 const LK = dataRootPath("anchor", "pilot-anchor-lookup.json")
@@ -58,23 +60,32 @@ const TAGS = [
 const GAZ = values["gazetteer-lexicon"] || ""
 const suppressGaz = values["suppress-gaz-near-postcode"] ?? false
 
-const card = JSON.parse(readFileSync("neural-weights-en-us/model-card.json", "utf8"))
-const [tokenizer, runner] = await Promise.all([
-	MailwomanTokenizer.loadFromFile(TOK),
-	ONNXRunner.create((values["model"] || "")!),
-])
-const neural = new NeuralAddressClassifier({
-	tokenizer,
-	runner,
-	labels: card.labels,
-	postcodeAnchorLookup: parseAnchorLookup(JSON.parse(readFileSync(LK, "utf8"))),
-	...(GAZ ? { gazetteerLexicon: parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))) } : {}),
-	suppressGazetteerNearPostcode: suppressGaz,
-	// #511 Tier A: --conventions auto|<system> enables the address-system conventions mask.
-	...(values["conventions"] || "" ? { addressSystemConventions: (values["conventions"] || "") as "auto" } : {}),
-	// v4.4.0 corrective: --bridge-gaps merges same-tag spans split at unlabeled punctuation.
-	...((values["bridge-gaps"] ?? false) ? { bridgePunctuationGaps: true } : {}),
-})
+// PACKAGE-SHAPED (#718-safe): `--weights-cache <root>` loads model + tokenizer + card + ALL soft channels
+// (anchor + gazetteer + country) from the package via loadFromWeights — the only in-distribution grade for a
+// country-channel model (v6.2.0+). Takes precedence over the explicit --model path.
+const WEIGHTS_CACHE = values["weights-cache"] || ""
+const neural = WEIGHTS_CACHE
+	? await NeuralAddressClassifier.loadFromWeights({ locale: "en-US", cacheRoot: WEIGHTS_CACHE })
+	: await (async () => {
+			const card = JSON.parse(readFileSync("neural-weights-en-us/model-card.json", "utf8"))
+			const [tokenizer, runner] = await Promise.all([
+				MailwomanTokenizer.loadFromFile(TOK),
+				ONNXRunner.create((values["model"] || "")!),
+			])
+
+			return new NeuralAddressClassifier({
+				tokenizer,
+				runner,
+				labels: card.labels,
+				postcodeAnchorLookup: parseAnchorLookup(JSON.parse(readFileSync(LK, "utf8"))),
+				...(GAZ ? { gazetteerLexicon: parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))) } : {}),
+				suppressGazetteerNearPostcode: suppressGaz,
+				// #511 Tier A: --conventions auto|<system> enables the address-system conventions mask.
+				...(values["conventions"] || "" ? { addressSystemConventions: (values["conventions"] || "") as "auto" } : {}),
+				// v4.4.0 corrective: --bridge-gaps merges same-tag spans split at unlabeled punctuation.
+				...((values["bridge-gaps"] ?? false) ? { bridgePunctuationGaps: true } : {}),
+			})
+		})()
 
 const rows = readFileSync(file, "utf8")
 	.split("\n")

--- a/scripts/eval/score-country-homograph.ts
+++ b/scripts/eval/score-country-homograph.ts
@@ -22,6 +22,7 @@ const { values: rawValues } = parseArgs({
 		model: { type: "string" },
 		"bridge-gaps": { type: "boolean" },
 		"suppress-gaz-near-postcode": { type: "boolean" },
+		"weights-cache": { type: "string" },
 	},
 	strict: false,
 	allowPositionals: true,
@@ -35,6 +36,7 @@ const values = rawValues as {
 	model?: string
 	"bridge-gaps"?: boolean
 	"suppress-gaz-near-postcode"?: boolean
+	"weights-cache"?: string
 }
 const TOK = dataRootPath("models", "tokenizer", "v0.6.0-a0", "tokenizer.model")
 const LK = dataRootPath("anchor", "pilot-anchor-lookup.json")
@@ -44,22 +46,31 @@ const GAZ = (values["gazetteer-lexicon"] || "data/gazetteer/anchor-lexicon-v1.js
 const file = (values["file"] || "data/eval/external/country-homograph-real.jsonl")!
 const TAGS = ["country", "region", "locality"] as const
 
-const card = JSON.parse(readFileSync("neural-weights-en-us/model-card.json", "utf8"))
-const [tokenizer, runner] = await Promise.all([
-	MailwomanTokenizer.loadFromFile(TOK),
-	ONNXRunner.create((values["model"] || "")!),
-])
-const neural = new NeuralAddressClassifier({
-	tokenizer,
-	runner,
-	labels: card.labels,
-	postcodeAnchorLookup: parseAnchorLookup(JSON.parse(readFileSync(LK, "utf8"))),
-	...(existsSync(GAZ) ? { gazetteerLexicon: parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))) } : {}),
-	suppressGazetteerNearPostcode: values["suppress-gaz-near-postcode"] ?? false,
-	// #511 Tier A: --conventions auto|<system> enables the address-system conventions mask.
-	...(values["conventions"] || "" ? { addressSystemConventions: (values["conventions"] || "") as "auto" } : {}),
-	...((values["bridge-gaps"] ?? false) ? { bridgePunctuationGaps: true } : {}),
-})
+// PACKAGE-SHAPED (#718-safe): `--weights-cache <root>` loads model + tokenizer + card + ALL soft channels
+// (anchor + gazetteer + country) from the package via loadFromWeights — the only in-distribution grade for a
+// country-channel model (v6.2.0+), which is exactly what this country probe must feed. Precedence over --model.
+const WEIGHTS_CACHE = values["weights-cache"] || ""
+const neural = WEIGHTS_CACHE
+	? await NeuralAddressClassifier.loadFromWeights({ locale: "en-US", cacheRoot: WEIGHTS_CACHE })
+	: await (async () => {
+			const card = JSON.parse(readFileSync("neural-weights-en-us/model-card.json", "utf8"))
+			const [tokenizer, runner] = await Promise.all([
+				MailwomanTokenizer.loadFromFile(TOK),
+				ONNXRunner.create((values["model"] || "")!),
+			])
+
+			return new NeuralAddressClassifier({
+				tokenizer,
+				runner,
+				labels: card.labels,
+				postcodeAnchorLookup: parseAnchorLookup(JSON.parse(readFileSync(LK, "utf8"))),
+				...(existsSync(GAZ) ? { gazetteerLexicon: parseGazetteerLexicon(JSON.parse(readFileSync(GAZ, "utf8"))) } : {}),
+				suppressGazetteerNearPostcode: values["suppress-gaz-near-postcode"] ?? false,
+				// #511 Tier A: --conventions auto|<system> enables the address-system conventions mask.
+				...(values["conventions"] || "" ? { addressSystemConventions: (values["conventions"] || "") as "auto" } : {}),
+				...((values["bridge-gaps"] ?? false) ? { bridgePunctuationGaps: true } : {}),
+			})
+		})()
 
 const rows = readFileSync(file, "utf8")
 	.split("\n")


### PR DESCRIPTION
Adds the `--weights-cache` package-shaped path to `eval gate` (the tooling you asked for) and backfills the eval ledger for the 6.0.0→6.2.0 gap. The new tooling immediately surfaced a v263 country-side trade the golden grade had missed.

## Tooling — `eval gate --weights-cache <root>`

The gate loaded models via `--model` (fp32), feeding NO country channel — the #718 trap for a country-channel model (v6.2.0+). Now it can load PACKAGE-SHAPED via `loadFromWeights({cacheRoot})`, feeding anchor+gazetteer+**country** exactly as production does (mirrors the gauntlet's #9 path + `eval parity --weights-cache`):

- **3 metric probes** (`per-locale-f1`, `score-affix`, `score-country-homograph`) short-circuit to `loadFromWeights({ locale: "en-US", cacheRoot })` when `--weights-cache` is set.
- **`promotion-gate.ts` + `gate.tsx`**: WC mode derives tokenizer/card from the cache siblings, skips the fp32/int8 dual-artifact asserts, runs the battery once. (Fork caught a subtlety — the verdict collector requires the `fp32-*` files, so the WC battery tags "fp32".)
- Validated e2e by the two real gate runs below (no unit test — the gate is an integration harness with no existing unit-test seam; a full gate run is the test).

## Backfill — `evals/scores-by-version.json` (was frozen at 5.9.0)

| npm | model | gate verdict (post-hoc, v5.3.0-family) | country_homograph |
|---|---|---|---|
| 6.0.0 | v241 (unchanged) | cloned from 5.9.0 (Hono code-only) | 85.1 |
| 6.1.0 | v261 | FAIL `fr.postcode` 98.9<99.2 only (op-excepted) | **89.8** (no country channel) |
| 6.2.0 | v263 | FAIL `country_homograph` 82.6<83.3 + `fr.postcode` 98.8<99.2 (op-excepted) | **82.6** |

Each FAIL is a coordinate-invisible per-tag trade on a model that shipped on the gauntlet **coordinate** gate + operator-approved documented exceptions — recorded honestly under `--operator-exception` with a clarifying note (the ledger refuses a silent FAIL; good).

## The finding — v263's country channel cuts both ways

The package-shaped grade exposed it: the `country_ambiguous` guard over-suppresses homograph countries (**Georgia, Jordan, Jamaica**), so `country_homograph` drops **89.8 → 82.6** even as golden WOF-admin country recall *rises* 84.8 → 89.3%. The ledger now shows the trajectory **85.1 → 89.8 → 82.6** (v241/v261/v263) — exactly the cross-model comparison the ledger is for. Coordinate-invisible (gauntlet PASS), so the v263 ship stands; a future tune could soften the guard. Documented in `2026-07-14-v263-country-channel-result.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)