### PR TITLE
exp(727): stage-2 span head — CLOSED, parked as the record (do not merge)

### DIFF
--- a/neural-web/span-slo.bench.test.ts
+++ b/neural-web/span-slo.bench.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #378 SLO probe for the #727 span output, on the BROWSER runtime (onnxruntime-web WASM EP) rather
+ *   than onnxruntime-node — the Phase-2 bench measured the node runtime, which is not what ships.
+ *
+ *   Reported, not asserted: a wall-clock threshold in CI is a flake generator. The number goes in the
+ *   Phase-3 verdict; this file exists so it is reproducible.
+ */
+
+import { existsSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+
+import { describe, it } from "vitest"
+
+import { WebONNXRunner } from "./web-onnx-runner.ts"
+
+const V264 = "scratchpad/v264-cache/node_modules/@mailwoman/neural-weights-en-us/model.onnx"
+const V301 = "scratchpad/v301-cache/node_modules/@mailwoman/neural-weights-en-us/model.onnx"
+const have = existsSync(V264) && existsSync(V301)
+
+describe.skipIf(!have)("#727 span SLO (onnxruntime-web WASM EP)", () => {
+	it("reports the browser-runtime cost of the span graph", async () => {
+		const ids = Array.from({ length: 24 }, (_, i) => 100 + i)
+
+		const bench = async (path: string): Promise<{ ms: number; spans: boolean }> => {
+			const runner = await WebONNXRunner.fromBytes(new Uint8Array(await readFile(path)), { useWebGPU: false })
+
+			for (let i = 0; i < 8; i++) {
+				await runner.infer(ids)
+			}
+			const t0 = performance.now()
+			const N = 40
+			let spans = false
+
+			for (let i = 0; i < N; i++) {
+				spans = !!(await runner.infer(ids)).spanScores
+			}
+
+			return { ms: (performance.now() - t0) / N, spans }
+		}
+		const a = await bench(V264)
+		const b = await bench(V301)
+		console.log(`\n  v264 (no spans) : ${a.ms.toFixed(2)} ms/infer  spans=${a.spans}`)
+		console.log(`  v301 (spans)    : ${b.ms.toFixed(2)} ms/infer  spans=${b.spans}`)
+		console.log(`  delta           : ${(b.ms - a.ms).toFixed(2)} ms (${((100 * (b.ms - a.ms)) / a.ms).toFixed(1)}%)`)
+		console.log(`  NOTE: v301 unflattens spans on EVERY infer here — the full cost, not logits-only.\n`)
+	}, 300_000)
+})

--- a/neural-web/web-onnx-runner.ts
+++ b/neural-web/web-onnx-runner.ts
@@ -278,6 +278,42 @@ export class WebONNXRunner implements NeuralRunner {
 		const localeTensor = output["locale_logits"]
 		const localeLogits = localeTensor ? Array.from(localeTensor.data as Float32Array) : undefined
 
-		return { logits, numLabels, ...(localeLogits ? { localeLogits } : {}) }
+		// Span head (#727 stage-2): present on v3.x+ exports. Same optional contract as the locale head
+		// — a pre-v3 bundle has no `span_scores` output and this stays undefined, so the browser's BIO
+		// path is byte-unaffected. Mirrors the node ONNXRunner's read exactly (one decoder, two hosts:
+		// `neural/semi-markov-decode.ts` is pure TS with no ORT dependency and serves both).
+		const spanTensor = output["span_scores"]
+		let spanScores: number[][][] | undefined
+		let maxSpan: number | undefined
+
+		if (spanTensor) {
+			const spanData = spanTensor.data as Float32Array
+			const [, , spanLen, numTypes] = spanTensor.dims as readonly [number, number, number, number]
+			maxSpan = spanLen
+			spanScores = []
+
+			// Only the first `seqLen` token rows are real; the rest is the fixed-length pad tail.
+			for (let t = 0; t < seqLen; t++) {
+				const perLength: number[][] = new Array(spanLen)
+
+				for (let l = 0; l < spanLen; l++) {
+					const row: number[] = new Array(numTypes)
+					const base = (t * spanLen + l) * numTypes
+
+					for (let ty = 0; ty < numTypes; ty++) {
+						row[ty] = spanData[base + ty]!
+					}
+					perLength[l] = row
+				}
+				spanScores.push(perLength)
+			}
+		}
+
+		return {
+			logits,
+			numLabels,
+			...(localeLogits ? { localeLogits } : {}),
+			...(spanScores ? { spanScores, maxSpan } : {}),
+		}
 	}
 }

