### PR TITLE
fix(eval): port the arena harness neural-only (#1151 broke the gate battery's arena leg)

### DIFF
--- a/scripts/eval/external-arenas.ts
+++ b/scripts/eval/external-arenas.ts
@@ -3,19 +3,20 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   External-arenas.ts — run the three UNBIASED capability arenas through harness-v0-neural.
+ *   External-arenas.ts — run the three UNBIASED capability arenas through harness-neural.
  *
- *   Our own 376-assertion suite is a Pelias/addressit port (v0's lineage), so it can't reveal where
- *   neural earns its keep. These three arenas come from outside that lineage and together map the
- *   v0-vs-neural capability surface:
+ *   Our own 376-assertion suite is a Pelias/addressit port (the retired rules parser's lineage), so
+ *   it over-represents that lineage's cases. These three arenas come from outside it and together
+ *   map the capability surface (formerly v0-vs-neural; the v7 excision #1151 deleted the rules arm,
+ *   so the arenas now grade neural alone — pass rates stay comparable, the harness's neural
+ *   semantics are unchanged):
  *
  *   1. Libpostal — statistical parser's hand-curated adversarial cases (clean, canonical)
  *   2. Perturbation — golden v0.1.2 with rule-defeating transforms (noisy, degraded)
  *   3. Postal-standards — postal-authority example addresses, edge formats by class (military APO/FPO,
  *        PO-box variety, secondary-unit, intl)
  *
- *   All three are scored with --symmetric-match (v0 scored on the same loose subset matcher as neural
- *   — fair to remapped/dropped-tag cases) and --postcode-repair.
+ *   All three are scored with --postcode-repair.
  *
  *   Usage (default shipped weights): node scripts/eval/external-arenas.ts
  *   Against a specific model (e.g. a fresh v0.7.2 export): MODEL=/path/model.int8.onnx
@@ -115,7 +116,7 @@ async function main() {
 	const runArena = async (name: string, dir: string): Promise<void> => {
 		console.log(`== arena: ${name} ==`)
 		const r =
-			await $`node scripts/eval/harness-v0-neural.ts --tests ${emptyTests} --falsehoods ${dir} ${modelArgs} --postcode-repair --symmetric-match --out-json ${join(outDir, `${name}.results.json`)}`
+			await $`node scripts/eval/harness-neural.ts --tests ${emptyTests} --falsehoods ${dir} ${modelArgs} --postcode-repair --out-json ${join(outDir, `${name}.results.json`)}`
 		writeFileSync(join(outDir, `${name}.stderr`), r.stderr)
 		console.log(r.stdout.split("\n").slice(-40).join("\n"))
 	}
@@ -125,7 +126,7 @@ async function main() {
 	await runArena("postal", join(outDir, "postal"))
 
 	console.log("")
-	console.log("== three-bucket summary + postal edge-class breakdown ==")
+	console.log("== arena summary + postal edge-class breakdown ==")
 	const summary = await $`node scripts/eval/summarize-arenas.ts ${outDir} data/eval/external/postal-cases.jsonl`
 	console.log(summary.stdout.trimEnd())
 

--- a/scripts/eval/harness-neural.ts
+++ b/scripts/eval/harness-neural.ts
@@ -1,0 +1,792 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Neural test harness — the arena scorer behind `external-arenas.ts` and the pre-ship gate
+ *   battery. Reads the 30+ `mailwoman/test/address.*.test.ts` files (and sibling
+ *   intersection/venue/compound_street tests), extracts every `assert(input, ...expected)` call via
+ *   TS AST, and grades each input's neural parse (`NeuralAddressClassifier`) against the expected
+ *   records. `--falsehoods <dir>` adds JSONL row files (the external arena fixtures).
+ *
+ *   LINEAGE: ported neural-only from `harness-v0-neural.ts` at the `legacy-rules-final` seal tag.
+ *   The v7 excision (#1151) deleted the rule-based parser, which was that harness's second arm; the
+ *   three-bucket v0-vs-neural comparison it existed for closed with the capability map. The NEURAL
+ *   arm here is semantically unchanged — same tag fold, same loose any-expected matcher — so neural
+ *   pass rates remain comparable with historical arena reports. The `--assembled` arm (#478, grade
+ *   `runPipeline` alongside raw neural) also survives; only the v0 arm and its buckets are gone.
+ *
+ *   Output: a markdown report on stdout + a JSON sidecar (`--out-json`) per-assertion containing
+ *   `{ file, locale, input, expected, neural_pass, neural_actual, ... }` so downstream scripts
+ *   (`summarize-arenas.ts`) can cluster failures by tag/locale/address-shape.
+ *
+ *   Usage: node scripts/eval/harness-neural.ts\
+ *   --tests mailwoman/test\
+ *   --out-json /tmp/harness.json\
+ *   [--model <onnx>] [--tokenizer <spm>] [--model-card <json>]\
+ *   [--admin-fst <bin>] [--morphology-fst <bin> | --no-morphology]\
+ *   [--falsehoods data/eval/falsehoods] # extra JSONL row files to include
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs"
+import { basename, join } from "node:path"
+import { parseArgs as parseNodeArgs } from "node:util"
+
+import { type ComponentTag, decodeAsJSON, type TreeViolation, validateTree } from "@mailwoman/core/decoder"
+import { runIfScript } from "@mailwoman/core/scripting"
+import type { ClassificationRecord } from "@mailwoman/core/types"
+import { repoRootPath } from "@mailwoman/core/utils"
+import {
+	type AnchorLookup,
+	type GazetteerLexicon,
+	NeuralAddressClassifier,
+	parseAnchorLookup,
+	parseGazetteerLexicon,
+} from "@mailwoman/neural"
+import { ONNXRunner } from "@mailwoman/neural/onnx-runner"
+import { MailwomanTokenizer } from "@mailwoman/neural/tokenizer"
+import { deserializeFST } from "@mailwoman/resolver-wof-sqlite/fst-serialize"
+import { buildStreetMorphologyFST } from "@mailwoman/resolver-wof-sqlite/street-morphology-fst-builder"
+import { createRuntimePipeline } from "mailwoman"
+import ts from "typescript"
+
+// -------------------------------------------------------------------------------------------------
+// Args
+// -------------------------------------------------------------------------------------------------
+
+interface Args {
+	testsDir: string
+	outJson?: string
+	modelPath?: string
+	tokenizerPath?: string
+	modelCardPath?: string
+	gazetteerLexiconPath?: string
+	anchorLookupPath?: string
+	conventions?: string
+	bridgeGaps?: boolean
+	adminFSTPath?: string
+	morphologyEnabled: boolean
+	morphologyBinPath?: string
+	falsehoodsDir?: string
+	postcodeRepair: boolean
+	unitRepair: boolean
+	/**
+	 * #478: also grade the ASSEMBLED runtime pipeline (`createRuntimePipeline` — normalize → kind/ fast-path → grouper →
+	 * reconcile → classify), not just the raw neural classifier. This is the #566-lesson gate: a pipeline regression
+	 * (e.g. a reconcile/arbitration change) is invisible when the eval grades raw neural. Off by default → the existing
+	 * raw-neural report is byte-stable.
+	 */
+	assembled: boolean
+}
+
+function parseArgs(): Args {
+	const out: Partial<Args> = {
+		morphologyEnabled: true,
+		postcodeRepair: false,
+		unitRepair: false,
+		assembled: false,
+	}
+
+	// node:util parseArgs (strict:false = old scan parity: unknown flags tolerated — including the
+	// retired `--symmetric-match` (only ever governed the deleted v0 arm's scoring) and the retired
+	// `--arbitrate` (#478 inc 3; the `arbitrate` PipelineOpt no longer exists)).
+	const { values } = parseNodeArgs({
+		options: {
+			"admin-fst": { type: "string" },
+			"anchor-lookup": { type: "string" },
+			assembled: { type: "boolean" },
+			"bridge-gaps": { type: "boolean" },
+			conventions: { type: "string" },
+			falsehoods: { type: "string" },
+			"gazetteer-lexicon": { type: "string" },
+			model: { type: "string" },
+			"model-card": { type: "string" },
+			"morphology-fst": { type: "string" },
+			"no-morphology": { type: "boolean" },
+			"out-json": { type: "string" },
+			"postcode-repair": { type: "boolean" },
+			tests: { type: "string" },
+			tokenizer: { type: "string" },
+			"unit-repair": { type: "boolean" },
+		},
+		strict: false,
+		allowPositionals: true,
+	})
+
+	if (values["tests"] != null) {
+		out.testsDir = values["tests"] as string
+	}
+
+	if (values["out-json"] != null) {
+		out.outJson = values["out-json"] as string
+	}
+
+	if (values["model"] != null) {
+		out.modelPath = values["model"] as string
+	}
+
+	if (values["tokenizer"] != null) {
+		out.tokenizerPath = values["tokenizer"] as string
+	}
+
+	if (values["model-card"] != null) {
+		out.modelCardPath = values["model-card"] as string
+	}
+
+	if (values["gazetteer-lexicon"] != null) {
+		out.gazetteerLexiconPath = values["gazetteer-lexicon"] as string
+	}
+
+	if (values["anchor-lookup"] != null) {
+		out.anchorLookupPath = values["anchor-lookup"] as string
+	}
+
+	if (values["conventions"] != null) {
+		out.conventions = values["conventions"] as string
+	}
+
+	if (values["bridge-gaps"] != null) {
+		out.bridgeGaps = true
+	}
+
+	if (values["admin-fst"] != null) {
+		out.adminFSTPath = values["admin-fst"] as string
+	}
+
+	if (values["morphology-fst"] != null) {
+		out.morphologyBinPath = values["morphology-fst"] as string
+	}
+
+	if (values["no-morphology"] != null) {
+		out.morphologyEnabled = false
+	}
+
+	if (values["falsehoods"] != null) {
+		out.falsehoodsDir = values["falsehoods"] as string
+	}
+
+	if (values["postcode-repair"] != null) {
+		out.postcodeRepair = true
+	}
+
+	if (values["unit-repair"] != null) {
+		out.unitRepair = true
+	}
+
+	if (values["assembled"] != null) {
+		out.assembled = true
+	}
+
+	if (!out.testsDir) {
+		console.error("Usage: scripts/eval/harness-neural.ts --tests <dir> [--out-json <path>] [...]")
+		process.exit(1)
+	}
+
+	return out as Args
+}
+
+// -------------------------------------------------------------------------------------------------
+// Assertion extraction — TS AST → list of (input, expected[])
+// -------------------------------------------------------------------------------------------------
+
+interface ExtractedAssertion {
+	file: string
+	locale: string // derived from filename (e.g., "usa" from "address.usa.test.ts")
+	input: string
+	expected: ClassificationRecord[]
+}
+
+function localeFromFilename(file: string): string {
+	const base = basename(file, ".test.ts").replace(/^address\.|^addressit\.|^place\./, "")
+
+	return base
+}
+
+/**
+ * Recursively unwrap a literal object expression like `{ street: ["Main St"] }` into a plain JS object. Returns `null`
+ * for anything that isn't a literal-of-literals (we intentionally don't try to evaluate variables or computed
+ * properties — none of the test files use those).
+ */
+function objectLiteralToRecord(node: ts.ObjectLiteralExpression): ClassificationRecord | null {
+	const out: Record<string, string[]> = {}
+
+	for (const prop of node.properties) {
+		if (!ts.isPropertyAssignment(prop)) return null
+		const name = prop.name
+		let key: string
+
+		if (ts.isIdentifier(name)) {
+			key = name.text
+		} else if (ts.isStringLiteralLike(name)) {
+			key = name.text
+		} else return null
+		const value = prop.initializer
+
+		if (!ts.isArrayLiteralExpression(value)) return null
+		const elements: string[] = []
+
+		for (const el of value.elements) {
+			if (ts.isStringLiteralLike(el)) {
+				elements.push(el.text)
+			} else return null
+		}
+		out[key] = elements
+	}
+
+	return out as ClassificationRecord
+}
+
+function extractAssertions(file: string): ExtractedAssertion[] {
+	const source = readFileSync(file, "utf8")
+	const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true)
+	const locale = localeFromFilename(file)
+	const out: ExtractedAssertion[] = []
+
+	function visit(node: ts.Node): void {
+		if (
+			ts.isCallExpression(node) &&
+			ts.isIdentifier(node.expression) &&
+			node.expression.text === "assert" &&
+			node.arguments.length >= 1
+		) {
+			const inputArg = node.arguments[0]
+
+			if (!inputArg || !ts.isStringLiteralLike(inputArg)) {
+				ts.forEachChild(node, visit)
+
+				return
+			}
+			const expected: ClassificationRecord[] = []
+			let allOk = true
+
+			for (let i = 1; i < node.arguments.length; i++) {
+				const arg = node.arguments[i]!
+
+				if (!ts.isObjectLiteralExpression(arg)) {
+					allOk = false
+					break
+				}
+				const rec = objectLiteralToRecord(arg)
+
+				if (!rec) {
+					allOk = false
+					break
+				}
+				expected.push(rec)
+			}
+
+			if (allOk) {
+				out.push({ file: basename(file), locale, input: inputArg.text, expected })
+			}
+		}
+		ts.forEachChild(node, visit)
+	}
+	visit(sf)
+
+	return out
+}
+
+function discoverAssertions(testsDir: string): ExtractedAssertion[] {
+	const all: ExtractedAssertion[] = []
+
+	for (const entry of readdirSync(testsDir)) {
+		// Only the address.*.test.ts / addressit.*.test.ts / venue.*.test.ts / intersection.test.ts
+		// / compound_street.test.ts / place.*.test.ts / transit.test.ts / libpostal.test.ts /
+		// functional.test.ts use the `assert(input, ...expected)` shape. CLI integration tests
+		// (resolve-flag, benchmark-flag, runtime-pipeline, etc.) use vitest's `test()` directly.
+		// We extract from all .test.ts files and skip the ones with zero matching calls — the
+		// extractor is a no-op on those.
+		if (!entry.endsWith(".test.ts")) continue
+		const filePath = join(testsDir, entry)
+
+		try {
+			const assertions = extractAssertions(filePath)
+			all.push(...assertions)
+		} catch (err) {
+			console.error(`[harness] WARN: failed to extract from ${entry}: ${(err as Error).message}`)
+		}
+	}
+
+	return all
+}
+
+// -------------------------------------------------------------------------------------------------
+// Neural output → the visible ClassificationRecord vocabulary
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Visible classification labels in the assertion vocabulary — the fixture format inherited from the retired rule-based
+ * suite: `country, dependency, house_number, level_designator, level, locality, postcode, region, street,
+ * unit_designator, unit, venue`. Anything outside this set is invisible to the comparison and gets folded or dropped.
+ */
+const VISIBLE_TAGS = new Set([
+	"country",
+	"dependency",
+	"house_number",
+	"level_designator",
+	"level",
+	"locality",
+	"postcode",
+	"region",
+	"street",
+	"unit_designator",
+	"unit",
+	"venue",
+])
+
+/**
+ * Fold the neural classifier's Stage 3 component tags into the visible classification set. The fold is principled but
+ * lossy:
+ *
+ * - `street_prefix` + `street_prefix_particle` + `street` + `street_suffix` → `street` (concat in document order,
+ *   preserving inter-token spacing implicitly via concatenation).
+ * - `intersection_a` + `intersection_b` → `street` (two separate values, matching the fixtures' `{street: ["Main St",
+ *   "Second Ave"]}` shape for intersections).
+ * - `house_number`, `unit`, `venue`, `country`, `region`, `locality`, `postcode` → identity.
+ * - `dependent_locality`, `subregion`, `attention`, `po_box`, `cedex`, JP-specific tags → dropped (no fixture
+ *   equivalent). The dropped tags are surfaced in the per-assertion report so the harness consumer can see what was
+ *   lost.
+ */
+function neuralTreeToVisibleRecord(flat: Partial<Record<ComponentTag, string>>): {
+	record: ClassificationRecord
+	dropped: Partial<Record<ComponentTag, string>>
+} {
+	const out: Record<string, string[]> = {}
+	const dropped: Partial<Record<ComponentTag, string>> = {}
+
+	const streetParts: string[] = []
+
+	for (const tag of ["street_prefix", "street_prefix_particle", "street", "street_suffix"] as const) {
+		const v = flat[tag]
+
+		if (v) {
+			streetParts.push(v)
+		}
+	}
+
+	if (streetParts.length > 0) {
+		out.street = [streetParts.join(" ")]
+	}
+
+	if (flat.intersection_a || flat.intersection_b) {
+		const xs: string[] = []
+
+		if (flat.intersection_a) {
+			xs.push(flat.intersection_a)
+		}
+
+		if (flat.intersection_b) {
+			xs.push(flat.intersection_b)
+		}
+		out.street = [...(out.street ?? []), ...xs]
+	}
+
+	for (const [tag, value] of Object.entries(flat) as Array<[ComponentTag, string]>) {
+		if (
+			tag === "street_prefix" ||
+			tag === "street_prefix_particle" ||
+			tag === "street" ||
+			tag === "street_suffix" ||
+			tag === "intersection_a" ||
+			tag === "intersection_b"
+		) {
+			continue // already folded above
+		}
+
+		if (VISIBLE_TAGS.has(tag)) {
+			out[tag] = [value]
+		} else {
+			dropped[tag] = value
+		}
+	}
+
+	return { record: out as ClassificationRecord, dropped }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Comparison — case-insensitive superset match
+// -------------------------------------------------------------------------------------------------
+
+function normalize(s: string): string {
+	return s.toLowerCase().trim()
+}
+
+/**
+ * Pass if every tag in `expected` is present in `actual` AND the actual value (string-equality, case-folded, trimmed)
+ * contains the expected value. We accept `actual` being a superset because the neural parser may emit extra components
+ * the test doesn't pin down (e.g. it labels a country when the test only asserted street).
+ */
+function expectedMatchesActual(expected: ClassificationRecord, actual: ClassificationRecord): boolean {
+	for (const [tag, expectedValues] of Object.entries(expected)) {
+		const actualValues = actual[tag as keyof ClassificationRecord]
+
+		if (!actualValues || !expectedValues) return false
+
+		// For multi-value tags (intersection: ["Main St", "Second Ave"]) we require ALL of the
+		// expected values to appear in actual, order-sensitive.
+		if (expectedValues.length !== actualValues.length) return false
+
+		for (let i = 0; i < expectedValues.length; i++) {
+			if (normalize(expectedValues[i]!) !== normalize(actualValues[i]!)) {
+				// Allow substring containment in either direction — the neural parser sometimes
+				// over- or under-spans (e.g. "5th Avenue" vs "Avenue"). The fixture suite is the
+				// authority on the EXPECTED span; we count a substring match as a partial pass.
+				const exp = normalize(expectedValues[i]!)
+				const act = normalize(actualValues[i]!)
+
+				if (!exp.includes(act) && !act.includes(exp)) return false
+			}
+		}
+	}
+
+	return true
+}
+
+function anyExpectedMatches(expected: ClassificationRecord[], actual: ClassificationRecord): boolean {
+	for (const e of expected) {
+		if (expectedMatchesActual(e, actual)) return true
+	}
+
+	return false
+}
+
+// -------------------------------------------------------------------------------------------------
+// Per-assertion runner
+// -------------------------------------------------------------------------------------------------
+
+interface AssertionResult {
+	file: string
+	locale: string
+	input: string
+	expected: ClassificationRecord[]
+	neural_pass: boolean
+	neural_actual: ClassificationRecord
+	neural_dropped: Partial<Record<ComponentTag, string>>
+	neural_tree_valid: boolean
+	neural_tree_violations: TreeViolation[]
+	/**
+	 * #478 assembled-pipeline arm (only when `--assembled`): the full `runPipeline` parse, graded like neural.
+	 */
+	assembled_pass?: boolean
+	assembled_actual?: ClassificationRecord
+}
+
+async function runAssertion(
+	a: ExtractedAssertion,
+	neuralClassifier: NeuralAddressClassifier,
+	parseOpts: Parameters<NeuralAddressClassifier["parse"]>[1],
+	pipeline?: ReturnType<typeof createRuntimePipeline>
+): Promise<AssertionResult> {
+	// neural — one tree, loose semantics: pass if ANY of the expected solutions is matched by
+	// the top-1 neural output. This is the natural reading for a single-result parser; the
+	// fixtures' multi-solution structure came from the retired multi-hypothesis rules API.
+	const tree = await neuralClassifier.parse(a.input, parseOpts)
+	const flat = decodeAsJSON(tree)
+	const { record: neuralRecord, dropped } = neuralTreeToVisibleRecord(flat)
+	const neuralPass = anyExpectedMatches(a.expected, neuralRecord)
+	const treeValidity = validateTree(tree) // #37 — structural coherence of the neural parse
+
+	// #478 assembled-pipeline arm: grade the full `runPipeline` parse (what production runs) — same
+	// loose top-1 semantics + tree→visible-record conversion as neural. Off unless `--assembled`
+	// wired the pipeline. This is the #566-lesson measurement: an assembled-pipeline regression is
+	// invisible against raw-neural F1.
+	let assembledPass: boolean | undefined
+	let assembledRecord: ClassificationRecord | undefined
+
+	if (pipeline) {
+		const { tree: assembledTree } = await pipeline(a.input)
+		assembledRecord = neuralTreeToVisibleRecord(decodeAsJSON(assembledTree)).record
+		assembledPass = anyExpectedMatches(a.expected, assembledRecord)
+	}
+
+	return {
+		file: a.file,
+		locale: a.locale,
+		input: a.input,
+		expected: a.expected,
+		neural_pass: neuralPass,
+		neural_actual: neuralRecord,
+		neural_dropped: dropped,
+		neural_tree_valid: treeValidity.valid,
+		neural_tree_violations: treeValidity.violations,
+		assembled_pass: assembledPass,
+		assembled_actual: assembledRecord,
+	}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Falsehoods JSONL loader
+// -------------------------------------------------------------------------------------------------
+
+interface FalsehoodRow {
+	input: string
+	locale?: string
+	expected: ClassificationRecord
+	falsehood?: string
+	expected_failure?: boolean
+}
+
+function loadFalsehoods(dir: string): ExtractedAssertion[] {
+	const out: ExtractedAssertion[] = []
+
+	for (const entry of readdirSync(dir)) {
+		if (!entry.endsWith(".jsonl")) continue
+		const file = basename(entry, ".jsonl")
+		const text = readFileSync(join(dir, entry), "utf8")
+
+		for (const line of text.split("\n")) {
+			if (!line.trim()) continue
+			let row: FalsehoodRow
+
+			try {
+				row = JSON.parse(line)
+			} catch (err) {
+				console.error(`[harness] WARN: bad JSON in ${entry}: ${(err as Error).message}`)
+				continue
+			}
+			out.push({
+				file: `falsehoods/${entry}`,
+				locale: row.locale ?? file,
+				input: row.input,
+				expected: [row.expected],
+			})
+		}
+	}
+
+	return out
+}
+
+// -------------------------------------------------------------------------------------------------
+// Report
+// -------------------------------------------------------------------------------------------------
+
+interface FileStats {
+	total: number
+	neural_pass: number
+}
+
+function printReport(results: AssertionResult[]): void {
+	const total = results.length
+	const neuralPass = results.filter((r) => r.neural_pass).length
+	const treeValid = results.filter((r) => r.neural_tree_valid).length
+	const passAndValid = results.filter((r) => r.neural_pass && r.neural_tree_valid).length
+
+	const byFile = new Map<string, FileStats>()
+
+	for (const r of results) {
+		const s = byFile.get(r.file) ?? { total: 0, neural_pass: 0 }
+		s.total++
+
+		if (r.neural_pass) {
+			s.neural_pass++
+		}
+		byFile.set(r.file, s)
+	}
+
+	const byLocale = new Map<string, FileStats>()
+
+	for (const r of results) {
+		const s = byLocale.get(r.locale) ?? { total: 0, neural_pass: 0 }
+		s.total++
+
+		if (r.neural_pass) {
+			s.neural_pass++
+		}
+		byLocale.set(r.locale, s)
+	}
+
+	console.log("# Neural Harness Report")
+	console.log("")
+	console.log(`**Assertions:** ${total}`)
+	console.log("")
+	console.log("## Overall")
+	console.log("")
+	console.log(`| Metric | Pass | Rate |`)
+	console.log(`|--------|------|------|`)
+	console.log(`| Neural | ${neuralPass} | ${((100 * neuralPass) / total).toFixed(1)}% |`)
+	console.log(`| Neural tree structurally valid (#37) | ${treeValid} | ${((100 * treeValid) / total).toFixed(1)}% |`)
+	console.log(
+		`| Neural pass AND structurally valid | ${passAndValid} | ${((100 * passAndValid) / total).toFixed(1)}% |`
+	)
+	console.log("")
+
+	// #478 assembled-pipeline arm (only when --assembled): what the ASSEMBLED pipeline (grouper +
+	// reconcile + fast-path) gains or loses against raw neural on the same assertions.
+	const hasAssembled = results.some((r) => r.assembled_pass !== undefined)
+
+	if (hasAssembled) {
+		const asmPass = results.filter((r) => r.assembled_pass).length
+		const asmGainedVsNeural = results.filter((r) => r.assembled_pass && !r.neural_pass).length
+		const asmLostVsNeural = results.filter((r) => !r.assembled_pass && r.neural_pass).length
+		console.log("## Assembled pipeline (#478 — `runPipeline`, the gate)")
+		console.log("")
+		console.log(`| Metric | Count | Rate |`)
+		console.log(`|--------|-------|------|`)
+		console.log(`| Assembled pass | ${asmPass} | ${((100 * asmPass) / total).toFixed(1)}% |`)
+		console.log(`| Assembled vs raw-neural (gained / lost) | +${asmGainedVsNeural} / -${asmLostVsNeural} | |`)
+		console.log("")
+	}
+
+	console.log("## Per-file")
+	console.log("")
+	console.log("| File | Total | Neural | Neural % |")
+	console.log("|------|-------|--------|----------|")
+	const sortedFiles = [...byFile.entries()].sort((a, b) => b[1].total - a[1].total)
+
+	for (const [file, s] of sortedFiles) {
+		console.log(`| ${file} | ${s.total} | ${s.neural_pass} | ${((100 * s.neural_pass) / s.total).toFixed(0)}% |`)
+	}
+	console.log("")
+
+	console.log("## Per-locale")
+	console.log("")
+	console.log("| Locale | Total | Neural | Neural % |")
+	console.log("|--------|-------|--------|----------|")
+	const sortedLocales = [...byLocale.entries()].sort((a, b) => b[1].total - a[1].total)
+
+	for (const [locale, s] of sortedLocales) {
+		console.log(`| ${locale} | ${s.total} | ${s.neural_pass} | ${((100 * s.neural_pass) / s.total).toFixed(0)}% |`)
+	}
+	console.log("")
+
+	// First 20 failures — the regression cluster the harness exists to surface.
+	const failures = results.filter((r) => !r.neural_pass).slice(0, 20)
+
+	if (failures.length > 0) {
+		console.log(`## Failures (sample of first ${failures.length})`)
+		console.log("")
+
+		for (const r of failures) {
+			console.log(`- \`${r.input}\` (${r.locale})`)
+			console.log(`  - expected: \`${JSON.stringify(r.expected[0])}\``)
+			console.log(`  - neural: \`${JSON.stringify(r.neural_actual)}\``)
+		}
+		console.log("")
+	}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Main
+// -------------------------------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+	const args = parseArgs()
+	console.error("--- harness-neural.ts ---")
+	console.error("Tests dir:        ", args.testsDir)
+	console.error("Falsehoods dir:   ", args.falsehoodsDir ?? "(none)")
+	console.error("Model:            ", args.modelPath ?? "(default — package resolve)")
+	console.error("Morphology:       ", args.morphologyEnabled ? "enabled" : "disabled")
+
+	console.error("Extracting assertions...")
+	const fromTests = discoverAssertions(args.testsDir)
+	const fromFalsehoods = args.falsehoodsDir ? loadFalsehoods(args.falsehoodsDir) : []
+	const all = [...fromTests, ...fromFalsehoods]
+	console.error(`  ${fromTests.length} from tests, ${fromFalsehoods.length} from falsehoods, ${all.length} total`)
+
+	console.error("Loading neural classifier...")
+	let neural: NeuralAddressClassifier
+
+	if (args.modelPath && args.tokenizerPath && args.modelCardPath) {
+		const modelCard = JSON.parse(readFileSync(args.modelCardPath, "utf8"))
+		const labels: readonly string[] = modelCard.labels
+		const [tokenizer, runner] = await Promise.all([
+			MailwomanTokenizer.loadFromFile(args.tokenizerPath),
+			ONNXRunner.create(args.modelPath),
+		])
+		// Gaz-trained models (v4.2.0+) MUST be fed the lexicon + the postcode-anchor lookup with
+		// near-postcode suppression — zero-filled clues depress country recall and fake an affix
+		// crash (the ship config; see CONTRIBUTING_MODEL_WORK eval invariants).
+		let gazetteerLexicon: GazetteerLexicon | undefined
+
+		if (args.gazetteerLexiconPath) {
+			gazetteerLexicon = parseGazetteerLexicon(JSON.parse(readFileSync(args.gazetteerLexiconPath, "utf8")))
+		}
+		let postcodeAnchorLookup: AnchorLookup | undefined
+
+		if (args.anchorLookupPath) {
+			postcodeAnchorLookup = parseAnchorLookup(JSON.parse(readFileSync(args.anchorLookupPath, "utf8")))
+		}
+		neural = new NeuralAddressClassifier({
+			tokenizer,
+			runner,
+			labels,
+			...(gazetteerLexicon ? { gazetteerLexicon, suppressGazetteerNearPostcode: true } : {}),
+			...(postcodeAnchorLookup ? { postcodeAnchorLookup } : {}),
+			// #511 Tier A: --conventions auto|<system> enables the address-system conventions mask.
+			...(args.conventions ? { addressSystemConventions: args.conventions as "auto" } : {}),
+			...(args.bridgeGaps ? { bridgePunctuationGaps: true } : {}),
+		})
+	} else {
+		neural = await NeuralAddressClassifier.loadFromWeights()
+	}
+
+	let adminFST: ReturnType<typeof deserializeFST> | undefined
+
+	if (args.adminFSTPath) {
+		console.error("Loading admin FST...")
+		adminFST = deserializeFST(readFileSync(args.adminFSTPath))
+	}
+
+	let morphologyFST: ReturnType<typeof deserializeFST> | undefined
+
+	if (args.morphologyEnabled) {
+		if (args.morphologyBinPath) {
+			console.error("Loading morphology FST from", args.morphologyBinPath)
+			morphologyFST = deserializeFST(readFileSync(args.morphologyBinPath))
+		} else {
+			console.error("Building morphology FST in-process...")
+			const built = buildStreetMorphologyFST({
+				dictionariesDir: repoRootPath("core", "data", "libpostal", "dictionaries"),
+			})
+			morphologyFST = built.matcher
+			console.error(`  ${built.canonicalCount} canonicals / ${built.variantCount} variants`)
+		}
+	}
+
+	const parseOpts = {
+		...(adminFST ? { fst: adminFST as never } : {}),
+		...(morphologyFST ? { fstStreetMorphology: morphologyFST as never } : {}),
+		postcodeRepair: args.postcodeRepair,
+		unitRepair: args.unitRepair,
+	} as Parameters<NeuralAddressClassifier["parse"]>[1]
+
+	// #478: the assembled runtime pipeline (reuses the neural classifier + admin FST). No resolver —
+	// the arena grades COMPONENT parses (Stage 3 / grouper / reconcile), not coordinates.
+	const pipeline = args.assembled
+		? createRuntimePipeline({ classifier: neural, ...(adminFST ? { fst: adminFST as never } : {}) })
+		: undefined
+
+	if (pipeline) {
+		console.error("Assembled-pipeline arm ON (--assembled): grading runPipeline alongside raw neural.")
+	}
+
+	console.error("Running harness...")
+	const t0 = performance.now()
+	const results: AssertionResult[] = []
+	let i = 0
+
+	for (const a of all) {
+		i++
+
+		try {
+			results.push(await runAssertion(a, neural, parseOpts, pipeline))
+		} catch (err) {
+			console.error(`[harness] WARN: error on assertion ${i} (${a.input}): ${(err as Error).message}`)
+		}
+
+		if (i % 50 === 0) {
+			const elapsed = (performance.now() - t0) / 1000
+			console.error(`  ${i}/${all.length} (${elapsed.toFixed(1)}s)`)
+		}
+	}
+	console.error(`Done in ${((performance.now() - t0) / 1000).toFixed(1)}s`)
+
+	printReport(results)
+
+	if (args.outJson) {
+		writeFileSync(args.outJson, JSON.stringify(results, null, 2))
+		console.error(`Wrote ${results.length} results to ${args.outJson}`)
+	}
+}
+
+runIfScript(import.meta, main)

--- a/scripts/eval/per-locale-f1.ts
+++ b/scripts/eval/per-locale-f1.ts
@@ -17,7 +17,7 @@
  *   earns its keep. Run again after adding any new locale: if an existing locale's F1 drops, that's
  *   the interference tripwire firing.
  *
- *   Scoring mirrors `harness-v0-neural.ts`: flatten the AddressTree via `decodeAsJSON`, fold the
+ *   Scoring mirrors `harness-neural.ts`: flatten the AddressTree via `decodeAsJSON`, fold the
  *   Stage-3 street parts (`street_prefix`/`street`/`street_suffix` → `street`,
  *   `intersection_a`/`_b` → `street`) into the golden component vocab, then compare case-folded
  *   strings per tag.
@@ -179,7 +179,7 @@ function parseArgs(): Args {
 }
 
 // -------------------------------------------------------------------------------------------------
-// Golden row + fold (shared semantics with harness-v0-neural.ts)
+// Golden row + fold (shared semantics with harness-neural.ts)
 // -------------------------------------------------------------------------------------------------
 
 interface GoldenRow {

--- a/scripts/eval/perturb-golden.ts
+++ b/scripts/eval/perturb-golden.ts
@@ -16,7 +16,7 @@
  *
  * Run: node scripts/eval/perturb-golden.ts\
  * --golden data/eval/golden/v0.1.2 --out /tmp/perturb-eval/perturbed.jsonl [--per-file 60] Then run
- * it through harness-v0-neural with --symmetric-match (see that flag).
+ * it through harness-neural (formerly harness-v0-neural with --symmetric-match).
  */
 
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs"

--- a/scripts/eval/summarize-arenas.ts
+++ b/scripts/eval/summarize-arenas.ts
@@ -3,14 +3,14 @@
  * @license AGPL-3.0
  * @author Teffen Ellis, et al.
  *
- *   Summarize-arenas.ts — three-bucket capability table from external-arenas.ts output.
+ *   Summarize-arenas.ts — per-arena pass-rate table from external-arenas.ts output.
  *
- *   Reads the per-arena `*.results.json` sidecars written by harness-v0-neural and prints the
- *   neural-only / both-pass / v0-only / both-fail buckets per arena. For the postal-standards arena
- *   it also joins back to the source JSONL (on `input`) to break the buckets down by edge_class —
- *   the dimension the harness sidecar drops.
+ *   Reads the per-arena `*.results.json` sidecars written by harness-neural. For the
+ *   postal-standards arena it also joins back to the source JSONL (on `input`) to break the rates
+ *   down by edge_class — the dimension the harness sidecar drops.
  *
- *   Ported faithfully from scripts/eval/summarize-arenas.py (pure JSON, no numpy).
+ *   Ported faithfully from scripts/eval/summarize-arenas.py (pure JSON, no numpy); the v0 buckets
+ *   went with the rules parser (v7 excision #1151 — harness-v0-neural was deleted with it).
  *
  *   Usage: node scripts/eval/summarize-arenas.ts <out-dir>
  *   <postal-cases.jsonl>
@@ -21,21 +21,9 @@ import { parseArgs } from "node:util"
 
 const { positionals } = parseArgs({ allowPositionals: true, strict: false })
 interface Result {
-	v0_pass: boolean
 	neural_pass: boolean
 	neural_tree_valid?: boolean
 	input: string
-}
-
-function buckets(results: Result[]): [number, number, number, number, number, number] {
-	const n = results.length
-	const both = results.filter((r) => r.v0_pass && r.neural_pass).length
-	const onlyN = results.filter((r) => !r.v0_pass && r.neural_pass).length
-	const onlyV0 = results.filter((r) => r.v0_pass && !r.neural_pass).length
-	const neither = results.filter((r) => !r.v0_pass && !r.neural_pass).length
-	const treeOk = results.filter((r) => r.neural_tree_valid).length
-
-	return [n, both, onlyN, onlyV0, neither, treeOk]
 }
 
 /** Python `format(x, ".{d}f")` — round-half-to-even (banker's), unlike JS `toFixed` (half-away). */
@@ -98,8 +86,8 @@ function main(): void {
 	const [outDir, postalSrc] = [positionals[0]!, positionals[1]!]
 	const arenas = ["libpostal", "perturb", "postal"]
 
-	console.log("| arena | n | v0 | neural | both | neural-only | v0-only | both-fail | tree-valid |")
-	console.log("| --- | --: | --: | --: | --: | --: | --: | --: | --: |")
+	console.log("| arena | n | neural | fail | tree-valid |")
+	console.log("| --- | --: | --: | --: | --: |")
 	const loaded: Record<string, Result[]> = {}
 
 	for (const a of arenas) {
@@ -115,13 +103,10 @@ function main(): void {
 			throw e
 		}
 		loaded[a] = res
-		const [n, both, onlyN, onlyV0, neither, treeOk] = buckets(res)
-		const v0 = res.filter((r) => r.v0_pass).length
+		const n = res.length
 		const ne = res.filter((r) => r.neural_pass).length
-		console.log(
-			`| ${a} | ${n} | ${pct(v0, n)} | ${pct(ne, n)} | ${pct(both, n)} ` +
-				`| ${pct(onlyN, n)} | ${pct(onlyV0, n)} | ${pct(neither, n)} | ${pct(treeOk, n)} |`
-		)
+		const treeOk = res.filter((r) => r.neural_tree_valid).length
+		console.log(`| ${a} | ${n} | ${pct(ne, n)} | ${pct(n - ne, n)} | ${pct(treeOk, n)} |`)
 	}
 
 	// postal edge-class breakdown (join on input)
@@ -140,18 +125,14 @@ function main(): void {
 			;(by[cls] ??= []).push(r)
 		}
 		console.log("\n### postal arena by edge_class")
-		console.log("| edge_class | n | v0 | neural | both | neural-only | v0-only |")
-		console.log("| --- | --: | --: | --: | --: | --: | --: |")
+		console.log("| edge_class | n | neural | fail |")
+		console.log("| --- | --: | --: | --: |")
 
 		for (const cls of Object.keys(by).sort()) {
 			const res = by[cls]!
-			const [n, both, onlyN, onlyV0] = buckets(res)
-			const v0 = res.filter((r) => r.v0_pass).length
+			const n = res.length
 			const ne = res.filter((r) => r.neural_pass).length
-			console.log(
-				`| ${cls} | ${n} | ${pct(v0, n)} | ${pct(ne, n)} | ${pct(both, n)} ` +
-					`| ${pct(onlyN, n)} | ${pct(onlyV0, n)} |`
-			)
+			console.log(`| ${cls} | ${n} | ${pct(ne, n)} | ${pct(n - ne, n)} |`)
 		}
 	}
 }


### PR DESCRIPTION
## What

The v7 excision (#1151) deleted `scripts/eval/harness-v0-neural.ts` (it imported the deleted rules parser) but `external-arenas.ts` — invoked by `mailwoman eval promotion-gate` — still called it. Every post-excision gate battery crashed at the arena leg with MODULE_NOT_FOUND; first seen grading v391 tonight.

## Fix

- **`scripts/eval/harness-neural.ts`** — the seal-tag (`legacy-rules-final`) harness ported neural-only. The neural arm is semantically unchanged (same TS-AST assertion extraction, same tag fold, same loose any-expected matcher), so arena pass rates stay comparable with historical reports. The `--assembled` (#478) arm survives. Removed: the v0 arm, `--symmetric-match` (only governed v0 scoring), and `--arbitrate` (targets a `PipelineOpt` that no longer exists) — both retired flags are tolerated and ignored (`strict: false`).
- **`external-arenas.ts`** — invoke the new harness; header updated.
- **`summarize-arenas.ts`** — drop the three-bucket v0 columns; per-arena table is now `n / neural / fail / tree-valid`, edge-class breakdown likewise.
- Comment repoints in `per-locale-f1.ts` + `perturb-golden.ts`. Dated retrospectives untouched.

## Verification

- `tsc --noEmit -p scripts` clean.
- Smoke end-to-end: 10-row libpostal subset → harness report + JSON sidecar → summarize table, on shipped weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1Kk2TojtVRejgGnobtjJ8