### PR TITLE
fix(evals): per-locale-f1 scores the PRODUCTION parse config

### DIFF
--- a/scripts/eval/per-locale-f1.ts
+++ b/scripts/eval/per-locale-f1.ts
@@ -55,6 +55,7 @@ import {
 } from "@mailwoman/neural"
 import { ONNXRunner } from "@mailwoman/neural/onnx-runner"
 import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+import { computeQueryShape } from "@mailwoman/query-shape"
 
 // Default anchor + gazetteer feed paths — the SAME ones `score-country-homograph.ts` and the verdict
 // `oa-resolver-eval` runs use. The current 33-label STAGE3 models (v1.5.x, v1.7.x; ONNX inputs
@@ -437,7 +438,16 @@ async function main(): Promise<void> {
 
 		for (const row of rows) {
 			const wordConsistency = parseWordConsistencyEnv($public.MAILWOMAN_WORD_CONSISTENCY)
-			const tree = await neural.parse(row.raw, wordConsistency ? { enforceWordConsistency: wordConsistency } : {})
+			// PRODUCTION-CONFIG parity (2026-07-17, the M1 gate-fidelity fix): production parses feed the
+			// query-shape prior + postcodeRepair on every path (safeClassify, geocode-core since #981), but
+			// this battery historically fed NEITHER — so the gate scored a config production doesn't run.
+			// M1 measured that gap at +2.3 micro on golden-us (the battery flattered production; the entire
+			// delta was the since-scoped locality bias, PR #1148). Score what ships.
+			const tree = await neural.parse(row.raw, {
+				postcodeRepair: true,
+				queryShape: computeQueryShape(row.raw),
+				...(wordConsistency ? { enforceWordConsistency: wordConsistency } : {}),
+			})
 			const pred = foldToComponents(decodeAsJSON(tree))
 			preds.push(pred)
 


### PR DESCRIPTION
The gate-fidelity half of the M1 queryShape finding (#1148 was the fix half).

**The gap:** every production parse path feeds the query-shape prior + `postcodeRepair` (safeClassify, geocode-core since #981), but the gate battery fed neither — the gate scored a config production doesn't run. M1 measured that gap at +2.3 micro on golden-us, and it hid for its whole lifetime because nothing compared the two configs.

**The fix:** the battery's parse call now matches production (`postcodeRepair: true` + `computeQueryShape`).

**Verified** vs the recorded v381 gate baselines on identical weights: us macro 47.9→47.7, adversarial 66.0→66.2 (noise), **us micro 86.8→87.7** — the production config reads slightly higher post-scoping, so every gate floor clears with wider margin. From here, any new inference-time prior is priced by the gate the day it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1Kk2TojtVRejgGnobtjJ8