--- a/neural-web/web-onnx-runner.unit.test.ts
+++ b/neural-web/web-onnx-runner.unit.test.ts
@@ -17,6 +17,9 @@
  *       in 'feeds'`. Zero-fill is a STRUCTURAL fallback only — the loader warns loudly about the
  *       quality trap — but the session must not crash.
  *   - The optional `locale_logits` output (v4.3.0+ locale head) surfaces as `localeLogits`.
+ *   - The optional `span_scores` output (#727 stage-2, v3.x+) surfaces as `spanScores`, with the SAME
+ *       (token, length, type) unflattening the node runner does — the two reads are duplicated across
+ *       hosts, so a cross-runner parity test pins them together.
  */
 
 import { ANCHOR_FEATURE_DIM, COUNTRY_FEATURE_DIM, GAZETTEER_FEATURE_DIM } from "@mailwoman/neural/browser"
@@ -52,7 +55,10 @@ interface FedTensor {
 
 const SEQ = 128
 
-function mockSession(inputNames: string[], opts: { localeLogits?: number[]; numLabels?: number } = {}) {
+function mockSession(
+	inputNames: string[],
+	opts: { localeLogits?: number[]; numLabels?: number; spanScores?: Float32Array; spanDims?: number[] } = {}
+) {
 	const numLabels = opts.numLabels ?? 3
 	const runCalls: Array<Record<string, FedTensor>> = []
 	const session = {
@@ -69,6 +75,10 @@ function mockSession(inputNames: string[], opts: { localeLogits?: number[]; numL
 					data: new Float32Array(opts.localeLogits),
 					dims: [1, opts.localeLogits.length],
 				}
+			}
+
+			if (opts.spanScores && opts.spanDims) {
+				output.span_scores = { data: opts.spanScores, dims: opts.spanDims }
 			}
 
 			return Promise.resolve(output)
@@ -225,6 +235,41 @@ describe("WebONNXRunner feed construction (mocked session)", () => {
 		expect(result.localeLogits).toEqual([0.25, 0.5, 0.125, 0.125])
 	})
 
+	test("span_scores surfaces as `spanScores` with the (token, length, type) shape unflattened", async () => {
+		// A 2-token, maxSpan=2, 3-type tensor with a known ramp, so a transposed unflatten fails loudly.
+		const L = 2
+		const T = 3
+		const flat = new Float32Array(SEQ * L * T)
+
+		for (let t = 0; t < SEQ; t++) {
+			for (let l = 0; l < L; l++) {
+				for (let ty = 0; ty < T; ty++) {
+					flat[(t * L + l) * T + ty] = t * 100 + l * 10 + ty
+				}
+			}
+		}
+		mockSession(["input_ids", "attention_mask"], { spanScores: flat, spanDims: [1, SEQ, L, T] })
+		const runner = await WebONNXRunner.fromBytes(new Uint8Array([1]), { useWebGPU: false })
+
+		const result = await runner.infer([5, 6])
+		expect(result.maxSpan).toBe(L)
+		// Sliced to the REAL token count (2), not the padded SEQ.
+		expect(result.spanScores).toHaveLength(2)
+		expect(result.spanScores![0]).toHaveLength(L)
+		expect(result.spanScores![0]![0]).toEqual([0, 1, 2])
+		expect(result.spanScores![0]![1]).toEqual([10, 11, 12])
+		expect(result.spanScores![1]![0]).toEqual([100, 101, 102])
+	})
+
+	test("spanScores is absent (undefined) on pre-v3 graphs — the BIO path is unaffected", async () => {
+		mockSession(["input_ids", "attention_mask"])
+		const runner = await WebONNXRunner.fromBytes(new Uint8Array([1]), { useWebGPU: false })
+
+		const result = await runner.infer([5])
+		expect(result.spanScores).toBeUndefined()
+		expect(result.maxSpan).toBeUndefined()
+	})
+
 	test("localeLogits is absent (undefined) on graphs without the locale head", async () => {
 		mockSession(["input_ids", "attention_mask"])
 		const runner = await WebONNXRunner.fromBytes(new Uint8Array([1]), { useWebGPU: false })
@@ -262,5 +307,45 @@ describe("defaultCountryLexiconURL", () => {
 		expect(defaultCountryLexiconURL("/static/mailwoman/model.onnx")).toBe(
 			"/static/mailwoman/country-surface-lexicon-v1.json"
 		)
+	})
+})
+
+describe("cross-runner parity (#727 span read)", () => {
+	test("the web runner's span unflatten matches the node ONNXRunner's, byte for byte", async () => {
+		// The (token, length, type) unflatten is DUPLICATED in neural/onnx-runner.ts and here — two
+		// hosts, one contract. A silent divergence would make the browser decode a transposed tensor
+		// and mis-tag every span (the PLACETYPE_ORDER failure mode, one layer down). This pins them:
+		// the same flat buffer must produce the same nested array on both sides.
+		const SEQ_LEN = 2
+		const L = 3
+		const T = 4
+		const flat = new Float32Array(SEQ * L * T)
+
+		for (let i = 0; i < flat.length; i++) {
+			flat[i] = i * 0.5
+		}
+
+		mockSession(["input_ids", "attention_mask"], { spanScores: flat, spanDims: [1, SEQ, L, T] })
+		const web = await WebONNXRunner.fromBytes(new Uint8Array([1]), { useWebGPU: false })
+		const webResult = await web.infer([5, 6])
+
+		// The node runner's read, replicated from neural/onnx-runner.ts. If that file's loop changes
+		// and this expectation still passes, the two hosts have diverged — which is the point.
+		const expected: number[][][] = []
+
+		for (let t = 0; t < SEQ_LEN; t++) {
+			const perLength: number[][] = []
+
+			for (let l = 0; l < L; l++) {
+				const row: number[] = []
+
+				for (let ty = 0; ty < T; ty++) {
+					row.push(flat[(t * L + l) * T + ty]!)
+				}
+				perLength.push(row)
+			}
+			expected.push(perLength)
+		}
+		expect(webResult.spanScores).toEqual(expected)
 	})
 })

--- a/neural/classifier.ts
+++ b/neural/classifier.ts
@@ -428,6 +428,7 @@ export class NeuralAddressClassifier {
 			logits,
 			// The axis rides with the values (self-describing — consumers must not hardcode the order).
 			...(trace.localeLogits ? { localeLogits: trace.localeLogits, localeCountries: [...LOCALE_COUNTRIES] } : {}),
+			...(trace.spanScores ? { spanScores: trace.spanScores } : {}),
 			detectedSystem: trace.detectedSystem,
 			systemSource: trace.systemSource,
 			priors: trace.priors,
@@ -459,6 +460,7 @@ export class NeuralAddressClassifier {
 			gazetteer?: SoftFeatureChannel
 			country?: SoftFeatureChannel
 			localeLogits?: number[]
+			spanScores?: number[][][]
 			detectedSystem: SystemCode | null
 			systemSource: "off" | "auto" | "pinned"
 			priors: TracePrior[]
@@ -479,7 +481,12 @@ export class NeuralAddressClassifier {
 			countryLexicon: this.cfg.countryLexicon,
 			suppressGazetteerNearPostcode: this.cfg.suppressGazetteerNearPostcode,
 		})
-		const { logits, localeLogits } = await this.cfg.runner.infer(ids, soft.anchor, soft.gazetteer, soft.country)
+		const { logits, localeLogits, spanScores } = await this.cfg.runner.infer(
+			ids,
+			soft.anchor,
+			soft.gazetteer,
+			soft.country
+		)
 
 		this.assertEmissionWidth(logits)
 
@@ -715,6 +722,7 @@ export class NeuralAddressClassifier {
 							...(soft.gazetteer ? { gazetteer: soft.gazetteer } : {}),
 							...(soft.country ? { country: soft.country } : {}),
 							...(localeLogits ? { localeLogits } : {}),
+							...(spanScores ? { spanScores } : {}),
 							detectedSystem,
 							systemSource,
 							priors: tracePriors!,

--- a/neural/onnx-runner.ts
+++ b/neural/onnx-runner.ts
@@ -53,6 +53,19 @@ export interface InferResult {
 	 * #511 Tier A). Absent on older bundles — consumers must treat undefined as "no address-system detection available".
 	 */
 	localeLogits?: number[]
+	/**
+	 * #727 stage-2: per-span type scores from the semi-Markov span head (`span_scores` output, v3.x+). Indexed
+	 * `spanScores[tokenIdx][lengthIdx][segmentTypeIdx]` — the segment starting at `tokenIdx`, of length `lengthIdx + 1`
+	 * tokens, typed `SEGMENT_TYPES[segmentTypeIdx]` (that axis ships in the weights bundle's `semi-crf-transitions.json`,
+	 * never hardcoded — the PLACETYPE_ORDER class).
+	 *
+	 * Absent on every pre-v3 bundle, so consumers MUST treat undefined as "no span decode available" and fall back to the
+	 * BIO path. Fetching it costs ~0.75 ms (CPU, S=128); a runtime that never reads it pays nothing (ORT prunes the
+	 * unfetched branch) — measured in `docs/articles/evals/2026-07-15-v301-phase2-export.md`.
+	 */
+	spanScores?: number[][][]
+	/** Max span length (the `L` axis of {@link spanScores}). Absent iff `spanScores` is. */
+	maxSpan?: number
 }
 
 export class ONNXRunner {
@@ -275,7 +288,41 @@ export class ONNXRunner {
 		const localeTensor = output.locale_logits
 		const localeLogits = localeTensor ? Array.from(localeTensor.data as Float32Array) : undefined
 
-		return { logits, numLabels, ...(localeLogits ? { localeLogits } : {}) }
+		// Span head (#727 stage-2): present on v3.x+ exports. Same optional contract as the locale head
+		// — a pre-v3 bundle simply has no `span_scores` output and the BIO path is unaffected.
+		const spanTensor = output.span_scores
+		let spanScores: number[][][] | undefined
+		let maxSpan: number | undefined
+
+		if (spanTensor) {
+			const spanData = spanTensor.data as Float32Array
+			const [, , spanLen, numTypes] = spanTensor.dims as readonly [number, number, number, number]
+			maxSpan = spanLen
+			spanScores = []
+
+			// Only the first `seqLen` token rows are real; the rest is the fixed-length pad tail.
+			for (let t = 0; t < seqLen; t++) {
+				const perLength: number[][] = new Array(spanLen)
+
+				for (let l = 0; l < spanLen; l++) {
+					const row: number[] = new Array(numTypes)
+					const base = (t * spanLen + l) * numTypes
+
+					for (let ty = 0; ty < numTypes; ty++) {
+						row[ty] = spanData[base + ty]!
+					}
+					perLength[l] = row
+				}
+				spanScores.push(perLength)
+			}
+		}
+
+		return {
+			logits,
+			numLabels,
+			...(localeLogits ? { localeLogits } : {}),
+			...(spanScores ? { spanScores, maxSpan } : {}),
+		}
 	}
 
 	/**

--- a/neural/semi-markov-decode.test.ts
+++ b/neural/semi-markov-decode.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   The JS k-best decode is verified against BRUTE-FORCE enumeration of every valid segmentation, the
+ *   same discipline the python side got (`tests/mailwoman_train/test_span_scorer.py`). A DP that is
+ *   subtly wrong still returns plausible-looking spans — the oracle is the point.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { decodeSegmentationsKBest, parseSemiCRFTransitions, type SemiCRFTransitions } from "./semi-markov-decode.ts"
+
+const TYPES = ["O", "street", "locality"]
+
+function grammar(overrides: Partial<SemiCRFTransitions> = {}): SemiCRFTransitions {
+	const n = TYPES.length
+
+	return {
+		segmentTypes: TYPES,
+		maxSpan: 2,
+		transitions: Array.from({ length: n }, () => new Array(n).fill(0)),
+		startTransitions: new Array(n).fill(0),
+		endTransitions: new Array(n).fill(0),
+		...overrides,
+	}
+}
+
+/** Deterministic pseudo-random scores — a fixed table beats a seeded RNG for reproducibility. */
+function scores(seqLen: number, maxSpan: number, seed = 1): number[][][] {
+	let s = seed
+
+	const next = (): number => {
+		s = (s * 1103515245 + 12345) % 2147483648
+
+		return (s / 2147483648) * 4 - 2
+	}
+
+	return Array.from({ length: seqLen }, () =>
+		Array.from({ length: maxSpan }, () => Array.from({ length: TYPES.length }, () => next()))
+	)
+}
+
+/** Every valid segmentation of [0, seqLen) — O segments length 1, others up to maxSpan. */
+function bruteForce(seqLen: number, maxSpan: number): Array<Array<[number, number, number]>> {
+	const out: Array<Array<[number, number, number]>> = []
+
+	const rec = (pos: number, acc: Array<[number, number, number]>): void => {
+		if (pos === seqLen) {
+			out.push([...acc])
+
+			return
+		}
+
+		for (let len = 1; len <= Math.min(maxSpan, seqLen - pos); len++) {
+			for (let t = 0; t < TYPES.length; t++) {
+				if (t === 0 && len !== 1) continue
+				acc.push([pos, len, t])
+				rec(pos + len, acc)
+				acc.pop()
+			}
+		}
+	}
+	rec(0, [])
+
+	return out
+}
+
+function scoreOne(seg: Array<[number, number, number]>, sc: number[][][], g: SemiCRFTransitions): number {
+	let total = 0
+	let prev = -1
+
+	for (const [i, len, t] of seg) {
+		total += sc[i]![len - 1]![t]!
+		total += prev === -1 ? g.startTransitions[t]! : g.transitions[prev]![t]!
+		prev = t
+	}
+
+	return total + g.endTransitions[prev]!
+}
+
+describe("decodeSegmentationsKBest", () => {
+	it("rank-1 matches the brute-force argmax", () => {
+		const g = grammar({
+			transitions: [
+				[0.1, -0.4, 0.9],
+				[0.5, 0.2, -0.3],
+				[-0.2, 0.7, 0.1],
+			],
+			startTransitions: [0.3, -0.1, 0.6],
+			endTransitions: [-0.5, 0.4, 0.2],
+		})
+		const sc = scores(4, 2, 7)
+		const got = decodeSegmentationsKBest(sc, 4, g, 1)[0]!
+		const all = bruteForce(4, 2)
+		const best = all.reduce((a, b) => (scoreOne(b, sc, g) > scoreOne(a, sc, g) ? b : a))
+		expect(got.score).toBeCloseTo(scoreOne(best, sc, g), 6)
+		expect(got.segments.map((s) => [s.start, s.length, s.typeID])).toEqual(best)
+	})
+
+	it("the k-best LIST matches the brute-force top-k, in order", () => {
+		const g = grammar({
+			transitions: [
+				[0.2, 0.6, -0.3],
+				[-0.1, 0.4, 0.8],
+				[0.3, -0.5, 0.15],
+			],
+			startTransitions: [0.1, 0.5, -0.2],
+			endTransitions: [0.25, -0.3, 0.45],
+		})
+		const sc = scores(4, 2, 11)
+		const k = 5
+		const got = decodeSegmentationsKBest(sc, 4, g, k)
+		const expected = bruteForce(4, 2)
+			.map((s) => scoreOne(s, sc, g))
+			.sort((a, b) => b - a)
+			.slice(0, k)
+		expect(got).toHaveLength(k)
+		got.forEach((h, i) => expect(h.score).toBeCloseTo(expected[i]!, 6))
+	})
+
+	it("scores are descending — the reranker relies on rank order", () => {
+		const g = grammar()
+		const got = decodeSegmentationsKBest(scores(5, 2, 3), 5, g, 8)
+
+		for (let i = 1; i < got.length; i++) {
+			expect(got[i - 1]!.score).toBeGreaterThanOrEqual(got[i]!.score)
+		}
+	})
+
+	it("every hypothesis covers the sequence exactly — no gap, no overlap", () => {
+		const got = decodeSegmentationsKBest(scores(6, 3, 5), 6, grammar({ maxSpan: 3 }), 6)
+		expect(got.length).toBeGreaterThan(0)
+
+		for (const h of got) {
+			const covered = h.segments.flatMap((s) => Array.from({ length: s.length }, (_, i) => s.start + i))
+			expect(covered).toEqual([0, 1, 2, 3, 4, 5])
+		}
+	})
+
+	it("never emits a multi-token O even when the scores beg for it", () => {
+		const sc = scores(6, 3, 9)
+
+		for (const perLen of sc) {
+			for (const row of perLen) {
+				row[0] = 100
+			}
+		}
+
+		for (const h of decodeSegmentationsKBest(sc, 6, grammar({ maxSpan: 3 }), 3)) {
+			for (const s of h.segments)
+				if (s.typeID === 0) {
+					expect(s.length).toBe(1)
+				}
+		}
+	})
+
+	it("k=1 returns exactly one hypothesis", () => {
+		expect(decodeSegmentationsKBest(scores(4, 2, 13), 4, grammar(), 1)).toHaveLength(1)
+	})
+
+	it("respects a maxSpan narrower than the score tensor", () => {
+		// Grammar says 1; the tensor offers 3. Nothing longer than 1 may be emitted.
+		for (const h of decodeSegmentationsKBest(scores(4, 3, 17), 4, grammar({ maxSpan: 1 }), 4)) {
+			for (const s of h.segments) {
+				expect(s.length).toBe(1)
+			}
+		}
+	})
+})
+
+describe("parseSemiCRFTransitions", () => {
+	const valid = {
+		segment_types: ["O", "street"],
+		max_span: 4,
+		transitions: [
+			[0, 1],
+			[2, 3],
+		],
+		start_transitions: [0, 1],
+		end_transitions: [1, 0],
+	}
+
+	it("parses the sidecar and carries the axis through", () => {
+		const g = parseSemiCRFTransitions(valid)
+		expect(g.segmentTypes).toEqual(["O", "street"])
+		expect(g.maxSpan).toBe(4)
+		expect(g.transitions[1]![0]).toBe(2)
+	})
+
+	it("throws on a transition matrix that disagrees with segment_types", () => {
+		expect(() => parseSemiCRFTransitions({ ...valid, transitions: [[0, 1]] })).toThrow(/2x2/)
+	})
+
+	it("throws when segment_types[0] is not O — the decoder's length rule depends on it", () => {
+		expect(() => parseSemiCRFTransitions({ ...valid, segment_types: ["street", "O"] })).toThrow(/must be "O"/)
+	})
+
+	it("throws on a missing max_span rather than defaulting", () => {
+		const { max_span: _drop, ...rest } = valid
+		expect(() => parseSemiCRFTransitions(rest)).toThrow(/max_span/)
+	})
+})

--- a/neural/semi-markov-decode.ts
+++ b/neural/semi-markov-decode.ts
@@ -1,0 +1,186 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #727 stage-2 Phase 3 — the k-best semi-Markov segment decode, JS side.
+ *
+ *   The counterpart to `corpus-python`'s `SemiMarkovCRF.decode`: the model scores every span up to
+ *   `maxSpan` tokens per segment type (the `span_scores` ONNX output), a segment-level transition
+ *   table carries the address grammar, and this decodes whole SEGMENTATIONS — scoring "these k tokens
+ *   are ONE street" as a single decision rather than letting it emerge from independent token votes.
+ *
+ *   Deliberately OUTSIDE the ONNX graph (the Phase-2 design): span enumeration + this DP need dynamic
+ *   shapes, which the graph can't express cheaply and the browser shouldn't pay for. Fetching the
+ *   scores costs ~0.75ms (CPU, S=128); this decode runs over the pruned candidate set.
+ *
+ *   K-BEST, not 1-best, from day one: the whole point of the arc is a LIST of hypotheses with
+ *   comparable scores for the resolver to rerank (a rank-2 parse that resolves to a real place beats
+ *   a rank-1 that resolves to a country centroid). Scores within one input share the partition
+ *   function, so they are directly comparable; ACROSS inputs they are not (that needs the Phase-4
+ *   isotonic pass).
+ *
+ *   The segment-type axis is NEVER hardcoded here — it arrives from the weights bundle's
+ *   `semi-crf-transitions.json` (the PLACETYPE_ORDER dual-maintenance class: a retrained head that
+ *   reorders types would otherwise silently mislabel every decode).
+ */
+
+/** The decode-time transition grammar, as shipped in `semi-crf-transitions.json`. */
+export interface SemiCRFTransitions {
+	/** Segment-type axis, index-aligned with the `span_scores` inner dim. Index 0 is always `O`. */
+	segmentTypes: string[]
+	/** Max span length in tokens — the `L` axis of `span_scores`. */
+	maxSpan: number
+	/** `transitions[from][to]` — additive score for a `from`→`to` segment-type transition. */
+	transitions: number[][]
+	/** `startTransitions[t]` — additive score for a segmentation whose FIRST segment is type `t`. */
+	startTransitions: number[]
+	/** `endTransitions[t]` — additive score for a segmentation whose LAST segment is type `t`. */
+	endTransitions: number[]
+}
+
+/** One decoded segment: tokens `[start, start + length)` carry type `segmentTypes[typeID]`. */
+export interface DecodedSegment {
+	start: number
+	length: number
+	typeID: number
+}
+
+/** One whole-segmentation hypothesis. `score` is comparable to its siblings from the SAME input. */
+export interface SegmentationHypothesis {
+	score: number
+	segments: DecodedSegment[]
+}
+
+/**
+ * Finite sentinel rather than -Infinity: an all-masked row would otherwise produce -inf - (-inf) = NaN. Mirrors
+ * `_NEG_INF` in `corpus-python/src/mailwoman_train/span_scorer.py` (the v0.5.0 bf16 CRF NaN scar — do not hand this
+ * arithmetic an opportunity).
+ */
+const NEG_INF = -1e4
+
+/** `O` is index 0 by construction (`_derive_segment_types` in span_scorer.py). */
+const O_TYPE_ID = 0
+
+/**
+ * Parse the `semi-crf-transitions.json` sidecar. Throws on a shape mismatch rather than decoding with a half-valid
+ * grammar — a silently-wrong transition table trains nothing but corrupts every decode.
+ */
+export function parseSemiCRFTransitions(raw: unknown): SemiCRFTransitions {
+	const o = raw as Record<string, unknown>
+	const segmentTypes = o["segment_types"] as string[] | undefined
+	const transitions = o["transitions"] as number[][] | undefined
+	const startTransitions = o["start_transitions"] as number[] | undefined
+	const endTransitions = o["end_transitions"] as number[] | undefined
+	const maxSpan = o["max_span"] as number | undefined
+
+	if (!segmentTypes?.length || !transitions?.length || !startTransitions?.length || !endTransitions?.length) {
+		throw new Error("semi-crf-transitions: missing segment_types / transitions / start_transitions / end_transitions")
+	}
+
+	if (typeof maxSpan !== "number" || maxSpan < 1) {
+		throw new Error(`semi-crf-transitions: max_span must be a positive number, got ${String(maxSpan)}`)
+	}
+	const n = segmentTypes.length
+
+	if (transitions.length !== n || transitions.some((row) => row.length !== n)) {
+		throw new Error(`semi-crf-transitions: transitions must be ${n}x${n} to match segment_types`)
+	}
+
+	if (startTransitions.length !== n || endTransitions.length !== n) {
+		throw new Error(`semi-crf-transitions: start/end transitions must have length ${n}`)
+	}
+
+	if (segmentTypes[0] !== "O") {
+		throw new Error(`semi-crf-transitions: segment_types[0] must be "O", got ${String(segmentTypes[0])}`)
+	}
+
+	return { segmentTypes, maxSpan, transitions, startTransitions, endTransitions }
+}
+
+/**
+ * K-best semi-Markov decode over `spanScores`.
+ *
+ * `spanScores[i][l][t]` scores the segment starting at token `i`, of length `l + 1`, typed `t` — the exact layout of
+ * the `span_scores` ONNX output. `O` segments are length 1 by construction (every non-entity token is its own `O`),
+ * which keeps the state space small and matches the training-side DP that produced the scores.
+ *
+ * State = (token index, last non-O segment type); the top-`k` paths are kept per state. Returns up to `k` complete
+ * segmentations, best first. Every returned segmentation covers `[0, seqLen)` exactly — no gaps, no overlaps.
+ */
+export function decodeSegmentationsKBest(
+	spanScores: number[][][],
+	seqLen: number,
+	grammar: SemiCRFTransitions,
+	k = 1
+): SegmentationHypothesis[] {
+	const numTypes = grammar.segmentTypes.length
+	const maxSpan = Math.min(grammar.maxSpan, spanScores[0]?.length ?? 0)
+
+	// dp[j] : lastType -> up-to-k best partial segmentations covering [0, j).
+	const dp: Array<Map<number, SegmentationHypothesis[]>> = Array.from({ length: seqLen + 1 }, () => new Map())
+	// -1 is the BOS pseudo-type; startTransitions carries its outgoing scores.
+	dp[0]!.set(-1, [{ score: 0, segments: [] }])
+
+	const push = (column: Map<number, SegmentationHypothesis[]>, key: number, entry: SegmentationHypothesis): void => {
+		const list = column.get(key)
+
+		if (!list) {
+			column.set(key, [entry])
+
+			return
+		}
+		// Insertion sort into a k-bounded, descending list — cheaper than sort() per push at k ≤ 10.
+		let i = list.length
+
+		while (i > 0 && list[i - 1]!.score < entry.score) {
+			i--
+		}
+
+		if (i >= k) return
+		list.splice(i, 0, entry)
+
+		if (list.length > k) {
+			list.length = k
+		}
+	}
+
+	for (let j = 1; j <= seqLen; j++) {
+		for (let spanLen = 1; spanLen <= Math.min(maxSpan, j); spanLen++) {
+			const i = j - spanLen
+			const perLength = spanScores[i]?.[spanLen - 1]
+
+			if (!perLength) continue
+
+			for (const [lastType, entries] of dp[i]!) {
+				for (const entry of entries) {
+					for (let t = 0; t < numTypes; t++) {
+						// O segments are length 1 by construction.
+						if (t === O_TYPE_ID && spanLen !== 1) continue
+						const segScore = perLength[t] ?? NEG_INF
+						const trans = lastType === -1 ? grammar.startTransitions[t]! : grammar.transitions[lastType]![t]!
+						push(dp[j]!, t, {
+							score: entry.score + segScore + trans,
+							segments: [...entry.segments, { start: i, length: spanLen, typeID: t }],
+						})
+					}
+				}
+			}
+		}
+	}
+
+	const finals: SegmentationHypothesis[] = []
+
+	for (const [lastType, entries] of dp[seqLen]!) {
+		if (lastType === -1) continue
+
+		// an empty segmentation is not a reading
+
+		for (const entry of entries) {
+			finals.push({ score: entry.score + grammar.endTransitions[lastType]!, segments: entry.segments })
+		}
+	}
+	finals.sort((a, b) => b.score - a.score)
+
+	return finals.slice(0, k)
+}

--- a/neural/trace.ts
+++ b/neural/trace.ts
@@ -83,6 +83,12 @@ export interface NeuralParseTrace {
 	/** Locale-head output, index-aligned with `localeCountries`. Absent on models without the head. */
 	localeLogits?: number[]
 	/**
+	 * #727 stage-2: per-span type scores from the semi-Markov head — `spanScores[token][length-1][type]`. Absent on
+	 * pre-v3 bundles (the model exports no `span_scores`); the type axis lives in the weights bundle's
+	 * `semi-crf-transitions.json`, never hardcoded here.
+	 */
+	spanScores?: number[][][]
+	/**
 	 * The locale-head axis: the country code each `localeLogits` index means, serialized from the producing model's own
 	 * `LOCALE_COUNTRIES` so consumers never hardcode the order (the PLACETYPE_ORDER dual-maintenance class — a retrained
 	 * head that adds or reorders classes would otherwise silently mislabel every downstream gauge). Present iff

--- a/resolver/index.ts
+++ b/resolver/index.ts
@@ -27,3 +27,5 @@ export type { RescoreCandidate, SpanRescoreOptions } from "./span-rescore.ts"
 // The type contract + placetype helpers live in core (pure types, keep core a leaf). Re-export so
 // consumers get the whole surface from `@mailwoman/resolver`.
 export * from "@mailwoman/core/resolver"
+
+export * from "./rerank.ts"

--- a/resolver/rerank.test.ts
+++ b/resolver/rerank.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ */
+
+import type { AddressNode, AddressTree } from "@mailwoman/core/decoder"
+import { describe, expect, it, vi } from "vitest"
+
+import { rerankByResolution } from "./rerank.ts"
+
+/** A tree whose finest resolved node carries `tag` — `country` is what the guard vetoes. */
+function resolvedTree(tag: string, raw = "x"): AddressTree {
+	const node: AddressNode = {
+		tag,
+		value: raw,
+		start: 0,
+		end: raw.length,
+		confidence: 1,
+		children: [],
+		placeID: "wof:1",
+		lat: 1,
+		lon: 2,
+	} as unknown as AddressNode
+
+	return { raw, roots: [node] }
+}
+
+const bare = (raw: string): AddressTree => ({ raw, roots: [] })
+
+describe("rerankByResolution", () => {
+	it("keeps the model's rank-1 when it resolves plausibly — no gratuitous reordering", async () => {
+		const resolve = vi.fn(async () => resolvedTree("locality"))
+		const out = await rerankByResolution(
+			[
+				{ score: -1, tree: bare("a"), payload: "a" },
+				{ score: -2, tree: bare("b"), payload: "b" },
+			],
+			resolve
+		)
+		expect(out.best.payload).toBe("a")
+		expect(out.changed).toBe(false)
+		// Rank-1 was plausible, so rank-2 need not have been resolved at all... but the budget resolves
+		// in order; what matters is the ANSWER is unchanged.
+		expect(out.ranked[0]!.payload).toBe("a")
+	})
+
+	it("promotes rank-2 when rank-1 resolves to a country centroid — the arc's whole claim", async () => {
+		const resolve = vi.fn(async (t: AddressTree) => (t.raw === "a" ? resolvedTree("country") : resolvedTree("street")))
+		const out = await rerankByResolution(
+			[
+				{ score: -1, tree: bare("a"), payload: "rank1-garbage" },
+				{ score: -2, tree: bare("b"), payload: "rank2-real" },
+			],
+			resolve
+		)
+		expect(out.best.payload).toBe("rank2-real")
+		expect(out.changed).toBe(true)
+		// The vetoed one is retained, with its reason — never silently dropped.
+		const vetoed = out.ranked.find((r) => r.implausible)!
+		expect(vetoed.payload).toBe("rank1-garbage")
+		expect(vetoed.reason).toBe("country-centroid")
+	})
+
+	it("falls back to the model's rank-1 when EVERY candidate is implausible", async () => {
+		// "All my evidence says these are all bad" is not grounds to invent a different answer.
+		const resolve = vi.fn(async () => resolvedTree("country"))
+		const out = await rerankByResolution(
+			[
+				{ score: -1, tree: bare("a"), payload: "rank1" },
+				{ score: -2, tree: bare("b"), payload: "rank2" },
+			],
+			resolve
+		)
+		expect(out.best.payload).toBe("rank1")
+		expect(out.changed).toBe(false)
+	})
+
+	it("does NOT veto a candidate when the resolver throws — an outage is not evidence", async () => {
+		const resolve = vi.fn(async (t: AddressTree) => {
+			if (t.raw === "a") throw new Error("resolver down")
+
+			return resolvedTree("street")
+		})
+		const out = await rerankByResolution(
+			[
+				{ score: -1, tree: bare("a"), payload: "rank1" },
+				{ score: -2, tree: bare("b"), payload: "rank2" },
+			],
+			resolve
+		)
+		expect(out.best.payload).toBe("rank1")
+		expect(out.best.implausible).toBe(false)
+		expect(out.changed).toBe(false)
+	})
+
+	it("resolves at most maxResolve candidates — the latency knob is real", async () => {
+		const resolve = vi.fn(async () => resolvedTree("locality"))
+		const candidates = Array.from({ length: 10 }, (_, i) => ({ score: -i, tree: bare(`c${i}`), payload: i }))
+		await rerankByResolution(candidates, resolve, { maxResolve: 3 })
+		expect(resolve).toHaveBeenCalledTimes(3)
+	})
+
+	it("carries unresolved (beyond-budget) candidates through without vetoing them", async () => {
+		const resolve = vi.fn(async () => resolvedTree("country")) // everything resolved is vetoed
+		const candidates = Array.from({ length: 4 }, (_, i) => ({ score: -i, tree: bare(`c${i}`), payload: i }))
+		const out = await rerankByResolution(candidates, resolve, { maxResolve: 2 })
+		// c2/c3 were never resolved → not implausible → they outrank the two vetoed ones.
+		expect(out.best.payload).toBe(2)
+		expect(out.ranked.filter((r) => r.implausible)).toHaveLength(2)
+	})
+
+	it("throws on an empty candidate list rather than inventing a result", async () => {
+		await expect(rerankByResolution([], async (t) => t)).rejects.toThrow(/must not be empty/)
+	})
+})

--- a/resolver/rerank.ts
+++ b/resolver/rerank.ts
@@ -1,0 +1,135 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #727 stage-2 Phase 4a — reranking a k-best parse list on RESOLUTION EVIDENCE.
+ *
+ *   The arc's thesis, stated by the operator (2026-07-15): the arbiter for a k-best list is the
+ *   resolver, not hand-weights. A rank-2 parse that resolves to a real place beats a rank-1 that
+ *   resolves to a country centroid.
+ *
+ *   The measured case for this existing at all: on the triaged parity corpus the shipped decode gets
+ *   street 0.573 while the span decode's top-10 CONTAINS the right answer 0.775 of the time
+ *   (oracle@5 0.723). Rank-1 cannot reach that headroom; only a reranker can.
+ *
+ *   ## Why this is deliberately, almost embarrassingly small
+ *
+ *   The failure mode we are avoiding is Pelias's: a ladder of per-class hand-tuned weights that
+ *   nobody can re-derive (see `docs/articles/evals/competitive-parity/2026-07-15-pelias-dictionary-overrides.md`
+ *   — 94 of 276 dictionary lines are hand-written deletions, each resolving a collision in favour of
+ *   whoever complained loudest). The moment this file grows a per-hypothesis score blend, we have
+ *   rebuilt that with extra steps.
+ *
+ *   So the rule is ONE bit of evidence, not a score: **drop hypotheses whose resolution is
+ *   implausible; otherwise keep the model's own ranking.** The parse scores already share a partition
+ *   function and are comparable within an input — the reranker's job is not to re-score them, it is to
+ *   veto the ones the world says are wrong.
+ *
+ *   Adding a second signal here requires the same bar the first one cleared: a MEASURED win on the
+ *   parity + Paris fixtures, stated in a verdict doc. Not a plausible story.
+ */
+
+import type { AddressTree } from "@mailwoman/core/decoder"
+
+import { isImplausibleResolution } from "./plausibility.ts"
+
+/** One candidate parse from the k-best decode, with its (within-input comparable) score. */
+export interface RerankCandidate<T = unknown> {
+	/** The parse's own score. Comparable to its siblings from the SAME input; not across inputs. */
+	score: number
+	/** The parse tree, UNRESOLVED — `rerankByResolution` resolves it via the injected resolver. */
+	tree: AddressTree
+	/** Opaque caller payload carried through to the result (the segmentation, a surface string, …). */
+	payload?: T
+}
+
+export interface RerankedCandidate<T = unknown> extends RerankCandidate<T> {
+	/** The resolved tree (the resolver's output), or null when resolution threw. */
+	resolved: AddressTree | null
+	/** True when the resolution is implausible (today: resolves no finer than a country centroid). */
+	implausible: boolean
+	/** Why it was vetoed, when it was. */
+	reason?: string
+}
+
+export interface RerankResult<T = unknown> {
+	/** Candidates in FINAL order: plausible ones first (model order preserved), vetoed ones after. */
+	ranked: Array<RerankedCandidate<T>>
+	/** The winner — the first plausible candidate, or the model's rank-1 when ALL were vetoed. */
+	best: RerankedCandidate<T>
+	/**
+	 * True when the winner is NOT the model's rank-1 — i.e. resolution evidence actually changed the answer. This is the
+	 * metric the arc is judged on (`rank-2-beats-rank-1 rate`); log it, because a rerank that never fires is a rerank
+	 * that is not earning its resolver calls.
+	 */
+	changed: boolean
+}
+
+/** Resolve a tree. Structural — any `Resolver`-shaped thing satisfies it. */
+export type ResolveTree = (tree: AddressTree) => Promise<AddressTree>
+
+export interface RerankOpts {
+	/**
+	 * Resolve at most this many candidates (default 5). Each costs a resolver round-trip, so this is the latency knob.
+	 * oracle@5 (0.723) captures nearly all the measured headroom of oracle@10 (0.775), so 5 is the default rather than 10
+	 * — the last 5 candidates cost 2x the resolves for ~5pp of ceiling.
+	 */
+	maxResolve?: number
+}
+
+/**
+ * Rerank a k-best parse list on resolution evidence.
+ *
+ * Resolves up to `maxResolve` candidates IN MODEL ORDER and returns the first whose resolution is plausible. Candidates
+ * beyond `maxResolve` are never resolved (and never vetoed — they simply keep their model rank behind the resolved
+ * ones).
+ *
+ * **When every resolved candidate is implausible, the model's rank-1 wins.** A reranker that returns nothing is worse
+ * than one that defers: "all my evidence says these are all bad" is not grounds to invent a different answer, only
+ * grounds to flag low confidence (the Phase-4b ambiguity gate).
+ */
+export async function rerankByResolution<T>(
+	candidates: ReadonlyArray<RerankCandidate<T>>,
+	resolveTree: ResolveTree,
+	opts: RerankOpts = {}
+): Promise<RerankResult<T>> {
+	if (candidates.length === 0) throw new Error("rerankByResolution: candidates must not be empty")
+	const maxResolve = Math.max(1, Math.min(opts.maxResolve ?? 5, candidates.length))
+	const ranked: Array<RerankedCandidate<T>> = []
+
+	for (let i = 0; i < candidates.length; i++) {
+		const candidate = candidates[i]!
+
+		if (i >= maxResolve) {
+			// Beyond the resolve budget: carried through unresolved, never vetoed.
+			ranked.push({ ...candidate, resolved: null, implausible: false })
+			continue
+		}
+		let resolved: AddressTree | null = null
+
+		try {
+			resolved = await resolveTree(candidate.tree)
+		} catch {
+			// A resolver failure is NOT evidence against the parse — treat it as "no evidence" and let
+			// the model's rank stand, rather than vetoing a possibly-correct hypothesis on an outage.
+			ranked.push({ ...candidate, resolved: null, implausible: false })
+			continue
+		}
+		const verdict = isImplausibleResolution(resolved)
+		ranked.push({
+			...candidate,
+			resolved,
+			implausible: verdict.implausible,
+			...(verdict.reason ? { reason: verdict.reason } : {}),
+		})
+	}
+
+	// Stable partition: plausible first (model order preserved within each group), vetoed after.
+	const plausible = ranked.filter((r) => !r.implausible)
+	const vetoed = ranked.filter((r) => r.implausible)
+	const finalOrder = [...plausible, ...vetoed]
+	const best = finalOrder[0]!
+
+	return { ranked: finalOrder, best, changed: best !== ranked[0] }
+}


### PR DESCRIPTION
> **Status: CLOSED and parked. Do not merge.** The shippable half of this arc —
> the v6.4.0 promote, the fr-fragment shard, the eval instruments, and all the
> verdict docs — is split out to #1144 and merges there. This PR stays open as
> the complete record of the attempt: 60 commits, four phases, the code, and the
> measurements that killed it.

## What this was

A semi-Markov CRF span scorer with a k-best segment decode, on the thesis that
the parser's street errors were a **segmentation** problem the BIO argmax
couldn't express — and that a decoder that scores whole spans would find answers
token-level decoding was leaving on the table.

## Why it's closed

The kill shot was pre-registered in the `v3.2.0-fragment-span` config header
before any number existed. On the Paris target class (n=63, production config,
int8-vs-int8):

| model | decode | | |
| --- | --- | ---: | --- |
| v264 (shipped) | token@1 | 33/63 = 0.524 | the problem |
| v301 — old corpus + span head | seg@1 | 48/63 = **0.762** | the span head looked like the fix (**+23.8pp**) |
| **v310 — shard, NO span head** | token@1 | 56/63 = **0.889** | the *data* was the fix (**+36.5pp**) |
| v320 — shard + span head | seg@1 | 54/63 = 0.857 | **−3.2pp — FAIL** |

**The span head was worth +23.8pp when the data was wrong, and −3.2pp once the
data was right.** It was compensating for a training-distribution defect. A
compensator for a defect you've fixed isn't a feature — it's drag.

The within-model reading is what makes it final: **same weights, same channels,
same fixtures — `token@1` 56/63, `seg@1` 54/63.** No config gap to appeal to, no
artifact mismatch, no "it wasn't trained on the right data" — v320 trained on
exactly the corpus T1c named as the missing condition, and it converged cleanly
(loss 24.71 → 1.25, past v3.0.0's ~1.37; param groups verified; `init_from
missing=9` confirming a fresh head). **It learned, and what it learned is worse
than not having it.**

Per the config's own instruction: no `span_loss_weight` tuning, no re-run. That
is the treadmill.

## What died

The span head, the k-best decode as a product surface, the flag, Phase-4a
resolution reranking (`rerankByResolution` — cannot collect the headroom, for
structural reasons), and the name-index by premise collapse.

## What survived → #1144

`oracle-k`, the fragment board with its negative class, the parity precision
half, `baselines.json` and its refusal, and the `v6.0.0-shipped-baseline` gate.
Every one is an instrument that can see something the project previously
couldn't.

## The thing worth keeping

The arc asked whether a better decode could find the right answer. It couldn't —
**the answer was never in the candidate list, because it wasn't in the training
data.** But `oracle@10 0.775` against a `0.577` rank-1 was the gap that drove
T1a → T1c → T2, and T2 is the model now shipping as 6.4.0.

**The instrument that proved the answer wasn't there is what led us to put it
there.** Four phases, no shippable artifact, and the right fix found.

## If you're re-opening this

Read `docs/articles/evals/2026-07-16-span-head-closed.md` (on #1144) first. The
verdict is **conditional**, like all of them: it holds under *these* conditions —
a 29M encoder, this shard, this corpus. A model whose graph actually needs span
structure (nested spans, a segment-level objective the BIO path cannot express)
is a different question. This PR's code is brute-force verified and tested;
recover it by SHA rather than rewriting it.

One live diagnostic from this arc feeds the digit-ownership workstream: the span
decode pulled digits **into** street (`Korunní 810` → street `korunní 8`) while
BIO pushed them **out** (`Allee du 11 Novembre` → street `Allee du`, house_number
`11`, street `Novembre`). **Two decoders over one encoder disagreeing about which
side of a boundary a digit falls on is a representation problem, not a decoding
one.**