### PR TITLE
fix(neural): scope the queryShape locality bias to bare admin doubletons

### DIFF
--- a/neural/query-shape-prior.test.ts
+++ b/neural/query-shape-prior.test.ts
@@ -116,133 +116,80 @@ describe("buildEmissionPriors", () => {
 	})
 })
 
-describe("buildEmissionPriors — locality bias", () => {
-	const FULL_LABELS = [
-		"O",
-		"B-country",
-		"I-country",
-		"B-region",
-		"I-region",
-		"B-locality",
-		"I-locality",
-		"B-postcode",
-		"I-postcode",
-	]
+describe("buildEmissionPriors — SCOPED locality bias (2026-07-17 rebuild)", () => {
+	// The original backward-walk locality bias was retired after the M1 stack ablation attributed the
+	// prior's entire −7.8pp golden-us locality cost to it (venue/org absorption: "DANVILLE HEALTH
+	// CENTER, 26 Cedar Lane, Danville VT" → locality "danville health center"). The gauntlet regression
+	// layer then caught the over-correction: bare "New York, NY" (us-new-york-nyc) NEEDS the bias — the
+	// model alone drops the locality. This scoped rebuild fires ONLY on that bare admin doubleton:
+	// no digits, abbreviation last, ≤4 preceding tokens, name ≠ the region's own name.
+	const bLoc = LABELS.indexOf("B-locality")
+	const iLoc = LABELS.indexOf("I-locality")
 
-	it("biases preceding token toward B-locality when region abbreviation detected", () => {
-		// "Washington, DC" — token "Washington" at [0,10], comma at [10,11], space, "DC" at [12,14]
-		const shape: QueryShapeLike = {
-			knownFormats: [],
-			regionAbbreviations: [{ start: 12, span: "DC" }],
-		}
-		// Token for "Washington" ends at 10; abbreviation starts at 12 (gap = 2 for ", ")
-		const toks = tokens([0, 10], [12, 14])
-		const m = buildEmissionPriors(shape, toks, FULL_LABELS)
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		expect(m[0]?.[bLocCol]).toBe(2.0)
-		// The abbreviation token itself should NOT get locality bias
-		expect(m[1]?.[bLocCol]).toBe(0)
+	it("fires on the bare doubleton — New York, NY", () => {
+		const shape = { knownFormats: [], regionAbbreviations: [{ start: 10, span: "NY" }] } as QueryShapeLike
+		const m = buildEmissionPriors(shape, tokens([0, 3], [4, 8], [10, 12]), LABELS, { inputText: "New York, NY" })
+
+		expect(m[0]![bLoc]).toBeGreaterThan(0)
+		expect(m[1]![iLoc]).toBeGreaterThan(0)
+		expect(m[2]![bLoc]).toBe(0)
 	})
 
-	it("biases multi-word locality with B- and I- correctly", () => {
-		// "New York, NY" — "New" at [0,3], "York" at [4,8], "NY" at [10,12]
-		const shape: QueryShapeLike = {
-			knownFormats: [],
-			regionAbbreviations: [{ start: 10, span: "NY" }],
+	it("does NOT fire when the input carries digits (the M1 venue/street failure class)", () => {
+		const text = "Danville Health Center, 26 Cedar Lane, Danville VT"
+		const shape = { knownFormats: [], regionAbbreviations: [{ start: 48, span: "VT" }] } as QueryShapeLike
+		const toks = tokens([0, 8], [9, 15], [16, 22], [24, 26], [27, 32], [33, 37], [39, 47], [48, 50])
+		const m = buildEmissionPriors(shape, toks, LABELS, { inputText: text })
+
+		for (const row of m) {
+			expect(row[bLoc]).toBe(0)
+			expect(row[iLoc]).toBe(0)
 		}
-		const toks = tokens([0, 3], [4, 8], [10, 12])
-		const m = buildEmissionPriors(shape, toks, FULL_LABELS)
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		const iLocCol = FULL_LABELS.indexOf("I-locality")
-		// "New" should get B-locality, "York" should get I-locality
-		expect(m[0]?.[bLocCol]).toBe(2.0)
-		expect(m[1]?.[iLocCol]).toBe(2.0)
-		// Abbreviation token gets nothing
-		expect(m[2]?.[bLocCol]).toBe(0)
 	})
 
-	it("does not bias when no region abbreviations present", () => {
-		const shape: QueryShapeLike = {
-			knownFormats: [],
-			regionAbbreviations: [],
+	it("does NOT fire when more than 4 tokens precede the abbreviation", () => {
+		const text = "Community Health Service Inc Grafton ND"
+		const shape = { knownFormats: [], regionAbbreviations: [{ start: 37, span: "ND" }] } as QueryShapeLike
+		const toks = tokens([0, 9], [10, 16], [17, 24], [25, 28], [29, 36], [37, 39])
+		const m = buildEmissionPriors(shape, toks, LABELS, { inputText: text })
+
+		for (const row of m) {
+			expect(row[bLoc]).toBe(0)
 		}
-		const m = buildEmissionPriors(shape, tokens([0, 5], [6, 10]), FULL_LABELS)
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		expect(m[0]?.[bLocCol]).toBe(0)
-		expect(m[1]?.[bLocCol]).toBe(0)
 	})
 
-	it("does not bias tokens that are too far from the abbreviation", () => {
-		// Token at [0,5], abbreviation at [50,52] — gap of 45 chars
-		const shape: QueryShapeLike = {
-			knownFormats: [],
-			regionAbbreviations: [{ start: 50, span: "DC" }],
+	it("does NOT fire when a token follows the abbreviation (not the doubleton shape)", () => {
+		const text = "New York, NY tomorrow"
+		const shape = { knownFormats: [], regionAbbreviations: [{ start: 10, span: "NY" }] } as QueryShapeLike
+		const m = buildEmissionPriors(shape, tokens([0, 3], [4, 8], [10, 12], [13, 21]), LABELS, { inputText: text })
+
+		for (const row of m) {
+			expect(row[bLoc]).toBe(0)
 		}
-		const m = buildEmissionPriors(shape, tokens([0, 5], [50, 52]), FULL_LABELS)
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		expect(m[0]?.[bLocCol]).toBe(0)
 	})
 
-	it("respects custom localityBiasScale", () => {
-		const shape: QueryShapeLike = {
-			knownFormats: [],
-			regionAbbreviations: [{ start: 12, span: "DC" }],
+	it("fires for Washington, DC and — deliberately — for Washington, WA (the old name-IS-region guard was dead in production)", () => {
+		// The retired version compared the preceding text against the region's full name, but production
+		// passes PIECE spans that include the trailing comma, so the comparison never matched. The bias is
+		// soft (+2.0 log-odds): a confident region emission on a true state-restatement still wins.
+		for (const [text, span] of [
+			["Washington, DC", "DC"],
+			["Washington, WA", "WA"],
+		] as const) {
+			const shape = { knownFormats: [], regionAbbreviations: [{ start: 12, span }] } as QueryShapeLike
+			const m = buildEmissionPriors(shape, tokens([0, 10], [12, 14]), LABELS, { inputText: text })
+
+			expect(m[0]![bLoc]).toBeGreaterThan(0)
 		}
-		const toks = tokens([0, 10], [12, 14])
-		const m = buildEmissionPriors(shape, toks, FULL_LABELS, { localityBiasScale: 3.0 })
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		expect(m[0]?.[bLocCol]).toBe(3.0)
 	})
 
-	it("does not bias when preceding text matches the region name (Washington, WA)", () => {
-		// "Washington, WA" — "Washington" IS the region name for WA, should NOT get locality bias
-		const shape: QueryShapeLike = {
-			knownFormats: [],
-			regionAbbreviations: [{ start: 12, span: "WA" }],
-		}
-		const toks = tokens([0, 10], [12, 14])
-		const m = buildEmissionPriors(shape, toks, FULL_LABELS, { inputText: "Washington, WA" })
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		expect(m[0]?.[bLocCol]).toBe(0)
-	})
+	it("never fires without inputText (the digit guard cannot run)", () => {
+		const shape = { knownFormats: [], regionAbbreviations: [{ start: 10, span: "NY" }] } as QueryShapeLike
+		const m = buildEmissionPriors(shape, tokens([0, 3], [4, 8], [10, 12]), LABELS)
 
-	it("still biases when text does NOT match region name (Washington, DC)", () => {
-		// "Washington, DC" — DC's region name is "District of Columbia", NOT "Washington"
-		const shape: QueryShapeLike = {
-			knownFormats: [],
-			regionAbbreviations: [{ start: 12, span: "DC" }],
+		for (const row of m) {
+			expect(row[bLoc]).toBe(0)
 		}
-		const toks = tokens([0, 10], [12, 14])
-		const m = buildEmissionPriors(shape, toks, FULL_LABELS, { inputText: "Washington, DC" })
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		expect(m[0]?.[bLocCol]).toBe(2.0)
-	})
-
-	it("does not bias New York before NY (region name match)", () => {
-		// "New York, NY" — "New York" IS the region name for NY
-		const shape: QueryShapeLike = {
-			knownFormats: [],
-			regionAbbreviations: [{ start: 10, span: "NY" }],
-		}
-		const toks = tokens([0, 3], [4, 8], [10, 12])
-		const m = buildEmissionPriors(shape, toks, FULL_LABELS, { inputText: "New York, NY" })
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		const iLocCol = FULL_LABELS.indexOf("I-locality")
-		expect(m[0]?.[bLocCol]).toBe(0)
-		expect(m[1]?.[iLocCol]).toBe(0)
-	})
-
-	it("skips tokens overlapping a known postcode format", () => {
-		// "10118, NY" — "10118" overlaps a postcode hit, should NOT get locality bias
-		const shape: QueryShapeLike = {
-			knownFormats: [{ format: "us_zip", span: { start: 0, end: 5 }, confidence: 0.6 }],
-			regionAbbreviations: [{ start: 7, span: "NY" }],
-		}
-		const toks = tokens([0, 5], [7, 9])
-		const m = buildEmissionPriors(shape, toks, FULL_LABELS)
-		const bLocCol = FULL_LABELS.indexOf("B-locality")
-		// Token 0 is a postcode — should NOT get locality bias
-		expect(m[0]?.[bLocCol]).toBe(0)
 	})
 })
 

--- a/neural/query-shape-prior.ts
+++ b/neural/query-shape-prior.ts
@@ -15,6 +15,17 @@
  *   authority on context-dependent calls (the "Buffalo Wild Wings, Buffalo, NY" disambiguation);
  *   the QueryShape prior helps on the easy cases (a 5-digit token is _probably_ a postcode).
  *
+ *   RETIRED 2026-07-17 — the LOCALITY bias (regionAbbreviations → boost B/I-locality on preceding
+ *   tokens). The M1 stack ablation (docs/articles/evals/2026-07-17-m1-stack-ablation.md) measured the
+ *   full prior at −2.3 micro / −7.8 locality on golden-us, and the three-arm sub-ablation attributed
+ *   100% of the damage to the locality half: stripping it recovered locality exact-match 0.7822 →
+ *   0.8546 (= the no-prior arm), while the known-format half was exactly neutral. The failure mode was
+ *   venue/org absorption on registry-style rows ("DANVILLE HEALTH CENTER, 26 Cedar Lane, Danville VT"
+ *   → locality "danville health center"): the backward walk from a detected region abbreviation
+ *   crossed comma gaps and dragged venue text into locality. The WOF bare-name over-emission it was
+ *   built to counter no longer reproduces — the model outgrew it (same lifecycle as the #956-era
+ *   near-postcode suppression, also measured negative in M1). The known-format boosts below remain.
+ *
  *   Uses structural typing for the QueryShape input so this module has zero dependencies on
  *   `@mailwoman/query-shape` — consumers compute the shape with that package, pass it in here.
  */
@@ -68,13 +79,10 @@ export interface BuildPriorsOpts {
 	 * Confidence-scaled, so a 0.6-confidence format hit gets +0.6 max bias.
 	 */
 	biasScale?: number
-
 	/**
-	 * Bias magnitude for the locality soft prior (in log-odds units). Default 2.0 — adds ~e^2 ≈ 7.4× odds to B-locality /
-	 * I-locality for tokens preceding a detected region abbreviation.
+	 * Raw input text — enables the SCOPED locality bias (bare admin doubletons only; see `applyScopedLocalityBias`).
+	 * Without it the digit guard cannot run, so the locality bias never fires.
 	 */
-	localityBiasScale?: number
-	/** Raw input text for region-name matching in the locality bias guard. */
 	inputText?: string
 }
 
@@ -109,7 +117,7 @@ export function buildEmissionPriors(
 		labelToCol.set(labels[k]!, k)
 	}
 
-	if (shape.knownFormats.length === 0 && (!shape.regionAbbreviations || shape.regionAbbreviations.length === 0)) {
+	if (shape.knownFormats.length === 0 && !shape.regionAbbreviations?.length) {
 		return matrix
 	}
 
@@ -131,38 +139,37 @@ export function buildEmissionPriors(
 		}
 	}
 
-	// Locality soft prior: when a region abbreviation is detected (e.g., "DC", "NY"), bias
-	// preceding alphabetic tokens toward B-locality / I-locality. This counters the WOF
-	// bare-name frequency dominance that makes the model over-emit B-region on ambiguous
-	// place names like "Washington" or "New York".
-	applyLocalityBias(matrix, shape, tokens, labelToCol, opts.localityBiasScale ?? 2.0, opts.inputText)
+	applyScopedLocalityBias(matrix, shape, tokens, labelToCol, opts.inputText)
 
 	return matrix
 }
 
 /**
- * Apply locality bias to tokens preceding a detected region abbreviation.
+ * The SCOPED locality bias — the 2026-07-17 rebuild of the retired backward-walk version (see the header). It fires
+ * ONLY on the bare admin doubleton the original was built for ("New York, NY", "Washington, DC" — a region-ambiguous
+ * city name before its state abbreviation, the gauntlet `us-new-york-nyc` regression case) and structurally cannot
+ * reach the venue/street inputs the old walk broke on. Guards, in order:
  *
- * For "Washington, DC" — "DC" is the region abbreviation; "Washington" gets biased toward B-locality. For "New York,
- * NY" — "New" gets B-locality and "York" gets I-locality.
+ * 1. NO DIGITS anywhere in the input — any house number / postcode means this is not an admin-only query, and the M1
+ *    failure class ("… 26 Cedar Lane, Danville VT") always carries digits.
+ * 2. The abbreviation is the FINAL token — the doubleton shape, not a mid-sentence state mention.
+ * 3. At most 4 tokens precede it ("Salt Lake City, UT" fits; "Community Health Service Inc - Grafton ND" does not).
  *
- * Guard: if the preceding text matches the full name of the region that the abbreviation represents (e.g., "Washington"
- * before "WA"), the locality bias is NOT applied — the text IS the region, not a locality within it.
- *
- * Constraint: only bias tokens that appear BEFORE the abbreviation's character offset and are alphabetic (start with
- * uppercase). Tokens that are part of a known postcode format or are themselves region abbreviations are skipped.
+ * The retired version also carried a "name IS the region" guard ("Washington, WA" stays region). It was DEAD in
+ * production — the classifier passes tokenizer PIECES whose spans include the trailing comma, so the string comparison
+ * never matched (and "New York, NY", the gauntlet regression case, needs the bias despite naming its own state).
+ * Deliberately dropped; the bias is soft, so a confident region emission on a true state restatement still wins.
  */
-function applyLocalityBias(
+function applyScopedLocalityBias(
 	matrix: number[][],
 	shape: QueryShapeLike,
-	tokens: ReadonlyArray<TokenLike & { piece?: string }>,
+	tokens: ReadonlyArray<TokenLike>,
 	labelToCol: Map<string, number>,
-	localityBias: number,
 	inputText?: string
 ): void {
 	const abbrevs = shape.regionAbbreviations
 
-	if (!abbrevs || abbrevs.length === 0) return
+	if (!abbrevs?.length || !inputText || /\d/.test(inputText)) return
 
 	const bLocCol = labelToCol.get("B-locality")
 	const iLocCol = labelToCol.get("I-locality")
@@ -170,115 +177,25 @@ function applyLocalityBias(
 	if (bLocCol === undefined) return
 
 	for (const abbrev of abbrevs) {
-		const candidates: number[] = []
-		let prevStart = abbrev.start
+		// Guard 2: nothing may follow the abbreviation token.
+		if (tokens.some((tok) => tok.start > abbrev.start + abbrev.span.length)) continue
 
-		for (let t = tokens.length - 1; t >= 0; t--) {
-			const tok = tokens[t]!
+		const candidates = tokens.map((tok, t) => ({ tok, t })).filter(({ tok }) => tok.end <= abbrev.start)
 
-			if (tok.end > abbrev.start) continue
-
-			const gap = prevStart - tok.end
-
-			if (candidates.length === 0 && gap > 4) break
-
-			if (candidates.length > 0 && gap > 2) break
-
-			let isPostcode = false
-
-			for (const fmt of shape.knownFormats) {
-				if (overlaps(tok, fmt.span)) {
-					isPostcode = true
-					break
-				}
-			}
-
-			if (isPostcode) break
-
-			candidates.push(t)
-			prevStart = tok.start
-		}
-
-		if (candidates.length === 0) continue
-		candidates.reverse()
-
-		if (inputText) {
-			const firstTok = tokens[candidates[0]!]!
-			const lastTok = tokens[candidates[candidates.length - 1]!]!
-			const candidateText = inputText.slice(firstTok.start, lastTok.end).toLowerCase()
-			const regionNames = ABBREV_TO_REGION.get(abbrev.span)
-
-			if (regionNames?.some((name) => candidateText === name)) continue
-		}
+		// Guard 3: the doubleton shape — a short leading name, not a sentence.
+		if (candidates.length === 0 || candidates.length > 4) continue
 
 		for (let i = 0; i < candidates.length; i++) {
-			const t = candidates[i]!
 			const col = i === 0 ? bLocCol : iLocCol
 
 			if (col === undefined) continue
-			matrix[t]![col] = Math.max(matrix[t]![col]!, localityBias)
+			matrix[candidates[i]!.t]![col] = Math.max(matrix[candidates[i]!.t]![col]!, SCOPED_LOCALITY_BIAS)
 		}
 	}
 }
 
-const ABBREV_TO_REGION: ReadonlyMap<string, string[]> = new Map([
-	["AL", ["alabama"]],
-	["AK", ["alaska"]],
-	["AZ", ["arizona"]],
-	["AR", ["arkansas"]],
-	["CA", ["california"]],
-	["CO", ["colorado"]],
-	["CT", ["connecticut"]],
-	["DE", ["delaware"]],
-	["DC", ["district of columbia"]],
-	["FL", ["florida"]],
-	["GA", ["georgia"]],
-	["HI", ["hawaii"]],
-	["ID", ["idaho"]],
-	["IL", ["illinois"]],
-	["IN", ["indiana"]],
-	["IA", ["iowa"]],
-	["KS", ["kansas"]],
-	["KY", ["kentucky"]],
-	["LA", ["louisiana"]],
-	["ME", ["maine"]],
-	["MD", ["maryland"]],
-	["MA", ["massachusetts"]],
-	["MI", ["michigan"]],
-	["MN", ["minnesota"]],
-	["MS", ["mississippi"]],
-	["MO", ["missouri"]],
-	["MT", ["montana"]],
-	["NE", ["nebraska"]],
-	["NV", ["nevada"]],
-	["NH", ["new hampshire"]],
-	["NJ", ["new jersey"]],
-	["NM", ["new mexico"]],
-	["NY", ["new york"]],
-	["NC", ["north carolina"]],
-	["ND", ["north dakota"]],
-	["OH", ["ohio"]],
-	["OK", ["oklahoma"]],
-	["OR", ["oregon"]],
-	["PA", ["pennsylvania"]],
-	["RI", ["rhode island"]],
-	["SC", ["south carolina"]],
-	["SD", ["south dakota"]],
-	["TN", ["tennessee"]],
-	["TX", ["texas"]],
-	["UT", ["utah"]],
-	["VT", ["vermont"]],
-	["VA", ["virginia"]],
-	["WA", ["washington"]],
-	["WV", ["west virginia"]],
-	["WI", ["wisconsin"]],
-	["WY", ["wyoming"]],
-	["AS", ["american samoa"]],
-	["GU", ["guam"]],
-	["MP", ["northern mariana islands"]],
-	["PR", ["puerto rico"]],
-	["VI", ["virgin islands"]],
-])
+/** Log-odds bias for the scoped doubleton case — the retired version's strength, now reachable only by the doubleton. */
+const SCOPED_LOCALITY_BIAS = 2.0
 
 function overlaps(a: { start: number; end: number }, b: { start: number; end: number }): boolean {
 	return a.start < b.end && b.start < a.end


### PR DESCRIPTION
## The M1 finding, fixed

The M1 stack ablation ([eval doc](../blob/main/docs/articles/evals/2026-07-17-m1-stack-ablation.md)) measured the query-shape prior at **−2.3 micro / −7.8 locality on golden-us**, and a three-arm sub-ablation attributed **100% of the damage to the `regionAbbreviations` locality bias**: its backward token walk crossed comma gaps and dragged venue/org names into locality — `DANVILLE HEALTH CENTER, 26 Cedar Lane, Danville VT` → locality `"danville health center"`. It broke exactly the registry-style rows it was originally built for.

## Why scoping, not deletion

Outright deletion **failed the gauntlet regression layer**: bare `New York, NY` (`us-new-york-nyc`) needs the bias — the model alone drops the locality and the geocode lands 283 km off. The bias is *correct* on the bare admin doubleton and *harmful* everywhere else, so it now fires only when:

1. the input carries **no digits** (the M1 failure class always has a house number/postcode),
2. the abbreviation is the **final token**, and
3. **≤ 4 tokens** precede it.

The old "name IS the region" guard (`Washington, WA`) is dropped as **dead code** — production passes tokenizer piece spans that include the trailing comma, so its string comparison never matched, and `New York, NY` requires firing despite naming its own state.

## Verification

| check | result |
| --- | --- |
| golden-us locality (production parse path) | **0.7822 → 0.8546** (= the no-prior arm; the full M1 gap recovered) |
| golden-adv | unchanged (0.9184) |
| Gauntlet | **PASS** — regression 33/33 incl. `us-new-york-nyc`, metamorphic clean |
| unit tests | 18/18, incl. pins for each guard + the M1 venue failure class |

Remaining half of #76 (gate fidelity — the battery should score the production parse opts) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1Kk2TojtVRejgGnobtjJ8