### PR TITLE
feat(resolver): resolution-plausibility guard (direction-agnostic)

### DIFF
--- a/resolver/index.ts
+++ b/resolver/index.ts
@@ -19,6 +19,8 @@ export type {
 	SerializableResolveOpts,
 } from "./remote-resolver.ts"
 export { createWOFResolver } from "./resolve.ts"
+export { finestResolvedCoordinate, isImplausibleResolution } from "./plausibility.ts"
+export type { PlausibilityVerdict, ResolvedCoordinate } from "./plausibility.ts"
 export { findRescoreCandidate, hasResolvedPlace } from "./span-rescore.ts"
 export type { RescoreCandidate, SpanRescoreOptions } from "./span-rescore.ts"
 

--- a/resolver/plausibility.test.ts
+++ b/resolver/plausibility.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the v7 hybrid-gate resolution-plausibility guard (#38). The guard trips only when a
+ *   resolved tree's finest place is a bare country centroid — the garbage-geocode archetype the
+ *   coordinate-parity study surfaced (`California` / `6000, NSW, Australia` → a country centroid).
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { describe, expect, test } from "vitest"
+
+import { finestResolvedCoordinate, isImplausibleResolution } from "./plausibility.ts"
+
+const node = (over: Partial<AddressNode> & Pick<AddressNode, "tag" | "value">): AddressNode => ({
+	start: 0,
+	end: over.value.length,
+	confidence: 1,
+	children: [],
+	...over,
+})
+
+const tree = (roots: AddressNode[], raw = ""): AddressTree => ({ raw, roots })
+
+describe("finestResolvedCoordinate", () => {
+	test("returns the deepest resolved tier when several nodes resolved", () => {
+		const t = tree([
+			node({
+				tag: "locality",
+				value: "Paris",
+				lat: 48.86,
+				lon: 2.35,
+				placeID: "wof:101751119",
+				children: [node({ tag: "street", value: "Rue de Rivoli", lat: 48.86, lon: 2.34, placeID: "wof:street" })],
+			}),
+			node({ tag: "country", value: "France", lat: 46.2, lon: 2.2, placeID: "wof:france" }),
+		])
+
+		expect(finestResolvedCoordinate(t)?.tag).toBe("street")
+	})
+
+	test("returns null when nothing carries a coordinate", () => {
+		expect(finestResolvedCoordinate(tree([node({ tag: "street", value: "Nowhere St" })]))).toBeNull()
+	})
+})
+
+describe("isImplausibleResolution", () => {
+	test("country-only resolution is implausible (the garbage archetype)", () => {
+		const t = tree(
+			[node({ tag: "country", value: "Australia", lat: -25.7, lon: 134.5, placeID: "wof:au" })],
+			"6000, NSW, Australia"
+		)
+		const verdict = isImplausibleResolution(t)
+
+		expect(verdict.implausible).toBe(true)
+		expect(verdict.reason).toBe("country-centroid")
+		expect(verdict.coordinate?.tag).toBe("country")
+	})
+
+	test("a locality resolution alongside a country is plausible", () => {
+		const t = tree([
+			node({ tag: "locality", value: "Melbourne", lat: -37.8, lon: 144.96, placeID: "wof:melb" }),
+			node({ tag: "country", value: "Australia", lat: -25.7, lon: 134.5, placeID: "wof:au" }),
+		])
+
+		expect(isImplausibleResolution(t).implausible).toBe(false)
+	})
+
+	test("a region-only (US state) resolution is plausible — a legitimate coarse geocode", () => {
+		const t = tree([node({ tag: "region", value: "Texas", lat: 31.0, lon: -100.0, placeID: "wof:tx" })], "Texas 76013")
+
+		expect(isImplausibleResolution(t).implausible).toBe(false)
+	})
+
+	test("an unresolved tree is not implausible (nothing to serve, not garbage)", () => {
+		const verdict = isImplausibleResolution(tree([node({ tag: "street", value: "Epleskogen" })], "Epleskogen 39A"))
+
+		expect(verdict.implausible).toBe(false)
+		expect(verdict.coordinate).toBeUndefined()
+	})
+})

--- a/resolver/plausibility.ts
+++ b/resolver/plausibility.ts
@@ -1,0 +1,111 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Resolution-plausibility guard (#727 / v7 excision arc).
+ *
+ *   The 2026-07-15 coordinate-parity study
+ *   (`docs/articles/evals/2026-07-15-v7-parity-floor-diagnosis.md`) found the neural parser is
+ *   coordinate-safe on well-formed input (98.6% within 1 km of the rules parser through the same
+ *   resolver) but produces a garbage-geocode tail on the bare-fragment / bare-state-name / US-highway
+ *   classes — inputs like `California` or `6000, NSW, Australia` that resolve to nothing finer than a
+ *   country centroid.
+ *
+ *   This guard is the cheap post-resolve check for that tail: a resolved tree whose finest resolved
+ *   place is only a `country` centroid is implausible for a structured address. It reads only the
+ *   decorated tree — no gazetteer, no extra query — so it is free to run on every resolve. It is
+ *   deliberately DIRECTION-AGNOSTIC about what the caller does with the signal: serve the result with
+ *   a low-confidence marker, prefer a sibling parse hypothesis (the #727 k-best rerank), or decline to
+ *   emit a coordinate. It is NOT a rules-fallback trigger — the v7 excision deletes the rules parser
+ *   outright (operator ruling 2026-07-15), so no consumer may route through legacy rules on a trip.
+ *
+ *   It deliberately does NOT flag region-tier resolutions: a US state or a province centroid
+ *   (`Texas` → the TX centroid) is a legitimate coarse geocode, not garbage. Only "resolved no finer
+ *   than a country" trips it.
+ */
+
+import type { AddressNode, AddressTree, ComponentTag } from "@mailwoman/core/decoder"
+
+/**
+ * Resolution granularity, coarse → fine. A resolved node's {@link AddressNode.tag} places it on this ladder; the
+ * geocode a caller serves comes from the FINEST resolved node. Tags absent here (unit, po_box, intersection halves, …)
+ * are treated as street-tier specificity when resolved.
+ */
+const RESOLUTION_TIER: Partial<Record<ComponentTag, number>> = {
+	country: 0,
+	region: 1,
+	subregion: 2,
+	dependent_locality: 3,
+	locality: 3,
+	postcode: 4,
+	venue: 4,
+	street: 4,
+	street_prefix: 4,
+	street_suffix: 4,
+	house_number: 5,
+}
+
+/** A resolved place lifted off the tree — the coordinate a caller would serve, plus its granularity tag. */
+export interface ResolvedCoordinate {
+	tag: ComponentTag
+	lat: number
+	lon: number
+	/** Canonical place URI (`wof:…`) when the resolver supplied one. */
+	placeID?: string
+}
+
+/**
+ * Walk a resolved {@link AddressTree} and return the FINEST resolved place — the node carrying a resolver-supplied
+ * coordinate at the deepest granularity tier. Returns `null` when nothing resolved (no node carries a `lat`/`lon`).
+ * Ties break toward the first node in document order.
+ */
+export function finestResolvedCoordinate(tree: AddressTree): ResolvedCoordinate | null {
+	let best: ResolvedCoordinate | null = null
+	let bestTier = -1
+
+	const visit = (node: AddressNode): void => {
+		if (node.lat !== undefined && node.lon !== undefined) {
+			const tier = RESOLUTION_TIER[node.tag] ?? 4
+
+			if (tier > bestTier) {
+				bestTier = tier
+				best = { tag: node.tag, lat: node.lat, lon: node.lon, placeID: node.placeID }
+			}
+		}
+
+		for (const child of node.children) {
+			visit(child)
+		}
+	}
+
+	for (const root of tree.roots) {
+		visit(root)
+	}
+
+	return best
+}
+
+/** Result of {@link isImplausibleResolution} — the boolean plus the reason, for telemetry + fallback logs. */
+export interface PlausibilityVerdict {
+	implausible: boolean
+	/** Set when `implausible` is true. `country-centroid` = resolved no finer than a country. */
+	reason?: "country-centroid"
+	/** The coordinate the verdict was drawn from, when anything resolved. */
+	coordinate?: ResolvedCoordinate
+}
+
+/**
+ * Decide whether a resolved tree's geocode is implausible for a structured address — the cheap guard the v7 hybrid gate
+ * runs after routing an input to the neural parser (#38). Trips only when the finest resolved place is a bare `country`
+ * centroid; an unresolved tree (nothing to serve) and any region-or-finer resolution are both plausible.
+ */
+export function isImplausibleResolution(tree: AddressTree): PlausibilityVerdict {
+	const coordinate = finestResolvedCoordinate(tree)
+
+	if (coordinate && coordinate.tag === "country") {
+		return { implausible: true, reason: "country-centroid", coordinate }
+	}
+
+	return { implausible: false, coordinate: coordinate ?? undefined }
+}


### PR DESCRIPTION
## Summary

`isImplausibleResolution(tree)` — trips when a resolved tree's finest resolved place is a bare **country centroid**, the signature of the garbage-geocode tail the 2026-07-15 coordinate-parity study measured (40% of street-failing parity fixtures move >25 km, frequently to a country centroid: `California` → Maryland-class errors, `6000, NSW, Australia` → the AU centroid). Region-tier resolutions (`Texas` → the TX centroid) deliberately do **not** trip it — a coarse geocode is legitimate.

Reads only the decorated tree (no gazetteer, no extra query), so it's free on every resolve.

## Framing

Lifted from the night-2 hybrid-gate exploration (`feat/v7-hybrid-swap-gate`, unpushed) and **reframed direction-agnostic**: the consumer decides what the trip means — a low-confidence marker on the response, a k-best sibling-hypothesis rerank (#727 stage-2), or declining to emit a coordinate. It is explicitly NOT a rules-fallback trigger; the v7 excision deletes the rules parser outright per the operator ruling of 2026-07-15, and the hybrid routing that motivated the original branch stays unbuilt.

## Testing

- 6 unit tests (`resolver/plausibility.test.ts`)
- `yarn compile` clean

Part of the #727 / v7 legacy-excision arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)