### PR TITLE
docs: reorder the Understand tree into a readable progression

### DIFF
--- a/docs/articles/concepts/onnxruntime-web-webgpu-gotcha.mdx
+++ b/docs/articles/concepts/onnxruntime-web-webgpu-gotcha.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 40
+sidebar_position: 10.5
 title: "onnxruntime-web: the two WebGPU providers"
 ---
 
@@ -19,7 +19,7 @@ You'll see all of these at once:
 
 ## Root cause
 
-[onnxruntime-web](../concepts/onnx-runtime.mdx) (as of v1.25–1.26) ships two distinct WebGPU execution providers in the same package:
+[onnxruntime-web](./onnx-runtime.mdx) (as of v1.25–1.26) ships two distinct WebGPU execution providers in the same package:
 
 | Import path              | Bundle                               | WebGPU EP                   | Int8 QDQ status                    |
 | ------------------------ | ------------------------------------ | --------------------------- | ---------------------------------- |

--- a/docs/articles/concepts/street-supplement-architecture.mdx
+++ b/docs/articles/concepts/street-supplement-architecture.mdx
@@ -261,7 +261,7 @@ The intersection restructure is a free win — orthogonal to layers, can land an
 - [WOF hierarchy gap](./wof-hierarchy-gap.mdx) — the original observation that motivated this design
 - [FST gazetteer prior](./fst-gazetteer-prior.mdx) — the existing admin FST infrastructure that Layer 1/1.5/2 extend
 - [FST gazetteer LM reference](../plan/reference/FST_GAZETTEER_LM.mdx) — Phase 2 (streets) is the Layer 2 implementation plan
-- [Falsehoods about street names](../understanding/why-its-hard/falsehoods-streets.mdx) — catalog of edge cases each layer addresses
+- [Falsehoods about street names](../understanding/why-its-hard/falsehoods/falsehoods-streets.mdx) — catalog of edge cases each layer addresses
 - [Franchise and brand queries](../understanding/exotic-poi/franchise-queries.mdx) — Layer 4 user-facing context
 - [v0.6.1 error analysis](../evals/model-versions/v0.6.1-error-analysis.mdx) — empirical regression that surfaced the gap
 - 2026-05-28 night-shift postmortem — postmortem that triggered this design consult

