### PR TITLE
feat(resolver): fold guard B (cross-country bbox) into the shipped plausibility module

### DIFF
--- a/mailwoman/test/v1-parse-gate.test.ts
+++ b/mailwoman/test/v1-parse-gate.test.ts
@@ -183,7 +183,9 @@ describe.skipIf(!weightsPresent() || !gazetteerPresent())(
 					const nTree = await neural.parse(fx.input, { postcodeRepair: true })
 					const resolved = await resolver.resolveTree(nTree, opts)
 					neuralCoord = finestResolvedCoordinate(resolved)
-					implausible = isImplausibleResolution(resolved).implausible
+					// Guard A (country-centroid) + guard B (cross-country bbox, folded into the shipped module
+					// 2026-07-17 from the receipt harness — the fixture's gold country is the expectedCountry).
+					implausible = isImplausibleResolution(resolved, { expectedCountry: fx.country || undefined }).implausible
 
 					for (const [label, tags] of [
 						["street", STREET_TAGS],

--- a/resolver/plausibility.test.ts
+++ b/resolver/plausibility.test.ts
@@ -73,6 +73,37 @@ describe("isImplausibleResolution", () => {
 		expect(isImplausibleResolution(t).implausible).toBe(false)
 	})
 
+	test("guard B: a coordinate outside the expected country's bbox is implausible (the cross-country jump)", () => {
+		// The V1 finding (PR #1147): "1210a IA 10 W IA" resolved ~10,000 km outside the US — locality-tier,
+		// so guard A (country-centroid) structurally cannot catch it. Guard B does, given the expected country.
+		const t = tree(
+			[node({ tag: "locality", value: "Ia", lat: -6.3, lon: 155.6, placeID: "wof:ia-png" })],
+			"1210a IA 10 W IA"
+		)
+		const verdict = isImplausibleResolution(t, { expectedCountry: "US" })
+
+		expect(verdict.implausible).toBe(true)
+		expect(verdict.reason).toBe("outside-expected-country")
+	})
+
+	test("guard B does NOT trip when the coordinate is inside the expected country", () => {
+		const t = tree([node({ tag: "locality", value: "Des Moines", lat: 41.59, lon: -93.62, placeID: "wof:dsm" })])
+
+		expect(isImplausibleResolution(t, { expectedCountry: "US" }).implausible).toBe(false)
+	})
+
+	test("guard B is fail-open for a country without a bbox", () => {
+		const t = tree([node({ tag: "locality", value: "Reykjavík", lat: 64.15, lon: -21.9 })])
+
+		expect(isImplausibleResolution(t, { expectedCountry: "IS" }).implausible).toBe(false)
+	})
+
+	test("guard B never runs without expectedCountry (backward-compatible default)", () => {
+		const t = tree([node({ tag: "locality", value: "Ia", lat: -6.3, lon: 155.6 })])
+
+		expect(isImplausibleResolution(t).implausible).toBe(false)
+	})
+
 	test("an unresolved tree is not implausible (nothing to serve, not garbage)", () => {
 		const verdict = isImplausibleResolution(tree([node({ tag: "street", value: "Epleskogen" })], "Epleskogen 39A"))
 

--- a/resolver/plausibility.ts
+++ b/resolver/plausibility.ts
@@ -86,25 +86,84 @@ export function finestResolvedCoordinate(tree: AddressTree): ResolvedCoordinate 
 	return best
 }
 
+/**
+ * Coarse per-country bounding boxes `[latMin, latMax, lonMin, lonMax]` for the cross-country guard (guard B). These are
+ * DELIBERATELY rough — a guard needs "obviously the wrong country", not cartography — and they mirror the boxes the
+ * 2026-07-15 coordinate-parity receipt harness measured with (`scratchpad/coord-parity.mjs`). The US box spans Alaska →
+ * the mainland east coast; continental FR only; etc. A country absent here simply never trips the guard (fail-open).
+ */
+const COUNTRY_BBOX: Readonly<Record<string, readonly [number, number, number, number]>> = {
+	US: [18, 72, -180, -66],
+	AU: [-44, -10, 112, 154],
+	BR: [-34, 6, -74, -34],
+	CZ: [48, 51.5, 12, 19],
+	DE: [47, 55.5, 5.5, 15.5],
+	ES: [35, 44, -10, 5],
+	FR: [41, 51.5, -5.5, 9.8],
+	GB: [49, 61, -8.7, 2],
+	HR: [42, 46.6, 13, 19.5],
+	IN: [6, 36, 68, 98],
+	NL: [50.7, 53.7, 3.3, 7.3],
+	NO: [57, 71.5, 4, 31],
+	PL: [49, 55, 14, 24.2],
+	PT: [36.5, 42.2, -9.6, -6.1],
+	RO: [43.5, 48.3, 20, 30],
+	SE: [55, 69.1, 10.9, 24.2],
+	SK: [47.7, 49.7, 16.8, 22.6],
+	SI: [45.4, 46.9, 13.3, 16.6],
+}
+
+/** True when the coordinate lies outside `countryCode`'s coarse bbox. Unknown country codes are fail-open (false). */
+export function outsideExpectedCountry(countryCode: string, lat: number, lon: number): boolean {
+	const b = COUNTRY_BBOX[countryCode.toUpperCase()]
+
+	if (!b) return false
+
+	return lat < b[0] || lat > b[1] || lon < b[2] || lon > b[3]
+}
+
 /** Result of {@link isImplausibleResolution} — the boolean plus the reason, for telemetry + fallback logs. */
 export interface PlausibilityVerdict {
 	implausible: boolean
-	/** Set when `implausible` is true. `country-centroid` = resolved no finer than a country. */
-	reason?: "country-centroid"
+	/**
+	 * Set when `implausible` is true. `country-centroid` = resolved no finer than a country (guard A);
+	 * `outside-expected-country` = the served coordinate lies outside the expected country's bbox (guard B).
+	 */
+	reason?: "country-centroid" | "outside-expected-country"
 	/** The coordinate the verdict was drawn from, when anything resolved. */
 	coordinate?: ResolvedCoordinate
 }
 
+export interface PlausibilityOpts {
+	/**
+	 * ISO-2 country the resolution is EXPECTED to land in, when the caller knows it (a locale hint, a parsed country, a
+	 * fixture's gold country). Enables guard B: a coordinate outside this country's coarse bbox is implausible — the
+	 * cross-country-jump class guard A structurally cannot catch (`1210a IA 10 W IA` → a coordinate ~10,000 km from the
+	 * US was country-centroid-free and sailed through until guard B landed here, 2026-07-17; previously the check lived
+	 * only in the receipt harness, so the shipped residual read 5/321 while the receipt said 3/321).
+	 */
+	expectedCountry?: string
+}
+
 /**
  * Decide whether a resolved tree's geocode is implausible for a structured address — the cheap guard the v7 hybrid gate
- * runs after routing an input to the neural parser (#38). Trips only when the finest resolved place is a bare `country`
- * centroid; an unresolved tree (nothing to serve) and any region-or-finer resolution are both plausible.
+ * runs after routing an input to the neural parser (#38). Trips when the finest resolved place is a bare `country`
+ * centroid (guard A), or — when the caller supplies `expectedCountry` — when the served coordinate falls outside that
+ * country's coarse bbox (guard B). An unresolved tree (nothing to serve) is plausible: there is no garbage to serve.
  */
-export function isImplausibleResolution(tree: AddressTree): PlausibilityVerdict {
+export function isImplausibleResolution(tree: AddressTree, opts: PlausibilityOpts = {}): PlausibilityVerdict {
 	const coordinate = finestResolvedCoordinate(tree)
 
 	if (coordinate && coordinate.tag === "country") {
 		return { implausible: true, reason: "country-centroid", coordinate }
+	}
+
+	if (
+		coordinate &&
+		opts.expectedCountry &&
+		outsideExpectedCountry(opts.expectedCountry, coordinate.lat, coordinate.lon)
+	) {
+		return { implausible: true, reason: "outside-expected-country", coordinate }
 	}
 
 	return { implausible: false, coordinate: coordinate ?? undefined }


### PR DESCRIPTION
Closes the V1 finding from #1147: the coord-parity receipt (3/321) was measured with two guards, but only guard A (country-centroid) ever shipped — guard B (coordinate outside the expected country's coarse bbox) lived only in the scratchpad harness, so the honest shipped residual was 5/321 including a 10,053 km out-of-country jump guard A structurally cannot catch.

`isImplausibleResolution(tree, { expectedCountry })` now runs guard B when the caller knows the expected ISO-2 country; without the opt, behavior is byte-identical.

**Measured on the v1-parse gate (both guards live):**

| property | before | after |
| --- | --- | --- |
| P3 garbage-tail residual | 5/321 (1.56%) | **4/321 (1.25%)** — the cross-country jump caught |
| P2 guard false positives | 0/78 | **0/78** — guard B costs nothing |
| P1 coordinate acceptability | 0.950 | 0.950 |

Unit tests 10/10 incl. pins for the jump, fail-open unknown countries, and the no-arg backward-compat default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1Kk2TojtVRejgGnobtjJ8