### PR TITLE
feat(727): phase-4c StreetLocalityEvidence — the k-best name-existence arbiter (interface + FR backend)

### DIFF
--- a/resolver-wof-sqlite/street-name-lookup.test.ts
+++ b/resolver-wof-sqlite/street-name-lookup.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for {@link SQLiteStreetNameLookup} (#727 phase-4c FR backend) against a fixture DB built
+ *   with the contract fold (`foldStreetSurface`). Covers unscoped + scoped lookups, the fold
+ *   contract (hyphen/apostrophe), positive-evidence fallback, and graceful degrade on a tableless db.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+
+import { foldStreetSurface } from "@mailwoman/resolver"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+import { SQLiteStreetNameLookup } from "./street-name-lookup.ts"
+
+let dir: string
+let dbPath: string
+let emptyPath: string
+
+beforeAll(() => {
+	dir = mkdtempSync(join(tmpdir(), "mw-street-name-"))
+	dbPath = join(dir, "street-centroids-fr.db")
+	const seed = new DatabaseSync(dbPath)
+	seed.exec("CREATE TABLE street_centroid (street_norm TEXT NOT NULL, postcode TEXT, locality_base TEXT NOT NULL)")
+	const ins = seed.prepare("INSERT INTO street_centroid (street_norm, postcode, locality_base) VALUES (?, ?, ?)")
+	// street_norm built with the CONTRACT fold (hyphen/apostrophe → space).
+	const rows: Array<[string, string, string]> = [
+		["Rue Corsier", "75001", "Paris"],
+		["Rue Pillet-Will", "75009", "Paris"],
+		["Chemin d'En Galinier", "31000", "Toulouse"],
+		["Rue Guarnieri", "13001", "Marseille"],
+	]
+
+	for (const [raw, pc, loc] of rows) {
+		ins.run(foldStreetSurface(raw), pc, foldStreetSurface(loc))
+	}
+	seed.close()
+
+	emptyPath = join(dir, "empty.db")
+	const empty = new DatabaseSync(emptyPath)
+	empty.exec("CREATE TABLE unrelated (x)")
+	empty.close()
+})
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+describe("SQLiteStreetNameLookup", () => {
+	test("unscoped hit on an existing street name", () => {
+		const lk = new SQLiteStreetNameLookup(dbPath)
+		expect(lk.hasStreetName("Rue Corsier")).toBe(true)
+		expect(lk.hasStreetName("Rue Guarnieri")).toBe(true)
+		lk.close()
+	})
+
+	test("miss on a street not in the index (positive evidence only)", () => {
+		const lk = new SQLiteStreetNameLookup(dbPath)
+		expect(lk.hasStreetName("Rue Nonexistent")).toBe(false)
+		lk.close()
+	})
+
+	test("fold contract: a hyphenated/apostrophe'd query matches the folded index entry", () => {
+		const lk = new SQLiteStreetNameLookup(dbPath)
+		expect(lk.hasStreetName("Rue Pillet-Will")).toBe(true) // hyphen → space, matches "rue pillet will"
+		expect(lk.hasStreetName("Chemin d'En Galinier")).toBe(true) // apostrophe → space
+		lk.close()
+	})
+
+	test("scoped lookup by locality hits when the pair exists", () => {
+		const lk = new SQLiteStreetNameLookup(dbPath)
+		expect(lk.hasStreetName("Rue Corsier", { locality: "Paris" })).toBe(true)
+		lk.close()
+	})
+
+	test("scoped miss falls back to the unscoped probe (scope incompleteness ≠ absence)", () => {
+		const lk = new SQLiteStreetNameLookup(dbPath)
+		// Right street, wrong locality → the scoped probe misses, but the unscoped fallback confirms the name exists.
+		expect(lk.hasStreetName("Rue Corsier", { locality: "Lyon" })).toBe(true)
+		lk.close()
+	})
+
+	test("scoped lookup by postcode", () => {
+		const lk = new SQLiteStreetNameLookup(dbPath)
+		expect(lk.hasStreetName("Rue Corsier", { postcode: "75001" })).toBe(true)
+		lk.close()
+	})
+
+	test("empty street surface is a miss", () => {
+		const lk = new SQLiteStreetNameLookup(dbPath)
+		expect(lk.hasStreetName("")).toBe(false)
+		expect(lk.hasStreetName("   ")).toBe(false)
+		lk.close()
+	})
+
+	test("graceful degrade: a tableless db is a no-op miss, not a crash", () => {
+		const lk = new SQLiteStreetNameLookup(emptyPath)
+		expect(lk.hasStreetName("Rue Corsier")).toBe(false)
+		lk.close()
+	})
+
+	test("countries defaults to FR, upper-cased, and is configurable", () => {
+		expect(new SQLiteStreetNameLookup(dbPath).countries.has("FR")).toBe(true)
+		const us = new SQLiteStreetNameLookup(dbPath, { countries: ["us"] })
+		expect(us.countries.has("US")).toBe(true)
+		expect(us.countries.has("FR")).toBe(false)
+	})
+})

--- a/resolver-wof-sqlite/street-name-lookup.ts
+++ b/resolver-wof-sqlite/street-name-lookup.ts
@@ -1,0 +1,88 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #727 stage-2 phase 4c — the SQLite backend for {@link StreetLocalityEvidence}.
+ *
+ *   Reads a street-name index (the FR instance = BAN `street-centroids-fr.db`, a `street_centroid`
+ *   table of `street_norm × locality_base × postcode` rows) and answers "does this street surface
+ *   exist as a name" for the k-best rerank. Sync-by-interface, `readOnly`, prepared statements,
+ *   graceful-degrade on a tableless shard — the same reader discipline as `AddressPointSqliteLookup`.
+ *
+ *   THE FOLD CONTRACT: the surface is folded with {@link foldStreetSurface} (the shared function),
+ *   and the DB's `street_norm` column MUST have been built with that SAME fold or every hyphenated /
+ *   apostrophe'd street silently misses. The current `street-centroids-fr.db` predates the contract
+ *   fold (it folded without hyphen/apostrophe normalization); it must be REBUILT with
+ *   `foldStreetSurface` + a `street_norm` index before this backend is wired in production. Until
+ *   then this class is correct-by-construction against a fixture built with the contract fold, and
+ *   the production rebuild is a tracked BAN-sdk follow-up.
+ */
+
+import { DatabaseSync } from "node:sqlite"
+
+import { foldStreetSurface, type StreetEvidenceScope, type StreetLocalityEvidence } from "@mailwoman/resolver"
+
+function hasTable(db: DatabaseSync, table: string): boolean {
+	const row = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1").get(table)
+
+	return row !== undefined
+}
+
+export interface SQLiteStreetNameLookupOpts {
+	/** ISO-2 (upper-case) countries this index answers for. Default `["FR"]` (the BAN street-centroids instance). */
+	countries?: Iterable<string>
+	/** Table name. Default `street_centroid`. */
+	table?: string
+}
+
+/**
+ * A {@link StreetLocalityEvidence} backed by a street-name SQLite index. Positive evidence only: any doubt (missing
+ * table, read miss) returns `false`, so the rerank fails open to the model's ranking.
+ */
+export class SQLiteStreetNameLookup implements StreetLocalityEvidence {
+	readonly countries: ReadonlySet<string>
+	readonly #db: DatabaseSync
+	readonly #byName: ReturnType<DatabaseSync["prepare"]> | undefined
+	readonly #byNameLocality: ReturnType<DatabaseSync["prepare"]> | undefined
+	readonly #byNamePostcode: ReturnType<DatabaseSync["prepare"]> | undefined
+
+	constructor(dbPath: string, opts: SQLiteStreetNameLookupOpts = {}) {
+		this.countries = new Set([...(opts.countries ?? ["FR"])].map((c) => c.toUpperCase()))
+		this.#db = new DatabaseSync(dbPath, { readOnly: true })
+		const table = opts.table ?? "street_centroid"
+
+		// Degrade gracefully on an empty/tableless shard — a no-op miss, never a crash (#568 discipline).
+		if (hasTable(this.#db, table)) {
+			this.#byName = this.#db.prepare(`SELECT 1 FROM ${table} WHERE street_norm = ? LIMIT 1`)
+			this.#byNameLocality = this.#db.prepare(
+				`SELECT 1 FROM ${table} WHERE street_norm = ? AND locality_base = ? LIMIT 1`
+			)
+			this.#byNamePostcode = this.#db.prepare(`SELECT 1 FROM ${table} WHERE street_norm = ? AND postcode = ? LIMIT 1`)
+		}
+	}
+
+	hasStreetName(streetSurface: string, scope?: StreetEvidenceScope): boolean {
+		if (!this.#byName) return false
+		const norm = foldStreetSurface(streetSurface)
+
+		if (!norm) return false
+
+		// Scoped lookups tighten precision when the hypothesis carries a locality/postcode; a scoped MISS falls back to the
+		// unscoped probe (index incompleteness in the scope column is not evidence of absence — positive-evidence rule).
+		if (scope?.locality && this.#byNameLocality) {
+			if (this.#byNameLocality.get(norm, foldStreetSurface(scope.locality)) !== undefined) return true
+		}
+
+		if (scope?.postcode && this.#byNamePostcode) {
+			if (this.#byNamePostcode.get(norm, scope.postcode) !== undefined) return true
+		}
+
+		return this.#byName.get(norm) !== undefined
+	}
+
+	/** Close the underlying handle. */
+	close(): void {
+		this.#db.close()
+	}
+}

--- a/resolver/index.ts
+++ b/resolver/index.ts
@@ -21,6 +21,14 @@ export type {
 export { createWOFResolver } from "./resolve.ts"
 export { finestResolvedCoordinate, isImplausibleResolution } from "./plausibility.ts"
 export type { PlausibilityVerdict, ResolvedCoordinate } from "./plausibility.ts"
+export { foldStreetSurface, isPureTypeVocabulary, pickByStreetEvidence } from "./street-evidence.ts"
+export type {
+	PickByStreetEvidenceOpts,
+	StreetCandidate,
+	StreetEvidencePick,
+	StreetEvidenceScope,
+	StreetLocalityEvidence,
+} from "./street-evidence.ts"
 export { findRescoreCandidate, hasResolvedPlace } from "./span-rescore.ts"
 export type { RescoreCandidate, SpanRescoreOptions } from "./span-rescore.ts"
 

--- a/resolver/street-evidence.test.ts
+++ b/resolver/street-evidence.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   Tests for the #727 phase-4c street-name-evidence rerank policy (`street-evidence.ts`). Covers the
+ *   fold contract, the G1 type-vocabulary guard, and the v2 pick policy's four cases (keep / fix /
+ *   G1-skip / G2-cap / fail-open) that the FR fragment board measured at 96 fixes / 3 breaks.
+ */
+
+import { describe, expect, test } from "vitest"
+
+import {
+	foldStreetSurface,
+	isPureTypeVocabulary,
+	pickByStreetEvidence,
+	type StreetCandidate,
+	type StreetLocalityEvidence,
+} from "./street-evidence.ts"
+
+/** A mock evidence provider: a fixed set of folded street names that "exist". Fails open on anything else. */
+const mockEvidence = (existing: string[]): StreetLocalityEvidence => {
+	const set = new Set(existing.map(foldStreetSurface))
+
+	return {
+		countries: new Set(["FR"]),
+		hasStreetName: (surface) => set.has(foldStreetSurface(surface)),
+	}
+}
+
+const cand = (streetSurface: string, score: number): StreetCandidate => ({ streetSurface, score })
+
+describe("foldStreetSurface", () => {
+	test("strips diacritics, lowercases, collapses whitespace", () => {
+		expect(foldStreetSurface("Rue Saint-Éleuthère")).toBe("rue saint eleuthere")
+		expect(foldStreetSurface("  Chemin   de la  Grenouillère ")).toBe("chemin de la grenouillere")
+	})
+
+	test("normalizes hyphens and apostrophes to spaces (the fold contract — the v1 break class)", () => {
+		expect(foldStreetSurface("Rue Pillet-Will")).toBe("rue pillet will")
+		expect(foldStreetSurface("Chemin d'En Galinier")).toBe("chemin d en galinier")
+		// A hyphenated index entry and an un-hyphenated one fold to the same key.
+		expect(foldStreetSurface("Pillet-Will")).toBe(foldStreetSurface("Pillet Will"))
+	})
+})
+
+describe("isPureTypeVocabulary (G1)", () => {
+	test("bare type/particle surfaces are pure — no name, no evidence credit", () => {
+		expect(isPureTypeVocabulary(foldStreetSurface("rue"))).toBe(true)
+		expect(isPureTypeVocabulary(foldStreetSurface("chemin de la"))).toBe(true)
+		expect(isPureTypeVocabulary(foldStreetSurface("route de"))).toBe(true)
+	})
+
+	test("a surface with a real name token is NOT pure", () => {
+		expect(isPureTypeVocabulary(foldStreetSurface("rue corsier"))).toBe(false)
+		expect(isPureTypeVocabulary(foldStreetSurface("chemin puget terrein"))).toBe(false)
+	})
+
+	test("empty is treated as pure (nothing to credit)", () => {
+		expect(isPureTypeVocabulary("")).toBe(true)
+	})
+})
+
+describe("pickByStreetEvidence — the v2 policy", () => {
+	test("keeps rank-1 when its street already exists (no move)", () => {
+		const evidence = mockEvidence(["Rue Corsier"])
+		const pick = pickByStreetEvidence([cand("Rue Corsier", 5), cand("Corsier", 3)], evidence)
+		expect(pick.index).toBe(0)
+		expect(pick.moved).toBe(false)
+	})
+
+	test("FIX: moves off a wrong rank-1 to the in-index sibling", () => {
+		// rank-1 "Puget" (not a street) loses to rank-3 "Chemin Puget Terrein" (in index), within margin.
+		const evidence = mockEvidence(["Chemin Puget Terrein"])
+		const cands = [cand("Puget", 5.0), cand("Puget Terrein", 4.9), cand("Chemin Puget Terrein", 4.6)]
+		const pick = pickByStreetEvidence(cands, evidence)
+		expect(pick.index).toBe(2)
+		expect(pick.moved).toBe(true)
+		expect(pick.candidate.streetSurface).toBe("Chemin Puget Terrein")
+	})
+
+	test("G1: does NOT credit a truncated pure-type sibling even though it exists in the index", () => {
+		// "rue" IS in the index but is pure type vocab → skipped; gold "Rue Guarnieri" is the real pick.
+		const evidence = mockEvidence(["rue", "Rue Guarnieri"])
+		const cands = [cand("rue", 5.0), cand("Rue Guarnieri", 4.5)]
+		const pick = pickByStreetEvidence(cands, evidence)
+		expect(pick.index).toBe(1)
+		expect(pick.candidate.streetSurface).toBe("Rue Guarnieri")
+	})
+
+	test("G2: does NOT promote an in-index candidate beyond the margin cap", () => {
+		// Gold "Rue Paul Marzin" exists but sits 4.6 below rank-1 (> 2.5 cap) → keep rank-1 (fail-open).
+		const evidence = mockEvidence(["Rue Paul Marzin"])
+		const cands = [cand("Paul", 6.0), cand("Rue Paul Marzin", 1.4)]
+		const pick = pickByStreetEvidence(cands, evidence)
+		expect(pick.index).toBe(0)
+		expect(pick.moved).toBe(false)
+	})
+
+	test("G2: DOES promote when the in-index candidate is within the margin cap", () => {
+		const evidence = mockEvidence(["Rue Paul Marzin"])
+		const cands = [cand("Paul", 6.0), cand("Rue Paul Marzin", 4.0)] // 2.0 gap ≤ 2.5
+		const pick = pickByStreetEvidence(cands, evidence)
+		expect(pick.index).toBe(1)
+		expect(pick.moved).toBe(true)
+	})
+
+	test("fail-open: keeps rank-1 when NOTHING is in the index (positive evidence only)", () => {
+		const evidence = mockEvidence([])
+		const pick = pickByStreetEvidence([cand("Typoed Steet", 5), cand("Other", 3)], evidence)
+		expect(pick.index).toBe(0)
+		expect(pick.moved).toBe(false)
+	})
+
+	test("skips empty street surfaces", () => {
+		const evidence = mockEvidence(["Rue Corsier"])
+		const pick = pickByStreetEvidence([cand("", 5), cand("Rue Corsier", 4)], evidence)
+		expect(pick.index).toBe(1)
+	})
+
+	test("custom marginCap is honored", () => {
+		const evidence = mockEvidence(["Rue Paul Marzin"])
+		const cands = [cand("Paul", 6.0), cand("Rue Paul Marzin", 1.4)]
+		// With a wide cap the deep candidate is now eligible.
+		const pick = pickByStreetEvidence(cands, evidence, { marginCap: 10 })
+		expect(pick.index).toBe(1)
+	})
+
+	test("throws on empty candidate list", () => {
+		expect(() => pickByStreetEvidence([], mockEvidence([]))).toThrow()
+	})
+})

--- a/resolver/street-evidence.ts
+++ b/resolver/street-evidence.ts
@@ -1,0 +1,190 @@
+/**
+ * @copyright Sister Software
+ * @license AGPL-3.0
+ * @author Teffen Ellis, et al.
+ *
+ *   #727 stage-2 phase 4c — street-NAME existence as the k-best arbiter signal.
+ *
+ *   Phase 4a measured the planned arbiter (full-geocode resolution tier) at exactly ZERO collected
+ *   headroom: the failing class is context-free fragments, which never reach rooftop layers, so
+ *   every hypothesis ties at admin tier. The corrected signal is street-NAME existence — "does this
+ *   hypothesis's street surface exist as a street name in the national register?" — which IS
+ *   queryable for a bare fragment. Measured on the FR fragment board over the v3.10.1 8k span model:
+ *   the rerank collects +6.0pp street@1 (0.791 → 0.851), 96 fixes / 3 breaks (32:1), the value
+ *   concentrated on the date-name class (+16.7pp). Receipts:
+ *   `docs/articles/evals/2026-07-17-v3101-span-head-8k-result.md`, spec
+ *   `docs/superpowers/specs/2026-07-17-727-phase4c-street-name-evidence.md`.
+ *
+ *   THE ANTI-PELIAS RULE (shared with `rerank.ts`): ONE bit of evidence, not a score. We do NOT
+ *   blend the name signal into the parse scores — those already share a partition function and rank
+ *   fine within an input. The reranker's only job is to prefer a sibling hypothesis whose street the
+ *   world confirms exists, over a rank-1 whose street it does not. Positive evidence only: the
+ *   ABSENCE of a name is never evidence against a parse (index incompleteness is the default state
+ *   of the world), so the policy always fails open to the model's own ranking.
+ *
+ *   This module is PURE — the interface + the fold + the measured pick policy, no SQLite. The FR BAN
+ *   backend lives in `@mailwoman/resolver-wof-sqlite` (`SQLiteStreetNameLookup`); callers inject it,
+ *   mirroring the `PlaceLookup` pattern.
+ */
+
+/**
+ * A street-name existence probe. Backend-agnostic; the FR instance is BAN street-centroids, a future US instance is
+ * TIGER, etc. (per the registry-backed-structured-prediction doctrine tiers).
+ */
+export interface StreetLocalityEvidence {
+	/**
+	 * True when `streetSurface` exists as a street name — optionally scoped to a locality or postcode when the hypothesis
+	 * carries one (fragments usually don't; unscoped is the measured mode). The implementation is responsible for folding
+	 * the surface with {@link foldStreetSurface} so the caller passes raw text.
+	 *
+	 * POSITIVE EVIDENCE ONLY: return `false` on any doubt — a missing index, an unsupported country, a read error — so
+	 * {@link pickByStreetEvidence} fails open to the model's ranking. Absence is never a veto.
+	 */
+	hasStreetName(streetSurface: string, scope?: StreetEvidenceScope): boolean
+	/** ISO-2 (upper-case) countries this instance can answer for. Anything else → no evidence, never a veto. */
+	readonly countries: ReadonlySet<string>
+}
+
+export interface StreetEvidenceScope {
+	locality?: string
+	postcode?: string
+}
+
+/**
+ * The fold CONTRACT — the index builder and every runtime prober MUST share this exact function, or lookups silently
+ * miss (the 4 v1-policy breaks were fold mismatches: `pillet-will` stored unhyphenated). NFD strip-diacritics,
+ * lowercase, hyphen/apostrophe → space, whitespace-collapse. Import this beside the interface; never re-implement it.
+ */
+export function foldStreetSurface(surface: string): string {
+	return surface
+		.normalize("NFD")
+		.replace(/[̀-ͯ]/g, "")
+		.toLowerCase()
+		.replace(/['’‐-―-]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+}
+
+/**
+ * FR street-type + particle vocabulary — the G1 guard. A street surface made ONLY of these words carries no NAME (bare
+ * `rue`/`chemin` is a truncation, and it IS in the index), so it earns no evidence credit. Folded forms (particles are
+ * pre-folded: `l'` → `l`). Kept small and lexical — it is a dictionary fact, not a tuned weight (the anti-Pelias
+ * line).
+ */
+const FR_STREET_TYPE_WORDS: ReadonlySet<string> = new Set([
+	"rue",
+	"avenue",
+	"boulevard",
+	"chemin",
+	"route",
+	"allee",
+	"impasse",
+	"place",
+	"quai",
+	"passage",
+	"sentier",
+	"square",
+	"cours",
+	"voie",
+	"chaussee",
+	"rond",
+	"point",
+	"clos",
+	"villa",
+	"cite",
+	"de",
+	"du",
+	"des",
+	"la",
+	"le",
+	"les",
+	"l",
+	"d",
+	"en",
+	"aux",
+	"au",
+	"sur",
+	"sous",
+])
+
+/** True when the folded surface contains no token outside {@link FR_STREET_TYPE_WORDS} — i.e. it is pure type/particle. */
+export function isPureTypeVocabulary(foldedSurface: string): boolean {
+	const tokens = foldedSurface.split(" ").filter(Boolean)
+
+	if (tokens.length === 0) return true
+
+	return tokens.every((t) => FR_STREET_TYPE_WORDS.has(t))
+}
+
+/** One candidate parse for the street-evidence rerank — its street surface + its (within-input comparable) score. */
+export interface StreetCandidate<T = unknown> {
+	/** The candidate's street surface (raw; folded internally). Empty string = no street parsed → never the evidence pick. */
+	streetSurface: string
+	/** The parse score, comparable to its siblings from the SAME input. Higher is better. */
+	score: number
+	/** Opaque caller payload carried through to the result (the segmentation, the tree, …). */
+	payload?: T
+}
+
+export interface PickByStreetEvidenceOpts {
+	/** Locality/postcode scope forwarded to {@link StreetLocalityEvidence.hasStreetName} (fragments usually carry none). */
+	scope?: StreetEvidenceScope
+	/**
+	 * G2 — the margin cap. A candidate whose score is more than this far below rank-1 is never promoted by evidence
+	 * (without it, evidence reaches deep down the list and moves off correct rank-1 parses). Default 2.5 — the value the
+	 * v2 board measured (148 fixes / 3 breaks). UNCALIBRATED across models: re-fit when the span head retrains, since raw
+	 * score margins are not comparable across models. (Plan #1134 pre-registers an isotonic ambiguity gate to replace
+	 * it.)
+	 */
+	marginCap?: number
+}
+
+export interface StreetEvidencePick<T = unknown> {
+	/** The chosen candidate — the first evidence-passing sibling, or rank-1 when none passes (fail-open). */
+	candidate: StreetCandidate<T>
+	/** Index of the chosen candidate in the input array. */
+	index: number
+	/** True when evidence MOVED the pick off rank-1 (a rank-2-beats-rank-1 correction — loggable training signal). */
+	moved: boolean
+}
+
+/**
+ * The measured v2 rerank policy. Given candidates in PARSE-SCORE order (rank-1 first) and an evidence probe, return the
+ * first candidate whose street surface passes ALL of: (1) exists in the index, (2) G1 — not pure type vocabulary, (3)
+ * G2 — within `marginCap` of rank-1. If none passes, return rank-1 (fail-open). Positive evidence only; the model's
+ * order is preserved among equal-evidence candidates. This is the `resolver/rerank.ts` anti-Pelias discipline applied
+ * to the name signal: one bit, no blending.
+ *
+ * @param candidates Parse candidates, rank-1 FIRST (the caller sorts by score descending).
+ */
+export function pickByStreetEvidence<T>(
+	candidates: ReadonlyArray<StreetCandidate<T>>,
+	evidence: StreetLocalityEvidence,
+	opts: PickByStreetEvidenceOpts = {}
+): StreetEvidencePick<T> {
+	const marginCap = opts.marginCap ?? 2.5
+
+	if (candidates.length === 0) {
+		throw new Error("pickByStreetEvidence: no candidates")
+	}
+	const rank1 = candidates[0]!
+	const topScore = rank1.score
+
+	for (let i = 0; i < candidates.length; i++) {
+		const c = candidates[i]!
+
+		if (!c.streetSurface) continue
+
+		// G2: candidates are score-ordered, so once one falls past the cap nothing deeper qualifies either.
+		if (topScore - c.score > marginCap) break
+
+		// G1: a pure street-type/particle surface (bare `rue`) carries no name — no evidence credit.
+		if (isPureTypeVocabulary(foldStreetSurface(c.streetSurface))) continue
+
+		if (evidence.hasStreetName(c.streetSurface, opts.scope)) {
+			return { candidate: c, index: i, moved: i > 0 }
+		}
+	}
+
+	return { candidate: rank1, index: 0, moved: false }
+}


### PR DESCRIPTION
## What

The measured phase-4 arbiter primitive from the #727 stage-2 arc. Phase-4a proved the planned arbiter (full-geocode resolution tier) collects **zero** headroom on context-free fragments (they never reach rooftop layers). The corrected signal is **street-NAME existence** — queryable even for a bare fragment. Measured on the v3.10.1 8k span substrate: the rerank collects **+6.0pp street@1 (0.791→0.851), 96 fixes / 3 breaks (32:1)**, the value concentrated on the **date-name class (+16.7pp)**.

Spec: `docs/superpowers/specs/2026-07-17-727-phase4c-street-name-evidence.md`. Receipts: `docs/articles/evals/2026-07-17-v3101-span-head-8k-result.md`.

## Contents

- **`resolver/street-evidence.ts`** (pure, no SQLite):
  - `StreetLocalityEvidence` interface — backend-agnostic name-existence probe, positive-evidence-only.
  - `foldStreetSurface` — the fold **CONTRACT** (NFD strip-diacritics / lowercase / hyphen+apostrophe→space / collapse). The index builder and every prober must share it.
  - `isPureTypeVocabulary` (G1) + `pickByStreetEvidence` — the measured **v2 policy**: G1 type-word guard + G2 margin cap (2.5), model order preserved, fail-open. One bit of evidence, no score blending (the anti-Pelias rule from `rerank.ts`).
  - 14 tests (fold, G1, the four policy cases: keep / fix / G1-skip / G2-cap / fail-open).
- **`resolver-wof-sqlite/street-name-lookup.ts`**: `SQLiteStreetNameLookup implements StreetLocalityEvidence` — the FR BAN backend. `readOnly`, prepared scoped+unscoped probes, graceful table-missing degrade (the `AddressPointSqliteLookup` discipline). 9 fixture-DB tests.

## Status — default-off, NOT wired

This is the arbiter **primitive**. Wiring it into the k-best rerank loop is the next step and needs PR #1154's decode surface on main. Nothing in production changes.

**Production follow-up (BAN sdk):** `street-centroids-fr.db` must be rebuilt with `foldStreetSurface` (the contract fold — it currently folds without hyphen/apostrophe normalization) **plus a `street_norm` index** before the backend is wired in production. This PR is correct-by-construction against a fixture built with the contract fold.

## Verification

- 23/23 tests pass (14 policy + 9 backend). `tsc --noEmit` clean on both packages. oxlint + oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1Kk2TojtVRejgGnobtjJ8