--- a/docs/articles/concepts/wof-hierarchy-gap.mdx
+++ b/docs/articles/concepts/wof-hierarchy-gap.mdx
@@ -71,9 +71,9 @@ The hierarchy goes administrative all the way down to `neighbourhood`/`microhood
 The omission is principled, not an oversight:
 
 1. **Streets are linear, not point or polygonal.** WOF stores geometries. A locality has a polygon, an address has a point. A street is a line — closer to OSM ways than to WOF places.
-2. **Streets recur per-locality.** London has [seventeen different High Streets](../understanding/why-its-hard/falsehoods-streets.mdx). A unique identifier for "High Street" doesn't exist without disambiguation by parent locality. WOF assigns one ID per place; streets break that assumption.
+2. **Streets recur per-locality.** London has [seventeen different High Streets](../understanding/why-its-hard/falsehoods/falsehoods-streets.mdx). A unique identifier for "High Street" doesn't exist without disambiguation by parent locality. WOF assigns one ID per place; streets break that assumption.
 3. **Streets are owned by different authorities.** Administrative places are governed by census bureaus, statistical offices, and political entities. Streets are governed by highway departments, postal services, and municipal planning. WOF concords with administrative authorities; street data lives elsewhere.
-4. **Streets compose differently across locales.** US street grammars assume `[number] [name] [type]`. French addresses are `[number] [type] [name]`. Japanese addresses [skip streets entirely](../understanding/why-its-hard/falsehoods-streets.mdx#addresses-have-a-street-at-all). Mannheim uses a grid. A single hierarchical slot can't encode this.
+4. **Streets compose differently across locales.** US street grammars assume `[number] [name] [type]`. French addresses are `[number] [type] [name]`. Japanese addresses [skip streets entirely](../understanding/why-its-hard/falsehoods/falsehoods-streets.mdx#addresses-have-a-street-at-all). Mannheim uses a grid. A single hierarchical slot can't encode this.
 
 WOF's decision to stop at `neighbourhood → address` is correct _for a place gazetteer_. It just leaves a gap _for an address parser_.
 
@@ -199,5 +199,5 @@ Each layer addresses a different vacuum. The cheapest layers don't subsume the m
 
 - [FST gazetteer prior](./fst-gazetteer-prior.mdx) — the prior this article extends
 - [FST gazetteer LM reference](../plan/reference/FST_GAZETTEER_LM.mdx) — Phase 2 (streets) is the layer 2 work
-- [Falsehoods about street names](../understanding/why-its-hard/falsehoods-streets.mdx) — the catalog of edge cases each layer addresses
+- [Falsehoods about street names](../understanding/why-its-hard/falsehoods/falsehoods-streets.mdx) — the catalog of edge cases each layer addresses
 - [v0.6.1 error analysis](../evals/model-versions/v0.6.1-error-analysis.mdx) — the empirical regression that surfaced the gap

--- a/docs/articles/evals/model-versions/2026-05-28-v0-vs-neural-harness.mdx
+++ b/docs/articles/evals/model-versions/2026-05-28-v0-vs-neural-harness.mdx
@@ -146,7 +146,7 @@ This is the "honest assessment" the postmortem called for. The implications:
 
 The harness also accepts a `--falsehoods <dir>` argument for JSONL files of structured rows.
 `data/eval/falsehoods/streets.jsonl` lands the catalog from
-[`falsehoods-streets.md`](../../understanding/why-its-hard/falsehoods-streets.mdx) as 22 explicit
+[`falsehoods-streets.md`](../../understanding/why-its-hard/falsehoods/falsehoods-streets.mdx) as 22 explicit
 test rows — Piccadilly, rue de Rivoli, Plein 1944, Avenue Road, Gondel 2695, the
 A1-as-composite-street, dependent streets, Japanese block addressing, rural routes, Mannheim
 grid. Each row carries `falsehood` (the category) and `expected_failure` (whether this is a
@@ -204,7 +204,7 @@ Total runtime: ~5 seconds for 376 assertions.
 - [Street-supplement architecture](../../concepts/street-supplement-architecture.mdx) — the design context
 - [Layer 1 morphology FST eval](../experiments/2026-05-28-layer-1-morphology-fst.mdx) — preceding eval that
   established the decoder-only fix is insufficient
-- [Falsehoods about street names](../../understanding/why-its-hard/falsehoods-streets.mdx) — the
+- [Falsehoods about street names](../../understanding/why-its-hard/falsehoods/falsehoods-streets.mdx) — the
   edge cases the harness's falsehoods row source captures
 - 2026-05-28 night-2 postmortem — postmortem that triggered
   this assessment

--- a/docs/articles/evals/retrospectives/2026-05-28-session-report.mdx
+++ b/docs/articles/evals/retrospectives/2026-05-28-session-report.mdx
@@ -32,7 +32,7 @@ One import path change: `onnxruntime-web` → `onnxruntime-web/webgpu`. WebGPU n
 
 Headless CI cannot catch GPU-specific bugs. The `verify` skill's Playwright tests were passing while every real user saw garbage. Added diagnostics (backend indicator, force-WASM toggle, build stamp) to make this class of issue visible.
 
-Reference: [Technical doc](/docs/understanding/onnxruntime-web-webgpu-gotcha). Research blog post: "Our model worked in CI but broke on every real device".
+Reference: [Technical doc](/docs/concepts/onnxruntime-web-webgpu-gotcha). Research blog post: "Our model worked in CI but broke on every real device".
 
 ## Infrastructure migration
 

--- a/docs/articles/understanding/README.mdx
+++ b/docs/articles/understanding/README.mdx
@@ -5,80 +5,78 @@ title: Start here
 
 # Understanding Mailwoman
 
-This track is for readers who want to understand **why** Mailwoman exists, **what problem** it solves, **what it parses**, and **how** it works — in that order. The articles build on each other, but each is self-contained enough to be read independently.
+This track is for readers who want to understand **why** Mailwoman exists, **what problem** it solves, **what it parses**, and **how** it works — in that order. The articles are grouped into five sections that match the sidebar, and build on each other within each section — but each article is self-contained enough to be read independently.
 
-## Four layers
+## The five sections
 
-### Tier 0 — The problem (articles 2–7)
+### The Problem (articles 1–7)
 
-These six articles establish the domain. If you are sceptical that address parsing needs a neural model, start here.
+The fundamentals of postal addressing — the things a parser parses and a resolver resolves.
 
-1. **[How mail delivery actually works](./the-problem/how-mail-delivery-works.mdx)** — the postal system is already fuzzy. It tolerates ambiguity through human intervention.
-2. **[How humans break addresses](./why-its-hard/how-humans-break-addresses.mdx)** — the failure taxonomy. Real input is messier than any database expects.
-3. **[The database fallacy](./why-its-hard/the-database-fallacy.mdx)** — why "just store all addresses" is economically infeasible and geometrically wrong.
-4. **[The tokenization tautology](./why-its-hard/the-tokenization-tautology.mdx)** — why traditional rule-based parsers hit a structural ceiling.
-5. **[The 90% trap](./why-its-hard/the-90-percent-trap.mdx)** — why 90% geocoder coverage is deceptively expensive.
-6. **[Why a neural parser?](./our-approach/why-a-neural-parser.mdx)** — the bitter-lesson argument applied to address parsing. Bridges Tier 0 → Tier 1.
+1. **[What is an address?](./the-problem/what-is-an-address.mdx)** — the data model, moved from concepts.
+2. **[How mail delivery actually works](./the-problem/how-mail-delivery-works.mdx)** — the postal system is already fuzzy. It tolerates ambiguity through human intervention.
+3. **[What is a postcode?](./the-problem/what-is-a-postcode.mdx)** — postcodes are routing instructions, not geographic areas. International comparison.
+4. **[What is a ZIP Code and how is it structured?](./the-problem/what-is-a-zip-code.mdx)** — the US 11-digit system in detail. Why US-trained parsers fail on non-US postcodes.
+5. **[How can a building have two addresses?](./the-problem/how-can-a-building-have-two-addresses.mdx)** — mailing vs 911 vs utility vs management. An address is a protocol, not a property.
+6. **[What is an intersection address?](./the-problem/what-is-an-intersection.mdx)** — crossing streets as locations. Why not all addresses have building numbers.
+7. **[What is a concordance?](./the-problem/what-is-a-concordance.mdx)** — how the resolver validates that parsed components form a coherent real-world place.
 
-### Tier 0.5 — Postal address concepts (articles 8–12)
+### Why It's Hard (articles 8–20)
 
-These five articles explain the fundamental concepts of postal addressing — the things a parser parses and a resolver resolves. New as of May 2026.
+Why the domain resists rules. If you are sceptical that address parsing needs a neural model, start here.
 
-7. **[What is a postcode?](./the-problem/what-is-a-postcode.mdx)** — postcodes are routing instructions, not geographic areas. International comparison.
-8. **[What is a ZIP Code and how is it structured?](./the-problem/what-is-a-zip-code.mdx)** — the US 11-digit system in detail. Why US-trained parsers fail on non-US postcodes.
-9. **[What is a concordance?](./the-problem/what-is-a-concordance.mdx)** — how the resolver validates that parsed components form a coherent real-world place.
-10. **[What is an intersection address?](./the-problem/what-is-an-intersection.mdx)** — crossing streets as locations. Why not all addresses have building numbers.
-11. **[How can a building have two addresses?](./the-problem/how-can-a-building-have-two-addresses.mdx)** — mailing vs 911 vs utility vs management. An address is a protocol, not a property.
+8. **[Addresses that break geocoders](./why-its-hard/addresses-that-break-geocoders.mdx)** — concrete failure examples, moved from concepts.
+9. **[How humans break addresses](./why-its-hard/how-humans-break-addresses.mdx)** — the failure taxonomy. Real input is messier than any database expects.
+10. **[The database fallacy](./why-its-hard/the-database-fallacy.mdx)** — why "just store all addresses" is economically infeasible and geometrically wrong.
+11. **[The 90% trap](./why-its-hard/the-90-percent-trap.mdx)** — why 90% geocoder coverage is deceptively expensive.
+12. **[The tokenization tautology](./why-its-hard/the-tokenization-tautology.mdx)** — why traditional rule-based parsers hit a structural ceiling.
 
-### Tier 1 — The architecture (articles 13–20)
-
-These describe Mailwoman's design. Most existed before May 2026 and have been reordered to follow the domain articles.
-
-12. **[What is an address?](./the-problem/what-is-an-address.mdx)** — the data model, moved from concepts.
-13. **[Addresses that break geocoders](./why-its-hard/addresses-that-break-geocoders.mdx)** — concrete failure examples, moved from concepts.
-14. **[From Pelias to Mailwoman](./our-approach/from-pelias-to-mailwoman.mdx)** — the short historical bridge.
-15. **[How it used to work](./our-approach/how-it-used-to-work.mdx)** — Mailwoman v1 (rule-based) in detail.
-16. **[How it works now](./our-approach/how-it-works-now.mdx)** — the current rule + neural hybrid.
-17. **[How it will work](./our-approach/how-it-will-work.mdx)** — the near-future roadmap.
-18. **[The knowledge ladder](./our-approach/the-knowledge-ladder.mdx)** — the decomposition principle behind the staged pipeline.
-19. **[The staged pipeline](./our-approach/the-staged-pipeline.mdx)** — the Mailwoman runtime end-to-end.
-
-### Reference
-
-20. **[Glossary](/glossary)** — every technical term defined on first use.
-
-### Appendix
-
-21. **[Why not just use Google's API?](./alternatives/why-not-google-api.mdx)** — pricing, terms, lock-in, and when renting is the right choice.
-22. **[Why not use geocode.earth?](./alternatives/why-not-geocode-earth.mdx)** — the open-source hosted alternative and its Pelias parser ceiling.
-
-### The case for simple geocoders
-
-_Steel-manning the reasonably defensible compromises that work for most applications._
-
-23. **[Overview](./alternatives/the-case-for-simple-geocoders.mdx)** — when simple is the right choice, and when it isn't.
-24. **[Normalize to match](./alternatives/simple-normalize-to-match.mdx)** — strip, lowercase, fuzzy-match against a known database.
-25. **[Postcode-only](./alternatives/simple-postcode-only.mdx)** — extract the postcode, centroid the result.
-26. **[Gazetteer-first](./alternatives/simple-gazetteer-first.mdx)** — skip parsing, treat as information retrieval.
-27. **[Regex-anchored fields](./alternatives/simple-regex-fields.mdx)** — extract the 3-4 fields you care about, ignore the rest.
-28. **[Locality-only](./alternatives/simple-locality-only.mdx)** — find the city, centroid it.
-29. **[Human-in-the-loop](./alternatives/simple-human-in-the-loop.mdx)** — don't parse, suggest, let the user confirm.
-30. **[Close-enough](./alternatives/simple-close-enough.mdx)** — define your precision requirement, pick the cheapest approach, stop.
-
-### Falsehoods about addresses
+#### Falsehoods about addresses
 
 _Inspired by and citing Michael Tandy's [original catalogue](https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/). Each article takes one category of falsehood, explains how traditional geocoders handled it, and what Mailwoman's neural approach changes._
 
-31. **[Overview](./why-its-hard/falsehoods-about-addresses.mdx)** — the taxonomy and why it matters for Mailwoman.
-32. **[Numbers in addresses](./why-its-hard/falsehoods-numbers.mdx)** — zero, negative, fractions, duplicates, ranges.
-33. **[Street names](./why-its-hard/falsehoods-streets.mdx)** — missing suffixes, numbered streets, recurring names, no streets at all.
-34. **[Postcodes](./why-its-hard/falsehoods-postcodes.mdx)** — leading zeros, multi-city, per-building, missing postcodes.
-35. **[Administrative hierarchy](./why-its-hard/falsehoods-hierarchy.mdx)** — no states, no counties, duplicate cities, city-states.
-36. **[Address format](./why-its-hard/falsehoods-format.mdx)** — non-ASCII, variable ordering, special characters, changing addresses.
-37. **[Shapes and dimensions](./why-its-hard/falsehoods-shapes.mdx)** — not a point, not a polygon, not a building, not at ground level, not unique per coordinate.
-38. **[Precision and frontages](./why-its-hard/falsehoods-proximity.mdx)** — not one correct coordinate, not always "close enough," not necessarily the front door.
+13. **[Overview](./why-its-hard/falsehoods/falsehoods-about-addresses.mdx)** — the taxonomy and why it matters for Mailwoman.
+14. **[Address format](./why-its-hard/falsehoods/falsehoods-format.mdx)** — non-ASCII, variable ordering, special characters, changing addresses.
+15. **[Street names](./why-its-hard/falsehoods/falsehoods-streets.mdx)** — missing suffixes, numbered streets, recurring names, no streets at all.
+16. **[Numbers in addresses](./why-its-hard/falsehoods/falsehoods-numbers.mdx)** — zero, negative, fractions, duplicates, ranges.
+17. **[Postcodes](./why-its-hard/falsehoods/falsehoods-postcodes.mdx)** — leading zeros, multi-city, per-building, missing postcodes.
+18. **[Administrative hierarchy](./why-its-hard/falsehoods/falsehoods-hierarchy.mdx)** — no states, no counties, duplicate cities, city-states.
+19. **[Shapes and dimensions](./why-its-hard/falsehoods/falsehoods-shapes.mdx)** — not a point, not a polygon, not a building, not at ground level, not unique per coordinate.
+20. **[Precision and frontages](./why-its-hard/falsehoods/falsehoods-proximity.mdx)** — not one correct coordinate, not always "close enough," not necessarily the front door.
 
-### Exotic point-of-interest queries
+### Alternatives (articles 21–30)
+
+_Steel-manning the reasonably defensible compromises that work for most applications, before making the case for Google's API and geocode.earth._
+
+21. **[The case for simple geocoders](./alternatives/the-case-for-simple-geocoders.mdx)** — when simple is the right choice, and when it isn't.
+
+#### The simple architectures
+
+22. **[Postcode-only](./alternatives/simple/simple-postcode-only.mdx)** — extract the postcode, centroid the result.
+23. **[Locality-only](./alternatives/simple/simple-locality-only.mdx)** — find the city, centroid it.
+24. **[Gazetteer-first](./alternatives/simple/simple-gazetteer-first.mdx)** — skip parsing, treat as information retrieval.
+25. **[Normalize to match](./alternatives/simple/simple-normalize-to-match.mdx)** — strip, lowercase, fuzzy-match against a known database.
+26. **[Regex-anchored fields](./alternatives/simple/simple-regex-fields.mdx)** — extract the 3-4 fields you care about, ignore the rest.
+27. **[Close-enough](./alternatives/simple/simple-close-enough.mdx)** — define your precision requirement, pick the cheapest approach, stop.
+28. **[Human-in-the-loop](./alternatives/simple/simple-human-in-the-loop.mdx)** — don't parse, suggest, let the user confirm.
+
+29. **[Why not just use Google's API?](./alternatives/why-not-google-api.mdx)** — pricing, terms, lock-in, and when renting is the right choice.
+30. **[Why not use geocode.earth?](./alternatives/why-not-geocode-earth.mdx)** — the open-source hosted alternative and its Pelias parser ceiling.
+
+### Our Approach (articles 31–38)
+
+Mailwoman's design, and how it got here.
+
+31. **[Why a neural parser?](./our-approach/why-a-neural-parser.mdx)** — the bitter-lesson argument applied to address parsing. Opens the case for everything that follows.
+32. **[The knowledge ladder](./our-approach/the-knowledge-ladder.mdx)** — the decomposition principle behind the staged pipeline.
+33. **[How it works now](./our-approach/how-it-works-now.mdx)** — the current rule + neural hybrid.
+34. **[The staged pipeline](./our-approach/the-staged-pipeline.mdx)** — the Mailwoman runtime end-to-end.
+35. **[From Pelias to Mailwoman](./our-approach/from-pelias-to-mailwoman.mdx)** — the short historical bridge.
+36. **[What the eval numbers mean](./our-approach/what-the-eval-numbers-mean.mdx)** — the golden-set results, and how to read each pipeline mode's metrics.
+37. **[How it used to work](./our-approach/how-it-used-to-work.mdx)** — Mailwoman v1 (rule-based) in detail.
+38. **[How it will work](./our-approach/how-it-will-work.mdx)** — the near-future roadmap.
+
+### Exotic point-of-interest queries (articles 39–44)
 
 _Not every geocoder query is an address. A large fraction of real-world searches ask for points of interest — named places, categories, brands, landmarks, and transit infrastructure._
 
@@ -89,13 +87,17 @@ _Not every geocoder query is an address. A large fraction of real-world searches
 43. **[Landmark queries](./exotic-poi/landmark-queries.mdx)** — Eiffel Tower, Golden Gate Bridge, Empire State Building.
 44. **[Transit queries](./exotic-poi/transit-queries.mdx)** — subway station, bus stop, airport, train station.
 
+### Reference
+
+**[Glossary](/glossary)** — every technical term defined on first use.
+
 ## Reading order
 
-If you are **sceptical about the whole project**, read Tier 0 in order (articles 2–6). It should take about 45 minutes. If you are still sceptical after that, the project has failed to make its case — open an issue.
+If you are **sceptical about the whole project**, read The Problem and the first five entries of Why It's Hard in order (articles 1–12), then jump to [Why a neural parser?](./our-approach/why-a-neural-parser.mdx) (article 31). That's the domain case, the failure case, and the pitch, in under an hour. If you are still sceptical after that, the project has failed to make its case — open an issue.
 
-If you are **new to geocoding but curious**, start with [What is an address?](./the-problem/what-is-an-address.mdx) (article 13), then read Tier 0. The data-model article grounds the domain arguments.
+If you are **new to geocoding but curious**, start with The Problem (articles 1–7) in order. It grounds the domain vocabulary everything after it assumes.
 
-If you are **from the Pelias world**, read [From Pelias to Mailwoman](./our-approach/from-pelias-to-mailwoman.mdx) (article 14), then [How it works now](./our-approach/how-it-works-now.mdx) (article 16). Those two articles bridge your existing knowledge to the current system.
+If you are **from the Pelias world**, read [From Pelias to Mailwoman](./our-approach/from-pelias-to-mailwoman.mdx) (article 35), then [How it works now](./our-approach/how-it-works-now.mdx) (article 33). Those two articles bridge your existing knowledge to the current system.
 
 If you want to **go deeper**, see the [`concepts/`](../concepts/README.mdx) track — per-topic deep dives into tokenization, BIO labels, the CRF decoder, ONNX runtime, training pipeline, corpus construction, and more.
 

--- a/docs/articles/understanding/alternatives/simple/_category_.json
+++ b/docs/articles/understanding/alternatives/simple/_category_.json
@@ -1,0 +1,4 @@
+{
+	"label": "The simple architectures",
+	"position": 2
+}

--- a/docs/articles/understanding/alternatives/simple/simple-close-enough.mdx
+++ b/docs/articles/understanding/alternatives/simple/simple-close-enough.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 38
+sidebar_position: 6
 title: Close-enough geocoding
 tags:
   - domain
@@ -65,8 +65,8 @@ Mailwoman is also the right choice when you need to **improve your precision ove
 
 ## See also
 
-- [The case for simple geocoders](./the-case-for-simple-geocoders.mdx) — the series overview
+- [The case for simple geocoders](../the-case-for-simple-geocoders.mdx) — the series overview
 - [Locality-only geocoding](./simple-locality-only.mdx) — the city-level approach
 - [Postcode-only geocoding](./simple-postcode-only.mdx) — the ZIP-level approach
-- [Falsehoods about geocoded precision and frontages](../why-its-hard/falsehoods-proximity.mdx) — the precision assumptions that break geocoders
-- [The 90% trap](../why-its-hard/the-90-percent-trap.mdx) — why the 10% tail costs more than the 90%
+- [Falsehoods about geocoded precision and frontages](../../why-its-hard/falsehoods/falsehoods-proximity.mdx) — the precision assumptions that break geocoders
+- [The 90% trap](../../why-its-hard/the-90-percent-trap.mdx) — why the 10% tail costs more than the 90%

--- a/docs/articles/understanding/alternatives/simple/simple-gazetteer-first.mdx
+++ b/docs/articles/understanding/alternatives/simple/simple-gazetteer-first.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 33
+sidebar_position: 3
 title: Gazetteer-first geocoding
 tags:
   - domain
@@ -51,6 +51,6 @@ A hybrid is possible: use gazetteer-first as a fallback when the parser's confid
 
 - [Normalize to match](./simple-normalize-to-match.mdx) — the string-matching approach
 - [Locality-only geocoding](./simple-locality-only.mdx) — the next step up in resolution
-- [Resolver and Who's On First](../../concepts/resolver-and-wof.mdx) — the gazetteer Mailwoman uses
+- [Resolver and Who's On First](../../../concepts/resolver-and-wof.mdx) — the gazetteer Mailwoman uses
 - [Airmail](https://github.com/ellenhp/airmail) — the reference implementation
-- [The case for simple geocoders](./the-case-for-simple-geocoders.mdx) — the series index this article belongs to
+- [The case for simple geocoders](../the-case-for-simple-geocoders.mdx) — the series index this article belongs to

--- a/docs/articles/understanding/alternatives/simple/simple-human-in-the-loop.mdx
+++ b/docs/articles/understanding/alternatives/simple/simple-human-in-the-loop.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 36
+sidebar_position: 7
 title: Human-in-the-loop geocoding
 tags:
   - domain
@@ -32,7 +32,7 @@ This is how Google Maps, Apple Maps, and every ride-sharing app work. The user t
 
 ## What you lose
 
-- **[Batch processing](../../recipes/batch-geocoding.md).** You cannot show suggestions to a million addresses in a CSV file. Human-in-the-loop requires a human. Batch geocoding requires a parser that works without one.
+- **[Batch processing](../../../recipes/batch-geocoding.md).** You cannot show suggestions to a million addresses in a CSV file. Human-in-the-loop requires a human. Batch geocoding requires a parser that works without one.
 - **Automation.** Every address that needs human confirmation is a step in a workflow that could have been automatic. If 95% of addresses are unambiguous and 5% need confirmation, the 5% drives your support costs.
 - **The user's patience.** `Springfield, IL` has one obvious candidate. Showing a dropdown of 34 Springfields is noise. The system should recognize when there's a single high-confidence match and skip the confirmation. Knowing when to skip requires a confidence signal — which requires a parser.
 - **The user who doesn't know their address.** A gift recipient, a new mover, a tourist types what they think the address is, and it might be wrong. The system shows candidates, and the user picks whichever looks right — which can also be wrong. Without ground truth in the loop, this is just two layers of guessing.
@@ -50,6 +50,6 @@ This is the architecture behind the Phase 5 Studio: a web UI where humans correc
 
 - [Normalize to match](./simple-normalize-to-match.mdx) — the backend for the autocomplete index
 - [Gazetteer-first geocoding](./simple-gazetteer-first.mdx) — another suggestion-engine approach
-- [How humans break addresses](../why-its-hard/how-humans-break-addresses.mdx) — the failure modes the human corrects
-- [How it will work](../our-approach/how-it-will-work.mdx) — Phase 5 Studio, the human-correction feedback loop
-- [The case for simple geocoders](./the-case-for-simple-geocoders.mdx) — the series index this article belongs to
+- [How humans break addresses](../../why-its-hard/how-humans-break-addresses.mdx) — the failure modes the human corrects
+- [How it will work](../../our-approach/how-it-will-work.mdx) — Phase 5 Studio, the human-correction feedback loop
+- [The case for simple geocoders](../the-case-for-simple-geocoders.mdx) — the series index this article belongs to

--- a/docs/articles/understanding/alternatives/simple/simple-locality-only.mdx
+++ b/docs/articles/understanding/alternatives/simple/simple-locality-only.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 35
+sidebar_position: 2
 title: Locality-only geocoding
 tags:
   - domain
@@ -49,6 +49,6 @@ A system that starts with locality-only geocoding can add Mailwoman as a **refin
 
 - [Gazetteer-first geocoding](./simple-gazetteer-first.mdx) — the full-index approach
 - [Postcode-only geocoding](./simple-postcode-only.mdx) — the other single-field approach
-- [Falsehoods about administrative hierarchy](../why-its-hard/falsehoods-hierarchy.mdx) — the city-name assumptions that break this
-- [Resolver and Who's On First](../../concepts/resolver-and-wof.mdx) — the gazetteer Mailwoman uses
-- [The case for simple geocoders](./the-case-for-simple-geocoders.mdx) — the series index this article belongs to
+- [Falsehoods about administrative hierarchy](../../why-its-hard/falsehoods/falsehoods-hierarchy.mdx) — the city-name assumptions that break this
+- [Resolver and Who's On First](../../../concepts/resolver-and-wof.mdx) — the gazetteer Mailwoman uses
+- [The case for simple geocoders](../the-case-for-simple-geocoders.mdx) — the series index this article belongs to

--- a/docs/articles/understanding/alternatives/simple/simple-normalize-to-match.mdx
+++ b/docs/articles/understanding/alternatives/simple/simple-normalize-to-match.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 31
+sidebar_position: 4
 title: Normalize to match
 tags:
   - domain
@@ -58,6 +58,6 @@ The parser handles the cold-start problem — adding new addresses to the databa
 
 - [Postcode-only geocoding](./simple-postcode-only.mdx) — the simplest geographic approach
 - [Regex-anchored fields](./simple-regex-fields.mdx) — when you care about a few specific components
-- [The database fallacy](../why-its-hard/the-database-fallacy.mdx) — why no database contains all addresses
-- [How humans break addresses](../why-its-hard/how-humans-break-addresses.mdx) — the failure modes normalization absorbs
-- [The case for simple geocoders](./the-case-for-simple-geocoders.mdx) — the series index this article belongs to
+- [The database fallacy](../../why-its-hard/the-database-fallacy.mdx) — why no database contains all addresses
+- [How humans break addresses](../../why-its-hard/how-humans-break-addresses.mdx) — the failure modes normalization absorbs
+- [The case for simple geocoders](../the-case-for-simple-geocoders.mdx) — the series index this article belongs to

--- a/docs/articles/understanding/alternatives/simple/simple-postcode-only.mdx
+++ b/docs/articles/understanding/alternatives/simple/simple-postcode-only.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 32
+sidebar_position: 1
 title: Postcode-only geocoding
 tags:
   - domain
@@ -46,8 +46,8 @@ The postcode-only approach and Mailwoman are not competitors. A system that star
 
 ## See also
 
-- [What is a postcode?](../the-problem/what-is-a-postcode.mdx) — postcodes as routing instructions
-- [What is a ZIP Code and how is it structured?](../the-problem/what-is-a-zip-code.mdx) — the US system in detail
-- [Falsehoods about postcodes](../why-its-hard/falsehoods-postcodes.mdx) — the assumptions that break postcode-based geocoders
+- [What is a postcode?](../../the-problem/what-is-a-postcode.mdx) — postcodes as routing instructions
+- [What is a ZIP Code and how is it structured?](../../the-problem/what-is-a-zip-code.mdx) — the US system in detail
+- [Falsehoods about postcodes](../../why-its-hard/falsehoods/falsehoods-postcodes.mdx) — the assumptions that break postcode-based geocoders
 - [Locality-only geocoding](./simple-locality-only.mdx) — the next step up in resolution
-- [The case for simple geocoders](./the-case-for-simple-geocoders.mdx) — the series index this article belongs to
+- [The case for simple geocoders](../the-case-for-simple-geocoders.mdx) — the series index this article belongs to

--- a/docs/articles/understanding/alternatives/simple/simple-regex-fields.mdx
+++ b/docs/articles/understanding/alternatives/simple/simple-regex-fields.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 34
+sidebar_position: 5
 title: Regex-anchored fields
 tags:
   - domain
@@ -49,6 +49,6 @@ A system that starts with regex-anchored field extraction can add Mailwoman as a
 
 - [Normalize to match](./simple-normalize-to-match.mdx) — when you don't need field extraction at all
 - [Postcode-only geocoding](./simple-postcode-only.mdx) — when you only need one field
-- [The tokenization tautology](../why-its-hard/the-tokenization-tautology.mdx) — why positional regexes fail on non-Anglophone addresses
-- [How it used to work](../our-approach/how-it-used-to-work.mdx) — Mailwoman v1's rule-based approach, which is essentially this with more rules
-- [The case for simple geocoders](./the-case-for-simple-geocoders.mdx) — the series index this article belongs to
+- [The tokenization tautology](../../why-its-hard/the-tokenization-tautology.mdx) — why positional regexes fail on non-Anglophone addresses
+- [How it used to work](../../our-approach/how-it-used-to-work.mdx) — Mailwoman v1's rule-based approach, which is essentially this with more rules
+- [The case for simple geocoders](../the-case-for-simple-geocoders.mdx) — the series index this article belongs to

--- a/docs/articles/understanding/alternatives/the-case-for-simple-geocoders.mdx
+++ b/docs/articles/understanding/alternatives/the-case-for-simple-geocoders.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 30
+sidebar_position: 1
 title: The case for simple geocoders
 tags:
   - domain
@@ -16,15 +16,15 @@ These are the architectures most production geocoders actually use, and for many
 
 ## Compromises
 
-| Compromise                                            | What you do                                                           | What you lose                                 |
-| ----------------------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------- |
-| [Normalize-to-match](./simple-normalize-to-match.mdx) | Strip, lowercase, abbreviate, fuzzy-match against a known database    | Understanding of what anything _means_        |
-| [Postcode-only](./simple-postcode-only.mdx)           | Parse the postcode, centroid the result                               | Everything finer than ~1 mile                 |
-| [Gazetteer-first](./simple-gazetteer-first.mdx)       | Skip parsing, treat as IR — try every token against a placename index | Streets, building numbers, venue names        |
-| [Regex-anchored fields](./simple-regex-fields.mdx)    | Extract the 3-4 fields you care about, ignore the rest                | The rest                                      |
-| [Locality-only](./simple-locality-only.mdx)           | Find the city, centroid it                                            | Street-level routing, delivery-point accuracy |
-| [Human-in-the-loop](./simple-human-in-the-loop.mdx)   | Don't parse — suggest, let the user confirm                           | Automation, scale                             |
-| [Close-enough](./simple-close-enough.mdx)             | Define your precision requirement, pick the cheapest approach, stop   | Everything below your requirement             |
+| Compromise                                                   | What you do                                                           | What you lose                                 |
+| ------------------------------------------------------------ | --------------------------------------------------------------------- | --------------------------------------------- |
+| [Normalize-to-match](./simple/simple-normalize-to-match.mdx) | Strip, lowercase, abbreviate, fuzzy-match against a known database    | Understanding of what anything _means_        |
+| [Postcode-only](./simple/simple-postcode-only.mdx)           | Parse the postcode, centroid the result                               | Everything finer than ~1 mile                 |
+| [Gazetteer-first](./simple/simple-gazetteer-first.mdx)       | Skip parsing, treat as IR — try every token against a placename index | Streets, building numbers, venue names        |
+| [Regex-anchored fields](./simple/simple-regex-fields.mdx)    | Extract the 3-4 fields you care about, ignore the rest                | The rest                                      |
+| [Locality-only](./simple/simple-locality-only.mdx)           | Find the city, centroid it                                            | Street-level routing, delivery-point accuracy |
+| [Human-in-the-loop](./simple/simple-human-in-the-loop.mdx)   | Don't parse — suggest, let the user confirm                           | Automation, scale                             |
+| [Close-enough](./simple/simple-close-enough.mdx)             | Define your precision requirement, pick the cheapest approach, stop   | Everything below your requirement             |
 
 ## When simple is the right choice
 
@@ -54,4 +54,4 @@ Mailwoman is the right choice when:
 
 - [Why a neural parser?](../our-approach/why-a-neural-parser.mdx) — the affirmative case
 - [The 90% trap](../why-its-hard/the-90-percent-trap.mdx) — the economic argument for going past 90%
-- [Falsehoods about addresses](../why-its-hard/falsehoods-about-addresses.mdx) — the counterexamples that break simple architectures
+- [Falsehoods about addresses](../why-its-hard/falsehoods/falsehoods-about-addresses.mdx) — the counterexamples that break simple architectures

--- a/docs/articles/understanding/alternatives/why-not-geocode-earth.mdx
+++ b/docs/articles/understanding/alternatives/why-not-geocode-earth.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+sidebar_position: 4
 title: Why not use geocode.earth?
 tags:
   - domain

--- a/docs/articles/understanding/alternatives/why-not-google-api.mdx
+++ b/docs/articles/understanding/alternatives/why-not-google-api.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 3
 title: Why not just use Google's API?
 tags:
   - domain

--- a/docs/articles/understanding/exotic-poi/_category.json
+++ b/docs/articles/understanding/exotic-poi/_category.json
@@ -1,5 +1,0 @@
-{
-	"label": "Exotic POI queries",
-	"position": 5,
-	"collapsed": true
-}

--- a/docs/articles/understanding/our-approach/from-pelias-to-mailwoman.mdx
+++ b/docs/articles/understanding/our-approach/from-pelias-to-mailwoman.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 5
 title: From Pelias to Mailwoman
 tags:
   - architecture

--- a/docs/articles/understanding/our-approach/how-it-used-to-work.mdx
+++ b/docs/articles/understanding/our-approach/how-it-used-to-work.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 7
 title: How it used to work
 tags:
   - architecture

--- a/docs/articles/understanding/our-approach/how-it-will-work.mdx
+++ b/docs/articles/understanding/our-approach/how-it-will-work.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 8
 title: How it will work
 tags:
   - architecture

--- a/docs/articles/understanding/our-approach/how-it-works-now.mdx
+++ b/docs/articles/understanding/our-approach/how-it-works-now.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 3
 title: How it works now
 tags:
   - architecture

--- a/docs/articles/understanding/our-approach/the-knowledge-ladder.mdx
+++ b/docs/articles/understanding/our-approach/the-knowledge-ladder.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 2
 title: The knowledge ladder
 tags:
   - architecture

--- a/docs/articles/understanding/our-approach/the-staged-pipeline.mdx
+++ b/docs/articles/understanding/our-approach/the-staged-pipeline.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 4
 title: The staged pipeline
 tags:
   - architecture

--- a/docs/articles/understanding/our-approach/what-the-eval-numbers-mean.mdx
+++ b/docs/articles/understanding/our-approach/what-the-eval-numbers-mean.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 6
 title: What the eval numbers mean
 ---
 

--- a/docs/articles/understanding/our-approach/why-a-neural-parser.mdx
+++ b/docs/articles/understanding/our-approach/why-a-neural-parser.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 1
 title: Why a neural parser?
 tags:
   - domain

--- a/docs/articles/understanding/the-problem/how-can-a-building-have-two-addresses.mdx
+++ b/docs/articles/understanding/the-problem/how-can-a-building-have-two-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 5
 title: How can a building have two addresses?
 tags:
   - domain

--- a/docs/articles/understanding/the-problem/what-is-a-concordance.mdx
+++ b/docs/articles/understanding/the-problem/what-is-a-concordance.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 7
 title: What is a concordance?
 tags:
   - domain

--- a/docs/articles/understanding/the-problem/what-is-a-postcode.mdx
+++ b/docs/articles/understanding/the-problem/what-is-a-postcode.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 3
 title: What is a postcode?
 tags:
   - domain

--- a/docs/articles/understanding/the-problem/what-is-a-zip-code.mdx
+++ b/docs/articles/understanding/the-problem/what-is-a-zip-code.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 4
 title: What is a ZIP Code?
 tags:
   - domain

--- a/docs/articles/understanding/the-problem/what-is-an-address.mdx
+++ b/docs/articles/understanding/the-problem/what-is-an-address.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 1
 title: What is an address?
 tags:
   - domain

--- a/docs/articles/understanding/the-problem/what-is-an-intersection.mdx
+++ b/docs/articles/understanding/the-problem/what-is-an-intersection.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 6
 title: What is an intersection address?
 tags:
   - domain

--- a/docs/articles/understanding/why-its-hard/addresses-that-break-geocoders.mdx
+++ b/docs/articles/understanding/why-its-hard/addresses-that-break-geocoders.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 1
 title: Addresses that break geocoders
 tags:
   - domain

--- a/docs/articles/understanding/why-its-hard/falsehoods/_category_.json
+++ b/docs/articles/understanding/why-its-hard/falsehoods/_category_.json
@@ -1,0 +1,4 @@
+{
+	"label": "Falsehoods",
+	"position": 6
+}

--- a/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-about-addresses.mdx
+++ b/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-about-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 24
+sidebar_position: 1
 title: Falsehoods about addresses
 tags:
   - domain
@@ -18,7 +18,7 @@ This article series is inspired by and cites Michael Tandy's [original catalogue
 
 Tandy's falsehoods are not edge cases. They are the central cases that rule-based geocoders fail on. Each falsehood is a place where a human can see what's happening ("that's a building number, even though it's a fraction") but a regex cannot. The thesis of Mailwoman's neural approach is that a model trained on diverse address data can learn to handle these cases without explicit rules, including combinations of falsehoods that no rule set could enumerate.
 
-Mailwoman is not the first project to notice this. Deepparse (2020) showed that a BiLSTM could match libpostal on structured addresses. The academic literature since has confirmed that transformers beat CRFs on noisy and multilingual address data. What Mailwoman adds is a **[staged pipeline](../our-approach/the-staged-pipeline.mdx)** that separates concerns: a phrase grouper proposes boundaries, a neural classifier types spans, a CRF enforces sequence validity, and a reconciler checks joint coherence against a gazetteer. Each stage handles a different class of falsehood without the others needing to know about it.
+Mailwoman is not the first project to notice this. Deepparse (2020) showed that a BiLSTM could match libpostal on structured addresses. The academic literature since has confirmed that transformers beat CRFs on noisy and multilingual address data. What Mailwoman adds is a **[staged pipeline](../../our-approach/the-staged-pipeline.mdx)** that separates concerns: a phrase grouper proposes boundaries, a neural classifier types spans, a CRF enforces sequence validity, and a reconciler checks joint coherence against a gazetteer. Each stage handles a different class of falsehood without the others needing to know about it.
 
 ## Categories
 
@@ -40,6 +40,6 @@ If you haven't read Michael Tandy's original article, start there: [Falsehoods p
 
 ## See also
 
-- [How mail delivery actually works](../the-problem/how-mail-delivery-works.mdx) — the system these falsehoods enter
-- [How humans break addresses](./how-humans-break-addresses.mdx) — the failure taxonomy organized by root cause
-- [The tokenization tautology](./the-tokenization-tautology.mdx) — why rule-based parsers can't handle combinations of falsehoods
+- [How mail delivery actually works](../../the-problem/how-mail-delivery-works.mdx) — the system these falsehoods enter
+- [How humans break addresses](../how-humans-break-addresses.mdx) — the failure taxonomy organized by root cause
+- [The tokenization tautology](../the-tokenization-tautology.mdx) — why rule-based parsers can't handle combinations of falsehoods

--- a/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-format.mdx
+++ b/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-format.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 29
+sidebar_position: 2
 title: Falsehoods about address format
 tags:
   - domain
@@ -77,7 +77,7 @@ Middlesex, Scunthorpe, Penistone, and many others are real English place names. 
 
 **The normalizer (Stage 1)** handles Unicode normalization (NFD → NFC), case folding, and whitespace collapsing. The normalizer operates on bytes, not semantics — it cleans the input for downstream stages without making classification decisions.
 
-**[The tokenizer](../../concepts/tokenization.mdx)** uses SentencePiece with byte-fallback. Characters in the trained vocabulary (16K for A0, 48K for A1) produce subword tokens with known embeddings. Characters outside the vocabulary fall back to byte-level encoding — the model sees raw bytes and learns byte-level patterns. This means the tokenizer can handle any Unicode character, even scripts that were not in the training data, without crashing or producing garbage.
+**[The tokenizer](../../../concepts/tokenization.mdx)** uses SentencePiece with byte-fallback. Characters in the trained vocabulary (16K for A0, 48K for A1) produce subword tokens with known embeddings. Characters outside the vocabulary fall back to byte-level encoding — the model sees raw bytes and learns byte-level patterns. This means the tokenizer can handle any Unicode character, even scripts that were not in the training data, without crashing or producing garbage.
 
 **The locale gate (Stage 2)** detects the script family before classification. CJK characters → `ja-JP`, Cyrillic → `ru`, Arabic → `ar`. The locale detection biases the classifier's expectations: a Japanese-formatted address triggers Japanese ordering expectations, a Cyrillic address triggers Russian postcode patterns. The classifier does not need to handle every script's ordering simultaneously.
 
@@ -95,6 +95,6 @@ Middlesex, Scunthorpe, Penistone, and many others are real English place names. 
 
 - [Series overview: Falsehoods about addresses](./falsehoods-about-addresses.mdx)
 - [Michael Tandy's original catalogue](https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/)
-- [How humans break addresses](./how-humans-break-addresses.mdx) — the failure taxonomy organized by root cause
-- [What is a postcode?](../the-problem/what-is-a-postcode.mdx) — why postcode formats vary by country
-- [The database fallacy](./the-database-fallacy.mdx) — why addresses change and databases don't keep up
+- [How humans break addresses](../how-humans-break-addresses.mdx) — the failure taxonomy organized by root cause
+- [What is a postcode?](../../the-problem/what-is-a-postcode.mdx) — why postcode formats vary by country
+- [The database fallacy](../the-database-fallacy.mdx) — why addresses change and databases don't keep up

--- a/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-hierarchy.mdx
+++ b/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-hierarchy.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 28
+sidebar_position: 6
 title: Falsehoods about administrative hierarchy
 tags:
   - domain
@@ -85,5 +85,5 @@ Geocoders that maintain their own administrative boundary snapshots go stale. Th
 - [Series overview: Falsehoods about addresses](./falsehoods-about-addresses.mdx)
 - [Michael Tandy's original catalogue](https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/)
 - [Falsehoods about postcodes](./falsehoods-postcodes.mdx) — the other half of the locality+postcode administrative pair
-- [What is a concordance?](../the-problem/what-is-a-concordance.mdx) — how the reconciler validates administrative coherence
-- [The database fallacy](./the-database-fallacy.mdx) — why administrative boundaries drift
+- [What is a concordance?](../../the-problem/what-is-a-concordance.mdx) — how the reconciler validates administrative coherence
+- [The database fallacy](../the-database-fallacy.mdx) — why administrative boundaries drift

--- a/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-numbers.mdx
+++ b/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-numbers.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 25
+sidebar_position: 4
 title: Falsehoods about numbers in addresses
 tags:
   - domain
@@ -83,5 +83,5 @@ The reconciler (Stage 5) helps with the "Ten Post Office Sq vs 10 Post Office Sq
 - [Series overview: Falsehoods about addresses](./falsehoods-about-addresses.mdx)
 - [Michael Tandy's original catalogue](https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/)
 - [Falsehoods about street names](./falsehoods-streets.mdx) — the street-side of the number/street pair
-- [What is an intersection address?](../the-problem/what-is-an-intersection.mdx) — why not all addresses have building numbers
-- [How can a building have two addresses?](../the-problem/how-can-a-building-have-two-addresses.mdx) — why buildings change numbers
+- [What is an intersection address?](../../the-problem/what-is-an-intersection.mdx) — why not all addresses have building numbers
+- [How can a building have two addresses?](../../the-problem/how-can-a-building-have-two-addresses.mdx) — why buildings change numbers

--- a/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-postcodes.mdx
+++ b/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-postcodes.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 27
+sidebar_position: 5
 title: Falsehoods about postcodes
 tags:
   - domain
@@ -86,6 +86,6 @@ Douglas Perreault's condo in Florida changed ZIP codes twice in a few years: `33
 
 - [Series overview: Falsehoods about addresses](./falsehoods-about-addresses.mdx)
 - [Michael Tandy's original catalogue](https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/)
-- [What is a postcode?](../the-problem/what-is-a-postcode.mdx) — postcodes as routing instructions, not geographic areas
-- [What is a ZIP Code and how is it structured?](../the-problem/what-is-a-zip-code.mdx) — the US 11-digit system in detail
-- [The database fallacy](./the-database-fallacy.mdx) — why postcode-to-place mappings are never complete
+- [What is a postcode?](../../the-problem/what-is-a-postcode.mdx) — postcodes as routing instructions, not geographic areas
+- [What is a ZIP Code and how is it structured?](../../the-problem/what-is-a-zip-code.mdx) — the US 11-digit system in detail
+- [The database fallacy](../the-database-fallacy.mdx) — why postcode-to-place mappings are never complete

--- a/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-proximity.mdx
+++ b/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-proximity.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 37
+sidebar_position: 8
 title: Falsehoods about geocoded precision and frontages
 tags:
   - domain
@@ -98,7 +98,7 @@ The reverse geocode is answering "what place is at this coordinate?" not "what a
 
 **The resolver can return multiple candidates per address component.** `locality=Springfield` returns 34 candidates, each with a different coordinate. The downstream system can choose the one that matches additional context (state, postcode) or surface all of them. The resolver does not pretend to know which Springfield when it doesn't.
 
-**[Confidence is per-component, not spatial](../../concepts/confidence-calibration.mdx).** The parser's confidence score is about the label — "I'm 95% sure this token is a locality" — not about the coordinate — "I'm 95% sure the locality is within 500 meters of this point." The resolver's score is about gazetteer match quality, not spatial accuracy. Separating these into different signals (label confidence, resolver match quality, spatial precision metadata) is future work.
+**[Confidence is per-component, not spatial](../../../concepts/confidence-calibration.mdx).** The parser's confidence score is about the label — "I'm 95% sure this token is a locality" — not about the coordinate — "I'm 95% sure the locality is within 500 meters of this point." The resolver's score is about gazetteer match quality, not spatial accuracy. Separating these into different signals (label confidence, resolver match quality, spatial precision metadata) is future work.
 
 ## What Mailwoman still can't do
 
@@ -111,5 +111,5 @@ The reverse geocode is answering "what place is at this coordinate?" not "what a
 - [Series overview: Falsehoods about addresses](./falsehoods-about-addresses.mdx)
 - [Michael Tandy's original catalogue](https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/)
 - [Falsehoods about address shapes and dimensions](./falsehoods-shapes.mdx) — the spatial companion piece
-- [How can a building have two addresses?](../the-problem/how-can-a-building-have-two-addresses.mdx) — why a building has multiple correct coordinates
-- [How mail delivery actually works](../the-problem/how-mail-delivery-works.mdx) — the delivery chain that consumes these coordinates
+- [How can a building have two addresses?](../../the-problem/how-can-a-building-have-two-addresses.mdx) — why a building has multiple correct coordinates
+- [How mail delivery actually works](../../the-problem/how-mail-delivery-works.mdx) — the delivery chain that consumes these coordinates

--- a/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-shapes.mdx
+++ b/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-shapes.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 36
+sidebar_position: 7
 title: Falsehoods about address shapes and dimensions
 tags:
   - domain
@@ -106,6 +106,6 @@ A building at the corner of Main St and Elm St might have address `123 Main St` 
 
 - [Series overview: Falsehoods about addresses](./falsehoods-about-addresses.mdx)
 - [Michael Tandy's original catalogue](https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/)
-- [What is a postcode?](../the-problem/what-is-a-postcode.mdx) — postcodes as routing instructions, not polygons
-- [What is a ZIP Code and how is it structured?](../the-problem/what-is-a-zip-code.mdx) — why ZIP codes don't have boundaries
-- [How can a building have two addresses?](../the-problem/how-can-a-building-have-two-addresses.mdx) — the vertical dimension of addressing
+- [What is a postcode?](../../the-problem/what-is-a-postcode.mdx) — postcodes as routing instructions, not polygons
+- [What is a ZIP Code and how is it structured?](../../the-problem/what-is-a-zip-code.mdx) — why ZIP codes don't have boundaries
+- [How can a building have two addresses?](../../the-problem/how-can-a-building-have-two-addresses.mdx) — the vertical dimension of addressing

--- a/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-streets.mdx
+++ b/docs/articles/understanding/why-its-hard/falsehoods/falsehoods-streets.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 26
+sidebar_position: 3
 title: Falsehoods about street names
 tags:
   - domain
@@ -43,7 +43,7 @@ Dutch: `Gondel 2695, Lelystad` — area Gondel, street 26, number 95. No separat
 
 London has seventeen different High Streets. Without a postcode, `10 High Street, London` is ambiguous across seventeen locations. The resolver needs the postcode or locality to disambiguate, but the parser may have already assigned `locality=London` to all seventeen.
 
-This is the same problem as duplicate locality names (Springfield, Paris) but at a finer grain. The resolver's concordance scoring (Stage 5) handles this by checking whether a `(street, locality, region, postcode)` tuple is jointly coherent in WOF — but [WOF does not index street names](../../concepts/wof-hierarchy-gap.mdx), only administrative places. Street duplication is outside the resolver's concordance reach.
+This is the same problem as duplicate locality names (Springfield, Paris) but at a finer grain. The resolver's concordance scoring (Stage 5) handles this by checking whether a `(street, locality, region, postcode)` tuple is jointly coherent in WOF — but [WOF does not index street names](../../../concepts/wof-hierarchy-gap.mdx), only administrative places. Street duplication is outside the resolver's concordance reach.
 
 ### "A road has exactly one name."
 
@@ -81,7 +81,7 @@ The staged pipeline addresses the falsehoods in layers:
 
 ## What Mailwoman still can't do
 
-- **Dependent streets.** The schema has no `dependent_street` tag. `6 Elm Avenue, Runcorn Road` would parse as `street=Runcorn Road` with `Elm Avenue` either dropped or classified as a second street. The resolver cannot use [dependent-street relationships](../../concepts/street-supplement-architecture.mdx) because WOF doesn't encode them.
+- **Dependent streets.** The schema has no `dependent_street` tag. `6 Elm Avenue, Runcorn Road` would parse as `street=Runcorn Road` with `Elm Avenue` either dropped or classified as a second street. The resolver cannot use [dependent-street relationships](../../../concepts/street-supplement-architecture.mdx) because WOF doesn't encode them.
 - **Street disambiguation without postcodes.** `10 High Street, London` is structurally ambiguous and the resolver cannot resolve it without a postcode or borough. The parser correctly identifies the components; the resolver correctly identifies the ambiguity. The downstream application must decide.
 - **Grid-based addressing.** Mannheim's `R 5, 6-13` requires block-and-row tags that Mailwoman's current schema does not have. Japan's `1-1-1` format is supported through the JP-specific tags (`district`, `block`, `sub_block`, `building_number`) but these are deferred to Phase 6.
 
@@ -90,5 +90,5 @@ The staged pipeline addresses the falsehoods in layers:
 - [Series overview: Falsehoods about addresses](./falsehoods-about-addresses.mdx)
 - [Michael Tandy's original catalogue](https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/)
 - [Falsehoods about numbers in addresses](./falsehoods-numbers.mdx) — the other half of the street+number pair
-- [What is an intersection address?](../the-problem/what-is-an-intersection.mdx) — the street-based format that doesn't use building numbers
-- [The tokenization tautology](./the-tokenization-tautology.mdx) — why the Dutch `Gondel 2695` pattern breaks per-token classification
+- [What is an intersection address?](../../the-problem/what-is-an-intersection.mdx) — the street-based format that doesn't use building numbers
+- [The tokenization tautology](../the-tokenization-tautology.mdx) — why the Dutch `Gondel 2695` pattern breaks per-token classification

--- a/docs/articles/understanding/why-its-hard/how-humans-break-addresses.mdx
+++ b/docs/articles/understanding/why-its-hard/how-humans-break-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 title: How humans break addresses
 tags:
   - domain
@@ -211,4 +211,4 @@ The postal system already works this way. The Remote Encoding Center operator se
 - [How mail delivery actually works](../the-problem/how-mail-delivery-works.mdx) — the system these addresses enter
 - [Addresses that break geocoders](./addresses-that-break-geocoders.mdx) — concrete failure examples from the geocoding literature
 - [The database fallacy](./the-database-fallacy.mdx) — why there is no perfect reference set that fixes these problems
-- [Falsehoods about addresses](./falsehoods-about-addresses.mdx) — the falsehoods catalogue, organized by category
+- [Falsehoods about addresses](./falsehoods/falsehoods-about-addresses.mdx) — the falsehoods catalogue, organized by category

--- a/docs/articles/understanding/why-its-hard/the-90-percent-trap.mdx
+++ b/docs/articles/understanding/why-its-hard/the-90-percent-trap.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 4
 title: The 90% trap
 tags:
   - domain

--- a/docs/articles/understanding/why-its-hard/the-database-fallacy.mdx
+++ b/docs/articles/understanding/why-its-hard/the-database-fallacy.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 title: The database fallacy
 tags:
   - domain
@@ -113,4 +113,4 @@ A parser that tries to memorize addresses will be wrong on every address that ch
 - [The 90% trap](./the-90-percent-trap.mdx) — why 90% database coverage is deceptively expensive
 - [The tokenization tautology](./the-tokenization-tautology.mdx) — why traditional parsers fall into a related completeness trap
 - [What is an address?](../the-problem/what-is-an-address.mdx) — the data model these databases attempt to capture
-- [Falsehoods about addresses](./falsehoods-about-addresses.mdx) — the falsehoods catalogue, organized by category
+- [Falsehoods about addresses](./falsehoods/falsehoods-about-addresses.mdx) — the falsehoods catalogue, organized by category

--- a/docs/research/2026-05-27-webgpu-safari-bug.mdx
+++ b/docs/research/2026-05-27-webgpu-safari-bug.mdx
@@ -70,6 +70,6 @@ The deeper lesson: test infrastructure that lacks GPU access will never catch GP
 
 ## References
 
-- [Technical reference: the two WebGPU providers](/docs/understanding/onnxruntime-web-webgpu-gotcha)
+- [Technical reference: the two WebGPU providers](/docs/concepts/onnxruntime-web-webgpu-gotcha)
 - [microsoft/onnxruntime#25227](https://github.com/microsoft/onnxruntime/issues/25227)
 - [huggingface/transformers.js#1512](https://github.com/huggingface/transformers.js/issues/1512)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -102,9 +102,6 @@ const sidebars: SidebarsConfig = {
 				},
 			],
 		},
-		// A narrow, dated debugging gotcha that doesn't fit any of the categories above.
-		// Kept in-nav per "do not drop pages" — parked at the end as an appendix.
-		"understanding/onnxruntime-web-webgpu-gotcha",
 	],
 	reference: [
 		"plan/SCOPE",


### PR DESCRIPTION
Operator-requested: the Understand section rendered in alphabetical file order with an 8-page falsehoods series and 7 parallel architecture sketches flattened into their parents. Now every subtree reads in pedagogical order, with two new nested subcategories.

- **The problem**: what an address is → how delivery works → postcodes → ZIP → dual addresses → intersections → concordance.
- **Why it's hard**: the two breakage essays, the three fallacy essays, then a **Falsehoods** subcategory (index + 7, format through proximity).
- **Alternatives**: the case for simple geocoders leads; the seven sketches nest under **The simple architectures**, ordered by ascending sophistication; the two why-not essays close.
- **Our approach**: why-neural → knowledge ladder → how it works now → staged pipeline → Pelias migration → eval numbers, with the two dated snapshots last.
- **Exotic POI**: intro first, then amenity → franchise → regional-variant → landmark → transit.
- Hygiene: the ONNX/WebGPU gotcha moved to `concepts/` (slotting after the ONNX runtime page), the dead `_category.json` typo-twin deleted, the section README rewritten to narrate the same order it renders.

16 files moved (`git mv`, history preserved), 15 URL changes with every inbound link across articles/evals/research/sidebars updated — per the standing no-old-links ruling, with `onBrokenLinks: "throw"` as the net. Structure gate + build green (twice); rendered sidebar dumped from the production build and verified against the target order section by section (screenshots in the work report; also sent to the operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)